### PR TITLE
fix(dev): restore mise chatto command routing

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -286,11 +286,11 @@ env = {
   CHATTO_SMTP_TLS = "opportunistic",
   CHATTO_SMTP_FROM = "chatto-dev@chatto.localhost",
 }
-run = "exec bin/chatto run"
+run = "exec bin/chatto"
 
 [tasks.dev-compiled]
 description = "Build and run the bundled Chatto stack with LiveKit and Mailpit"
-run = { tasks = ["chatto", "dev-livekit", "dev-mailpit"] }
+run = { tasks = ["chatto run", "dev-livekit", "dev-mailpit"] }
 
 # =============================================================================
 # Benchmarking


### PR DESCRIPTION
## Why

The generic `mise chatto` task accidentally hard-coded the `run` subcommand, causing commands such as `mise chatto version` to execute as `chatto run version`.

## What changed

Restore direct argument routing for `mise chatto <command>` while passing `run` explicitly from the server-only `dev-compiled` task.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise run --dry-run chatto version` resolves to `exec bin/chatto version`.
- `mise run --dry-run dev-compiled` resolves its Chatto task to `exec bin/chatto run`.
- `mise chatto version` completed successfully and reported `chatto version 0.4.8`.
- `git diff --check` passed.
