### PR TITLE
perf(core): accelerate cold projection replay

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -119,6 +119,12 @@ authorization, live events, backup/restore, and backend tests.
   boot-time sequence waiters when installing a restored cutoff, and test
   all-restored, partial, corrupt, future, tail-replay, and restore-in-flight
   waiter interleavings.
+- Keep projection `Subjects()` precise as the logical application and readiness
+  contract. Prefer one physical replay filter where practical. In particular,
+  benchmark a broad wildcard combined with sparse extra families against one
+  broader `ReplaySubjects()` filter on real EVT history: JetStream multi-filter
+  scanning can cost more than delivering extra envelopes, and the projector
+  rejects non-logical subjects before protobuf decoding.
 - Projection snapshot methods are optional. Locally checkpointed projections
   own disposable derived state and must bind it to a stable projection key,
   contract ID, EVT stream incarnation, and retained sequence bounds. A

--- a/cli/internal/core/projection_subjects_test.go
+++ b/cli/internal/core/projection_subjects_test.go
@@ -58,6 +58,14 @@ func TestProjectionSubjectPolicy(t *testing.T) {
 			want: []string{events.RoomSubjectFilter()},
 		},
 		{
+			name: "room timeline uses room aggregate namespace plus key shredding",
+			got:  NewRoomTimelineProjection().Subjects(),
+			want: []string{
+				events.RoomSubjectFilter(),
+				events.UserEventTypeFilter(events.EventUserKeyShredded),
+			},
+		},
+		{
 			name: "threads use focused room event families plus key shredding",
 			got:  NewThreadProjection().Subjects(),
 			want: []string{
@@ -136,10 +144,17 @@ func TestFocusedProjectionsDoNotUseAggregateNamespaceFilters(t *testing.T) {
 	}
 }
 
-func TestThreadProjectionReplaySubjectsUseSharedRoomReplay(t *testing.T) {
-	got := NewThreadProjection().ReplaySubjects()
-	want := []string{events.RoomSubjectFilter(), events.UserEventTypeFilter(events.EventUserKeyShredded)}
-	if !slices.Equal(got, want) {
-		t.Fatalf("ReplaySubjects() = %v, want %v", got, want)
+func TestBroadRoomAndSparseUserProjectionsUseSinglePhysicalReplayFilter(t *testing.T) {
+	for name, projection := range map[string]events.ReplaySubjectProjection{
+		"room timeline": NewRoomTimelineProjection(),
+		"threads":       NewThreadProjection(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := projection.ReplaySubjects()
+			want := []string{events.EventSubjectFilter()}
+			if !slices.Equal(got, want) {
+				t.Fatalf("ReplaySubjects() = %v, want %v", got, want)
+			}
+		})
 	}
 }

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -130,6 +130,14 @@ func (p *RoomTimelineProjection) Subjects() []string {
 	return []string{events.RoomSubjectFilter(), events.UserEventTypeFilter(events.EventUserKeyShredded)}
 }
 
+// ReplaySubjects uses one stream-wide physical filter because JetStream's
+// multi-filter scan is expensive when it combines the broad room wildcard with
+// the sparse user-key-shredded family. The Projector rejects unrelated subjects
+// before decoding or applying them.
+func (p *RoomTimelineProjection) ReplaySubjects() []string {
+	return []string{events.EventSubjectFilter()}
+}
+
 // Apply implements events.Projection. Extracts the room_id from whichever
 // room-scoped event variant we recognise and appends visible entries to that
 // room's slice. Events that don't carry a room_id (shouldn't appear on

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -101,11 +101,12 @@ func (p *ThreadProjection) Subjects() []string {
 	}
 }
 
-// ReplaySubjects uses one broad room filter because it is cheaper on current
-// self-host scale than a larger multi-filter consumer. The Threads projector
-// still rejects non-thread events before decoding or applying them.
+// ReplaySubjects uses one stream-wide physical filter because JetStream's
+// multi-filter scan is expensive when it combines the broad room wildcard with
+// the sparse user-key-shredded family. The Projector rejects unrelated subjects
+// before decoding or applying them.
 func (p *ThreadProjection) ReplaySubjects() []string {
-	return []string{events.RoomSubjectFilter(), events.UserEventTypeFilter(events.EventUserKeyShredded)}
+	return []string{events.EventSubjectFilter()}
 }
 
 // Apply implements events.Projection.

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -868,6 +868,35 @@ func TestProjector_AppliesEventsInOrder(t *testing.T) {
 	}
 }
 
+func TestProjectorSkipsBroadReplaySubjectsBeforeDecoding(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	if _, err := js.Publish(ctx, ConfigAggregate().Subject(EventServerNameChanged), []byte("not protobuf")); err != nil {
+		t.Fatalf("publish malformed unrelated event: %v", err)
+	}
+	pub := NewPublisher(js, stream, testLogger())
+	if _, err := pub.Append(ctx, RoomAggregate("R1").Subject(EventUserJoinedRoom), makeEvent("R1", "U1")); err != nil {
+		t.Fatalf("publish logical event: %v", err)
+	}
+
+	projection := newReplayTrackingProjection(
+		[]string{RoomEventTypeFilter(EventUserJoinedRoom)},
+		[]string{EventSubjectFilter()},
+	)
+	projector := NewProjector(js, stream, projection, testLogger())
+	runCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = projector.Run(runCtx) }()
+
+	waitFor(t, 2*time.Second, func() bool { return projector.Status().StartupComplete })
+	if err := projector.Err(); err != nil {
+		t.Fatalf("broad physical replay decoded unrelated payload: %v", err)
+	}
+	if got := projection.Count(); got != 1 {
+		t.Fatalf("Apply count = %d, want 1 logical event", got)
+	}
+}
+
 func TestProjectorRunsProjectionWithoutSnapshotMethods(t *testing.T) {
 	js, stream := setupTestStream(t)
 	pub := NewPublisher(js, stream, testLogger())

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -163,7 +163,7 @@ reconstruction. Legacy cohort paths remain outside application S3 expiry.
 | ------------------ | -------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | Room directory     | Room Directory       | `evt.room.>`                                               | `RoomCatalogProjection`, `RoomMembershipProjection`, `RoomBanProjection`; room/member queries, room authorization, and Universal-room effective membership |
 | Room organization  | Room Group Layout    | `evt.group.>`, `evt.layout.>`                              | `RoomGroupProjection`, `RoomLayoutProjection`; sidebar groups, sidebar links, and mixed sidebar item ordering |
-| Room timeline      | Room Timeline        | `evt.room.>`                                               | Visible room timeline, latest message bodies, tombstone timestamps, hidden echoes, current attachment-bearing message index, direct message-post lookup, and message asset references |
+| Room timeline      | Room Timeline        | `evt.room.>`, `evt.user.*.user_key_shredded`               | Visible room timeline, latest message bodies, tombstone timestamps, hidden echoes, current attachment-bearing message index, direct message-post lookup, and message asset references |
 | Assets             | Assets               | `evt.asset.>`, legacy `evt.room.*.asset_*`                 | Asset creation metadata, room scope, processing manifests, derivative graph, deletion state, and legacy room-asset compatibility |
 | Threads            | Threads              | `evt.room.*.thread_created`, `evt.room.*.thread_followed`, `evt.room.*.thread_unfollowed`, `evt.room.*.message_posted`, `evt.room.*.message_edited`, `evt.room.*.message_retracted`, `evt.user.*.user_key_shredded` | Per-thread reply logs, summaries, participants, reply counts, and follow state             |
 | Reactions          | Reactions            | `evt.room.>`                                               | Current canonical per-message reaction sets, echo-to-original reaction aliases, and room-scoped snapshot OCC positions; intentionally broad so reaction writes can OCC against the room tail |
@@ -189,6 +189,13 @@ filters remain intentional for projections whose snapshots expose room-tail
 OCC positions, such as Reactions and Call State. Threads reports the focused
 logical subjects above for waits and diagnostics; non-thread room facts are
 skipped before `Apply`.
+
+Room Timeline and Threads physically replay through one `evt.>` filter. Their
+logical room and key-shredding subjects still determine readiness and
+application. The projector rejects other subjects before protobuf decoding.
+This avoids JetStream's expensive multi-filter scan for a broad room wildcard
+combined with a sparse user event while preserving independent consumers and
+projection-local replay frontiers.
 
 `UserProjection` retains encrypted user fields and their AAD metadata. The user
 and mentionable projections decrypt login and email values only transiently


### PR DESCRIPTION
## Why

Cold projection rebuilds over a representative 54k-event EVT history took about 14.3 seconds because JetStream's multi-filter scan performed poorly for a broad room wildcard combined with sparse key-shredding events.

## What changed

- Give Room Timeline and Threads one physical `evt.>` replay filter while retaining their precise logical subjects, independent consumers, readiness, and snapshot frontiers.
- Reject unrelated subjects before protobuf decoding, lock the behaviour down with projector and subject tests, and document the runtime filter contract and maintainer guidance.
- Real-history cold boot fell to 1.24–1.35 seconds, roughly 10–11× faster.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unaffected.
- Newer client → older server: unaffected.
- Capability discovery or minimum client/server version: none.

## Test plan

- `mise test-cli`
- Real 54k-event cold replay with `CHATTO_CORE_PROJECTION_SNAPSHOTS=false`
- `git diff --check`
