### PR TITLE
refactor(core): remove legacy space plumbing from calls

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4882,7 +4882,7 @@ func TestVoiceCallServiceRoomRemovalClearsCallParticipant(t *testing.T) {
 	if _, err := env.core.JoinRoom(env.ctx, target.Id, core.KindChannel, target.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom target: %v", err)
 	}
-	if err := env.core.RecordCallParticipantJoined(env.ctx, core.KindChannel, room.Id, target.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := env.core.RecordCallParticipantJoined(env.ctx, room.Id, target.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	if err := env.core.GrantUserRoomPermission(env.ctx, core.SystemActorID, room.Id, env.viewer.Id, core.PermRoomManage); err != nil {

--- a/cli/internal/connectapi/voice_calls.go
+++ b/cli/internal/connectapi/voice_calls.go
@@ -102,7 +102,7 @@ func (s *voiceCallService) ListCallParticipants(ctx context.Context, req *connec
 		return connect.NewResponse(&apiv1.ListCallParticipantsResponse{}), nil
 	}
 
-	participants, err := s.api.core.GetCallParticipants(ctx, core.LegacySpaceIDForRoomKind(core.KindOfRoom(room)), room.GetId())
+	participants, err := s.api.core.GetCallParticipants(room.GetId())
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -125,14 +125,13 @@ func (s *voiceCallService) JoinCall(ctx context.Context, req *connect.Request[ap
 	if err != nil {
 		return nil, err
 	}
-	_, kind, err := s.api.core.VoiceCallRoomForMember(ctx, caller.UserID, req.Msg.GetRoomId())
-	if err != nil {
+	if _, _, err := s.api.core.VoiceCallRoomForMember(ctx, caller.UserID, req.Msg.GetRoomId()); err != nil {
 		return nil, connectError(err)
 	}
 	if !s.api.config.LiveKit.IsConfigured() {
 		return connect.NewResponse(&apiv1.JoinCallResponse{}), nil
 	}
-	if err := s.api.core.RecordCallParticipantJoined(ctx, kind, req.Msg.GetRoomId(), caller.UserID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := s.api.core.RecordCallParticipantJoined(ctx, req.Msg.GetRoomId(), caller.UserID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.JoinCallResponse{Joined: true}), nil
@@ -165,7 +164,7 @@ func (s *voiceCallService) GetCallToken(ctx context.Context, req *connect.Reques
 	}
 	avatarSize := 96
 	avatarURL, _ := s.api.core.GetUserAvatarURL(ctx, caller.UserID, &avatarSize, &avatarSize, "cover")
-	roomName := core.LiveKitRoomName(s.api.config.LiveKit.ServerID, core.LegacySpaceIDForRoomKind(kind), req.Msg.GetRoomId(), activeCall.CallID)
+	roomName := core.LiveKitRoomName(s.api.config.LiveKit.ServerID, kind, req.Msg.GetRoomId(), activeCall.CallID)
 	token, err := core.GenerateVoiceCallToken(
 		s.api.config.LiveKit.APIKey,
 		s.api.config.LiveKit.APISecret,
@@ -193,14 +192,13 @@ func (s *voiceCallService) LeaveCall(ctx context.Context, req *connect.Request[a
 	if err != nil {
 		return nil, err
 	}
-	_, kind, err := s.api.core.VoiceCallRoomForMember(ctx, caller.UserID, req.Msg.GetRoomId())
-	if err != nil {
+	if _, _, err := s.api.core.VoiceCallRoomForMember(ctx, caller.UserID, req.Msg.GetRoomId()); err != nil {
 		return nil, connectError(err)
 	}
 	if !s.api.config.LiveKit.IsConfigured() {
 		return connect.NewResponse(&apiv1.LeaveCallResponse{}), nil
 	}
-	if err := s.api.core.RecordCallParticipantLeft(ctx, kind, req.Msg.GetRoomId(), caller.UserID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := s.api.core.RecordCallParticipantLeft(ctx, req.Msg.GetRoomId(), caller.UserID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.LeaveCallResponse{Left: true}), nil
@@ -219,7 +217,7 @@ func activeCall(ctx context.Context, api *API, actorID, roomID string) (*apiv1.A
 		return nil, core.ErrNotFound
 	}
 
-	participants, err := api.core.GetCallParticipants(ctx, core.LegacySpaceIDForRoomKind(core.KindOfRoom(room)), room.GetId())
+	participants, err := api.core.GetCallParticipants(room.GetId())
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/core/call_model.go
+++ b/cli/internal/core/call_model.go
@@ -37,10 +37,10 @@ const (
 )
 
 type liveKitParticipantSnapshot struct {
-	SpaceID string
-	RoomID  string
-	CallID  string
-	UserIDs []string
+	LegacySpaceID string
+	RoomID        string
+	CallID        string
+	UserIDs       []string
 }
 
 type liveKitParticipantLister interface {
@@ -48,7 +48,7 @@ type liveKitParticipantLister interface {
 }
 
 type liveKitParticipantRemover interface {
-	RemoveCallParticipant(ctx context.Context, spaceID, roomID, callID, userID string) error
+	RemoveCallParticipant(ctx context.Context, legacySpaceID, roomID, callID, userID string) error
 }
 
 type CallModel struct {
@@ -203,7 +203,7 @@ func (c *liveKitRoomClient) ListCallParticipants(ctx context.Context) ([]liveKit
 		if room == nil || !liveKitRoomBelongsToInstance(room.GetName(), c.serverID) {
 			continue
 		}
-		spaceID, roomID, callID := ParseLiveKitRoomIdentity(room.GetName())
+		legacySpaceID, roomID, callID := ParseLiveKitRoomIdentity(room.GetName())
 		if roomID == "" {
 			continue
 		}
@@ -213,7 +213,7 @@ func (c *liveKitRoomClient) ListCallParticipants(ctx context.Context) ([]liveKit
 		)
 		if err != nil {
 			if isLiveKitRoomNotFound(err) {
-				out = append(out, liveKitParticipantSnapshot{SpaceID: spaceID, RoomID: roomID, CallID: callID})
+				out = append(out, liveKitParticipantSnapshot{LegacySpaceID: legacySpaceID, RoomID: roomID, CallID: callID})
 				continue
 			}
 			return nil, err
@@ -225,13 +225,13 @@ func (c *liveKitRoomClient) ListCallParticipants(ctx context.Context) ([]liveKit
 			}
 		}
 		sort.Strings(userIDs)
-		out = append(out, liveKitParticipantSnapshot{SpaceID: spaceID, RoomID: roomID, CallID: callID, UserIDs: userIDs})
+		out = append(out, liveKitParticipantSnapshot{LegacySpaceID: legacySpaceID, RoomID: roomID, CallID: callID, UserIDs: userIDs})
 	}
 	return out, nil
 }
 
-func (c *liveKitRoomClient) RemoveCallParticipant(ctx context.Context, spaceID, roomID, callID, userID string) error {
-	roomName := LiveKitRoomName(c.serverID, spaceID, roomID, callID)
+func (c *liveKitRoomClient) RemoveCallParticipant(ctx context.Context, legacySpaceID, roomID, callID, userID string) error {
+	roomName := liveKitRoomName(c.serverID, legacySpaceID, roomID, callID)
 	_, err := c.service.RemoveParticipant(
 		c.withVideoGrant(ctx, &lkauth.VideoGrant{RoomAdmin: true, Room: roomName}),
 		&livekit.RoomParticipantIdentity{Room: roomName, Identity: userID},
@@ -290,7 +290,7 @@ func (s *CallModel) GetE2EEKey(ctx context.Context, roomID string) (string, erro
 	return key, nil
 }
 
-func (s *CallModel) RemoveLiveKitParticipant(ctx context.Context, spaceID, roomID, callID, userID string) error {
+func (s *CallModel) RemoveLiveKitParticipant(ctx context.Context, kind RoomKind, roomID, callID, userID string) error {
 	if s.livekit == nil {
 		return nil
 	}
@@ -298,7 +298,7 @@ func (s *CallModel) RemoveLiveKitParticipant(ctx context.Context, spaceID, roomI
 	if !ok {
 		return nil
 	}
-	return remover.RemoveCallParticipant(ctx, spaceID, roomID, callID, userID)
+	return remover.RemoveCallParticipant(ctx, LegacySpaceIDForRoomKind(kind), roomID, callID, userID)
 }
 
 func (s *CallModel) cleanupQueuedCallKey(ctx context.Context, keyRef string) error {
@@ -691,7 +691,7 @@ func (s *CallModel) cleanupUnmatchedLiveKitSnapshot(ctx context.Context, snapsho
 		if userID == "" {
 			continue
 		}
-		if err := remover.RemoveCallParticipant(ctx, snapshot.SpaceID, snapshot.RoomID, snapshot.CallID, userID); err != nil {
+		if err := remover.RemoveCallParticipant(ctx, snapshot.LegacySpaceID, snapshot.RoomID, snapshot.CallID, userID); err != nil {
 			return fmt.Errorf("remove participant from unmatched LiveKit call: %w", err)
 		}
 	}

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1900,17 +1900,6 @@ func newLiveEvent(actorID string, event *corev1.LiveEvent) *corev1.LiveEvent {
 }
 
 // ============================================================================
-// Stream Management
-// ============================================================================
-
-// createSpaceResources is now a no-op: room/user domain state lives in EVT and
-// deployment-wide projections. Kept as a stub so callers don't have to be
-// edited until the broader Space-retirement pass.
-func (c *ChattoCore) createSpaceResources(_ context.Context, _ string) error {
-	return nil
-}
-
-// ============================================================================
 // Event Streaming
 // ============================================================================
 

--- a/cli/internal/core/ids.go
+++ b/cli/internal/core/ids.go
@@ -28,11 +28,6 @@ func NewUserID() string {
 	return newID("U")
 }
 
-// NewSpaceID generates a new space ID with "S" prefix.
-func NewSpaceID() string {
-	return newID("S")
-}
-
 // NewRoomID generates a new room ID with "R" prefix.
 func NewRoomID() string {
 	return newID("R")

--- a/cli/internal/core/ids_test.go
+++ b/cli/internal/core/ids_test.go
@@ -18,18 +18,6 @@ func TestNewUserID(t *testing.T) {
 	}
 }
 
-func TestNewSpaceID(t *testing.T) {
-	id := NewSpaceID()
-
-	if !strings.HasPrefix(id, "S") {
-		t.Errorf("NewSpaceID() should start with 'S', got %s", id)
-	}
-
-	if len(id) != 15 {
-		t.Errorf("NewSpaceID() should be 15 characters, got %d", len(id))
-	}
-}
-
 func TestNewRoomID(t *testing.T) {
 	id := NewRoomID()
 

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -447,7 +447,7 @@ func (c *ChattoCore) removeLiveKitParticipantAfterRoomLeave(ctx context.Context,
 	if cleanup.callID == "" || c.callModel == nil {
 		return
 	}
-	if err := c.callModel.RemoveLiveKitParticipant(ctx, LegacySpaceIDForRoomKind(cleanup.kind), cleanup.roomID, cleanup.callID, cleanup.userID); err != nil {
+	if err := c.callModel.RemoveLiveKitParticipant(ctx, cleanup.kind, cleanup.roomID, cleanup.callID, cleanup.userID); err != nil {
 		c.logger.Warn("Failed to remove room-leaving participant from LiveKit call", "room_id", cleanup.roomID, "call_id", cleanup.callID, "error", err)
 	}
 }

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -98,15 +98,6 @@ func (c *ChattoCore) CleanupUserState(ctx context.Context, userID string, kind R
 	return nil
 }
 
-// GetChannelRoomCount returns the number of channel rooms on the server.
-func (c *ChattoCore) GetChannelRoomCount(ctx context.Context) (int, error) {
-	rooms, err := c.ListRooms(ctx, KindChannel)
-	if err != nil {
-		return 0, err
-	}
-	return len(rooms), nil
-}
-
 // GetAssetCount returns the number of assets (attachments) on the server.
 func (c *ChattoCore) GetAssetCount(ctx context.Context) (int, error) {
 	store, err := c.mediaModel.GetAttachmentsStore(ctx)

--- a/cli/internal/core/voice.go
+++ b/cli/internal/core/voice.go
@@ -46,14 +46,19 @@ func ParseParticipantMetadata(metadata string) participantMetadata {
 	return md
 }
 
-// LiveKitRoomName constructs a deterministic LiveKit room name from space and room IDs.
+// LiveKitRoomName constructs a deterministic LiveKit room name from a room kind
+// and room ID while preserving the legacy space token in LiveKit's wire name.
 // When serverID is non-empty, the room name is prefixed with "{serverID}." so the
 // webhook bridge can route events to the correct Chatto server in shared deployments.
 // Authorization: Caller must verify room membership before calling.
-func LiveKitRoomName(serverID, spaceID, roomID string, callID ...string) string {
-	base := spaceID + "_" + roomID
-	if len(callID) > 0 && callID[0] != "" {
-		base += "@" + callID[0]
+func LiveKitRoomName(serverID string, kind RoomKind, roomID string, callID ...string) string {
+	return liveKitRoomName(serverID, LegacySpaceIDForRoomKind(kind), roomID, optionalCallID(callID))
+}
+
+func liveKitRoomName(serverID, legacySpaceID, roomID, callID string) string {
+	base := legacySpaceID + "_" + roomID
+	if callID != "" {
+		base += "@" + callID
 	}
 	if serverID != "" {
 		return serverID + "." + base
@@ -61,23 +66,16 @@ func LiveKitRoomName(serverID, spaceID, roomID string, callID ...string) string 
 	return base
 }
 
-// ParseLiveKitRoomName extracts the space ID and room ID from a LiveKit room name.
-// Handles both prefixed ("{serverID}.{spaceID}_{roomID}") and unprefixed
-// ("{spaceID}_{roomID}") formats. Returns empty strings if the format is unexpected.
-func ParseLiveKitRoomName(lkRoomName string) (spaceID, roomID string) {
-	spaceID, roomID, _ = ParseLiveKitRoomIdentity(lkRoomName)
-	return spaceID, roomID
-}
-
-// ParseLiveKitRoomIdentity extracts the space ID, room ID, and optional Chatto
-// call ID from a LiveKit room name. New room names append "@{callId}" so LiveKit
-// room_finished events can be tied to one Chatto call session; names without
-// a suffix are accepted for compatibility with older active LiveKit rooms.
-func ParseLiveKitRoomIdentity(lkRoomName string) (spaceID, roomID, callID string) {
+// ParseLiveKitRoomIdentity extracts the legacy space token, room ID, and
+// optional Chatto call ID from a LiveKit room name. New room names append
+// "@{callId}" so LiveKit room_finished events can be tied to one Chatto call
+// session; names without a suffix are accepted for compatibility with older
+// active LiveKit rooms.
+func ParseLiveKitRoomIdentity(lkRoomName string) (legacySpaceID, roomID, callID string) {
 	name := lkRoomName
 
 	// Strip server ID prefix if present (dot separator).
-	// Safe because server IDs (K8s names, UUIDs, NanoIDs) and space/room NanoIDs
+	// Safe because server IDs (K8s names, UUIDs, NanoIDs) and legacy/room IDs
 	// never contain dots.
 	if idx := strings.IndexByte(name, '.'); idx >= 0 {
 		name = name[idx+1:]
@@ -88,7 +86,7 @@ func ParseLiveKitRoomIdentity(lkRoomName string) (spaceID, roomID, callID string
 		name = name[:idx]
 	}
 
-	// Split on first underscore: {spaceID}_{roomID}
+	// Split on first underscore: {legacySpaceID}_{roomID}
 	idx := strings.IndexByte(name, '_')
 	if idx < 0 {
 		return "", "", ""
@@ -140,7 +138,7 @@ func GenerateVoiceCallToken(apiKey, apiSecret, roomName, userID, displayName, lo
 
 // HandleCallParticipantJoined appends a durable LiveKit-observed join fact.
 // Called by the webhook handler when LiveKit reports a participant joined.
-func (c *ChattoCore) HandleCallParticipantJoined(ctx context.Context, spaceID, roomID, userID, displayName, login, avatarURL string, callID ...string) error {
+func (c *ChattoCore) HandleCallParticipantJoined(ctx context.Context, roomID, userID string, callID ...string) error {
 	expectedCallID := optionalCallID(callID)
 	if c.callModel == nil {
 		return fmt.Errorf("call model is not initialized")
@@ -150,7 +148,7 @@ func (c *ChattoCore) HandleCallParticipantJoined(ctx context.Context, spaceID, r
 
 // HandleCallParticipantLeft appends a durable LiveKit-observed leave fact.
 // Called by the webhook handler when LiveKit reports a participant left.
-func (c *ChattoCore) HandleCallParticipantLeft(ctx context.Context, spaceID, roomID, userID string, callID ...string) error {
+func (c *ChattoCore) HandleCallParticipantLeft(ctx context.Context, roomID, userID string, callID ...string) error {
 	if c.callModel == nil {
 		return fmt.Errorf("call model is not initialized")
 	}
@@ -160,7 +158,7 @@ func (c *ChattoCore) HandleCallParticipantLeft(ctx context.Context, spaceID, roo
 // HandleCallRoomFinished appends LiveKit-observed leave facts for any remaining
 // projected participants in the room.
 // Called by the webhook handler when LiveKit reports a room has finished (closed).
-func (c *ChattoCore) HandleCallRoomFinished(ctx context.Context, spaceID, roomID string, callID ...string) error {
+func (c *ChattoCore) HandleCallRoomFinished(ctx context.Context, roomID string, callID ...string) error {
 	expectedCallID := optionalCallID(callID)
 	if expectedCallID != "" {
 		active, ok := c.CallState.ActiveCall(roomID)
@@ -186,14 +184,14 @@ func optionalCallID(callID []string) string {
 	return callID[0]
 }
 
-func (c *ChattoCore) RecordCallParticipantJoined(ctx context.Context, kind RoomKind, roomID, userID string, source corev1.CallParticipantEventSource) error {
+func (c *ChattoCore) RecordCallParticipantJoined(ctx context.Context, roomID, userID string, source corev1.CallParticipantEventSource) error {
 	if c.callModel == nil {
 		return fmt.Errorf("call model is not initialized")
 	}
 	return c.callModel.AppendJoined(ctx, roomID, userID, source)
 }
 
-func (c *ChattoCore) RecordCallParticipantLeft(ctx context.Context, kind RoomKind, roomID, userID string, source corev1.CallParticipantEventSource) error {
+func (c *ChattoCore) RecordCallParticipantLeft(ctx context.Context, roomID, userID string, source corev1.CallParticipantEventSource) error {
 	if c.callModel == nil {
 		return fmt.Errorf("call model is not initialized")
 	}
@@ -214,7 +212,7 @@ func (c *ChattoCore) GetVoiceCallE2EEKey(ctx context.Context, roomID string) (st
 // GetCallParticipants returns the participants currently in a voice call.
 // Returns an empty slice if no call is active.
 // Authorization: Caller must verify room membership before calling.
-func (c *ChattoCore) GetCallParticipants(ctx context.Context, spaceID, roomID string) ([]CallParticipant, error) {
+func (c *ChattoCore) GetCallParticipants(roomID string) ([]CallParticipant, error) {
 	return c.CallState.Participants(roomID), nil
 }
 

--- a/cli/internal/core/voice_test.go
+++ b/cli/internal/core/voice_test.go
@@ -152,72 +152,52 @@ func TestLiveKitRoomName(t *testing.T) {
 	tests := []struct {
 		name     string
 		serverID string
-		spaceID  string
+		kind     RoomKind
 		roomID   string
 		callID   string
 		want     string
 	}{
 		{
-			name:    "no server ID",
-			spaceID: "space123",
-			roomID:  "room456",
-			want:    "space123_room456",
+			name:   "channel without server ID",
+			kind:   KindChannel,
+			roomID: "room456",
+			want:   "server_room456",
 		},
 		{
 			name:     "with server ID",
 			serverID: "my-instance",
-			spaceID:  "space123",
+			kind:     KindChannel,
 			roomID:   "room456",
-			want:     "my-instance.space123_room456",
+			want:     "my-instance.server_room456",
 		},
 		{
-			name:    "with call ID",
-			spaceID: "space123",
-			roomID:  "room456",
-			callID:  "call789",
-			want:    "space123_room456@call789",
+			name:   "channel with call ID",
+			kind:   KindChannel,
+			roomID: "room456",
+			callID: "call789",
+			want:   "server_room456@call789",
 		},
 		{
-			name:     "with server ID and call ID",
+			name:     "DM with server ID and call ID",
 			serverID: "my-instance",
-			spaceID:  "space123",
+			kind:     KindDM,
 			roomID:   "room456",
 			callID:   "call789",
-			want:     "my-instance.space123_room456@call789",
-		},
-		{
-			name:    "nanoid-style IDs without instance",
-			spaceID: "V1StGXR8_Z5jdHi6B-myT",
-			roomID:  "xYz9Abc_def",
-			want:    "V1StGXR8_Z5jdHi6B-myT_xYz9Abc_def",
-		},
-		{
-			name:     "nanoid-style IDs with instance",
-			serverID: "prod-tenant-1",
-			spaceID:  "V1StGXR8_Z5jdHi6B-myT",
-			roomID:   "xYz9Abc_def",
-			want:     "prod-tenant-1.V1StGXR8_Z5jdHi6B-myT_xYz9Abc_def",
-		},
-		{
-			name:     "empty server ID treated as no prefix",
-			serverID: "",
-			spaceID:  "space123",
-			roomID:   "room456",
-			want:     "space123_room456",
+			want:     "my-instance.DM_room456@call789",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := LiveKitRoomName(tt.serverID, tt.spaceID, tt.roomID, tt.callID)
+			got := LiveKitRoomName(tt.serverID, tt.kind, tt.roomID, tt.callID)
 			if got != tt.want {
-				t.Errorf("LiveKitRoomName(%q, %q, %q, %q) = %q, want %q", tt.serverID, tt.spaceID, tt.roomID, tt.callID, got, tt.want)
+				t.Errorf("LiveKitRoomName(%q, %q, %q, %q) = %q, want %q", tt.serverID, tt.kind, tt.roomID, tt.callID, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestParseLiveKitRoomName(t *testing.T) {
+func TestParseLiveKitRoomIdentity(t *testing.T) {
 	tests := []struct {
 		name        string
 		lkRoomName  string
@@ -285,11 +265,6 @@ func TestParseLiveKitRoomName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotSpace, gotRoom := ParseLiveKitRoomName(tt.lkRoomName)
-			if gotSpace != tt.wantSpaceID || gotRoom != tt.wantRoomID {
-				t.Errorf("ParseLiveKitRoomName(%q) = (%q, %q), want (%q, %q)",
-					tt.lkRoomName, gotSpace, gotRoom, tt.wantSpaceID, tt.wantRoomID)
-			}
 			gotSpace, gotRoom, gotCall := ParseLiveKitRoomIdentity(tt.lkRoomName)
 			if gotSpace != tt.wantSpaceID || gotRoom != tt.wantRoomID || gotCall != tt.wantCallID {
 				t.Errorf("ParseLiveKitRoomIdentity(%q) = (%q, %q, %q), want (%q, %q, %q)",
@@ -514,7 +489,7 @@ func TestCallState_JoinAndLeave(t *testing.T) {
 	roomID := "room1"
 
 	// Initially no participants
-	participants, err := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, err := core.GetCallParticipants(roomID)
 	if err != nil {
 		t.Fatalf("GetCallParticipants() error = %v", err)
 	}
@@ -523,7 +498,7 @@ func TestCallState_JoinAndLeave(t *testing.T) {
 	}
 
 	// Join — appends a durable LiveKit-observed fact
-	err = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", "https://example.com/alice.jpg")
+	err = core.HandleCallParticipantJoined(ctx, roomID, "user1")
 	if err != nil {
 		t.Fatalf("HandleCallParticipantJoined() error = %v", err)
 	}
@@ -545,7 +520,7 @@ func TestCallState_JoinAndLeave(t *testing.T) {
 		t.Fatal("CallId should be set")
 	}
 
-	participants, err = core.GetCallParticipants(ctx, "channel", roomID)
+	participants, err = core.GetCallParticipants(roomID)
 	if err != nil {
 		t.Fatalf("GetCallParticipants() error = %v", err)
 	}
@@ -566,7 +541,7 @@ func TestCallState_JoinAndLeave(t *testing.T) {
 	}
 
 	// Leave — appends a durable LiveKit-observed fact and removes active participant
-	err = core.HandleCallParticipantLeft(ctx, "channel", roomID, "user1")
+	err = core.HandleCallParticipantLeft(ctx, roomID, "user1")
 	if err != nil {
 		t.Fatalf("HandleCallParticipantLeft() error = %v", err)
 	}
@@ -587,7 +562,7 @@ func TestCallState_JoinAndLeave(t *testing.T) {
 		t.Fatal("Expected voice call left event")
 	}
 
-	participants, err = core.GetCallParticipants(ctx, "channel", roomID)
+	participants, err = core.GetCallParticipants(roomID)
 	if err != nil {
 		t.Fatalf("GetCallParticipants() error = %v", err)
 	}
@@ -602,10 +577,10 @@ func TestCallState_JoinIdempotent(t *testing.T) {
 	roomID := "room1"
 
 	// Join twice while still active: one participant and one durable transition.
-	_ = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", "")
-	_ = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", "")
+	_ = core.HandleCallParticipantJoined(ctx, roomID, "user1")
+	_ = core.HandleCallParticipantJoined(ctx, roomID, "user1")
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Errorf("Expected 1 participant (idempotent), got %d", len(participants))
 	}
@@ -677,7 +652,7 @@ func TestCallState_SnapshotIgnoresAssetAggregateLifecycleSeq(t *testing.T) {
 	if snapshot.Seq != roomSeq {
 		t.Fatalf("RoomSnapshot().Seq = %d, want room seq %d", snapshot.Seq, roomSeq)
 	}
-	if err := core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", ""); err != nil {
+	if err := core.HandleCallParticipantJoined(ctx, roomID, "user1"); err != nil {
 		t.Fatalf("HandleCallParticipantJoined() after asset aggregate event error = %v", err)
 	}
 }
@@ -688,7 +663,7 @@ func TestCallState_LeaveNotInCall(t *testing.T) {
 
 	// Leave when not in a call is a no-op, not a duplicate transition fact.
 	roomID := "room1"
-	err := core.HandleCallParticipantLeft(ctx, "space1", roomID, "user1")
+	err := core.HandleCallParticipantLeft(ctx, roomID, "user1")
 	if err != nil {
 		t.Fatalf("HandleCallParticipantLeft() for absent user should not error, got %v", err)
 	}
@@ -706,10 +681,10 @@ func TestCallState_UserAndLiveKitReportsDoNotDuplicateTransitions(t *testing.T) 
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
-	if err := core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", ""); err != nil {
+	if err := core.HandleCallParticipantJoined(ctx, roomID, "user1"); err != nil {
 		t.Fatalf("HandleCallParticipantJoined() error = %v", err)
 	}
 	joins, _, err := core.EventPublisher.SubjectEvents(ctx, events.RoomAggregate(roomID).Subject(events.EventCallParticipantJoined))
@@ -720,10 +695,10 @@ func TestCallState_UserAndLiveKitReportsDoNotDuplicateTransitions(t *testing.T) 
 		t.Fatalf("Expected USER+LIVEKIT join reports to produce 1 durable transition fact, got %d", len(joins))
 	}
 
-	if err := core.RecordCallParticipantLeft(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantLeft(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantLeft() error = %v", err)
 	}
-	if err := core.HandleCallParticipantLeft(ctx, "channel", roomID, "user1"); err != nil {
+	if err := core.HandleCallParticipantLeft(ctx, roomID, "user1"); err != nil {
 		t.Fatalf("HandleCallParticipantLeft() error = %v", err)
 	}
 	leaves, _, err := core.EventPublisher.SubjectEvents(ctx, events.RoomAggregate(roomID).Subject(events.EventCallParticipantLeft))
@@ -741,10 +716,10 @@ func TestCallState_RejoinAfterLeaveRecordsNewTransitions(t *testing.T) {
 	roomID := "room1"
 
 	for i := 0; i < 2; i++ {
-		if err := core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", ""); err != nil {
+		if err := core.HandleCallParticipantJoined(ctx, roomID, "user1"); err != nil {
 			t.Fatalf("HandleCallParticipantJoined(%d) error = %v", i, err)
 		}
-		if err := core.HandleCallParticipantLeft(ctx, "channel", roomID, "user1"); err != nil {
+		if err := core.HandleCallParticipantLeft(ctx, roomID, "user1"); err != nil {
 			t.Fatalf("HandleCallParticipantLeft(%d) error = %v", i, err)
 		}
 	}
@@ -778,17 +753,17 @@ func TestCallState_MultipleParticipants(t *testing.T) {
 	ctx := testContext(t)
 	roomID := "room1"
 
-	_ = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", "")
-	_ = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user2", "Bob", "bob", "")
+	_ = core.HandleCallParticipantJoined(ctx, roomID, "user1")
+	_ = core.HandleCallParticipantJoined(ctx, roomID, "user2")
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 2 {
 		t.Fatalf("Expected 2 participants, got %d", len(participants))
 	}
 
 	// Remove one — other should remain
-	_ = core.HandleCallParticipantLeft(ctx, "channel", roomID, "user1")
-	participants, _ = core.GetCallParticipants(ctx, "channel", roomID)
+	_ = core.HandleCallParticipantLeft(ctx, roomID, "user1")
+	participants, _ = core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected 1 participant after leave, got %d", len(participants))
 	}
@@ -802,15 +777,15 @@ func TestCallState_RoomFinished(t *testing.T) {
 	ctx := testContext(t)
 	roomID := "room1"
 
-	_ = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user1", "Alice", "alice", "")
-	_ = core.HandleCallParticipantJoined(ctx, "channel", roomID, "user2", "Bob", "bob", "")
+	_ = core.HandleCallParticipantJoined(ctx, roomID, "user1")
+	_ = core.HandleCallParticipantJoined(ctx, roomID, "user2")
 
-	err := core.HandleCallRoomFinished(ctx, "channel", roomID)
+	err := core.HandleCallRoomFinished(ctx, roomID)
 	if err != nil {
 		t.Fatalf("HandleCallRoomFinished() error = %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Errorf("Expected 0 participants after room finished, got %d", len(participants))
 	}
@@ -821,14 +796,14 @@ func TestCallState_StaleLiveKitEventsForOldCallAreIgnored(t *testing.T) {
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined(first) error = %v", err)
 	}
 	firstCallID := activeCallIDForTest(t, core, roomID)
-	if err := core.RecordCallParticipantLeft(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantLeft(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantLeft(first) error = %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined(second) error = %v", err)
 	}
 	secondCallID := activeCallIDForTest(t, core, roomID)
@@ -836,17 +811,17 @@ func TestCallState_StaleLiveKitEventsForOldCallAreIgnored(t *testing.T) {
 		t.Fatalf("Expected distinct call IDs, got %q", firstCallID)
 	}
 
-	if err := core.HandleCallParticipantJoined(ctx, "channel", roomID, "user2", "Bob", "bob", "", firstCallID); err != nil {
+	if err := core.HandleCallParticipantJoined(ctx, roomID, "user2", firstCallID); err != nil {
 		t.Fatalf("stale HandleCallParticipantJoined() error = %v", err)
 	}
-	if err := core.HandleCallParticipantLeft(ctx, "channel", roomID, "user1", firstCallID); err != nil {
+	if err := core.HandleCallParticipantLeft(ctx, roomID, "user1", firstCallID); err != nil {
 		t.Fatalf("stale HandleCallParticipantLeft() error = %v", err)
 	}
-	if err := core.HandleCallRoomFinished(ctx, "channel", roomID, firstCallID); err != nil {
+	if err := core.HandleCallRoomFinished(ctx, roomID, firstCallID); err != nil {
 		t.Fatalf("stale HandleCallRoomFinished() error = %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 || participants[0].UserID != "user1" || participants[0].CallID != secondCallID {
 		t.Fatalf("Expected only user1 in second call, got %#v", participants)
 	}
@@ -870,8 +845,8 @@ func TestGetActiveCallRoomIDs(t *testing.T) {
 	}
 
 	// Add calls in both channel and DM rooms.
-	_ = core.HandleCallParticipantJoined(ctx, LegacyServerSpaceID, "channel-room", "user1", "Alice", "alice", "")
-	_ = core.HandleCallParticipantJoined(ctx, LegacyDMRoomSpaceID, "dm-room", "user2", "Bob", "bob", "")
+	_ = core.HandleCallParticipantJoined(ctx, "channel-room", "user1")
+	_ = core.HandleCallParticipantJoined(ctx, "dm-room", "user2")
 
 	ids, err = core.GetActiveCallRoomIDs(ctx)
 	if err != nil {
@@ -882,7 +857,7 @@ func TestGetActiveCallRoomIDs(t *testing.T) {
 	}
 
 	// Remove the channel participant; the DM call remains visible.
-	_ = core.HandleCallParticipantLeft(ctx, LegacyServerSpaceID, "channel-room", "user1")
+	_ = core.HandleCallParticipantLeft(ctx, "channel-room", "user1")
 	ids, err = core.GetActiveCallRoomIDs(ctx)
 	if err != nil {
 		t.Fatalf("GetActiveCallRoomIDs after leave: %v", err)
@@ -897,10 +872,10 @@ func TestCallState_UserIntentFacts(t *testing.T) {
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
-	participants, err := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, err := core.GetCallParticipants(roomID)
 	if err != nil {
 		t.Fatalf("GetCallParticipants() error = %v", err)
 	}
@@ -911,10 +886,10 @@ func TestCallState_UserIntentFacts(t *testing.T) {
 		t.Fatalf("Source = %v, want USER", participants[0].Source)
 	}
 
-	if err := core.RecordCallParticipantLeft(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantLeft(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantLeft() error = %v", err)
 	}
-	participants, _ = core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ = core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected 0 participants after explicit leave, got %d", len(participants))
 	}
@@ -973,7 +948,7 @@ func TestCallState_RoomLeaveRemovesFinalCallParticipant(t *testing.T) {
 	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	active := activeCallIDForTest(t, core, room.Id)
@@ -986,7 +961,7 @@ func TestCallState_RoomLeaveRemovesFinalCallParticipant(t *testing.T) {
 		t.Fatalf("LeaveRoom: %v", err)
 	}
 
-	participants, err := core.GetCallParticipants(ctx, "channel", room.Id)
+	participants, err := core.GetCallParticipants(room.Id)
 	if err != nil {
 		t.Fatalf("GetCallParticipants: %v", err)
 	}
@@ -1049,7 +1024,7 @@ func TestCallState_RemoveMemberRemovesOnlyTargetFromCall(t *testing.T) {
 		if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 			t.Fatalf("JoinRoom %s: %v", user.Id, err)
 		}
-		if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+		if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 			t.Fatalf("RecordCallParticipantJoined %s: %v", user.Id, err)
 		}
 	}
@@ -1065,7 +1040,7 @@ func TestCallState_RemoveMemberRemovesOnlyTargetFromCall(t *testing.T) {
 		t.Fatal("RemoveMember removed=false, want true")
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", room.Id)
+	participants, _ := core.GetCallParticipants(room.Id)
 	if len(participants) != 1 || participants[0].UserID != other.Id {
 		t.Fatalf("participants after RemoveMember = %#v, want only other", participants)
 	}
@@ -1097,7 +1072,7 @@ func TestCallState_BanMemberRemovesTargetFromCall(t *testing.T) {
 	if _, err := core.JoinRoom(ctx, target.Id, KindChannel, target.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom target: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, target.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, target.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	recorder := &recordingLiveKitParticipantClient{}
@@ -1107,7 +1082,7 @@ func TestCallState_BanMemberRemovesTargetFromCall(t *testing.T) {
 		t.Fatalf("BanMember: %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", room.Id)
+	participants, _ := core.GetCallParticipants(room.Id)
 	if len(participants) != 0 {
 		t.Fatalf("participants after BanMember = %#v, want none", participants)
 	}
@@ -1134,7 +1109,7 @@ func TestCallState_DeleteUserRemovesUserFromRoomCall(t *testing.T) {
 	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	recorder := &recordingLiveKitParticipantClient{}
@@ -1144,7 +1119,7 @@ func TestCallState_DeleteUserRemovesUserFromRoomCall(t *testing.T) {
 		t.Fatalf("DeleteUser: %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", room.Id)
+	participants, _ := core.GetCallParticipants(room.Id)
 	if len(participants) != 0 {
 		t.Fatalf("participants after DeleteUser = %#v, want none", participants)
 	}
@@ -1168,7 +1143,7 @@ func TestCallState_LiveKitRemovalFailureDoesNotFailRoomLeave(t *testing.T) {
 	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	core.callModel.livekit = &recordingLiveKitParticipantClient{removeErr: errors.New("livekit unavailable")}
@@ -1196,7 +1171,7 @@ func TestCallState_RoomLeaveRetriesCommittedKeyCleanupDuringReconciliation(t *te
 	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	session, _ := core.CallState.ActiveCall(room.Id)
@@ -1255,7 +1230,7 @@ func TestCallState_LeaseHolderDiscoversLaterReplicaKeyCleanup(t *testing.T) {
 	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	session, _ := core.CallState.ActiveCall(room.Id)
@@ -1291,7 +1266,7 @@ func TestCallState_ReconciliationCleansHistoricalMembershipOnlyLeave(t *testing.
 	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom: %v", err)
 	}
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, room.Id, user.Id, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined: %v", err)
 	}
 	session, _ := core.CallState.ActiveCall(room.Id)
@@ -1311,10 +1286,10 @@ func TestCallState_ReconciliationCleansHistoricalMembershipOnlyLeave(t *testing.
 	}
 
 	recorder := &recordingLiveKitParticipantClient{snapshots: []liveKitParticipantSnapshot{{
-		SpaceID: LegacySpaceIDForRoomKind(KindChannel),
-		RoomID:  room.Id,
-		CallID:  session.CallID,
-		UserIDs: []string{user.Id},
+		LegacySpaceID: LegacySpaceIDForRoomKind(KindChannel),
+		RoomID:        room.Id,
+		CallID:        session.CallID,
+		UserIDs:       []string{user.Id},
 	}}}
 	core.callModel.livekit = recorder
 	workingKeys := core.encryption.callKeys
@@ -1365,7 +1340,7 @@ func TestCallState_ReconciliationCorrectsProjection(t *testing.T) {
 	if err := core.callModel.ReconcileRoomParticipants(ctx, roomID, []string{"user1"}); err != nil {
 		t.Fatalf("ReconcileRoomParticipants(join) error = %v", err)
 	}
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected 1 participant after reconcile join, got %d", len(participants))
 	}
@@ -1376,7 +1351,7 @@ func TestCallState_ReconciliationCorrectsProjection(t *testing.T) {
 	if err := core.callModel.ReconcileRoomParticipants(ctx, roomID, nil); err != nil {
 		t.Fatalf("ReconcileRoomParticipants(leave) error = %v", err)
 	}
-	participants, _ = core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ = core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected 0 participants after reconcile leave, got %d", len(participants))
 	}
@@ -1387,7 +1362,7 @@ func TestCallState_ReconcileWithLiveKitClosesRoomMissingFromLiveKit(t *testing.T
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callEvents, _, err := core.EventPublisher.SubjectEvents(ctx, events.RoomAggregate(roomID).AllEventsFilter())
@@ -1404,7 +1379,7 @@ func TestCallState_ReconcileWithLiveKitClosesRoomMissingFromLiveKit(t *testing.T
 		t.Fatalf("ReconcileWithLiveKit() error = %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected missing LiveKit room to clear participants, got %d", len(participants))
 	}
@@ -1437,7 +1412,7 @@ func TestCallState_ReconcileWithLiveKitClosesObservedEmptyRoom(t *testing.T) {
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callID := activeCallIDForTest(t, core, roomID)
@@ -1448,7 +1423,7 @@ func TestCallState_ReconcileWithLiveKitClosesObservedEmptyRoom(t *testing.T) {
 		t.Fatalf("ReconcileWithLiveKit() error = %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected observed empty LiveKit room to clear participants, got %d", len(participants))
 	}
@@ -1476,7 +1451,7 @@ func TestCallState_ReconcileWithLiveKitIgnoresRoomWithoutProjectedActiveCall(t *
 		t.Fatalf("ReconcileWithLiveKit() error = %v", err)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected LiveKit room without projected active call to be ignored, got %#v", participants)
 	}
@@ -1486,8 +1461,8 @@ func TestCallState_ReconcileWithLiveKitIgnoresRoomWithoutProjectedActiveCall(t *
 }
 
 func TestLiveKitRoomClientListCallParticipantsTreatsRoomNotFoundAsEmpty(t *testing.T) {
-	room1 := LiveKitRoomName("", "channel", "room1", "C1")
-	room2 := LiveKitRoomName("", "channel", "room2", "C2")
+	room1 := LiveKitRoomName("", KindChannel, "room1", "C1")
+	room2 := LiveKitRoomName("", KindChannel, "room2", "C2")
 	client := &liveKitRoomClient{
 		service: &fakeLiveKitRoomService{
 			rooms:        []string{room1, room2},
@@ -1520,7 +1495,7 @@ func TestCallState_ReconcileWithLiveKitErrorDefersActiveCallCleanupBeforeThresho
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callEvents, _, err := core.EventPublisher.SubjectEvents(ctx, events.RoomAggregate(roomID).AllEventsFilter())
@@ -1541,7 +1516,7 @@ func TestCallState_ReconcileWithLiveKitErrorDefersActiveCallCleanupBeforeThresho
 		}
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected failed LiveKit reconciliation below threshold to keep participants, got %d", len(participants))
 	}
@@ -1562,7 +1537,7 @@ func TestCallState_ReconcileWithLiveKitErrorEndsActiveCallsAtThreshold(t *testin
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callEvents, _, err := core.EventPublisher.SubjectEvents(ctx, events.RoomAggregate(roomID).AllEventsFilter())
@@ -1583,7 +1558,7 @@ func TestCallState_ReconcileWithLiveKitErrorEndsActiveCallsAtThreshold(t *testin
 		}
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected failed LiveKit reconciliation at threshold to clear participants, got %d", len(participants))
 	}
@@ -1623,7 +1598,7 @@ func TestCallState_ReconcileWithLiveKitErrorEndsAllActiveRoomsAtThreshold(t *tes
 	}
 
 	for _, room := range rooms {
-		if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.roomID, room.userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+		if err := core.RecordCallParticipantJoined(ctx, room.roomID, room.userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 			t.Fatalf("RecordCallParticipantJoined(%s) error = %v", room.roomID, err)
 		}
 	}
@@ -1639,7 +1614,7 @@ func TestCallState_ReconcileWithLiveKitErrorEndsAllActiveRoomsAtThreshold(t *tes
 	}
 
 	for _, room := range rooms {
-		participants, _ := core.GetCallParticipants(ctx, "channel", room.roomID)
+		participants, _ := core.GetCallParticipants(room.roomID)
 		if len(participants) != 0 {
 			t.Fatalf("Expected room %s participants to clear, got %d", room.roomID, len(participants))
 		}
@@ -1661,7 +1636,7 @@ func TestCallState_ReconcileWithLiveKitTimeoutUsesFreshCleanupContext(t *testing
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 
@@ -1684,7 +1659,7 @@ func TestCallState_ReconcileWithLiveKitTimeoutUsesFreshCleanupContext(t *testing
 		t.Fatal("Expected reconciliation failure to create a cleanup context")
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 0 {
 		t.Fatalf("Expected cleanup with fresh context to clear participants, got %d", len(participants))
 	}
@@ -1704,7 +1679,7 @@ func TestCallState_ReconcileBestEffortLogsDeferredLiveKitFailure(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 	roomID := "room1"
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 
@@ -1734,7 +1709,7 @@ func TestCallState_ReconcileBestEffortKeepsLeaseOnDeferredLiveKitFailure(t *test
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 	roomID := "room1"
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 
@@ -1751,7 +1726,7 @@ func TestCallState_ReconcileBestEffortKeepsLeaseOnDeferredLiveKitFailure(t *test
 	if logger.warnMessage != "LiveKit listing failed; active-call cleanup deferred" {
 		t.Fatalf("Warn message = %q", logger.warnMessage)
 	}
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected deferred reconciliation below threshold to keep participants, got %d", len(participants))
 	}
@@ -1771,7 +1746,7 @@ func TestCallState_ReconcileBestEffortLogsLiveKitFailureCleanupSummaryAtThreshol
 		{roomID: "room2", userID: "user2"},
 	}
 	for _, room := range rooms {
-		if err := core.RecordCallParticipantJoined(ctx, KindChannel, room.roomID, room.userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+		if err := core.RecordCallParticipantJoined(ctx, room.roomID, room.userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 			t.Fatalf("RecordCallParticipantJoined(%s) error = %v", room.roomID, err)
 		}
 	}
@@ -1813,7 +1788,7 @@ func TestCallState_ReconcileWithLiveKitErrorReportsCleanupFailure(t *testing.T) 
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	liveKitErr := errors.New("livekit unavailable")
@@ -1855,7 +1830,7 @@ func TestCallState_ReconcileWithLiveKitSuccessResetsListFailureCounter(t *testin
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callID := activeCallIDForTest(t, core, roomID)
@@ -1882,7 +1857,7 @@ func TestCallState_ReconcileWithLiveKitSuccessResetsListFailureCounter(t *testin
 		}
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected failures after reset below threshold to keep participants, got %d", len(participants))
 	}
@@ -1896,7 +1871,7 @@ func TestCallState_ReconcileWithLiveKitSuccessOnAnotherReplicaResetsListFailureC
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callID := activeCallIDForTest(t, core, roomID)
@@ -1935,7 +1910,7 @@ func TestCallState_ReconcileWithLiveKitSuccessOnAnotherReplicaResetsListFailureC
 		t.Fatalf("failing replica ReconcileWithLiveKit(after success) error = %v, want %v", err, liveKitErr)
 	}
 
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected one new failure after another replica's success to keep participants, got %d", len(participants))
 	}
@@ -1949,7 +1924,7 @@ func TestCallState_CallEndedCommitsWhenKeyShredFails(t *testing.T) {
 	ctx := testContext(t)
 	roomID := "room1"
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	callEvents, _, err := core.EventPublisher.SubjectEvents(ctx, events.RoomAggregate(roomID).AllEventsFilter())
@@ -1966,7 +1941,7 @@ func TestCallState_CallEndedCommitsWhenKeyShredFails(t *testing.T) {
 		delegate: core.encryption.callKeys,
 		err:      shredErr,
 	}
-	err = core.RecordCallParticipantLeft(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER)
+	err = core.RecordCallParticipantLeft(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER)
 	if !errors.Is(err, shredErr) {
 		t.Fatalf("RecordCallParticipantLeft() error = %v, want shred error", err)
 	}
@@ -2021,7 +1996,7 @@ func TestCallState_ReconciliationRechecksAfterConflict(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("appendEvent called %d times, want 1", calls)
 	}
-	participants, _ := core.GetCallParticipants(ctx, "channel", roomID)
+	participants, _ := core.GetCallParticipants(roomID)
 	if len(participants) != 1 {
 		t.Fatalf("Expected 1 participant after simulated concurrent correction, got %d", len(participants))
 	}
@@ -2036,7 +2011,7 @@ func TestVoiceCallE2EEKey_PerCallAndShreddedOnEnd(t *testing.T) {
 		t.Fatal("GetVoiceCallE2EEKey() before call should error")
 	}
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	key1, err := core.GetVoiceCallE2EEKey(ctx, roomID)
@@ -2073,7 +2048,7 @@ func TestVoiceCallE2EEKey_PerCallAndShreddedOnEnd(t *testing.T) {
 		t.Fatal("Call key should exist while call is active")
 	}
 
-	if err := core.RecordCallParticipantLeft(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantLeft(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantLeft() error = %v", err)
 	}
 	exists, err = core.encryption.callKeys.CallKeyExists(ctx, started.GetE2EeKeyRef())
@@ -2084,7 +2059,7 @@ func TestVoiceCallE2EEKey_PerCallAndShreddedOnEnd(t *testing.T) {
 		t.Fatal("Call key should be shredded when the call ends")
 	}
 
-	if err := core.RecordCallParticipantJoined(ctx, KindChannel, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := core.RecordCallParticipantJoined(ctx, roomID, "user1", corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() second call error = %v", err)
 	}
 	key3, err := core.GetVoiceCallE2EEKey(ctx, roomID)

--- a/cli/internal/http_server/test_endpoints.go
+++ b/cli/internal/http_server/test_endpoints.go
@@ -442,12 +442,8 @@ func registerTestWebhookEndpoints(webhooks *gin.RouterGroup, s *HTTPServer) {
 	// Simulate a participant joining a call
 	webhooks.POST("/test/call-join", func(c *gin.Context) {
 		var req struct {
-			SpaceID     string `json:"spaceId" binding:"required"`
-			RoomID      string `json:"roomId" binding:"required"`
-			UserID      string `json:"userId" binding:"required"`
-			DisplayName string `json:"displayName"`
-			Login       string `json:"login"`
-			AvatarURL   string `json:"avatarUrl"`
+			RoomID string `json:"roomId" binding:"required"`
+			UserID string `json:"userId" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -456,9 +452,7 @@ func registerTestWebhookEndpoints(webhooks *gin.RouterGroup, s *HTTPServer) {
 
 		if err := s.core.HandleCallParticipantJoined(
 			c.Request.Context(),
-			req.SpaceID, req.RoomID,
-			req.UserID, req.DisplayName,
-			req.Login, req.AvatarURL,
+			req.RoomID, req.UserID,
 		); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
@@ -469,9 +463,8 @@ func registerTestWebhookEndpoints(webhooks *gin.RouterGroup, s *HTTPServer) {
 	// Simulate a participant leaving a call
 	webhooks.POST("/test/call-leave", func(c *gin.Context) {
 		var req struct {
-			SpaceID string `json:"spaceId" binding:"required"`
-			RoomID  string `json:"roomId" binding:"required"`
-			UserID  string `json:"userId" binding:"required"`
+			RoomID string `json:"roomId" binding:"required"`
+			UserID string `json:"userId" binding:"required"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -480,8 +473,7 @@ func registerTestWebhookEndpoints(webhooks *gin.RouterGroup, s *HTTPServer) {
 
 		if err := s.core.HandleCallParticipantLeft(
 			c.Request.Context(),
-			req.SpaceID, req.RoomID,
-			req.UserID,
+			req.RoomID, req.UserID,
 		); err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/cli/internal/http_server/webhooks.go
+++ b/cli/internal/http_server/webhooks.go
@@ -33,7 +33,7 @@ func (s *HTTPServer) handleLiveKitWebhook(c *gin.Context) {
 		return
 	}
 
-	// Extract space and room IDs from the LiveKit room name
+	// Parse the legacy LiveKit room name at the integration boundary.
 	if event.Room == nil {
 		c.Status(http.StatusOK)
 		return
@@ -43,8 +43,8 @@ func (s *HTTPServer) handleLiveKitWebhook(c *gin.Context) {
 		c.Status(http.StatusOK)
 		return
 	}
-	spaceID, roomID, callID := core.ParseLiveKitRoomIdentity(event.Room.Name)
-	if spaceID == "" || roomID == "" {
+	legacySpaceID, roomID, callID := core.ParseLiveKitRoomIdentity(event.Room.Name)
+	if legacySpaceID == "" || roomID == "" {
 		logger.Warn("Unrecognized LiveKit room name", "name", event.Room.Name)
 		c.Status(http.StatusOK)
 		return
@@ -67,10 +67,8 @@ func (s *HTTPServer) handleLiveKitWebhook(c *gin.Context) {
 			break
 		}
 		if err := s.core.HandleCallParticipantJoined(
-			ctx, spaceID, roomID,
+			ctx, roomID,
 			event.Participant.Identity,
-			event.Participant.Name,
-			md.Login, md.AvatarURL,
 			eventCallID,
 		); err != nil {
 			logger.Warn("Failed to handle participant joined", "error", err)
@@ -93,7 +91,7 @@ func (s *HTTPServer) handleLiveKitWebhook(c *gin.Context) {
 			break
 		}
 		if err := s.core.HandleCallParticipantLeft(
-			ctx, spaceID, roomID,
+			ctx, roomID,
 			event.Participant.Identity,
 			eventCallID,
 		); err != nil {
@@ -105,7 +103,7 @@ func (s *HTTPServer) handleLiveKitWebhook(c *gin.Context) {
 			logger.Warn("Ignoring LiveKit room finished without call ID", "room", event.Room.Name)
 			break
 		}
-		if err := s.core.HandleCallRoomFinished(ctx, spaceID, roomID, callID); err != nil {
+		if err := s.core.HandleCallRoomFinished(ctx, roomID, callID); err != nil {
 			logger.Warn("Failed to handle room finished", "error", err)
 		}
 	}

--- a/cli/internal/http_server/webhooks_test.go
+++ b/cli/internal/http_server/webhooks_test.go
@@ -38,7 +38,7 @@ func TestLiveKitWebhookDuplicateIdentityLeaveDoesNotEndCall(t *testing.T) {
 	}
 	s.setupWebhookRoutes()
 
-	if err := s.core.RecordCallParticipantJoined(ctx, core.KindChannel, roomID, userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+	if err := s.core.RecordCallParticipantJoined(ctx, roomID, userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
 		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
 	}
 	active, ok := s.core.CallState.ActiveCall(roomID)
@@ -52,7 +52,7 @@ func TestLiveKitWebhookDuplicateIdentityLeaveDoesNotEndCall(t *testing.T) {
 	event := &livekit.WebhookEvent{
 		Event: webhook.EventParticipantLeft,
 		Room: &livekit.Room{
-			Name: core.LiveKitRoomName(serverID, core.LegacySpaceIDForRoomKind(core.KindChannel), roomID, active.CallID),
+			Name: core.LiveKitRoomName(serverID, core.KindChannel, roomID, active.CallID),
 		},
 		Participant: &livekit.ParticipantInfo{
 			Identity:         userID,
@@ -66,7 +66,7 @@ func TestLiveKitWebhookDuplicateIdentityLeaveDoesNotEndCall(t *testing.T) {
 		t.Fatalf("webhook status = %d, body = %s", recorder.Code, recorder.Body.String())
 	}
 
-	participants, err := s.core.GetCallParticipants(ctx, core.LegacySpaceIDForRoomKind(core.KindChannel), roomID)
+	participants, err := s.core.GetCallParticipants(roomID)
 	if err != nil {
 		t.Fatalf("GetCallParticipants() error = %v", err)
 	}
@@ -93,6 +93,55 @@ func TestLiveKitWebhookDuplicateIdentityLeaveDoesNotEndCall(t *testing.T) {
 	}
 	if len(endedEvents) != 0 {
 		t.Fatalf("call_ended events after duplicate identity leave = %d, want 0", len(endedEvents))
+	}
+}
+
+func TestLiveKitWebhookParticipantLeftUsesParsedRoomID(t *testing.T) {
+	const (
+		apiKey    = "devkey"
+		apiSecret = "devsecret"
+		serverID  = "test-server"
+		roomID    = "room1"
+		userID    = "user1"
+	)
+	ctx := testContext(t)
+	s := setupHTTPServerTestServer(t, config.AuthConfig{})
+	s.config.LiveKit = config.LiveKitConfig{
+		Enabled:   true,
+		URL:       "ws://livekit.example.test",
+		APIKey:    apiKey,
+		APISecret: apiSecret,
+		ServerID:  serverID,
+	}
+	s.setupWebhookRoutes()
+
+	if err := s.core.RecordCallParticipantJoined(ctx, roomID, userID, corev1.CallParticipantEventSource_CALL_PARTICIPANT_EVENT_SOURCE_USER); err != nil {
+		t.Fatalf("RecordCallParticipantJoined() error = %v", err)
+	}
+	active, ok := s.core.CallState.ActiveCall(roomID)
+	if !ok || active.CallID == "" {
+		t.Fatalf("expected active call for room %s", roomID)
+	}
+
+	event := &livekit.WebhookEvent{
+		Event: webhook.EventParticipantLeft,
+		Room: &livekit.Room{
+			Name: core.LiveKitRoomName(serverID, core.KindChannel, roomID, active.CallID),
+		},
+		Participant: &livekit.ParticipantInfo{Identity: userID},
+	}
+	recorder := httptest.NewRecorder()
+	s.router.ServeHTTP(recorder, signedLiveKitWebhookRequest(t, apiKey, apiSecret, event))
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("webhook status = %d, body = %s", recorder.Code, recorder.Body.String())
+	}
+
+	participants, err := s.core.GetCallParticipants(roomID)
+	if err != nil {
+		t.Fatalf("GetCallParticipants() error = %v", err)
+	}
+	if len(participants) != 0 {
+		t.Fatalf("participants after leave = %+v, want none", participants)
 	}
 }
 


### PR DESCRIPTION
## Why

Legacy Space-era parameters and helpers made room-scoped call code harder to understand even though call state is keyed entirely by room ID.

## What changed

- Removed dead Space-era helpers and narrowed call-state methods to the values they actually use.
- Kept the historical space token only at the LiveKit room-name boundary while preserving existing room names and reconciliation behavior.
- Simplified ConnectRPC and webhook callers and added signed-webhook coverage proving participant leaves update the parsed room.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise test-cli`
- `mise lint`
- `mise x -- buf breaking . --against "../.git#branch=origin/main,subdir=proto"` from `proto/`
- `git diff --check`
