### PR TITLE
refactor(metrics)!: retire legacy service inventory

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -64,7 +64,6 @@ type ChattoCore struct {
 	callModel                *CallModel
 	assetModel               *AssetModel
 	assetUploadModel         *AssetUploadModel
-	models                   []modelRegistration
 	s3Client                 *S3Client            // Optional S3 client for S3-compatible storage
 	permissionResolver       *PermissionResolver  // Hierarchical permission resolver
 	linkPreviewCache         *linkpreview.Cache   // Cache for link preview metadata
@@ -1494,27 +1493,6 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	core.presenceModel = NewPresenceModel(js, storage.memoryCacheKV, logger)
 	core.PresenceHub = core.presenceModel.hub
 	core.myEventsModel = NewMyEventsModel(core)
-	core.models = []modelRegistration{
-		{key: "chatto_core", name: "Chatto Core"},
-		{key: "event_publisher", name: "Event Publisher"},
-		{key: "config_model", name: "Config Model", legacyServiceKey: "config_service"},
-		{key: "notification_preferences_model", name: "Notification Preferences Model", legacyServiceKey: "notification_preferences_service"},
-		{key: "message_model", name: "Message Model", legacyServiceKey: "message_service"},
-		{key: "reaction_model", name: "Reaction Model", legacyServiceKey: "reaction_service"},
-		{key: "room_timeline_read_model", name: "Room Timeline Read Model", legacyServiceKey: "room_timeline_read_service"},
-		{key: "read_state_model", name: "Read State Model", legacyServiceKey: "read_state_service"},
-		{key: "thread_follow_model", name: "Thread Follow Model", legacyServiceKey: "thread_follow_service"},
-		{key: "room_model", name: "Room Model", legacyServiceKey: "room_service"},
-		{key: "user_model", name: "User Model", legacyServiceKey: "user_service"},
-		{key: "rbac_model", name: "RBAC Model", legacyServiceKey: "rbac_service"},
-		{key: "mentionables_model", name: "Mentionables Model", legacyServiceKey: "mentionables_service"},
-		{key: "presence_model", name: "Presence Model", legacyServiceKey: "presence_service"},
-		{key: "my_events_model", name: "My Events Model", legacyServiceKey: "my_events_service"},
-		{key: "call_model", name: "Call Model", legacyServiceKey: "call_service"},
-		{key: "media_model", name: "Media Model", legacyServiceKey: "media_service"},
-		{key: "asset_model", name: "Asset Model", legacyServiceKey: "asset_service"},
-	}
-
 	return core, nil
 }
 

--- a/cli/internal/core/model_inventory.go
+++ b/cli/internal/core/model_inventory.go
@@ -1,35 +1,25 @@
 package core
 
-type modelRegistration struct {
-	key              string
-	name             string
-	legacyServiceKey string
-}
-
-// ModelMetadata is stable metadata for a core model exposed in operator
-// metrics and diagnostics.
-type ModelMetadata struct {
-	Key              string
-	Name             string
-	LegacyServiceKey string
-}
-
-// ModelMetadata returns the core model inventory registered by this process.
-func (c *ChattoCore) ModelMetadata() []ModelMetadata {
-	out := make([]ModelMetadata, 0, len(c.models))
-	for _, model := range c.models {
-		out = append(out, ModelMetadata{
-			Key:              model.key,
-			Name:             model.name,
-			LegacyServiceKey: model.legacyServiceKeyOrDefault(),
-		})
+// ModelKeys returns the stable metric keys in the core model inventory.
+func ModelKeys() []string {
+	return []string{
+		"chatto_core",
+		"event_publisher",
+		"config_model",
+		"notification_preferences_model",
+		"message_model",
+		"reaction_model",
+		"room_timeline_read_model",
+		"read_state_model",
+		"thread_follow_model",
+		"room_model",
+		"user_model",
+		"rbac_model",
+		"mentionables_model",
+		"presence_model",
+		"my_events_model",
+		"call_model",
+		"media_model",
+		"asset_model",
 	}
-	return out
-}
-
-func (r modelRegistration) legacyServiceKeyOrDefault() string {
-	if r.legacyServiceKey != "" {
-		return r.legacyServiceKey
-	}
-	return r.key
 }

--- a/cli/internal/core/model_inventory_test.go
+++ b/cli/internal/core/model_inventory_test.go
@@ -1,93 +1,44 @@
 package core
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 func TestModelInventoryUsesStableKeys(t *testing.T) {
-	core, _ := setupTestCore(t)
-
-	models := core.ModelMetadata()
-	if len(models) != 18 {
-		t.Fatalf("registered models = %d, want 18", len(models))
+	want := []string{
+		"chatto_core",
+		"event_publisher",
+		"config_model",
+		"notification_preferences_model",
+		"message_model",
+		"reaction_model",
+		"room_timeline_read_model",
+		"read_state_model",
+		"thread_follow_model",
+		"room_model",
+		"user_model",
+		"rbac_model",
+		"mentionables_model",
+		"presence_model",
+		"my_events_model",
+		"call_model",
+		"media_model",
+		"asset_model",
 	}
 
-	keys := make(map[string]string, len(models))
-	legacyKeys := make(map[string]string, len(models))
-	names := make(map[string]struct{}, len(models))
-	for _, model := range models {
-		if model.Key == "" {
-			t.Fatal("registered model has empty key")
-		}
-		if !registryKeyPattern.MatchString(model.Key) {
-			t.Fatalf("registered model %q has invalid key %q", model.Name, model.Key)
-		}
-		if model.Name == "" {
-			t.Fatalf("registered model %q has empty name", model.Key)
-		}
-		if model.LegacyServiceKey == "" {
-			t.Fatalf("registered model %q has empty legacy service key", model.Key)
-		}
-		if !registryKeyPattern.MatchString(model.LegacyServiceKey) {
-			t.Fatalf("registered model %q has invalid legacy service key %q", model.Name, model.LegacyServiceKey)
-		}
-		if existingName, exists := keys[model.Key]; exists {
-			t.Fatalf("duplicate model registration key %q for %q and %q", model.Key, existingName, model.Name)
-		}
-		if existingName, exists := legacyKeys[model.LegacyServiceKey]; exists {
-			t.Fatalf("duplicate legacy service key %q for %q and %q", model.LegacyServiceKey, existingName, model.Name)
-		}
-		if _, exists := names[model.Name]; exists {
-			t.Fatalf("duplicate model registration name %q", model.Name)
-		}
-		keys[model.Key] = model.Name
-		legacyKeys[model.LegacyServiceKey] = model.Name
-		names[model.Name] = struct{}{}
+	got := ModelKeys()
+	if !slices.Equal(got, want) {
+		t.Fatalf("ModelKeys() = %q, want %q", got, want)
 	}
-
-	for key, name := range map[string]string{
-		"chatto_core":                    "Chatto Core",
-		"event_publisher":                "Event Publisher",
-		"config_model":                   "Config Model",
-		"notification_preferences_model": "Notification Preferences Model",
-		"message_model":                  "Message Model",
-		"reaction_model":                 "Reaction Model",
-		"room_timeline_read_model":       "Room Timeline Read Model",
-		"read_state_model":               "Read State Model",
-		"thread_follow_model":            "Thread Follow Model",
-		"room_model":                     "Room Model",
-		"user_model":                     "User Model",
-		"rbac_model":                     "RBAC Model",
-		"mentionables_model":             "Mentionables Model",
-		"presence_model":                 "Presence Model",
-		"my_events_model":                "My Events Model",
-		"call_model":                     "Call Model",
-		"media_model":                    "Media Model",
-		"asset_model":                    "Asset Model",
-	} {
-		if got, ok := keys[key]; !ok || got != name {
-			t.Fatalf("model registration %q = %q, %v; want %q, true", key, got, ok, name)
+	for _, key := range got {
+		if !registryKeyPattern.MatchString(key) {
+			t.Fatalf("registered model has invalid key %q", key)
 		}
 	}
 
-	for key, name := range map[string]string{
-		"config_service":                   "Config Model",
-		"notification_preferences_service": "Notification Preferences Model",
-		"message_service":                  "Message Model",
-		"reaction_service":                 "Reaction Model",
-		"room_timeline_read_service":       "Room Timeline Read Model",
-		"read_state_service":               "Read State Model",
-		"thread_follow_service":            "Thread Follow Model",
-		"room_service":                     "Room Model",
-		"user_service":                     "User Model",
-		"rbac_service":                     "RBAC Model",
-		"mentionables_service":             "Mentionables Model",
-		"presence_service":                 "Presence Model",
-		"my_events_service":                "My Events Model",
-		"call_service":                     "Call Model",
-		"media_service":                    "Media Model",
-		"asset_service":                    "Asset Model",
-	} {
-		if got, ok := legacyKeys[key]; !ok || got != name {
-			t.Fatalf("legacy service key %q = %q, %v; want %q, true", key, got, ok, name)
-		}
+	got[0] = "changed"
+	if ModelKeys()[0] != want[0] {
+		t.Fatal("ModelKeys() exposed mutable inventory state")
 	}
 }

--- a/cli/internal/http_server/metrics.go
+++ b/cli/internal/http_server/metrics.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"hmans.de/chatto/internal/core"
 )
 
 type processMetrics struct {
@@ -109,7 +110,6 @@ type chattoCollector struct {
 	presenceRefreshes        *prometheus.Desc
 	presenceFailures         *prometheus.Desc
 	modelInfo                *prometheus.Desc
-	legacyServiceInfo        *prometheus.Desc
 	natsConnected            *prometheus.Desc
 	natsRTT                  *prometheus.Desc
 	natsMessages             *prometheus.Desc
@@ -207,12 +207,6 @@ func newChattoCollector(server *HTTPServer) *chattoCollector {
 			"chatto_model_info",
 			"Registered core model in this Chatto process.",
 			[]string{"model"},
-			nil,
-		),
-		legacyServiceInfo: prometheus.NewDesc(
-			"chatto_service_info",
-			"Deprecated compatibility alias for chatto_model_info.",
-			[]string{"service"},
 			nil,
 		),
 		natsConnected: prometheus.NewDesc(
@@ -322,7 +316,6 @@ func (c *chattoCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.presenceRefreshes
 	ch <- c.presenceFailures
 	ch <- c.modelInfo
-	ch <- c.legacyServiceInfo
 	ch <- c.natsConnected
 	ch <- c.natsRTT
 	ch <- c.natsMessages
@@ -401,9 +394,8 @@ func (c *chattoCollector) collectCoreMetrics(ch chan<- prometheus.Metric) {
 	ch <- prometheus.MustNewConstMetric(c.myEventsSlowDisconnects, prometheus.CounterValue, float64(myEvents.SlowDisconnects))
 	ch <- prometheus.MustNewConstMetric(c.presenceRefreshes, prometheus.CounterValue, float64(myEvents.PresenceRefreshes))
 	ch <- prometheus.MustNewConstMetric(c.presenceFailures, prometheus.CounterValue, float64(myEvents.PresenceFailures))
-	for _, model := range c.server.core.ModelMetadata() {
-		ch <- prometheus.MustNewConstMetric(c.modelInfo, prometheus.GaugeValue, 1, model.Key)
-		ch <- prometheus.MustNewConstMetric(c.legacyServiceInfo, prometheus.GaugeValue, 1, model.LegacyServiceKey)
+	for _, modelKey := range core.ModelKeys() {
+		ch <- prometheus.MustNewConstMetric(c.modelInfo, prometheus.GaugeValue, 1, modelKey)
 	}
 
 	projections, err := c.server.core.ProjectionAdminStates(ctx)

--- a/cli/internal/http_server/metrics_test.go
+++ b/cli/internal/http_server/metrics_test.go
@@ -172,14 +172,8 @@ func TestMetricsServerUsesProjectionAndModelKeys(t *testing.T) {
 	if !strings.Contains(text, `chatto_model_info{model="message_model"} 1`) {
 		t.Fatalf("metrics body missing message_model model label\n%s", text)
 	}
-	if !strings.Contains(text, `chatto_service_info{service="message_service"} 1`) {
-		t.Fatalf("metrics body missing deprecated message_service alias\n%s", text)
-	}
-	if strings.Contains(text, `service="Config Model"`) {
-		t.Fatalf("metrics body used human service name in deprecated label\n%s", text)
-	}
-	if strings.Contains(text, `service="message_model"`) {
-		t.Fatalf("metrics body used model key in deprecated service label\n%s", text)
+	if strings.Contains(text, "chatto_service_info") {
+		t.Fatalf("metrics body contains retired chatto_service_info metric\n%s", text)
 	}
 	if strings.Contains(text, `model="Message Model"`) {
 		t.Fatalf("metrics body used human model name as label\n%s", text)

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -7,7 +7,7 @@ The core runtime is process-local but must be safe under multiple Chatto replica
 Related decisions: [ADR-033](../adr/ADR-033-event-sourced-state-with-projections.md)
 and [ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md).
 
-`ChattoCore` keeps a core model inventory with stable machine-readable keys such as `config_model`, `message_model`, and `my_events_model`. Per-process metrics expose these keys via `chatto_model_info`; `chatto_service_info` remains a deprecated compatibility alias that emits the previous `*_service` label values. Display names remain operator-facing text only.
+The core model inventory is a list of stable machine-readable keys such as `config_model`, `message_model`, and `my_events_model`. Per-process metrics expose these keys via `chatto_model_info`.
 
 | Model                            | Key files                                                                                                                                                   | Responsibility                                                                                                                                |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Why

The core model inventory maintained three names per component even though only the stable metric key remained useful.

## What changed

- Replaced per-instance model registration metadata with one static list of stable keys.
- Removed unused display names, legacy `*_service` mappings, and the deprecated `chatto_service_info` metric.
- Updated inventory and scrape tests plus the runtime-component architecture inventory.

## API compatibility

- No public API or protocol behaviour changed.
- Operational breaking change: dashboards using `chatto_service_info{service="*_service"}` must migrate to `chatto_model_info{model="*_model"}`.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- go test ./internal/core -run TestModelInventoryUsesStableKeys -count=1 -timeout 60s`
- `mise test-cli`
- `git diff --check`
