### PR TITLE
refactor(cli)!: remove passphrase argument flags

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/backup-restore.mdx
@@ -101,7 +101,7 @@ vault kv get -field=passphrase secret/chatto | \
   chatto backup -c chatto.toml --encrypt --include-keys --passphrase-stdin
 ```
 
-The legacy `--passphrase` argument is deprecated because command-line secrets can appear in shell history and process listings. Migrate unattended jobs to `--passphrase-file` or `--passphrase-stdin` before Chatto 0.5.
+Chatto does not accept passphrases directly in command-line arguments because secrets can appear in shell history and process listings. Use `--passphrase-file` or `--passphrase-stdin` for unattended jobs.
 Non-interactive commands do not consume stdin unless `--passphrase-stdin` is present; this prevents inherited pipes from hanging a backup or becoming an accidental secret source.
 
 <Aside type="caution">

--- a/cli/cmd/backup.go
+++ b/cli/cmd/backup.go
@@ -54,7 +54,6 @@ var (
 	backupConfigFile      string
 	backupOutput          string
 	backupEncrypt         bool
-	backupPassphrase      string
 	backupPassphraseFile  string
 	backupPassphraseStdin bool
 	backupIncludeKeys     bool
@@ -102,8 +101,6 @@ func init() {
 	backupCmd.Flags().StringVarP(&backupConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
 	backupCmd.Flags().StringVarP(&backupOutput, "output", "o", "", "output path for the backup archive (default: backups/<timestamp>.tar.gz)")
 	backupCmd.Flags().BoolVar(&backupEncrypt, "encrypt", false, "encrypt the backup with a passphrase (age encryption)")
-	backupCmd.Flags().StringVar(&backupPassphrase, "passphrase", "", "encryption passphrase (if not set, prompts interactively)")
-	_ = backupCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
 	backupCmd.Flags().StringVar(&backupPassphraseFile, "passphrase-file", "", "file containing the encryption passphrase")
 	backupCmd.Flags().BoolVar(&backupPassphraseStdin, "passphrase-stdin", false, "read the encryption passphrase from stdin")
 	backupCmd.Flags().BoolVar(&backupIncludeKeys, "include-keys", false, "include KV_ENCRYPTION_KEYS in the archive (treat the archive as sensitive)")
@@ -122,10 +119,8 @@ func runBackup(cmd *cobra.Command, args []string) {
 	if backupEncrypt {
 		var err error
 		passphrase, err = getPassphrase(passphraseInput{
-			argument:    backupPassphrase,
-			argumentSet: cmd.Flags().Changed("passphrase"),
-			file:        backupPassphraseFile,
-			stdin:       backupPassphraseStdin,
+			file:  backupPassphraseFile,
+			stdin: backupPassphraseStdin,
 		}, "Enter passphrase for backup encryption: ", true)
 		if err != nil {
 			log.Fatal("Failed to read passphrase", "error", err)

--- a/cli/cmd/keys.go
+++ b/cli/cmd/keys.go
@@ -42,7 +42,6 @@ type ExportedKey struct {
 var (
 	keysConfigFile      string
 	keysOutput          string
-	keysPassphrase      string
 	keysPassphraseFile  string
 	keysPassphraseStdin bool
 )
@@ -92,15 +91,11 @@ func init() {
 
 	keysExportCmd.Flags().StringVarP(&keysConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
 	keysExportCmd.Flags().StringVarP(&keysOutput, "output", "o", "", "output file path (required)")
-	keysExportCmd.Flags().StringVar(&keysPassphrase, "passphrase", "", "encryption passphrase (if not set, prompts interactively)")
-	_ = keysExportCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
 	keysExportCmd.Flags().StringVar(&keysPassphraseFile, "passphrase-file", "", "file containing the encryption passphrase")
 	keysExportCmd.Flags().BoolVar(&keysPassphraseStdin, "passphrase-stdin", false, "read the encryption passphrase from stdin")
 	_ = keysExportCmd.MarkFlagRequired("output")
 
 	keysImportCmd.Flags().StringVarP(&keysConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
-	keysImportCmd.Flags().StringVar(&keysPassphrase, "passphrase", "", "decryption passphrase (if not set, prompts interactively)")
-	_ = keysImportCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
 	keysImportCmd.Flags().StringVar(&keysPassphraseFile, "passphrase-file", "", "file containing the decryption passphrase")
 	keysImportCmd.Flags().BoolVar(&keysPassphraseStdin, "passphrase-stdin", false, "read the decryption passphrase from stdin")
 }
@@ -112,10 +107,8 @@ func runKeysExport(cmd *cobra.Command, args []string) {
 	}
 
 	passphrase, err := getPassphrase(passphraseInput{
-		argument:    keysPassphrase,
-		argumentSet: cmd.Flags().Changed("passphrase"),
-		file:        keysPassphraseFile,
-		stdin:       keysPassphraseStdin,
+		file:  keysPassphraseFile,
+		stdin: keysPassphraseStdin,
 	}, "Enter passphrase for key export: ", true)
 	if err != nil {
 		log.Fatal("Failed to read passphrase", "error", err)
@@ -167,10 +160,8 @@ func runKeysImport(cmd *cobra.Command, args []string) {
 	}
 
 	passphrase, err := getPassphrase(passphraseInput{
-		argument:    keysPassphrase,
-		argumentSet: cmd.Flags().Changed("passphrase"),
-		file:        keysPassphraseFile,
-		stdin:       keysPassphraseStdin,
+		file:  keysPassphraseFile,
+		stdin: keysPassphraseStdin,
 	}, "Enter passphrase for key import: ", false)
 	if err != nil {
 		log.Fatal("Failed to read passphrase", "error", err)
@@ -399,26 +390,20 @@ func decryptKeysFromFile(filePath, passphrase string) ([]ExportedKey, error) {
 }
 
 type passphraseInput struct {
-	argument    string
-	argumentSet bool
-	file        string
-	stdin       bool
+	file  string
+	stdin bool
 }
 
 // getPassphrase reads one validated passphrase from an explicit source or a
 // hidden interactive prompt.
 func getPassphrase(input passphraseInput, prompt string, confirm bool) (string, error) {
 	if err := validateSecretSources(
-		"--passphrase", input.argumentSet,
 		"--passphrase-file", input.file != "",
 		"--passphrase-stdin", input.stdin,
 	); err != nil {
 		return "", err
 	}
 
-	if input.argumentSet {
-		return requirePassphrase(input.argument)
-	}
 	if input.file != "" {
 		passphrase, err := readSecretFile(input.file)
 		if err != nil {

--- a/cli/cmd/passphrase_test.go
+++ b/cli/cmd/passphrase_test.go
@@ -36,33 +36,15 @@ func TestGetPassphraseExplicitSources(t *testing.T) {
 		})
 	})
 
-	t.Run("argument remains compatible", func(t *testing.T) {
-		got, err := getPassphrase(passphraseInput{argument: "argument-secret", argumentSet: true}, "unused", false)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if got != "argument-secret" {
-			t.Fatalf("passphrase from deprecated argument = %q", got)
-		}
-	})
 }
 
 func TestGetPassphraseRejectsUnsafeSourceCombinationsAndEmptyValues(t *testing.T) {
-	secret := "must-not-appear"
 	_, err := getPassphrase(passphraseInput{
-		argument:    secret,
-		argumentSet: true,
-		file:        "/tmp/passphrase",
+		file:  "/tmp/passphrase",
+		stdin: true,
 	}, "unused", false)
 	if err == nil || !strings.Contains(err.Error(), "provide only one") {
 		t.Fatalf("conflicting sources error = %v", err)
-	}
-	if strings.Contains(err.Error(), secret) {
-		t.Fatalf("conflicting sources error leaked passphrase: %v", err)
-	}
-
-	if _, err := getPassphrase(passphraseInput{argumentSet: true}, "unused", false); err == nil || err.Error() != "passphrase cannot be empty" {
-		t.Fatalf("empty argument error = %v", err)
 	}
 
 	path := filepath.Join(t.TempDir(), "empty-passphrase")
@@ -82,14 +64,16 @@ func TestGetPassphraseNonInteractiveRequiresExplicitSource(t *testing.T) {
 	})
 }
 
-func TestPassphraseCommandsExposeSecureSourcesAndDeprecateArgument(t *testing.T) {
+func TestPassphraseCommandsExposeOnlySecureAutomationSources(t *testing.T) {
 	for _, cmd := range []*cobra.Command{backupCmd, restoreCmd, keysExportCmd, keysImportCmd} {
 		if cmd.Flags().Lookup("passphrase-file") == nil || cmd.Flags().Lookup("passphrase-stdin") == nil {
 			t.Errorf("%s is missing secure passphrase flags", cmd.CommandPath())
 		}
-		flag := cmd.Flags().Lookup("passphrase")
-		if flag == nil || flag.Deprecated == "" {
-			t.Errorf("%s --passphrase is not deprecated", cmd.CommandPath())
+		if cmd.Flags().Lookup("passphrase") != nil {
+			t.Errorf("%s still accepts passphrases in process arguments", cmd.CommandPath())
+		}
+		if err := cmd.Flags().Parse([]string{"--passphrase", "secret"}); err == nil || !strings.Contains(err.Error(), "unknown flag") {
+			t.Errorf("%s --passphrase parse error = %v, want unknown flag", cmd.CommandPath(), err)
 		}
 	}
 }

--- a/cli/cmd/restore.go
+++ b/cli/cmd/restore.go
@@ -26,7 +26,6 @@ import (
 var (
 	restoreConfigFile      string
 	restoreConflict        string
-	restorePassphrase      string
 	restorePassphraseFile  string
 	restorePassphraseStdin bool
 )
@@ -56,8 +55,6 @@ func init() {
 	rootCmd.AddCommand(restoreCmd)
 	restoreCmd.Flags().StringVarP(&restoreConfigFile, "config", "c", "", "path to configuration file (default: chatto.toml)")
 	restoreCmd.Flags().StringVar(&restoreConflict, "conflict", "error", "conflict handling: error, skip, overwrite")
-	restoreCmd.Flags().StringVar(&restorePassphrase, "passphrase", "", "decryption passphrase for encrypted backups (if not set, prompts interactively)")
-	_ = restoreCmd.Flags().MarkDeprecated("passphrase", "use --passphrase-stdin or --passphrase-file so the secret is not exposed in process arguments")
 	restoreCmd.Flags().StringVar(&restorePassphraseFile, "passphrase-file", "", "file containing the decryption passphrase")
 	restoreCmd.Flags().BoolVar(&restorePassphraseStdin, "passphrase-stdin", false, "read the decryption passphrase from stdin")
 }
@@ -102,10 +99,8 @@ func runRestore(cmd *cobra.Command, args []string) error {
 	if encrypted {
 		log.Info("Archive is encrypted, decryption required")
 		passphrase, err := getPassphrase(passphraseInput{
-			argument:    restorePassphrase,
-			argumentSet: cmd.Flags().Changed("passphrase"),
-			file:        restorePassphraseFile,
-			stdin:       restorePassphraseStdin,
+			file:  restorePassphraseFile,
+			stdin: restorePassphraseStdin,
 		}, "Enter passphrase for backup decryption: ", false)
 		if err != nil {
 			return fmt.Errorf("failed to read passphrase: %w", err)

--- a/docs/architecture/runtime-state.md
+++ b/docs/architecture/runtime-state.md
@@ -40,8 +40,7 @@ owner-only archives through a same-directory temporary file and atomic rename.
 
 Backup, restore, and key export/import accept passphrases through hidden
 terminal prompts or explicit `--passphrase-file` and `--passphrase-stdin`
-automation sources. The process-argument `--passphrase` compatibility path is
-deprecated for removal in 0.5.
+automation sources. They do not accept passphrases in process arguments.
 
 Restore extracts into an owner-only temporary directory. Before connecting
 restored paths to JetStream, it rejects non-local manifest stream names and


### PR DESCRIPTION
## Why

Passing backup and key passphrases as command-line arguments exposes secrets through shell history and process listings.

## What changed

- Removed the deprecated `--passphrase` flag from backup, restore, key export, and key import; hidden prompts, `--passphrase-file`, and `--passphrase-stdin` remain supported.
- Simplified passphrase-source validation, added coverage proving the removed flag is rejected, and updated operator and runtime-state documentation.

## API compatibility

- No public protobuf, ConnectRPC, realtime, auth, discovery, admin, or HTTP behaviour changed.
- Breaking CLI change for Chatto 0.5: unattended scripts must replace `--passphrase` with `--passphrase-file` or `--passphrase-stdin`; mixed client/server versions and capability discovery are unaffected.

## Test plan

- `mise x -- go test ./cmd -run 'Passphrase' -count=1 -timeout 120s` (passed)
- `mise test-cli` (passed)
- `mise x -- pnpm --filter docs-website build` (passed)
- `git diff --check` (passed)
