### PR TITLE
feat(frontend): unify interactive control styling

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -26,6 +26,19 @@ This order is a decision aid, not a ban on native elements. Specialized chat,
 media, menu, and toolbar controls often need native buttons combined with a
 semantic utility because their behavior is not a committed form action.
 
+## Selectable Record Collections
+
+Selectable or directly actionable records use the same inset-box treatment as
+message search results:
+
+- Use `selectable-list` on non-table collections and `selectable-list-item` on
+  each navigable, draggable, or directly actionable record.
+- Rows rest transparently on the owning `background` work plane. Hover and
+  keyboard focus rise exactly one level to `surface`; do not introduce ruled
+  separators or a stronger surface jump.
+- Each row owns its rounded shape. The collection owns only the 1px inset and
+  gap, so selections never merge into a single slab.
+
 ## Choosing A Primitive
 
 | Need                                      | Use                                                                        | Avoid                                                        |
@@ -34,6 +47,7 @@ semantic utility because their behavior is not a committed form action.
 | Form field                                | `TextInput`, `TextArea`, `Select`, `Combobox`, `Checkbox`, or `RangeField` | Raw controls unless the interaction is genuinely specialized |
 | One-of-many settings choice               | `ChoiceRow` inside a `radiogroup`                                          | Repeating indicator and selected-state markup                |
 | Compact one-of-many mode                  | `SegmentedControl`                                                         | Separate buttons or independently styled chips               |
+| Selectable non-table collection            | `selectable-list` and `selectable-list-item`                                | Feature-local hover recipes                            |
 | Modal form                                | `FormDialog`                                                               | A dialog containing an unrelated hand-rolled form footer     |
 | Confirmation                              | `ConfirmDialog`                                                            | A custom destructive modal                                   |
 | General dialog                            | `Dialog`; `BottomSheet` for touch-specific presentation                    | Fixed-position modal shells                                  |
@@ -129,13 +143,42 @@ recommended path and `neutral-action` for an emphasized control that should not
 compete with it. Retired `accent` and `primary` color utilities are rejected by
 the design-system guardrail.
 
+Focused form fields use the action colour for their border without an additional
+glow. Invalid fields follow the same treatment with the error-coloured border.
+
 Compact filled controls pair each tone with its `on-*` foreground token.
 Prominent action, success, warning, and danger buttons use dedicated fills with
-white labels. Light-theme action buttons share the friendly action blue; dark
-mode uses deeper button fills so white labels remain clear without darkening
-the brighter semantic tones used for links, focus rings, and status UI.
+white labels. The action colour is the single blue accent in each theme: primary
+buttons, links, focus borders, selection indicators, and compact status UI all
+derive from that same token rather than maintaining a separate button blue.
+Buttons frame their fills with a tight inset related to `SegmentedControl`.
+Prominent semantic buttons tint the outer border to match their fill; quieter
+secondary and ghost buttons retain the input-coloured border. The tight inset
+keeps a standalone button from looking double-framed. The frame is part of the
+standard button geometry: do not remove it from individual variants or reproduce
+it with feature-local wrappers.
+
+A one-pixel black outer ring keeps framed controls legible on mid-tone surfaces.
+Buttons, form inputs, and `SegmentedControl` share the `control-frame` utility,
+which owns their radius, one-pixel border, and non-layout outer ring. Individual
+controls only add semantic border colours and their appropriate inset treatment.
+
+Button frames and `SegmentedControl` use one pixel for both the outer border and
+the inset gap. Keep these dimensions aligned so adjacent controls share the same
+optical height and edge rhythm.
 
 Surfaces form a small semantic ladder:
+
+### Surface Escalation Rule — Mandatory
+
+> [!IMPORTANT]
+> **NEVER INCREASE A NESTED ELEMENT BY MORE THAN ONE SURFACE LEVEL.** A child on
+> `background` may use `surface`; a child on `surface` may use
+> `surface-emphasized`; a child on `surface-emphasized` may use
+> `surface-strong`. Never jump directly from `background` to
+> `surface-emphasized` or from `surface` to `surface-strong`. If one level does
+> not provide enough separation, add an appropriate border or revise the
+> surrounding composition instead of skipping a level.
 
 - Light and dark mode are intentionally asymmetric. Do not infer elevation by
   mechanically reversing luminance between themes.

--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -148,9 +148,11 @@ glow. Invalid fields follow the same treatment with the error-coloured border.
 
 Compact filled controls pair each tone with its `on-*` foreground token.
 Prominent action, success, warning, and danger buttons use dedicated fills with
-white labels. The action colour is the single blue accent in each theme: primary
-buttons, links, focus borders, selection indicators, and compact status UI all
-derive from that same token rather than maintaining a separate button blue.
+contrast-safe labels. The action colour is the single blue accent in each theme:
+primary buttons, links, focus borders, selection indicators, and compact status
+UI all derive from that same token rather than maintaining a separate button blue.
+Each theme's action token must retain WCAG AA contrast both as text on its
+surrounding work surfaces and with its paired `on-action` button label.
 Buttons frame their fills with a tight inset related to `SegmentedControl`.
 Prominent semantic buttons tint the outer border to match their fill; quieter
 secondary and ghost buttons retain the input-coloured border. The tight inset

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -60,17 +60,16 @@
   --color-input: var(--color-white);
   --color-input-border: var(--color-gray-300);
 
-  --color-action: var(--color-sky-700);
-  --color-action-hover: var(--color-sky-800);
-  --color-on-action: var(--color-white);
-  --color-button-action: color-mix(
+  --color-action: color-mix(
     in srgb,
     var(--color-sky-600),
     var(--color-sky-700) 35%
   );
+  --color-action-hover: color-mix(in srgb, var(--color-action), black 15%);
+  --color-on-action: var(--color-white);
   --color-button-success: var(--color-green-700);
   --color-button-warning: var(--color-amber-700);
-  --color-button-danger: var(--color-red-600);
+  --color-button-danger: var(--color-red-700);
   --color-neutral-action: var(--color-slate-600);
   --color-neutral-action-hover: var(--color-slate-700);
   --color-on-neutral-action: var(--color-white);
@@ -124,15 +123,12 @@
   --color-input: var(--color-neutral-950);
   --color-input-border: var(--color-neutral-700);
 
-  --color-action: var(--color-sky-400);
-  --color-action-hover: var(--color-sky-300);
-  --color-on-action: var(--color-neutral-950);
-  /* Prominent buttons use deeper fills with light labels. Keep the brighter
-     semantic tones above for links, focus rings, and compact status UI. */
-  --color-button-action: var(--color-sky-700);
+  --color-action: var(--color-sky-700);
+  --color-action-hover: color-mix(in srgb, var(--color-action), white 15%);
+  --color-on-action: var(--color-white);
   --color-button-success: var(--color-green-700);
   --color-button-warning: var(--color-amber-700);
-  --color-button-danger: var(--color-red-600);
+  --color-button-danger: var(--color-red-700);
   --color-neutral-action: var(--color-neutral-600);
   --color-neutral-action-hover: var(--color-neutral-500);
   --color-on-neutral-action: var(--color-white);
@@ -226,6 +222,18 @@
   @apply px-4 py-2.5 font-medium;
 }
 
+/* Selectable non-table collections use the same inset and rounded-row treatment.
+ * Records rest on their owner's background plane; hover or keyboard focus rises
+ * exactly one level.
+ */
+@utility selectable-list {
+  @apply flex flex-col gap-1 p-1;
+}
+
+@utility selectable-list-item {
+  @apply rounded-md transition-colors duration-100 hover:bg-surface focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-action;
+}
+
 /* Compact framed surface for inline rows inside forms, dialogs, and settings. */
 @utility surface-box {
   @apply rounded-md border border-border bg-surface-emphasized/60;
@@ -291,26 +299,35 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-/* Buttons are deliberately solid and compact. Tone communicates hierarchy;
- * subtle borders and pressed scale provide depth without decorative gradients.
+/* Buttons place their semantic fill inside framed, inset geometry related to
+ * SegmentedControl. The tight inset keeps solid actions from appearing
+ * optically larger than equally sized inputs without looking double-framed.
  */
+@utility control-frame {
+  @apply rounded-md border border-input-border;
+  box-shadow:
+    var(--control-inset-shadow, 0 0 #0000),
+    0 0 0 1px black;
+}
+
 @utility btn {
-  @apply inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-2 rounded-md px-4 py-2 font-medium;
+  @apply control-frame inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-2 px-4 py-1.5 font-medium;
   @apply transition-[background-color,border-color,color,box-shadow,scale] duration-150 active:scale-[0.97];
   @apply focus-visible:ring-2 focus-visible:ring-action/35 focus-visible:outline-none;
   @apply disabled:cursor-not-allowed disabled:opacity-50;
+  --control-inset-shadow: inset 0 0 0 1px var(--color-input);
 }
 
 @utility btn-neutral {
-  @apply btn bg-neutral-action text-on-neutral-action hover:bg-neutral-action-hover;
+  @apply btn border-neutral-action bg-neutral-action text-on-neutral-action hover:border-neutral-action-hover hover:bg-neutral-action-hover;
 }
 
 @utility btn-action {
-  @apply btn bg-(--color-button-action) text-white hover:bg-(--color-button-action)/90;
+  @apply btn border-action bg-action text-on-action hover:border-action/90 hover:bg-action/90;
 }
 
 @utility btn-success {
-  @apply btn bg-(--color-button-success) text-white hover:bg-(--color-button-success)/90;
+  @apply btn border-(--color-button-success) bg-(--color-button-success) text-white hover:border-(--color-button-success)/90 hover:bg-(--color-button-success)/90;
 }
 
 @utility btn-secondary {
@@ -322,11 +339,11 @@
 }
 
 @utility btn-warning {
-  @apply btn bg-(--color-button-warning) text-white hover:bg-(--color-button-warning)/90;
+  @apply btn border-(--color-button-warning) bg-(--color-button-warning) text-white hover:border-(--color-button-warning)/90 hover:bg-(--color-button-warning)/90;
 }
 
 @utility btn-danger {
-  @apply btn bg-(--color-button-danger) text-white hover:bg-(--color-button-danger)/90;
+  @apply btn border-(--color-button-danger) bg-(--color-button-danger) text-white hover:border-(--color-button-danger)/90 hover:bg-(--color-button-danger)/90;
 }
 
 /* Quiet destructive action: neutral at rest, destructive on hover/focus. */
@@ -366,11 +383,11 @@
 
 /* Form input utilities */
 @utility input {
-  @apply min-h-10 w-full rounded-md border border-input-border bg-input px-3 py-2 text-text;
+  @apply control-frame min-h-10 w-full bg-input px-3 py-1.5 text-text;
   @apply placeholder:text-muted/70;
-  @apply transition-[border-color,box-shadow] duration-100;
-  @apply focus:border-action focus:ring-2 focus:ring-action/30 focus:outline-none;
-  @apply aria-invalid:border-error aria-invalid:focus:ring-error/30;
+  @apply transition-colors duration-100;
+  @apply focus:border-action focus:outline-none;
+  @apply aria-invalid:border-error;
   @apply disabled:cursor-not-allowed disabled:opacity-60;
   @apply select-text; /* Re-enable text selection in form fields */
 }
@@ -406,7 +423,7 @@
 }
 
 @utility choice-row-selected {
-  @apply border-(--color-button-action) bg-(--color-button-action)/10 hover:border-(--color-button-action) hover:bg-(--color-button-action)/10;
+  @apply border-action bg-action/10 hover:border-action hover:bg-action/10;
 }
 
 @utility choice-indicator {
@@ -414,7 +431,7 @@
 }
 
 @utility choice-indicator-selected {
-  @apply border-(--color-button-action) bg-(--color-button-action);
+  @apply border-action bg-action;
 }
 
 @utility choice-indicator-dot {

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -60,11 +60,7 @@
   --color-input: var(--color-white);
   --color-input-border: var(--color-gray-300);
 
-  --color-action: color-mix(
-    in srgb,
-    var(--color-sky-600),
-    var(--color-sky-700) 35%
-  );
+  --color-action: var(--color-sky-700);
   --color-action-hover: color-mix(in srgb, var(--color-action), black 15%);
   --color-on-action: var(--color-white);
   --color-button-success: var(--color-green-700);
@@ -123,9 +119,9 @@
   --color-input: var(--color-neutral-950);
   --color-input-border: var(--color-neutral-700);
 
-  --color-action: var(--color-sky-700);
+  --color-action: var(--color-sky-400);
   --color-action-hover: color-mix(in srgb, var(--color-action), white 15%);
-  --color-on-action: var(--color-white);
+  --color-on-action: var(--color-neutral-950);
   --color-button-success: var(--color-green-700);
   --color-button-warning: var(--color-amber-700);
   --color-button-danger: var(--color-red-700);

--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -212,11 +212,7 @@ registry.
     serverId: serverSegment,
     roomId: room.id
   })}
-  <li
-    class="flex items-center gap-3 rounded-md px-3 py-1.5 transition-colors {joined
-      ? 'hover:bg-surface/70'
-      : ''}"
-  >
+  <li class="selectable-list-item flex items-center gap-3 px-3 py-1.5">
     {#snippet roomLabel()}
       <div class="flex min-w-0 items-start gap-2 font-medium">
         <span class="mt-0.5 shrink-0 text-muted/60">#</span>
@@ -310,7 +306,7 @@ registry.
 
       <!-- Horizontal inset (`px-1` + the menu-item's own `px-3` = 16px)
            keeps per-row actions aligned within the shared panel inset. -->
-      <ul class="flex flex-col gap-0.5 px-1 py-2">
+      <ul class="selectable-list py-2">
         {#each rooms as room (room.id)}
           {@render roomRow(room)}
         {/each}

--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -80,9 +80,8 @@ describe('RoomDirectory', () => {
     const joinedRow = [...container.querySelectorAll('li')].find((item) =>
       item.textContent?.includes('r1')
     ) as HTMLElement;
-    expect(joinedRow.className).toContain('rounded-md');
-    expect(joinedRow.className).toContain('hover:bg-surface/70');
-    expect(joinedRow.className).not.toContain('hover:bg-surface-emphasized');
+    expect(joinedRow.className).toContain('selectable-list-item');
+    expect(joinedRow.className).not.toContain('hover:bg-surface/70');
   });
 
   it('renders universal joined rooms without a leave action', () => {

--- a/apps/frontend/src/lib/ServerSettings.svelte
+++ b/apps/frontend/src/lib/ServerSettings.svelte
@@ -319,7 +319,7 @@
         />
         <!-- Logo Preview -->
         <div
-          class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-xl bg-surface-emphasized text-5xl font-black text-muted shadow-md"
+          class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-xl bg-surface text-5xl font-black text-muted shadow-md"
         >
           {#if logoUrl}
             <img

--- a/apps/frontend/src/lib/ui/ScrollArea.svelte
+++ b/apps/frontend/src/lib/ui/ScrollArea.svelte
@@ -41,7 +41,6 @@ primitive when a scroll viewport also needs edge fades.
     ...rest
   }: Props = $props();
 
-  let scrollProps = $derived({ tabindex: 0, ...rest });
 </script>
 
 <div class={['relative flex min-h-0 min-w-0 flex-col', fill && 'flex-1', className]}>
@@ -53,7 +52,7 @@ primitive when a scroll viewport also needs edge fades.
       scrollX ? 'overflow-x-auto' : 'overflow-x-hidden',
       scrollClass
     ]}
-    {...scrollProps}
+    {...rest}
   >
     {@render children()}
   </div>

--- a/apps/frontend/src/lib/ui/ScrollArea.svelte
+++ b/apps/frontend/src/lib/ui/ScrollArea.svelte
@@ -26,6 +26,8 @@ primitive when a scroll viewport also needs edge fades.
     scrollEl?: HTMLDivElement;
     /** Optional lifecycle attachment for the inner scroll container. */
     scrollAttachment?: Attachment<HTMLDivElement>;
+    /** Keep the scroll viewport in the tab order for keyboard scrolling. */
+    keyboardFocusable?: boolean;
     [key: string]: unknown;
   };
 
@@ -38,15 +40,21 @@ primitive when a scroll viewport also needs edge fades.
     scrollClass = '',
     scrollEl = $bindable(),
     scrollAttachment,
+    keyboardFocusable = true,
     ...rest
   }: Props = $props();
 
 </script>
 
 <div class={['relative flex min-h-0 min-w-0 flex-col', fill && 'flex-1', className]}>
+  <!-- A scroll viewport must be keyboard-focusable for WCAG 2.1. Svelte's
+       generic non-interactive tabindex warning does not model that exception. -->
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
     bind:this={scrollEl}
     {@attach scrollAttachment}
+    role={keyboardFocusable ? 'region' : undefined}
+    tabindex={keyboardFocusable ? 0 : undefined}
     class={[
       'flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto',
       scrollX ? 'overflow-x-auto' : 'overflow-x-hidden',

--- a/apps/frontend/src/lib/ui/ScrollArea.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ScrollArea.svelte.spec.ts
@@ -21,5 +21,18 @@ it('provides a native horizontal and vertical scroll viewport', () => {
   expect(scrollArea.className).toContain('overflow-x-auto');
   expect(scrollArea.className).toContain('overscroll-contain');
   expect(scrollArea.parentElement?.className).toContain('relative');
+  expect(scrollArea.tabIndex).toBe(0);
+});
+
+it('can stay out of the tab order when its content supplies navigation', () => {
+  const { container } = render(ScrollArea, {
+    props: {
+      children: testSnippet('<a href="/example">Focusable content</a>'),
+      keyboardFocusable: false,
+      'data-testid': 'scroll-area'
+    }
+  });
+
+  const scrollArea = container.querySelector<HTMLElement>('[data-testid="scroll-area"]')!;
   expect(scrollArea.hasAttribute('tabindex')).toBe(false);
 });

--- a/apps/frontend/src/lib/ui/ScrollArea.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ScrollArea.svelte.spec.ts
@@ -21,4 +21,5 @@ it('provides a native horizontal and vertical scroll viewport', () => {
   expect(scrollArea.className).toContain('overflow-x-auto');
   expect(scrollArea.className).toContain('overscroll-contain');
   expect(scrollArea.parentElement?.className).toContain('relative');
+  expect(scrollArea.hasAttribute('tabindex')).toBe(false);
 });

--- a/apps/frontend/src/lib/ui/ScrollFader.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.svelte
@@ -40,6 +40,8 @@ scroll container; children render inside the scroll container.
     scrollClass?: string;
     /** Bound to the inner scroll container so callers can reference it. */
     scrollEl?: HTMLDivElement;
+    /** Keep the scroll viewport in the tab order for keyboard scrolling. */
+    keyboardFocusable?: boolean;
     [key: string]: unknown;
   };
 
@@ -55,6 +57,7 @@ scroll container; children render inside the scroll container.
     class: className = '',
     scrollClass = '',
     scrollEl = $bindable(),
+    keyboardFocusable = true,
     ...rest
   }: Props = $props();
 
@@ -139,6 +142,7 @@ scroll container; children render inside the scroll container.
   class={className}
   {scrollClass}
   bind:scrollEl
+  {keyboardFocusable}
   scrollAttachment={trackScrollEdges}
   overlay={fades}
   {...rest}

--- a/apps/frontend/src/lib/ui/SegmentedControl.svelte
+++ b/apps/frontend/src/lib/ui/SegmentedControl.svelte
@@ -35,15 +35,15 @@ Use `ToggleChip` instead when choices can be toggled independently.
 
 <fieldset
   class={[
-    'inline-flex min-h-10 w-fit min-w-0 items-center rounded-md border border-input-border bg-input p-0.5',
+    'control-frame inline-flex h-10 w-fit min-w-0 items-center gap-px bg-input p-px',
     className
   ]}
   {disabled}
 >
   <legend class="sr-only">{label}</legend>
 
-  {#each options as option (option.value)}
-    <label class="relative min-w-0 cursor-pointer">
+  {#each options as option, index (option.value)}
+    <label class="relative flex min-w-0 cursor-pointer">
       <input
         class="peer absolute inset-0 z-10 m-0 h-full w-full cursor-pointer appearance-none rounded-full opacity-0 disabled:cursor-not-allowed"
         type="radio"
@@ -54,7 +54,11 @@ Use `ToggleChip` instead when choices can be toggled independently.
         onchange={() => onchange(option.value)}
       />
       <span
-        class="inline-flex min-h-9 min-w-10 items-center justify-center rounded px-3 text-sm font-medium text-muted transition-[background-color,color] duration-150 peer-checked:bg-surface-selected peer-checked:text-text-top peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-action peer-disabled:cursor-not-allowed peer-disabled:opacity-60 hover:bg-surface-emphasized hover:text-text"
+        class={[
+          'inline-flex min-h-9 min-w-10 items-center justify-center px-3 text-sm font-medium text-muted transition-[background-color,color] duration-150 peer-checked:bg-surface-selected peer-checked:text-text-top peer-[:not(:checked):hover]:bg-surface-emphasized/50 peer-[:not(:checked):hover]:text-text peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2 peer-focus-visible:outline-action peer-disabled:cursor-not-allowed peer-disabled:opacity-60',
+          index === 0 ? 'rounded-l' : '',
+          index === options.length - 1 ? 'rounded-r' : ''
+        ]}
       >
         {option.label}
       </span>

--- a/apps/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/apps/frontend/src/lib/ui/Utilities.stories.svelte
@@ -61,6 +61,44 @@
 </Story>
 
 <Story
+  name="selectable list"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          '`selectable-list` and `selectable-list-item` provide the canonical inset, independently rounded treatment for navigable or actionable records.'
+      }
+    }
+  }}
+>
+  <div class="max-w-md rounded-lg bg-background selectable-list">
+    <a href="https://example.com/alice" class="selectable-list-item flex items-center gap-3 p-3">
+      <span
+        class="grid h-10 w-10 shrink-0 place-items-center rounded-full bg-surface text-sm font-semibold"
+        >A</span
+      >
+      <span class="min-w-0 flex-1">
+        <span class="block truncate font-medium">Alice</span>
+        <span class="block truncate text-sm text-muted">@alice</span>
+      </span>
+      <span class="iconify text-muted uil--angle-right" aria-hidden="true"></span>
+    </a>
+    <a href="https://example.com/bob" class="selectable-list-item flex items-center gap-3 p-3">
+      <span
+        class="grid h-10 w-10 shrink-0 place-items-center rounded-full bg-surface text-sm font-semibold"
+        >B</span
+      >
+      <span class="min-w-0 flex-1">
+        <span class="block truncate font-medium">Bob</span>
+        <span class="block truncate text-sm text-muted">@bob</span>
+      </span>
+      <span class="iconify text-muted uil--angle-right" aria-hidden="true"></span>
+    </a>
+  </div>
+</Story>
+
+<Story
   name="link"
   asChild
   parameters={{

--- a/apps/frontend/src/lib/ui/form/TextInput.svelte
+++ b/apps/frontend/src/lib/ui/form/TextInput.svelte
@@ -74,7 +74,7 @@
       {autofocus}
       {onkeydown}
       {oninput}
-      class={['input', leadingIcon && 'pl-7', trailingText && 'pr-10']}
+      class={['input', leadingIcon && 'pl-8', trailingText && 'pr-10']}
       aria-invalid={error ? 'true' : undefined}
       aria-describedby={error ? `${id}-error` : description ? `${id}-description` : undefined}
     />

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -279,6 +279,7 @@ describe('ModalContainer sign out modal', () => {
     expect(
       [...container.querySelectorAll('button')].map((button) => button.textContent?.trim())
     ).toEqual(['Cancel', 'Current Server', 'All Servers']);
+    expect(findButton(container, 'All Servers').dataset.variant).toBe('danger');
   });
 
   it('signs out of only the active remote server', async () => {

--- a/apps/frontend/src/routes/chat/ModalContainerButtonMock.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainerButtonMock.svelte
@@ -8,17 +8,25 @@ Tiny test double for form Button used by ModalContainer specs.
 
   let {
     children,
+    variant,
     disabled = false,
     loading = false,
     onclick
   }: {
     children: Snippet;
+    variant?: string;
     disabled?: boolean;
     loading?: boolean;
     onclick?: (e: MouseEvent) => void;
   } = $props();
 </script>
 
-<button type="button" disabled={disabled || loading} aria-busy={loading || undefined} {onclick}>
+<button
+  type="button"
+  data-variant={variant}
+  disabled={disabled || loading}
+  aria-busy={loading || undefined}
+  {onclick}
+>
   {@render children()}
 </button>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte
@@ -468,7 +468,7 @@
 
             <div class="px-1 pb-1">
               <div
-                class="min-h-12 overflow-hidden panel-inset p-2"
+                class="min-h-12 overflow-hidden panel-inset selectable-list"
                 use:dragHandleZone={{
                   items: group.items,
                   flipDurationMs: 200,
@@ -487,7 +487,7 @@
                   <div
                     animate:flip={{ duration: 200 }}
                     class={[
-                      'group flex cursor-grab items-center gap-3 rounded-lg py-2 pr-2 pl-3 hover:bg-surface',
+                      'group selectable-list-item flex cursor-grab items-center gap-3 py-2 pr-2 pl-3',
                       room.kind === 'room' && room.room.archived && 'opacity-60'
                     ]}
                   >

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -58,6 +58,12 @@ in the active server store so browser Back can restore the current search.
     const trimmed = store.query.trim();
     if (!trimmed || !store.available) return;
     void store.search({ query: trimmed, order: store.order });
+
+    const queryInput = (event.currentTarget as HTMLFormElement).querySelector<HTMLInputElement>(
+      'input[type="text"]'
+    );
+    queryInput?.focus({ preventScroll: true });
+    queryInput?.select();
   }
 
   function setOrder(nextOrder: MessageSearchOrder): void {
@@ -199,7 +205,7 @@ in the active server store so browser Back can restore the current search.
                 autofocus
               />
             </div>
-            <Button type="submit" disabled={!store.query.trim()} loading={store.loading}>
+            <Button type="submit" disabled={!store.query.trim()}>
               {m['search.action']()}
             </Button>
             <SegmentedControl
@@ -220,17 +226,14 @@ in the active server store so browser Back can restore the current search.
         <Panel title={m['search.results']()} noPadding fillHeight>
           <ScrollFader top bottom class="min-h-0 flex-1">
             <div class="flex min-h-full flex-col" aria-live="polite">
-              {#if store.loading}
-                <div class="flex flex-1 items-center justify-center text-muted">
-                  <span class="mr-2 iconify animate-spin uil--spinner-alt" aria-hidden="true"
-                  ></span>
-                  {m['search.searching']()}
-                </div>
-              {:else if store.error}
+              {#if store.error}
                 <EmptyState icon="uil--exclamation-triangle" title={m['search.error.title']()}>
                   {m['search.error.description']()}
                 </EmptyState>
-              {:else if store.hasSearched && store.results.length === 0 && !store.nextCursor}
+              {:else if store.hasSearched &&
+                !store.loading &&
+                store.results.length === 0 &&
+                !store.nextCursor}
                 <EmptyState icon="uil--search-minus" title={m['search.no_results.title']()}>
                   {m['search.no_results.description']()}
                 </EmptyState>
@@ -239,14 +242,14 @@ in the active server store so browser Back can restore the current search.
                   {m['search.prompt.description']()}
                 </EmptyState>
               {:else}
-                <ol class="flex flex-col gap-4 p-1">
+                <ol class="selectable-list gap-4">
                   {#each store.results as result (result.id)}
                     <li>
                       <div
                         role="link"
                         tabindex="0"
                         data-search-result-id={result.id}
-                        class="cursor-pointer rounded-md focus-visible:outline-2 focus-visible:outline-action"
+                        class="selectable-list-item cursor-pointer"
                         onclick={(event) => openResult(event, result)}
                         onkeydown={(event) => openResultFromKeyboard(event, result)}
                       >
@@ -260,7 +263,7 @@ in the active server store so browser Back can restore the current search.
                           body={result.body}
                           timestampSettings={timeFormatSettings}
                           timestampLocale={activeLocale}
-                          rowClass="md:mx-0 md:pr-2"
+                          rowClass="hover:bg-transparent md:mx-0 md:pr-2"
                         >
                           {#snippet headerMeta()}
                             <a

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -224,7 +224,7 @@ in the active server store so browser Back can restore the current search.
         </Panel>
 
         <Panel title={m['search.results']()} noPadding fillHeight>
-          <ScrollFader top bottom class="min-h-0 flex-1">
+          <ScrollFader top bottom keyboardFocusable={false} class="min-h-0 flex-1">
             <div class="flex min-h-full flex-col" aria-live="polite">
               {#if store.error}
                 <EmptyState icon="uil--exclamation-triangle" title={m['search.error.title']()}>

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -107,6 +107,19 @@ describe('message search page', () => {
       query: 'motherfucking search',
       order: MessageSearchOrder.RELEVANCE
     });
+    expect(document.activeElement).toBe(input);
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
+
+    await userEvent.type(input, 'replacement query');
+    await userEvent.keyboard('{Enter}');
+
+    expect(mocks.search).toHaveBeenLastCalledWith({
+      query: 'replacement query',
+      order: MessageSearchOrder.RELEVANCE
+    });
+    expect(input.selectionStart).toBe(0);
+    expect(input.selectionEnd).toBe(input.value.length);
   });
 
   it('switches form state when SvelteKit reuses the page for another server', async () => {


### PR DESCRIPTION
## Why

Interactive controls and selectable non-table records used inconsistent framing, spacing, colour, and focus treatments, making equally sized controls feel visually mismatched.

## What changed

- Consolidates accessible action colours and framed button/input/segmented-control geometry, removes input focus glow, refines danger colour, and documents the one-level surface escalation rule.
- Adds shared selectable-list utilities with Storybook coverage, applies them to room navigation and room layout editing, aligns server artwork placeholders, and keeps the search-results scroll frame out of the tab order while preserving keyboard access for shared scroll regions by default.
- Keeps search results visible while loading, selects the query after submission for immediate replacement, removes the button spinner, and increases search-icon spacing.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Unchanged.

Newer client → older server: Unchanged.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise lint-frontend` — passed, including design-system guardrails, ESLint, and Svelte checks with 0 errors and 0 warnings.
- `mise test-frontend` — 285 files and 2,446 tests passed.
- `pnpm exec playwright test e2e/accessibility.test.ts` — all four tests passed; the mobile target-size check passed on retry after one unrelated flaky attempt.
- Storybook visual review completed for the updated control and selectable-list states in light and dark themes.
