### PR TITLE
fix(threads): distinguish unread and notified thread badges

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
@@ -40,6 +40,7 @@ Request for a page of followed threads for the current user.
 | Field | Type | Description |
 | --- | --- | --- |
 | `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `unread_only` | `bool` | When true, returns only threads with unread replies. |
 
 
 <a id="chatto-api-v1-ListFollowedThreadsResponse"></a>
@@ -53,6 +54,7 @@ Response containing one followed-thread page.
 | `threads` | repeated [`FollowedThread`](/reference/connectrpc-api/types/#chatto-api-v1-FollowedThread) | Followed threads in newest-activity-first order. |
 | `includes` | [`RoomTimelineIncludes`](/reference/connectrpc-api/types/#chatto-api-v1-RoomTimelineIncludes) | Hot-path related entities needed to render this feed page without per-thread hydration. |
 | `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Page metadata. |
+| `unread_only` | `bool` | True when the response is restricted to threads with unread replies. |
 
 
 <a id="chatto-api-v1-ThreadService-FollowThread"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -223,6 +223,7 @@ Permission-derived capabilities for the authenticated user.
 | --- | --- | --- |
 | `grants` | repeated [`CapabilityGrant`](#chatto-api-v1-CapabilityGrant) | Keyed capability decisions for the authenticated user. |
 | `has_unread_followed_threads` | `bool` | Whether the user has unread followed threads. |
+| `has_pending_followed_thread_notifications` | `bool` | Whether a followed channel thread has a pending notification. |
 
 <a id="chatto-api-v1-ViewerUser"></a>
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -2834,6 +2834,7 @@ Request for a page of followed threads for the current user.
 | Field | Type | Description |
 | --- | --- | --- |
 | `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `unread_only` | `bool` | When true, returns only threads with unread replies. |
 
 
 <a id="chatto-api-v1-ListFollowedThreadsResponse"></a>
@@ -2847,6 +2848,7 @@ Response containing one followed-thread page.
 | `threads` | repeated [`FollowedThread`](#chatto-api-v1-FollowedThread) | Followed threads in newest-activity-first order. |
 | `includes` | [`RoomTimelineIncludes`](#chatto-api-v1-RoomTimelineIncludes) | Hot-path related entities needed to render this feed page without per-thread hydration. |
 | `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
+| `unread_only` | `bool` | True when the response is restricted to threads with unread replies. |
 
 
 <a id="chatto-api-v1-ThreadService-FollowThread"></a>
@@ -3513,6 +3515,7 @@ Permission-derived capabilities for the authenticated user.
 | --- | --- | --- |
 | `grants` | repeated [`CapabilityGrant`](#chatto-api-v1-CapabilityGrant) | Keyed capability decisions for the authenticated user. |
 | `has_unread_followed_threads` | `bool` | Whether the user has unread followed threads. |
+| `has_pending_followed_thread_notifications` | `bool` | Whether a followed channel thread has a pending notification. |
 
 
 

--- a/apps/frontend/src/lib/api-client-tests/roomTimeline.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomTimeline.spec.ts
@@ -294,7 +294,7 @@ describe('roomTimelinePageToEventConnectionPage', () => {
                   replyCount: 1,
                   participantPreviewUserIds: ['u2'],
                   participantCount: 1,
-                  viewerState: { isFollowing: true }
+                  viewerState: { isFollowing: true, hasUnread: true }
                 },
                 reactions: [
                   {
@@ -368,7 +368,8 @@ describe('roomTimelinePageToEventConnectionPage', () => {
           }
         ],
         threadParticipants: [{ id: 'u2', displayName: 'Bob' }],
-        viewerIsFollowingThread: true
+        viewerIsFollowingThread: true,
+        viewerHasUnreadThread: true
       }
     });
     expect(mapped.events[1]).toMatchObject({

--- a/apps/frontend/src/lib/api-client-tests/threads.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/threads.spec.ts
@@ -58,6 +58,7 @@ describe('createThreadAPI', () => {
         }
       ],
       page: { totalCount: 3n, hasMore: true },
+      unreadOnly: true,
       includes: { users: {} }
     });
 
@@ -66,10 +67,10 @@ describe('createThreadAPI', () => {
       baseUrl: 'https://remote.example.test/api/connect',
       bearerToken: 'remote-token'
     });
-    const page = await api.listFollowedThreads({ limit: 20, offset: 40 });
+    const page = await api.listFollowedThreads({ limit: 20, offset: 40, unreadOnly: true });
 
     expect(mocks.listFollowedThreads).toHaveBeenCalledWith(
-      { page: { limit: 20, offset: 40 } },
+      { page: { limit: 20, offset: 40 }, unreadOnly: true },
       {
         headers: { Authorization: 'Bearer remote-token' }
       }
@@ -87,7 +88,8 @@ describe('createThreadAPI', () => {
         }
       ],
       totalCount: 3,
-      hasMore: true
+      hasMore: true,
+      unreadOnly: true
     });
   });
 

--- a/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
@@ -137,6 +137,7 @@ describe('getCurrentUserViaConnect', () => {
       },
       capabilities: {
         hasUnreadFollowedThreads: true,
+        hasPendingFollowedThreadNotifications: true,
         grants: [
           { capability: 'admin.view', granted: true },
           { capability: 'dm.start', granted: true },
@@ -190,6 +191,7 @@ describe('getCurrentUserViaConnect', () => {
         canAdminViewAudit: true,
         canManageUserPermissions: true,
         viewerHasUnreadFollowedThreads: true,
+        viewerHasPendingFollowedThreadNotifications: true,
         serverNotificationPreference: {
           level: NotificationLevel.AllMessages,
           effectiveLevel: NotificationLevel.AllMessages

--- a/apps/frontend/src/lib/api-client/renderTypes.ts
+++ b/apps/frontend/src/lib/api-client/renderTypes.ts
@@ -198,6 +198,7 @@ export type RoomEventPayload =
       threadParticipantCount?: number;
       threadParticipants: UserAvatarUserView[];
       viewerIsFollowingThread?: boolean | null;
+      viewerHasUnreadThread?: boolean | null;
     }
   | {
       kind: 'messageRetracted';

--- a/apps/frontend/src/lib/api-client/roomTimeline.ts
+++ b/apps/frontend/src/lib/api-client/roomTimeline.ts
@@ -343,6 +343,8 @@ export function messagePostedPayload(message: Message, users: Record<string, Use
       .filter((user): user is NonNullable<ReturnType<typeof userView>> => user !== null),
     viewerIsFollowingThread:
       thread?.viewerState?.isFollowing !== undefined ? thread.viewerState.isFollowing : null,
+    viewerHasUnreadThread:
+      thread?.viewerState?.hasUnread !== undefined ? thread.viewerState.hasUnread : null,
     reactions: message.reactions.map((reaction) => ({
       emoji: reaction.emoji,
       count: reaction.count,

--- a/apps/frontend/src/lib/api-client/threads.ts
+++ b/apps/frontend/src/lib/api-client/threads.ts
@@ -25,6 +25,7 @@ export type FollowedThreadsPage = {
   threads: FollowedThread[];
   totalCount: number;
   hasMore: boolean;
+  unreadOnly: boolean;
 };
 
 export type ThreadFollowState = {
@@ -45,10 +46,14 @@ export function createThreadAPI(config: ConnectAPIConfig) {
     async listFollowedThreads(input: {
       limit: number;
       offset: number;
+      unreadOnly?: boolean;
     }): Promise<FollowedThreadsPage> {
       try {
         const response = await client.listFollowedThreads(
-          { page: { limit: input.limit, offset: input.offset } },
+          {
+            page: { limit: input.limit, offset: input.offset },
+            unreadOnly: input.unreadOnly ?? false
+          },
           { headers: headers() }
         );
         const users = response.includes?.users ?? {};
@@ -65,7 +70,8 @@ export function createThreadAPI(config: ConnectAPIConfig) {
             hasUnread: thread.thread?.viewerState?.hasUnread ?? false
           })),
           totalCount: Number(response.page?.totalCount ?? 0),
-          hasMore: response.page?.hasMore ?? false
+          hasMore: response.page?.hasMore ?? false,
+          unreadOnly: response.unreadOnly
         };
       } catch (err) {
         return handleAuthError(config, err);

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -62,6 +62,7 @@ export type ViewerState = ViewerCapabilities & {
   viewerPermissions: Record<string, boolean>;
   viewerHasUnreadRooms: boolean;
   viewerHasUnreadFollowedThreads: boolean;
+  viewerHasPendingFollowedThreadNotifications: boolean;
 };
 
 const capabilityKeys = {
@@ -133,6 +134,8 @@ export async function getViewerStateViaConnect(config: ViewerAPIConfig): Promise
     viewerPermissions,
     viewerHasUnreadRooms: response.viewerState?.hasUnreadRooms ?? false,
     viewerHasUnreadFollowedThreads: response.capabilities?.hasUnreadFollowedThreads ?? false,
+    viewerHasPendingFollowedThreadNotifications:
+      response.capabilities?.hasPendingFollowedThreadNotifications ?? false,
     serverNotificationPreference: {
       level: apiNotificationLevel(response.serverNotificationPreference?.level),
       effectiveLevel: apiNotificationLevel(response.serverNotificationPreference?.effectiveLevel)

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -331,6 +331,8 @@
           <MyThreadsNavItem
             active={isMyThreadsActive}
             hasUnread={serverRegistry.getStore(getActiveServer()).rooms.hasUnreadFollowedThreads}
+            hasNotification={serverRegistry.getStore(getActiveServer()).rooms
+              .hasPendingFollowedThreadNotifications}
           />
         </nav>
 

--- a/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte
+++ b/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte
@@ -5,7 +5,11 @@
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import * as m from '$lib/i18n/messages';
 
-  let { active, hasUnread }: { active: boolean; hasUnread: boolean } = $props();
+  let {
+    active,
+    hasUnread,
+    hasNotification
+  }: { active: boolean; hasUnread: boolean; hasNotification: boolean } = $props();
 </script>
 
 <a
@@ -14,7 +18,9 @@
 >
   <span class="sidebar-icon iconify uil--comment-alt-lines"></span>
   {m['chat.threads.title']()}
-  {#if hasUnread}
+  {#if hasNotification}
     <UnreadDot class="ml-auto" testid="my-threads-unread-dot" />
+  {:else if hasUnread}
+    <UnreadDot color="primary" class="ml-auto" testid="my-threads-unread-dot" />
   {/if}
 </a>

--- a/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte.spec.ts
@@ -16,21 +16,26 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 }));
 
 describe('MyThreadsNavItem', () => {
-  it('renders and clears the dot from followed-thread unread state', async () => {
+  it('uses the room-unread color for unread activity and warning for notifications', async () => {
     const rendered = render(MyThreadsNavItem, {
-      props: { active: false, hasUnread: false }
+      props: { active: false, hasUnread: false, hasNotification: false }
     });
 
     expect(rendered.container.querySelector('[data-testid="my-threads-unread-dot"]')).toBeNull();
 
-    await rendered.rerender({ active: false, hasUnread: true });
-    await expect
-      .element(
-        rendered.container.querySelector<HTMLElement>('[data-testid="my-threads-unread-dot"]')
-      )
-      .toBeInTheDocument();
+    await rendered.rerender({ active: false, hasUnread: true, hasNotification: false });
+    const unreadDot = rendered.container.querySelector<HTMLElement>(
+      '[data-testid="my-threads-unread-dot"]'
+    );
+    await expect.element(unreadDot).toBeInTheDocument();
+    expect(unreadDot).toHaveClass('bg-primary');
 
-    await rendered.rerender({ active: false, hasUnread: false });
+    await rendered.rerender({ active: false, hasUnread: true, hasNotification: true });
+    expect(
+      rendered.container.querySelector<HTMLElement>('[data-testid="my-threads-unread-dot"]')
+    ).toHaveClass('bg-warning');
+
+    await rendered.rerender({ active: false, hasUnread: false, hasNotification: false });
     expect(rendered.container.querySelector('[data-testid="my-threads-unread-dot"]')).toBeNull();
   });
 });

--- a/apps/frontend/src/lib/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/eventBus.svelte.ts
@@ -92,6 +92,7 @@ type EventEnvelopeEvent =
       lastReplyAt?: string | null;
       threadParticipants?: UserAvatarUserView[];
       viewerIsFollowingThread?: boolean | null;
+      viewerHasUnreadThread?: boolean | null;
     }
   | {
       kind: typeof RoomEventKind.MessageRetracted;

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -1534,7 +1534,12 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.ingestEvent(returnedReply as never);
     store.ingestServerEvent(returnedReply as never);
 
-    expect(store.rootEvents[0].event).toMatchObject({ replyCount: 1 });
+    expect(store.rootEvents[0].event).toMatchObject({
+      replyCount: 1,
+      viewerHasUnreadThread: true
+    });
+    store.markThreadRead('t1');
+    expect(store.rootEvents[0].event).toMatchObject({ viewerHasUnreadThread: false });
     store.dispose();
   });
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -328,6 +328,24 @@ export class MessagesStore {
     };
   }
 
+  /** Clear unread state on a known thread root after its read marker advances. */
+  markThreadRead(threadRootEventId: string): void {
+    const idx = this.events.findIndex((event) => event.id === threadRootEventId);
+    if (idx === -1) return;
+
+    const rootEvent = this.events[idx];
+    if (!isMessagePostedPayload(rootEvent.event)) return;
+    if (rootEvent.event.viewerHasUnreadThread === false) return;
+
+    this.events[idx] = {
+      ...rootEvent,
+      event: {
+        ...rootEvent.event,
+        viewerHasUnreadThread: false
+      }
+    };
+  }
+
   /** Fetch an off-window event for previews. Transient errors are not cached. */
   ensureEvent(eventId: string): Promise<void> | undefined {
     if (!this.roomId) return undefined;
@@ -1351,6 +1369,7 @@ export class MessagesStore {
         replyCount: rootEvent.event.replyCount + 1,
         lastReplyAt: spaceEvent.createdAt,
         viewerIsFollowingThread,
+        viewerHasUnreadThread: !viewerIsReplier,
         threadParticipants:
           isNewParticipant && spaceEvent.actor
             ? [...existingParticipants, spaceEvent.actor]

--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -312,9 +312,19 @@ describe('NotificationStore', () => {
       summary: 'sent you a message',
       room: { id: 'dm-room' }
     } as unknown as NotificationItem;
+    const threadMention = {
+      kind: NotificationItemKind.Mention,
+      id: 'thread-mention-kind',
+      createdAt: new Date().toISOString(),
+      actor: null,
+      summary: 'mentioned you',
+      mentionRoom: { id: 'room-kind', name: 'general' },
+      mentionEventId: 'mention-event',
+      mentionInThread: 'mentioned-thread-root'
+    } as unknown as NotificationItem;
 
     const store = new NotificationStore(makeAPI());
-    store.notifications = [threadReply, dm];
+    store.notifications = [threadReply, threadMention, dm];
 
     expect(notificationTarget(threadReply)).toMatchObject({
       isDM: false,
@@ -323,6 +333,7 @@ describe('NotificationStore', () => {
       threadRootId: 'thread-root'
     });
     expect(store.hasThreadNotification('thread-root')).toBe(true);
+    expect(store.hasThreadNotification('mentioned-thread-root')).toBe(true);
     expect(store.hasDMRoomNotification('dm-room')).toBe(true);
   });
 

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -155,8 +155,9 @@ export class NotificationStore {
   get threadsWithNotifications(): SvelteSet<string> {
     const threadIds = new SvelteSet<string>();
     for (const n of this.notifications) {
-      if (isReplyNotification(n) && n.replyInThread) {
-        threadIds.add(n.replyInThread);
+      const threadRootId = notificationTarget(n).threadRootId;
+      if (threadRootId) {
+        threadIds.add(threadRootId);
       }
     }
     return threadIds;
@@ -166,9 +167,9 @@ export class NotificationStore {
    * Check if a specific thread has pending notifications.
    */
   hasThreadNotification(threadRootId: string): boolean {
-    return this.notifications.some(
-      (n) => isReplyNotification(n) && n.replyInThread === threadRootId
-    );
+    return this.notifications.some((notification) => {
+      return notificationTarget(notification).threadRootId === threadRootId;
+    });
   }
 
   /**

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -96,6 +96,7 @@ function makeViewer(overrides: Partial<ViewerState> = {}): ViewerState {
     viewerPermissions: {},
     viewerHasUnreadRooms: false,
     viewerHasUnreadFollowedThreads: false,
+    viewerHasPendingFollowedThreadNotifications: false,
     ...overrides
   };
 }
@@ -254,7 +255,8 @@ describe('RoomsStore - refresh', () => {
               effectiveLevel: NotificationLevel.AllMessages
             }
           ],
-          viewerHasUnreadFollowedThreads: true
+          viewerHasUnreadFollowedThreads: true,
+          viewerHasPendingFollowedThreadNotifications: true
         })
       )
     });
@@ -263,6 +265,7 @@ describe('RoomsStore - refresh', () => {
 
     expect(store.currentUserId).toBe('U2');
     expect(store.hasUnreadFollowedThreads).toBe(true);
+    expect(store.hasPendingFollowedThreadNotifications).toBe(true);
     expect(notificationLevels.getServerPreference()).toEqual({
       level: NotificationLevel.Muted,
       effectiveLevel: NotificationLevel.Muted
@@ -287,11 +290,17 @@ describe('RoomsStore - refresh', () => {
     expect(first).toBe(second);
     expect(viewerStateLoader).toHaveBeenCalledOnce();
 
-    resolveFirst(makeViewer({ viewerHasUnreadFollowedThreads: true }));
+    resolveFirst(
+      makeViewer({
+        viewerHasUnreadFollowedThreads: true,
+        viewerHasPendingFollowedThreadNotifications: true
+      })
+    );
     await first;
 
     expect(viewerStateLoader).toHaveBeenCalledTimes(2);
     expect(store.hasUnreadFollowedThreads).toBe(false);
+    expect(store.hasPendingFollowedThreadNotifications).toBe(false);
   });
 
   it('does not let an older full refresh overwrite newer followed-thread unread state', async () => {
@@ -304,10 +313,16 @@ describe('RoomsStore - refresh', () => {
 
     const fullRefresh = store.refresh();
     await store.refreshUnreadFollowedThreads();
-    resolveFullViewer(makeViewer({ viewerHasUnreadFollowedThreads: true }));
+    resolveFullViewer(
+      makeViewer({
+        viewerHasUnreadFollowedThreads: true,
+        viewerHasPendingFollowedThreadNotifications: true
+      })
+    );
     await fullRefresh;
 
     expect(store.hasUnreadFollowedThreads).toBe(false);
+    expect(store.hasPendingFollowedThreadNotifications).toBe(false);
   });
 
   it('discards out-of-order responses', async () => {
@@ -712,6 +727,7 @@ describe('RoomsStore - ingestServerEvent', () => {
 
   it.each([
     [RoomEventKind.ThreadFollowChanged, {}],
+    [RoomEventKind.NotificationCreated, {}],
     [RoomEventKind.NotificationDismissed, {}],
     [RoomEventKind.MessagePosted, { threadRootEventId: 'thread-root', roomId: 'room-1' }]
   ])('refreshes followed-thread unread state on %s', (kind, extra) => {

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -212,6 +212,7 @@ export class RoomsStore {
   roomGroups = $state<RoomsListGroup[] | null>(null);
   isInitialLoading = $state(true);
   hasUnreadFollowedThreads = $state(false);
+  hasPendingFollowedThreadNotifications = $state(false);
   // The viewer's user ID, captured from the same sidebar bootstrap query that
   // produced DM `room.members`. Use this in preference to a global auth
   // context when filtering self out of DM labels and avatars.
@@ -250,6 +251,8 @@ export class RoomsStore {
     this.currentUserId = viewer.user.id;
     if (this.threadUnreadRevision === threadUnreadSnapshotRevision) {
       this.hasUnreadFollowedThreads = viewer.viewerHasUnreadFollowedThreads;
+      this.hasPendingFollowedThreadNotifications =
+        viewer.viewerHasPendingFollowedThreadNotifications;
     }
     this.notificationLevels.setServerPreference(
       viewer.serverNotificationPreference.level,
@@ -385,6 +388,8 @@ export class RoomsStore {
           const viewer = await this.viewerStateLoader();
           this.threadUnreadRevision += 1;
           this.hasUnreadFollowedThreads = viewer.viewerHasUnreadFollowedThreads;
+          this.hasPendingFollowedThreadNotifications =
+            viewer.viewerHasPendingFollowedThreadNotifications;
         } catch (err) {
           console.warn('failed to refresh followed-thread unread state', err);
         }
@@ -478,6 +483,7 @@ export class RoomsStore {
     }
     if (
       kind === RoomEventKind.ThreadFollowChanged ||
+      kind === RoomEventKind.NotificationCreated ||
       kind === RoomEventKind.NotificationDismissed ||
       (isMessagePostedEvent(event) && !!event.threadRootEventId)
     ) {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -439,6 +439,7 @@
   const hasThreadNotification = $derived(
     hasReplies && event && notificationStore.hasThreadNotification(event.id)
   );
+  const hasThreadUnread = $derived(hasReplies && messageEvent?.viewerHasUnreadThread === true);
   const hasMessageFooter = $derived(
     (isEcho && !!onOpenThread) ||
       (hasReplies && !!onOpenThread) ||
@@ -893,6 +894,7 @@
             replyCount={messageEvent?.replyCount}
             threadParticipants={messageEvent?.threadParticipants}
             {hasThreadNotification}
+            {hasThreadUnread}
             canReact={roomPermissions.canReact}
             {messageStore}
             {isFollowingThread}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.stories.svelte
@@ -33,6 +33,10 @@
   <MessageMetaBarStoryFrame variant="unread-followed-thread" />
 </Story>
 
+<Story name="Notified followed thread" asChild>
+  <MessageMetaBarStoryFrame variant="notified-followed-thread" />
+</Story>
+
 <Story name="Thread echo" asChild>
   <MessageMetaBarStoryFrame variant="thread-echo" />
 </Story>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -13,7 +13,8 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
 - `reactions` - Array of reaction summaries
 - `replyCount` - Number of thread replies
 - `threadParticipants` - Thread participant user fragments (for avatars)
-- `hasThreadNotification` - Whether there's an unread thread notification
+- `hasThreadNotification` - Whether the thread has a pending notification
+- `hasThreadUnread` - Whether the thread has unread replies
 - `canReact` - Whether the user can add reactions
 - `isFollowingThread` - Whether the viewer is following this thread
 - `onToggleThreadFollow` - Callback to toggle thread follow state
@@ -51,6 +52,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     replyCount = 0,
     threadParticipants,
     hasThreadNotification = false,
+    hasThreadUnread = false,
     canReact = false,
     messageStore = null,
     isFollowingThread = false,
@@ -68,6 +70,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     replyCount?: number;
     threadParticipants?: MessagePostedEvent['threadParticipants'];
     hasThreadNotification?: boolean;
+    hasThreadUnread?: boolean;
     canReact?: boolean;
     messageStore?: MessagesStore | null;
     isFollowingThread?: boolean;
@@ -206,6 +209,8 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
       </span>
       {#if hasThreadNotification}
         <UnreadDot />
+      {:else if hasThreadUnread}
+        <UnreadDot color="primary" />
       {/if}
     </a>
     {#if onToggleThreadFollow}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -84,6 +84,29 @@ describe('MessageMetaBar', () => {
     expect(link.textContent?.replace(/\s+/g, ' ').trim()).toContain('2 replies');
   });
 
+  it('uses gray for unread replies and orange for pending notifications', async () => {
+    const rendered = render(MessageMetaBar, {
+      props: {
+        ...baseProps,
+        replyCount: 2,
+        hasThreadUnread: true
+      }
+    });
+
+    expect(rendered.container.querySelector('.bg-primary')).not.toBeNull();
+    expect(rendered.container.querySelector('.bg-warning')).toBeNull();
+
+    await rendered.rerender({
+      ...baseProps,
+      replyCount: 2,
+      hasThreadUnread: true,
+      hasThreadNotification: true
+    });
+
+    expect(rendered.container.querySelector('.bg-warning')).not.toBeNull();
+    expect(rendered.container.querySelector('.bg-primary')).toBeNull();
+  });
+
   it('renders the echo thread badge as a native thread link', async () => {
     const { container } = render(MessageMetaBar, {
       props: {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
@@ -14,6 +14,7 @@
     | 'reactions'
     | 'replies-and-reactions'
     | 'unread-followed-thread'
+    | 'notified-followed-thread'
     | 'thread-echo'
     | 'read-only-reactions'
     | 'short-reaction-popover'
@@ -140,7 +141,24 @@
       reactions={[]}
       replyCount={5}
       threadParticipants={[alice, jordan, mika]}
+      hasThreadUnread
+      canReact
+      isFollowingThread
+      onToggleThreadFollow={noop}
+      onOpenThread={noop}
+      onOpenEmojiPicker={noop}
+    />
+  {:else if variant === 'notified-followed-thread'}
+    <MessageMetaBar
+      {roomId}
+      {messageEventId}
+      {serverSegment}
+      {threadRootEventId}
+      reactions={[]}
+      replyCount={5}
+      threadParticipants={[alice, jordan, mika]}
       hasThreadNotification
+      hasThreadUnread
       canReact
       isFollowingThread
       onToggleThreadFollow={noop}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -616,6 +616,7 @@
           onReplyConsumed={() => {
             pendingThreadReply = null;
           }}
+          onMarkedRead={() => roomMessageStore.markThreadRead(threadId)}
         />
       {/if}
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -42,7 +42,8 @@
     pendingReply = null,
     onHighlightComplete,
     onQuoteConsumed,
-    onReplyConsumed
+    onReplyConsumed,
+    onMarkedRead
   }: {
     roomId: string;
     roomName: string;
@@ -57,6 +58,7 @@
     onHighlightComplete?: () => void;
     onQuoteConsumed?: () => void;
     onReplyConsumed?: () => void;
+    onMarkedRead?: () => void;
   } = $props();
 
   const connection = useConnection();
@@ -314,6 +316,7 @@
         bearerToken: conn.bearerToken
       }).markThreadAsRead({ roomId, threadRootEventId: currentThreadId, upToEventId });
       void serverStore.rooms.refreshUnreadFollowedThreads();
+      onMarkedRead?.();
       return result;
     } catch (err) {
       console.error('Failed to mark thread as read:', err);

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -71,6 +71,7 @@
   let error = $state<string | null>(null);
   let hasMore = $state(false);
   let totalCount = $state(0);
+  let serverFilteredUnread = $state(false);
   let loadId = 0;
 
   const filter = $derived(page.state.threadFilter ?? 'all');
@@ -79,8 +80,10 @@
     replaceState('', { ...page.state, threadFilter: value });
   }
 
-  const filteredThreads = $derived(
-    filter === 'unread' ? threads.filter((t) => t.hasUnread) : threads
+  const displayedThreads = $derived(
+    filter === 'unread' && !serverFilteredUnread
+      ? threads.filter((thread) => thread.hasUnread)
+      : threads
   );
 
   async function loadThreads({ append = false }: { append?: boolean } = {}) {
@@ -100,7 +103,8 @@
         bearerToken: conn.bearerToken
       }).listFollowedThreads({
         limit: PAGE_SIZE,
-        offset: append ? threads.length : 0
+        offset: append ? threads.length : 0,
+        unreadOnly: filter === 'unread'
       });
 
       if (thisId !== loadId) return;
@@ -109,6 +113,7 @@
       threads = append ? mergeThreads(threads, nextThreads) : nextThreads;
       hasMore = result.hasMore;
       totalCount = result.totalCount;
+      serverFilteredUnread = result.unreadOnly;
     } catch (e) {
       if (thisId !== loadId) return;
       error = e instanceof Error ? e.message : 'Failed to load threads';
@@ -219,10 +224,15 @@
         <Hint tone="danger">{error}</Hint>
       </div>
     {:else if threads.length === 0}
-      <EmptyState icon="uil--comment-lines" title={m['chat.threads.empty_title']()}>
-        {m['chat.threads.empty_body']()}
+      <EmptyState
+        icon={filter === 'unread' ? 'uil--comment-check' : 'uil--comment-lines'}
+        title={filter === 'unread'
+          ? m['chat.threads.all_caught_up']()
+          : m['chat.threads.empty_title']()}
+      >
+        {filter === 'unread' ? m['chat.threads.no_unread']() : m['chat.threads.empty_body']()}
       </EmptyState>
-    {:else if filteredThreads.length === 0}
+    {:else if displayedThreads.length === 0}
       <EmptyState
         icon="uil--comment-check"
         title={hasMore ? m['chat.threads.no_unread_loaded']() : m['chat.threads.all_caught_up']()}
@@ -247,7 +257,7 @@
       </EmptyState>
     {:else}
       <div class="flex flex-col divide-y divide-border">
-        {#each filteredThreads as thread (thread.threadRootEventId)}
+        {#each displayedThreads as thread (thread.threadRootEventId)}
           <div class="group relative" data-testid="my-thread-item">
             <!-- Channel label above the message -->
             <div class="flex gap-4 px-2 pt-4 pb-2 md:mx-2">

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -1832,6 +1832,22 @@ func TestViewerServiceGetViewerReturnsSelfScopedState(t *testing.T) {
 	if err := env.core.GrantServerPermission(env.ctx, core.SystemActorID, core.RoleEveryone, core.PermRoleAssign); err != nil {
 		t.Fatalf("GrantServerPermission role.assign: %v", err)
 	}
+	threadRoot := env.post(room.Id, env.viewer.Id, "viewer thread root", "")
+	if err := env.core.FollowThread(env.ctx, core.KindChannel, env.viewer.Id, room.Id, threadRoot.Id); err != nil {
+		t.Fatalf("FollowThread viewer: %v", err)
+	}
+	if _, err := env.core.CreateNotification(env.ctx, env.viewer.Id, core.SystemActorID, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{
+				RoomId:      room.Id,
+				EventId:     "viewer-thread-reply",
+				InReplyToId: threadRoot.Id,
+				InThread:    threadRoot.Id,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateNotification viewer thread: %v", err)
+	}
 
 	resp, err := env.viewerService.GetViewer(ctx, connect.NewRequest(&apiv1.GetViewerRequest{}))
 	if err != nil {
@@ -1874,6 +1890,9 @@ func TestViewerServiceGetViewerReturnsSelfScopedState(t *testing.T) {
 	}
 	if apiCapabilityGranted(resp.Msg.GetCapabilities().GetGrants(), viewerCapabilityAdminViewSystem) {
 		t.Fatalf("viewer system capability = true for regular viewer, want false")
+	}
+	if !resp.Msg.GetCapabilities().GetHasPendingFollowedThreadNotifications() {
+		t.Fatal("viewer pending followed-thread notifications = false, want true")
 	}
 	if resp.Msg.GetViewerPermissions() == nil {
 		t.Fatal("ViewerPermissions = nil")
@@ -5039,6 +5058,9 @@ func TestMessageServiceReactionOnEchoCanonicalizesToOriginal(t *testing.T) {
 	if echoEvent == nil || echoEvent.GetMessagePosted() == nil {
 		t.Fatalf("echo event %s missing from room page", echoID)
 	}
+	if got := echoEvent.GetMessagePosted().GetMessage().GetThread(); got != nil {
+		t.Fatalf("echo thread summary = %+v, want nil", got)
+	}
 	if got := echoEvent.GetMessagePosted().GetMessage().GetReactions(); len(got) != 1 || got[0].GetEmoji() != "thumbsup" || got[0].GetCount() != 1 || !got[0].GetHasReacted() {
 		t.Fatalf("echo reactions = %+v, want thumbsup count 1 hasReacted", got)
 	}
@@ -7300,9 +7322,29 @@ func TestThreadServiceListFollowedThreadsReturnsHydratedPage(t *testing.T) {
 	if got := rootMessage.GetBody(); got != "root body" {
 		t.Fatalf("root message body = %q, want root body", got)
 	}
+	if !rootMessage.GetThread().GetViewerState().GetHasUnread() {
+		t.Fatal("root message thread viewer state has_unread = false, want true")
+	}
 	users := resp.Msg.GetIncludes().GetUsers()
 	if users[env.viewer.Id] == nil || users[participant.Id] == nil {
 		t.Fatalf("includes users missing viewer or participant: got %d included users", len(users))
+	}
+
+	if _, err := env.core.SetThreadLastOpened(env.ctx, core.KindChannel, env.viewer.Id, room.Id, root.Id); err != nil {
+		t.Fatalf("SetThreadLastOpened: %v", err)
+	}
+	resp, err = env.threads.ListFollowedThreads(ctx, connect.NewRequest(&apiv1.ListFollowedThreadsRequest{
+		Page:       &apiv1.PageRequest{Limit: 20},
+		UnreadOnly: true,
+	}))
+	if err != nil {
+		t.Fatalf("ListFollowedThreads unread only: %v", err)
+	}
+	if len(resp.Msg.GetThreads()) != 0 || resp.Msg.GetPage().GetTotalCount() != 0 {
+		t.Fatalf("read thread returned by unread-only list: threads %d total %d", len(resp.Msg.GetThreads()), resp.Msg.GetPage().GetTotalCount())
+	}
+	if !resp.Msg.GetUnreadOnly() {
+		t.Fatal("unread-only response did not confirm that the filter was applied")
 	}
 }
 

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -240,7 +240,7 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 		}
 	}
 
-	if payload.GetInThread() == "" {
+	if payload.GetInThread() == "" && payload.GetEchoOfEventId() == "" {
 		thread := &apiv1.ThreadSummary{
 			ThreadRootEventId: event.Id,
 		}
@@ -261,7 +261,21 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 		if err != nil {
 			return nil, err
 		}
-		thread.ViewerState = &apiv1.ThreadViewerState{IsFollowing: &following}
+		hasUnread := false
+		if metadata != nil {
+			hasUnread = h.api.core.ThreadHasUnread(
+				ctx,
+				h.kind,
+				h.viewerID,
+				payload.GetRoomId(),
+				event.Id,
+				metadata.LastReplyAt,
+			)
+		}
+		thread.ViewerState = &apiv1.ThreadViewerState{
+			IsFollowing: &following,
+			HasUnread:   &hasUnread,
+		}
 		message.Thread = thread
 	}
 

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -23,7 +23,7 @@ func (s *threadService) ListFollowedThreads(ctx context.Context, req *connect.Re
 	}
 
 	limit, offset := apiPagination(req.Msg.GetPage(), defaultFollowedThreadLimit, maxFollowedThreadLimit)
-	page, err := s.api.core.ThreadFollows().ListFollowedThreads(ctx, caller.UserID, limit, offset)
+	page, err := s.api.core.ThreadFollows().ListFollowedThreads(ctx, caller.UserID, req.Msg.GetUnreadOnly(), limit, offset)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -32,6 +32,7 @@ func (s *threadService) ListFollowedThreads(ctx context.Context, req *connect.Re
 	if err != nil {
 		return nil, connectError(err)
 	}
+	resp.UnreadOnly = req.Msg.GetUnreadOnly()
 	return connect.NewResponse(resp), nil
 }
 

--- a/cli/internal/connectapi/viewer.go
+++ b/cli/internal/connectapi/viewer.go
@@ -151,6 +151,10 @@ func (s *viewerService) viewerCapabilities(ctx context.Context, userID string) (
 	if err != nil {
 		return nil, connectError(err)
 	}
+	hasPendingFollowedThreadNotifications, err := s.api.core.HasPendingFollowedThreadNotifications(ctx, userID, []string{core.LegacySpaceIDForRoomKind(core.KindChannel)})
+	if err != nil {
+		return nil, connectError(err)
+	}
 
 	return &apiv1.ViewerCapabilities{
 		Grants: []*apiv1.CapabilityGrant{
@@ -165,7 +169,8 @@ func (s *viewerService) viewerCapabilities(ctx context.Context, userID string) (
 			{Capability: viewerCapabilityAdminViewAudit, Granted: canAdminViewAudit},
 			{Capability: viewerCapabilityManageUserPerms, Granted: canManageUserPermissions},
 		},
-		HasUnreadFollowedThreads: hasUnreadFollowedThreads,
+		HasUnreadFollowedThreads:              hasUnreadFollowedThreads,
+		HasPendingFollowedThreadNotifications: hasPendingFollowedThreadNotifications,
 	}, nil
 }
 

--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -315,6 +315,73 @@ func (c *ChattoCore) GetNotificationCount(ctx context.Context, userID string) (i
 	return count, nil
 }
 
+// HasPendingFollowedThreadNotifications reports whether a pending notification
+// belongs to a thread the user currently follows in one of the requested
+// spaces.
+func (c *ChattoCore) HasPendingFollowedThreadNotifications(ctx context.Context, userID string, spaceIDs []string) (bool, error) {
+	notifications, err := c.GetNotifications(ctx, userID)
+	if err != nil {
+		return false, err
+	}
+
+	allowedKinds := make(map[RoomKind]struct{}, len(spaceIDs))
+	for _, spaceID := range spaceIDs {
+		allowedKinds[RoomKindFromLegacySpaceID(spaceID)] = struct{}{}
+	}
+
+	for _, notification := range notifications {
+		roomID, threadRootEventID := notificationThreadTarget(notification)
+		if roomID == "" || threadRootEventID == "" {
+			continue
+		}
+
+		room, err := c.FindRoomByID(ctx, roomID)
+		if err != nil {
+			c.logger.Warn("Skipping followed-thread notification with unavailable room",
+				"room_id", roomID,
+				"thread_root_event_id", threadRootEventID,
+				"error", err)
+			continue
+		}
+		kind := KindOfRoom(room)
+		if _, ok := allowedKinds[kind]; !ok {
+			continue
+		}
+
+		isMember, err := c.RoomMembershipExists(ctx, kind, userID, roomID)
+		if err != nil {
+			return false, err
+		}
+		if !isMember {
+			continue
+		}
+
+		following, err := c.IsFollowingThread(ctx, kind, userID, roomID, threadRootEventID)
+		if err != nil {
+			return false, err
+		}
+		if following {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func notificationThreadTarget(notification *corev1.Notification) (roomID, threadRootEventID string) {
+	if notification == nil {
+		return "", ""
+	}
+	switch payload := notification.GetNotification().(type) {
+	case *corev1.Notification_Mention:
+		return payload.Mention.GetRoomId(), payload.Mention.GetInThread()
+	case *corev1.Notification_Reply:
+		return payload.Reply.GetRoomId(), payload.Reply.GetInThread()
+	default:
+		return "", ""
+	}
+}
+
 func (c *ChattoCore) GetRoomNotificationsForMember(ctx context.Context, actorID, roomID string) ([]*corev1.Notification, error) {
 	if err := requireAuthenticatedActor(actorID); err != nil {
 		return nil, err

--- a/cli/internal/core/notifications_test.go
+++ b/cli/internal/core/notifications_test.go
@@ -233,6 +233,77 @@ func TestCreateNotification(t *testing.T) {
 	})
 }
 
+func TestHasPendingFollowedThreadNotifications(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "thread-notifications", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	follower, err := core.CreateUser(ctx, SystemActorID, "thread-follower", "Thread Follower", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser follower: %v", err)
+	}
+	author, err := core.CreateUser(ctx, SystemActorID, "thread-author", "Thread Author", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser author: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, follower.Id, KindChannel, follower.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom follower: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom author: %v", err)
+	}
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage root: %v", err)
+	}
+	if err := core.FollowThread(ctx, KindChannel, follower.Id, room.Id, root.Id); err != nil {
+		t.Fatalf("FollowThread: %v", err)
+	}
+
+	hasPending, err := core.HasPendingFollowedThreadNotifications(ctx, follower.Id, []string{LegacySpaceIDForRoomKind(KindChannel)})
+	if err != nil {
+		t.Fatalf("HasPendingFollowedThreadNotifications before notification: %v", err)
+	}
+	if hasPending {
+		t.Fatal("HasPendingFollowedThreadNotifications = true before notification")
+	}
+
+	if _, err := core.CreateNotification(ctx, follower.Id, author.Id, &corev1.Notification{
+		Notification: &corev1.Notification_Reply{
+			Reply: &corev1.ReplyNotification{
+				RoomId:      room.Id,
+				EventId:     "reply-event",
+				InReplyToId: root.Id,
+				InThread:    root.Id,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("CreateNotification: %v", err)
+	}
+
+	hasPending, err = core.HasPendingFollowedThreadNotifications(ctx, follower.Id, []string{LegacySpaceIDForRoomKind(KindChannel)})
+	if err != nil {
+		t.Fatalf("HasPendingFollowedThreadNotifications after notification: %v", err)
+	}
+	if !hasPending {
+		t.Fatal("HasPendingFollowedThreadNotifications = false for followed thread notification")
+	}
+
+	if err := core.UnfollowThread(ctx, KindChannel, follower.Id, room.Id, root.Id); err != nil {
+		t.Fatalf("UnfollowThread: %v", err)
+	}
+	hasPending, err = core.HasPendingFollowedThreadNotifications(ctx, follower.Id, []string{LegacySpaceIDForRoomKind(KindChannel)})
+	if err != nil {
+		t.Fatalf("HasPendingFollowedThreadNotifications after unfollow: %v", err)
+	}
+	if hasPending {
+		t.Fatal("HasPendingFollowedThreadNotifications = true for unfollowed thread")
+	}
+}
+
 func TestGetNotifications(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := context.Background()

--- a/cli/internal/core/thread_follow_model.go
+++ b/cli/internal/core/thread_follow_model.go
@@ -15,11 +15,11 @@ type ThreadFollowModel struct {
 	core *ChattoCore
 }
 
-func (s *ThreadFollowModel) ListFollowedThreads(ctx context.Context, actorID string, limit, offset int) (*FollowedThreadsPage, error) {
+func (s *ThreadFollowModel) ListFollowedThreads(ctx context.Context, actorID string, unreadOnly bool, limit, offset int) (*FollowedThreadsPage, error) {
 	if err := requireAuthenticatedActor(actorID); err != nil {
 		return nil, err
 	}
-	return s.core.ListFollowedThreadsPage(ctx, actorID, []string{LegacySpaceIDForRoomKind(KindChannel)}, limit, offset)
+	return s.core.ListFollowedThreadsPage(ctx, actorID, []string{LegacySpaceIDForRoomKind(KindChannel)}, unreadOnly, limit, offset)
 }
 
 func (s *ThreadFollowModel) HasUnreadFollowedThreads(ctx context.Context, actorID string) (bool, error) {

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -798,7 +798,7 @@ func (c *ChattoCore) GetThreadFollowers(ctx context.Context, kind RoomKind, room
 // spaces, sorted by last activity (newest first).
 // Authorization: Caller must verify space membership before calling.
 func (c *ChattoCore) ListFollowedThreads(ctx context.Context, userID string, spaceIDs []string) ([]*FollowedThread, error) {
-	page, err := c.ListFollowedThreadsPage(ctx, userID, spaceIDs, 0, 0)
+	page, err := c.ListFollowedThreadsPage(ctx, userID, spaceIDs, false, 0, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -806,11 +806,11 @@ func (c *ChattoCore) ListFollowedThreads(ctx context.Context, userID string, spa
 }
 
 // ListFollowedThreadsPage returns followed threads for the user in the given
-// spaces, sorted by last activity (newest first), with pagination applied before
-// per-thread read-marker lookups.
+// spaces, sorted by last activity (newest first). When unreadOnly is true, the
+// unread filter is applied before pagination.
 //
 // Authorization: Caller must verify space membership before calling.
-func (c *ChattoCore) ListFollowedThreadsPage(ctx context.Context, userID string, spaceIDs []string, limit, offset int) (*FollowedThreadsPage, error) {
+func (c *ChattoCore) ListFollowedThreadsPage(ctx context.Context, userID string, spaceIDs []string, unreadOnly bool, limit, offset int) (*FollowedThreadsPage, error) {
 	var allThreads []*FollowedThread
 
 	for _, spaceID := range spaceIDs {
@@ -833,6 +833,17 @@ func (c *ChattoCore) ListFollowedThreadsPage(ctx context.Context, userID string,
 		return allThreads[i].LastReplyAt.After(*allThreads[j].LastReplyAt)
 	})
 
+	if unreadOnly {
+		unreadThreads := make([]*FollowedThread, 0, len(allThreads))
+		for _, thread := range allThreads {
+			thread.HasUnread = c.followedThreadHasUnread(ctx, userID, thread)
+			if thread.HasUnread {
+				unreadThreads = append(unreadThreads, thread)
+			}
+		}
+		allThreads = unreadThreads
+	}
+
 	totalCount := len(allThreads)
 	if offset < 0 {
 		offset = 0
@@ -854,8 +865,10 @@ func (c *ChattoCore) ListFollowedThreadsPage(ctx context.Context, userID string,
 		pageThreads = allThreads[offset:]
 	}
 
-	for _, thread := range pageThreads {
-		thread.HasUnread = c.followedThreadHasUnread(ctx, userID, thread)
+	if !unreadOnly {
+		for _, thread := range pageThreads {
+			thread.HasUnread = c.followedThreadHasUnread(ctx, userID, thread)
+		}
 	}
 
 	return &FollowedThreadsPage{
@@ -899,6 +912,11 @@ func (c *ChattoCore) listFollowedThreadsInSpace(ctx context.Context, userID stri
 			continue
 		}
 
+		if _, err := c.requireThreadRoot(ctx, kind, roomID, threadRootEventID); err != nil {
+			c.logger.Warn("Skipping followed thread with invalid root", "error", err, "room_id", roomID, "thread_root_event_id", threadRootEventID)
+			continue
+		}
+
 		// Get thread metadata (reply count, last reply, participants)
 		metadata, err := c.GetThreadMetadata(ctx, kind, roomID, threadRootEventID)
 		if err != nil {
@@ -924,11 +942,21 @@ func (c *ChattoCore) followedThreadHasUnread(ctx context.Context, userID string,
 		return false
 	}
 	kind := RoomKindFromLegacySpaceID(thread.SpaceID)
-	lastOpened, err := c.GetThreadLastOpened(ctx, kind, userID, thread.RoomID, thread.ThreadRootEventID)
+	return c.ThreadHasUnread(ctx, kind, userID, thread.RoomID, thread.ThreadRootEventID, thread.LastReplyAt)
+}
+
+// ThreadHasUnread reports whether the latest reply is newer than the viewer's
+// read marker. Read-marker lookup failures are treated conservatively as
+// unread.
+func (c *ChattoCore) ThreadHasUnread(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string, lastReplyAt *time.Time) bool {
+	if lastReplyAt == nil {
+		return false
+	}
+	lastOpened, err := c.GetThreadLastOpened(ctx, kind, userID, roomID, threadRootEventID)
 	if err != nil {
 		return true
 	}
-	return lastOpened.IsZero() || thread.LastReplyAt.After(lastOpened)
+	return lastOpened.IsZero() || lastReplyAt.After(lastOpened)
 }
 
 // HasUnreadFollowedThreads reports whether any followed thread has unread

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -812,7 +812,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 	})
 
 	t.Run("returns a paged followed thread list", func(t *testing.T) {
-		page, err := core.ListFollowedThreadsPage(ctx, userA.Id, []string{LegacyServerSpaceID}, 1, 0)
+		page, err := core.ListFollowedThreadsPage(ctx, userA.Id, []string{LegacyServerSpaceID}, false, 1, 0)
 		if err != nil {
 			t.Fatalf("Failed to list followed thread page: %v", err)
 		}
@@ -829,7 +829,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 			t.Errorf("first page root = %q, want %q", page.Threads[0].ThreadRootEventID, rootMsg2.Id)
 		}
 
-		page, err = core.ListFollowedThreadsPage(ctx, userA.Id, []string{LegacyServerSpaceID}, 1, 1)
+		page, err = core.ListFollowedThreadsPage(ctx, userA.Id, []string{LegacyServerSpaceID}, false, 1, 1)
 		if err != nil {
 			t.Fatalf("Failed to list followed thread second page: %v", err)
 		}
@@ -914,6 +914,19 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 		}
 	})
 
+	t.Run("filters unread threads before pagination", func(t *testing.T) {
+		page, err := core.ListFollowedThreadsPage(ctx, userA.Id, []string{LegacyServerSpaceID}, true, 1, 0)
+		if err != nil {
+			t.Fatalf("Failed to list unread followed threads: %v", err)
+		}
+		if page.TotalCount != 1 || page.HasMore {
+			t.Fatalf("unread page metadata = total %d hasMore %v, want total 1 hasMore false", page.TotalCount, page.HasMore)
+		}
+		if len(page.Threads) != 1 || page.Threads[0].ThreadRootEventID != rootMsg1.Id {
+			t.Fatalf("unread page = %+v, want older unread thread %q", page.Threads, rootMsg1.Id)
+		}
+	})
+
 	t.Run("excludes unfollowed threads", func(t *testing.T) {
 		// User A unfollows thread 1
 		core.UnfollowThread(ctx, KindChannel, userA.Id, room1.Id, rootMsg1.Id)
@@ -951,7 +964,7 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 	})
 
 	t.Run("orphaned follow key is skipped gracefully", func(t *testing.T) {
-		// Manually follow a thread that has no metadata (orphaned)
+		// Simulate legacy/corrupt follow state that references a missing event.
 		core.FollowThread(ctx, KindChannel, userA.Id, room1.Id, "nonexistent-thread-id")
 
 		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
@@ -959,22 +972,41 @@ func TestChattoCore_ListFollowedThreads(t *testing.T) {
 			t.Fatalf("Failed to list followed threads: %v", err)
 		}
 
-		// Should still work, including the orphaned thread (with zero metadata)
-		foundOrphan := false
 		for _, thread := range threads {
 			if thread.ThreadRootEventID == "nonexistent-thread-id" {
-				foundOrphan = true
-				if thread.ReplyCount != 0 {
-					t.Errorf("Expected 0 replies for orphaned thread, got %d", thread.ReplyCount)
-				}
+				t.Fatal("orphaned follow state appeared in followed thread list")
 			}
-		}
-		if !foundOrphan {
-			t.Error("Expected orphaned thread to still appear in list (with zero metadata)")
 		}
 
 		// Clean up
 		core.UnfollowThread(ctx, KindChannel, userA.Id, room1.Id, "nonexistent-thread-id")
+	})
+
+	t.Run("echo follow state is skipped gracefully", func(t *testing.T) {
+		reply, err := core.PostMessage(ctx, KindChannel, room2.Id, userB.Id, "Echoed reply", nil, rootMsg2.Id, rootMsg2.Id, nil, true)
+		if err != nil {
+			t.Fatalf("PostMessage echoed reply: %v", err)
+		}
+		echoID, ok := core.RoomTimeline.ChannelEchoEventID(reply.Id)
+		if !ok {
+			t.Fatal("expected channel echo for reply")
+		}
+
+		// Low-level follow APIs historically allowed invalid IDs, so restored
+		// data can contain an echo reference even though public mutations reject it.
+		if err := core.FollowThread(ctx, KindChannel, userA.Id, room2.Id, echoID); err != nil {
+			t.Fatalf("FollowThread echo: %v", err)
+		}
+
+		threads, err := core.ListFollowedThreads(ctx, userA.Id, []string{LegacyServerSpaceID})
+		if err != nil {
+			t.Fatalf("ListFollowedThreads: %v", err)
+		}
+		for _, thread := range threads {
+			if thread.ThreadRootEventID == echoID {
+				t.Fatal("echo appeared in followed thread list as a thread root")
+			}
+		}
 	})
 
 	t.Run("returns empty list for empty spaceIDs slice", func(t *testing.T) {
@@ -1318,7 +1350,7 @@ func TestChattoCore_LegacyThreadFollowValueStillLists(t *testing.T) {
 		t.Fatal("legacy positive value should still count as following")
 	}
 
-	page, err := second.ListFollowedThreadsPage(ctx, legacyFollower.Id, []string{LegacySpaceIDForRoomKind(KindChannel)}, 10, 0)
+	page, err := second.ListFollowedThreadsPage(ctx, legacyFollower.Id, []string{LegacySpaceIDForRoomKind(KindChannel)}, false, 10, 0)
 	if err != nil {
 		t.Fatalf("ListFollowedThreadsPage: %v", err)
 	}

--- a/cli/internal/pb/chatto/api/v1/threads.pb.go
+++ b/cli/internal/pb/chatto/api/v1/threads.pb.go
@@ -374,7 +374,9 @@ func (x *FollowedThread) GetThread() *ThreadSummary {
 type ListFollowedThreadsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Page request. Defaults to 20 results when absent or limit is zero.
-	Page          *PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	Page *PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// When true, returns only threads with unread replies.
+	UnreadOnly    bool `protobuf:"varint,4,opt,name=unread_only,json=unreadOnly,proto3" json:"unread_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -416,6 +418,13 @@ func (x *ListFollowedThreadsRequest) GetPage() *PageRequest {
 	return nil
 }
 
+func (x *ListFollowedThreadsRequest) GetUnreadOnly() bool {
+	if x != nil {
+		return x.UnreadOnly
+	}
+	return false
+}
+
 // Response containing one followed-thread page.
 type ListFollowedThreadsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -425,7 +434,9 @@ type ListFollowedThreadsResponse struct {
 	// per-thread hydration.
 	Includes *RoomTimelineIncludes `protobuf:"bytes,4,opt,name=includes,proto3" json:"includes,omitempty"`
 	// Page metadata.
-	Page          *PageInfo `protobuf:"bytes,5,opt,name=page,proto3" json:"page,omitempty"`
+	Page *PageInfo `protobuf:"bytes,5,opt,name=page,proto3" json:"page,omitempty"`
+	// True when the response is restricted to threads with unread replies.
+	UnreadOnly    bool `protobuf:"varint,6,opt,name=unread_only,json=unreadOnly,proto3" json:"unread_only,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -481,6 +492,13 @@ func (x *ListFollowedThreadsResponse) GetPage() *PageInfo {
 	return nil
 }
 
+func (x *ListFollowedThreadsResponse) GetUnreadOnly() bool {
+	if x != nil {
+		return x.UnreadOnly
+	}
+	return false
+}
+
 var File_chatto_api_v1_threads_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_threads_proto_rawDesc = "" +
@@ -506,13 +524,17 @@ const file_chatto_api_v1_threads_proto_rawDesc = "" +
 	"\froot_message\x18\x04 \x01(\v2\x16.chatto.api.v1.MessageR\vrootMessage\x12.\n" +
 	"\x04room\x18\b \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04room\x124\n" +
 	"\x06thread\x18\t \x01(\v2\x1c.chatto.api.v1.ThreadSummaryR\x06threadJ\x04\b\x01\x10\x04J\x04\b\x05\x10\bR\aroom_idR\troom_nameR\x14thread_root_event_idR\vreply_countR\rlast_reply_atR\n" +
-	"has_unread\"g\n" +
+	"has_unread\"\x88\x01\n" +
 	"\x1aListFollowedThreadsRequest\x12.\n" +
-	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04pageJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x05limitR\x06offset\"\xe7\x01\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\x12\x1f\n" +
+	"\vunread_only\x18\x04 \x01(\bR\n" +
+	"unreadOnlyJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x05limitR\x06offset\"\x88\x02\n" +
 	"\x1bListFollowedThreadsResponse\x127\n" +
 	"\athreads\x18\x01 \x03(\v2\x1d.chatto.api.v1.FollowedThreadR\athreads\x12?\n" +
 	"\bincludes\x18\x04 \x01(\v2#.chatto.api.v1.RoomTimelineIncludesR\bincludes\x12+\n" +
-	"\x04page\x18\x05 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04pageJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vtotal_countR\bhas_more2\xf0\x04\n" +
+	"\x04page\x18\x05 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\x12\x1f\n" +
+	"\vunread_only\x18\x06 \x01(\bR\n" +
+	"unreadOnlyJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vtotal_countR\bhas_more2\xf0\x04\n" +
 	"\rThreadService\x12l\n" +
 	"\x13ListFollowedThreads\x12).chatto.api.v1.ListFollowedThreadsRequest\x1a*.chatto.api.v1.ListFollowedThreadsResponse\x12W\n" +
 	"\fFollowThread\x12\".chatto.api.v1.FollowThreadRequest\x1a#.chatto.api.v1.FollowThreadResponse\x12]\n" +

--- a/cli/internal/pb/chatto/api/v1/viewer.pb.go
+++ b/cli/internal/pb/chatto/api/v1/viewer.pb.go
@@ -233,8 +233,10 @@ type ViewerCapabilities struct {
 	Grants []*CapabilityGrant `protobuf:"bytes,1,rep,name=grants,proto3" json:"grants,omitempty"`
 	// Whether the user has unread followed threads.
 	HasUnreadFollowedThreads bool `protobuf:"varint,2,opt,name=has_unread_followed_threads,json=hasUnreadFollowedThreads,proto3" json:"has_unread_followed_threads,omitempty"`
-	unknownFields            protoimpl.UnknownFields
-	sizeCache                protoimpl.SizeCache
+	// Whether a followed channel thread has a pending notification.
+	HasPendingFollowedThreadNotifications bool `protobuf:"varint,3,opt,name=has_pending_followed_thread_notifications,json=hasPendingFollowedThreadNotifications,proto3" json:"has_pending_followed_thread_notifications,omitempty"`
+	unknownFields                         protoimpl.UnknownFields
+	sizeCache                             protoimpl.SizeCache
 }
 
 func (x *ViewerCapabilities) Reset() {
@@ -277,6 +279,13 @@ func (x *ViewerCapabilities) GetGrants() []*CapabilityGrant {
 func (x *ViewerCapabilities) GetHasUnreadFollowedThreads() bool {
 	if x != nil {
 		return x.HasUnreadFollowedThreads
+	}
+	return false
+}
+
+func (x *ViewerCapabilities) GetHasPendingFollowedThreadNotifications() bool {
+	if x != nil {
+		return x.HasPendingFollowedThreadNotifications
 	}
 	return false
 }
@@ -575,10 +584,11 @@ const file_chatto_api_v1_viewer_proto_rawDesc = "" +
 	" \x01(\v2\x1a.google.protobuf.TimestampR\x0flastLoginChange\x12-\n" +
 	"\aprofile\x18\v \x01(\v2\x13.chatto.api.v1.UserR\aprofile\x12!\n" +
 	"\fhas_password\x18\f \x01(\bR\vhasPasswordJ\x04\b\x01\x10\aR\x02idR\x05loginR\fdisplay_nameR\n" +
-	"avatar_urlR\rcustom_statusR\x0fpresence_status\"\x8b\x01\n" +
+	"avatar_urlR\rcustom_statusR\x0fpresence_status\"\xe5\x01\n" +
 	"\x12ViewerCapabilities\x126\n" +
 	"\x06grants\x18\x01 \x03(\v2\x1e.chatto.api.v1.CapabilityGrantR\x06grants\x12=\n" +
-	"\x1bhas_unread_followed_threads\x18\x02 \x01(\bR\x18hasUnreadFollowedThreads\"[\n" +
+	"\x1bhas_unread_followed_threads\x18\x02 \x01(\bR\x18hasUnreadFollowedThreads\x12X\n" +
+	")has_pending_followed_thread_notifications\x18\x03 \x01(\bR%hasPendingFollowedThreadNotifications\"[\n" +
 	"\x17ServerViewerPermissions\x12@\n" +
 	"\vpermissions\x18\x01 \x03(\v2\x1e.chatto.api.v1.PermissionGrantR\vpermissions\"=\n" +
 	"\x11ServerViewerState\x12(\n" +

--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -1,7 +1,7 @@
 # FDR-002: Replies & Threads
 
 **Status:** Active
-**Last reviewed:** 2026-07-16
+**Last reviewed:** 2026-07-23
 
 ## Overview
 
@@ -16,6 +16,7 @@ Chatto messages can link to one another via reply attribution, and channel-room 
 - Clicking the avatar or name in the byline opens the user's context menu.
 - If the user selects text inside a message body before choosing Reply or Reply in thread, the target composer inserts that selected plain text as a Markdown blockquote while preserving any existing draft text.
 - A thread is a sequence of messages starting from a root message and continuing inside a dedicated thread pane. Threads can contain plain messages or reply-attributed messages; both are valid.
+- My Threads lists followed threads by their valid root messages. Channel echoes link back to their source thread but never appear as thread roots themselves.
 - Thread badges in the room timeline are normal links to the thread URL, so users can copy or open the thread link through browser-native link actions.
 - Links copied from messages inside a thread reopen that thread and focus the linked message. A root message can be opened in its thread pane before the thread has any replies.
 - A user can post a plain message into a room, a reply into the room timeline, a plain message into a thread, or a reply inside a thread — each gated by separate permissions, so a room can be configured for many threading styles.

--- a/docs/fdr/FDR-012-notifications.md
+++ b/docs/fdr/FDR-012-notifications.md
@@ -1,7 +1,7 @@
 # FDR-012: Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-07-04
+**Last reviewed:** 2026-07-23
 
 ## Overview
 
@@ -18,6 +18,7 @@ Chatto has a persistent notification system surfaced through a bell icon and not
 - The installed PWA dock badge reflects pending notifications only; ordinary unread rooms stay in the in-app sidebar unless the user has configured them to create notifications.
 - Users can choose and locally shape the notification sound on each browser with volume, tone, and effect controls.
 - Sidebar orange dots for mentions, replies, DMs, and all-message subscriptions derive from pending notification records.
+- My Threads and individual thread badges use a gray dot for unread replies and an orange dot only while the thread contains a pending notification.
 - A recipient's Do Not Disturb presence still stores new notifications and updates counts, but those creation events are silent: no notification sound and no web push while DND is active.
 
 ## Notification Levels
@@ -101,6 +102,12 @@ from API callers.
 **Decision:** Do Not Disturb is checked at notification creation time. While the recipient has live DND presence, Chatto still creates the persistent notification and publishes a silent live sync event, but it suppresses legacy attention live events, notification sounds, and web push delivery.
 **Why:** DND means "do not interrupt me now", not "discard things I should review later". Storing the notification preserves missed activity in the notification center and sidebar counts, while the silent marker lets clients update state without making noise.
 **Tradeoff:** A user may see badge/sidebar changes while actively viewing Chatto in DND. That is less disruptive than sound or push, and it avoids losing important mentions or DMs.
+
+### 11. Thread badges distinguish unread activity from pending attention
+
+**Decision:** Thread indicators use gray for unread replies and reserve orange for threads with pending notifications. The same precedence applies to the My Threads navigation item and thread badges in room timelines.
+**Why:** Unread activity means new content is available, while a pending notification means the user has an unhandled attention item. Reusing the room-sidebar color language keeps those meanings consistent.
+**Tradeoff:** A thread can remain gray after its notification is dismissed until the user reads the replies. This is intentional because dismissal and reading represent different actions.
 
 ## Permissions
 

--- a/packages/api-types/src/chatto/api/v1/threads_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/threads_pb.ts
@@ -333,6 +333,13 @@ export class ListFollowedThreadsRequest extends Message<ListFollowedThreadsReque
    */
   page?: PageRequest;
 
+  /**
+   * When true, returns only threads with unread replies.
+   *
+   * @generated from field: bool unread_only = 4;
+   */
+  unreadOnly = false;
+
   constructor(data?: PartialMessage<ListFollowedThreadsRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -342,6 +349,7 @@ export class ListFollowedThreadsRequest extends Message<ListFollowedThreadsReque
   static readonly typeName = "chatto.api.v1.ListFollowedThreadsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 3, name: "page", kind: "message", T: PageRequest },
+    { no: 4, name: "unread_only", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListFollowedThreadsRequest {
@@ -389,6 +397,13 @@ export class ListFollowedThreadsResponse extends Message<ListFollowedThreadsResp
    */
   page?: PageInfo;
 
+  /**
+   * True when the response is restricted to threads with unread replies.
+   *
+   * @generated from field: bool unread_only = 6;
+   */
+  unreadOnly = false;
+
   constructor(data?: PartialMessage<ListFollowedThreadsResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -400,6 +415,7 @@ export class ListFollowedThreadsResponse extends Message<ListFollowedThreadsResp
     { no: 1, name: "threads", kind: "message", T: FollowedThread, repeated: true },
     { no: 4, name: "includes", kind: "message", T: RoomTimelineIncludes },
     { no: 5, name: "page", kind: "message", T: PageInfo },
+    { no: 6, name: "unread_only", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListFollowedThreadsResponse {

--- a/packages/api-types/src/chatto/api/v1/viewer_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/viewer_pb.ts
@@ -202,6 +202,13 @@ export class ViewerCapabilities extends Message<ViewerCapabilities> {
    */
   hasUnreadFollowedThreads = false;
 
+  /**
+   * Whether a followed channel thread has a pending notification.
+   *
+   * @generated from field: bool has_pending_followed_thread_notifications = 3;
+   */
+  hasPendingFollowedThreadNotifications = false;
+
   constructor(data?: PartialMessage<ViewerCapabilities>) {
     super();
     proto3.util.initPartial(data, this);
@@ -212,6 +219,7 @@ export class ViewerCapabilities extends Message<ViewerCapabilities> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "grants", kind: "message", T: CapabilityGrant, repeated: true },
     { no: 2, name: "has_unread_followed_threads", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "has_pending_followed_thread_notifications", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ViewerCapabilities {

--- a/proto/chatto/api/v1/threads.proto
+++ b/proto/chatto/api/v1/threads.proto
@@ -71,6 +71,8 @@ message ListFollowedThreadsRequest {
 
   // Page request. Defaults to 20 results when absent or limit is zero.
   PageRequest page = 3;
+  // When true, returns only threads with unread replies.
+  bool unread_only = 4;
 }
 
 // Response containing one followed-thread page.
@@ -85,6 +87,8 @@ message ListFollowedThreadsResponse {
   RoomTimelineIncludes includes = 4;
   // Page metadata.
   PageInfo page = 5;
+  // True when the response is restricted to threads with unread replies.
+  bool unread_only = 6;
 }
 
 // Manages thread follow state for the current user.

--- a/proto/chatto/api/v1/viewer.proto
+++ b/proto/chatto/api/v1/viewer.proto
@@ -53,6 +53,8 @@ message ViewerCapabilities {
   repeated CapabilityGrant grants = 1;
   // Whether the user has unread followed threads.
   bool has_unread_followed_threads = 2;
+  // Whether a followed channel thread has a pending notification.
+  bool has_pending_followed_thread_notifications = 3;
 }
 
 // Effective server/channel permission decisions for the authenticated user.


### PR DESCRIPTION
Fixes My Threads unread state being computed from only the current client page by filtering unread followed threads before server pagination, with a response-confirmation fallback for mixed versions.
Distinguishes unread thread activity (gray) from pending notification attention (orange) in sidebar and room-timeline badges, keeps that state live, and clears the loaded thread badge when the thread is marked read.
Filters invalid or echo follow records so channel echoes cannot surface as roots in My Threads, and records the resulting behavior in the thread and notification FDRs.
Validation: full frontend unit suite (1,990 tests), focused badge/state tests (111 tests), full core and ConnectAPI Go packages, frontend lint/Svelte checks, and browser verification of both Storybook states.
The protobuf additions are backward-compatible and the generated bindings and API reference are included.
