### PR TITLE
fix(dev): keep Conductor tasks in process group

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -17,20 +17,20 @@ setup = "mise trust && mise setup"
 run_mode = "concurrent"
 
 [scripts.run.chatto]
-command = "mise dev"
+command = "exec mise dev"
 icon = "message-square"
 
 [scripts.run.chatto-compiled]
-command = "mise dev-compiled"
+command = "exec mise dev-compiled"
 default = true
 icon = "package"
 
 [scripts.run.docs-website]
-command = "mise dev-docs-website"
+command = "exec mise dev-docs-website"
 icon = "book-open"
 
 [scripts.run.storybook]
-command = "mise storybook"
+command = "exec mise storybook"
 icon = "palette"
 
 [prompts]


### PR DESCRIPTION
## Why

Conductor needs to track the `mise` process directly so stopping a multi-process development task reliably reaches its complete process group instead of leaving descendants behind an intermediary shell.

## What changed

- Prefix all shared Conductor run commands with `exec`, replacing the non-interactive wrapper shell with `mise`.
- Preserve the existing tasks, default selection, icons, ports, and concurrent workspace behaviour.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x taplo@latest -- taplo check .conductor/settings.toml`
- `git diff --check`
- Reproduced a Conductor-style parallel mise process tree on macOS and verified process-group shutdown left no surviving child processes.
