### PR TITLE
refactor(core): use event IDs for message bodies

### DIFF
--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -642,7 +642,7 @@ func fetchPayloadContext(ctx context.Context, chattoCore *core.ChattoCore, notif
 
 	// Extract message body from the event
 	if _, ok := event.Event.(*corev1.Event_MessagePosted); ok {
-		body, err := chattoCore.GetMessageBody(ctx, kind, event.Id)
+		body, err := chattoCore.GetMessageBody(ctx, event.Id)
 		if err != nil {
 			logger.Debug("Failed to fetch message body for push notification preview",
 				"event_id", event.Id,

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -5084,7 +5084,7 @@ func TestMessageServiceFetchLinkPreviewRequiresAuthMapsPreviewAndPostsToken(t *t
 	if message == nil {
 		t.Fatalf("CreateMessage message = nil")
 	}
-	body, err := env.core.GetFullMessageBody(env.ctx, core.KindChannel, message.GetId())
+	body, err := env.core.GetFullMessageBody(env.ctx, message.GetId())
 	if err != nil {
 		t.Fatalf("GetFullMessageBody: %v", err)
 	}
@@ -6003,7 +6003,7 @@ func TestMessageServiceUpdateMessageAuthorAndRBAC(t *testing.T) {
 	if authorResp.Msg.GetMessage().GetBody() != "author edit" {
 		t.Fatalf("author UpdateMessage response = %+v, want hydrated edited event", authorResp.Msg)
 	}
-	if body, err := env.core.GetMessageBody(env.ctx, core.KindChannel, original.Id); err != nil || body != "author edit" {
+	if body, err := env.core.GetMessageBody(env.ctx, original.Id); err != nil || body != "author edit" {
 		t.Fatalf("body after author edit = %q, %v; want author edit, nil", body, err)
 	}
 
@@ -6035,7 +6035,7 @@ func TestMessageServiceUpdateMessageAuthorAndRBAC(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("moderator UpdateMessage: %v", err)
 	}
-	if body, err := env.core.GetMessageBody(env.ctx, core.KindChannel, moderated.Id); err != nil || body != "moderator edit" {
+	if body, err := env.core.GetMessageBody(env.ctx, moderated.Id); err != nil || body != "moderator edit" {
 		t.Fatalf("body after moderator edit = %q, %v; want moderator edit, nil", body, err)
 	}
 
@@ -6089,7 +6089,7 @@ func TestMessageServiceDeleteMessageAuthorAndRBAC(t *testing.T) {
 	if !resp.Msg.Deleted {
 		t.Fatal("moderator DeleteMessage Deleted = false, want true")
 	}
-	if body, err := env.core.GetMessageBody(env.ctx, core.KindChannel, target.Id); err != nil || body != "" {
+	if body, err := env.core.GetMessageBody(env.ctx, target.Id); err != nil || body != "" {
 		t.Fatalf("body after moderator delete = %q, %v; want empty, nil", body, err)
 	}
 
@@ -6155,7 +6155,7 @@ func TestMessageServiceDeleteAttachmentAndLinkPreviewAuthorOnly(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("author DeleteAttachment: %v", err)
 	}
-	body, err := env.core.GetFullMessageBody(env.ctx, core.KindChannel, attachmentEvent.Id)
+	body, err := env.core.GetFullMessageBody(env.ctx, attachmentEvent.Id)
 	if err != nil {
 		t.Fatalf("GetFullMessageBody attachment: %v", err)
 	}
@@ -6170,7 +6170,7 @@ func TestMessageServiceDeleteAttachmentAndLinkPreviewAuthorOnly(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("author DeleteLinkPreview: %v", err)
 	}
-	body, err = env.core.GetFullMessageBody(env.ctx, core.KindChannel, previewEvent.Id)
+	body, err = env.core.GetFullMessageBody(env.ctx, previewEvent.Id)
 	if err != nil {
 		t.Fatalf("GetFullMessageBody preview: %v", err)
 	}
@@ -6913,7 +6913,7 @@ func TestRoomTimelineKeepsDMReadableWhenMessageBodyCannotHydrate(t *testing.T) {
 		t.Fatalf("PostMessage bad: %v", err)
 	}
 	corruptMessageBody(t, env, dm.Id, bad.Id, env.viewer.Id)
-	if _, err := env.core.GetFullMessageBodyByEventID(env.ctx, bad.Id); !errors.Is(err, core.ErrMessageBodyCorrupt) {
+	if _, err := env.core.GetFullMessageBody(env.ctx, bad.Id); !errors.Is(err, core.ErrMessageBodyCorrupt) {
 		t.Fatalf("corrupt message body hydration error = %v, want ErrMessageBodyCorrupt", err)
 	}
 

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -222,7 +222,7 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 		message.ChannelEchoEventId = echoID
 	}
 
-	body, err := h.api.core.GetFullMessageBodyByEventID(ctx, event.Id)
+	body, err := h.api.core.GetFullMessageBody(ctx, event.Id)
 	if err != nil {
 		if !errors.Is(err, core.ErrMessageBodyCorrupt) {
 			return nil, err

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1791,15 +1791,6 @@ func roomNameIndexKey(name string) string {
 	return fmt.Sprintf("room_name_index.%s", strings.ToLower(strings.TrimSpace(name)))
 }
 
-// eventIDFromBodyKey extracts the event ID portion from a message body key.
-// Body keys have the format {userId}.{eventId}.
-func eventIDFromBodyKey(bodyKey string) string {
-	if idx := strings.IndexByte(bodyKey, '.'); idx >= 0 && idx < len(bodyKey)-1 {
-		return bodyKey[idx+1:]
-	}
-	return bodyKey
-}
-
 // ============================================================================
 // Event Publishing Helpers
 // ============================================================================

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -126,7 +126,7 @@ func TestPostMessage_EncryptsMessageBody(t *testing.T) {
 	require.Error(t, err, "wrapped DEK should not be stored in ENCRYPTION_KEYS")
 
 	// Verify we can read the message back (decrypted)
-	body, err := core.GetMessageBody(ctx, KindChannel, event.Id)
+	body, err := core.GetMessageBody(ctx, event.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Secret message content", body, "decrypted message should match original")
 }
@@ -286,10 +286,10 @@ func TestGetMessageBody_ReusesRequestCachedMessageBodyDEK(t *testing.T) {
 	core.dekResolver.keyWrapper = wrapper
 
 	readCtx := WithDEKRequestCache(ctx)
-	body, err := core.GetMessageBody(readCtx, KindChannel, event.Id)
+	body, err := core.GetMessageBody(readCtx, event.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Secret message content", body)
-	body, err = core.GetMessageBody(readCtx, KindChannel, event.Id)
+	body, err = core.GetMessageBody(readCtx, event.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Secret message content", body)
 	require.EqualValues(t, 1, wrapper.unwraps.Load(), "message body DEK should be unwrapped once and then served from cache")
@@ -382,13 +382,13 @@ func TestDeleteUserEncryptionKeyAsInvalidatesRequestCachedDEK(t *testing.T) {
 	require.NoError(t, err)
 
 	readCtx := WithDEKRequestCache(ctx)
-	body, err := core.GetMessageBody(readCtx, KindChannel, event.Id)
+	body, err := core.GetMessageBody(readCtx, event.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Secret message content", body)
 
 	require.NoError(t, core.DeleteUserEncryptionKeyAs(readCtx, user.Id, user.Id))
 
-	body, err = core.GetMessageBody(readCtx, KindChannel, event.Id)
+	body, err = core.GetMessageBody(readCtx, event.Id)
 	require.NoError(t, err)
 	require.Empty(t, body, "same request context should not keep using a DEK after deleting it")
 }
@@ -411,7 +411,7 @@ func TestGetMessageBody_CryptoShredding(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify message can be read before key deletion
-	body, err := core.GetMessageBody(ctx, KindChannel, event.Id)
+	body, err := core.GetMessageBody(ctx, event.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Secret message content", body)
 
@@ -419,12 +419,12 @@ func TestGetMessageBody_CryptoShredding(t *testing.T) {
 	require.NoError(t, core.DeleteUserEncryptionKeyAs(ctx, user.Id, user.Id))
 
 	// Verify message now returns empty string (crypto-shredded)
-	body, err = core.GetMessageBody(ctx, KindChannel, event.Id)
+	body, err = core.GetMessageBody(ctx, event.Id)
 	require.NoError(t, err)
 	require.Empty(t, body, "message should be empty after crypto-shredding")
 
 	// Also test GetFullMessageBody - returns nil for crypto-shredded (same as deleted)
-	fullBody, err := core.GetFullMessageBody(ctx, KindChannel, event.Id)
+	fullBody, err := core.GetFullMessageBody(ctx, event.Id)
 	require.NoError(t, err)
 	require.Nil(t, fullBody, "message should be nil after crypto-shredding (treated same as deleted)")
 }
@@ -549,7 +549,7 @@ func TestDeleteUser_CryptoShredEventTombstonesMessagesAndDeletesAssetGraph(t *te
 	require.Equal(t, author.Id, shredEvents[0].GetActorId())
 	require.Equal(t, author.Id, shredEvents[0].GetUserKeyShredded().GetUserId())
 
-	fullBody, err := core.GetFullMessageBodyByEventID(ctx, event.Id)
+	fullBody, err := core.GetFullMessageBody(ctx, event.Id)
 	require.NoError(t, err)
 	require.Nil(t, fullBody, "message body should be tombstoned by UserKeyShreddedEvent before decrypt")
 
@@ -600,10 +600,10 @@ func TestEditMessage_PreservesEncryptionState(t *testing.T) {
 	// Post an encrypted message
 	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Original content", nil, "", "", nil, false)
 	require.NoError(t, err)
-	messageBodyID := event.Id
+	eventID := event.Id
 
 	// Edit the message
-	err = core.EditMessage(ctx, user.Id, KindChannel, room.Id, messageBodyID, "Edited content")
+	err = core.EditMessage(ctx, user.Id, KindChannel, room.Id, eventID, "Edited content")
 	require.NoError(t, err)
 
 	// Post-#597 cutover: the edited body rides on a MessageEditedEvent
@@ -618,7 +618,7 @@ func TestEditMessage_PreservesEncryptionState(t *testing.T) {
 	require.EqualValues(t, 1, stored.ContentKeyEpoch, "edited messages should reference the active message-body DEK epoch")
 
 	// Verify we can read the edited content
-	body, err := core.GetMessageBody(ctx, KindChannel, messageBodyID)
+	body, err := core.GetMessageBody(ctx, eventID)
 	require.NoError(t, err)
 	require.Equal(t, "Edited content", body)
 }
@@ -645,7 +645,7 @@ func TestCrossUserDecryption(t *testing.T) {
 	require.NoError(t, err)
 
 	// User B should be able to read User A's message (decrypted)
-	bodyA, err := core.GetMessageBody(ctx, KindChannel, eventA.Id)
+	bodyA, err := core.GetMessageBody(ctx, eventA.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Message from User A", bodyA, "User B should be able to read User A's decrypted message")
 
@@ -654,7 +654,7 @@ func TestCrossUserDecryption(t *testing.T) {
 	require.NoError(t, err)
 
 	// User A should be able to read User B's message (decrypted)
-	bodyB, err := core.GetMessageBody(ctx, KindChannel, eventB.Id)
+	bodyB, err := core.GetMessageBody(ctx, eventB.Id)
 	require.NoError(t, err)
 	require.Equal(t, "Message from User B", bodyB, "User A should be able to read User B's decrypted message")
 }

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -206,7 +206,7 @@ func TestLinkPreviewImageStorageAndRetrieval(t *testing.T) {
 	}
 	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "preview", nil, "", "", postPreview, false)
 	require.NoError(t, err)
-	body, err := core.GetFullMessageBodyByEventID(ctx, event.GetId())
+	body, err := core.GetFullMessageBody(ctx, event.GetId())
 	require.NoError(t, err)
 	require.NotNil(t, body)
 	require.NotNil(t, body.LinkPreview.GetImageAsset(), "posted ID-only preview should be stored with ImageAsset")

--- a/cli/internal/core/message_body.go
+++ b/cli/internal/core/message_body.go
@@ -22,30 +22,11 @@ type DecryptedMessageBody struct {
 	UpdatedAt   *time.Time
 }
 
-// GetFullMessageBody returns the decrypted message body for a message.
-//
-// `messageBodyKey` is the legacy compound key `{userId}.{eventId}`
-// retained for API compatibility with older resolver call sites. We
-// extract the eventId from the second segment, look the message up in
-// the RoomTimelineProjection, and fold any subsequent edit / retract
-// events to produce the current body. The userId prefix on the key is
-// not consulted — the projection knows the author from the event
-// envelope.
-//
+// GetFullMessageBody returns the decrypted message body for a message event,
+// folding any subsequent edit or retract events to produce the current body.
 // Returns nil if the message has been retracted or doesn't exist, or
 // if the author's encryption key has been crypto-shredded.
-func (c *ChattoCore) GetFullMessageBody(ctx context.Context, kind RoomKind, messageBodyKey string) (*DecryptedMessageBody, error) {
-	eventID := eventIDFromBodyKey(messageBodyKey)
-	if eventID == "" {
-		return nil, nil
-	}
-	return c.GetFullMessageBodyByEventID(ctx, eventID)
-}
-
-// GetFullMessageBodyByEventID is the canonical post-cutover body
-// accessor — look the message up directly by its envelope event id
-// without the legacy compound key indirection.
-func (c *ChattoCore) GetFullMessageBodyByEventID(ctx context.Context, eventID string) (*DecryptedMessageBody, error) {
+func (c *ChattoCore) GetFullMessageBody(ctx context.Context, eventID string) (*DecryptedMessageBody, error) {
 	if eventID == "" {
 		return nil, nil
 	}
@@ -93,10 +74,10 @@ func (c *ChattoCore) GetFullMessageBodyByEventID(ctx context.Context, eventID st
 }
 
 // GetMessageBody is a thin wrapper returning just the plaintext body
-// text. Same semantics as GetFullMessageBody — retracted / crypto-
+// text. Same semantics as GetFullMessageBody: retracted or crypto-
 // shredded messages return empty string.
-func (c *ChattoCore) GetMessageBody(ctx context.Context, kind RoomKind, messageBodyKey string) (string, error) {
-	body, err := c.GetFullMessageBody(ctx, kind, messageBodyKey)
+func (c *ChattoCore) GetMessageBody(ctx context.Context, eventID string) (string, error) {
+	body, err := c.GetFullMessageBody(ctx, eventID)
 	if err != nil {
 		return "", err
 	}
@@ -104,20 +85,6 @@ func (c *ChattoCore) GetMessageBody(ctx context.Context, kind RoomKind, messageB
 		return "", nil
 	}
 	return body.Body, nil
-}
-
-// GetMessageAuthorID returns the author of a message by its compound body key.
-// Used by public operation models to check ownership before edit/delete.
-func (c *ChattoCore) GetMessageAuthorID(ctx context.Context, kind RoomKind, messageBodyID string) (string, error) {
-	eventID := eventIDFromBodyKey(messageBodyID)
-	if eventID == "" {
-		return "", nil
-	}
-	entry, ok := c.roomModel.timelineEntry(eventID)
-	if !ok {
-		return "", nil
-	}
-	return entry.Event.GetActorId(), nil
 }
 
 // decryptMessageBody decrypts an encrypted message body. Legacy bodies are
@@ -179,8 +146,3 @@ func messageBodyEnvelopeError(err error) error {
 	}
 	return err
 }
-
-// (eventIDFromBodyKey is defined in core.go and shared with the
-// publish path. Body keys have the legacy format {userId}.{eventId};
-// the projection-backed body readers in this file consult it to
-// extract the event-id portion.)

--- a/cli/internal/core/message_body_benchmark_test.go
+++ b/cli/internal/core/message_body_benchmark_test.go
@@ -19,10 +19,10 @@ type messageBodyBenchmarkPage struct {
 	eventIDs []string
 }
 
-// BenchmarkGetFullMessageBodyByEventID_DEKCache measures timeline body
+// BenchmarkGetFullMessageBody_DEKCache measures timeline body
 // hydration with a request-scoped DEK cache compared to no request cache, which
 // approximates the old per-message unwrap behavior.
-func BenchmarkGetFullMessageBodyByEventID_DEKCache(b *testing.B) {
+func BenchmarkGetFullMessageBody_DEKCache(b *testing.B) {
 	runMessageBodyPageBenchmark(b, "same_author_page_50", 1, 50)
 	runMessageBodyPageBenchmark(b, "five_authors_page_50", 5, 50)
 }
@@ -109,7 +109,7 @@ func readBenchmarkPage(b *testing.B, ctx context.Context, page messageBodyBenchm
 
 func readBenchmarkBody(b *testing.B, ctx context.Context, core *ChattoCore, eventID string) int {
 	b.Helper()
-	body, err := core.GetFullMessageBodyByEventID(ctx, eventID)
+	body, err := core.GetFullMessageBody(ctx, eventID)
 	require.NoError(b, err)
 	require.NotNil(b, body)
 	return len(body.Body)

--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -310,7 +310,7 @@ func (s *MessageModel) UpdateMessage(ctx context.Context, input MessageUpdateInp
 		return nil, kind, invalidArgument("body or also_send_to_channel is required")
 	}
 
-	body, err := s.core.GetFullMessageBodyByEventID(ctx, input.EventID)
+	body, err := s.core.GetFullMessageBody(ctx, input.EventID)
 	if err != nil {
 		return nil, kind, err
 	}
@@ -372,14 +372,12 @@ func (s *MessageModel) DeleteMessage(ctx context.Context, input MessageDeleteInp
 	if strings.TrimSpace(input.EventID) == "" {
 		return invalidArgument("event_id is required")
 	}
-	if _, err := s.requireMessagePostedEvent(ctx, kind, room.Id, input.EventID); err != nil {
-		return err
-	}
-
-	authorID, err := s.core.GetMessageAuthorID(ctx, kind, input.EventID)
+	event, err := s.requireMessagePostedEvent(ctx, kind, room.Id, input.EventID)
 	if err != nil {
 		return err
 	}
+
+	authorID := event.GetActorId()
 	if authorID != "" && authorID != input.ActorID {
 		can, err := s.core.CanManageOthersMessage(ctx, input.ActorID, kind, room.Id)
 		if err != nil {

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -614,11 +614,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 		}
 	}
 
-	// messageBodyKey retained as a label for log lines and downstream
-	// notifications that historically logged the compound key — the
-	// projection-keyed event_id is the new canonical identifier.
-	messageBodyKey := event.Id
-	c.logger.Debug("Message posted", "kind", kind, "room_id", room_id, "message_body_key", messageBodyKey, "sequence_id", sequenceID, "user_id", user_id)
+	c.logger.Debug("Message posted", "kind", kind, "room_id", room_id, "event_id", event.Id, "sequence_id", sequenceID, "user_id", user_id)
 
 	// Mark the room as read for the poster. For root posts, the just-
 	// published event is the new last root. For thread replies, we look up
@@ -832,11 +828,9 @@ func (c *ChattoCore) notifyAllMessageSubscribers(ctx context.Context, kind RoomK
 // compliance while preserving the event in the stream for audit. For echoes,
 // the same durable MessageRetractedEvent hides only the echo artifact from the
 // room timeline; the original thread reply remains readable.
-// The messageBodyKey parameter is the legacy body key or canonical event ID.
 // Authorization: Caller must verify the actor is the message author OR
 // CanManageOthersMessage before calling.
-func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind RoomKind, roomID, messageBodyKey string) error {
-	eventID := eventIDFromBodyKey(messageBodyKey)
+func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind RoomKind, roomID, eventID string) error {
 	if eventID == "" {
 		return ErrMessageNotFound
 	}
@@ -905,14 +899,12 @@ func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind Roo
 
 // EditMessage edits a message body. Updates the body content and sets updated_at.
 // Publishes a MessageEditedEvent to notify connected clients in real-time.
-// The messageBodyKey parameter is the full compound key ({userId}.{bodyId}) stored in the event.
-//
 // Business rule: Authors can only edit their own messages within MessageEditWindow (3 hours).
 // Non-authors (moderators with message.manage) can edit at any time.
 //
 // Authorization: Caller must verify the actor is the author OR
 // CanManageOthersMessage before calling.
-func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomKind, roomID, messageBodyKey, newBody string, opts ...EditMessageOption) error {
+func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomKind, roomID, eventID, newBody string, opts ...EditMessageOption) error {
 	options := collectEditMessageOptions(opts)
 	if len(newBody) > MaxMessageBodyLength {
 		return ErrMessageTooLong
@@ -927,7 +919,6 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		return ErrRoomArchived
 	}
 
-	eventID := eventIDFromBodyKey(messageBodyKey)
 	if eventID == "" {
 		return ErrMessageNotFound
 	}
@@ -1324,10 +1315,9 @@ func (c *ChattoCore) editEmbeddedBody(
 	ctx context.Context,
 	actorID string,
 	kind RoomKind,
-	roomID, messageBodyKey string,
+	roomID, eventID string,
 	mutate func(*corev1.MessageBody) error,
 ) error {
-	eventID := eventIDFromBodyKey(messageBodyKey)
 	if eventID == "" {
 		return ErrMessageNotFound
 	}
@@ -1395,9 +1385,9 @@ func (c *ChattoCore) editEmbeddedBody(
 // message. Only the message author can delete their attachments.
 // Emits a MessageEditedEvent with the attachment removed; also
 // deletes the file from the asset store best-effort.
-func (c *ChattoCore) DeleteAttachmentFromMessage(ctx context.Context, actorID string, kind RoomKind, roomID, messageBodyKey, attachmentID string) error {
+func (c *ChattoCore) DeleteAttachmentFromMessage(ctx context.Context, actorID string, kind RoomKind, roomID, eventID, attachmentID string) error {
 	var removed *corev1.Attachment
-	err := c.editEmbeddedBody(ctx, actorID, kind, roomID, messageBodyKey, func(body *corev1.MessageBody) error {
+	err := c.editEmbeddedBody(ctx, actorID, kind, roomID, eventID, func(body *corev1.MessageBody) error {
 		// Resolve the attachment (new bodies hold IDs; older bodies hold
 		// embedded protos). Then trim from whichever shape holds it.
 		for _, att := range c.mediaModel.MessageBodyAttachments(body) {
@@ -1434,12 +1424,12 @@ func (c *ChattoCore) DeleteAttachmentFromMessage(ctx context.Context, actorID st
 		if err := c.assetModel.RecordAssetDeleted(ctx, actorID, roomID, removed.GetId()); err != nil {
 			c.logger.Warn("Failed to publish asset deletion event",
 				"attachment_id", attachmentID,
-				"message_body_key", messageBodyKey,
+				"event_id", eventID,
 				"error", err)
 		} else if delErr := c.DeleteAttachmentFromStorage(ctx, removed); delErr != nil {
 			c.logger.Warn("Failed to delete attachment file after removing from message",
 				"attachment_id", attachmentID,
-				"message_body_key", messageBodyKey,
+				"event_id", eventID,
 				"error", delErr)
 		}
 	}
@@ -1447,7 +1437,7 @@ func (c *ChattoCore) DeleteAttachmentFromMessage(ctx context.Context, actorID st
 	c.logger.Debug("Attachment deleted from message",
 		"kind", kind,
 		"room_id", roomID,
-		"message_body_key", messageBodyKey,
+		"event_id", eventID,
 		"attachment_id", attachmentID,
 		"actor_id", actorID)
 	return nil
@@ -1456,8 +1446,8 @@ func (c *ChattoCore) DeleteAttachmentFromMessage(ctx context.Context, actorID st
 // DeleteLinkPreviewFromMessage removes a link preview from a message.
 // Only the message author can delete link previews from their
 // messages.
-func (c *ChattoCore) DeleteLinkPreviewFromMessage(ctx context.Context, actorID string, kind RoomKind, roomID, messageBodyKey, previewURL string) error {
-	err := c.editEmbeddedBody(ctx, actorID, kind, roomID, messageBodyKey, func(body *corev1.MessageBody) error {
+func (c *ChattoCore) DeleteLinkPreviewFromMessage(ctx context.Context, actorID string, kind RoomKind, roomID, eventID, previewURL string) error {
+	err := c.editEmbeddedBody(ctx, actorID, kind, roomID, eventID, func(body *corev1.MessageBody) error {
 		if body.GetLinkPreview() == nil || body.GetLinkPreview().GetUrl() != previewURL {
 			return fmt.Errorf("link preview not found in message: %w", ErrMessageLinkPreviewNotFound)
 		}
@@ -1470,7 +1460,7 @@ func (c *ChattoCore) DeleteLinkPreviewFromMessage(ctx context.Context, actorID s
 	c.logger.Debug("Link preview deleted from message",
 		"kind", kind,
 		"room_id", roomID,
-		"message_body_key", messageBodyKey,
+		"event_id", eventID,
 		"link_preview_removed", true,
 		"actor_id", actorID)
 	return nil

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -50,7 +50,7 @@ func TestChattoCore_PostMessage(t *testing.T) {
 	}
 
 	// Body is lazy-loaded from the body projection using the message event ID.
-	fetchedBody, err := core.GetMessageBody(ctx, KindChannel, roomEvent.Id)
+	fetchedBody, err := core.GetMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to fetch message body: %v", err)
 	}
@@ -126,7 +126,7 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	if !ok {
 		t.Fatal("expected edit to create a channel echo")
 	}
-	echoText, err := core.GetMessageBody(ctx, KindChannel, echoID)
+	echoText, err := core.GetMessageBody(ctx, echoID)
 	if err != nil {
 		t.Fatalf("Get echo body: %v", err)
 	}
@@ -147,7 +147,7 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	if _, ok := core.RoomTimeline.ChannelEchoEventID(reply.Id); ok {
 		t.Fatal("expected echo to be hidden after unchecking")
 	}
-	replyText, err := core.GetMessageBody(ctx, KindChannel, reply.Id)
+	replyText, err := core.GetMessageBody(ctx, reply.Id)
 	if err != nil {
 		t.Fatalf("Get reply body: %v", err)
 	}
@@ -194,7 +194,7 @@ func TestChattoCore_EditMessageRejectsInvalidEchoStateTargets(t *testing.T) {
 	if err := core.EditMessage(ctx, other.Id, KindChannel, room.Id, reply.Id, "other edit", WithMessageChannelEcho(true)); !errors.Is(err, ErrNotMessageAuthor) {
 		t.Fatalf("expected ErrNotMessageAuthor, got %v", err)
 	}
-	if body, err := core.GetMessageBody(ctx, KindChannel, reply.Id); err != nil || body != "reply" {
+	if body, err := core.GetMessageBody(ctx, reply.Id); err != nil || body != "reply" {
 		t.Fatalf("invalid echo-state edit should not change body; body=%q err=%v", body, err)
 	}
 }
@@ -264,7 +264,7 @@ func TestChattoCore_PostMessage_BodyStoredInMessageBodyEvent(t *testing.T) {
 	}
 
 	// Verify the body can be fetched via GetMessageBody using the message event ID.
-	fetchedBody, err := core.GetMessageBody(ctx, KindChannel, roomEvent.Id)
+	fetchedBody, err := core.GetMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to fetch message body: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestChattoCore_MessageBodyEventsKeepPublicEventsBodyless(t *testing.T) {
 	if editEvents[0].GetMessageEdited() == nil {
 		t.Fatal("expected MessageEditedEvent")
 	}
-	body, err := core.GetMessageBody(ctx, KindChannel, posted.Id)
+	body, err := core.GetMessageBody(ctx, posted.Id)
 	if err != nil {
 		t.Fatalf("GetMessageBody: %v", err)
 	}
@@ -872,7 +872,7 @@ func TestChattoCore_DeleteMessage_GDPR(t *testing.T) {
 	}
 
 	// Pre-deletion: GetMessageBody returns the plaintext.
-	bodyText, err := core.GetMessageBody(ctx, KindChannel, roomEvent.Id)
+	bodyText, err := core.GetMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to fetch message body before deletion: %v", err)
 	}
@@ -888,7 +888,7 @@ func TestChattoCore_DeleteMessage_GDPR(t *testing.T) {
 
 	// Post-deletion: projection tombstones the message, body
 	// disappears from GetMessageBody.
-	bodyText, err = core.GetMessageBody(ctx, KindChannel, roomEvent.Id)
+	bodyText, err = core.GetMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("GetMessageBody on retracted message returned error: %v", err)
 	}
@@ -954,7 +954,7 @@ func TestChattoCore_DeleteEcho_HidesEchoOnly(t *testing.T) {
 		t.Fatal("hidden echo should not be directly loadable from room event API")
 	}
 
-	body, err := core.GetMessageBody(ctx, KindChannel, replyEvent.Id)
+	body, err := core.GetMessageBody(ctx, replyEvent.Id)
 	if err != nil {
 		t.Fatalf("Get original reply body: %v", err)
 	}
@@ -1024,7 +1024,7 @@ func TestChattoCore_DeleteEcho_PreservesOriginalAttachment(t *testing.T) {
 	if _, err := store.Get(ctx, attachment.Id); err != nil {
 		t.Fatalf("echo delete should preserve backing attachment: %v", err)
 	}
-	body, err := core.GetFullMessageBody(ctx, KindChannel, replyEvent.Id)
+	body, err := core.GetFullMessageBody(ctx, replyEvent.Id)
 	if err != nil {
 		t.Fatalf("Get original reply body: %v", err)
 	}
@@ -1085,14 +1085,14 @@ func TestChattoCore_DeleteOriginalReply_TombstonesEcho(t *testing.T) {
 	if !foundEcho {
 		t.Fatal("echo should remain visible as a tombstone when original is deleted")
 	}
-	replyBody, err := core.GetMessageBody(ctx, KindChannel, replyEvent.Id)
+	replyBody, err := core.GetMessageBody(ctx, replyEvent.Id)
 	if err != nil {
 		t.Fatalf("Get original reply body: %v", err)
 	}
 	if replyBody != "" {
 		t.Fatalf("deleted original reply body = %q, want empty", replyBody)
 	}
-	echoBody, err := core.GetMessageBody(ctx, KindChannel, echoID)
+	echoBody, err := core.GetMessageBody(ctx, echoID)
 	if err != nil {
 		t.Fatalf("Get echo body: %v", err)
 	}
@@ -1154,7 +1154,7 @@ func TestChattoCore_DeleteMessage_DeletesAttachments(t *testing.T) {
 	}
 
 	// Verify message body is deleted
-	body, err := core.GetMessageBody(ctx, KindChannel, roomEvent.Id)
+	body, err := core.GetMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to get message body: %v", err)
 	}
@@ -1225,7 +1225,7 @@ func TestChattoCore_DeleteAttachmentFromMessage(t *testing.T) {
 	}
 
 	// Verify message body still has attachment 2 but not attachment 1
-	messageBody, err := core.GetFullMessageBody(ctx, KindChannel, roomEvent.Id)
+	messageBody, err := core.GetFullMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to get message body: %v", err)
 	}
@@ -1430,7 +1430,7 @@ func TestChattoCore_DeleteAttachmentFromMessage_S3(t *testing.T) {
 	}
 
 	// Verify message body still has attachment 2 but not attachment 1
-	messageBody, err := core.GetFullMessageBody(ctx, KindChannel, roomEvent.Id)
+	messageBody, err := core.GetFullMessageBody(ctx, roomEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to get message body: %v", err)
 	}

--- a/cli/internal/core/room_attachments.go
+++ b/cli/internal/core/room_attachments.go
@@ -188,7 +188,7 @@ func (c *ChattoCore) messageAttachments(ctx context.Context, kind RoomKind, room
 	if event == nil || event.GetMessagePosted() == nil {
 		return nil, ErrMessageNotFound
 	}
-	body, err := c.GetFullMessageBodyByEventID(ctx, eventID)
+	body, err := c.GetFullMessageBody(ctx, eventID)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/core/room_events_stream_test.go
+++ b/cli/internal/core/room_events_stream_test.go
@@ -46,7 +46,7 @@ func TestChattoCore_StreamRoomEventsLive(t *testing.T) {
 	})
 
 	// Body lookup is keyed by the durable event envelope id.
-	fetchedBody, err := core.GetMessageBody(ctx, KindChannel, event.Id)
+	fetchedBody, err := core.GetMessageBody(ctx, event.Id)
 	if err != nil {
 		t.Fatalf("Failed to fetch message body: %v", err)
 	}

--- a/cli/internal/core/room_events_test.go
+++ b/cli/internal/core/room_events_test.go
@@ -47,7 +47,7 @@ func TestChattoCore_GetRoomEvents(t *testing.T) {
 	for _, event := range events {
 		if msg := event.GetMessagePosted(); msg != nil {
 			// Body lookup is keyed by the durable event envelope id.
-			fetchedBody, err := core.GetMessageBody(ctx, KindChannel, event.Id)
+			fetchedBody, err := core.GetMessageBody(ctx, event.Id)
 			if err != nil {
 				t.Errorf("Failed to fetch message body: %v", err)
 			}
@@ -287,7 +287,7 @@ func TestChattoCore_GetRoomEvents_DeletedMessageBody(t *testing.T) {
 	messagePosted := messageEvent.GetMessagePosted()
 
 	// Verify the body is empty (deleted) when fetched via GetMessageBody
-	fetchedBody, err := core.GetMessageBody(ctx, KindChannel, messageEvent.Id)
+	fetchedBody, err := core.GetMessageBody(ctx, messageEvent.Id)
 	if err != nil {
 		t.Fatalf("Failed to fetch message body: %v", err)
 	}
@@ -342,7 +342,7 @@ func TestChattoCore_GetRoomEvents_Pagination(t *testing.T) {
 		}
 
 		// The last message in our result should be "Message 100" (most recent)
-		lastMsgBody, err := core.GetMessageBody(ctx, KindChannel, messageEvents[len(messageEvents)-1].Id)
+		lastMsgBody, err := core.GetMessageBody(ctx, messageEvents[len(messageEvents)-1].Id)
 		if err != nil {
 			t.Fatalf("Failed to get last message body: %v", err)
 		}
@@ -351,7 +351,7 @@ func TestChattoCore_GetRoomEvents_Pagination(t *testing.T) {
 		}
 
 		// The first message in our result should be "Message 51" (51st newest)
-		firstMsgBody, err := core.GetMessageBody(ctx, KindChannel, messageEvents[0].Id)
+		firstMsgBody, err := core.GetMessageBody(ctx, messageEvents[0].Id)
 		if err != nil {
 			t.Fatalf("Failed to get first message body: %v", err)
 		}
@@ -398,7 +398,7 @@ func TestChattoCore_GetRoomEvents_Pagination(t *testing.T) {
 
 		// The newest message in the older batch should be before our cursor
 		if len(olderMessageEvents) > 0 {
-			newestOldBody, err := core.GetMessageBody(ctx, KindChannel, olderMessageEvents[len(olderMessageEvents)-1].Id)
+			newestOldBody, err := core.GetMessageBody(ctx, olderMessageEvents[len(olderMessageEvents)-1].Id)
 			if err != nil {
 				t.Fatalf("Failed to get newest old message body: %v", err)
 			}

--- a/cli/internal/core/room_timeline_read_model.go
+++ b/cli/internal/core/room_timeline_read_model.go
@@ -242,7 +242,7 @@ func (s *RoomTimelineReadModel) messageEvent(ctx context.Context, kind RoomKind,
 	if err != nil {
 		return nil, err
 	}
-	body, err := s.core.GetFullMessageBodyByEventID(ctx, eventID)
+	body, err := s.core.GetFullMessageBody(ctx, eventID)
 	if err != nil {
 		return nil, err
 	}

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -1482,11 +1482,11 @@ func TestChattoCore_PostMessage_ThreadReplyEcho(t *testing.T) {
 		if string(echoBody.EncryptedBody) == string(replyBody.EncryptedBody) {
 			t.Errorf("Echo body ciphertext should be independently encrypted")
 		}
-		echoText, err := core.GetMessageBody(ctx, KindChannel, echoID)
+		echoText, err := core.GetMessageBody(ctx, echoID)
 		if err != nil {
 			t.Fatalf("Failed to decrypt echo body: %v", err)
 		}
-		replyText, err := core.GetMessageBody(ctx, KindChannel, replyEvent.Id)
+		replyText, err := core.GetMessageBody(ctx, replyEvent.Id)
 		if err != nil {
 			t.Fatalf("Failed to decrypt reply body: %v", err)
 		}

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -2675,15 +2675,15 @@ func TestChattoCore_DeleteUser_WithMessageBodies(t *testing.T) {
 	msg3ID := event3.Id
 
 	// Verify all message bodies exist
-	_, err = core.GetMessageBody(ctx, KindChannel, msg1ID)
+	_, err = core.GetMessageBody(ctx, msg1ID)
 	if err != nil {
 		t.Fatalf("Expected message 1 to exist: %v", err)
 	}
-	_, err = core.GetMessageBody(ctx, KindChannel, msg2ID)
+	_, err = core.GetMessageBody(ctx, msg2ID)
 	if err != nil {
 		t.Fatalf("Expected message 2 to exist: %v", err)
 	}
-	_, err = core.GetMessageBody(ctx, KindChannel, msg3ID)
+	_, err = core.GetMessageBody(ctx, msg3ID)
 	if err != nil {
 		t.Fatalf("Expected message 3 to exist: %v", err)
 	}
@@ -2695,7 +2695,7 @@ func TestChattoCore_DeleteUser_WithMessageBodies(t *testing.T) {
 	}
 
 	// Verify user 1's message bodies are deleted (GetMessageBody returns empty string for missing bodies)
-	body1, err := core.GetMessageBody(ctx, KindChannel, msg1ID)
+	body1, err := core.GetMessageBody(ctx, msg1ID)
 	if err != nil {
 		t.Fatalf("Unexpected error getting message 1: %v", err)
 	}
@@ -2703,7 +2703,7 @@ func TestChattoCore_DeleteUser_WithMessageBodies(t *testing.T) {
 		t.Errorf("Expected message 1 body to be empty after user deletion, got: %s", body1)
 	}
 
-	body2, err := core.GetMessageBody(ctx, KindChannel, msg2ID)
+	body2, err := core.GetMessageBody(ctx, msg2ID)
 	if err != nil {
 		t.Fatalf("Unexpected error getting message 2: %v", err)
 	}
@@ -2712,7 +2712,7 @@ func TestChattoCore_DeleteUser_WithMessageBodies(t *testing.T) {
 	}
 
 	// Verify user 2's message body still exists
-	body3, err := core.GetMessageBody(ctx, KindChannel, msg3ID)
+	body3, err := core.GetMessageBody(ctx, msg3ID)
 	if err != nil {
 		t.Fatalf("Failed to get message 3: %v", err)
 	}


### PR DESCRIPTION
## Why

Message operations already use stable event IDs, but core still carried a legacy `{userId}.{eventId}` body-key abstraction that obscured the real contract.

## What changed

- Made event IDs canonical for message-body reads, edits, deletion, attachment removal, and link-preview removal.
- Removed the compound-key parser and duplicate full-body accessor, dropped unused room-kind arguments, reused the validated event for deletion authorization, and renamed stale log fields.

## API compatibility

- No public protobuf, ConnectRPC, realtime, auth, discovery, admin, HTTP, persisted event, or projection behaviour changed; mixed client/server versions and capability discovery are unaffected.

## Test plan

- Focused core message, body, attachment, and link-preview tests (passed)
- Focused ConnectRPC message tests (passed)
- `mise test-cli` (passed)
- `git diff --check` (passed)
