### PR TITLE
refactor(api): decouple response assembly from handlers

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -7208,7 +7208,7 @@ func TestRoomAndThreadTimelineGetThreadEventsRequiresMembership(t *testing.T) {
 	}
 }
 
-func TestRoomAndThreadTimelineHydratesProcessedVideoAttachments(t *testing.T) {
+func TestTimelineAndAssetServicesHydrateProcessedVideoAttachments(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("timeline-video")
 
@@ -7281,6 +7281,27 @@ func TestRoomAndThreadTimelineHydratesProcessedVideoAttachments(t *testing.T) {
 	}
 	if got := processing.GetHls().GetMasterPlaylistUrl().GetUrl(); !strings.Contains(got, "/assets/hls/"+original.Id+"/master.m3u8?access=") {
 		t.Fatalf("videoProcessing HLS master URL = %q", got)
+	}
+
+	assetResponse, err := env.assets.GetAsset(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.GetAssetRequest{
+		RoomId:  room.Id,
+		AssetId: original.Id,
+	}))
+	if err != nil {
+		t.Fatalf("GetAsset: %v", err)
+	}
+	assetProcessing := assetResponse.Msg.GetAsset().GetVideoProcessing()
+	if assetProcessing.GetStatus() != apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_COMPLETED {
+		t.Fatalf("asset videoProcessing status = %v, want COMPLETED", assetProcessing.GetStatus())
+	}
+	if assetProcessing.GetDurationMs() != 1234 || assetProcessing.GetWidth() != 1280 || assetProcessing.GetHeight() != 720 {
+		t.Fatalf("asset videoProcessing dimensions = %d/%d/%d, want 1234/1280/720", assetProcessing.GetDurationMs(), assetProcessing.GetWidth(), assetProcessing.GetHeight())
+	}
+	if assetProcessing.GetThumbnailAssetUrl().GetUrl() == "" || len(assetProcessing.GetVariants()) != 1 || assetProcessing.GetVariants()[0].GetAssetUrl().GetUrl() == "" {
+		t.Fatalf("asset videoProcessing derivative URLs missing: %+v", assetProcessing)
+	}
+	if got := assetProcessing.GetHls().GetMasterPlaylistUrl().GetUrl(); !strings.Contains(got, "/assets/hls/"+original.Id+"/master.m3u8?access=") {
+		t.Fatalf("asset videoProcessing HLS master URL = %q", got)
 	}
 }
 

--- a/cli/internal/connectapi/attachments.go
+++ b/cli/internal/connectapi/attachments.go
@@ -2,6 +2,7 @@ package connectapi
 
 import (
 	"context"
+	"strings"
 
 	"connectrpc.com/connect"
 	"hmans.de/chatto/internal/core"
@@ -103,10 +104,6 @@ func apiAsset(api *API, attachment *corev1.Attachment, viewerID string, thumbnai
 	if attachment == nil {
 		return nil
 	}
-	h := &timelineHydrator{
-		api:      api,
-		viewerID: viewerID,
-	}
 	return &apiv1.Asset{
 		Id:                attachment.Id,
 		Filename:          attachment.Filename,
@@ -116,7 +113,100 @@ func apiAsset(api *API, attachment *corev1.Attachment, viewerID string, thumbnai
 		Height:            attachment.Height,
 		AssetUrl:          assetURLView(api.core.GetStableAttachmentAssetURL(attachment.Id, viewerID)),
 		ThumbnailAssetUrl: assetURLView(api.core.GetStableTransformedAttachmentAssetURL(attachment.Id, viewerID, thumbnail.width, thumbnail.height, thumbnail.fit)),
-		VideoProcessing:   h.videoProcessing(attachment),
+		VideoProcessing:   apiVideoProcessing(api, viewerID, attachment),
+	}
+}
+
+func apiVideoProcessing(api *API, viewerID string, attachment *corev1.Attachment) *apiv1.MessageVideoProcessing {
+	if attachment == nil || (!strings.HasPrefix(attachment.GetContentType(), "video/") && attachment.GetContentType() != "image/gif") {
+		return nil
+	}
+
+	manifest, ok := api.core.Assets.VideoAttachmentManifest(attachment.GetId())
+	if !ok || manifest == nil {
+		return nil
+	}
+
+	if succeeded := manifest.Succeeded; succeeded != nil {
+		video := succeeded.GetVideo()
+		if video == nil {
+			return nil
+		}
+		result := &apiv1.MessageVideoProcessing{
+			Status:          apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_COMPLETED,
+			DurationMs:      video.GetDurationMs(),
+			Width:           video.GetWidth(),
+			Height:          video.GetHeight(),
+			SourceAvailable: assetSourceAvailable(api, attachment.GetId(), true),
+		}
+		if thumbnailID := video.GetThumbnailAssetId(); thumbnailID != "" {
+			result.ThumbnailAssetUrl = assetURLView(api.core.GetStableAttachmentAssetURL(thumbnailID, viewerID))
+		}
+		for _, variant := range video.GetVariants() {
+			if variant == nil {
+				continue
+			}
+			var width, height int32
+			var size int64
+			if created, ok := api.core.Assets.AssetCreation(variant.GetAssetId()); ok {
+				asset := created.GetAsset()
+				if asset != nil {
+					width = asset.GetWidth()
+					height = asset.GetHeight()
+					size = asset.GetSize()
+				}
+			}
+			result.Variants = append(result.Variants, &apiv1.MessageVideoVariant{
+				Quality:  variant.GetQuality(),
+				Width:    width,
+				Height:   height,
+				Size:     size,
+				AssetUrl: assetURLView(api.core.GetStableAttachmentAssetURL(variant.GetAssetId(), viewerID)),
+			})
+		}
+		if hls := video.GetHls(); hls != nil && len(hls.GetRenditions()) > 0 {
+			result.Hls = &apiv1.MessageVideoHLS{
+				MasterPlaylistUrl: assetURLView(api.core.GetStableHLSMasterPlaylistAssetURL(attachment.GetId(), viewerID)),
+			}
+		}
+		return result
+	}
+
+	if failed := manifest.Failed; failed != nil {
+		reasonCode := assetProcessingFailureReasonCode(failed.GetFailureCode())
+		return &apiv1.MessageVideoProcessing{
+			Status:          apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_FAILED,
+			SourceAvailable: reasonCode != "original_missing" && assetSourceAvailable(api, attachment.GetId(), true),
+			ReasonCode:      reasonCode,
+		}
+	}
+
+	if manifest.Started != nil {
+		return &apiv1.MessageVideoProcessing{
+			Status:          apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_PROCESSING,
+			SourceAvailable: assetSourceAvailable(api, attachment.GetId(), true),
+		}
+	}
+
+	return nil
+}
+
+func assetSourceAvailable(api *API, assetID string, fallback bool) bool {
+	created, ok := api.core.Assets.AssetCreation(assetID)
+	if !ok || created == nil {
+		return fallback
+	}
+	return created.GetOriginalBinaryAvailable()
+}
+
+func assetProcessingFailureReasonCode(code corev1.AssetProcessingFailureCode) string {
+	switch code {
+	case corev1.AssetProcessingFailureCode_ASSET_PROCESSING_FAILURE_CODE_SOURCE_MISSING:
+		return "original_missing"
+	case corev1.AssetProcessingFailureCode_ASSET_PROCESSING_FAILURE_CODE_PROCESSING_FAILED:
+		return "processing_failed"
+	default:
+		return "processing_failed"
 	}
 }
 

--- a/cli/internal/connectapi/realtime_projection.go
+++ b/cli/internal/connectapi/realtime_projection.go
@@ -268,10 +268,9 @@ func (a *API) BuildRealtimeProjectionActiveCalls(ctx context.Context, userID str
 	if err != nil {
 		return nil, err
 	}
-	service := &voiceCallService{api: a}
 	calls := make([]*apiv1.ActiveCall, 0, len(roomIDs))
 	for _, roomID := range roomIDs {
-		call, err := service.activeCall(ctx, userID, roomID)
+		call, err := activeCall(ctx, a, userID, roomID)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) || errors.Is(err, core.ErrPermissionDenied) || errors.Is(err, core.ErrNotRoomMember) {
 				continue
@@ -324,8 +323,7 @@ func (a *API) BuildRealtimeProjectionRoomTimeline(ctx context.Context, userID, r
 // BuildRealtimeProjectionServerState returns current authenticated server
 // presentation and runtime settings for snapshot and live convergence.
 func (a *API) BuildRealtimeProjectionServerState() *RealtimeProjectionServerState {
-	service := &serverService{api: a}
-	return &RealtimeProjectionServerState{MOTD: service.serverMotd(), Runtime: service.serverRuntimeConfig()}
+	return &RealtimeProjectionServerState{MOTD: serverMOTD(a), Runtime: serverRuntimeConfig(a)}
 }
 
 func (a *API) realtimeProjectionUsers(ctx context.Context) ([]*apiv1.DirectoryMember, error) {

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync"
 
 	"github.com/charmbracelet/log"
@@ -300,103 +299,10 @@ func (h *timelineHydrator) attachments(roomID, messageEventID string, attachment
 			Height:            attachment.Height,
 			AssetUrl:          assetURLView(assetURL),
 			ThumbnailAssetUrl: assetURLView(thumbnailURL),
-			VideoProcessing:   h.videoProcessing(attachment),
+			VideoProcessing:   apiVideoProcessing(h.api, h.viewerID, attachment),
 		})
 	}
 	return result
-}
-
-func (h *timelineHydrator) videoProcessing(attachment *corev1.Attachment) *apiv1.MessageVideoProcessing {
-	if attachment == nil || (!strings.HasPrefix(attachment.GetContentType(), "video/") && attachment.GetContentType() != "image/gif") {
-		return nil
-	}
-
-	manifest, ok := h.api.core.Assets.VideoAttachmentManifest(attachment.GetId())
-	if !ok || manifest == nil {
-		return nil
-	}
-
-	if succeeded := manifest.Succeeded; succeeded != nil {
-		video := succeeded.GetVideo()
-		if video == nil {
-			return nil
-		}
-		result := &apiv1.MessageVideoProcessing{
-			Status:          apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_COMPLETED,
-			DurationMs:      video.GetDurationMs(),
-			Width:           video.GetWidth(),
-			Height:          video.GetHeight(),
-			SourceAvailable: h.assetSourceAvailable(attachment.GetId(), true),
-		}
-		if thumbnailID := video.GetThumbnailAssetId(); thumbnailID != "" {
-			result.ThumbnailAssetUrl = assetURLView(h.api.core.GetStableAttachmentAssetURL(thumbnailID, h.viewerID))
-		}
-		for _, variant := range video.GetVariants() {
-			if variant == nil {
-				continue
-			}
-			var width, height int32
-			var size int64
-			if created, ok := h.api.core.Assets.AssetCreation(variant.GetAssetId()); ok {
-				asset := created.GetAsset()
-				if asset != nil {
-					width = asset.GetWidth()
-					height = asset.GetHeight()
-					size = asset.GetSize()
-				}
-			}
-			result.Variants = append(result.Variants, &apiv1.MessageVideoVariant{
-				Quality:  variant.GetQuality(),
-				Width:    width,
-				Height:   height,
-				Size:     size,
-				AssetUrl: assetURLView(h.api.core.GetStableAttachmentAssetURL(variant.GetAssetId(), h.viewerID)),
-			})
-		}
-		if hls := video.GetHls(); hls != nil && len(hls.GetRenditions()) > 0 {
-			result.Hls = &apiv1.MessageVideoHLS{
-				MasterPlaylistUrl: assetURLView(h.api.core.GetStableHLSMasterPlaylistAssetURL(attachment.GetId(), h.viewerID)),
-			}
-		}
-		return result
-	}
-
-	if failed := manifest.Failed; failed != nil {
-		reasonCode := assetProcessingFailureReasonCode(failed.GetFailureCode())
-		return &apiv1.MessageVideoProcessing{
-			Status:          apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_FAILED,
-			SourceAvailable: reasonCode != "original_missing" && h.assetSourceAvailable(attachment.GetId(), true),
-			ReasonCode:      reasonCode,
-		}
-	}
-
-	if manifest.Started != nil {
-		return &apiv1.MessageVideoProcessing{
-			Status:          apiv1.MessageVideoProcessingStatus_MESSAGE_VIDEO_PROCESSING_STATUS_PROCESSING,
-			SourceAvailable: h.assetSourceAvailable(attachment.GetId(), true),
-		}
-	}
-
-	return nil
-}
-
-func (h *timelineHydrator) assetSourceAvailable(assetID string, fallback bool) bool {
-	created, ok := h.api.core.Assets.AssetCreation(assetID)
-	if !ok || created == nil {
-		return fallback
-	}
-	return created.GetOriginalBinaryAvailable()
-}
-
-func assetProcessingFailureReasonCode(code corev1.AssetProcessingFailureCode) string {
-	switch code {
-	case corev1.AssetProcessingFailureCode_ASSET_PROCESSING_FAILURE_CODE_SOURCE_MISSING:
-		return "original_missing"
-	case corev1.AssetProcessingFailureCode_ASSET_PROCESSING_FAILURE_CODE_PROCESSING_FAILED:
-		return "processing_failed"
-	default:
-		return "processing_failed"
-	}
 }
 
 func (h *timelineHydrator) linkPreview(preview *corev1.LinkPreview) *apiv1.LinkPreview {

--- a/cli/internal/connectapi/server_state.go
+++ b/cli/internal/connectapi/server_state.go
@@ -22,7 +22,7 @@ func (s *serverService) GetMotd(ctx context.Context, _ *connect.Request[apiv1.Ge
 	}
 
 	resp := &apiv1.GetMotdResponse{}
-	motd := s.serverMotd()
+	motd := serverMOTD(s.api)
 	if motd != "" {
 		resp.Motd = stringPtr(motd)
 	}
@@ -34,27 +34,27 @@ func (s *serverService) GetRuntimeConfig(ctx context.Context, _ *connect.Request
 		return nil, err
 	}
 
-	return connect.NewResponse(&apiv1.GetRuntimeConfigResponse{Runtime: s.serverRuntimeConfig()}), nil
+	return connect.NewResponse(&apiv1.GetRuntimeConfigResponse{Runtime: serverRuntimeConfig(s.api)}), nil
 }
 
-func (s *serverService) serverRuntimeConfig() *apiv1.ServerRuntimeConfig {
-	maxUploadSize := s.api.core.AssetsConfig().MaxUploadSize
+func serverRuntimeConfig(api *API) *apiv1.ServerRuntimeConfig {
+	maxUploadSize := api.core.AssetsConfig().MaxUploadSize
 	maxVideoUploadSize := maxUploadSize
-	if s.api.config.Video.Enabled {
-		maxVideoUploadSize = int64(s.api.config.Video.MaxUploadSizeOrDefault())
+	if api.config.Video.Enabled {
+		maxVideoUploadSize = int64(api.config.Video.MaxUploadSizeOrDefault())
 	}
 	runtime := &apiv1.ServerRuntimeConfig{
-		PushNotificationsEnabled: s.api.config.Push.IsConfigured(),
-		VideoProcessingEnabled:   s.api.config.Video.Enabled,
+		PushNotificationsEnabled: api.config.Push.IsConfigured(),
+		VideoProcessingEnabled:   api.config.Video.Enabled,
 		MaxUploadSize:            maxUploadSize,
 		MaxVideoUploadSize:       maxVideoUploadSize,
 		MessageEditWindowSeconds: int32(core.MessageEditWindow / time.Second),
 	}
-	if s.api.config.Push.IsConfigured() {
-		runtime.VapidPublicKey = stringPtr(s.api.config.Push.VAPIDPublicKey)
+	if api.config.Push.IsConfigured() {
+		runtime.VapidPublicKey = stringPtr(api.config.Push.VAPIDPublicKey)
 	}
-	if s.api.config.LiveKit.IsConfigured() {
-		runtime.LivekitUrl = stringPtr(s.api.config.LiveKit.URL)
+	if api.config.LiveKit.IsConfigured() {
+		runtime.LivekitUrl = stringPtr(api.config.LiveKit.URL)
 	}
 	return runtime
 }
@@ -220,8 +220,8 @@ func adminServerConfig(cfg *configv1.ServerConfig) *adminv1.ServerConfig {
 	}
 }
 
-func (s *serverService) serverMotd() string {
-	if cm := s.api.core.ConfigManager(); cm != nil {
+func serverMOTD(api *API) string {
+	if cm := api.core.ConfigManager(); cm != nil {
 		return cm.GetEffectiveMOTD()
 	}
 	return ""

--- a/cli/internal/connectapi/viewer.go
+++ b/cli/internal/connectapi/viewer.go
@@ -40,25 +40,24 @@ func (s *viewerService) GetViewer(ctx context.Context, _ *connect.Request[apiv1.
 }
 
 func (a *API) buildViewer(ctx context.Context, userID string) (*apiv1.GetViewerResponse, error) {
-	service := &viewerService{api: a}
 	user, err := a.core.GetUser(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
-	responseUser, err := service.viewerUser(ctx, user)
+	responseUser, err := viewerUser(ctx, a, user)
 	if err != nil {
 		return nil, err
 	}
-	capabilities, err := service.viewerCapabilities(ctx, userID)
+	capabilities, err := viewerCapabilities(ctx, a, userID)
 	if err != nil {
 		return nil, err
 	}
-	serverPreference, err := service.serverNotificationPreference(ctx, userID)
+	serverPreference, err := serverNotificationPreference(ctx, a, userID)
 	if err != nil {
 		return nil, err
 	}
-	roomPreferences, err := service.roomNotificationPreferences(ctx, userID)
+	roomPreferences, err := roomNotificationPreferences(ctx, a, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -77,28 +76,28 @@ func (a *API) buildViewer(ctx context.Context, userID string) (*apiv1.GetViewerR
 	}, nil
 }
 
-func (s *viewerService) viewerUser(ctx context.Context, user *corev1.User) (*apiv1.ViewerUser, error) {
-	hasVerifiedEmail, err := s.api.core.HasVerifiedEmail(ctx, user.GetId())
+func viewerUser(ctx context.Context, api *API, user *corev1.User) (*apiv1.ViewerUser, error) {
+	hasVerifiedEmail, err := api.core.HasVerifiedEmail(ctx, user.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
-	settings, err := s.api.core.GetUserSettings(ctx, user.GetId())
+	settings, err := api.core.GetUserSettings(ctx, user.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
-	apiUser, err := userSummary(ctx, s.api, user, nil)
+	apiUser, err := userSummary(ctx, api, user, nil)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canDeleteAccount, err := s.api.core.CanDeleteUser(ctx, user.GetId(), user.GetId())
+	canDeleteAccount, err := api.core.CanDeleteUser(ctx, user.GetId(), user.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
-	lastLoginChange, err := s.api.core.GetLastLoginChange(ctx, user.GetId())
+	lastLoginChange, err := api.core.GetLastLoginChange(ctx, user.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
-	hasPassword, err := s.api.core.HasPassword(ctx, user.GetId())
+	hasPassword, err := api.core.HasPassword(ctx, user.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -117,45 +116,45 @@ func (s *viewerService) viewerUser(ctx context.Context, user *corev1.User) (*api
 	return response, nil
 }
 
-func (s *viewerService) viewerCapabilities(ctx context.Context, userID string) (*apiv1.ViewerCapabilities, error) {
-	canViewAdmin, err := s.api.core.HasAnyAdminPermission(ctx, userID)
+func viewerCapabilities(ctx context.Context, api *API, userID string) (*apiv1.ViewerCapabilities, error) {
+	canViewAdmin, err := api.core.HasAnyAdminPermission(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canStartDMs, err := s.api.core.CanStartDM(ctx, userID)
+	canStartDMs, err := api.core.CanStartDM(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canAdminViewUsers, err := s.api.core.CanAdminUsersView(ctx, userID)
+	canAdminViewUsers, err := api.core.CanAdminUsersView(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canAdminManageAccounts, err := s.api.core.CanManageUserAccounts(ctx, userID)
+	canAdminManageAccounts, err := api.core.CanManageUserAccounts(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canAssignRoles, err := s.api.core.CanAssignRoles(ctx, userID)
+	canAssignRoles, err := api.core.CanAssignRoles(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canAdminManageRoles, err := s.api.core.CanManageRoles(ctx, userID)
+	canAdminManageRoles, err := api.core.CanManageRoles(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canManageUserPermissions, err := s.api.core.CanManageUserPermissions(ctx, userID)
+	canManageUserPermissions, err := api.core.CanManageUserPermissions(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
 	canAdminViewRoles := canAdminManageRoles || canAssignRoles || canManageUserPermissions
-	canAdminViewSystem, err := s.api.core.CanAdminSystemView(ctx, userID)
+	canAdminViewSystem, err := api.core.CanAdminSystemView(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	canAdminViewAudit, err := s.api.core.CanAdminAuditView(ctx, userID)
+	canAdminViewAudit, err := api.core.CanAdminAuditView(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	hasUnreadFollowedThreads, err := s.api.core.HasUnreadFollowedThreads(ctx, userID, []string{core.LegacySpaceIDForRoomKind(core.KindChannel)})
+	hasUnreadFollowedThreads, err := api.core.HasUnreadFollowedThreads(ctx, userID, []string{core.LegacySpaceIDForRoomKind(core.KindChannel)})
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -177,8 +176,8 @@ func (s *viewerService) viewerCapabilities(ctx context.Context, userID string) (
 	}, nil
 }
 
-func (s *viewerService) serverNotificationPreference(ctx context.Context, userID string) (*apiv1.NotificationPreference, error) {
-	level, err := s.api.core.GetSpaceNotificationLevel(ctx, userID)
+func serverNotificationPreference(ctx context.Context, api *API, userID string) (*apiv1.NotificationPreference, error) {
+	level, err := api.core.GetSpaceNotificationLevel(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -189,8 +188,8 @@ func (s *viewerService) serverNotificationPreference(ctx context.Context, userID
 	return apiNotificationPreference(level, effectiveLevel), nil
 }
 
-func (s *viewerService) roomNotificationPreferences(ctx context.Context, userID string) ([]*apiv1.RoomNotificationPreference, error) {
-	prefs, err := s.api.core.GetAllRoomNotificationPreferences(ctx, userID)
+func roomNotificationPreferences(ctx context.Context, api *API, userID string) ([]*apiv1.RoomNotificationPreference, error) {
+	prefs, err := api.core.GetAllRoomNotificationPreferences(ctx, userID)
 	if err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/connectapi/voice_calls.go
+++ b/cli/internal/connectapi/voice_calls.go
@@ -32,7 +32,7 @@ func (s *voiceCallService) ListActiveCalls(ctx context.Context, _ *connect.Reque
 	}
 	calls := make([]*apiv1.ActiveCall, 0, len(roomIDs))
 	for _, roomID := range roomIDs {
-		call, err := s.activeCall(ctx, caller.UserID, roomID)
+		call, err := activeCall(ctx, s.api, caller.UserID, roomID)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) ||
 				errors.Is(err, core.ErrPermissionDenied) ||
@@ -51,7 +51,7 @@ func (s *voiceCallService) GetActiveCall(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, err
 	}
-	call, err := s.activeCall(ctx, caller.UserID, req.Msg.GetRoomId())
+	call, err := activeCall(ctx, s.api, caller.UserID, req.Msg.GetRoomId())
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -75,7 +75,7 @@ func (s *voiceCallService) BatchGetActiveCalls(ctx context.Context, req *connect
 		}
 		seen[roomID] = struct{}{}
 
-		call, err := s.activeCall(ctx, caller.UserID, roomID)
+		call, err := activeCall(ctx, s.api, caller.UserID, roomID)
 		if err != nil {
 			if errors.Is(err, core.ErrNotFound) ||
 				errors.Is(err, core.ErrPermissionDenied) ||
@@ -109,7 +109,7 @@ func (s *voiceCallService) ListCallParticipants(ctx context.Context, req *connec
 
 	responseParticipants := make([]*apiv1.CallParticipant, 0, len(participants))
 	for _, participant := range participants {
-		mapped, err := s.callParticipant(ctx, participant)
+		mapped, err := callParticipant(ctx, s.api, participant)
 		if err != nil {
 			return nil, err
 		}
@@ -206,26 +206,26 @@ func (s *voiceCallService) LeaveCall(ctx context.Context, req *connect.Request[a
 	return connect.NewResponse(&apiv1.LeaveCallResponse{Left: true}), nil
 }
 
-func (s *voiceCallService) activeCall(ctx context.Context, actorID, roomID string) (*apiv1.ActiveCall, error) {
-	room, _, err := s.api.core.VoiceCallRoomForMember(ctx, actorID, roomID)
+func activeCall(ctx context.Context, api *API, actorID, roomID string) (*apiv1.ActiveCall, error) {
+	room, _, err := api.core.VoiceCallRoomForMember(ctx, actorID, roomID)
 	if err != nil {
 		return nil, err
 	}
-	if !s.api.config.LiveKit.IsConfigured() {
+	if !api.config.LiveKit.IsConfigured() {
 		return nil, core.ErrNotFound
 	}
-	activeCall, ok := s.api.core.CallState.ActiveCall(room.GetId())
+	activeCall, ok := api.core.CallState.ActiveCall(room.GetId())
 	if !ok {
 		return nil, core.ErrNotFound
 	}
 
-	participants, err := s.api.core.GetCallParticipants(ctx, core.LegacySpaceIDForRoomKind(core.KindOfRoom(room)), room.GetId())
+	participants, err := api.core.GetCallParticipants(ctx, core.LegacySpaceIDForRoomKind(core.KindOfRoom(room)), room.GetId())
 	if err != nil {
 		return nil, err
 	}
 	responseParticipants := make([]*apiv1.CallParticipant, 0, len(participants))
 	for _, participant := range participants {
-		mapped, err := s.callParticipant(ctx, participant)
+		mapped, err := callParticipant(ctx, api, participant)
 		if err != nil {
 			return nil, err
 		}
@@ -240,8 +240,8 @@ func (s *voiceCallService) activeCall(ctx context.Context, actorID, roomID strin
 	}, nil
 }
 
-func (s *voiceCallService) callParticipant(ctx context.Context, participant core.CallParticipant) (*apiv1.CallParticipant, error) {
-	user, err := s.api.core.GetUser(ctx, participant.UserID)
+func callParticipant(ctx context.Context, api *API, participant core.CallParticipant) (*apiv1.CallParticipant, error) {
+	user, err := api.core.GetUser(ctx, participant.UserID)
 	if err != nil {
 		if errors.Is(err, core.ErrNotFound) {
 			return nil, nil
@@ -249,7 +249,7 @@ func (s *voiceCallService) callParticipant(ctx context.Context, participant core
 		return nil, connectError(err)
 	}
 	avatarSize := 96
-	apiUser, err := userSummary(ctx, s.api, user, &apiv1.ImageTransformOptions{
+	apiUser, err := userSummary(ctx, api, user, &apiv1.ImageTransformOptions{
 		Width:  int32(avatarSize),
 		Height: int32(avatarSize),
 		Fit:    apiv1.ImageFitMode_IMAGE_FIT_MODE_COVER,


### PR DESCRIPTION
## Why

Reusable response assembly was coupled to ConnectRPC handler and timeline-hydrator objects, forcing non-transport code to construct partially initialised handlers just to call private helpers.

## What changed

- Extracted viewer, server-state, active-call, participant, and video-processing assembly into plain package functions with explicit API dependencies.
- Kept ConnectRPC service structs focused on transport handling and moved shared video processing mapping alongside asset mapping.
- Extended processed-video coverage through `AssetService.GetAsset`, including derivative and HLS URLs.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: unchanged.

Newer client → older server: unchanged.

Capability discovery or minimum client/server version: none.

## Test plan

- `mise x -- go test ./internal/connectapi -run 'Test(ViewerServiceGetViewerReturnsSelfScopedState|ServerServiceGetMotdAndRuntimeConfig|VoiceCallServiceRecordsAndListsCalls|VoiceCallServiceListsDMCallsForParticipants|TimelineAndAssetServicesHydrateProcessedVideoAttachments)$' -count=1 -timeout 90s`
- `mise x -- go test ./internal/connectapi -count=1 -timeout 180s`
- `mise test-cli`
- CI-equivalent Buf breaking checks for storage/internal/Operator and public APIs against `origin/main`
