### PR TITLE
feat(dev): add compiled Conductor run task

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -18,11 +18,11 @@ run_mode = "concurrent"
 
 [scripts.run.chatto]
 command = "mise dev"
-default = true
 icon = "message-square"
 
-[scripts.run.dev-compiled]
+[scripts.run.chatto-compiled]
 command = "mise dev-compiled"
+default = true
 icon = "package"
 
 [scripts.run.docs-website]

--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -21,6 +21,10 @@ command = "mise dev"
 default = true
 icon = "message-square"
 
+[scripts.run.dev-compiled]
+command = "mise dev-compiled"
+icon = "package"
+
 [scripts.run.docs-website]
 command = "mise dev-docs-website"
 icon = "book-open"

--- a/mise.toml
+++ b/mise.toml
@@ -287,6 +287,10 @@ env = {
 }
 run = "exec bin/chatto"
 
+[tasks.dev-compiled]
+description = "Build and run the bundled Chatto stack with LiveKit and Mailpit"
+run = { tasks = ["chatto", "dev-livekit", "dev-mailpit"] }
+
 # =============================================================================
 # Benchmarking
 # =============================================================================

--- a/mise.toml
+++ b/mise.toml
@@ -285,7 +285,7 @@ env = {
   CHATTO_SMTP_TLS = "opportunistic",
   CHATTO_SMTP_FROM = "chatto-dev@chatto.localhost",
 }
-run = "exec bin/chatto"
+run = "exec bin/chatto run"
 
 [tasks.dev-compiled]
 description = "Build and run the bundled Chatto stack with LiveKit and Mailpit"


### PR DESCRIPTION
## Why

Developers need a Conductor run option that exercises the compiled, bundled Chatto application while retaining the local LiveKit and Mailpit services used for end-to-end development.

## What changed

- Added a `dev-compiled` Mise task that runs the compiled Chatto binary, LiveKit, and Mailpit together with workspace-safe ports.
- Exposed it as the default `chatto-compiled` Conductor run script alongside the existing hot-reload development stack.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise tasks ls | rg '^dev-compiled\b'`
- `mise run --dry-run dev-compiled`
- `mise config ls`
- `CONDUCTOR_PORT=45100 mise dev-compiled` (verified Chatto HTTP, embedded NATS, LiveKit, and Mailpit started; then shut down cleanly)
- `git diff --check origin/main...HEAD`
