### PR TITLE
feat(rooms): manage channel room members

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/community-structure.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/community-structure.mdx
@@ -50,6 +50,12 @@ Universal rooms do not write one membership record per user. Chatto derives effe
   Members cannot leave a universal room. Tell members to mute noisy universal rooms instead of trying to leave them.
 </Aside>
 
+## Explicit Room Members
+
+Use explicit membership for private or opt-in channel rooms. Open **Server Admin → Rooms**, select the room, and use its **Members** section to search the server directory, add a user, or remove an existing member with confirmation. You need effective `room.manage` permission for that room.
+
+Explicit membership can grant access independently of `room.list` and `room.join`. Review the member list when tightening a room's permissions, because denying discovery or self-join does not remove people who are already explicit members. Membership cannot be edited while the room is archived. Universal rooms derive membership automatically and therefore do not expose add or remove controls.
+
 ## Permissions Strategy
 
 Start broad and add local exceptions:

--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -81,7 +81,7 @@ Room-relevant permissions such as `message.post`, `message.attach`, `message.rea
 | `room.list`               | See rooms in the directory and room lists.                                                                                                                                      |
 | `room.join`               | Join channel rooms.                                                                                                                                                             |
 | `room.create`             | Create channel rooms.                                                                                                                                                           |
-| `room.manage`             | Configure, rename, archive, or delete rooms and room groups at the effective scope. A server-scope grant also permits global room-group creation and ordering.                  |
+| `room.manage`             | Configure, rename, archive, or delete rooms and room groups at the effective scope, including explicit channel-room membership. A server-scope grant also permits global room-group creation and ordering. |
 | `room.ban-member`         | Ban members from channel rooms.                                                                                                                                                 |
 | `role.manage`             | Configure role definitions and role permission decisions, including room and room-group overrides.                                                                              |
 | `role.assign`             | Assign or revoke roles for users. Non-owners can only manage roles whose explicit scoped decisions are within their own authority; the `owner` role is owner-only.              |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -299,8 +299,8 @@ Result of leaving a room.
 
 ### ListMembers
 
-Lists effective room members. Existing members may list their room;
-nonmembers of a channel room need both room.list and room.join.
+Lists effective room members. Existing members and room.manage holders may
+list a channel room; other nonmembers need both room.list and room.join.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/ListMembers
@@ -314,7 +314,7 @@ Request for members of one room.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `room_id` | `string` | Required. Room whose effective members should be listed. Existing members may list their room; nonmembers of a channel room need both room.list and room.join. |
+| `room_id` | `string` | Required. Room whose effective members should be listed. Existing members and room.manage holders may list a channel room; other nonmembers need both room.list and room.join. |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
 | `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 250 results when absent or limit is zero. |
 
@@ -335,8 +335,9 @@ Room member page.
 
 ### GetMember
 
-Gets one explicit member of a room. The caller must be a member of the
-room. Returns NOT_FOUND when the target is unknown or not a room member.
+Gets one explicit member of a room. Existing members and room.manage
+holders may read channel-room members; DMs remain membership-only. Returns
+NOT_FOUND when the target is unknown or not a room member.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/GetMember
@@ -369,8 +370,9 @@ Room member response.
 
 ### BatchGetMembers
 
-Gets explicit room member rows for multiple users. The caller must be a
-member of the room.
+Gets explicit room member rows for multiple users. Existing members and
+room.manage holders may read channel-room members; DMs remain
+membership-only.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/BatchGetMembers

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -47,7 +47,7 @@ has not declared a lower bound for the bundled Chatto web client.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `protocol_capabilities` | `repeated string` | Stable protocol capability keys supported by this server. Current keys: `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`, `chatto.admin.v1`, `chatto.api.message-search.v1`, `chatto.realtime.v1`, and `chatto.realtime.projection.v1`. |
+| `protocol_capabilities` | `repeated string` | Stable protocol capability keys supported by this server. Current keys: `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`, `chatto.admin.v1`, `chatto.api.message-search.v1`, `chatto.api.room-manager-member-reads.v1`, `chatto.realtime.v1`, and `chatto.realtime.projection.v1`. |
 | `minimum_web_client_version` | `optional string` | Oldest bundled Chatto web-client version this server supports, when a lower bound is required. Third-party clients should use capabilities. |
 
 <a id="chatto-api-v1-ImageTransformOptions"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1717,8 +1717,8 @@ Result of leaving a room.
 
 ### ListMembers
 
-Lists effective room members. Existing members may list their room;
-nonmembers of a channel room need both room.list and room.join.
+Lists effective room members. Existing members and room.manage holders may
+list a channel room; other nonmembers need both room.list and room.join.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/ListMembers
@@ -1732,7 +1732,7 @@ Request for members of one room.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `room_id` | `string` | Required. Room whose effective members should be listed. Existing members may list their room; nonmembers of a channel room need both room.list and room.join. |
+| `room_id` | `string` | Required. Room whose effective members should be listed. Existing members and room.manage holders may list a channel room; other nonmembers need both room.list and room.join. |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
 | `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 250 results when absent or limit is zero. |
 
@@ -1753,8 +1753,9 @@ Room member page.
 
 ### GetMember
 
-Gets one explicit member of a room. The caller must be a member of the
-room. Returns NOT_FOUND when the target is unknown or not a room member.
+Gets one explicit member of a room. Existing members and room.manage
+holders may read channel-room members; DMs remain membership-only. Returns
+NOT_FOUND when the target is unknown or not a room member.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/GetMember
@@ -1787,8 +1788,9 @@ Room member response.
 
 ### BatchGetMembers
 
-Gets explicit room member rows for multiple users. The caller must be a
-member of the room.
+Gets explicit room member rows for multiple users. Existing members and
+room.manage holders may read channel-room members; DMs remain
+membership-only.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/BatchGetMembers

--- a/apps/docs-website/src/generated/connectrpc-api/discovery.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/discovery.raw.mdx
@@ -70,5 +70,5 @@ has not declared a lower bound for the bundled Chatto web client.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `protocol_capabilities` | `repeated string` | Stable protocol capability keys supported by this server. Current keys: `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`, `chatto.admin.v1`, `chatto.api.message-search.v1`, `chatto.realtime.v1`, and `chatto.realtime.projection.v1`. |
+| `protocol_capabilities` | `repeated string` | Stable protocol capability keys supported by this server. Current keys: `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`, `chatto.admin.v1`, `chatto.api.message-search.v1`, `chatto.api.room-manager-member-reads.v1`, `chatto.realtime.v1`, and `chatto.realtime.projection.v1`. |
 | `minimum_web_client_version` | `optional string` | Oldest bundled Chatto web-client version this server supports, when a lower bound is required. Third-party clients should use capabilities. |

--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -47,7 +47,7 @@ message search results:
 | Form field                                | `TextInput`, `TextArea`, `Select`, `Combobox`, `Checkbox`, or `RangeField` | Raw controls unless the interaction is genuinely specialized |
 | One-of-many settings choice               | `ChoiceRow` inside a `radiogroup`                                          | Repeating indicator and selected-state markup                |
 | Compact one-of-many mode                  | `SegmentedControl`                                                         | Separate buttons or independently styled chips               |
-| Selectable non-table collection            | `selectable-list` and `selectable-list-item`                                | Feature-local hover recipes                            |
+| Selectable non-table collection           | `selectable-list` and `selectable-list-item`                               | Feature-local hover recipes                                  |
 | Modal form                                | `FormDialog`                                                               | A dialog containing an unrelated hand-rolled form footer     |
 | Confirmation                              | `ConfirmDialog`                                                            | A custom destructive modal                                   |
 | General dialog                            | `Dialog`; `BottomSheet` for touch-specific presentation                    | Fixed-position modal shells                                  |
@@ -211,10 +211,14 @@ the frame gap from visually adding to the title band's bottom padding. Untitled
 edge-to-edge panels use the same rule so the gap does not add to a table header's
 top padding. Untitled padded panels retain `p-1`. Custom shells such as draggable
 room groups must compose the same structure instead of approximating it.
-`DataTable` owns only its scrollable table viewport. Dense matrices may keep an
-intrinsic content width inside it; ordinary record tables fill it. Standard
-record-table headings use `table-header-cell`; matrix headings remain bespoke
-because their vertical labels have different spatial needs.
+`DataTable` owns only its scrollable table viewport and keeps a radius when used
+standalone or inside padded content. Inside `Panel noPadding`, the panel owns the
+single outer radius and clipping boundary: the table viewport becomes square so
+preceding controls or notices meet its header without an inset corner. Do not
+add feature-local radius overrides for this composition. Dense matrices may keep
+an intrinsic content width inside the viewport; ordinary record tables fill it.
+Standard record-table headings use `table-header-cell`; matrix headings remain
+bespoke because their vertical labels have different spatial needs.
 
 Panel title bands use `px-6 py-3`. The horizontal inset aligns titles with
 `p-5` panel content after accounting for the frame, while keeping the band

--- a/apps/frontend/messages/de-AT/admin.json
+++ b/apps/frontend/messages/de-AT/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Raum konnte nicht archiviert werden: {error}",
       "unarchive_room_failed": "Raum konnte nicht wiederhergestellt werden: {error}",
       "save_link_failed": "Link konnte nicht gespeichert werden: {error}",
-      "delete_link_failed": "Link konnte nicht gelöscht werden: {error}"
+      "delete_link_failed": "Link konnte nicht gelöscht werden: {error}",
+      "universal_members_description": "Die Mitgliedschaft in universellen Räumen erfolgt automatisch. Alle Personen mit Zugriffsberechtigung für diesen Raum sind enthalten.",
+      "archived_members_description": "Die Mitgliedschaft kann nicht geändert werden, solange dieser Raum archiviert ist.",
+      "add_member": "Mitglied hinzufügen",
+      "adding_member": "Mitglied wird hinzugefügt...",
+      "load_members_failed": "Raummitglieder konnten nicht geladen werden: {error}",
+      "remove_member": "Mitglied entfernen",
+      "remove_member_prompt": "{name} aus {room} entfernen? Die Person ist dann kein ausdrückliches Mitglied dieses Raums mehr.",
+      "member_added": "{name} wurde dem Raum hinzugefügt",
+      "add_member_failed": "Mitglied konnte nicht hinzugefügt werden: {error}",
+      "member_removed": "{name} wurde aus dem Raum entfernt",
+      "remove_member_failed": "Mitglied konnte nicht entfernt werden: {error}"
     },
     "security": {
       "title": "Sicherheit",

--- a/apps/frontend/messages/de-CH/admin.json
+++ b/apps/frontend/messages/de-CH/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Raum konnte nicht archiviert werden: {error}",
       "unarchive_room_failed": "Raum konnte nicht wiederhergestellt werden: {error}",
       "save_link_failed": "Link konnte nicht gespeichert werden: {error}",
-      "delete_link_failed": "Link konnte nicht gelöscht werden: {error}"
+      "delete_link_failed": "Link konnte nicht gelöscht werden: {error}",
+      "universal_members_description": "Die Mitgliedschaft in universellen Räumen erfolgt automatisch. Alle Personen mit Zugriffsberechtigung für diesen Raum sind enthalten.",
+      "archived_members_description": "Die Mitgliedschaft kann nicht geändert werden, solange dieser Raum archiviert ist.",
+      "add_member": "Mitglied hinzufügen",
+      "adding_member": "Mitglied wird hinzugefügt...",
+      "load_members_failed": "Raummitglieder konnten nicht geladen werden: {error}",
+      "remove_member": "Mitglied entfernen",
+      "remove_member_prompt": "{name} aus {room} entfernen? Die Person ist dann kein ausdrückliches Mitglied dieses Raums mehr.",
+      "member_added": "{name} wurde dem Raum hinzugefügt",
+      "add_member_failed": "Mitglied konnte nicht hinzugefügt werden: {error}",
+      "member_removed": "{name} wurde aus dem Raum entfernt",
+      "remove_member_failed": "Mitglied konnte nicht entfernt werden: {error}"
     },
     "security": {
       "title": "Sicherheit",

--- a/apps/frontend/messages/de-DE/admin.json
+++ b/apps/frontend/messages/de-DE/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Raum konnte nicht archiviert werden: {error}",
       "unarchive_room_failed": "Raum konnte nicht wiederhergestellt werden: {error}",
       "save_link_failed": "Link konnte nicht gespeichert werden: {error}",
-      "delete_link_failed": "Link konnte nicht gelöscht werden: {error}"
+      "delete_link_failed": "Link konnte nicht gelöscht werden: {error}",
+      "universal_members_description": "Die Mitgliedschaft in universellen Räumen erfolgt automatisch. Alle Personen mit Zugriffsberechtigung für diesen Raum sind enthalten.",
+      "archived_members_description": "Die Mitgliedschaft kann nicht geändert werden, solange dieser Raum archiviert ist.",
+      "add_member": "Mitglied hinzufügen",
+      "adding_member": "Mitglied wird hinzugefügt...",
+      "load_members_failed": "Raummitglieder konnten nicht geladen werden: {error}",
+      "remove_member": "Mitglied entfernen",
+      "remove_member_prompt": "{name} aus {room} entfernen? Die Person ist dann kein ausdrückliches Mitglied dieses Raums mehr.",
+      "member_added": "{name} wurde dem Raum hinzugefügt",
+      "add_member_failed": "Mitglied konnte nicht hinzugefügt werden: {error}",
+      "member_removed": "{name} wurde aus dem Raum entfernt",
+      "remove_member_failed": "Mitglied konnte nicht entfernt werden: {error}"
     },
     "security": {
       "title": "Sicherheit",

--- a/apps/frontend/messages/en-GB/admin.json
+++ b/apps/frontend/messages/en-GB/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Failed to archive room: {error}",
       "unarchive_room_failed": "Failed to unarchive room: {error}",
       "save_link_failed": "Failed to save link: {error}",
-      "delete_link_failed": "Failed to delete link: {error}"
+      "delete_link_failed": "Failed to delete link: {error}",
+      "universal_members_description": "Membership is automatic in Universal rooms. Everyone with permission to access this room is included.",
+      "archived_members_description": "Membership cannot be changed while this room is archived.",
+      "add_member": "Add member",
+      "adding_member": "Adding member...",
+      "load_members_failed": "Failed to load room members: {error}",
+      "remove_member": "Remove member",
+      "remove_member_prompt": "Remove {name} from {room}? They will no longer be an explicit member of this room.",
+      "member_added": "Added {name} to the room",
+      "add_member_failed": "Failed to add member: {error}",
+      "member_removed": "Removed {name} from the room",
+      "remove_member_failed": "Failed to remove member: {error}"
     },
     "security": {
       "title": "Security",

--- a/apps/frontend/messages/eo/admin.json
+++ b/apps/frontend/messages/eo/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Malsukcesis arkivi ĉambron: {error}",
       "unarchive_room_failed": "Malsukcesis malarkivi ĉambron: {error}",
       "save_link_failed": "Malsukcesis konservi ligilon: {error}",
-      "delete_link_failed": "Malsukcesis forigi ligilon: {error}"
+      "delete_link_failed": "Malsukcesis forigi ligilon: {error}",
+      "universal_members_description": "Membreco estas aŭtomata en universalaj ĉambroj. Ĉiu kun permeso aliri ĉi tiun ĉambron estas inkluzivita.",
+      "archived_members_description": "Membreco ne povas esti ŝanĝita dum ĉi tiu ĉambro estas arkivita.",
+      "add_member": "Aldoni membron",
+      "adding_member": "Aldonante membron...",
+      "load_members_failed": "Malsukcesis ŝargi ĉambromembrojn: {error}",
+      "remove_member": "Forigi membron",
+      "remove_member_prompt": "Ĉu forigi {name} el {room}? Tiu persono ne plu estos eksplicita membro de ĉi tiu ĉambro.",
+      "member_added": "{name} estis aldonita al la ĉambro",
+      "add_member_failed": "Malsukcesis aldoni membron: {error}",
+      "member_removed": "{name} estis forigita el la ĉambro",
+      "remove_member_failed": "Malsukcesis forigi membron: {error}"
     },
     "security": {
       "title": "Sekureco",

--- a/apps/frontend/messages/es-419/admin.json
+++ b/apps/frontend/messages/es-419/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "No se pudo archivar la sala: {error}",
       "unarchive_room_failed": "No se pudo desarchivar la sala: {error}",
       "save_link_failed": "No se pudo guardar el enlace: {error}",
-      "delete_link_failed": "No se pudo eliminar el enlace: {error}"
+      "delete_link_failed": "No se pudo eliminar el enlace: {error}",
+      "universal_members_description": "La membresía es automática en las salas universales. Se incluye a toda persona con permiso para acceder a esta sala.",
+      "archived_members_description": "No se puede cambiar la membresía mientras esta sala esté archivada.",
+      "add_member": "Agregar miembro",
+      "adding_member": "Agregando miembro...",
+      "load_members_failed": "No se pudieron cargar los miembros de la sala: {error}",
+      "remove_member": "Quitar miembro",
+      "remove_member_prompt": "¿Quitar a {name} de {room}? Dejará de ser miembro explícito de esta sala.",
+      "member_added": "Se agregó a {name} a la sala",
+      "add_member_failed": "No se pudo agregar al miembro: {error}",
+      "member_removed": "Se quitó a {name} de la sala",
+      "remove_member_failed": "No se pudo quitar al miembro: {error}"
     },
     "security": {
       "title": "Seguridad",

--- a/apps/frontend/messages/es-ES/admin.json
+++ b/apps/frontend/messages/es-ES/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "No se pudo archivar la sala: {error}",
       "unarchive_room_failed": "No se pudo desarchivar la sala: {error}",
       "save_link_failed": "No se pudo guardar el enlace: {error}",
-      "delete_link_failed": "No se pudo eliminar el enlace: {error}"
+      "delete_link_failed": "No se pudo eliminar el enlace: {error}",
+      "universal_members_description": "La pertenencia es automática en las salas universales. Se incluye a toda persona con permiso para acceder a esta sala.",
+      "archived_members_description": "No se puede cambiar la pertenencia mientras esta sala esté archivada.",
+      "add_member": "Añadir miembro",
+      "adding_member": "Añadiendo miembro...",
+      "load_members_failed": "No se pudieron cargar los miembros de la sala: {error}",
+      "remove_member": "Quitar miembro",
+      "remove_member_prompt": "¿Quitar a {name} de {room}? Dejará de ser miembro explícito de esta sala.",
+      "member_added": "Se añadió a {name} a la sala",
+      "add_member_failed": "No se pudo añadir al miembro: {error}",
+      "member_removed": "Se quitó a {name} de la sala",
+      "remove_member_failed": "No se pudo quitar al miembro: {error}"
     },
     "security": {
       "title": "Seguridad",

--- a/apps/frontend/messages/fr-CA/admin.json
+++ b/apps/frontend/messages/fr-CA/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Échec de l'archivage de la salle : {error}",
       "unarchive_room_failed": "Échec de la désarchive de la salle : {error}",
       "save_link_failed": "Échec de l'enregistrement du lien : {error}",
-      "delete_link_failed": "Échec de la suppression du lien : {error}"
+      "delete_link_failed": "Échec de la suppression du lien : {error}",
+      "universal_members_description": "L’adhésion est automatique dans les salons universels. Toute personne autorisée à accéder à ce salon en fait partie.",
+      "archived_members_description": "L’adhésion ne peut pas être modifiée tant que ce salon est archivé.",
+      "add_member": "Ajouter un membre",
+      "adding_member": "Ajout du membre...",
+      "load_members_failed": "Échec du chargement des membres du salon : {error}",
+      "remove_member": "Retirer le membre",
+      "remove_member_prompt": "Retirer {name} de {room} ? Cette personne ne sera plus membre explicite de ce salon.",
+      "member_added": "{name} a été ajouté au salon",
+      "add_member_failed": "Échec de l’ajout du membre : {error}",
+      "member_removed": "{name} a été retiré du salon",
+      "remove_member_failed": "Échec du retrait du membre : {error}"
     },
     "security": {
       "title": "Sécurité",

--- a/apps/frontend/messages/fr-FR/admin.json
+++ b/apps/frontend/messages/fr-FR/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Échec de l'archivage de la salle : {error}",
       "unarchive_room_failed": "Échec de la désarchive de la salle : {error}",
       "save_link_failed": "Échec de l'enregistrement du lien : {error}",
-      "delete_link_failed": "Échec de la suppression du lien : {error}"
+      "delete_link_failed": "Échec de la suppression du lien : {error}",
+      "universal_members_description": "L’adhésion est automatique dans les salons universels. Toute personne autorisée à accéder à ce salon en fait partie.",
+      "archived_members_description": "L’adhésion ne peut pas être modifiée tant que ce salon est archivé.",
+      "add_member": "Ajouter un membre",
+      "adding_member": "Ajout du membre...",
+      "load_members_failed": "Échec du chargement des membres du salon : {error}",
+      "remove_member": "Retirer le membre",
+      "remove_member_prompt": "Retirer {name} de {room} ? Cette personne ne sera plus membre explicite de ce salon.",
+      "member_added": "{name} a été ajouté au salon",
+      "add_member_failed": "Échec de l’ajout du membre : {error}",
+      "member_removed": "{name} a été retiré du salon",
+      "remove_member_failed": "Échec du retrait du membre : {error}"
     },
     "security": {
       "title": "Sécurité",

--- a/apps/frontend/messages/ja-JP/admin.json
+++ b/apps/frontend/messages/ja-JP/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "ルームのアーカイブに失敗しました: {error}",
       "unarchive_room_failed": "ルームのアーカイブを解除できませんでした: {error}",
       "save_link_failed": "リンクの保存に失敗しました: {error}",
-      "delete_link_failed": "リンクの削除に失敗しました: {error}"
+      "delete_link_failed": "リンクの削除に失敗しました: {error}",
+      "universal_members_description": "ユニバーサルルームのメンバーシップは自動です。このルームへのアクセス権限を持つ全員が含まれます。",
+      "archived_members_description": "このルームがアーカイブされている間はメンバーシップを変更できません。",
+      "add_member": "メンバーを追加",
+      "adding_member": "メンバーを追加中...",
+      "load_members_failed": "ルームメンバーの読み込みに失敗しました: {error}",
+      "remove_member": "メンバーを削除",
+      "remove_member_prompt": "{name}を{room}から削除しますか？このルームの明示的なメンバーではなくなります。",
+      "member_added": "{name}をルームに追加しました",
+      "add_member_failed": "メンバーの追加に失敗しました: {error}",
+      "member_removed": "{name}をルームから削除しました",
+      "remove_member_failed": "メンバーの削除に失敗しました: {error}"
     },
     "security": {
       "title": "セキュリティ",

--- a/apps/frontend/messages/nb-NO/admin.json
+++ b/apps/frontend/messages/nb-NO/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Kunne ikke arkivere rommet: {error}",
       "unarchive_room_failed": "Kunne ikke dearkivere rom: {error}",
       "save_link_failed": "Kunne ikke lagre koblingen: {error}",
-      "delete_link_failed": "Kunne ikke slette linken: {error}"
+      "delete_link_failed": "Kunne ikke slette linken: {error}",
+      "universal_members_description": "Medlemskap er automatisk i universelle rom. Alle med tilgang til rommet blir inkludert.",
+      "archived_members_description": "Medlemskapet kan ikke endres mens rommet er arkivert.",
+      "add_member": "Legg til medlem",
+      "adding_member": "Legger til medlem...",
+      "load_members_failed": "Kunne ikke laste rommedlemmer: {error}",
+      "remove_member": "Fjern medlem",
+      "remove_member_prompt": "Fjerne {name} fra {room}? Personen vil ikke lenger være eksplisitt medlem av rommet.",
+      "member_added": "{name} ble lagt til i rommet",
+      "add_member_failed": "Kunne ikke legge til medlemmet: {error}",
+      "member_removed": "{name} ble fjernet fra rommet",
+      "remove_member_failed": "Kunne ikke fjerne medlemmet: {error}"
     },
     "security": {
       "title": "Sikkerhet",

--- a/apps/frontend/messages/nl-BE/admin.json
+++ b/apps/frontend/messages/nl-BE/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Kan ruimte niet archiveren: {error}",
       "unarchive_room_failed": "Kan kamer niet uit het archief halen: {error}",
       "save_link_failed": "Kan link niet opslaan: {error}",
-      "delete_link_failed": "Kan link niet verwijderen: {error}"
+      "delete_link_failed": "Kan link niet verwijderen: {error}",
+      "universal_members_description": "Lidmaatschap is automatisch in universele ruimtes. Iedereen met toegang tot deze ruimte wordt opgenomen.",
+      "archived_members_description": "Het lidmaatschap kan niet worden gewijzigd zolang deze ruimte is gearchiveerd.",
+      "add_member": "Lid toevoegen",
+      "adding_member": "Lid wordt toegevoegd...",
+      "load_members_failed": "Kan ruimteleden niet laden: {error}",
+      "remove_member": "Lid verwijderen",
+      "remove_member_prompt": "{name} uit {room} verwijderen? Deze persoon is dan niet langer expliciet lid van deze ruimte.",
+      "member_added": "{name} is aan de ruimte toegevoegd",
+      "add_member_failed": "Kan lid niet toevoegen: {error}",
+      "member_removed": "{name} is uit de ruimte verwijderd",
+      "remove_member_failed": "Kan lid niet verwijderen: {error}"
     },
     "security": {
       "title": "Beveiliging",

--- a/apps/frontend/messages/nl-NL/admin.json
+++ b/apps/frontend/messages/nl-NL/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Kan ruimte niet archiveren: {error}",
       "unarchive_room_failed": "Kan kamer niet uit het archief halen: {error}",
       "save_link_failed": "Kan link niet opslaan: {error}",
-      "delete_link_failed": "Kan link niet verwijderen: {error}"
+      "delete_link_failed": "Kan link niet verwijderen: {error}",
+      "universal_members_description": "Lidmaatschap is automatisch in universele ruimtes. Iedereen met toegang tot deze ruimte wordt opgenomen.",
+      "archived_members_description": "Het lidmaatschap kan niet worden gewijzigd zolang deze ruimte is gearchiveerd.",
+      "add_member": "Lid toevoegen",
+      "adding_member": "Lid wordt toegevoegd...",
+      "load_members_failed": "Kan ruimteleden niet laden: {error}",
+      "remove_member": "Lid verwijderen",
+      "remove_member_prompt": "{name} uit {room} verwijderen? Deze persoon is dan niet langer expliciet lid van deze ruimte.",
+      "member_added": "{name} is aan de ruimte toegevoegd",
+      "add_member_failed": "Kan lid niet toevoegen: {error}",
+      "member_removed": "{name} is uit de ruimte verwijderd",
+      "remove_member_failed": "Kan lid niet verwijderen: {error}"
     },
     "security": {
       "title": "Beveiliging",

--- a/apps/frontend/messages/pl-PL/admin.json
+++ b/apps/frontend/messages/pl-PL/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Nie udało się zarchiwizować pokoju: {error}",
       "unarchive_room_failed": "Nie udało się przywrócić archiwum pokoju: {error}",
       "save_link_failed": "Nie udało się zapisać linku: {error}",
-      "delete_link_failed": "Nie udało się usunąć linku: {error}"
+      "delete_link_failed": "Nie udało się usunąć linku: {error}",
+      "universal_members_description": "Członkostwo w pokojach uniwersalnych jest automatyczne. Obejmuje każdą osobę z uprawnieniem dostępu do tego pokoju.",
+      "archived_members_description": "Nie można zmieniać członkostwa, gdy ten pokój jest zarchiwizowany.",
+      "add_member": "Dodaj członka",
+      "adding_member": "Dodawanie członka...",
+      "load_members_failed": "Nie udało się wczytać członków pokoju: {error}",
+      "remove_member": "Usuń członka",
+      "remove_member_prompt": "Usunąć użytkownika {name} z {room}? Nie będzie już bezpośrednim członkiem tego pokoju.",
+      "member_added": "Dodano użytkownika {name} do pokoju",
+      "add_member_failed": "Nie udało się dodać członka: {error}",
+      "member_removed": "Usunięto użytkownika {name} z pokoju",
+      "remove_member_failed": "Nie udało się usunąć członka: {error}"
     },
     "security": {
       "title": "Bezpieczeństwo",

--- a/apps/frontend/messages/pt-BR/admin.json
+++ b/apps/frontend/messages/pt-BR/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Falha ao arquivar sala: {error}",
       "unarchive_room_failed": "Falha ao desarquivar sala: {error}",
       "save_link_failed": "Falha ao salvar link: {error}",
-      "delete_link_failed": "Falha ao excluir link: {error}"
+      "delete_link_failed": "Falha ao excluir link: {error}",
+      "universal_members_description": "A participação é automática em salas universais. Todas as pessoas com permissão para acessar esta sala são incluídas.",
+      "archived_members_description": "A participação não pode ser alterada enquanto esta sala estiver arquivada.",
+      "add_member": "Adicionar membro",
+      "adding_member": "Adicionando membro...",
+      "load_members_failed": "Falha ao carregar membros da sala: {error}",
+      "remove_member": "Remover membro",
+      "remove_member_prompt": "Remover {name} de {room}? Essa pessoa deixará de ser membro explícito desta sala.",
+      "member_added": "{name} foi adicionado à sala",
+      "add_member_failed": "Falha ao adicionar membro: {error}",
+      "member_removed": "{name} foi removido da sala",
+      "remove_member_failed": "Falha ao remover membro: {error}"
     },
     "security": {
       "title": "Segurança",

--- a/apps/frontend/messages/pt-PT/admin.json
+++ b/apps/frontend/messages/pt-PT/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Falha ao arquivar a sala: {error}",
       "unarchive_room_failed": "Falha ao desarquivar a sala: {error}",
       "save_link_failed": "Falha ao guardar link: {error}",
-      "delete_link_failed": "Falha ao eliminar ligação: {error}"
+      "delete_link_failed": "Falha ao eliminar ligação: {error}",
+      "universal_members_description": "A participação é automática em salas universais. Todas as pessoas com permissão para aceder a esta sala são incluídas.",
+      "archived_members_description": "A participação não pode ser alterada enquanto esta sala estiver arquivada.",
+      "add_member": "Adicionar membro",
+      "adding_member": "A adicionar membro...",
+      "load_members_failed": "Falha ao carregar membros da sala: {error}",
+      "remove_member": "Remover membro",
+      "remove_member_prompt": "Remover {name} de {room}? Esta pessoa deixará de ser membro explícito desta sala.",
+      "member_added": "{name} foi adicionado à sala",
+      "add_member_failed": "Falha ao adicionar membro: {error}",
+      "member_removed": "{name} foi removido da sala",
+      "remove_member_failed": "Falha ao remover membro: {error}"
     },
     "security": {
       "title": "Segurança",

--- a/apps/frontend/messages/sv-SE/admin.json
+++ b/apps/frontend/messages/sv-SE/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Det gick inte att arkivera rum: {error}",
       "unarchive_room_failed": "Det gick inte att ta bort rum: {error}",
       "save_link_failed": "Det gick inte att spara länken: {error}",
-      "delete_link_failed": "Det gick inte att ta bort länken: {error}"
+      "delete_link_failed": "Det gick inte att ta bort länken: {error}",
+      "universal_members_description": "Medlemskap är automatiskt i universella rum. Alla som har behörighet att komma åt rummet ingår.",
+      "archived_members_description": "Medlemskapet kan inte ändras medan rummet är arkiverat.",
+      "add_member": "Lägg till medlem",
+      "adding_member": "Lägger till medlem...",
+      "load_members_failed": "Det gick inte att läsa in rummets medlemmar: {error}",
+      "remove_member": "Ta bort medlem",
+      "remove_member_prompt": "Ta bort {name} från {room}? Personen kommer inte längre att vara uttrycklig medlem i rummet.",
+      "member_added": "{name} lades till i rummet",
+      "add_member_failed": "Det gick inte att lägga till medlemmen: {error}",
+      "member_removed": "{name} togs bort från rummet",
+      "remove_member_failed": "Det gick inte att ta bort medlemmen: {error}"
     },
     "security": {
       "title": "Säkerhet",

--- a/apps/frontend/messages/uk-UA/admin.json
+++ b/apps/frontend/messages/uk-UA/admin.json
@@ -217,7 +217,18 @@
       "archive_room_failed": "Не вдалося заархівувати кімнату: {error}",
       "unarchive_room_failed": "Не вдалося розархівувати кімнату: {error}",
       "save_link_failed": "Не вдалося зберегти посилання: {error}",
-      "delete_link_failed": "Не вдалося видалити посилання: {error}"
+      "delete_link_failed": "Не вдалося видалити посилання: {error}",
+      "universal_members_description": "Участь в універсальних кімнатах надається автоматично. До них входять усі, хто має дозвіл на доступ до кімнати.",
+      "archived_members_description": "Не можна змінювати учасників, доки цю кімнату заархівовано.",
+      "add_member": "Додати учасника",
+      "adding_member": "Додавання учасника...",
+      "load_members_failed": "Не вдалося завантажити учасників кімнати: {error}",
+      "remove_member": "Видалити учасника",
+      "remove_member_prompt": "Видалити {name} з {room}? Ця особа більше не буде безпосереднім учасником кімнати.",
+      "member_added": "{name} додано до кімнати",
+      "add_member_failed": "Не вдалося додати учасника: {error}",
+      "member_removed": "{name} видалено з кімнати",
+      "remove_member_failed": "Не вдалося видалити учасника: {error}"
     },
     "security": {
       "title": "Безпека",

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -35,22 +35,14 @@
   --color-background: var(--color-gray-100);
   --color-text: var(--color-gray-600);
   --color-text-top: var(--color-black);
-  --color-muted: color-mix(
-    in srgb,
-    var(--color-gray-500),
-    var(--color-gray-600) 75%
-  );
+  --color-muted: color-mix(in srgb, var(--color-gray-500), var(--color-gray-600) 75%);
 
   --color-border: var(--color-gray-200);
   /* Light mode is deliberately not a luminance mirror of dark mode. The pale
      background is the primary work plane; cool gray surfaces make anchored
      chrome and controls feel inset and substantial instead of pasted on. */
   --color-surface: var(--color-gray-200);
-  --color-surface-emphasized: color-mix(
-    in srgb,
-    var(--color-gray-200),
-    var(--color-gray-300) 55%
-  );
+  --color-surface-emphasized: color-mix(in srgb, var(--color-gray-200), var(--color-gray-300) 55%);
   --color-surface-strong: var(--color-gray-300);
   --color-surface-selected: var(--color-gray-300);
 
@@ -211,6 +203,22 @@
   @apply rounded-md bg-background;
 }
 
+/* Edge-to-edge panel content is clipped to the work plane's outer radius.
+ * Nested table viewports become square so controls, notices, and table headers
+ * meet at a clean internal boundary instead of stacking rounded corners.
+ */
+@utility panel-inset-flush {
+  @apply overflow-hidden;
+}
+
+@utility data-table-viewport {
+  @apply rounded-md bg-background;
+}
+
+.panel-inset-flush > .data-table-viewport {
+  border-radius: 0;
+}
+
 /* Standard record-table header cell. Matrix headers remain deliberately
  * bespoke because their vertical labels encode a different interaction.
  */
@@ -307,7 +315,7 @@
 }
 
 @utility btn {
-  @apply control-frame inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-2 px-4 py-1.5 font-medium;
+  @apply inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-2 control-frame px-4 py-1.5 font-medium;
   @apply transition-[background-color,border-color,color,box-shadow,scale] duration-150 active:scale-[0.97];
   @apply focus-visible:ring-2 focus-visible:ring-action/35 focus-visible:outline-none;
   @apply disabled:cursor-not-allowed disabled:opacity-50;
@@ -379,7 +387,7 @@
 
 /* Form input utilities */
 @utility input {
-  @apply control-frame min-h-10 w-full bg-input px-3 py-1.5 text-text;
+  @apply min-h-10 w-full control-frame bg-input px-3 py-1.5 text-text;
   @apply placeholder:text-muted/70;
   @apply transition-colors duration-100;
   @apply focus:border-action focus:outline-none;

--- a/apps/frontend/src/lib/components/admin/DataTable.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/DataTable.stories.svelte
@@ -4,6 +4,7 @@
   import Panel from './Panel.svelte';
   import CopyId from './CopyId.svelte';
   import Pill from '$lib/ui/Pill.svelte';
+  import { Button } from '$lib/ui/form';
 
   type SpaceRow = {
     id: string;
@@ -25,9 +26,10 @@
   })) satisfies SpaceRow[];
 
   const componentDescription = `
-  Admin table primitive with a rounded scroll viewport, contrasting header and
-  body, empty state row, optional row hover/click affordance, and automatic
-  load-more support. Place it inside \`Panel noPadding\`; Panel owns the shared frame.
+  Admin table primitive with a standalone rounded scroll viewport, contrasting
+  header and body, empty state row, optional row hover/click affordance, and
+  automatic load-more support. Inside \`Panel noPadding\`, the panel owns the
+  shared radius and the table meets adjacent content at square internal seams.
   `.trim();
 
   const { Story } = defineMeta({
@@ -70,12 +72,42 @@
 </Story>
 
 <Story
+  name="Following controls"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'When controls or notices precede an edge-to-edge table, the panel keeps one outer radius and the internal boundary remains square.'
+      }
+    }
+  }}
+>
+  <div class="max-w-3xl">
+    <Panel title="Members" noPadding>
+      <div class="flex items-center justify-between gap-3 border-b border-border p-5">
+        <span class="text-sm text-muted">Add people who should have access to this space.</span>
+        <Button size="sm" variant="secondary">Add member</Button>
+      </div>
+      <DataTable
+        items={rows}
+        columns={4}
+        getKey={(row) => row.id}
+        header={tableHeader}
+        row={tableRow}
+      />
+    </Panel>
+  </div>
+</Story>
+
+<Story
   name="Sticky header"
   asChild
   parameters={{
     docs: {
       description: {
-        story: 'Dense matrices and long administrative tables can retain their column labels in a bounded scrolling viewport.'
+        story:
+          'Dense matrices and long administrative tables can retain their column labels in a bounded scrolling viewport.'
       }
     }
   }}

--- a/apps/frontend/src/lib/components/admin/DataTable.svelte
+++ b/apps/frontend/src/lib/components/admin/DataTable.svelte
@@ -129,12 +129,7 @@
 </script>
 
 {#snippet tableContent()}
-  <table
-    class={[
-      fitContent ? 'w-max' : 'w-full',
-      '[&_thead_th]:whitespace-nowrap'
-    ]}
-  >
+  <table class={[fitContent ? 'w-max' : 'w-full', '[&_thead_th]:whitespace-nowrap']}>
     <thead class={stickyHeader ? 'sticky top-0 z-20' : ''}>
       <tr class="panel-header text-left text-sm text-muted">
         {@render header()}
@@ -194,12 +189,12 @@
     bottom
     scrollX
     topFadeOffset={stickyHeaderFadeOffset}
-    class={`rounded-md bg-background ${fillHeight ? 'min-h-0 flex-1' : 'max-h-[70dvh]'}`}
+    class={`data-table-viewport ${fillHeight ? 'min-h-0 flex-1' : 'max-h-[70dvh]'}`}
   >
     {@render tableContent()}
   </ScrollFader>
 {:else}
-  <div class="overflow-x-auto rounded-md bg-background">
+  <div class="overflow-x-auto data-table-viewport">
     {@render tableContent()}
   </div>
 {/if}

--- a/apps/frontend/src/lib/components/admin/DataTable.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/admin/DataTable.svelte.spec.ts
@@ -104,14 +104,14 @@ describe('DataTable.hoverable', () => {
     expect(tr.className).not.toContain('hover:bg-surface/70');
   });
 
-  it('uses a rounded background viewport beneath the surface header', async () => {
+  it('uses the shared table viewport beneath the surface header', async () => {
     const { container } = renderTable();
     const table = container.querySelector('table') as HTMLTableElement;
     const viewport = table.parentElement as HTMLElement;
     const header = container.querySelector('thead tr') as HTMLElement;
     const body = container.querySelector('tbody') as HTMLElement;
 
-    expect(viewport.className).toContain('rounded-md');
+    expect(viewport.className).toContain('data-table-viewport');
     expect(viewport.className).toContain('overflow-x-auto');
     expect(header.className).toContain('panel-header');
     expect(body.className).toContain('bg-background');
@@ -139,6 +139,7 @@ describe('DataTable.hoverable', () => {
     const viewport = table.parentElement?.parentElement as HTMLElement;
     const header = container.querySelector('thead') as HTMLElement;
 
+    expect(viewport.className).toContain('data-table-viewport');
     expect(viewport.className).toContain('max-h-[70dvh]');
     expect((table.parentElement as HTMLElement).className).toContain('overflow-y-auto');
     expect((table.parentElement as HTMLElement).className).toContain('overflow-x-auto');

--- a/apps/frontend/src/lib/components/admin/Panel.svelte
+++ b/apps/frontend/src/lib/components/admin/Panel.svelte
@@ -58,11 +58,13 @@
       {/if}
     </div>
   {/if}
-  <div class={[title || noPadding ? 'px-1 pb-1' : 'p-1', fillHeight && 'flex min-h-0 flex-1 flex-col']}>
+  <div
+    class={[title || noPadding ? 'px-1 pb-1' : 'p-1', fillHeight && 'flex min-h-0 flex-1 flex-col']}
+  >
     <div
       class={[
         'panel-inset',
-        noPadding ? 'overflow-hidden' : 'p-5',
+        noPadding ? 'panel-inset-flush' : 'p-5',
         fillHeight && 'flex min-h-0 flex-1 flex-col'
       ]}
     >

--- a/apps/frontend/src/lib/components/admin/Panel.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/admin/Panel.svelte.spec.ts
@@ -37,7 +37,7 @@ describe('Panel inset structure', () => {
     const { container } = renderPanel(true);
     const inset = container.querySelector('.panel-shell > div:last-child > div') as HTMLElement;
 
-    expect(inset.className).toContain('overflow-hidden');
+    expect(inset.className).toContain('panel-inset-flush');
     expect(inset.className).not.toContain('p-5');
   });
 
@@ -75,7 +75,9 @@ describe('Panel inset structure', () => {
       }
     });
 
-    expect(container.querySelector('[data-testid="subtitle-link"]')?.getAttribute('href')).toBe('/rooms');
+    expect(container.querySelector('[data-testid="subtitle-link"]')?.getAttribute('href')).toBe(
+      '/rooms'
+    );
   });
 
   it('can fill a flex page while preserving its inset structure', () => {
@@ -90,5 +92,4 @@ describe('Panel inset structure', () => {
     expect(frame.className).toContain('flex-1');
     expect(inset.className).toContain('flex-1');
   });
-
 });

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
@@ -17,8 +17,9 @@ Scope is implied by which of `spaceId` / `roomId` are set:
   set     | set    | same role set at room scope, inheriting the
                      resolved space + instance state per role
 
-The table viewport scrolls when there are too many rows or roles to fit;
-the role header and first column (permission name) remain sticky. Column
+The table viewport scrolls when there are too many rows or roles to fit unless
+`scrollContents` is disabled for a page-owned scroll container. The role header
+and first column (permission name) remain sticky in the contained variant. Column
 headers are clickable when `onRoleClick` is provided
 (routing to per-role detail pages owned by the parent route). Hovering or
 focusing a cell highlights its permission row and role column.
@@ -97,7 +98,8 @@ focusing a cell highlights its permission row and role column.
     isRoleClickable,
     newRoleHref,
     subtitle,
-    fillHeight = false
+    fillHeight = false,
+    scrollContents = true
   }: {
     spaceId?: string | null;
     roomId?: string | null;
@@ -126,6 +128,8 @@ focusing a cell highlights its permission row and role column.
     subtitle?: string | Snippet;
     /** Fill the remaining height when this matrix is the page's primary content. */
     fillHeight?: boolean;
+    /** Use a contained vertical viewport instead of flowing with the owning page. */
+    scrollContents?: boolean;
   } = $props();
 
   const connection = useConnection();
@@ -209,7 +213,9 @@ focusing a cell highlights its permission row and role column.
   let permissionFilter = $state('');
   const filteredPermissions = $derived.by(() => {
     const query = permissionFilter.trim().toLowerCase();
-    return query ? permissions.filter((permission) => permission.toLowerCase().includes(query)) : permissions;
+    return query
+      ? permissions.filter((permission) => permission.toLowerCase().includes(query))
+      : permissions;
   });
   const panelTitle = $derived(
     !spaceId && !roomId && !groupId ? CATEGORY_META.space.title : m['admin.permissions.title']()
@@ -336,7 +342,7 @@ focusing a cell highlights its permission row and role column.
       columns={columnCount}
       getKey={(permission) => permission}
       emptyMessage={m['rbac.permissions.no_filter_matches']()}
-      stickyHeader
+      stickyHeader={scrollContents}
       {fillHeight}
       stickyHeaderFadeOffset="top-48"
       hoverable={false}
@@ -350,7 +356,9 @@ focusing a cell highlights its permission row and role column.
         </th>
         {#each roles as role (role.roleName)}
           {@const handle =
-            onRoleClick && (isRoleClickable ? isRoleClickable(role) : true) ? onRoleClick : undefined}
+            onRoleClick && (isRoleClickable ? isRoleClickable(role) : true)
+              ? onRoleClick
+              : undefined}
           <th
             class={[
               'px-0 py-3 text-center align-bottom font-medium',
@@ -412,7 +420,8 @@ focusing a cell highlights its permission row and role column.
             </HelpTooltip>
             <code
               data-testid="permission-name"
-              class={['text-sm', rowIsHighlighted(category, permission) ? 'text-action' : '']}>{permission}</code
+              class={['text-sm', rowIsHighlighted(category, permission) ? 'text-action' : '']}
+              >{permission}</code
             >
           </div>
         </td>

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
@@ -248,6 +248,22 @@ describe('PermissionMatrix', () => {
     expect(fades[fades.length - 1].className).toContain('z-30');
   });
 
+  it('flows vertically with the page when contained scrolling is disabled', async () => {
+    const { container } = render(PermissionMatrix, {
+      props: { roomId: 'room-1', scrollContents: false }
+    });
+    await settle();
+
+    const table = container.querySelector('table') as HTMLTableElement;
+    const viewport = table.parentElement as HTMLElement;
+    const header = container.querySelector('thead') as HTMLElement;
+
+    expect(viewport.className).toContain('overflow-x-auto');
+    expect(viewport.className).not.toContain('overflow-y-auto');
+    expect(viewport.className).not.toContain('max-h-[70dvh]');
+    expect(header.className).not.toContain('sticky');
+  });
+
   it('highlights the hovered permission row and the role column across categories', async () => {
     const { container } = render(PermissionMatrix, { props: { spaceId: 'space-1' } });
     await settle();

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
@@ -105,7 +105,9 @@ describe('PermissionMatrix', () => {
     // The permission and role columns, followed by the flexible spacer.
     expect(container.querySelectorAll('thead th')).toHaveLength(5);
     expect(container.querySelectorAll('tbody tr')).toHaveLength(2);
-    expect(container.querySelectorAll('[data-testid="permission-section-divider"]')).toHaveLength(0);
+    expect(container.querySelectorAll('[data-testid="permission-section-divider"]')).toHaveLength(
+      0
+    );
     expect(container.querySelector('table')?.className).toContain('w-full');
     expect(container.querySelectorAll('[data-testid="permission-matrix-spacer"]')).toHaveLength(2);
     expect(container.querySelector('thead th:last-child')?.className).toContain('bg-background');
@@ -115,12 +117,7 @@ describe('PermissionMatrix', () => {
   it('orders permission names alphabetically', async () => {
     nextTierRoles = {
       ...HAPPY_TIER_ROLES,
-      applicablePermissions: [
-        'user.delete-self',
-        'room.manage',
-        'server.manage',
-        'user.delete-any'
-      ]
+      applicablePermissions: ['user.delete-self', 'room.manage', 'server.manage', 'user.delete-any']
     };
     const { container } = render(PermissionMatrix, { props: { spaceId: 'space-1' } });
     await settle();
@@ -141,9 +138,11 @@ describe('PermissionMatrix', () => {
     filter.dispatchEvent(new Event('input', { bubbles: true }));
     flushSync();
 
-    expect([...container.querySelectorAll('[data-testid="permission-name"]')].map((row) => row.textContent)).toEqual(
-      ['room.create']
-    );
+    expect(
+      [...container.querySelectorAll('[data-testid="permission-name"]')].map(
+        (row) => row.textContent
+      )
+    ).toEqual(['room.create']);
 
     filter.value = 'missing';
     filter.dispatchEvent(new Event('input', { bubbles: true }));
@@ -232,7 +231,8 @@ describe('PermissionMatrix', () => {
     expect(getComputedStyle(viewport).backgroundColor).toBe(backgroundColor);
     expect(frame.className).toContain('px-1');
     expect(frame.className).toContain('pb-1');
-    expect(viewport.className).toContain('rounded-md');
+    expect(viewport.className).toContain('data-table-viewport');
+    expect(viewport.className).not.toContain('rounded-md');
     expect((panel.querySelector('table')?.parentElement as HTMLElement).className).toContain(
       'overflow-y-auto'
     );

--- a/apps/frontend/src/lib/i18n/messages.ts
+++ b/apps/frontend/src/lib/i18n/messages.ts
@@ -1488,6 +1488,29 @@ const msg_admin_rooms_admin_save_link_failed = (
 const msg_admin_rooms_admin_delete_link_failed = (
   inputs: Parameters<LocaleMessages['admin_rooms_admin_delete_link_failed']>[0]
 ): LocalizedString => messages().admin_rooms_admin_delete_link_failed(inputs);
+const msg_admin_rooms_admin_universal_members_description = (): LocalizedString => messages().admin_rooms_admin_universal_members_description(empty());
+const msg_admin_rooms_admin_archived_members_description = (): LocalizedString => messages().admin_rooms_admin_archived_members_description(empty());
+const msg_admin_rooms_admin_add_member = (): LocalizedString => messages().admin_rooms_admin_add_member(empty());
+const msg_admin_rooms_admin_adding_member = (): LocalizedString => messages().admin_rooms_admin_adding_member(empty());
+const msg_admin_rooms_admin_load_members_failed = (
+  inputs: Parameters<LocaleMessages['admin_rooms_admin_load_members_failed']>[0]
+): LocalizedString => messages().admin_rooms_admin_load_members_failed(inputs);
+const msg_admin_rooms_admin_remove_member = (): LocalizedString => messages().admin_rooms_admin_remove_member(empty());
+const msg_admin_rooms_admin_remove_member_prompt = (
+  inputs: Parameters<LocaleMessages['admin_rooms_admin_remove_member_prompt']>[0]
+): LocalizedString => messages().admin_rooms_admin_remove_member_prompt(inputs);
+const msg_admin_rooms_admin_member_added = (
+  inputs: Parameters<LocaleMessages['admin_rooms_admin_member_added']>[0]
+): LocalizedString => messages().admin_rooms_admin_member_added(inputs);
+const msg_admin_rooms_admin_add_member_failed = (
+  inputs: Parameters<LocaleMessages['admin_rooms_admin_add_member_failed']>[0]
+): LocalizedString => messages().admin_rooms_admin_add_member_failed(inputs);
+const msg_admin_rooms_admin_member_removed = (
+  inputs: Parameters<LocaleMessages['admin_rooms_admin_member_removed']>[0]
+): LocalizedString => messages().admin_rooms_admin_member_removed(inputs);
+const msg_admin_rooms_admin_remove_member_failed = (
+  inputs: Parameters<LocaleMessages['admin_rooms_admin_remove_member_failed']>[0]
+): LocalizedString => messages().admin_rooms_admin_remove_member_failed(inputs);
 const msg_admin_security_title = (): LocalizedString => messages().admin_security_title(empty());
 const msg_admin_security_subtitle = (): LocalizedString => messages().admin_security_subtitle(empty());
 const msg_admin_security_blocked_usernames = (): LocalizedString => messages().admin_security_blocked_usernames(empty());
@@ -2872,6 +2895,17 @@ export { msg_admin_rooms_admin_archive_room_failed as 'admin.rooms_admin.archive
 export { msg_admin_rooms_admin_unarchive_room_failed as 'admin.rooms_admin.unarchive_room_failed' };
 export { msg_admin_rooms_admin_save_link_failed as 'admin.rooms_admin.save_link_failed' };
 export { msg_admin_rooms_admin_delete_link_failed as 'admin.rooms_admin.delete_link_failed' };
+export { msg_admin_rooms_admin_universal_members_description as 'admin.rooms_admin.universal_members_description' };
+export { msg_admin_rooms_admin_archived_members_description as 'admin.rooms_admin.archived_members_description' };
+export { msg_admin_rooms_admin_add_member as 'admin.rooms_admin.add_member' };
+export { msg_admin_rooms_admin_adding_member as 'admin.rooms_admin.adding_member' };
+export { msg_admin_rooms_admin_load_members_failed as 'admin.rooms_admin.load_members_failed' };
+export { msg_admin_rooms_admin_remove_member as 'admin.rooms_admin.remove_member' };
+export { msg_admin_rooms_admin_remove_member_prompt as 'admin.rooms_admin.remove_member_prompt' };
+export { msg_admin_rooms_admin_member_added as 'admin.rooms_admin.member_added' };
+export { msg_admin_rooms_admin_add_member_failed as 'admin.rooms_admin.add_member_failed' };
+export { msg_admin_rooms_admin_member_removed as 'admin.rooms_admin.member_removed' };
+export { msg_admin_rooms_admin_remove_member_failed as 'admin.rooms_admin.remove_member_failed' };
 export { msg_admin_security_title as 'admin.security.title' };
 export { msg_admin_security_subtitle as 'admin.security.subtitle' };
 export { msg_admin_security_blocked_usernames as 'admin.security.blocked_usernames' };

--- a/apps/frontend/src/lib/state/server/compatibility.spec.ts
+++ b/apps/frontend/src/lib/state/server/compatibility.spec.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   compareReleaseVersions,
   evaluateServerCompatibility,
-  hasProtocolCapability
+  hasProtocolCapability,
+  ROOM_MANAGER_MEMBER_READS_CAPABILITY,
+  supportsRoomManagerMemberReads
 } from './compatibility';
 
 describe('server compatibility evaluation', () => {
@@ -160,5 +162,15 @@ describe('server compatibility evaluation', () => {
     expect(hasProtocolCapability(null, 'chatto.realtime.v1')).toBeNull();
     expect(hasProtocolCapability([], 'chatto.realtime.v1')).toBe(false);
     expect(hasProtocolCapability(['chatto.realtime.v1'], 'chatto.realtime.v1')).toBe(true);
+  });
+
+  it('gates manager member reads by capability with a legacy version fallback', () => {
+    expect(supportsRoomManagerMemberReads([ROOM_MANAGER_MEMBER_READS_CAPABILITY], '0.4.0')).toBe(
+      true
+    );
+    expect(supportsRoomManagerMemberReads(['chatto.api.v1'], '0.5.0')).toBe(false);
+    expect(supportsRoomManagerMemberReads(null, '0.5.0')).toBe(true);
+    expect(supportsRoomManagerMemberReads(null, '0.4.12')).toBe(false);
+    expect(supportsRoomManagerMemberReads(null, 'custom-build')).toBe(false);
   });
 });

--- a/apps/frontend/src/lib/state/server/compatibility.ts
+++ b/apps/frontend/src/lib/state/server/compatibility.ts
@@ -6,6 +6,7 @@ export const CHATTO_WEB_CLIENT_VERSION = frontendPackage.version;
 export const LEGACY_SERVER_WARNING_BEFORE_VERSION = '0.5.0';
 export const REALTIME_PROJECTION_CAPABILITY = 'chatto.realtime.projection.v1';
 export const MESSAGE_SEARCH_CAPABILITY = 'chatto.api.message-search.v1';
+export const ROOM_MANAGER_MEMBER_READS_CAPABILITY = 'chatto.api.room-manager-member-reads.v1';
 
 export const REQUIRED_PROTOCOL_CAPABILITIES = [
   'chatto.api.v1',
@@ -108,4 +109,20 @@ export function hasProtocolCapability(
   capability: string
 ): boolean | null {
   return capabilities === null ? null : capabilities.includes(capability);
+}
+
+/**
+ * Whether room managers can read channel membership without joining first.
+ *
+ * Capability metadata is authoritative when present. The version fallback is
+ * limited to servers that predate discovery capabilities altogether.
+ */
+export function supportsRoomManagerMemberReads(
+  capabilities: readonly string[] | null,
+  serverVersion: string
+): boolean {
+  const advertised = hasProtocolCapability(capabilities, ROOM_MANAGER_MEMBER_READS_CAPABILITY);
+  if (advertised !== null) return advertised;
+  const comparison = compareReleaseVersions(serverVersion, LEGACY_SERVER_WARNING_BEFORE_VERSION);
+  return comparison !== null && comparison >= 0;
 }

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -6,6 +6,7 @@
   import { createRoomDirectoryAPI, type DirectoryRoomDetails } from '$lib/api-client/roomDirectory';
   import { createAdminRoomLayoutAPI, type AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
+  import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
   import { Code, ConnectError } from '@connectrpc/connect';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { getChromePermissions } from '$lib/state/server/chromePermissions.svelte';
@@ -13,7 +14,7 @@
   import { Panel } from '$lib/components/admin';
   import { Button, Checkbox, TextArea, TextInput } from '$lib/ui/form';
   import AccessDenied from '$lib/ui/AccessDenied.svelte';
-  import { EmptyState } from '$lib/ui';
+  import { EmptyState, PaneContent } from '$lib/ui';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import Hint from '$lib/ui/Hint.svelte';
@@ -23,6 +24,8 @@
   import { isCurrentResourceOperation } from '$lib/utils/resourceOperationFence';
   import { classifyManagementLoadError } from '$lib/utils/managementLoadError';
   import { buildRoomSettingsUpdate } from './roomSettings';
+  import RoomMembersPanel from './RoomMembersPanel.svelte';
+  import { RoomMemberManagementStore } from './RoomMemberManagementStore.svelte';
   import * as m from '$lib/i18n/messages';
 
   const roomId = $derived(page.params.roomId!);
@@ -43,6 +46,23 @@
   let originalDescription = $state('');
   let originalUniversal = $state(false);
   let loadId = 0;
+  let scrollContainer = $state<HTMLDivElement>();
+
+  const memberManagement = new RoomMemberManagementStore(() => {
+    const conn = connection();
+    return {
+      directory: createMemberDirectoryAPI({
+        serverId: conn.serverId,
+        baseUrl: conn.connectBaseUrl,
+        bearerToken: conn.bearerToken
+      }),
+      commands: createRoomCommandAPI({
+        serverId: conn.serverId,
+        baseUrl: conn.connectBaseUrl,
+        bearerToken: conn.bearerToken
+      })
+    };
+  });
 
   const canManageRoom = $derived(room?.canManageRoom ?? false);
   const canManagePermissions = $derived(room?.canManagePermissions ?? false);
@@ -218,54 +238,67 @@
       showMobileNav
     />
 
-    <div class="flex flex-col gap-6 overflow-y-auto p-6">
-      {#if canManageRoom}
-        <Panel title={m['admin.nav.general']()} icon="iconify uil--setting">
-          <form class="flex max-w-2xl flex-col gap-4" onsubmit={saveGeneralSettings}>
-            <TextInput
-              id="room-settings-name"
-              label={m['rbac.role_form.name']()}
-              bind:value={name}
-              required
-              disabled={saving}
-              error={nameError}
-            />
-            <TextArea
-              id="room-settings-description"
-              label={m['rbac.role_form.description']()}
-              bind:value={description}
-              rows={3}
-              disabled={saving}
-              placeholder={m['admin.rooms_admin.room_description_placeholder']()}
-            />
-            <Checkbox
-              id="room-settings-universal"
-              bind:checked={universal}
-              disabled={saving}
-              label={m['admin.rooms_admin.universal_room']()}
-              description={UNIVERSAL_ROOM_HELP_TEXT}
-            />
-            <div class="flex justify-end">
-              <Button
-                type="submit"
-                loading={saving}
-                disabled={!name.trim() || !!nameError || !changed}
-              >
-                {m['admin.permissions.save_changes']()}
-              </Button>
-            </div>
-          </form>
-        </Panel>
-      {/if}
+    <PaneContent bind:scrollContainer>
+      <div class="flex flex-col gap-6">
+        {#if canManageRoom}
+          <Panel title={m['admin.nav.general']()} icon="iconify uil--setting">
+            <form class="flex max-w-2xl flex-col gap-4" onsubmit={saveGeneralSettings}>
+              <TextInput
+                id="room-settings-name"
+                label={m['rbac.role_form.name']()}
+                bind:value={name}
+                required
+                disabled={saving}
+                error={nameError}
+              />
+              <TextArea
+                id="room-settings-description"
+                label={m['rbac.role_form.description']()}
+                bind:value={description}
+                rows={3}
+                disabled={saving}
+                placeholder={m['admin.rooms_admin.room_description_placeholder']()}
+              />
+              <Checkbox
+                id="room-settings-universal"
+                bind:checked={universal}
+                disabled={saving}
+                label={m['admin.rooms_admin.universal_room']()}
+                description={UNIVERSAL_ROOM_HELP_TEXT}
+              />
+              <div class="flex justify-end">
+                <Button
+                  type="submit"
+                  loading={saving}
+                  disabled={!name.trim() || !!nameError || !changed}
+                >
+                  {m['admin.permissions.save_changes']()}
+                </Button>
+              </div>
+            </form>
+          </Panel>
+        {/if}
 
-      <div class="flex flex-col gap-4">
-        <h2 class="text-lg font-semibold text-text-top">
-          {m['admin.rooms_admin.room_permissions_title_fallback']()}
-        </h2>
-        <Hint>{m['admin.rooms_admin.room_permissions_hint']()}</Hint>
-        <Hint>{m['admin.permissions.resolution_hint']()}</Hint>
-        <PermissionMatrix {roomId} />
+        <RoomMembersPanel
+          serverId={activeServerId}
+          {roomId}
+          roomName={room.name}
+          isUniversal={room.isUniversal}
+          archived={room.archived}
+          canManageMembers={canManageRoom}
+          scrollRoot={scrollContainer}
+          store={memberManagement}
+        />
+
+        <div class="flex flex-col gap-4">
+          <h2 class="text-lg font-semibold text-text-top">
+            {m['admin.rooms_admin.room_permissions_title_fallback']()}
+          </h2>
+          <Hint>{m['admin.rooms_admin.room_permissions_hint']()}</Hint>
+          <Hint>{m['admin.permissions.resolution_hint']()}</Hint>
+          <PermissionMatrix {roomId} />
+        </div>
       </div>
-    </div>
+    </PaneContent>
   </div>
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -361,7 +361,7 @@
           </h2>
           <Hint>{m['admin.rooms_admin.room_permissions_hint']()}</Hint>
           <Hint>{m['admin.permissions.resolution_hint']()}</Hint>
-          <PermissionMatrix {roomId} />
+          <PermissionMatrix {roomId} scrollContents={false} />
         </div>
       </div>
     </PaneContent>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { untrack } from 'svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
@@ -8,9 +9,11 @@
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
   import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
   import { Code, ConnectError } from '@connectrpc/connect';
-  import { useConnection } from '$lib/state/server/connection.svelte';
   import { getChromePermissions } from '$lib/state/server/chromePermissions.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
+  import { supportsRoomManagerMemberReads } from '$lib/state/server/compatibility';
+  import { useProjectionEvent } from '$lib/hooks';
   import { Panel } from '$lib/components/admin';
   import { Button, Checkbox, TextArea, TextInput } from '$lib/ui/form';
   import AccessDenied from '$lib/ui/AccessDenied.svelte';
@@ -31,7 +34,6 @@
   const roomId = $derived(page.params.roomId!);
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
-  const connection = useConnection();
   const chromePermissions = getChromePermissions();
 
   let room = $state<AdminManagedRoom | null>(null);
@@ -48,8 +50,8 @@
   let loadId = 0;
   let scrollContainer = $state<HTMLDivElement>();
 
-  const memberManagement = new RoomMemberManagementStore(() => {
-    const conn = connection();
+  const memberManagement = new RoomMemberManagementStore((serverId) => {
+    const conn = serverConnectionManager.getClient(serverId);
     return {
       directory: createMemberDirectoryAPI({
         serverId: conn.serverId,
@@ -66,6 +68,11 @@
 
   const canManageRoom = $derived(room?.canManageRoom ?? false);
   const canManagePermissions = $derived(room?.canManagePermissions ?? false);
+  const supportsMemberManagement = $derived.by(() => {
+    const info = serverRegistry.tryGetStore(activeServerId)?.serverInfo;
+    if (!info) return false;
+    return supportsRoomManagerMemberReads(info.protocolCapabilities, info.version);
+  });
   const backHref = $derived(
     chromePermissions.current.canManageRooms
       ? resolve('/chat/[serverId]/manage/rooms', { serverId: serverSegment })
@@ -97,15 +104,25 @@
     originalUniversal = nextRoom.isUniversal;
   }
 
-  async function loadRoom(targetRoomId: string): Promise<void> {
+  function isCurrentLoad(requestId: number, targetServerId: string, targetRoomId: string): boolean {
+    return requestId === loadId && targetServerId === activeServerId && targetRoomId === roomId;
+  }
+
+  async function loadRoom(
+    targetServerId: string,
+    targetRoomId: string,
+    preserveRoom = false
+  ): Promise<void> {
     const thisId = ++loadId;
-    loading = true;
-    saving = false;
-    room = null;
+    if (!preserveRoom) {
+      loading = true;
+      room = null;
+      saving = false;
+    }
     accessDenied = false;
     loadFailure = null;
     try {
-      const conn = connection();
+      const conn = serverConnectionManager.getClient(targetServerId);
       const adminAPI = createAdminRoomLayoutAPI({
         serverId: conn.serverId,
         baseUrl: conn.connectBaseUrl,
@@ -135,14 +152,14 @@
             }
           : null;
       }
-      if (thisId !== loadId) return;
+      if (!isCurrentLoad(thisId, targetServerId, targetRoomId)) return;
       if (nextRoom) {
         applyRoom(nextRoom);
       } else {
         accessDenied = true;
       }
     } catch (error) {
-      if (thisId !== loadId) return;
+      if (!isCurrentLoad(thisId, targetServerId, targetRoomId)) return;
       const classified = classifyManagementLoadError(error);
       if (classified.kind === 'access-denied') {
         accessDenied = true;
@@ -150,19 +167,36 @@
         loadFailure = classified.message;
       }
     } finally {
-      if (thisId === loadId) loading = false;
+      if (isCurrentLoad(thisId, targetServerId, targetRoomId)) loading = false;
     }
   }
 
   $effect(() => {
-    void loadRoom(roomId);
+    const targetServerId = activeServerId;
+    const targetRoomId = roomId;
+    untrack(() => void loadRoom(targetServerId, targetRoomId));
+  });
+
+  useProjectionEvent((event) => {
+    for (const operation of event.operations) {
+      const projectedRoomId =
+        operation.operation.case === 'roomUpsert'
+          ? operation.operation.value.room?.room?.id
+          : operation.operation.case === 'roomRemove'
+            ? operation.operation.value.roomId
+            : null;
+      if (projectedRoomId === roomId) {
+        void loadRoom(activeServerId, roomId, true);
+        return;
+      }
+    }
   });
 
   async function saveGeneralSettings(event: SubmitEvent): Promise<void> {
     event.preventDefault();
     if (!canManageRoom || saving || nameError || !name.trim() || !changed) return;
 
-    const target = { resourceId: roomId, generation: loadId };
+    const target = { serverId: activeServerId, resourceId: roomId, generation: loadId };
     const update = buildRoomSettingsUpdate(
       target.resourceId,
       { name, description, universal },
@@ -174,14 +208,19 @@
     );
     saving = true;
     try {
-      const conn = connection();
+      const conn = serverConnectionManager.getClient(target.serverId);
       const api = createRoomCommandAPI({
         serverId: conn.serverId,
         baseUrl: conn.connectBaseUrl,
         bearerToken: conn.bearerToken
       });
       const updated = await api.updateRoom(update);
-      if (!isCurrentResourceOperation(target, roomId, loadId)) return;
+      if (
+        target.serverId !== activeServerId ||
+        !isCurrentResourceOperation(target, roomId, loadId)
+      ) {
+        return;
+      }
       if (!updated || !room) throw new Error('Room update returned no room');
 
       applyRoom({
@@ -194,14 +233,24 @@
       void serverRegistry.getStore(activeServerId).rooms.refresh();
       toast.success(m['admin.rooms_admin.room_updated']());
     } catch (error) {
-      if (!isCurrentResourceOperation(target, roomId, loadId)) return;
+      if (
+        target.serverId !== activeServerId ||
+        !isCurrentResourceOperation(target, roomId, loadId)
+      ) {
+        return;
+      }
       toast.error(
         m['admin.rooms_admin.update_room_failed']({
           error: error instanceof Error ? error.message : String(error)
         })
       );
     } finally {
-      if (isCurrentResourceOperation(target, roomId, loadId)) saving = false;
+      if (
+        target.serverId === activeServerId &&
+        isCurrentResourceOperation(target, roomId, loadId)
+      ) {
+        saving = false;
+      }
     }
   }
 
@@ -218,7 +267,7 @@
   <EmptyState icon="uil--exclamation-triangle" title={m['common.error.generic']()}>
     <div class="flex flex-col items-center gap-4">
       <p>{loadFailure}</p>
-      <Button variant="secondary" onclick={() => void loadRoom(roomId)}>
+      <Button variant="secondary" onclick={() => void loadRoom(activeServerId, roomId)}>
         {m['common.retry']()}
       </Button>
     </div>
@@ -279,16 +328,18 @@
           </Panel>
         {/if}
 
-        <RoomMembersPanel
-          serverId={activeServerId}
-          {roomId}
-          roomName={room.name}
-          isUniversal={room.isUniversal}
-          archived={room.archived}
-          canManageMembers={canManageRoom}
-          scrollRoot={scrollContainer}
-          store={memberManagement}
-        />
+        {#if supportsMemberManagement}
+          <RoomMembersPanel
+            serverId={activeServerId}
+            {roomId}
+            roomName={room.name}
+            isUniversal={room.isUniversal}
+            archived={room.archived}
+            canManageMembers={canManageRoom}
+            scrollRoot={scrollContainer}
+            store={memberManagement}
+          />
+        {/if}
 
         <div class="flex flex-col gap-4">
           <h2 class="text-lg font-semibold text-text-top">

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -24,7 +24,6 @@
   import PermissionMatrix from '$lib/components/rbac/PermissionMatrix.svelte';
   import { toast } from '$lib/ui/toast';
   import { UNIVERSAL_ROOM_HELP_TEXT } from '$lib/utils/roomCopy';
-  import { isCurrentResourceOperation } from '$lib/utils/resourceOperationFence';
   import { classifyManagementLoadError } from '$lib/utils/managementLoadError';
   import { buildRoomSettingsUpdate } from './roomSettings';
   import RoomMembersPanel from './RoomMembersPanel.svelte';
@@ -48,6 +47,7 @@
   let originalDescription = $state('');
   let originalUniversal = $state(false);
   let loadId = 0;
+  let identityGeneration = 0;
   let scrollContainer = $state<HTMLDivElement>();
 
   const memberManagement = new RoomMemberManagementStore((serverId) => {
@@ -106,6 +106,18 @@
 
   function isCurrentLoad(requestId: number, targetServerId: string, targetRoomId: string): boolean {
     return requestId === loadId && targetServerId === activeServerId && targetRoomId === roomId;
+  }
+
+  function isCurrentIdentity(target: {
+    serverId: string;
+    roomId: string;
+    identityGeneration: number;
+  }): boolean {
+    return (
+      target.serverId === activeServerId &&
+      target.roomId === roomId &&
+      target.identityGeneration === identityGeneration
+    );
   }
 
   async function loadRoom(
@@ -174,20 +186,30 @@
   $effect(() => {
     const targetServerId = activeServerId;
     const targetRoomId = roomId;
-    untrack(() => void loadRoom(targetServerId, targetRoomId));
+    untrack(() => {
+      identityGeneration++;
+      saving = false;
+      void loadRoom(targetServerId, targetRoomId);
+    });
   });
 
   useProjectionEvent((event) => {
     for (const operation of event.operations) {
-      const projectedRoomId =
-        operation.operation.case === 'roomUpsert'
-          ? operation.operation.value.room?.room?.id
-          : operation.operation.case === 'roomRemove'
-            ? operation.operation.value.roomId
-            : null;
-      if (projectedRoomId === roomId) {
-        void loadRoom(activeServerId, roomId, true);
-        return;
+      switch (operation.operation.case) {
+        case 'roomUpsert':
+          if (operation.operation.value.room?.room?.id === roomId) {
+            void loadRoom(activeServerId, roomId, true);
+            return;
+          }
+          break;
+        case 'roomRemove':
+          if (operation.operation.value.roomId === roomId) {
+            identityGeneration++;
+            saving = false;
+            void loadRoom(activeServerId, roomId);
+            return;
+          }
+          break;
       }
     }
   });
@@ -196,9 +218,14 @@
     event.preventDefault();
     if (!canManageRoom || saving || nameError || !name.trim() || !changed) return;
 
-    const target = { serverId: activeServerId, resourceId: roomId, generation: loadId };
+    const target = {
+      serverId: activeServerId,
+      roomId,
+      identityGeneration,
+      loadId
+    };
     const update = buildRoomSettingsUpdate(
-      target.resourceId,
+      target.roomId,
       { name, description, universal },
       {
         name: originalName,
@@ -215,42 +242,29 @@
         bearerToken: conn.bearerToken
       });
       const updated = await api.updateRoom(update);
-      if (
-        target.serverId !== activeServerId ||
-        !isCurrentResourceOperation(target, roomId, loadId)
-      ) {
-        return;
-      }
-      if (!updated || !room) throw new Error('Room update returned no room');
+      if (!isCurrentIdentity(target)) return;
+      if (!updated) throw new Error('Room update returned no room');
 
-      applyRoom({
-        ...room,
-        name: updated.name,
-        description: updated.description || null,
-        isUniversal: updated.universal,
-        archived: updated.archived
-      });
+      if (target.loadId === loadId && room) {
+        applyRoom({
+          ...room,
+          name: updated.name,
+          description: updated.description || null,
+          isUniversal: updated.universal,
+          archived: updated.archived
+        });
+      }
       void serverRegistry.getStore(activeServerId).rooms.refresh();
       toast.success(m['admin.rooms_admin.room_updated']());
     } catch (error) {
-      if (
-        target.serverId !== activeServerId ||
-        !isCurrentResourceOperation(target, roomId, loadId)
-      ) {
-        return;
-      }
+      if (!isCurrentIdentity(target)) return;
       toast.error(
         m['admin.rooms_admin.update_room_failed']({
           error: error instanceof Error ? error.message : String(error)
         })
       );
     } finally {
-      if (
-        target.serverId === activeServerId &&
-        isCurrentResourceOperation(target, roomId, loadId)
-      ) {
-        saving = false;
-      }
+      if (isCurrentIdentity(target)) saving = false;
     }
   }
 

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomManagementPagePermissionMatrixMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomManagementPagePermissionMatrixMock.svelte
@@ -1,0 +1,1 @@
+<div data-testid="permission-matrix"></div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomManagementPagePermissionMatrixMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomManagementPagePermissionMatrixMock.svelte
@@ -1,1 +1,5 @@
-<div data-testid="permission-matrix"></div>
+<script lang="ts">
+  let { scrollContents = true }: { scrollContents?: boolean } = $props();
+</script>
+
+<div data-testid="permission-matrix" data-scroll-contents={scrollContents}></div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomManagementPageTestState.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomManagementPageTestState.svelte.ts
@@ -1,0 +1,20 @@
+class RoomManagementPageTestState {
+  serverId = $state('server-a');
+  roomId = $state('shared-room');
+
+  reset(): void {
+    this.serverId = 'server-a';
+    this.roomId = 'shared-room';
+  }
+}
+
+export const roomManagementPageTestState = new RoomManagementPageTestState();
+
+export const roomManagementTestPage = {
+  get params() {
+    return {
+      serverId: roomManagementPageTestState.serverId,
+      roomId: roomManagementPageTestState.roomId
+    };
+  }
+};

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.spec.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  DirectoryMember,
+  MemberDirectoryAPI,
+  MemberDirectoryPage
+} from '$lib/api-client/memberDirectory';
+import { PresenceStatus } from '$lib/api-client/renderTypes';
+import type { RoomCommandAPI } from '$lib/api-client/rooms';
+import {
+  ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
+  RoomMemberManagementStore,
+  type RoomMemberManagementAPIs
+} from './RoomMemberManagementStore.svelte';
+
+function member(id: string): DirectoryMember {
+  return {
+    id,
+    login: id,
+    displayName: id.toUpperCase(),
+    deleted: false,
+    avatarUrl: null,
+    presenceStatus: PresenceStatus.Offline,
+    customStatus: null,
+    roles: ['everyone'],
+    createdAt: null
+  };
+}
+
+function page(
+  members: DirectoryMember[],
+  totalCount = members.length,
+  hasMore = false
+): MemberDirectoryPage {
+  return { members, totalCount, hasMore };
+}
+
+function APIs(
+  overrides: {
+    listRoomMembers?: MemberDirectoryAPI['listRoomMembers'];
+    listUsers?: MemberDirectoryAPI['listUsers'];
+    batchGetRoomMembers?: MemberDirectoryAPI['batchGetRoomMembers'];
+    addMember?: RoomCommandAPI['addMember'];
+    removeMember?: RoomCommandAPI['removeMember'];
+  } = {}
+): RoomMemberManagementAPIs {
+  return {
+    directory: {
+      listRoomMembers: overrides.listRoomMembers ?? vi.fn().mockResolvedValue(page([])),
+      listUsers: overrides.listUsers ?? vi.fn().mockResolvedValue(page([])),
+      batchGetRoomMembers: overrides.batchGetRoomMembers ?? vi.fn().mockResolvedValue([]),
+      getUser: vi.fn(),
+      getUserByLogin: vi.fn(),
+      batchGetUsers: vi.fn(),
+      getRoomMember: vi.fn()
+    } as unknown as MemberDirectoryAPI,
+    commands: {
+      addMember: overrides.addMember ?? vi.fn().mockResolvedValue(null),
+      removeMember: overrides.removeMember ?? vi.fn().mockResolvedValue(true)
+    } as unknown as RoomCommandAPI
+  };
+}
+
+describe('RoomMemberManagementStore', () => {
+  it('loads members in offset pages without replacing previously loaded rows', async () => {
+    const first = Array.from({ length: ROOM_MEMBER_MANAGEMENT_PAGE_SIZE }, (_, index) =>
+      member(`user-${index}`)
+    );
+    const listRoomMembers = vi
+      .fn()
+      .mockResolvedValueOnce(page(first, 21, true))
+      .mockResolvedValueOnce(page([member('user-20')], 21, false));
+    const store = new RoomMemberManagementStore(() => APIs({ listRoomMembers }));
+
+    store.setRoom('server-1', 'room-1');
+    await store.loadFirstPage();
+    await store.loadMore();
+
+    expect(listRoomMembers).toHaveBeenNthCalledWith(
+      1,
+      'room-1',
+      '',
+      ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
+      0
+    );
+    expect(listRoomMembers).toHaveBeenNthCalledWith(
+      2,
+      'room-1',
+      '',
+      ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
+      ROOM_MEMBER_MANAGEMENT_PAGE_SIZE
+    );
+    expect(store.members).toHaveLength(21);
+    expect(store.hasMore).toBe(false);
+  });
+
+  it('excludes existing room members from server-directory search results', async () => {
+    const alice = member('alice');
+    const bob = member('bob');
+    const listUsers = vi.fn().mockResolvedValue(page([alice, bob]));
+    const batchGetRoomMembers = vi.fn().mockResolvedValue([alice]);
+    const store = new RoomMemberManagementStore(() => APIs({ listUsers, batchGetRoomMembers }));
+
+    store.setRoom('server-1', 'room-1');
+    await store.searchDirectory('a');
+
+    expect(batchGetRoomMembers).toHaveBeenCalledWith('room-1', ['alice', 'bob']);
+    expect(store.directoryResults).toEqual([bob]);
+  });
+
+  it('continues directory paging when the first page contains only existing members', async () => {
+    const existing = Array.from({ length: 20 }, (_, index) => member(`existing-${index}`));
+    const bob = member('bob');
+    const listUsers = vi
+      .fn()
+      .mockResolvedValueOnce(page(existing, 21, true))
+      .mockResolvedValueOnce(page([bob], 21, false));
+    const batchGetRoomMembers = vi.fn().mockResolvedValueOnce(existing).mockResolvedValueOnce([]);
+    const store = new RoomMemberManagementStore(() => APIs({ listUsers, batchGetRoomMembers }));
+
+    store.setRoom('server-1', 'room-1');
+    await store.searchDirectory('b');
+
+    expect(listUsers).toHaveBeenNthCalledWith(1, 'b', 20, 0);
+    expect(listUsers).toHaveBeenNthCalledWith(2, 'b', 20, 20);
+    expect(store.directoryResults).toEqual([bob]);
+  });
+
+  it('does not retain or restore members when the server changes with the same room ID', async () => {
+    let resolveFirst!: (value: MemberDirectoryPage) => void;
+    const firstPage = new Promise<MemberDirectoryPage>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const listRoomMembers = vi
+      .fn()
+      .mockReturnValueOnce(firstPage)
+      .mockResolvedValueOnce(page([member('bob')]));
+    const store = new RoomMemberManagementStore(() => APIs({ listRoomMembers }));
+
+    store.setRoom('server-1', 'shared-room');
+    const staleLoad = store.loadFirstPage();
+    store.setRoom('server-2', 'shared-room');
+    await store.loadFirstPage();
+    resolveFirst(page([member('alice')]));
+    await staleLoad;
+
+    expect(store.members).toEqual([member('bob')]);
+  });
+
+  it('purges room data and fences an older refresh at the access-loss boundary', async () => {
+    let resolveRefresh!: (value: MemberDirectoryPage) => void;
+    const refreshPage = new Promise<MemberDirectoryPage>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const listRoomMembers = vi
+      .fn()
+      .mockResolvedValueOnce(page([member('alice')]))
+      .mockReturnValueOnce(refreshPage);
+    const store = new RoomMemberManagementStore(() => APIs({ listRoomMembers }));
+
+    store.setRoom('server-1', 'room-1');
+    await store.loadFirstPage();
+    const staleRefresh = store.refresh();
+
+    expect(store.clearRoom('server-1', 'room-1')).toBe(true);
+    expect(store.members).toEqual([]);
+    resolveRefresh(page([member('alice')]));
+    await staleRefresh;
+
+    expect(store.members).toEqual([]);
+  });
+
+  it('re-reads canonical membership after add and remove', async () => {
+    const alice = member('alice');
+    const bob = member('bob');
+    let current = [alice];
+    const listRoomMembers = vi.fn().mockImplementation(() => Promise.resolve(page(current)));
+    const addMember = vi.fn().mockImplementation(async () => {
+      current = [alice, bob];
+      return bob;
+    });
+    const removeMember = vi.fn().mockImplementation(async () => {
+      current = [bob];
+      return true;
+    });
+    const api = APIs({ listRoomMembers, addMember, removeMember });
+    const store = new RoomMemberManagementStore(() => api);
+
+    store.setRoom('server-1', 'room-1');
+    await store.loadFirstPage();
+    expect(await store.addMember(bob)).toBe(true);
+    expect(store.members).toEqual([alice, bob]);
+    expect(await store.removeMember(alice)).toBe(true);
+
+    expect(store.members).toEqual([bob]);
+  });
+
+  it('keeps command success authoritative when the canonical reread fails', async () => {
+    const alice = member('alice');
+    const bob = member('bob');
+    const listRoomMembers = vi
+      .fn()
+      .mockResolvedValueOnce(page([alice]))
+      .mockRejectedValueOnce(new Error('projection temporarily unavailable'));
+    const addMember = vi.fn().mockResolvedValue(bob);
+    const store = new RoomMemberManagementStore(() => APIs({ listRoomMembers, addMember }));
+
+    store.setRoom('server-1', 'room-1');
+    await store.loadFirstPage();
+
+    expect(await store.addMember(bob)).toBe(true);
+    expect(store.loadError).toBe('projection temporarily unavailable');
+    expect(store.members).toEqual([alice]);
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.ts
@@ -1,0 +1,287 @@
+import type {
+  DirectoryMember,
+  MemberDirectoryAPI,
+  MemberDirectoryPage
+} from '$lib/api-client/memberDirectory';
+import type { RoomCommandAPI } from '$lib/api-client/rooms';
+import { SvelteSet } from 'svelte/reactivity';
+
+export const ROOM_MEMBER_MANAGEMENT_PAGE_SIZE = 20;
+const USER_PICKER_PAGE_SIZE = 20;
+
+export type RoomMemberManagementAPIs = {
+  directory: MemberDirectoryAPI;
+  commands: RoomCommandAPI;
+};
+
+type APIProvider = () => RoomMemberManagementAPIs;
+
+function appendMembers(current: DirectoryMember[], incoming: DirectoryMember[]): DirectoryMember[] {
+  const incomingIds = new Set(incoming.map((member) => member.id));
+  return [...current.filter((member) => !incomingIds.has(member.id)), ...incoming];
+}
+
+/**
+ * Owns the room-management page's paged membership reads and mutation lifecycle.
+ *
+ * Mutations never optimistically rewrite the list. The store re-reads the canonical
+ * membership projection after each command. The server-scoped realtime projection
+ * independently reconciles shared room mirrors.
+ */
+export class RoomMemberManagementStore {
+  members = $state.raw<DirectoryMember[]>([]);
+  totalCount = $state(0);
+  hasMore = $state(false);
+  loading = $state(false);
+  loadingMore = $state(false);
+  loadError = $state<string | null>(null);
+
+  directoryResults = $state.raw<DirectoryMember[]>([]);
+  directoryLoading = $state(false);
+  directoryError = $state<string | null>(null);
+  activeDirectorySearch = $state('');
+
+  addingUserId = $state<string | null>(null);
+  removingUserId = $state<string | null>(null);
+
+  readonly #getAPIs: APIProvider;
+  #serverId = '';
+  #roomId = '';
+  #roomGeneration = 0;
+  #membersRequestId = 0;
+  #directoryRequestId = 0;
+
+  constructor(getAPIs: APIProvider) {
+    this.#getAPIs = getAPIs;
+  }
+
+  setRoom(serverId: string, roomId: string): void {
+    if (serverId === this.#serverId && roomId === this.#roomId) return;
+    this.#serverId = serverId;
+    this.#roomId = roomId;
+    this.#fenceAndClear();
+  }
+
+  /**
+   * Immediately purge state for a projected room removal before attempting any
+   * authorised reload. Incrementing both request generations prevents older
+   * responses from reopening the privacy boundary.
+   */
+  clearRoom(serverId: string, roomId: string): boolean {
+    if (!this.#isCurrentRoom(serverId, roomId)) return false;
+    this.#fenceAndClear();
+    return true;
+  }
+
+  #fenceAndClear(): void {
+    this.#roomGeneration++;
+    this.#membersRequestId++;
+    this.#directoryRequestId++;
+    this.members = [];
+    this.totalCount = 0;
+    this.hasMore = false;
+    this.loading = false;
+    this.loadingMore = false;
+    this.loadError = null;
+    this.activeDirectorySearch = '';
+    this.directoryResults = [];
+    this.directoryLoading = false;
+    this.directoryError = null;
+    this.addingUserId = null;
+    this.removingUserId = null;
+  }
+
+  async loadFirstPage(): Promise<void> {
+    if (!this.#serverId || !this.#roomId || this.loading) return;
+    const requestId = ++this.#membersRequestId;
+    const serverId = this.#serverId;
+    const roomId = this.#roomId;
+    this.loading = true;
+    this.loadingMore = false;
+    this.loadError = null;
+
+    try {
+      const page = await this.#getAPIs().directory.listRoomMembers(
+        roomId,
+        '',
+        ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
+        0
+      );
+      if (!this.#isCurrentMembersRequest(requestId, serverId, roomId)) return;
+      this.applyFirstPage(page);
+    } catch (error) {
+      if (!this.#isCurrentMembersRequest(requestId, serverId, roomId)) return;
+      this.loadError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (this.#isCurrentMembersRequest(requestId, serverId, roomId)) this.loading = false;
+    }
+  }
+
+  async refresh(): Promise<void> {
+    if (!this.#serverId || !this.#roomId) return;
+    this.#membersRequestId++;
+    this.loading = false;
+    await this.loadFirstPage();
+  }
+
+  async loadMore(): Promise<void> {
+    if (!this.#serverId || !this.#roomId || this.loading || this.loadingMore || !this.hasMore) {
+      return;
+    }
+    const requestId = this.#membersRequestId;
+    const serverId = this.#serverId;
+    const roomId = this.#roomId;
+    const offset = this.members.length;
+    this.loadingMore = true;
+    this.loadError = null;
+
+    try {
+      const page = await this.#getAPIs().directory.listRoomMembers(
+        roomId,
+        '',
+        ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
+        offset
+      );
+      if (!this.#isCurrentMembersRequest(requestId, serverId, roomId)) return;
+      this.members = appendMembers(this.members, page.members);
+      this.totalCount = page.totalCount;
+      this.hasMore = page.hasMore && page.members.length > 0;
+    } catch (error) {
+      if (!this.#isCurrentMembersRequest(requestId, serverId, roomId)) return;
+      this.loadError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (this.#isCurrentMembersRequest(requestId, serverId, roomId)) this.loadingMore = false;
+    }
+  }
+
+  async searchDirectory(search: string): Promise<void> {
+    const query = search.trim();
+    const requestId = ++this.#directoryRequestId;
+    const serverId = this.#serverId;
+    const roomId = this.#roomId;
+    this.activeDirectorySearch = query;
+    this.directoryResults = [];
+    this.directoryError = null;
+
+    if (!query || !serverId || !roomId) {
+      this.directoryLoading = false;
+      return;
+    }
+
+    this.directoryLoading = true;
+    try {
+      const api = this.#getAPIs().directory;
+      const eligible: DirectoryMember[] = [];
+      const seenIds = new SvelteSet<string>();
+      let offset = 0;
+      let hasMore = true;
+
+      while (hasMore && eligible.length < USER_PICKER_PAGE_SIZE) {
+        const page = await api.listUsers(query, USER_PICKER_PAGE_SIZE, offset);
+        if (!this.#isCurrentDirectoryRequest(requestId, serverId, roomId, query)) return;
+
+        const candidates = page.members.filter(
+          (member) => !member.deleted && !seenIds.has(member.id)
+        );
+        for (const candidate of candidates) seenIds.add(candidate.id);
+
+        const existing = candidates.length
+          ? await api.batchGetRoomMembers(
+              roomId,
+              candidates.map((member) => member.id)
+            )
+          : [];
+        if (!this.#isCurrentDirectoryRequest(requestId, serverId, roomId, query)) return;
+
+        const existingIds = new SvelteSet(existing.map((member) => member.id));
+        eligible.push(...candidates.filter((member) => !existingIds.has(member.id)));
+
+        hasMore = page.hasMore && page.members.length > 0;
+        offset += page.members.length;
+      }
+
+      this.directoryResults = eligible.slice(0, USER_PICKER_PAGE_SIZE);
+    } catch (error) {
+      if (!this.#isCurrentDirectoryRequest(requestId, serverId, roomId, query)) return;
+      this.directoryError = error instanceof Error ? error.message : String(error);
+    } finally {
+      if (this.#isCurrentDirectoryRequest(requestId, serverId, roomId, query)) {
+        this.directoryLoading = false;
+      }
+    }
+  }
+
+  clearDirectorySearch(): void {
+    this.#directoryRequestId++;
+    this.activeDirectorySearch = '';
+    this.directoryResults = [];
+    this.directoryLoading = false;
+    this.directoryError = null;
+  }
+
+  async addMember(user: DirectoryMember): Promise<boolean> {
+    if (!this.#serverId || !this.#roomId || this.addingUserId || this.removingUserId) return false;
+    const serverId = this.#serverId;
+    const roomId = this.#roomId;
+    const roomGeneration = this.#roomGeneration;
+    const api = this.#getAPIs();
+    this.addingUserId = user.id;
+    try {
+      await api.commands.addMember({ roomId, userId: user.id });
+      if (!this.#isCurrentRoom(serverId, roomId, roomGeneration)) return false;
+      this.directoryResults = this.directoryResults.filter((candidate) => candidate.id !== user.id);
+      await this.refresh();
+      return this.#isCurrentRoom(serverId, roomId, roomGeneration);
+    } finally {
+      if (this.#isCurrentRoom(serverId, roomId, roomGeneration)) this.addingUserId = null;
+    }
+  }
+
+  async removeMember(user: DirectoryMember): Promise<boolean> {
+    if (!this.#serverId || !this.#roomId || this.addingUserId || this.removingUserId) return false;
+    const serverId = this.#serverId;
+    const roomId = this.#roomId;
+    const roomGeneration = this.#roomGeneration;
+    const api = this.#getAPIs();
+    this.removingUserId = user.id;
+    try {
+      await api.commands.removeMember({ roomId, userId: user.id });
+      if (!this.#isCurrentRoom(serverId, roomId, roomGeneration)) return false;
+      await this.refresh();
+      return this.#isCurrentRoom(serverId, roomId, roomGeneration);
+    } finally {
+      if (this.#isCurrentRoom(serverId, roomId, roomGeneration)) this.removingUserId = null;
+    }
+  }
+
+  private applyFirstPage(page: MemberDirectoryPage): void {
+    this.members = page.members;
+    this.totalCount = page.totalCount;
+    this.hasMore = page.hasMore;
+  }
+
+  #isCurrentRoom(serverId: string, roomId: string, roomGeneration?: number): boolean {
+    return (
+      serverId === this.#serverId &&
+      roomId === this.#roomId &&
+      (roomGeneration === undefined || roomGeneration === this.#roomGeneration)
+    );
+  }
+
+  #isCurrentMembersRequest(requestId: number, serverId: string, roomId: string): boolean {
+    return requestId === this.#membersRequestId && this.#isCurrentRoom(serverId, roomId);
+  }
+
+  #isCurrentDirectoryRequest(
+    requestId: number,
+    serverId: string,
+    roomId: string,
+    search: string
+  ): boolean {
+    return (
+      requestId === this.#directoryRequestId &&
+      this.#isCurrentRoom(serverId, roomId) &&
+      search === this.activeDirectorySearch
+    );
+  }
+}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.ts
@@ -14,7 +14,7 @@ export type RoomMemberManagementAPIs = {
   commands: RoomCommandAPI;
 };
 
-type APIProvider = () => RoomMemberManagementAPIs;
+type APIProvider = (serverId: string) => RoomMemberManagementAPIs;
 
 function appendMembers(current: DirectoryMember[], incoming: DirectoryMember[]): DirectoryMember[] {
   const incomingIds = new Set(incoming.map((member) => member.id));
@@ -101,7 +101,7 @@ export class RoomMemberManagementStore {
     this.loadError = null;
 
     try {
-      const page = await this.#getAPIs().directory.listRoomMembers(
+      const page = await this.#getAPIs(serverId).directory.listRoomMembers(
         roomId,
         '',
         ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
@@ -136,7 +136,7 @@ export class RoomMemberManagementStore {
     this.loadError = null;
 
     try {
-      const page = await this.#getAPIs().directory.listRoomMembers(
+      const page = await this.#getAPIs(serverId).directory.listRoomMembers(
         roomId,
         '',
         ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
@@ -170,7 +170,7 @@ export class RoomMemberManagementStore {
 
     this.directoryLoading = true;
     try {
-      const api = this.#getAPIs().directory;
+      const api = this.#getAPIs(serverId).directory;
       const eligible: DirectoryMember[] = [];
       const seenIds = new SvelteSet<string>();
       let offset = 0;
@@ -224,7 +224,7 @@ export class RoomMemberManagementStore {
     const serverId = this.#serverId;
     const roomId = this.#roomId;
     const roomGeneration = this.#roomGeneration;
-    const api = this.#getAPIs();
+    const api = this.#getAPIs(serverId);
     this.addingUserId = user.id;
     try {
       await api.commands.addMember({ roomId, userId: user.id });
@@ -242,7 +242,7 @@ export class RoomMemberManagementStore {
     const serverId = this.#serverId;
     const roomId = this.#roomId;
     const roomGeneration = this.#roomGeneration;
-    const api = this.#getAPIs();
+    const api = this.#getAPIs(serverId);
     this.removingUserId = user.id;
     try {
       await api.commands.removeMember({ roomId, userId: user.id });

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersConfirmDialogMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersConfirmDialogMock.svelte
@@ -1,0 +1,25 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    children,
+    title,
+    actionLabel,
+    loading = false,
+    onconfirm,
+    onclose
+  }: {
+    children: Snippet;
+    title: string;
+    actionLabel: string;
+    loading?: boolean;
+    onconfirm: () => void;
+    onclose: () => void;
+  } = $props();
+</script>
+
+<dialog open aria-label={title}>
+  <div>{@render children()}</div>
+  <button type="button" onclick={onclose}>Cancel</button>
+  <button type="button" disabled={loading} onclick={onconfirm}>{actionLabel}</button>
+</dialog>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
@@ -45,6 +45,7 @@
     const selectedServerId = serverId;
     const selectedRoomId = roomId;
     untrack(() => {
+      clearLocalState();
       store.setRoom(selectedServerId, selectedRoomId);
       void store.loadFirstPage();
     });

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
@@ -1,0 +1,292 @@
+<script lang="ts">
+  import { onDestroy, untrack } from 'svelte';
+  import type { DirectoryMember } from '$lib/api-client/memberDirectory';
+  import { DataTable, Panel } from '$lib/components/admin';
+  import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
+  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+  import Hint from '$lib/ui/Hint.svelte';
+  import { Button, Combobox } from '$lib/ui/form';
+  import { useProjectionEvent } from '$lib/hooks';
+  import { toast } from '$lib/ui/toast';
+  import { getAvatarInitials } from '$lib/utils/initials';
+  import * as m from '$lib/i18n/messages';
+  import { RoomMemberManagementStore } from './RoomMemberManagementStore.svelte';
+
+  let {
+    serverId,
+    roomId,
+    roomName,
+    isUniversal,
+    archived,
+    canManageMembers,
+    scrollRoot,
+    store
+  }: {
+    serverId: string;
+    roomId: string;
+    roomName: string;
+    isUniversal: boolean;
+    archived: boolean;
+    canManageMembers: boolean;
+    scrollRoot?: HTMLElement;
+    store: RoomMemberManagementStore;
+  } = $props();
+
+  let selectedUser = $state<DirectoryMember | null>(null);
+  let selectedUserId = $state('');
+  let selectedUserText = $state('');
+  let removeCandidate = $state<DirectoryMember | null>(null);
+  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const canEditMembership = $derived(canManageMembers && !isUniversal && !archived);
+  const columns = $derived(canEditMembership ? 3 : 2);
+
+  $effect(() => {
+    const selectedServerId = serverId;
+    const selectedRoomId = roomId;
+    untrack(() => {
+      store.setRoom(selectedServerId, selectedRoomId);
+      void store.loadFirstPage();
+    });
+  });
+
+  useProjectionEvent((event) => {
+    for (const operation of event.operations) {
+      switch (operation.operation.case) {
+        case 'roomUpsert':
+          if (operation.operation.value.room?.room?.id === roomId) {
+            void store.refresh();
+            return;
+          }
+          break;
+        case 'roomRemove':
+          if (operation.operation.value.roomId === roomId) {
+            clearLocalState();
+            if (store.clearRoom(serverId, roomId)) void store.loadFirstPage();
+            return;
+          }
+          break;
+      }
+    }
+  });
+
+  onDestroy(() => {
+    if (searchTimer) clearTimeout(searchTimer);
+  });
+
+  function memberLabel(member: DirectoryMember): string {
+    return `${member.displayName} @${member.login}`;
+  }
+
+  function scheduleDirectorySearch(text: string): void {
+    selectedUser = null;
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = setTimeout(() => void store.searchDirectory(text), 200);
+  }
+
+  function clearLocalState(): void {
+    if (searchTimer) clearTimeout(searchTimer);
+    searchTimer = null;
+    selectedUser = null;
+    selectedUserId = '';
+    selectedUserText = '';
+    removeCandidate = null;
+  }
+
+  function clearSelectedUser(): void {
+    clearLocalState();
+    store.clearDirectorySearch();
+  }
+
+  async function addSelectedMember(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (!selectedUser || !canEditMembership || store.addingUserId) return;
+    const user = selectedUser;
+    try {
+      if (!(await store.addMember(user))) return;
+      clearSelectedUser();
+      toast.success(m['admin.rooms_admin.member_added']({ name: user.displayName }));
+    } catch (error) {
+      toast.error(
+        m['admin.rooms_admin.add_member_failed']({
+          error: error instanceof Error ? error.message : String(error)
+        })
+      );
+    }
+  }
+
+  async function confirmRemoveMember(): Promise<void> {
+    const user = removeCandidate;
+    if (!user || !canEditMembership) return;
+    try {
+      if (!(await store.removeMember(user))) return;
+      removeCandidate = null;
+      toast.success(m['admin.rooms_admin.member_removed']({ name: user.displayName }));
+    } catch (error) {
+      toast.error(
+        m['admin.rooms_admin.remove_member_failed']({
+          error: error instanceof Error ? error.message : String(error)
+        })
+      );
+    }
+  }
+</script>
+
+<Panel
+  title={m['admin.nav.members']()}
+  icon="iconify uil--users-alt"
+  count={store.totalCount}
+  noPadding
+>
+  {#if isUniversal}
+    <div class="border-b border-border p-5">
+      <Hint>{m['admin.rooms_admin.universal_members_description']()}</Hint>
+    </div>
+  {:else if archived}
+    <div class="border-b border-border p-5">
+      <Hint>{m['admin.rooms_admin.archived_members_description']()}</Hint>
+    </div>
+  {:else if canManageMembers}
+    <form
+      class="flex flex-col items-end gap-3 border-b border-border p-5 sm:flex-row"
+      onsubmit={addSelectedMember}
+    >
+      <div class="w-full sm:max-w-md">
+        <Combobox
+          id="room-member-picker"
+          label={m['admin.rooms_admin.add_member']()}
+          placeholder={m['admin.members.search_placeholder']()}
+          bind:value={selectedUserId}
+          bind:text={selectedUserText}
+          items={store.directoryResults}
+          getValue={(user) => user.id}
+          getLabel={memberLabel}
+          loading={store.directoryLoading}
+          error={store.directoryError ?? undefined}
+          allowFreeform={false}
+          emptyMessage={m['admin.users.empty']()}
+          clearLabel={m['common.clear']()}
+          ontextchange={scheduleDirectorySearch}
+          onselect={(user) => (selectedUser = user)}
+          onclear={clearSelectedUser}
+        >
+          {#snippet item({ item: user })}
+            {#if user.avatarUrl}
+              <SkeletonImg
+                loading="lazy"
+                src={user.avatarUrl}
+                alt=""
+                class="h-8 w-8 shrink-0 rounded-full object-cover"
+              />
+            {:else}
+              <div
+                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface-emphasized text-sm font-semibold text-muted"
+              >
+                {getAvatarInitials(user.displayName, user.login)}
+              </div>
+            {/if}
+            <span class="min-w-0 truncate">{user.displayName}</span>
+            <span class="min-w-0 truncate text-muted">@{user.login}</span>
+          {/snippet}
+        </Combobox>
+      </div>
+      <Button
+        type="submit"
+        disabled={!selectedUser}
+        loading={!!store.addingUserId}
+        loadingText={m['admin.rooms_admin.adding_member']()}
+      >
+        {m['admin.rooms_admin.add_member']()}
+      </Button>
+    </form>
+  {/if}
+
+  {#if store.loadError}
+    <div class="border-b border-border p-5">
+      <Hint tone="danger">
+        <div class="flex flex-wrap items-center justify-between gap-3">
+          <span>{m['admin.rooms_admin.load_members_failed']({ error: store.loadError })}</span>
+          <Button variant="secondary" size="sm" onclick={() => void store.refresh()}>
+            {m['common.retry']()}
+          </Button>
+        </div>
+      </Hint>
+    </div>
+  {/if}
+
+  {#if store.loading && store.members.length === 0}
+    <div class="p-5 text-muted">{m['admin.members.loading']()}</div>
+  {:else}
+    <DataTable
+      items={store.members}
+      {columns}
+      emptyMessage={m['admin.members.empty']()}
+      hasMore={store.hasMore && !store.loadError}
+      loadingMore={store.loadingMore}
+      onLoadMore={() => store.loadMore()}
+      loadMoreRoot={scrollRoot}
+      loadingMoreMessage={m['admin.members.loading_more']()}
+      hoverable={false}
+    >
+      {#snippet header()}
+        <th class="table-header-cell">{m['admin.common.user']()}</th>
+        <th class="table-header-cell">{m['admin.users.login']()}</th>
+        {#if canEditMembership}
+          <th class="table-header-cell text-right">
+            <span class="sr-only">{m['admin.rooms_admin.remove_member']()}</span>
+          </th>
+        {/if}
+      {/snippet}
+      {#snippet row(member)}
+        <td class="px-4 py-3">
+          <div class="flex min-w-0 items-center gap-3">
+            {#if member.avatarUrl}
+              <SkeletonImg
+                loading="lazy"
+                src={member.avatarUrl}
+                alt=""
+                class="h-8 w-8 shrink-0 rounded-full object-cover"
+              />
+            {:else}
+              <div
+                class="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-surface text-sm font-semibold text-muted"
+              >
+                {getAvatarInitials(member.displayName, member.login)}
+              </div>
+            {/if}
+            <span class="min-w-0 truncate font-medium text-text-top">{member.displayName}</span>
+          </div>
+        </td>
+        <td class="px-4 py-3 text-muted">@{member.login}</td>
+        {#if canEditMembership}
+          <td class="px-4 py-3 text-right">
+            <Button
+              variant="danger-secondary"
+              size="sm"
+              disabled={!!store.addingUserId || !!store.removingUserId}
+              onclick={() => (removeCandidate = member)}
+            >
+              {m['admin.rooms_admin.remove_member']()}
+            </Button>
+          </td>
+        {/if}
+      {/snippet}
+    </DataTable>
+  {/if}
+</Panel>
+
+{#if removeCandidate}
+  <ConfirmDialog
+    title={m['admin.rooms_admin.remove_member']()}
+    actionLabel={m['admin.rooms_admin.remove_member']()}
+    actionIcon="iconify uil--user-minus"
+    loading={store.removingUserId === removeCandidate.id}
+    onconfirm={() => void confirmRemoveMember()}
+    onclose={() => (removeCandidate = null)}
+  >
+    {m['admin.rooms_admin.remove_member_prompt']({
+      name: removeCandidate.displayName,
+      room: `#${roomName}`
+    })}
+  </ConfirmDialog>
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte.spec.ts
@@ -106,6 +106,8 @@ function setup(
 function renderPanel(
   store: RoomMemberManagementStore,
   overrides: Partial<{
+    serverId: string;
+    roomId: string;
     isUniversal: boolean;
     archived: boolean;
     canManageMembers: boolean;
@@ -113,8 +115,8 @@ function renderPanel(
 ) {
   return render(RoomMembersPanel, {
     props: {
-      serverId: 'server-1',
-      roomId: 'room-1',
+      serverId: overrides.serverId ?? 'server-1',
+      roomId: overrides.roomId ?? 'room-1',
       roomName: 'general',
       isUniversal: overrides.isUniversal ?? false,
       archived: overrides.archived ?? false,
@@ -259,6 +261,61 @@ describe('RoomMembersPanel', () => {
     await settle();
     expect(container.textContent).toContain('permission denied');
     expect(container.textContent).not.toContain('Alice');
+  });
+
+  it('clears a selected add candidate when the server identity changes', async () => {
+    const bob = member('bob', 'Bob');
+    const { store, addMember } = setup({ directoryUsers: [bob] });
+    const rendered = renderPanel(store);
+    await settle();
+
+    const input = rendered.container.querySelector('#room-member-picker') as HTMLInputElement;
+    input.value = 'bob';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await settleDirectorySearch();
+    (document.querySelector('[role="option"]') as HTMLButtonElement).click();
+    flushSync();
+    expect(buttonByText(rendered.container, 'Add member').disabled).toBe(false);
+
+    await rendered.rerender({
+      serverId: 'server-2',
+      roomId: 'room-1',
+      roomName: 'general',
+      isUniversal: false,
+      archived: false,
+      canManageMembers: true,
+      store
+    });
+    await settle();
+
+    expect(buttonByText(rendered.container, 'Add member').disabled).toBe(true);
+    buttonByText(rendered.container, 'Add member').click();
+    await settle();
+    expect(addMember).not.toHaveBeenCalled();
+  });
+
+  it('closes a removal confirmation when the server identity changes', async () => {
+    const { store, removeMember } = setup();
+    const rendered = renderPanel(store);
+    await settle();
+
+    buttonByText(rendered.container, 'Remove member').click();
+    flushSync();
+    expect(document.querySelector('dialog')).not.toBeNull();
+
+    await rendered.rerender({
+      serverId: 'server-2',
+      roomId: 'room-1',
+      roomName: 'general',
+      isUniversal: false,
+      archived: false,
+      canManageMembers: true,
+      store
+    });
+    await settle();
+
+    expect(document.querySelector('dialog')).toBeNull();
+    expect(removeMember).not.toHaveBeenCalled();
   });
 
   it('reports add and remove API errors without claiming success', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte.spec.ts
@@ -1,0 +1,297 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import {
+  RealtimeProjectionEvent,
+  RealtimeProjectionOperation,
+  RealtimeProjectionRoomRemove
+} from '@chatto/api-types/realtime/v1/realtime_pb';
+import type {
+  DirectoryMember,
+  MemberDirectoryAPI,
+  MemberDirectoryPage
+} from '$lib/api-client/memberDirectory';
+import { PresenceStatus } from '$lib/api-client/renderTypes';
+import type { RoomCommandAPI } from '$lib/api-client/rooms';
+import RoomMembersPanel from './RoomMembersPanel.svelte';
+import {
+  RoomMemberManagementStore,
+  type RoomMemberManagementAPIs
+} from './RoomMemberManagementStore.svelte';
+
+const mocks = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  projectionHandler: null as ((event: RealtimeProjectionEvent) => void) | null
+}));
+
+vi.mock('$lib/ui/toast', () => ({
+  toast: {
+    success: mocks.toastSuccess,
+    error: mocks.toastError
+  }
+}));
+
+vi.mock('$lib/ui/ConfirmDialog.svelte', async () => ({
+  default: (await import('./RoomMembersConfirmDialogMock.svelte')).default
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useProjectionEvent: (handler: (event: RealtimeProjectionEvent) => void) => {
+    mocks.projectionHandler = handler;
+  }
+}));
+
+function member(id: string, displayName = id.toUpperCase()): DirectoryMember {
+  return {
+    id,
+    login: id,
+    displayName,
+    deleted: false,
+    avatarUrl: null,
+    presenceStatus: PresenceStatus.Offline,
+    customStatus: null,
+    roles: ['everyone'],
+    createdAt: null
+  };
+}
+
+function page(members: DirectoryMember[]): MemberDirectoryPage {
+  return { members, totalCount: members.length, hasMore: false };
+}
+
+function setup(
+  overrides: {
+    members?: DirectoryMember[];
+    directoryUsers?: DirectoryMember[];
+    existingSearchMembers?: DirectoryMember[];
+    addError?: Error;
+    removeError?: Error;
+  } = {}
+) {
+  let current = overrides.members ?? [member('alice', 'Alice')];
+  const listRoomMembers = vi.fn().mockImplementation(() => Promise.resolve(page(current)));
+  const listUsers = vi.fn().mockResolvedValue(page(overrides.directoryUsers ?? []));
+  const batchGetRoomMembers = vi.fn().mockResolvedValue(overrides.existingSearchMembers ?? []);
+  const addMember = vi.fn().mockImplementation(async ({ userId }: { userId: string }) => {
+    if (overrides.addError) throw overrides.addError;
+    const added = (overrides.directoryUsers ?? []).find((user) => user.id === userId) ?? null;
+    if (added) current = [...current, added];
+    return added;
+  });
+  const removeMember = vi.fn().mockImplementation(async ({ userId }: { userId: string }) => {
+    if (overrides.removeError) throw overrides.removeError;
+    current = current.filter((candidate) => candidate.id !== userId);
+    return true;
+  });
+  const api: RoomMemberManagementAPIs = {
+    directory: {
+      listRoomMembers,
+      listUsers,
+      batchGetRoomMembers,
+      getUser: vi.fn(),
+      getUserByLogin: vi.fn(),
+      batchGetUsers: vi.fn(),
+      getRoomMember: vi.fn()
+    } as unknown as MemberDirectoryAPI,
+    commands: {
+      addMember,
+      removeMember
+    } as unknown as RoomCommandAPI
+  };
+  const store = new RoomMemberManagementStore(() => api);
+  return { store, listRoomMembers, listUsers, batchGetRoomMembers, addMember, removeMember };
+}
+
+function renderPanel(
+  store: RoomMemberManagementStore,
+  overrides: Partial<{
+    isUniversal: boolean;
+    archived: boolean;
+    canManageMembers: boolean;
+  }> = {}
+) {
+  return render(RoomMembersPanel, {
+    props: {
+      serverId: 'server-1',
+      roomId: 'room-1',
+      roomName: 'general',
+      isUniversal: overrides.isUniversal ?? false,
+      archived: overrides.archived ?? false,
+      canManageMembers: overrides.canManageMembers ?? true,
+      store
+    }
+  });
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+}
+
+async function settleDirectorySearch(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 220));
+  await settle();
+}
+
+function buttonByText(root: ParentNode, text: string): HTMLButtonElement {
+  const button = [...root.querySelectorAll('button')].find(
+    (candidate) => candidate.textContent?.trim() === text
+  );
+  if (!(button instanceof HTMLButtonElement)) throw new Error(`Button not found: ${text}`);
+  return button;
+}
+
+describe('RoomMembersPanel', () => {
+  beforeEach(() => {
+    mocks.toastSuccess.mockReset();
+    mocks.toastError.mockReset();
+    mocks.projectionHandler = null;
+  });
+
+  it('searches the directory, excludes existing members, and successfully adds a user', async () => {
+    const alice = member('alice', 'Alice');
+    const bob = member('bob', 'Bob');
+    const { store, addMember } = setup({
+      members: [alice],
+      directoryUsers: [alice, bob],
+      existingSearchMembers: [alice]
+    });
+    const { container } = renderPanel(store);
+    await settle();
+
+    const input = container.querySelector('#room-member-picker') as HTMLInputElement;
+    input.value = 'bo';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await settleDirectorySearch();
+
+    const options = [...document.querySelectorAll('[role="option"]')];
+    expect(options).toHaveLength(1);
+    expect(options[0].textContent).toContain('Bob');
+    expect(options[0].textContent).not.toContain('Alice');
+    (options[0] as HTMLButtonElement).click();
+    flushSync();
+    buttonByText(container, 'Add member').click();
+    await settle();
+
+    expect(addMember).toHaveBeenCalledWith({ roomId: 'room-1', userId: 'bob' });
+    expect(container.textContent).toContain('Bob');
+    await vi.waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Added Bob to the room')
+    );
+  });
+
+  it('requires confirmation before removing a member', async () => {
+    const { store, removeMember } = setup();
+    const { container } = renderPanel(store);
+    await settle();
+
+    buttonByText(container, 'Remove member').click();
+    flushSync();
+    expect(removeMember).not.toHaveBeenCalled();
+    expect(document.querySelector('dialog')?.textContent).toContain('Remove Alice from #general?');
+
+    buttonByText(document.querySelector('dialog')!, 'Remove member').click();
+    await settle();
+
+    expect(removeMember).toHaveBeenCalledWith({ roomId: 'room-1', userId: 'alice' });
+    await vi.waitFor(() =>
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Removed Alice from the room')
+    );
+  });
+
+  it('hides editing controls without room.manage permission', async () => {
+    const { store } = setup();
+    const { container } = renderPanel(store, { canManageMembers: false });
+    await settle();
+
+    expect(container.textContent).toContain('Alice');
+    expect(container.querySelector('#room-member-picker')).toBeNull();
+    expect([...container.querySelectorAll('button')]).toHaveLength(0);
+  });
+
+  it('explains automatic Universal membership without rendering editing controls', async () => {
+    const { store } = setup();
+    const { container } = renderPanel(store, { isUniversal: true });
+    await settle();
+
+    expect(container.textContent).toContain('Membership is automatic in Universal rooms.');
+    expect(container.querySelector('#room-member-picker')).toBeNull();
+    expect(container.textContent).not.toContain('Remove member');
+  });
+
+  it('keeps archived room membership read-only', async () => {
+    const { store } = setup();
+    const { container } = renderPanel(store, { archived: true });
+    await settle();
+
+    expect(container.textContent).toContain(
+      'Membership cannot be changed while this room is archived.'
+    );
+    expect(container.querySelector('#room-member-picker')).toBeNull();
+    expect(container.textContent).not.toContain('Remove member');
+  });
+
+  it('immediately clears member identities when realtime removes the room', async () => {
+    const { store, listRoomMembers } = setup();
+    const { container } = renderPanel(store);
+    await settle();
+    expect(container.textContent).toContain('Alice');
+
+    listRoomMembers.mockRejectedValueOnce(new Error('permission denied'));
+    mocks.projectionHandler?.(
+      new RealtimeProjectionEvent({
+        operations: [
+          new RealtimeProjectionOperation({
+            operation: {
+              case: 'roomRemove',
+              value: new RealtimeProjectionRoomRemove({ roomId: 'room-1' })
+            }
+          })
+        ]
+      })
+    );
+    flushSync();
+
+    expect(container.textContent).not.toContain('Alice');
+    await settle();
+    expect(container.textContent).toContain('permission denied');
+    expect(container.textContent).not.toContain('Alice');
+  });
+
+  it('reports add and remove API errors without claiming success', async () => {
+    const bob = member('bob', 'Bob');
+    const addSetup = setup({
+      directoryUsers: [bob],
+      addError: new Error('user is banned')
+    });
+    const addRender = renderPanel(addSetup.store);
+    await settle();
+    const input = addRender.container.querySelector('#room-member-picker') as HTMLInputElement;
+    input.value = 'bob';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    await settleDirectorySearch();
+    (document.querySelector('[role="option"]') as HTMLButtonElement).click();
+    flushSync();
+    buttonByText(addRender.container, 'Add member').click();
+    await settle();
+
+    await vi.waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith('Failed to add member: user is banned')
+    );
+    const removeSetup = setup({ removeError: new Error('room is archived') });
+    const removeRender = renderPanel(removeSetup.store);
+    await settle();
+    buttonByText(removeRender.container, 'Remove member').click();
+    flushSync();
+    const dialogs = document.querySelectorAll('dialog');
+    buttonByText(dialogs[dialogs.length - 1], 'Remove member').click();
+    await settle();
+
+    await vi.waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith('Failed to remove member: room is archived')
+    );
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import {
+  RealtimeProjectionEvent,
+  RealtimeProjectionOperation,
+  RealtimeProjectionRoom
+} from '@chatto/api-types/realtime/v1/realtime_pb';
+import { Room } from '@chatto/api-types/api/v1/rooms_pb';
+import { RoomWithViewerState } from '@chatto/api-types/api/v1/room_directory_pb';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
+import {
+  roomManagementPageTestState,
+  roomManagementTestPage
+} from './RoomManagementPageTestState.svelte';
+
+const mocks = vi.hoisted(() => ({
+  getRoom: vi.fn(),
+  projectionHandlers: [] as Array<(event: RealtimeProjectionEvent) => void>,
+  refreshRooms: vi.fn(),
+  protocolCapabilities: ['chatto.api.room-manager-member-reads.v1'] as string[]
+}));
+
+vi.mock('$app/state', () => ({ page: roomManagementTestPage }));
+
+vi.mock('$lib/state/activeServer.svelte', () => ({
+  getActiveServer: () => roomManagementPageTestState.serverId
+}));
+
+vi.mock('$lib/hooks', () => ({
+  useProjectionEvent: (handler: (event: RealtimeProjectionEvent) => void) => {
+    mocks.projectionHandlers.push(handler);
+  }
+}));
+
+vi.mock('$lib/state/server/serverConnection.svelte', () => ({
+  serverConnectionManager: {
+    getClient: (serverId: string) => ({
+      serverId,
+      connectBaseUrl: `https://${serverId}.example.test/api/connect`,
+      bearerToken: `${serverId}-token`
+    })
+  }
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: {
+    isOriginServer: () => false,
+    getServer: (serverId: string) => ({ id: serverId, url: `https://${serverId}.example.test` }),
+    tryGetStore: () => ({
+      serverInfo: {
+        version: '0.5.0',
+        get protocolCapabilities() {
+          return mocks.protocolCapabilities;
+        }
+      }
+    }),
+    getStore: () => ({ rooms: { refresh: mocks.refreshRooms } })
+  }
+}));
+
+vi.mock('$lib/state/server/chromePermissions.svelte', () => ({
+  getChromePermissions: () => ({
+    current: { canManageRooms: true, canManageRoles: true }
+  })
+}));
+
+vi.mock('$lib/api-client/adminRoomLayout', () => ({
+  createAdminRoomLayoutAPI: ({ serverId }: { serverId: string }) => ({
+    getRoom: (roomId: string) => mocks.getRoom(serverId, roomId)
+  })
+}));
+
+vi.mock('$lib/api-client/memberDirectory', () => ({
+  createMemberDirectoryAPI: () => ({
+    listRoomMembers: () => Promise.resolve({ members: [], totalCount: 0, hasMore: false }),
+    listUsers: () => Promise.resolve({ members: [], totalCount: 0, hasMore: false }),
+    batchGetRoomMembers: () => Promise.resolve([])
+  })
+}));
+
+vi.mock('$lib/api-client/rooms', () => ({
+  createRoomCommandAPI: () => ({
+    updateRoom: vi.fn(),
+    addMember: vi.fn(),
+    removeMember: vi.fn()
+  })
+}));
+
+vi.mock('$lib/components/rbac/PermissionMatrix.svelte', async () => ({
+  default: (await import('./RoomManagementPagePermissionMatrixMock.svelte')).default
+}));
+
+import RoomManagementPage from './+page.svelte';
+
+function managedRoom(
+  name: string,
+  overrides: Partial<{
+    archived: boolean;
+    isUniversal: boolean;
+    canManageRoom: boolean;
+    canManagePermissions: boolean;
+  }> = {}
+) {
+  return {
+    id: 'shared-room',
+    name,
+    description: null,
+    archived: overrides.archived ?? false,
+    isUniversal: overrides.isUniversal ?? false,
+    canManageRoom: overrides.canManageRoom ?? true,
+    canManagePermissions: overrides.canManagePermissions ?? true
+  };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+}
+
+describe('room management page identity and realtime authority', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mocks.projectionHandlers = [];
+    mocks.protocolCapabilities = ['chatto.api.room-manager-member-reads.v1'];
+    roomManagementPageTestState.reset();
+    await loadLocaleMessages('en-GB');
+    setReactiveLocale('en-GB');
+  });
+
+  it('reloads metadata when the server changes but the room ID stays the same', async () => {
+    mocks.getRoom.mockImplementation((serverId: string) =>
+      Promise.resolve(managedRoom(serverId === 'server-a' ? 'alpha' : 'beta'))
+    );
+    const { container } = render(RoomManagementPage);
+    await settle();
+    expect(container.textContent).toContain('#alpha');
+
+    roomManagementPageTestState.serverId = 'server-b';
+    flushSync();
+    await settle();
+
+    expect(mocks.getRoom).toHaveBeenCalledWith('server-b', 'shared-room');
+    expect(container.textContent).toContain('#beta');
+    expect(container.textContent).not.toContain('#alpha');
+  });
+
+  it('reconciles room rules and permissions after a realtime room update', async () => {
+    mocks.getRoom.mockResolvedValueOnce(managedRoom('general')).mockResolvedValueOnce(
+      managedRoom('general', {
+        archived: true,
+        isUniversal: true,
+        canManageRoom: false
+      })
+    );
+    const { container } = render(RoomManagementPage);
+    await settle();
+    expect(container.querySelector('#room-member-picker')).not.toBeNull();
+
+    for (const handler of mocks.projectionHandlers) {
+      handler(
+        new RealtimeProjectionEvent({
+          operations: [
+            new RealtimeProjectionOperation({
+              operation: {
+                case: 'roomUpsert',
+                value: new RealtimeProjectionRoom({
+                  room: new RoomWithViewerState({
+                    room: new Room({ id: 'shared-room', name: 'general' })
+                  })
+                })
+              }
+            })
+          ]
+        })
+      );
+    }
+    await settle();
+
+    expect(container.querySelector('#room-member-picker')).toBeNull();
+    expect(container.textContent).toContain('Membership is automatic in Universal rooms.');
+  });
+
+  it('hides member management when the server does not advertise manager reads', async () => {
+    mocks.protocolCapabilities = ['chatto.api.v1'];
+    mocks.getRoom.mockResolvedValue(managedRoom('general'));
+
+    const { container } = render(RoomManagementPage);
+    await settle();
+
+    expect(container.textContent).not.toContain('Members');
+    expect(container.querySelector('#room-member-picker')).toBeNull();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -4,7 +4,8 @@ import { render } from 'vitest-browser-svelte';
 import {
   RealtimeProjectionEvent,
   RealtimeProjectionOperation,
-  RealtimeProjectionRoom
+  RealtimeProjectionRoom,
+  RealtimeProjectionRoomRemove
 } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { Room } from '@chatto/api-types/api/v1/rooms_pb';
 import { RoomWithViewerState } from '@chatto/api-types/api/v1/room_directory_pb';
@@ -19,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   getRoom: vi.fn(),
   projectionHandlers: [] as Array<(event: RealtimeProjectionEvent) => void>,
   refreshRooms: vi.fn(),
+  updateRoom: vi.fn(),
   protocolCapabilities: ['chatto.api.room-manager-member-reads.v1'] as string[]
 }));
 
@@ -82,7 +84,7 @@ vi.mock('$lib/api-client/memberDirectory', () => ({
 
 vi.mock('$lib/api-client/rooms', () => ({
   createRoomCommandAPI: () => ({
-    updateRoom: vi.fn(),
+    updateRoom: mocks.updateRoom,
     addMember: vi.fn(),
     removeMember: vi.fn()
   })
@@ -121,11 +123,44 @@ async function settle(): Promise<void> {
   flushSync();
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function dispatchProjection(operation: RealtimeProjectionOperation): void {
+  const event = new RealtimeProjectionEvent({ operations: [operation] });
+  for (const handler of mocks.projectionHandlers) handler(event);
+}
+
+function roomUpsert(): RealtimeProjectionOperation {
+  return new RealtimeProjectionOperation({
+    operation: {
+      case: 'roomUpsert',
+      value: new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({
+          room: new Room({ id: 'shared-room', name: 'general' })
+        })
+      })
+    }
+  });
+}
+
 describe('room management page identity and realtime authority', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.projectionHandlers = [];
     mocks.protocolCapabilities = ['chatto.api.room-manager-member-reads.v1'];
+    mocks.updateRoom.mockResolvedValue({
+      id: 'shared-room',
+      name: 'general',
+      description: '',
+      universal: false,
+      archived: false
+    });
     roomManagementPageTestState.reset();
     await loadLocaleMessages('en-GB');
     setReactiveLocale('en-GB');
@@ -160,24 +195,7 @@ describe('room management page identity and realtime authority', () => {
     await settle();
     expect(container.querySelector('#room-member-picker')).not.toBeNull();
 
-    for (const handler of mocks.projectionHandlers) {
-      handler(
-        new RealtimeProjectionEvent({
-          operations: [
-            new RealtimeProjectionOperation({
-              operation: {
-                case: 'roomUpsert',
-                value: new RealtimeProjectionRoom({
-                  room: new RoomWithViewerState({
-                    room: new Room({ id: 'shared-room', name: 'general' })
-                  })
-                })
-              }
-            })
-          ]
-        })
-      );
-    }
+    dispatchProjection(roomUpsert());
     await settle();
 
     expect(container.querySelector('#room-member-picker')).toBeNull();
@@ -193,5 +211,71 @@ describe('room management page identity and realtime authority', () => {
 
     expect(container.textContent).not.toContain('Members');
     expect(container.querySelector('#room-member-picker')).toBeNull();
+  });
+
+  it('purges room metadata synchronously when realtime removes access', async () => {
+    mocks.getRoom.mockResolvedValueOnce(managedRoom('private-room'));
+    const pendingReload = deferred<ReturnType<typeof managedRoom>>();
+    const { container } = render(RoomManagementPage);
+    await settle();
+    expect(container.textContent).toContain('#private-room');
+
+    mocks.getRoom.mockReturnValueOnce(pendingReload.promise);
+    dispatchProjection(
+      new RealtimeProjectionOperation({
+        operation: {
+          case: 'roomRemove',
+          value: new RealtimeProjectionRoomRemove({ roomId: 'shared-room' })
+        }
+      })
+    );
+    flushSync();
+
+    expect(container.textContent).not.toContain('#private-room');
+    expect(container.querySelector('#room-settings-name')).toBeNull();
+
+    pendingReload.resolve(managedRoom('private-room'));
+    await settle();
+  });
+
+  it('clears saving after a realtime refresh supersedes the save response', async () => {
+    const pendingSave = deferred<{
+      id: string;
+      name: string;
+      description: string;
+      universal: boolean;
+      archived: boolean;
+    }>();
+    mocks.getRoom.mockResolvedValue(managedRoom('general'));
+    mocks.updateRoom.mockReturnValueOnce(pendingSave.promise);
+    const { container } = render(RoomManagementPage);
+    await settle();
+
+    const nameInput = container.querySelector('#room-settings-name') as HTMLInputElement;
+    nameInput.value = 'renamed';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    (container.querySelector('form button[type="submit"]') as HTMLButtonElement).click();
+    await settle();
+
+    dispatchProjection(roomUpsert());
+    await settle();
+    pendingSave.resolve({
+      id: 'shared-room',
+      name: 'renamed',
+      description: '',
+      universal: false,
+      archived: false
+    });
+    await settle();
+
+    const refreshedInput = container.querySelector('#room-settings-name') as HTMLInputElement;
+    refreshedInput.value = 'later';
+    refreshedInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    expect(
+      (container.querySelector('form button[type="submit"]') as HTMLButtonElement).disabled
+    ).toBe(false);
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -173,6 +173,11 @@ describe('room management page identity and realtime authority', () => {
     const { container } = render(RoomManagementPage);
     await settle();
     expect(container.textContent).toContain('#alpha');
+    expect(
+      container
+        .querySelector('[data-testid="permission-matrix"]')
+        ?.getAttribute('data-scroll-contents')
+    ).toBe('false');
 
     roomManagementPageTestState.serverId = 'server-b';
     flushSync();

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4177,6 +4177,32 @@ func TestRoomServiceMemberReadAuthorization(t *testing.T) {
 	if _, err := env.rooms.ListMembers(withCaller(env.ctx, outsider), req); connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("list-denied outsider ListMembers code = %v, want %v", connect.CodeOf(err), connect.CodePermissionDenied)
 	}
+	manager, err := env.core.CreateUser(env.ctx, core.SystemActorID, "room-member-manager", "Room Manager", "password")
+	if err != nil {
+		t.Fatalf("CreateUser manager: %v", err)
+	}
+	if err := env.core.GrantUserRoomPermission(env.ctx, core.SystemActorID, room.Id, manager.Id, core.PermRoomManage); err != nil {
+		t.Fatalf("GrantUserRoomPermission manager room.manage: %v", err)
+	}
+	if err := env.core.DenyUserRoomPermission(env.ctx, core.SystemActorID, room.Id, manager.Id, core.PermRoomJoin); err != nil {
+		t.Fatalf("DenyUserRoomPermission manager room.join: %v", err)
+	}
+	managerCtx := withCaller(env.ctx, manager)
+	if _, err := env.rooms.ListMembers(managerCtx, req); err != nil {
+		t.Fatalf("manager ListMembers: %v", err)
+	}
+	if _, err := env.rooms.GetMember(managerCtx, connect.NewRequest(&apiv1.GetRoomMemberRequest{
+		RoomId: room.Id,
+		UserId: member.Id,
+	})); err != nil {
+		t.Fatalf("manager GetMember: %v", err)
+	}
+	if _, err := env.rooms.BatchGetMembers(managerCtx, connect.NewRequest(&apiv1.BatchGetRoomMembersRequest{
+		RoomId:  room.Id,
+		UserIds: []string{member.Id},
+	})); err != nil {
+		t.Fatalf("manager BatchGetMembers: %v", err)
+	}
 
 	resp, err := env.rooms.ListMembers(withCaller(env.ctx, env.viewer), req)
 	if err != nil {

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -498,6 +498,7 @@ func TestServerDiscoveryServiceGetServerPublicMetadata(t *testing.T) {
 		"chatto.auth.v1",
 		"chatto.api.v1",
 		"chatto.api.message-search.v1",
+		"chatto.api.room-manager-member-reads.v1",
 		"chatto.admin.v1",
 		"chatto.realtime.v1",
 		"chatto.realtime.projection.v1",

--- a/cli/internal/connectapi/member_directory.go
+++ b/cli/internal/connectapi/member_directory.go
@@ -178,7 +178,7 @@ func (s *roomService) GetMember(ctx context.Context, req *connect.Request[apiv1.
 		return nil, err
 	}
 
-	users, err := s.api.core.ListRoomMemberReferences(ctx, caller.UserID, req.Msg.GetRoomId())
+	users, err := s.api.core.ListRoomMemberReferencesForLookup(ctx, caller.UserID, req.Msg.GetRoomId())
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -199,7 +199,7 @@ func (s *roomService) BatchGetMembers(ctx context.Context, req *connect.Request[
 		return nil, err
 	}
 
-	users, err := s.api.core.ListRoomMemberReferences(ctx, caller.UserID, req.Msg.GetRoomId())
+	users, err := s.api.core.ListRoomMemberReferencesForLookup(ctx, caller.UserID, req.Msg.GetRoomId())
 	if err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/connectapi/server.go
+++ b/cli/internal/connectapi/server.go
@@ -23,6 +23,7 @@ var discoveryProtocolCapabilities = []string{
 	"chatto.auth.v1",
 	"chatto.api.v1",
 	"chatto.api.message-search.v1",
+	"chatto.api.room-manager-member-reads.v1",
 	"chatto.admin.v1",
 	"chatto.realtime.v1",
 	"chatto.realtime.projection.v1",

--- a/cli/internal/core/room_member_read_authorization_test.go
+++ b/cli/internal/core/room_member_read_authorization_test.go
@@ -23,6 +23,10 @@ func TestRoomMemberReadOperationsRequireMembership(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser actor: %v", err)
 	}
+	manager, err := core.CreateUser(ctx, SystemActorID, "room-read-manager", "Room Read Manager", "password")
+	if err != nil {
+		t.Fatalf("CreateUser manager: %v", err)
+	}
 	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "room-read-auth", "")
 	if err != nil {
 		t.Fatalf("CreateRoom: %v", err)
@@ -47,6 +51,29 @@ func TestRoomMemberReadOperationsRequireMembership(t *testing.T) {
 	if _, err := core.ListRoomMemberReferencesForList(ctx, outsider.Id, room.Id); !errors.Is(err, ErrPermissionDenied) {
 		t.Fatalf("join-denied ListRoomMemberReferencesForList error = %v, want ErrPermissionDenied", err)
 	}
+	if err := core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, manager.Id, PermRoomManage); err != nil {
+		t.Fatalf("GrantUserRoomPermission room.manage: %v", err)
+	}
+	if err := core.DenyUserRoomPermission(ctx, SystemActorID, room.Id, manager.Id, PermRoomList); err != nil {
+		t.Fatalf("DenyUserRoomPermission room.list: %v", err)
+	}
+	if err := core.DenyUserRoomPermission(ctx, SystemActorID, room.Id, manager.Id, PermRoomJoin); err != nil {
+		t.Fatalf("DenyUserRoomPermission room.join: %v", err)
+	}
+	managerMembers, err := core.ListRoomMemberReferencesForList(ctx, manager.Id, room.Id)
+	if err != nil {
+		t.Fatalf("manager ListRoomMemberReferencesForList: %v", err)
+	}
+	if !userRefsContain(managerMembers, member.Id) {
+		t.Fatalf("manager list member references = %+v, want member %s", managerMembers, member.Id)
+	}
+	managerLookups, err := core.ListRoomMemberReferencesForLookup(ctx, manager.Id, room.Id)
+	if err != nil {
+		t.Fatalf("manager ListRoomMemberReferencesForLookup: %v", err)
+	}
+	if !userRefsContain(managerLookups, member.Id) {
+		t.Fatalf("manager lookup member references = %+v, want member %s", managerLookups, member.Id)
+	}
 	members, err := core.ListRoomMemberReferences(ctx, member.Id, room.Id)
 	if err != nil {
 		t.Fatalf("ListRoomMemberReferences member: %v", err)
@@ -64,6 +91,15 @@ func TestRoomMemberReadOperationsRequireMembership(t *testing.T) {
 	if _, err := core.ListRoomMemberReferencesForList(ctx, outsider.Id, dm.Id); !errors.Is(err, ErrNotRoomMember) {
 		t.Fatalf("DM outsider ListRoomMemberReferencesForList error = %v, want ErrNotRoomMember", err)
 	}
+	if err := core.GrantUserRoomPermission(ctx, SystemActorID, dm.Id, outsider.Id, PermRoomManage); err != nil {
+		t.Fatalf("GrantUserRoomPermission DM room.manage: %v", err)
+	}
+	if _, err := core.ListRoomMemberReferencesForList(ctx, outsider.Id, dm.Id); !errors.Is(err, ErrNotRoomMember) {
+		t.Fatalf("DM manager ListRoomMemberReferencesForList error = %v, want ErrNotRoomMember", err)
+	}
+	if _, err := core.ListRoomMemberReferencesForLookup(ctx, outsider.Id, dm.Id); !errors.Is(err, ErrNotRoomMember) {
+		t.Fatalf("DM manager ListRoomMemberReferencesForLookup error = %v, want ErrNotRoomMember", err)
+	}
 	archivedRoom, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "room-read-archived", "")
 	if err != nil {
 		t.Fatalf("CreateRoom archived: %v", err)
@@ -73,6 +109,15 @@ func TestRoomMemberReadOperationsRequireMembership(t *testing.T) {
 	}
 	if _, err := core.ListRoomMemberReferencesForList(ctx, outsider.Id, archivedRoom.Id); !errors.Is(err, ErrNotRoomMember) {
 		t.Fatalf("archived outsider ListRoomMemberReferencesForList error = %v, want ErrNotRoomMember", err)
+	}
+	if err := core.GrantUserRoomPermission(ctx, SystemActorID, archivedRoom.Id, manager.Id, PermRoomManage); err != nil {
+		t.Fatalf("GrantUserRoomPermission archived room.manage: %v", err)
+	}
+	if _, err := core.ListRoomMemberReferencesForList(ctx, manager.Id, archivedRoom.Id); err != nil {
+		t.Fatalf("archived manager ListRoomMemberReferencesForList: %v", err)
+	}
+	if _, err := core.ListRoomMemberReferencesForLookup(ctx, manager.Id, archivedRoom.Id); err != nil {
+		t.Fatalf("archived manager ListRoomMemberReferencesForLookup: %v", err)
 	}
 
 	if _, err := core.CreateNotification(ctx, member.Id, actor.Id, &corev1.Notification{

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -699,10 +699,21 @@ func (c *ChattoCore) ListRoomMemberReferences(ctx context.Context, actorID, room
 }
 
 // ListRoomMemberReferencesForList authorizes the public room-member listing.
-// Existing members may list their room. A channel-room nonmember may list only
-// when both room.list and room.join resolve to allow at that room; DMs retain
-// their membership-only privacy boundary.
+// Existing members and channel-room managers may list their room. Other
+// channel-room nonmembers need both room.list and room.join; DMs retain their
+// membership-only privacy boundary.
 func (c *ChattoCore) ListRoomMemberReferencesForList(ctx context.Context, actorID, roomID string) ([]*corev1.User, error) {
+	return c.listRoomMemberReferencesForRead(ctx, actorID, roomID, true)
+}
+
+// ListRoomMemberReferencesForLookup authorizes singular and batch member
+// hydration. Existing members and channel-room managers may hydrate rows; DMs
+// retain their membership-only privacy boundary.
+func (c *ChattoCore) ListRoomMemberReferencesForLookup(ctx context.Context, actorID, roomID string) ([]*corev1.User, error) {
+	return c.listRoomMemberReferencesForRead(ctx, actorID, roomID, false)
+}
+
+func (c *ChattoCore) listRoomMemberReferencesForRead(ctx context.Context, actorID, roomID string, allowDiscoverableNonmember bool) ([]*corev1.User, error) {
 	room, kind, err := c.requireRoomMember(ctx, actorID, roomID)
 	if err == nil {
 		return c.roomMemberReferences(ctx, kind, room.GetId())
@@ -716,7 +727,17 @@ func (c *ChattoCore) ListRoomMemberReferencesForList(ctx context.Context, actorI
 		return nil, err
 	}
 	kind = KindOfRoom(room)
-	if kind == KindDM || room.GetArchived() {
+	if kind == KindDM {
+		return nil, ErrNotRoomMember
+	}
+	canManage, err := c.hasRoomPermission(ctx, kind, room.GetId(), actorID, PermRoomManage)
+	if err != nil {
+		return nil, err
+	}
+	if canManage {
+		return c.roomMemberReferences(ctx, kind, room.GetId())
+	}
+	if !allowDiscoverableNonmember || room.GetArchived() {
 		return nil, ErrNotRoomMember
 	}
 	canList, err := c.hasRoomPermission(ctx, kind, room.GetId(), actorID, PermRoomList)

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
@@ -111,14 +111,16 @@ type RoomServiceClient interface {
 	// Leaves the room as the current user. Direct-message and universal rooms
 	// cannot be left.
 	LeaveRoom(context.Context, *connect.Request[v1.LeaveRoomRequest]) (*connect.Response[v1.LeaveRoomResponse], error)
-	// Lists effective room members. Existing members may list their room;
-	// nonmembers of a channel room need both room.list and room.join.
+	// Lists effective room members. Existing members and room.manage holders may
+	// list a channel room; other nonmembers need both room.list and room.join.
 	ListMembers(context.Context, *connect.Request[v1.ListRoomMembersRequest]) (*connect.Response[v1.ListRoomMembersResponse], error)
-	// Gets one explicit member of a room. The caller must be a member of the
-	// room. Returns NOT_FOUND when the target is unknown or not a room member.
+	// Gets one explicit member of a room. Existing members and room.manage
+	// holders may read channel-room members; DMs remain membership-only. Returns
+	// NOT_FOUND when the target is unknown or not a room member.
 	GetMember(context.Context, *connect.Request[v1.GetRoomMemberRequest]) (*connect.Response[v1.GetRoomMemberResponse], error)
-	// Gets explicit room member rows for multiple users. The caller must be a
-	// member of the room.
+	// Gets explicit room member rows for multiple users. Existing members and
+	// room.manage holders may read channel-room members; DMs remain
+	// membership-only.
 	BatchGetMembers(context.Context, *connect.Request[v1.BatchGetRoomMembersRequest]) (*connect.Response[v1.BatchGetRoomMembersResponse], error)
 	// Adds a user as an explicit member of a channel room. The caller must be
 	// allowed to manage the room. Direct-message and universal rooms cannot be
@@ -454,14 +456,16 @@ type RoomServiceHandler interface {
 	// Leaves the room as the current user. Direct-message and universal rooms
 	// cannot be left.
 	LeaveRoom(context.Context, *connect.Request[v1.LeaveRoomRequest]) (*connect.Response[v1.LeaveRoomResponse], error)
-	// Lists effective room members. Existing members may list their room;
-	// nonmembers of a channel room need both room.list and room.join.
+	// Lists effective room members. Existing members and room.manage holders may
+	// list a channel room; other nonmembers need both room.list and room.join.
 	ListMembers(context.Context, *connect.Request[v1.ListRoomMembersRequest]) (*connect.Response[v1.ListRoomMembersResponse], error)
-	// Gets one explicit member of a room. The caller must be a member of the
-	// room. Returns NOT_FOUND when the target is unknown or not a room member.
+	// Gets one explicit member of a room. Existing members and room.manage
+	// holders may read channel-room members; DMs remain membership-only. Returns
+	// NOT_FOUND when the target is unknown or not a room member.
 	GetMember(context.Context, *connect.Request[v1.GetRoomMemberRequest]) (*connect.Response[v1.GetRoomMemberResponse], error)
-	// Gets explicit room member rows for multiple users. The caller must be a
-	// member of the room.
+	// Gets explicit room member rows for multiple users. Existing members and
+	// room.manage holders may read channel-room members; DMs remain
+	// membership-only.
 	BatchGetMembers(context.Context, *connect.Request[v1.BatchGetRoomMembersRequest]) (*connect.Response[v1.BatchGetRoomMembersResponse], error)
 	// Adds a user as an explicit member of a channel room. The caller must be
 	// allowed to manage the room. Direct-message and universal rooms cannot be

--- a/cli/internal/pb/chatto/api/v1/member_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/member_directory.pb.go
@@ -427,8 +427,8 @@ func (x *BatchGetUsersResponse) GetUsers() []*DirectoryMember {
 type ListRoomMembersRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. Room whose effective members should be listed. Existing members
-	// may list their room; nonmembers of a channel room need both room.list and
-	// room.join.
+	// and room.manage holders may list a channel room; other nonmembers need both
+	// room.list and room.join.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Optional case-insensitive search against login and display name.
 	Search string `protobuf:"bytes,2,opt,name=search,proto3" json:"search,omitempty"`

--- a/cli/internal/pb/chatto/discovery/v1/server.pb.go
+++ b/cli/internal/pb/chatto/discovery/v1/server.pb.go
@@ -137,6 +137,7 @@ type ServerCompatibility struct {
 	// Stable protocol capability keys supported by this server. Current keys:
 	// `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`,
 	// `chatto.admin.v1`, `chatto.api.message-search.v1`,
+	// `chatto.api.room-manager-member-reads.v1`,
 	// `chatto.realtime.v1`, and
 	// `chatto.realtime.projection.v1`.
 	ProtocolCapabilities []string `protobuf:"bytes,1,rep,name=protocol_capabilities,json=protocolCapabilities,proto3" json:"protocol_capabilities,omitempty"`

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -104,6 +104,12 @@ when the operator disables the feature. Compatible clients use
 provider readiness rather than interpreting the protocol capability as an
 enablement flag.
 
+`chatto.api.room-manager-member-reads.v1` advertises that effective
+`room.manage` grants channel-room `ListMembers`, `GetMember`, and
+`BatchGetMembers` reads without requiring the manager to join. Current clients
+gate the room-member management surface on this contract; version comparison is
+used only for legacy servers that omit capability metadata.
+
 Public URL generation prefers the configured `webserver.url`. Without it, the
 HTTP edge uses only the direct request TLS state and host; forwarded protocol
 headers are not implicitly trusted. `webserver.trusted_proxies` affects client

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-019: Room Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-07-20
+**Last reviewed:** 2026-07-23
 
 ## Overview
 
@@ -20,7 +20,7 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 - **API surface** — ConnectRPC `RoomService` exposes create, edit, archive, unarchive, Universal, join, leave, manager add/remove, ban, and unban commands. ConnectRPC `RoomDirectoryService` exposes the complementary room list, room-group/sidebar list, single-room refresh, per-room viewer capability state, and group join-all command.
 - **Archive** — `room.manage` toggles an `archived` flag on the room. Archived rooms vanish from the sidebar, the Browse Rooms page, and search results, but members stay joined and history is intact. The owner can still navigate to the room directly.
 - **Unarchive** — same permission, flips the flag back. The room reappears in the sidebar and discovery surfaces.
-- **Manage members** — `room.manage` holders can add or remove explicit members of non-Universal channel rooms. Adding can bring a user into a private room even when that user could not self-join through `room.join`. Active room bans still block adding; the user must be unbanned first.
+- **Manage members** — `room.manage` holders can list, inspect, add, or remove members of channel rooms, including when they are not themselves members or eligible to join. Adding can bring a user into a private room even when that user could not self-join through `room.join`. Active room bans still block adding; the user must be unbanned first. DM membership remains visible only to its participants.
 - **Ban member** — `room.ban-member` holders can ban a user from a channel room with a required reason and optional expiry. The banned user loses room read/write/live access immediately and cannot rejoin until the ban is removed or expires.
 - **Delete** — `room.manage` appends `RoomDeletedEvent` to `EVT`, releases the room from its group layout, and causes projections to remove the room, its name claim, and its memberships.
 - Moving a room between groups requires `room.manage` in both groups (see FDR-017).
@@ -89,18 +89,18 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 
 ### 11. Member listing follows membership or discovery-and-join eligibility
 
-**Decision:** Existing room members may list the room's effective members. A channel-room non-member may list them only when both `room.list` and `room.join` allow it at that room. DMs remain membership-only. The pre-join screen requests the first five alphabetically sorted members and uses the list's total count for its compact preview.
-**Why:** Room membership is an existing paginated resource and should use its own authorization contract instead of adding a preview-specific shape to room-directory reads. Requiring both discovery and join eligibility limits nonmember access to rooms they can knowingly enter.
-**Tradeoff:** An eligible nonmember can paginate the full member directory even though the join screen displays only five samples. Messages, files, activity, and other membership-gated room content remain inaccessible until joining.
+**Decision:** Existing room members and effective `room.manage` holders may list a channel room's effective members and hydrate individual member rows. Other channel-room non-members may list members only when both `room.list` and `room.join` allow it at that room. DMs remain membership-only. The pre-join screen requests the first five alphabetically sorted members and uses the list's total count for its compact preview.
+**Why:** Room managers need the same member resource they are authorised to change, even when management authority deliberately does not grant room participation. Room membership remains an existing paginated resource instead of adding a preview- or management-specific shape. Requiring both discovery and join eligibility for other nonmembers limits access to rooms they can knowingly enter.
+**Tradeoff:** A manager or eligible nonmember can paginate the full member directory without joining. Messages, files, activity, and other membership-gated room content remain inaccessible until joining, and DM participant privacy is unchanged.
 
 ## Permissions
 
 - `room.create` — create a new channel room in a group. Configurable per group.
-- `room.manage` — edit, archive, unarchive, delete, change Universal state, and add/remove explicit members for a channel room. Configurable per group and per room.
+- `room.manage` — edit, archive, unarchive, delete, change Universal state, and list, inspect, add, or remove members for a channel room. Configurable per group and per room.
 - `role.manage` — configure role permission decisions at room scope without granting general room-management authority.
 - `room.ban-member` — ban members from a channel room. Configurable per group and per room.
 - `room.join` — gates whether a user can become an explicit member of an unarchived room and whether a user is an implicit member of a Universal room. Configurable per group and per room.
-- `room.list` + `room.join` — together allow a channel-room nonmember to list its effective members. Existing members do not need these grants for member listing.
+- `room.list` + `room.join` — together allow a channel-room nonmember without `room.manage` to list its effective members. Existing members and room managers do not need these grants for member listing.
 
 ## Related
 

--- a/packages/api-types/src/chatto/api/v1/member_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/member_directory_pb.ts
@@ -353,8 +353,8 @@ export class BatchGetUsersResponse extends Message<BatchGetUsersResponse> {
 export class ListRoomMembersRequest extends Message<ListRoomMembersRequest> {
   /**
    * Required. Room whose effective members should be listed. Existing members
-   * may list their room; nonmembers of a channel room need both room.list and
-   * room.join.
+   * and room.manage holders may list a channel room; other nonmembers need both
+   * room.list and room.join.
    *
    * @generated from field: string room_id = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/rooms_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_connect.ts
@@ -119,8 +119,8 @@ export const RoomService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Lists effective room members. Existing members may list their room;
-     * nonmembers of a channel room need both room.list and room.join.
+     * Lists effective room members. Existing members and room.manage holders may
+     * list a channel room; other nonmembers need both room.list and room.join.
      *
      * @generated from rpc chatto.api.v1.RoomService.ListMembers
      */
@@ -131,8 +131,9 @@ export const RoomService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Gets one explicit member of a room. The caller must be a member of the
-     * room. Returns NOT_FOUND when the target is unknown or not a room member.
+     * Gets one explicit member of a room. Existing members and room.manage
+     * holders may read channel-room members; DMs remain membership-only. Returns
+     * NOT_FOUND when the target is unknown or not a room member.
      *
      * @generated from rpc chatto.api.v1.RoomService.GetMember
      */
@@ -143,8 +144,9 @@ export const RoomService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Gets explicit room member rows for multiple users. The caller must be a
-     * member of the room.
+     * Gets explicit room member rows for multiple users. Existing members and
+     * room.manage holders may read channel-room members; DMs remain
+     * membership-only.
      *
      * @generated from rpc chatto.api.v1.RoomService.BatchGetMembers
      */

--- a/packages/api-types/src/chatto/discovery/v1/server_pb.ts
+++ b/packages/api-types/src/chatto/discovery/v1/server_pb.ts
@@ -114,6 +114,7 @@ export class ServerCompatibility extends Message<ServerCompatibility> {
    * Stable protocol capability keys supported by this server. Current keys:
    * `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`,
    * `chatto.admin.v1`, `chatto.api.message-search.v1`,
+   * `chatto.api.room-manager-member-reads.v1`,
    * `chatto.realtime.v1`, and
    * `chatto.realtime.projection.v1`.
    *

--- a/proto/chatto/api/v1/member_directory.proto
+++ b/proto/chatto/api/v1/member_directory.proto
@@ -82,8 +82,8 @@ message ListRoomMembersRequest {
   reserved "limit", "offset";
 
   // Required. Room whose effective members should be listed. Existing members
-  // may list their room; nonmembers of a channel room need both room.list and
-  // room.join.
+  // and room.manage holders may list a channel room; other nonmembers need both
+  // room.list and room.join.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Optional case-insensitive search against login and display name.
   string search = 2 [(buf.validate.field).string.max_len = 100];

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -351,14 +351,16 @@ service RoomService {
   // Leaves the room as the current user. Direct-message and universal rooms
   // cannot be left.
   rpc LeaveRoom(LeaveRoomRequest) returns (LeaveRoomResponse);
-  // Lists effective room members. Existing members may list their room;
-  // nonmembers of a channel room need both room.list and room.join.
+  // Lists effective room members. Existing members and room.manage holders may
+  // list a channel room; other nonmembers need both room.list and room.join.
   rpc ListMembers(ListRoomMembersRequest) returns (ListRoomMembersResponse);
-  // Gets one explicit member of a room. The caller must be a member of the
-  // room. Returns NOT_FOUND when the target is unknown or not a room member.
+  // Gets one explicit member of a room. Existing members and room.manage
+  // holders may read channel-room members; DMs remain membership-only. Returns
+  // NOT_FOUND when the target is unknown or not a room member.
   rpc GetMember(GetRoomMemberRequest) returns (GetRoomMemberResponse);
-  // Gets explicit room member rows for multiple users. The caller must be a
-  // member of the room.
+  // Gets explicit room member rows for multiple users. Existing members and
+  // room.manage holders may read channel-room members; DMs remain
+  // membership-only.
   rpc BatchGetMembers(BatchGetRoomMembersRequest) returns (BatchGetRoomMembersResponse);
   // Adds a user as an explicit member of a channel room. The caller must be
   // allowed to manage the room. Direct-message and universal rooms cannot be

--- a/proto/chatto/discovery/v1/server.proto
+++ b/proto/chatto/discovery/v1/server.proto
@@ -30,6 +30,7 @@ message ServerCompatibility {
   // Stable protocol capability keys supported by this server. Current keys:
   // `chatto.discovery.v1`, `chatto.auth.v1`, `chatto.api.v1`,
   // `chatto.admin.v1`, `chatto.api.message-search.v1`,
+  // `chatto.api.room-manager-member-reads.v1`,
   // `chatto.realtime.v1`, and
   // `chatto.realtime.projection.v1`.
   repeated string protocol_capabilities = 1;


### PR DESCRIPTION
## Why

Room managers need a safe way to inspect and change explicit channel-room
membership. This also establishes the user-management foundation needed before
bot room approval is introduced as a separate feature.

## What

- add an automatically paginated Members panel to channel-room management
- search the server directory, exclude existing members, and add eligible users
- confirm explicit-member removals and keep Universal/archived rooms read-only
- fence member and page state by server plus room, including realtime revocation
- authorise effective `room.manage` holders to read channel membership while
  preserving DM participant privacy
- advertise `chatto.api.room-manager-member-reads.v1` and gate the UI for
  mixed-version servers
- align panel/table seams and let the room permission matrix use page-owned
  vertical scrolling
- align FDR-019, API comments, generated references, operator guides, and the
  runtime interface inventory

## Compatibility

This is an additive discovery capability and a compatible behavioural
authorisation expansion for existing channel-room member reads. Existing
clients require no migration. Current clients hide the management surface when
capability-aware older servers do not advertise manager reads; version fallback
is limited to legacy servers without capability metadata. No persisted
protobufs or event formats change.

## Verification

- `mise test-frontend` — 288 files, 2,469 tests
- `mise test-cli`
- `pnpm check`
- `pnpm lint`
- public Buf breaking check against `origin/main`
- `mise license-check`
- docs website production build
- browser review of add/remove, panel/table styling, discovery capability, and
  console output

Closes #1712.
