### PR TITLE
perf(core): bucket and index timeline projections

### DIFF
--- a/apps/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/apps/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -195,6 +195,10 @@ See [Enabling Search](/guides/operations/search/) for a complete setup guide, an
   Delete marked S3 projection snapshot generations older than `core.projection_snapshot_retention`. Disable this when the bucket has an external lifecycle policy for `internal/projection-snapshots/`. When enabled, S3 credentials need permission to list that prefix, inspect object metadata, and delete matching objects. Chatto validates the exact internal generation path, content type, and object-purpose marker before deletion; asset paths are never eligible.
 </EnvVar>
 
+<EnvVar name="CHATTO_CORE_ROOM_TIMELINE_HOT_WINDOW" toml="core.room_timeline_hot_window" default="30d">
+  Keep this much recent room timeline history decoded in RAM after startup. Older fixed UTC-week buckets retain lightweight metadata and load their payload from `EVT` when a member opens them. Loaded historical buckets currently remain in RAM until the process restarts. Supports values such as `14d`, `4w`, and `720h`.
+</EnvVar>
+
 <EnvVar name="CHATTO_CORE_SECRET_KEY" toml="core.secret_key" required>
   256-bit hex secret for HMAC-derived bearer-token, cookie-session, OAuth-code, and account-flow credential verifiers. Generate with `openssl rand -hex 32`. Keep this stable across restores if you want sessions and pending credentials to survive. Changing it also makes projection snapshots unreadable; Chatto safely rebuilds them from `EVT`.
 </EnvVar>

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -510,6 +510,7 @@ type CoreConfig struct {
 	ProjectionSnapshots         bool           `toml:"projection_snapshots,commented" env:"CHATTO_CORE_PROJECTION_SNAPSHOTS" comment:"Persist encrypted projection snapshots and replay only the later EVT delta at startup. Missing or incompatible snapshots safely fall back to EVT replay. Default: false."`
 	ProjectionSnapshotRetention Duration       `toml:"projection_snapshot_retention,commented" env:"CHATTO_CORE_PROJECTION_SNAPSHOT_RETENTION" comment:"How long projection snapshot generations are retained. NATS enforces this as an Object Store TTL; Chatto uses it for optional S3 cleanup. Supports '7d', '1w', '168h', etc. Default: 7d."`
 	ProjectionSnapshotS3Cleanup *bool          `toml:"projection_snapshot_s3_cleanup,commented" env:"CHATTO_CORE_PROJECTION_SNAPSHOT_S3_CLEANUP" comment:"Delete S3 projection snapshot generations older than projection_snapshot_retention. Disable when an external S3 lifecycle policy owns expiry. Default: true."`
+	RoomTimelineHotWindow       Duration       `toml:"room_timeline_hot_window,commented" env:"CHATTO_CORE_ROOM_TIMELINE_HOT_WINDOW" comment:"How much recent room timeline history remains decoded in RAM after startup. Older UTC-week buckets load from EVT when read. Supports '30d', '4w', etc. Default: 30d."`
 	Assets                      AssetsConfig   `toml:"assets"`
 	AuthTokenTTL                time.Duration  `toml:"-" env:"-"` // Set by caller from AuthConfig.TokenTTLOrDefault()
 	EmailOTP                    EmailOTPConfig `toml:"-" env:"-"` // Set by caller from AuthConfig.EmailOTP
@@ -531,6 +532,14 @@ func (c *CoreConfig) ProjectionSnapshotRetentionOrDefault() time.Duration {
 // ProjectionSnapshotS3CleanupOrDefault reports whether Chatto owns S3 expiry.
 func (c *CoreConfig) ProjectionSnapshotS3CleanupOrDefault() bool {
 	return c.ProjectionSnapshotS3Cleanup == nil || *c.ProjectionSnapshotS3Cleanup
+}
+
+// RoomTimelineHotWindowOrDefault returns the recent decoded-payload window.
+func (c *CoreConfig) RoomTimelineHotWindowOrDefault() time.Duration {
+	if c.RoomTimelineHotWindow == 0 {
+		return 30 * 24 * time.Hour
+	}
+	return c.RoomTimelineHotWindow.Duration()
 }
 
 const (
@@ -1301,6 +1310,9 @@ func (c *ChattoConfig) Validate() error {
 	}
 	if c.Core.ProjectionSnapshotRetention.Duration() < 0 {
 		errs = append(errs, "core.projection_snapshot_retention must be positive")
+	}
+	if c.Core.RoomTimelineHotWindow.Duration() < 0 {
+		errs = append(errs, "core.room_timeline_hot_window must be positive")
 	}
 
 	// Storage backend validation

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -1109,6 +1109,25 @@ func TestChattoConfig_ValidateProjectionSnapshotRetention(t *testing.T) {
 	}
 }
 
+func TestCoreConfig_RoomTimelineHotWindowDefault(t *testing.T) {
+	var cfg CoreConfig
+	if got := cfg.RoomTimelineHotWindowOrDefault(); got != 30*24*time.Hour {
+		t.Fatalf("default room timeline hot window = %s", got)
+	}
+	cfg.RoomTimelineHotWindow = Duration(14 * 24 * time.Hour)
+	if got := cfg.RoomTimelineHotWindowOrDefault(); got != 14*24*time.Hour {
+		t.Fatalf("configured room timeline hot window = %s", got)
+	}
+}
+
+func TestChattoConfig_ValidateRoomTimelineHotWindow(t *testing.T) {
+	cfg := validTestConfig()
+	cfg.Core.RoomTimelineHotWindow = Duration(-time.Hour)
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "core.room_timeline_hot_window must be positive") {
+		t.Fatalf("Validate() error = %v, want room timeline hot window error", err)
+	}
+}
+
 func TestMetricsConfig_Defaults(t *testing.T) {
 	cfg := MetricsConfig{}
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1270,7 +1270,10 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 
 	// Per-room event-log + per-thread event-log projections (#597 phase 2).
 	// Each owns an independent consumer and logical readiness contract.
-	roomTimeline := NewRoomTimelineProjection()
+	roomTimeline := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: jetStreamRoomTimelineEventLoader{stream: storage.serverEvtStream},
+		hotWindow:   cfg.RoomTimelineHotWindowOrDefault(),
+	})
 	roomTimelineProjector := newProjector(roomTimeline, "room_timeline", "Room Timeline", roomTimeline.adminProjectionEstimate)
 
 	callState := NewCallStateProjection()

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -1273,6 +1273,7 @@ func NewChattoCore(ctx context.Context, nc *nats.Conn, cfg config.CoreConfig) (*
 	roomTimeline := newRoomTimelineProjection(roomTimelineProjectionOptions{
 		eventLoader: jetStreamRoomTimelineEventLoader{stream: storage.serverEvtStream},
 		hotWindow:   cfg.RoomTimelineHotWindowOrDefault(),
+		logger:      logger.WithPrefix("core.RoomTimelineProjection"),
 	})
 	roomTimelineProjector := newProjector(roomTimeline, "room_timeline", "Room Timeline", roomTimeline.adminProjectionEstimate)
 

--- a/cli/internal/core/message_body.go
+++ b/cli/internal/core/message_body.go
@@ -31,7 +31,10 @@ func (c *ChattoCore) GetFullMessageBody(ctx context.Context, eventID string) (*D
 		return nil, nil
 	}
 
-	entry, ok := c.roomModel.timelineEntry(eventID)
+	entry, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load message timeline bucket: %w", err)
+	}
 	if !ok {
 		return nil, nil
 	}
@@ -40,7 +43,10 @@ func (c *ChattoCore) GetFullMessageBody(ctx context.Context, eventID string) (*D
 		return nil, nil
 	}
 
-	body, retracted, _ := c.roomModel.latestBody(eventID)
+	body, retracted, _, err := c.roomModel.latestBodyContext(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load message body bucket: %w", err)
+	}
 	if retracted || body == nil {
 		// Retracted message: same shape as a legacy GDPR delete —
 		// resolver renders "[Message unavailable]".

--- a/cli/internal/core/message_search_read_model.go
+++ b/cli/internal/core/message_search_read_model.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -152,7 +153,10 @@ func (s *MessageSearchReadModel) HydrateHits(ctx context.Context, actorID string
 		if !ok {
 			continue
 		}
-		body, retracted, bodyKnown := s.core.roomModel.latestBody(hit.MessageID)
+		body, retracted, bodyKnown, err := s.core.roomModel.latestBodyContext(ctx, hit.MessageID)
+		if err != nil {
+			return nil, fmt.Errorf("load search result timeline bucket: %w", err)
+		}
 		if !bodyKnown || retracted || body == nil || body.GetBodyEventId() != hit.BodyEventID {
 			continue
 		}

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -854,7 +854,10 @@ func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind Roo
 	// Snapshot the projection state for attachment cleanup before
 	// emitting the retract event. After retract, LatestBody returns
 	// nil (the message is tombstoned), so we need a copy first.
-	originalEntry, ok := c.roomModel.timelineEntry(eventID)
+	originalEntry, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message timeline bucket: %w", err)
+	}
 	if !ok {
 		c.logger.Debug("Delete on unknown message — no-op", "event_id", eventID)
 		return nil
@@ -863,7 +866,10 @@ func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind Roo
 	if isEcho && c.roomModel.isHiddenEcho(eventID) {
 		return nil
 	}
-	body, retracted, _ := c.roomModel.latestBody(eventID)
+	body, retracted, _, err := c.roomModel.latestBodyContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message body bucket: %w", err)
+	}
 	if retracted {
 		// Already tombstoned.
 		return nil
@@ -938,7 +944,10 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 	if eventID == "" {
 		return ErrMessageNotFound
 	}
-	originalEntry, ok := c.roomModel.timelineEntry(eventID)
+	originalEntry, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message timeline bucket: %w", err)
+	}
 	if !ok {
 		return ErrMessageNotFound
 	}
@@ -960,7 +969,10 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		echoTargetEvent := originalEntry.Event
 		echoTargetPost := origPost
 		if echoOf := origPost.GetEchoOfEventId(); echoOf != "" {
-			origEchoEntry, ok := c.RoomTimeline.Get(echoOf)
+			origEchoEntry, ok, err := c.RoomTimeline.GetContext(ctx, echoOf)
+			if err != nil {
+				return fmt.Errorf("load original echo timeline bucket: %w", err)
+			}
 			if !ok || origEchoEntry.Event == nil {
 				return ErrMessageNotFound
 			}
@@ -984,7 +996,10 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 	// Fold in current body so attachments/link preview/timestamps
 	// survive the edit. We then overwrite ciphertext + nonce with the
 	// new content.
-	current, retracted, _ := c.roomModel.latestBody(eventID)
+	current, retracted, _, err := c.roomModel.latestBodyContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message body bucket: %w", err)
+	}
 	if retracted {
 		return ErrMessageNotFound
 	}
@@ -1036,7 +1051,10 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 }
 
 func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, actorID string, kind RoomKind, roomID, eventID string, enabled bool) error {
-	entry, ok := c.RoomTimeline.Get(eventID)
+	entry, ok, err := c.RoomTimeline.GetContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message timeline bucket: %w", err)
+	}
 	if !ok || entry.Event == nil {
 		return ErrMessageNotFound
 	}
@@ -1050,7 +1068,10 @@ func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, acto
 	originalID := eventID
 	if echoOf := posted.GetEchoOfEventId(); echoOf != "" {
 		originalID = echoOf
-		originalEntry, ok := c.RoomTimeline.Get(originalID)
+		originalEntry, ok, err := c.RoomTimeline.GetContext(ctx, originalID)
+		if err != nil {
+			return fmt.Errorf("load original timeline bucket: %w", err)
+		}
 		if !ok || originalEntry.Event == nil {
 			return ErrMessageNotFound
 		}
@@ -1069,7 +1090,10 @@ func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, acto
 	if time.Since(originalEvent.GetCreatedAt().AsTime()) > MessageEditWindow {
 		return ErrEditWindowExpired
 	}
-	current, retracted, _ := c.RoomTimeline.LatestBody(originalID)
+	current, retracted, _, err := c.RoomTimeline.LatestBodyContext(ctx, originalID)
+	if err != nil {
+		return fmt.Errorf("load original body bucket: %w", err)
+	}
 	if retracted || current == nil {
 		return ErrMessageNotFound
 	}
@@ -1340,14 +1364,20 @@ func (c *ChattoCore) editEmbeddedBody(
 	if eventID == "" {
 		return ErrMessageNotFound
 	}
-	entry, ok := c.roomModel.timelineEntry(eventID)
+	entry, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message timeline bucket: %w", err)
+	}
 	if !ok {
 		return ErrMessageNotFound
 	}
 	if entry.Event.GetMessagePosted() == nil {
 		return ErrMessageNotFound
 	}
-	current, retracted, _ := c.roomModel.latestBody(eventID)
+	current, retracted, _, err := c.roomModel.latestBodyContext(ctx, eventID)
+	if err != nil {
+		return fmt.Errorf("load message body bucket: %w", err)
+	}
 	if retracted || current == nil {
 		return ErrMessageNotFound
 	}
@@ -1374,7 +1404,10 @@ func (c *ChattoCore) editEmbeddedBody(
 	}
 	c.secureDeleteObsoleteMessageBodyEvents(ctx, eventID)
 	for _, linkedID := range c.roomModel.linkedEventIDs(eventID) {
-		linkedCurrent, linkedRetracted, _ := c.roomModel.latestBody(linkedID)
+		linkedCurrent, linkedRetracted, _, err := c.roomModel.latestBodyContext(ctx, linkedID)
+		if err != nil {
+			return fmt.Errorf("load linked message body bucket: %w", err)
+		}
 		if linkedRetracted || linkedCurrent == nil {
 			continue
 		}

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -327,8 +327,8 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 			entries++
 			eventBytes := timelineEntryEstimatedBytes(entry)
 			roomBytes += eventBytes
-			if entry != nil && entry.Event != nil && entry.Event.GetId() != "" {
-				timelineEventIDs[entry.Event.GetId()] = struct{}{}
+			if entry != nil && entry.eventID != "" {
+				timelineEventIDs[entry.eventID] = struct{}{}
 			}
 		}
 		rawBytes += roomBytes
@@ -389,10 +389,20 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 		}
 	}
 	shreddedUserBytes := estimateStringSetBytes(p.shreddedUsers)
+	var bucketBytes, bucketRefs, residentBuckets, residentBucketPayloadBytes int64
+	for key, bucket := range p.buckets {
+		bucketBytes += projectionMapEntryOverhead + int64(len(key.roomID)) + 8 + 24 + 1 + 24
+		bucketRefs += int64(len(bucket.refs))
+		bucketBytes += int64(cap(bucket.refs)) * 16
+		if bucket.resident {
+			residentBuckets++
+			residentBucketPayloadBytes += bucket.residentBytes
+		}
+	}
 
 	totalBytes := rawBytes + messagePostIndexBytes + eventIndexBytes + eventIndexRetainedEntryBytes +
 		appliedEventIDsBytes + bodyStateBytes + retractedBytes +
-		tombstonedAtBytes + shreddedAtBytes + hiddenEchoBytes + echoBytes + shreddedUserBytes
+		tombstonedAtBytes + shreddedAtBytes + hiddenEchoBytes + echoBytes + shreddedUserBytes + bucketBytes
 	return entries, totalBytes, []ProjectionAdminMetric{
 		{Name: "rooms", Value: int64(len(p.byRoom)), Bytes: 0},
 		{Name: "timeline_entries", Value: entries, Bytes: rawBytes},
@@ -404,6 +414,11 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 		{Name: "event_id_compatibility_mode", Value: p.replayGuard.compatibilityValue(), Bytes: 0},
 		{Name: "body_state_index", Value: int64(len(p.bodyStates)), Bytes: bodyStateBytes},
 		{Name: "latest_bodies", Value: latestBodies, Bytes: latestBodyBytes},
+		{Name: "timeline_buckets", Value: int64(len(p.buckets)), Bytes: bucketBytes},
+		{Name: "resident_timeline_buckets", Value: residentBuckets, Bytes: 0},
+		{Name: "resident_timeline_bucket_payloads", Value: residentBuckets, Bytes: residentBucketPayloadBytes},
+		{Name: "cold_timeline_buckets", Value: int64(len(p.buckets)) - residentBuckets, Bytes: 0},
+		{Name: "timeline_bucket_event_refs", Value: bucketRefs, Bytes: int64(bucketRefs) * 16},
 		{Name: "superseded_body_event_seqs", Value: supersededSeqs, Bytes: supersededSeqBytes},
 		{Name: "retracted_flags", Value: int64(len(p.retractedFlags)), Bytes: retractedBytes},
 		{Name: "tombstoned_at_index", Value: int64(len(p.tombstonedAt)), Bytes: tombstonedAtBytes},
@@ -691,10 +706,14 @@ func (p *ContentKeyProjection) adminProjectionEstimate() (int64, int64, []Projec
 }
 
 func timelineEntryEstimatedBytes(entry *TimelineEntry) int64 {
-	if entry == nil || entry.Event == nil {
+	if entry == nil {
 		return projectionSliceEntryOverhead
 	}
-	return projectionSliceEntryOverhead + int64(proto.Size(entry.Event)) + 8
+	bytes := projectionSliceEntryOverhead + 8 + 8 + int64(len(entry.eventID)+len(entry.roomID)+len(entry.authorID)+len(entry.echoOriginalID))
+	if entry.Event != nil {
+		bytes += int64(proto.Size(entry.Event))
+	}
+	return bytes
 }
 
 func estimateStringSetBytes(values map[string]struct{}) int64 {

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -389,11 +389,12 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 		}
 	}
 	shreddedUserBytes := estimateStringSetBytes(p.shreddedUsers)
-	var bucketBytes, bucketRefs, residentBuckets, residentBucketPayloadBytes int64
+	var bucketBytes, bucketRefs, bucketRefBytes, residentBuckets, residentBucketPayloadBytes int64
 	for key, bucket := range p.buckets {
-		bucketBytes += projectionMapEntryOverhead + int64(len(key.roomID)) + 8 + 24 + 1 + 24
-		bucketRefs += int64(len(bucket.refs))
-		bucketBytes += int64(cap(bucket.refs)) * 16
+		bucketBytes += projectionMapEntryOverhead + int64(len(key.roomID)) + 8 + 24 + 8 + 8 + 1 + 8 + 8 + 24
+		bucketRefs += int64(bucket.referenceCount)
+		bucketRefBytes += int64(cap(bucket.encodedRefs))
+		bucketBytes += int64(cap(bucket.encodedRefs))
 		if bucket.resident {
 			residentBuckets++
 			residentBucketPayloadBytes += bucket.residentBytes
@@ -418,7 +419,7 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 		{Name: "resident_timeline_buckets", Value: residentBuckets, Bytes: 0},
 		{Name: "resident_timeline_bucket_payloads", Value: residentBuckets, Bytes: residentBucketPayloadBytes},
 		{Name: "cold_timeline_buckets", Value: int64(len(p.buckets)) - residentBuckets, Bytes: 0},
-		{Name: "timeline_bucket_event_refs", Value: bucketRefs, Bytes: int64(bucketRefs) * 16},
+		{Name: "timeline_bucket_event_refs", Value: bucketRefs, Bytes: bucketRefBytes},
 		{Name: "superseded_body_event_seqs", Value: supersededSeqs, Bytes: supersededSeqBytes},
 		{Name: "retracted_flags", Value: int64(len(p.retractedFlags)), Bytes: retractedBytes},
 		{Name: "tombstoned_at_index", Value: int64(len(p.tombstonedAt)), Bytes: tombstonedAtBytes},

--- a/cli/internal/core/projection_admin.go
+++ b/cli/internal/core/projection_admin.go
@@ -318,77 +318,67 @@ func (p *RoomGroupLayoutProjection) adminProjectionEstimate() (int64, int64, []P
 func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []ProjectionAdminMetric) {
 	p.RLock()
 	defer p.RUnlock()
-	var entries, rawBytes int64
-	timelineEventIDs := make(map[string]struct{}, len(p.byEventID))
-	for _, roomEntries := range p.byRoom {
-		var roomBytes int64
-		for _, idx := range roomEntries {
-			entry := p.entryAtLocked(idx)
-			entries++
-			eventBytes := timelineEntryEstimatedBytes(entry)
-			roomBytes += eventBytes
-			if entry != nil && entry.eventID != "" {
-				timelineEventIDs[entry.eventID] = struct{}{}
-			}
-		}
-		rawBytes += roomBytes
+	entries := int64(len(p.entries))
+	var rawBytes int64
+	for i := range p.entries {
+		rawBytes += timelineEntryEstimatedBytes(&p.entries[i])
+	}
+
+	var roomIndexBytes, roomEntryCount int64
+	for _, refs := range p.byRoom {
+		roomIndexBytes += projectionMapEntryOverhead + int64(cap(refs))*4
+		roomEntryCount += int64(len(refs))
 	}
 
 	var messagePostIndexBytes, messagePosts int64
-	for roomID, roomEntries := range p.messagePostsByRoom {
-		messagePostIndexBytes += projectionMapEntryOverhead + int64(len(roomID))
+	for _, roomEntries := range p.messagePostsByRoom {
+		messagePostIndexBytes += projectionMapEntryOverhead
 		messagePosts += int64(len(roomEntries))
-		messagePostIndexBytes += int64(len(roomEntries)) * projectionIntIndexBytes
+		messagePostIndexBytes += int64(cap(roomEntries)) * 4
 	}
 
-	var eventIndexBytes, eventIndexRetainedEntryBytes, eventIndexRetainedEntries int64
-	for eventID, idx := range p.byEventID {
-		eventIndexBytes += projectionMapEntryOverhead + int64(len(eventID))
-		if _, counted := timelineEventIDs[eventID]; counted {
-			continue
-		}
-		eventIndexRetainedEntries++
-		entry := p.entryAtLocked(idx)
-		eventIndexRetainedEntryBytes += timelineEntryEstimatedBytes(entry)
+	var eventIDBytes int64
+	for _, id := range p.eventIDs.values {
+		eventIDBytes += int64(len(id))
 	}
+	eventIDBytes += int64(len(p.eventIDs.byValue))*projectionMapEntryOverhead + int64(cap(p.eventIDs.values))*16
+	var roomIDBytes int64
+	for _, id := range p.roomIDs.values {
+		roomIDBytes += int64(len(id))
+	}
+	roomIDBytes += int64(len(p.roomIDs.byValue))*projectionMapEntryOverhead + int64(cap(p.roomIDs.values))*16
+	var userIDBytes int64
+	for _, id := range p.userIDs.values {
+		userIDBytes += int64(len(id))
+	}
+	userIDBytes += int64(len(p.userIDs.byValue))*projectionMapEntryOverhead + int64(cap(p.userIDs.values))*16
+	eventIndexBytes := eventIDBytes + int64(cap(p.entryByEvent))*4
 	retainedEventIDs := p.replayGuard.retainedEventIDs()
 	appliedEventIDsBytes := estimateStringSetBytes(retainedEventIDs)
 	var bodyStateBytes, latestBodyBytes, latestBodies, supersededSeqBytes, supersededSeqs int64
-	for eventID, state := range p.bodyStates {
-		// The body pointer, current sequence, and slice header live inline in
-		// the map value. Only edited messages allocate the slice backing array.
-		bodyStateBytes += projectionMapEntryOverhead + int64(len(eventID)) + 8 + 8 + 24
-		if state.body != nil {
+	for eventIndex, state := range p.bodyStates {
+		if !state.known {
+			continue
+		}
+		if p.currentBodies[eventIndex] != nil {
 			latestBodies++
-			latestBodyBytes += int64(proto.Size(state.body))
-			bodyStateBytes += int64(proto.Size(state.body))
+			latestBodyBytes += int64(proto.Size(p.currentBodies[eventIndex]))
 		}
-		supersededSeqs += int64(len(state.supersededSequences))
-		supersededSeqBytes += int64(cap(state.supersededSequences)) * 8
-		bodyStateBytes += int64(cap(state.supersededSequences)) * 8
+		superseded := p.supersededBodySequences[timelineEventRef(eventIndex)]
+		supersededSeqs += int64(len(superseded))
+		supersededSeqBytes += int64(cap(superseded)) * 8
 	}
-	var retractedBytes int64
-	for eventID := range p.retractedFlags {
-		retractedBytes += projectionMapEntryOverhead + int64(len(eventID))
-	}
-	var tombstonedAtBytes int64
-	for eventID := range p.tombstonedAt {
-		tombstonedAtBytes += projectionMapEntryOverhead + int64(len(eventID)) + 24
-	}
-	var shreddedAtBytes int64
-	for userID := range p.shreddedAt {
-		shreddedAtBytes += projectionMapEntryOverhead + int64(len(userID)) + 24
-	}
-	hiddenEchoBytes := estimateStringSetBytes(p.hiddenEchoes)
+	bodyStateBytes = int64(cap(p.bodyStates))*40 + int64(cap(p.currentBodies))*8 +
+		int64(len(p.supersededBodySequences))*projectionMapEntryOverhead + supersededSeqBytes + latestBodyBytes
+	messageFlagBytes := int64(cap(p.messageFlags))
+	tombstonedAtBytes := int64(len(p.tombstonedAt)) * (projectionMapEntryOverhead + 4 + 24)
+	shreddedAtBytes := int64(len(p.shreddedAt)) * (projectionMapEntryOverhead + 4 + 24)
 	var echoBytes, echoLinks int64
-	for eventID, echoes := range p.echoLinks {
-		echoBytes += projectionMapEntryOverhead + int64(len(eventID))
-		for _, echoID := range echoes {
-			echoLinks++
-			echoBytes += projectionSliceEntryOverhead + int64(len(echoID))
-		}
+	for _, echoes := range p.echoLinks {
+		echoBytes += projectionMapEntryOverhead + int64(cap(echoes))*4
+		echoLinks += int64(len(echoes))
 	}
-	shreddedUserBytes := estimateStringSetBytes(p.shreddedUsers)
+	shreddedUserBytes := int64(cap(p.shreddedUsers))
 	var bucketBytes, bucketRefs, bucketRefBytes, residentBuckets, residentBucketPayloadBytes int64
 	for key, bucket := range p.buckets {
 		bucketBytes += projectionMapEntryOverhead + int64(len(key.roomID)) + 8 + 24 + 8 + 8 + 1 + 8 + 8 + 24
@@ -401,19 +391,21 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 		}
 	}
 
-	totalBytes := rawBytes + messagePostIndexBytes + eventIndexBytes + eventIndexRetainedEntryBytes +
-		appliedEventIDsBytes + bodyStateBytes + retractedBytes +
-		tombstonedAtBytes + shreddedAtBytes + hiddenEchoBytes + echoBytes + shreddedUserBytes + bucketBytes
+	totalBytes := rawBytes + roomIndexBytes + messagePostIndexBytes + eventIndexBytes + roomIDBytes + userIDBytes +
+		appliedEventIDsBytes + bodyStateBytes + messageFlagBytes +
+		tombstonedAtBytes + shreddedAtBytes + echoBytes + shreddedUserBytes + bucketBytes
 	return entries, totalBytes, []ProjectionAdminMetric{
 		{Name: "rooms", Value: int64(len(p.byRoom)), Bytes: 0},
 		{Name: "timeline_entries", Value: entries, Bytes: rawBytes},
+		{Name: "room_entry_index", Value: roomEntryCount, Bytes: roomIndexBytes},
 		{Name: "message_posts", Value: messagePosts, Bytes: 0},
 		{Name: "message_posts_by_room_index", Value: messagePosts, Bytes: messagePostIndexBytes},
-		{Name: "event_id_index", Value: int64(len(p.byEventID)), Bytes: eventIndexBytes},
-		{Name: "event_id_retained_entries", Value: eventIndexRetainedEntries, Bytes: eventIndexRetainedEntryBytes},
+		{Name: "event_id_index", Value: int64(len(p.eventIDs.byValue)), Bytes: eventIndexBytes},
+		{Name: "room_id_dictionary", Value: int64(len(p.roomIDs.byValue)), Bytes: roomIDBytes},
+		{Name: "user_id_dictionary", Value: int64(len(p.userIDs.byValue)), Bytes: userIDBytes},
 		{Name: "applied_event_ids", Value: int64(len(retainedEventIDs)), Bytes: appliedEventIDsBytes},
 		{Name: "event_id_compatibility_mode", Value: p.replayGuard.compatibilityValue(), Bytes: 0},
-		{Name: "body_state_index", Value: int64(len(p.bodyStates)), Bytes: bodyStateBytes},
+		{Name: "body_state_index", Value: int64(len(p.bodyStates) - 1), Bytes: bodyStateBytes},
 		{Name: "latest_bodies", Value: latestBodies, Bytes: latestBodyBytes},
 		{Name: "timeline_buckets", Value: int64(len(p.buckets)), Bytes: bucketBytes},
 		{Name: "resident_timeline_buckets", Value: residentBuckets, Bytes: 0},
@@ -421,12 +413,11 @@ func (p *RoomTimelineProjection) adminProjectionEstimate() (int64, int64, []Proj
 		{Name: "cold_timeline_buckets", Value: int64(len(p.buckets)) - residentBuckets, Bytes: 0},
 		{Name: "timeline_bucket_event_refs", Value: bucketRefs, Bytes: bucketRefBytes},
 		{Name: "superseded_body_event_seqs", Value: supersededSeqs, Bytes: supersededSeqBytes},
-		{Name: "retracted_flags", Value: int64(len(p.retractedFlags)), Bytes: retractedBytes},
+		{Name: "message_flags", Value: int64(len(p.messageFlags) - 1), Bytes: messageFlagBytes},
 		{Name: "tombstoned_at_index", Value: int64(len(p.tombstonedAt)), Bytes: tombstonedAtBytes},
 		{Name: "shredded_at_index", Value: int64(len(p.shreddedAt)), Bytes: shreddedAtBytes},
-		{Name: "hidden_echoes", Value: int64(len(p.hiddenEchoes)), Bytes: hiddenEchoBytes},
 		{Name: "echo_links", Value: echoLinks, Bytes: echoBytes},
-		{Name: "shredded_users", Value: int64(len(p.shreddedUsers)), Bytes: shreddedUserBytes},
+		{Name: "shredded_users", Value: int64(len(p.shreddedUsers) - 1), Bytes: shreddedUserBytes},
 	}
 }
 
@@ -435,86 +426,77 @@ func (p *ThreadProjection) adminProjectionEstimate() (int64, int64, []Projection
 	defer p.RUnlock()
 	var entries, rawBytes, replies int64
 	for _, threadEntries := range p.byThread {
+		rawBytes += projectionMapEntryOverhead + int64(cap(threadEntries))*16
 		for _, entry := range threadEntries {
 			entries++
-			rawBytes += projectionSliceEntryOverhead + int64(len(entry.EventID)) + 8
-			if entry.EventID != "" {
+			if entry.Event != 0 {
 				replies++
 			}
 		}
 	}
-	var indexBytes int64
-	for eventID, threadID := range p.messageToThread {
-		indexBytes += projectionMapEntryOverhead + int64(len(eventID)+len(threadID))
+	var eventIDBytes int64
+	for _, id := range p.eventIDs.values {
+		eventIDBytes += int64(len(id))
 	}
-	var replySummaryBytes int64
-	for eventID, summary := range p.replySummaries {
-		replySummaryBytes += projectionMapEntryOverhead + int64(len(eventID))
-		if summary != nil {
-			replySummaryBytes += int64(len(summary.actorID)) + 24
-		}
+	eventIDBytes += int64(len(p.eventIDs.byValue))*projectionMapEntryOverhead + int64(cap(p.eventIDs.values))*16
+	indexBytes := int64(cap(p.messageToThread)) * 4
+	replySummaryBytes := int64(cap(p.replySummaries)) * 24
+	var roomIDBytes, userIDBytes int64
+	for _, id := range p.roomIDs.values {
+		roomIDBytes += int64(len(id))
 	}
-	var threadSummaryBytes, summaryReplies, summaryParticipants int64
-	for threadID, summary := range p.summaryByThread {
-		threadSummaryBytes += projectionMapEntryOverhead + int64(len(threadID))
+	for _, id := range p.userIDs.values {
+		userIDBytes += int64(len(id))
+	}
+	roomIDBytes += int64(len(p.roomIDs.byValue))*projectionMapEntryOverhead + int64(cap(p.roomIDs.values))*16
+	userIDBytes += int64(len(p.userIDs.byValue))*projectionMapEntryOverhead + int64(cap(p.userIDs.values))*16
+	var threadSummaryBytes, summaryParticipants int64
+	for _, summary := range p.summaryByThread {
+		threadSummaryBytes += projectionMapEntryOverhead + 64
 		if summary == nil {
 			continue
-		}
-		for _, replyID := range summary.replyIDs {
-			summaryReplies++
-			threadSummaryBytes += projectionSliceEntryOverhead + int64(len(replyID))
 		}
 		if summary.lastReplyAt != nil {
 			threadSummaryBytes += 24
 		}
-		for _, participantID := range summary.participantIDs {
-			summaryParticipants++
-			threadSummaryBytes += projectionSliceEntryOverhead + int64(len(participantID))
-		}
-		for participantID := range summary.participantCounts {
-			threadSummaryBytes += projectionMapEntryOverhead + int64(len(participantID)) + 8
-		}
+		summaryParticipants += int64(len(summary.participantIDs))
+		threadSummaryBytes += int64(cap(summary.participantIDs)+cap(summary.participantCounts)) * 4
 	}
 	retainedEventIDs := p.replayGuard.retainedEventIDs()
 	appliedEventIDsBytes := estimateStringSetBytes(retainedEventIDs)
-	shreddedUserBytes := estimateStringSetBytes(p.shreddedUsers)
-	var followStateBytes int64
-	for key, state := range p.followState {
-		followStateBytes += projectionMapEntryOverhead + int64(len(key)+len(state))
-	}
+	shreddedUserBytes := int64(cap(p.shreddedUsers))
+	followStateBytes := int64(len(p.followState)) * (projectionMapEntryOverhead + 12 + 1)
 	var followerBytes, followerRefs int64
-	for key, followers := range p.followers {
-		followerBytes += projectionMapEntryOverhead + int64(len(key))
-		for userID := range followers {
-			followerRefs++
-			followerBytes += projectionMapEntryOverhead + int64(len(userID))
-		}
+	for _, followers := range p.followers {
+		followerBytes += projectionMapEntryOverhead + 8
+		followerRefs += int64(len(followers))
+		followerBytes += int64(cap(followers)) * 4
 	}
 	var followedByUserBytes, followedRefs int64
-	for userID, followed := range p.followedByUser {
-		followedByUserBytes += projectionMapEntryOverhead + int64(len(userID))
-		for key, ref := range followed {
-			followedRefs++
-			followedByUserBytes += projectionMapEntryOverhead + int64(len(key)+len(ref.roomID)+len(ref.threadRootEventID))
-		}
+	for _, followed := range p.followedByUser {
+		followedByUserBytes += projectionMapEntryOverhead + 4
+		followedRefs += int64(len(followed))
+		followedByUserBytes += int64(cap(followed)) * 8
 	}
 	followBytes := followStateBytes + followerBytes + followedByUserBytes
 	totalEntries := entries + int64(len(p.followState))
-	totalBytes := rawBytes + indexBytes + replySummaryBytes + threadSummaryBytes + appliedEventIDsBytes + shreddedUserBytes + followBytes
+	totalBytes := rawBytes + eventIDBytes + roomIDBytes + userIDBytes + indexBytes + replySummaryBytes + threadSummaryBytes + appliedEventIDsBytes + shreddedUserBytes + followBytes
 	return totalEntries, totalBytes, []ProjectionAdminMetric{
 		{Name: "threads", Value: int64(len(p.byThread)), Bytes: 0},
 		{Name: "thread_entries", Value: entries, Bytes: rawBytes},
 		{Name: "replies", Value: replies, Bytes: 0},
-		{Name: "message_to_thread_index", Value: int64(len(p.messageToThread)), Bytes: indexBytes},
-		{Name: "reply_summaries", Value: int64(len(p.replySummaries)), Bytes: replySummaryBytes},
-		{Name: "thread_summary_replies", Value: summaryReplies, Bytes: 0},
+		{Name: "event_id_dictionary", Value: int64(len(p.eventIDs.byValue)), Bytes: eventIDBytes},
+		{Name: "room_id_dictionary", Value: int64(len(p.roomIDs.byValue)), Bytes: roomIDBytes},
+		{Name: "user_id_dictionary", Value: int64(len(p.userIDs.byValue)), Bytes: userIDBytes},
+		{Name: "message_to_thread_index", Value: int64(len(p.messageToThread) - 1), Bytes: indexBytes},
+		{Name: "reply_summaries", Value: int64(len(p.replySummaries) - 1), Bytes: replySummaryBytes},
 		{Name: "thread_summary_participants", Value: summaryParticipants, Bytes: threadSummaryBytes},
 		{Name: "follow_states", Value: int64(len(p.followState)), Bytes: followStateBytes},
 		{Name: "follower_refs", Value: followerRefs, Bytes: followerBytes},
 		{Name: "followed_thread_refs", Value: followedRefs, Bytes: followedByUserBytes},
 		{Name: "applied_event_ids", Value: int64(len(retainedEventIDs)), Bytes: appliedEventIDsBytes},
 		{Name: "event_id_compatibility_mode", Value: p.replayGuard.compatibilityValue(), Bytes: 0},
-		{Name: "shredded_users", Value: int64(len(p.shreddedUsers)), Bytes: shreddedUserBytes},
+		{Name: "shredded_users", Value: int64(len(p.shreddedUsers) - 1), Bytes: shreddedUserBytes},
 	}
 }
 
@@ -710,7 +692,7 @@ func timelineEntryEstimatedBytes(entry *TimelineEntry) int64 {
 	if entry == nil {
 		return projectionSliceEntryOverhead
 	}
-	bytes := projectionSliceEntryOverhead + 8 + 8 + int64(len(entry.eventID)+len(entry.roomID)+len(entry.authorID)+len(entry.echoOriginalID))
+	bytes := projectionSliceEntryOverhead + 8 + 8 + 4 + 4 + 4 + 4 + 24 + 1
 	if entry.Event != nil {
 		bytes += int64(proto.Size(entry.Event))
 	}

--- a/cli/internal/core/projection_handles.go
+++ b/cli/internal/core/projection_handles.go
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Chatto contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package core
+
+// projectionStringTable interns repeated projection identifiers and gives
+// dense projection-local handles to callers. Handle zero is reserved for the
+// empty or absent value, which keeps optional relationships allocation-free.
+//
+// Handles are process-local indexes. Snapshot codecs must persist the stable
+// string value and rebuild handles during restore.
+type projectionStringTable struct {
+	byValue map[string]uint32
+	values  []string
+}
+
+func newProjectionStringTable() projectionStringTable {
+	return projectionStringTable{
+		byValue: make(map[string]uint32),
+		values:  []string{""},
+	}
+}
+
+func (t *projectionStringTable) intern(value string) uint32 {
+	if value == "" {
+		return 0
+	}
+	if ref, ok := t.byValue[value]; ok {
+		return ref
+	}
+	ref := uint32(len(t.values))
+	if int(ref) != len(t.values) {
+		panic("projection identifier table exhausted uint32 handles")
+	}
+	t.values = append(t.values, value)
+	// Use the canonical retained string as the map key. A repeated identifier
+	// decoded from a later protobuf can then be released after this lookup.
+	t.byValue[t.values[ref]] = ref
+	return ref
+}
+
+func (t *projectionStringTable) lookup(value string) (uint32, bool) {
+	if value == "" {
+		return 0, false
+	}
+	ref, ok := t.byValue[value]
+	return ref, ok
+}
+
+func (t *projectionStringTable) value(ref uint32) string {
+	if ref == 0 || int(ref) >= len(t.values) {
+		return ""
+	}
+	return t.values[ref]
+}
+
+func growProjectionSlice[T any](values []T, ref uint32) []T {
+	if int(ref) < len(values) {
+		return values
+	}
+	return append(values, make([]T, int(ref)-len(values)+1)...)
+}

--- a/cli/internal/core/projection_handles_test.go
+++ b/cli/internal/core/projection_handles_test.go
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2026 Chatto contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package core
+
+import "testing"
+
+func TestProjectionStringTableInternsStableDenseHandles(t *testing.T) {
+	table := newProjectionStringTable()
+
+	if got := table.intern(""); got != 0 {
+		t.Fatalf("empty handle = %d, want reserved zero", got)
+	}
+	first := table.intern("first")
+	second := table.intern("second")
+	if first != 1 || second != 2 {
+		t.Fatalf("handles = (%d, %d), want (1, 2)", first, second)
+	}
+	if repeated := table.intern(string([]byte("first"))); repeated != first {
+		t.Fatalf("repeated handle = %d, want %d", repeated, first)
+	}
+	if got := table.value(first); got != "first" {
+		t.Fatalf("value(%d) = %q, want first", first, got)
+	}
+	if got, ok := table.lookup("missing"); ok || got != 0 {
+		t.Fatalf("missing lookup = (%d, %v), want (0, false)", got, ok)
+	}
+	if len(table.values) != 3 || len(table.byValue) != 2 {
+		t.Fatalf("table sizes = values %d map %d, want 3 and 2", len(table.values), len(table.byValue))
+	}
+}
+
+func TestGrowProjectionSlicePreservesHandleIndex(t *testing.T) {
+	values := []uint32{0}
+	values = growProjectionSlice(values, 4)
+	values[4] = 99
+	values = growProjectionSlice(values, 2)
+	if len(values) != 5 || values[4] != 99 {
+		t.Fatalf("grown values = %v, want length 5 with handle 4 preserved", values)
+	}
+}

--- a/cli/internal/core/projection_replay_benchmark_test.go
+++ b/cli/internal/core/projection_replay_benchmark_test.go
@@ -42,7 +42,7 @@ type projectionBenchmarkTarget struct {
 func BenchmarkProjectionReplay(b *testing.B) {
 	for _, logicalMessages := range []int{1_000, 10_000} {
 		fixture := newProjectionBenchmarkFixture(b, logicalMessages)
-		for _, scope := range []string{"room_timeline", "threads", "timeline_and_threads"} {
+		for _, scope := range []string{"room_timeline", "room_timeline_bucketed", "threads", "timeline_and_threads"} {
 			b.Run(fmt.Sprintf("%s/%s/messages_%d", projectionBenchmarkFixtureVersion, scope, logicalMessages), func(b *testing.B) {
 				b.ReportAllocs()
 				b.SetBytes(int64(projectionBenchmarkWireBytes(fixture)))
@@ -117,7 +117,7 @@ func BenchmarkProjectionRetainedHeap(b *testing.B) {
 	}
 
 	for _, logicalMessages := range []int{10_000, 50_000} {
-		for _, scope := range []string{"room_timeline", "threads", "timeline_and_threads"} {
+		for _, scope := range []string{"room_timeline", "room_timeline_bucketed", "threads", "timeline_and_threads"} {
 			b.Run(fmt.Sprintf("%s/%s/messages_%d", projectionBenchmarkFixtureVersion, scope, logicalMessages), func(b *testing.B) {
 				if b.N != 1 {
 					b.Skip("run with -benchtime=1x")
@@ -408,6 +408,11 @@ func newProjectionBenchmarkTargets(scope string) ([]projectionBenchmarkTarget, e
 	switch scope {
 	case "room_timeline":
 		return []projectionBenchmarkTarget{newTarget(NewRoomTimelineProjection())}, nil
+	case "room_timeline_bucketed":
+		return []projectionBenchmarkTarget{newTarget(newRoomTimelineProjection(roomTimelineProjectionOptions{
+			hotWindow: 30 * 24 * time.Hour,
+			now:       func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+		}))}, nil
 	case "threads":
 		return []projectionBenchmarkTarget{newTarget(NewThreadProjection())}, nil
 	case "timeline_and_threads":

--- a/cli/internal/core/projection_snapshots_test.go
+++ b/cli/internal/core/projection_snapshots_test.go
@@ -41,12 +41,12 @@ func TestCurrentProjectionSnapshotCodecsContainOnlyCurrentState(t *testing.T) {
 	timeline.replayGuard.completeReplay()
 	timelinePayload, err := timeline.Snapshot()
 	require.NoError(t, err)
-	timelineSnapshot := &corev1.RoomTimelineProjectionSnapshot{}
+	timelineSnapshot := &corev1.RoomTimelineProjectionSnapshotV3{}
 	require.NoError(t, proto.Unmarshal(timelinePayload, timelineSnapshot))
 	require.Equal(t, uint64(41), timelineSnapshot.GetReplayGuard().GetHighestSequence())
 	timelineFields := timelineSnapshot.ProtoReflect().Descriptor().Fields()
-	require.Equal(t, "replay_guard", string(timelineFields.ByNumber(protoreflect.FieldNumber(8)).Name()))
-	require.Nil(t, timelineFields.ByNumber(protoreflect.FieldNumber(9)))
+	require.Equal(t, "replay_guard", string(timelineFields.ByNumber(protoreflect.FieldNumber(9)).Name()))
+	require.Nil(t, timelineFields.ByNumber(protoreflect.FieldNumber(10)))
 }
 
 func TestProjectionSnapshotContractsIncludeCurrentSchema(t *testing.T) {
@@ -64,7 +64,7 @@ func TestProjectionSnapshotContractsIncludeCurrentSchema(t *testing.T) {
 		{reactionSnapshotContractID, "v1", &corev1.ReactionProjectionSnapshot{}},
 		{roomDirectorySnapshotContractID, "v1", &corev1.RoomDirectoryProjectionSnapshot{}},
 		{roomGroupLayoutSnapshotContractID, "v1", &corev1.RoomGroupLayoutProjectionSnapshot{}},
-		{roomTimelineSnapshotContractID, "v2", &corev1.RoomTimelineProjectionSnapshot{}},
+		{roomTimelineSnapshotContractID, "v3", &corev1.RoomTimelineProjectionSnapshotV3{}},
 		{threadSnapshotContractID, "v1", &corev1.ThreadProjectionSnapshot{}},
 		{userSnapshotContractID, "v2", &corev1.UserProfileProjectionSnapshot{}},
 	}
@@ -246,7 +246,7 @@ func TestProjectionSnapshotsRoundTripTransactionally(t *testing.T) {
 
 	expectedContractPrefix := map[string]string{
 		"room_directory": "v1-", "server_config": "v1-", "room_group_layout": "v1-",
-		"room_timeline": "v2-", "call_state": "v1-", "assets": "v2-", "reactions": "v1-",
+		"room_timeline": "v3-", "call_state": "v1-", "assets": "v2-", "reactions": "v1-",
 		"content_keys": "v1-", "rbac": "v1-", "mentionables": "v1-", "users": "v2-",
 	}
 	for _, tt := range tests {

--- a/cli/internal/core/projection_snapshots_test.go
+++ b/cli/internal/core/projection_snapshots_test.go
@@ -41,7 +41,7 @@ func TestCurrentProjectionSnapshotCodecsContainOnlyCurrentState(t *testing.T) {
 	timeline.replayGuard.completeReplay()
 	timelinePayload, err := timeline.Snapshot()
 	require.NoError(t, err)
-	timelineSnapshot := &corev1.RoomTimelineProjectionSnapshotV3{}
+	timelineSnapshot := &corev1.RoomTimelineProjectionSnapshot{}
 	require.NoError(t, proto.Unmarshal(timelinePayload, timelineSnapshot))
 	require.Equal(t, uint64(41), timelineSnapshot.GetReplayGuard().GetHighestSequence())
 	timelineFields := timelineSnapshot.ProtoReflect().Descriptor().Fields()
@@ -64,7 +64,7 @@ func TestProjectionSnapshotContractsIncludeCurrentSchema(t *testing.T) {
 		{reactionSnapshotContractID, "v1", &corev1.ReactionProjectionSnapshot{}},
 		{roomDirectorySnapshotContractID, "v1", &corev1.RoomDirectoryProjectionSnapshot{}},
 		{roomGroupLayoutSnapshotContractID, "v1", &corev1.RoomGroupLayoutProjectionSnapshot{}},
-		{roomTimelineSnapshotContractID, "v3", &corev1.RoomTimelineProjectionSnapshotV3{}},
+		{roomTimelineSnapshotContractID, "v2", &corev1.RoomTimelineProjectionSnapshot{}},
 		{threadSnapshotContractID, "v1", &corev1.ThreadProjectionSnapshot{}},
 		{userSnapshotContractID, "v2", &corev1.UserProfileProjectionSnapshot{}},
 	}
@@ -246,7 +246,7 @@ func TestProjectionSnapshotsRoundTripTransactionally(t *testing.T) {
 
 	expectedContractPrefix := map[string]string{
 		"room_directory": "v1-", "server_config": "v1-", "room_group_layout": "v1-",
-		"room_timeline": "v3-", "call_state": "v1-", "assets": "v2-", "reactions": "v1-",
+		"room_timeline": "v2-", "call_state": "v1-", "assets": "v2-", "reactions": "v1-",
 		"content_keys": "v1-", "rbac": "v1-", "mentionables": "v1-", "users": "v2-",
 	}
 	for _, tt := range tests {

--- a/cli/internal/core/reactions.go
+++ b/cli/internal/core/reactions.go
@@ -200,20 +200,18 @@ func (c *ChattoCore) canonicalReactionMessageEventID(roomID, messageEventID stri
 	if c == nil || c.RoomTimeline == nil {
 		return messageEventID, nil
 	}
-	entry, ok := c.RoomTimeline.Get(messageEventID)
-	if !ok || entry == nil || entry.Event == nil {
+	messageRoomID, originalID, ok := c.RoomTimeline.messageLocator(messageEventID)
+	if !ok {
 		return messageEventID, nil
 	}
-	if roomID != "" && roomIDOfEvent(entry.Event) != roomID {
+	if roomID != "" && messageRoomID != roomID {
 		return "", ErrMessageNotFound
 	}
-	posted := entry.Event.GetMessagePosted()
-	if posted == nil || posted.GetEchoOfEventId() == "" {
+	if originalID == "" {
 		return messageEventID, nil
 	}
-	originalID := posted.GetEchoOfEventId()
 	if roomID != "" {
-		if originalEntry, ok := c.RoomTimeline.Get(originalID); ok && originalEntry != nil && originalEntry.Event != nil && roomIDOfEvent(originalEntry.Event) != roomID {
+		if originalRoomID, _, ok := c.RoomTimeline.messageLocator(originalID); ok && originalRoomID != roomID {
 			return "", ErrMessageNotFound
 		}
 	}

--- a/cli/internal/core/room_attachments.go
+++ b/cli/internal/core/room_attachments.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -225,7 +226,11 @@ func (c *ChattoCore) GetRoomAttachments(ctx context.Context, kind RoomKind, room
 	}
 
 	items := make([]*RoomAttachmentItem, 0)
-	for _, message := range c.roomModel.currentRoomAttachmentMessages(roomID) {
+	messages, err := c.roomModel.currentRoomAttachmentMessagesContext(ctx, roomID)
+	if err != nil {
+		return nil, fmt.Errorf("load room attachment timeline buckets: %w", err)
+	}
+	for _, message := range messages {
 		if message.Entry == nil || message.Entry.Event == nil || message.Body == nil {
 			continue
 		}

--- a/cli/internal/core/room_events.go
+++ b/cli/internal/core/room_events.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -62,7 +63,10 @@ func (c *ChattoCore) GetRoomEvents(ctx context.Context, kind RoomKind, room_id s
 
 	// Bounded newest-first walk via the visible-room timeline. Fetch
 	// limit+1 to detect HasOlder without a second call.
-	raw := c.roomModel.visibleRoomTimeline(room_id, limit+1, before, nil)
+	raw, err := c.roomModel.visibleRoomTimelineContext(ctx, room_id, limit+1, before, nil)
+	if err != nil {
+		return nil, fmt.Errorf("load room timeline: %w", err)
+	}
 	hasOlder := len(raw) > limit
 	if hasOlder {
 		raw = raw[:limit]
@@ -96,7 +100,10 @@ func (c *ChattoCore) GetRoomEvents(ctx context.Context, kind RoomKind, room_id s
 //
 // Authorization: caller must verify room membership before calling.
 func (c *ChattoCore) GetRoomEventByEventID(ctx context.Context, kind RoomKind, roomID, eventID string) (*corev1.Event, error) {
-	entry, ok := c.roomModel.timelineEntry(eventID)
+	entry, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load room timeline event: %w", err)
+	}
 	if !ok {
 		return nil, nil
 	}
@@ -122,7 +129,10 @@ func (c *ChattoCore) GetRoomEventByEventID(ctx context.Context, kind RoomKind, r
 func (c *ChattoCore) GetRoomEventsAround(ctx context.Context, kind RoomKind, roomID, eventID string, limit int) (*RoomEventsAroundResult, error) {
 	limit = clampHistoricalMessageLimit(limit)
 
-	target, ok := c.roomModel.timelineEntry(eventID)
+	target, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return nil, fmt.Errorf("load room timeline target: %w", err)
+	}
 	if !ok {
 		return nil, ErrMessageNotFound
 	}
@@ -137,7 +147,10 @@ func (c *ChattoCore) GetRoomEventsAround(ctx context.Context, kind RoomKind, roo
 		return nil, ErrMessageNotFound
 	}
 
-	raw, targetIdx, hasOlder, hasNewer, ok := c.roomModel.visibleRoomTimelineAround(roomID, eventID, limit)
+	raw, targetIdx, hasOlder, hasNewer, ok, err := c.roomModel.visibleRoomTimelineAroundContext(ctx, roomID, eventID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("load room timeline window: %w", err)
+	}
 	if !ok {
 		return nil, ErrMessageNotFound
 	}
@@ -164,7 +177,10 @@ func (c *ChattoCore) GetRoomEventsAfter(ctx context.Context, kind RoomKind, room
 	// Walk visible entries oldest-first from the cursor so forward
 	// pagination returns the nearest newer events first. Fetch limit+1
 	// to detect whether another forward page exists.
-	raw := c.roomModel.visibleRoomTimelineAfter(roomID, limit+1, afterSeq, nil)
+	raw, err := c.roomModel.visibleRoomTimelineAfterContext(ctx, roomID, limit+1, afterSeq, nil)
+	if err != nil {
+		return nil, fmt.Errorf("load room timeline: %w", err)
+	}
 	hasNewer := len(raw) > limit
 	if hasNewer {
 		raw = raw[:limit]
@@ -199,9 +215,9 @@ func clampHistoricalMessageLimit(limit int) int {
 // GetEventSequence returns the stream sequence number for an event by
 // its envelope id, or 0 if not found.
 func (c *ChattoCore) GetEventSequence(ctx context.Context, kind RoomKind, roomID, eventID string) (uint64, error) {
-	entry, ok := c.roomModel.timelineEntry(eventID)
+	seq, ok := c.roomModel.eventSequence(eventID)
 	if !ok {
 		return 0, nil
 	}
-	return entry.StreamSeq, nil
+	return seq, nil
 }

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -178,16 +178,20 @@ func (m *RoomModel) isRoomBanActive(roomID, userID string, now time.Time) bool {
 	return m.directory.Bans.IsActive(roomID, userID, now)
 }
 
-func (m *RoomModel) timelineEntry(eventID string) (*TimelineEntry, bool) {
-	return m.timeline.Get(eventID)
+func (m *RoomModel) timelineEntryContext(ctx context.Context, eventID string) (*TimelineEntry, bool, error) {
+	return m.timeline.GetContext(ctx, eventID)
 }
 
-func (m *RoomModel) latestBody(eventID string) (*corev1.MessageBody, bool, bool) {
-	return m.timeline.LatestBody(eventID)
+func (m *RoomModel) eventSequence(eventID string) (uint64, bool) {
+	return m.timeline.EventSequence(eventID)
 }
 
-func (m *RoomModel) currentRoomAttachmentMessages(roomID string) []projectedRoomAttachmentMessage {
-	return m.timeline.CurrentRoomAttachmentMessages(roomID)
+func (m *RoomModel) latestBodyContext(ctx context.Context, eventID string) (*corev1.MessageBody, bool, bool, error) {
+	return m.timeline.LatestBodyContext(ctx, eventID)
+}
+
+func (m *RoomModel) currentRoomAttachmentMessagesContext(ctx context.Context, roomID string) ([]projectedRoomAttachmentMessage, error) {
+	return m.timeline.CurrentRoomAttachmentMessagesContext(ctx, roomID)
 }
 
 func (m *RoomModel) isEcho(eventID string) bool {
@@ -218,42 +222,41 @@ func (m *RoomModel) messageTombstoned(eventID string) bool {
 	return m.timeline.MessageTombstoned(eventID)
 }
 
-func (m *RoomModel) lastVisibleRoomEntry(roomID string, visible func(*corev1.Event) bool) (*TimelineEntry, bool) {
-	return m.timeline.LastVisibleRoomEntry(roomID, visible)
+func (m *RoomModel) lastVisibleRoomEntryContext(ctx context.Context, roomID string, visible func(*corev1.Event) bool) (*TimelineEntry, bool, error) {
+	return m.timeline.LastVisibleRoomEntryContext(ctx, roomID, visible)
 }
 
-func (m *RoomModel) lastRoomMessageEntry(roomID string) (*TimelineEntry, bool) {
-	return m.timeline.LastRoomMessageEntry(roomID)
-}
-
-func (m *RoomModel) visibleRoomTimeline(roomID string, limit int, beforeStreamSeq uint64, visible func(*corev1.Event) bool) []*TimelineEntry {
-	return m.timeline.VisibleRoomTimeline(roomID, limit, beforeStreamSeq, visible)
+func (m *RoomModel) visibleRoomTimelineContext(ctx context.Context, roomID string, limit int, beforeStreamSeq uint64, visible func(*corev1.Event) bool) ([]*TimelineEntry, error) {
+	return m.timeline.VisibleRoomTimelineContext(ctx, roomID, limit, beforeStreamSeq, visible)
 }
 
 func (m *RoomModel) roomEventCount(roomID string) int {
 	return m.timeline.RoomEventCount(roomID)
 }
 
-func (m *RoomModel) visibleRoomTimelineAfter(roomID string, limit int, afterStreamSeq uint64, visible func(*corev1.Event) bool) []*TimelineEntry {
-	return m.timeline.VisibleRoomTimelineAfter(roomID, limit, afterStreamSeq, visible)
+func (m *RoomModel) visibleRoomTimelineAfterContext(ctx context.Context, roomID string, limit int, afterStreamSeq uint64, visible func(*corev1.Event) bool) ([]*TimelineEntry, error) {
+	return m.timeline.VisibleRoomTimelineAfterContext(ctx, roomID, limit, afterStreamSeq, visible)
 }
 
-func (m *RoomModel) visibleRoomTimelineAround(roomID, eventID string, limit int) ([]*TimelineEntry, int, bool, bool, bool) {
-	return m.timeline.VisibleRoomTimelineAround(roomID, eventID, limit)
+func (m *RoomModel) visibleRoomTimelineAroundContext(ctx context.Context, roomID, eventID string, limit int) ([]*TimelineEntry, int, bool, bool, bool, error) {
+	return m.timeline.VisibleRoomTimelineAroundContext(ctx, roomID, eventID, limit)
 }
 
 func (m *RoomModel) threadExists(rootEventID string) bool {
 	return m.threads.ThreadExists(rootEventID)
 }
 
-func (m *RoomModel) threadEvents(rootEventID string) []*TimelineEntry {
+func (m *RoomModel) threadEventsContext(ctx context.Context, rootEventID string) ([]*TimelineEntry, error) {
 	refs := m.threads.ThreadEvents(rootEventID)
 	if len(refs) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]*TimelineEntry, 0, len(refs))
 	for _, ref := range refs {
-		entry, ok := m.timeline.Get(ref.EventID)
+		entry, ok, err := m.timeline.GetContext(ctx, ref.EventID)
+		if err != nil {
+			return nil, err
+		}
 		if !ok || entry == nil {
 			continue
 		}
@@ -262,7 +265,7 @@ func (m *RoomModel) threadEvents(rootEventID string) []*TimelineEntry {
 		}
 		out = append(out, entry)
 	}
-	return out
+	return out, nil
 }
 
 func (m *RoomModel) threadMetadata(rootEventID string) *ThreadMetadata {

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -247,7 +247,14 @@ func (m *RoomModel) threadExists(rootEventID string) bool {
 }
 
 func (m *RoomModel) threadEventsContext(ctx context.Context, rootEventID string) ([]*TimelineEntry, error) {
-	refs := m.threads.ThreadEvents(rootEventID)
+	return m.hydrateThreadEventsContext(ctx, m.threadEventRefs(rootEventID))
+}
+
+func (m *RoomModel) threadEventRefs(rootEventID string) []ThreadTimelineEntry {
+	return m.threads.ThreadEvents(rootEventID)
+}
+
+func (m *RoomModel) hydrateThreadEventsContext(ctx context.Context, refs []ThreadTimelineEntry) ([]*TimelineEntry, error) {
 	if len(refs) == 0 {
 		return nil, nil
 	}

--- a/cli/internal/core/room_timeline_buckets.go
+++ b/cli/internal/core/room_timeline_buckets.go
@@ -38,8 +38,14 @@ type timelineBucket struct {
 	refs          []timelineBucketEventRef
 	resident      bool
 	residentBytes int64
-	loading       chan struct{}
+	loading       *timelineBucketLoad
 	lastAccess    time.Time
+}
+
+type timelineBucketLoad struct {
+	done    chan struct{}
+	err     error
+	waiters int
 }
 
 type roomTimelineEventLoader interface {
@@ -193,11 +199,21 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			return nil
 		}
 		if loading := bucket.loading; loading != nil {
+			loading.waiters++
 			p.Unlock()
 			select {
 			case <-ctx.Done():
+				p.Lock()
+				loading.waiters--
+				p.Unlock()
 				return ctx.Err()
-			case <-loading:
+			case <-loading.done:
+				p.Lock()
+				loading.waiters--
+				p.Unlock()
+				if loading.err != nil {
+					return loading.err
+				}
 				continue
 			}
 		}
@@ -205,7 +221,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			p.Unlock()
 			return fmt.Errorf("Room Timeline bucket %s/%d is cold and has no EVT loader", key.roomID, key.weekStart)
 		}
-		loading := make(chan struct{})
+		loading := &timelineBucketLoad{done: make(chan struct{})}
 		bucket.loading = loading
 		refs := append([]timelineBucketEventRef(nil), bucket.refs...)
 		p.Unlock()
@@ -216,7 +232,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 		bucket = p.buckets[key]
 		if err == nil && len(bucket.refs) != len(refs) {
 			bucket.loading = nil
-			close(loading)
+			close(loading.done)
 			p.Unlock()
 			continue
 		}
@@ -227,8 +243,9 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			bucket.resident = true
 			bucket.lastAccess = p.now()
 		}
+		loading.err = err
 		bucket.loading = nil
-		close(loading)
+		close(loading.done)
 		p.Unlock()
 		return err
 	}
@@ -314,7 +331,19 @@ func (p *RoomTimelineProjection) installBucketPayloadLocked(key timelineBucketKe
 		if state.bucket != key {
 			continue
 		}
-		state.body = bodyPayloads[eventID]
+		body := bodyPayloads[eventID]
+		if _, retracted := p.retractedFlags[eventID]; retracted {
+			body = nil
+		}
+		if _, hidden := p.hiddenEchoes[eventID]; hidden {
+			body = nil
+		}
+		if entry, ok := p.entryByEventIDLocked(eventID); ok {
+			if _, shredded := p.shreddedUsers[entry.authorID]; shredded {
+				body = nil
+			}
+		}
+		state.body = body
 		p.bodyStates[eventID] = state
 		residentBytes += int64(proto.Size(state.body))
 	}

--- a/cli/internal/core/room_timeline_buckets.go
+++ b/cli/internal/core/room_timeline_buckets.go
@@ -188,6 +188,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 	if key.roomID == "" {
 		return nil
 	}
+	bucketStart := time.Unix(key.weekStart, 0).UTC()
 	for {
 		p.Lock()
 		bucket := p.buckets[key]
@@ -206,6 +207,11 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 				p.Lock()
 				loading.waiters--
 				p.Unlock()
+				p.logger.Debug("Stopped waiting for cold Room Timeline bucket",
+					"room_id", key.roomID,
+					"bucket_start", bucketStart,
+					"error", ctx.Err(),
+				)
 				return ctx.Err()
 			case <-loading.done:
 				p.Lock()
@@ -219,21 +225,44 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 		}
 		if p.eventLoader == nil {
 			p.Unlock()
-			return fmt.Errorf("Room Timeline bucket %s/%d is cold and has no EVT loader", key.roomID, key.weekStart)
+			err := fmt.Errorf("Room Timeline bucket %s/%d is cold and has no EVT loader", key.roomID, key.weekStart)
+			p.logger.Warn("Cannot load cold Room Timeline bucket",
+				"room_id", key.roomID,
+				"bucket_start", bucketStart,
+				"event_references", len(bucket.refs),
+				"error", err,
+			)
+			return err
 		}
 		loading := &timelineBucketLoad{done: make(chan struct{})}
 		bucket.loading = loading
 		refs := append([]timelineBucketEventRef(nil), bucket.refs...)
 		p.Unlock()
 
+		startedAt := time.Now()
+		p.logger.Debug("Loading cold Room Timeline bucket",
+			"room_id", key.roomID,
+			"bucket_start", bucketStart,
+			"event_references", len(refs),
+		)
 		loaded, err := p.eventLoader.loadRoomTimelineEvents(ctx, refs)
 
 		p.Lock()
 		bucket = p.buckets[key]
 		if err == nil && len(bucket.refs) != len(refs) {
+			currentRefs := len(bucket.refs)
+			waiters := loading.waiters
 			bucket.loading = nil
 			close(loading.done)
 			p.Unlock()
+			p.logger.Debug("Restarting cold Room Timeline bucket load after concurrent projection updates",
+				"room_id", key.roomID,
+				"bucket_start", bucketStart,
+				"loaded_event_references", len(refs),
+				"current_event_references", currentRefs,
+				"shared_waiters", waiters,
+				"duration", time.Since(startedAt),
+			)
 			continue
 		}
 		if err == nil {
@@ -243,10 +272,41 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			bucket.resident = true
 			bucket.lastAccess = p.now()
 		}
+		residentBytes := bucket.residentBytes
+		waiters := loading.waiters
 		loading.err = err
 		bucket.loading = nil
 		close(loading.done)
 		p.Unlock()
+		duration := time.Since(startedAt)
+		if err == nil {
+			p.logger.Debug("Loaded cold Room Timeline bucket",
+				"room_id", key.roomID,
+				"bucket_start", bucketStart,
+				"event_references", len(refs),
+				"resident_payload_bytes", residentBytes,
+				"shared_waiters", waiters,
+				"duration", duration,
+			)
+		} else if errors.Is(err, context.Canceled) {
+			p.logger.Debug("Cold Room Timeline bucket load was canceled",
+				"room_id", key.roomID,
+				"bucket_start", bucketStart,
+				"event_references", len(refs),
+				"shared_waiters", waiters,
+				"duration", duration,
+				"error", err,
+			)
+		} else {
+			p.logger.Warn("Failed to load cold Room Timeline bucket",
+				"room_id", key.roomID,
+				"bucket_start", bucketStart,
+				"event_references", len(refs),
+				"shared_waiters", waiters,
+				"duration", duration,
+				"error", err,
+			)
+		}
 		return err
 	}
 }

--- a/cli/internal/core/room_timeline_buckets.go
+++ b/cli/internal/core/room_timeline_buckets.go
@@ -195,13 +195,13 @@ func (p *RoomTimelineProjection) bucketForEventLocked(event *corev1.Event) timel
 }
 
 func (p *RoomTimelineProjection) messageBucketLocked(eventID, roomID string, event *corev1.Event) timelineBucketKey {
-	if state, ok := p.bodyStates[eventID]; ok && state.bucket.roomID != "" {
-		return state.bucket
-	}
-	if idx, ok := p.byEventID[eventID]; ok {
-		if entry := p.entryAtLocked(idx); entry != nil && entry.bucket.roomID != "" {
-			return entry.bucket
+	if eventRef, ok := p.eventRefLocked(eventID); ok {
+		if state := p.bodyStates[eventRef]; state.known && state.bucket.roomID != "" {
+			return state.bucket
 		}
+	}
+	if entry, ok := p.entryByEventIDLocked(eventID); ok && entry.bucket.roomID != "" {
+		return entry.bucket
 	}
 	return timelineBucketKey{roomID: roomID, weekStart: roomTimelineWeekStart(eventCreatedAt(event))}
 }
@@ -387,7 +387,7 @@ func (p *RoomTimelineProjection) installBucketPayloadLocked(key timelineBucketKe
 		return fmt.Errorf("Room Timeline bucket %s/%d loaded %d events for %d references", key.roomID, key.weekStart, len(loaded), len(refs))
 	}
 	entryPayloads := make(map[int]*corev1.Event)
-	bodyPayloads := make(map[string]*corev1.MessageBody)
+	bodyPayloads := make(map[timelineEventRef]*corev1.MessageBody)
 	for index, event := range loaded {
 		if event == nil {
 			continue
@@ -395,22 +395,27 @@ func (p *RoomTimelineProjection) installBucketPayloadLocked(key timelineBucketKe
 		ref := refs[index]
 		if bodyEvent := event.GetMessageBody(); bodyEvent != nil {
 			targetID := bodyEvent.GetEventId()
-			state, ok := p.bodyStates[targetID]
-			if !ok || state.bucket != key || state.currentSequence != ref.sequence {
+			targetRef, ok := p.eventRefLocked(targetID)
+			if !ok {
+				continue
+			}
+			state := p.bodyStates[targetRef]
+			if !state.known || state.bucket != key || state.currentSequence != ref.sequence {
 				continue
 			}
 			body := bodyEvent.GetBody()
 			if body == nil || (body.GetBodyEventId() != "" && body.GetBodyEventId() != event.GetId()) {
 				return fmt.Errorf("Room Timeline bucket %s/%d has invalid body envelope at sequence %d", key.roomID, key.weekStart, ref.sequence)
 			}
-			if _, shredded := p.shreddedUsers[body.GetAuthorId()]; shredded {
+			authorRaw, authorKnown := p.userIDs.lookup(body.GetAuthorId())
+			if authorKnown && p.shreddedUsers[authorRaw] {
 				continue
 			}
 			loadedBody := cloneMessageBody(body)
 			if loadedBody.GetBodyEventId() == "" {
 				loadedBody.BodyEventId = event.GetId()
 			}
-			bodyPayloads[targetID] = loadedBody
+			bodyPayloads[targetRef] = loadedBody
 			continue
 		}
 
@@ -419,36 +424,39 @@ func (p *RoomTimelineProjection) installBucketPayloadLocked(key timelineBucketKe
 		if !ok || entry.bucket != key || entry.StreamSeq != ref.sequence {
 			continue
 		}
-		entryPayloads[p.byEventID[eventID]] = event
+		eventRef, _ := p.eventRefLocked(eventID)
+		entryPayloads[int(p.entryByEvent[eventRef])] = event
 	}
 
-	for eventID, state := range p.bodyStates {
-		if state.bucket != key || state.currentSequence == 0 {
+	for eventIndex, state := range p.bodyStates {
+		if !state.known || state.bucket != key || state.currentSequence == 0 {
 			continue
 		}
-		if _, retracted := p.retractedFlags[eventID]; retracted {
+		eventRef := timelineEventRef(eventIndex)
+		if p.messageFlagLocked(eventRef, timelineMessageRetracted) {
 			continue
 		}
-		if _, hidden := p.hiddenEchoes[eventID]; hidden {
+		if p.messageFlagLocked(eventRef, timelineMessageHiddenEcho) {
 			continue
 		}
+		eventID := p.eventIDLocked(eventRef)
 		entry, _ := p.entryByEventIDLocked(eventID)
 		if entry != nil {
-			if _, shredded := p.shreddedUsers[entry.authorID]; shredded {
+			if int(entry.authorID) < len(p.shreddedUsers) && p.shreddedUsers[entry.authorID] {
 				continue
 			}
 		}
-		if _, loaded := bodyPayloads[eventID]; !loaded {
+		if _, loaded := bodyPayloads[eventRef]; !loaded {
 			return fmt.Errorf("Room Timeline bucket %s/%d is missing current body sequence %d for %s", key.roomID, key.weekStart, state.currentSequence, eventID)
 		}
 	}
-	for _, idx := range p.byEventID {
-		entry := p.entryAtLocked(idx)
+	for idx := range p.entries {
+		entry := &p.entries[idx]
 		if entry != nil && entry.bucket == key {
 			if _, loaded := entryPayloads[idx]; loaded {
 				continue
 			}
-			return fmt.Errorf("Room Timeline bucket %s/%d is missing event sequence %d for %s", key.roomID, key.weekStart, entry.StreamSeq, entry.eventID)
+			return fmt.Errorf("Room Timeline bucket %s/%d is missing event sequence %d for %s", key.roomID, key.weekStart, entry.StreamSeq, p.eventIDLocked(entry.eventID))
 		}
 	}
 	for idx, event := range entryPayloads {
@@ -458,31 +466,32 @@ func (p *RoomTimelineProjection) installBucketPayloadLocked(key timelineBucketKe
 	for _, event := range entryPayloads {
 		residentBytes += int64(proto.Size(event))
 	}
-	for eventID, state := range p.bodyStates {
-		if state.bucket != key {
+	for eventIndex, state := range p.bodyStates {
+		if !state.known || state.bucket != key {
 			continue
 		}
-		body := bodyPayloads[eventID]
-		if _, retracted := p.retractedFlags[eventID]; retracted {
+		eventRef := timelineEventRef(eventIndex)
+		body := bodyPayloads[eventRef]
+		if p.messageFlagLocked(eventRef, timelineMessageRetracted) {
 			body = nil
 		}
-		if _, hidden := p.hiddenEchoes[eventID]; hidden {
+		if p.messageFlagLocked(eventRef, timelineMessageHiddenEcho) {
 			body = nil
 		}
+		eventID := p.eventIDLocked(eventRef)
 		if entry, ok := p.entryByEventIDLocked(eventID); ok {
-			if _, shredded := p.shreddedUsers[entry.authorID]; shredded {
+			if int(entry.authorID) < len(p.shreddedUsers) && p.shreddedUsers[entry.authorID] {
 				body = nil
 			}
 		}
-		state.body = body
-		p.bodyStates[eventID] = state
-		residentBytes += int64(proto.Size(state.body))
+		p.currentBodies[eventRef] = body
+		residentBytes += int64(proto.Size(body))
 	}
 	p.buckets[key].residentBytes = residentBytes
 	return nil
 }
 
-func (p *RoomTimelineProjection) ensureEntryIndexes(ctx context.Context, indexes []int) error {
+func (p *RoomTimelineProjection) ensureEntryIndexes(ctx context.Context, indexes []timelineEntryRef) error {
 	p.RLock()
 	keys := make(map[timelineBucketKey]struct{})
 	for _, idx := range indexes {

--- a/cli/internal/core/room_timeline_buckets.go
+++ b/cli/internal/core/room_timeline_buckets.go
@@ -5,9 +5,12 @@
 package core
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -35,11 +38,13 @@ type timelineBucketEventRef struct {
 }
 
 type timelineBucket struct {
-	refs          []timelineBucketEventRef
-	resident      bool
-	residentBytes int64
-	loading       *timelineBucketLoad
-	lastAccess    time.Time
+	encodedRefs    []byte
+	referenceCount int
+	lastSequence   uint64
+	resident       bool
+	residentBytes  int64
+	loading        *timelineBucketLoad
+	lastAccess     time.Time
 }
 
 type timelineBucketLoad struct {
@@ -54,6 +59,64 @@ type roomTimelineEventLoader interface {
 
 type jetStreamRoomTimelineEventLoader struct {
 	stream jetstream.Stream
+}
+
+func appendTimelineBucketEventRef(bucket *timelineBucket, sequence uint64, optionalBody bool) error {
+	if sequence == 0 {
+		return errors.New("Room Timeline bucket reference has zero sequence")
+	}
+	if bucket.referenceCount > 0 && sequence <= bucket.lastSequence {
+		return fmt.Errorf("Room Timeline bucket reference sequence %d does not follow %d", sequence, bucket.lastSequence)
+	}
+	delta := sequence - bucket.lastSequence
+	if delta > math.MaxUint64>>1 {
+		return fmt.Errorf("Room Timeline bucket reference delta %d is too large", delta)
+	}
+	value := delta << 1
+	if optionalBody {
+		value |= 1
+	}
+	bucket.encodedRefs = binary.AppendUvarint(bucket.encodedRefs, value)
+	bucket.referenceCount++
+	bucket.lastSequence = sequence
+	return nil
+}
+
+func decodeTimelineBucketEventRefs(encoded []byte, capacityHint int) ([]timelineBucketEventRef, error) {
+	refs := make([]timelineBucketEventRef, 0, capacityHint)
+	_, _, err := walkTimelineBucketEventRefs(encoded, func(ref timelineBucketEventRef) {
+		refs = append(refs, ref)
+	})
+	return refs, err
+}
+
+func inspectTimelineBucketEventRefs(encoded []byte) (count int, lastSequence uint64, err error) {
+	return walkTimelineBucketEventRefs(encoded, nil)
+}
+
+func walkTimelineBucketEventRefs(encoded []byte, visit func(timelineBucketEventRef)) (count int, lastSequence uint64, err error) {
+	var sequence uint64
+	for len(encoded) > 0 {
+		value, n := binary.Uvarint(encoded)
+		if n <= 0 {
+			return 0, 0, errors.New("Room Timeline bucket references contain an invalid varint")
+		}
+		delta := value >> 1
+		if delta == 0 || sequence > math.MaxUint64-delta {
+			return 0, 0, errors.New("Room Timeline bucket references contain an invalid sequence delta")
+		}
+		sequence += delta
+		ref := timelineBucketEventRef{
+			sequence:     sequence,
+			optionalBody: value&1 != 0,
+		}
+		if visit != nil {
+			visit(ref)
+		}
+		count++
+		encoded = encoded[n:]
+	}
+	return count, sequence, nil
 }
 
 func (l jetStreamRoomTimelineEventLoader) loadRoomTimelineEvents(ctx context.Context, refs []timelineBucketEventRef) ([]*corev1.Event, error) {
@@ -161,22 +224,22 @@ func (p *RoomTimelineProjection) bucketIsHotLocked(key timelineBucketKey) bool {
 	return !bucketEnd.Before(p.now().UTC().Add(-p.hotWindow))
 }
 
-func (p *RoomTimelineProjection) recordBucketRefLocked(key timelineBucketKey, sequence uint64, optionalBody bool) {
+func (p *RoomTimelineProjection) recordBucketRefLocked(key timelineBucketKey, sequence uint64, optionalBody bool) error {
 	if key.roomID == "" || sequence == 0 {
-		return
+		return nil
 	}
 	bucket := p.buckets[key]
 	if bucket == nil {
 		bucket = &timelineBucket{resident: p.bucketIsHotLocked(key)}
 		p.buckets[key] = bucket
 	}
-	bucket.refs = append(bucket.refs, timelineBucketEventRef{
-		sequence:     sequence,
-		optionalBody: optionalBody,
-	})
+	if err := appendTimelineBucketEventRef(bucket, sequence, optionalBody); err != nil {
+		return err
+	}
 	if bucket.resident {
 		bucket.lastAccess = p.now()
 	}
+	return nil
 }
 
 func (p *RoomTimelineProjection) bucketResidentLocked(key timelineBucketKey) bool {
@@ -229,28 +292,36 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			p.logger.Warn("Cannot load cold Room Timeline bucket",
 				"room_id", key.roomID,
 				"bucket_start", bucketStart,
-				"event_references", len(bucket.refs),
+				"event_references", bucket.referenceCount,
 				"error", err,
 			)
 			return err
 		}
 		loading := &timelineBucketLoad{done: make(chan struct{})}
 		bucket.loading = loading
-		refs := append([]timelineBucketEventRef(nil), bucket.refs...)
+		encodedRefs := bytes.Clone(bucket.encodedRefs)
+		referenceCount := bucket.referenceCount
 		p.Unlock()
 
 		startedAt := time.Now()
 		p.logger.Debug("Loading cold Room Timeline bucket",
 			"room_id", key.roomID,
 			"bucket_start", bucketStart,
-			"event_references", len(refs),
+			"event_references", referenceCount,
 		)
-		loaded, err := p.eventLoader.loadRoomTimelineEvents(ctx, refs)
+		refs, err := decodeTimelineBucketEventRefs(encodedRefs, referenceCount)
+		var loaded []*corev1.Event
+		if err == nil && len(refs) != referenceCount {
+			err = fmt.Errorf("Room Timeline bucket %s/%d decoded %d events for %d references", key.roomID, key.weekStart, len(refs), referenceCount)
+		}
+		if err == nil {
+			loaded, err = p.eventLoader.loadRoomTimelineEvents(ctx, refs)
+		}
 
 		p.Lock()
 		bucket = p.buckets[key]
-		if err == nil && len(bucket.refs) != len(refs) {
-			currentRefs := len(bucket.refs)
+		if err == nil && bucket.referenceCount != referenceCount {
+			currentRefs := bucket.referenceCount
 			waiters := loading.waiters
 			bucket.loading = nil
 			close(loading.done)
@@ -258,7 +329,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			p.logger.Debug("Restarting cold Room Timeline bucket load after concurrent projection updates",
 				"room_id", key.roomID,
 				"bucket_start", bucketStart,
-				"loaded_event_references", len(refs),
+				"loaded_event_references", referenceCount,
 				"current_event_references", currentRefs,
 				"shared_waiters", waiters,
 				"duration", time.Since(startedAt),
@@ -283,7 +354,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			p.logger.Debug("Loaded cold Room Timeline bucket",
 				"room_id", key.roomID,
 				"bucket_start", bucketStart,
-				"event_references", len(refs),
+				"event_references", referenceCount,
 				"resident_payload_bytes", residentBytes,
 				"shared_waiters", waiters,
 				"duration", duration,
@@ -292,7 +363,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			p.logger.Debug("Cold Room Timeline bucket load was canceled",
 				"room_id", key.roomID,
 				"bucket_start", bucketStart,
-				"event_references", len(refs),
+				"event_references", referenceCount,
 				"shared_waiters", waiters,
 				"duration", duration,
 				"error", err,
@@ -301,7 +372,7 @@ func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineB
 			p.logger.Warn("Failed to load cold Room Timeline bucket",
 				"room_id", key.roomID,
 				"bucket_start", bucketStart,
-				"event_references", len(refs),
+				"event_references", referenceCount,
 				"shared_waiters", waiters,
 				"duration", duration,
 				"error", err,

--- a/cli/internal/core/room_timeline_buckets.go
+++ b/cli/internal/core/room_timeline_buckets.go
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: 2026 Chatto contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package core
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"google.golang.org/protobuf/proto"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+const (
+	roomTimelineBucketWidth     = 7 * 24 * time.Hour
+	roomTimelineLoadConcurrency = 16
+)
+
+// timelineBucketKey deliberately includes the room. A busy room therefore
+// cannot force an unrelated room's historical payload into memory.
+type timelineBucketKey struct {
+	roomID    string
+	weekStart int64
+}
+
+type timelineBucketEventRef struct {
+	sequence     uint64
+	optionalBody bool
+}
+
+type timelineBucket struct {
+	refs          []timelineBucketEventRef
+	resident      bool
+	residentBytes int64
+	loading       chan struct{}
+	lastAccess    time.Time
+}
+
+type roomTimelineEventLoader interface {
+	loadRoomTimelineEvents(context.Context, []timelineBucketEventRef) ([]*corev1.Event, error)
+}
+
+type jetStreamRoomTimelineEventLoader struct {
+	stream jetstream.Stream
+}
+
+func (l jetStreamRoomTimelineEventLoader) loadRoomTimelineEvents(ctx context.Context, refs []timelineBucketEventRef) ([]*corev1.Event, error) {
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	eventsByIndex := make([]*corev1.Event, len(refs))
+	workers := min(roomTimelineLoadConcurrency, len(refs))
+	jobs := make(chan int)
+	loadCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var firstErr error
+	var errOnce sync.Once
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				ref := refs[index]
+				msg, err := l.stream.GetMsg(loadCtx, ref.sequence)
+				if err != nil {
+					if ref.optionalBody && errors.Is(err, jetstream.ErrMsgNotFound) {
+						continue
+					}
+					errOnce.Do(func() {
+						firstErr = fmt.Errorf("load Room Timeline EVT sequence %d: %w", ref.sequence, err)
+						cancel()
+					})
+					continue
+				}
+				var event corev1.Event
+				if err := proto.Unmarshal(msg.Data, &event); err != nil {
+					errOnce.Do(func() {
+						firstErr = fmt.Errorf("decode Room Timeline EVT sequence %d: %w", ref.sequence, err)
+						cancel()
+					})
+					continue
+				}
+				eventsByIndex[index] = &event
+			}
+		}()
+	}
+sendJobs:
+	for index := range refs {
+		select {
+		case jobs <- index:
+		case <-loadCtx.Done():
+			break sendJobs
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
+	return eventsByIndex, nil
+}
+
+func roomTimelineWeekStart(at time.Time) int64 {
+	if at.IsZero() {
+		return 0
+	}
+	utc := at.UTC()
+	dayStart := time.Date(utc.Year(), utc.Month(), utc.Day(), 0, 0, 0, 0, time.UTC)
+	daysSinceMonday := (int(dayStart.Weekday()) + 6) % 7
+	return dayStart.AddDate(0, 0, -daysSinceMonday).Unix()
+}
+
+func (p *RoomTimelineProjection) bucketForEventLocked(event *corev1.Event) timelineBucketKey {
+	return timelineBucketKey{
+		roomID:    roomIDOfEvent(event),
+		weekStart: roomTimelineWeekStart(eventCreatedAt(event)),
+	}
+}
+
+func (p *RoomTimelineProjection) messageBucketLocked(eventID, roomID string, event *corev1.Event) timelineBucketKey {
+	if state, ok := p.bodyStates[eventID]; ok && state.bucket.roomID != "" {
+		return state.bucket
+	}
+	if idx, ok := p.byEventID[eventID]; ok {
+		if entry := p.entryAtLocked(idx); entry != nil && entry.bucket.roomID != "" {
+			return entry.bucket
+		}
+	}
+	return timelineBucketKey{roomID: roomID, weekStart: roomTimelineWeekStart(eventCreatedAt(event))}
+}
+
+func (p *RoomTimelineProjection) bucketForMutationLocked(event *corev1.Event, roomID string) timelineBucketKey {
+	if posted := event.GetMessagePosted(); posted != nil {
+		return p.messageBucketLocked(event.GetId(), roomID, event)
+	}
+	if retracted := event.GetMessageRetracted(); retracted != nil {
+		return p.messageBucketLocked(retracted.GetEventId(), roomID, event)
+	}
+	return timelineBucketKey{roomID: roomID, weekStart: roomTimelineWeekStart(eventCreatedAt(event))}
+}
+
+func (p *RoomTimelineProjection) bucketIsHotLocked(key timelineBucketKey) bool {
+	if p.retainAll || key.weekStart == 0 {
+		return true
+	}
+	bucketEnd := time.Unix(key.weekStart, 0).UTC().Add(roomTimelineBucketWidth)
+	return !bucketEnd.Before(p.now().UTC().Add(-p.hotWindow))
+}
+
+func (p *RoomTimelineProjection) recordBucketRefLocked(key timelineBucketKey, sequence uint64, optionalBody bool) {
+	if key.roomID == "" || sequence == 0 {
+		return
+	}
+	bucket := p.buckets[key]
+	if bucket == nil {
+		bucket = &timelineBucket{resident: p.bucketIsHotLocked(key)}
+		p.buckets[key] = bucket
+	}
+	bucket.refs = append(bucket.refs, timelineBucketEventRef{
+		sequence:     sequence,
+		optionalBody: optionalBody,
+	})
+	if bucket.resident {
+		bucket.lastAccess = p.now()
+	}
+}
+
+func (p *RoomTimelineProjection) bucketResidentLocked(key timelineBucketKey) bool {
+	bucket := p.buckets[key]
+	return bucket == nil || bucket.resident
+}
+
+func (p *RoomTimelineProjection) ensureBucket(ctx context.Context, key timelineBucketKey) error {
+	if key.roomID == "" {
+		return nil
+	}
+	for {
+		p.Lock()
+		bucket := p.buckets[key]
+		if bucket == nil || bucket.resident {
+			if bucket != nil {
+				bucket.lastAccess = p.now()
+			}
+			p.Unlock()
+			return nil
+		}
+		if loading := bucket.loading; loading != nil {
+			p.Unlock()
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-loading:
+				continue
+			}
+		}
+		if p.eventLoader == nil {
+			p.Unlock()
+			return fmt.Errorf("Room Timeline bucket %s/%d is cold and has no EVT loader", key.roomID, key.weekStart)
+		}
+		loading := make(chan struct{})
+		bucket.loading = loading
+		refs := append([]timelineBucketEventRef(nil), bucket.refs...)
+		p.Unlock()
+
+		loaded, err := p.eventLoader.loadRoomTimelineEvents(ctx, refs)
+
+		p.Lock()
+		bucket = p.buckets[key]
+		if err == nil && len(bucket.refs) != len(refs) {
+			bucket.loading = nil
+			close(loading)
+			p.Unlock()
+			continue
+		}
+		if err == nil {
+			err = p.installBucketPayloadLocked(key, refs, loaded)
+		}
+		if err == nil {
+			bucket.resident = true
+			bucket.lastAccess = p.now()
+		}
+		bucket.loading = nil
+		close(loading)
+		p.Unlock()
+		return err
+	}
+}
+
+func (p *RoomTimelineProjection) installBucketPayloadLocked(key timelineBucketKey, refs []timelineBucketEventRef, loaded []*corev1.Event) error {
+	if len(refs) != len(loaded) {
+		return fmt.Errorf("Room Timeline bucket %s/%d loaded %d events for %d references", key.roomID, key.weekStart, len(loaded), len(refs))
+	}
+	entryPayloads := make(map[int]*corev1.Event)
+	bodyPayloads := make(map[string]*corev1.MessageBody)
+	for index, event := range loaded {
+		if event == nil {
+			continue
+		}
+		ref := refs[index]
+		if bodyEvent := event.GetMessageBody(); bodyEvent != nil {
+			targetID := bodyEvent.GetEventId()
+			state, ok := p.bodyStates[targetID]
+			if !ok || state.bucket != key || state.currentSequence != ref.sequence {
+				continue
+			}
+			body := bodyEvent.GetBody()
+			if body == nil || (body.GetBodyEventId() != "" && body.GetBodyEventId() != event.GetId()) {
+				return fmt.Errorf("Room Timeline bucket %s/%d has invalid body envelope at sequence %d", key.roomID, key.weekStart, ref.sequence)
+			}
+			if _, shredded := p.shreddedUsers[body.GetAuthorId()]; shredded {
+				continue
+			}
+			loadedBody := cloneMessageBody(body)
+			if loadedBody.GetBodyEventId() == "" {
+				loadedBody.BodyEventId = event.GetId()
+			}
+			bodyPayloads[targetID] = loadedBody
+			continue
+		}
+
+		eventID := event.GetId()
+		entry, ok := p.entryByEventIDLocked(eventID)
+		if !ok || entry.bucket != key || entry.StreamSeq != ref.sequence {
+			continue
+		}
+		entryPayloads[p.byEventID[eventID]] = event
+	}
+
+	for eventID, state := range p.bodyStates {
+		if state.bucket != key || state.currentSequence == 0 {
+			continue
+		}
+		if _, retracted := p.retractedFlags[eventID]; retracted {
+			continue
+		}
+		if _, hidden := p.hiddenEchoes[eventID]; hidden {
+			continue
+		}
+		entry, _ := p.entryByEventIDLocked(eventID)
+		if entry != nil {
+			if _, shredded := p.shreddedUsers[entry.authorID]; shredded {
+				continue
+			}
+		}
+		if _, loaded := bodyPayloads[eventID]; !loaded {
+			return fmt.Errorf("Room Timeline bucket %s/%d is missing current body sequence %d for %s", key.roomID, key.weekStart, state.currentSequence, eventID)
+		}
+	}
+	for _, idx := range p.byEventID {
+		entry := p.entryAtLocked(idx)
+		if entry != nil && entry.bucket == key {
+			if _, loaded := entryPayloads[idx]; loaded {
+				continue
+			}
+			return fmt.Errorf("Room Timeline bucket %s/%d is missing event sequence %d for %s", key.roomID, key.weekStart, entry.StreamSeq, entry.eventID)
+		}
+	}
+	for idx, event := range entryPayloads {
+		p.entries[idx].Event = event
+	}
+	var residentBytes int64
+	for _, event := range entryPayloads {
+		residentBytes += int64(proto.Size(event))
+	}
+	for eventID, state := range p.bodyStates {
+		if state.bucket != key {
+			continue
+		}
+		state.body = bodyPayloads[eventID]
+		p.bodyStates[eventID] = state
+		residentBytes += int64(proto.Size(state.body))
+	}
+	p.buckets[key].residentBytes = residentBytes
+	return nil
+}
+
+func (p *RoomTimelineProjection) ensureEntryIndexes(ctx context.Context, indexes []int) error {
+	p.RLock()
+	keys := make(map[timelineBucketKey]struct{})
+	for _, idx := range indexes {
+		if entry := p.entryAtLocked(idx); entry != nil {
+			keys[entry.bucket] = struct{}{}
+		}
+	}
+	p.RUnlock()
+	for key := range keys {
+		if err := p.ensureBucket(ctx, key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cli/internal/core/room_timeline_buckets_test.go
+++ b/cli/internal/core/room_timeline_buckets_test.go
@@ -172,9 +172,9 @@ func TestRoomTimelineColdBucketLoadsFromExactEVTReferences(t *testing.T) {
 	if !ok || entry.Event != nil {
 		t.Fatalf("cold entry = %#v, want metadata without payload", entry)
 	}
-	state := projection.bodyStates["M1"]
+	state, _ := projection.bodyStateByEventIDLocked("M1")
 	bucket := projection.buckets[state.bucket]
-	if state.body != nil || bucket == nil || bucket.resident || bucket.referenceCount != 2 {
+	if projection.currentBodyByEventIDLocked("M1") != nil || bucket == nil || bucket.resident || bucket.referenceCount != 2 {
 		t.Fatalf("cold body/bucket = %#v / %#v", state, bucket)
 	}
 	projection.RUnlock()
@@ -400,7 +400,7 @@ func TestRoomTimelineColdBucketDoesNotRestoreBodyShreddedDuringLoad(t *testing.T
 	}
 	projection.RLock()
 	defer projection.RUnlock()
-	if projection.bodyStates["M1"].body != nil {
+	if projection.currentBodyByEventIDLocked("M1") != nil {
 		t.Fatal("shredded body was reinstalled by the completing cold load")
 	}
 }
@@ -429,7 +429,7 @@ func TestRoomTimelineColdBucketInstallIsTransactional(t *testing.T) {
 	projection.RLock()
 	defer projection.RUnlock()
 	entry, _ := projection.entryByEventIDLocked("M1")
-	if entry.Event != nil || projection.bodyStates["M1"].body != nil || projection.buckets[entry.bucket].resident {
+	if entry.Event != nil || projection.currentBodyByEventIDLocked("M1") != nil || projection.buckets[entry.bucket].resident {
 		t.Fatal("failed bucket load installed partial payload")
 	}
 }

--- a/cli/internal/core/room_timeline_buckets_test.go
+++ b/cli/internal/core/room_timeline_buckets_test.go
@@ -7,6 +7,7 @@ package core
 import (
 	"context"
 	"errors"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -52,6 +53,28 @@ func (l *fakeRoomTimelineEventLoader) callCount() int {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	return l.calls
+}
+
+func waitForRoomTimelineBucketWaiters(t *testing.T, projection *RoomTimelineProjection, want int) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		projection.RLock()
+		waiters := 0
+		for _, bucket := range projection.buckets {
+			if bucket.loading != nil {
+				waiters = bucket.loading.waiters
+			}
+		}
+		projection.RUnlock()
+		if waiters == want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("bucket load waiters = %d, want %d", waiters, want)
+		}
+		runtime.Gosched()
+	}
 }
 
 func bucketTestMessageEvents(at time.Time, bodyID, messageID string) (*corev1.Event, *corev1.Event) {
@@ -147,13 +170,18 @@ func TestRoomTimelineColdBucketSharesConcurrentLoad(t *testing.T) {
 	}
 
 	errs := make(chan error, 8)
-	for range 8 {
+	go func() {
+		_, _, err := projection.GetContext(context.Background(), "M1")
+		errs <- err
+	}()
+	<-loader.started
+	for range 7 {
 		go func() {
 			_, _, err := projection.GetContext(context.Background(), "M1")
 			errs <- err
 		}()
 	}
-	<-loader.started
+	waitForRoomTimelineBucketWaiters(t, projection, 7)
 	close(loader.release)
 	for range 8 {
 		if err := <-errs; err != nil {
@@ -162,6 +190,108 @@ func TestRoomTimelineColdBucketSharesConcurrentLoad(t *testing.T) {
 	}
 	if loader.callCount() != 1 {
 		t.Fatalf("EVT loads = %d, want one shared load", loader.callCount())
+	}
+}
+
+func TestRoomTimelineColdBucketSharesConcurrentLoadError(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	body, post := bucketTestMessageEvents(at, "B1", "M1")
+	loader := &fakeRoomTimelineEventLoader{
+		events:  map[uint64]*corev1.Event{10: body},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   7 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+	if err := projection.Apply(body, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	errs := make(chan error, 8)
+	go func() {
+		_, _, err := projection.GetContext(context.Background(), "M1")
+		errs <- err
+	}()
+	<-loader.started
+	for range 7 {
+		go func() {
+			_, _, err := projection.GetContext(context.Background(), "M1")
+			errs <- err
+		}()
+	}
+	waitForRoomTimelineBucketWaiters(t, projection, 7)
+	close(loader.release)
+	for range 8 {
+		if err := <-errs; err == nil {
+			t.Fatal("concurrent cold load unexpectedly succeeded")
+		}
+	}
+	if loader.callCount() != 1 {
+		t.Fatalf("EVT loads = %d, want one shared failed load", loader.callCount())
+	}
+}
+
+func TestRoomTimelineColdBucketDoesNotRestoreBodyShreddedDuringLoad(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	body, post := bucketTestMessageEvents(at, "B1", "M1")
+	loader := &fakeRoomTimelineEventLoader{
+		events:  map[uint64]*corev1.Event{10: body, 11: post},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   7 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+	if err := projection.Apply(body, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	type bodyResult struct {
+		body      *corev1.MessageBody
+		retracted bool
+		known     bool
+		err       error
+	}
+	result := make(chan bodyResult, 1)
+	go func() {
+		loaded, retracted, known, err := projection.LatestBodyContext(context.Background(), "M1")
+		result <- bodyResult{body: loaded, retracted: retracted, known: known, err: err}
+	}()
+	<-loader.started
+	shredded := &corev1.Event{
+		Id:        "S1",
+		CreatedAt: timestamppb.New(at.Add(time.Hour)),
+		Event: &corev1.Event_UserKeyShredded{UserKeyShredded: &corev1.UserKeyShreddedEvent{
+			UserId: "U1",
+		}},
+	}
+	if err := projection.Apply(shredded, 12); err != nil {
+		t.Fatal(err)
+	}
+	close(loader.release)
+
+	got := <-result
+	if got.err != nil {
+		t.Fatal(got.err)
+	}
+	if got.body != nil || !got.retracted || !got.known {
+		t.Fatalf("LatestBodyContext() = body %#v, retracted %v, known %v", got.body, got.retracted, got.known)
+	}
+	projection.RLock()
+	defer projection.RUnlock()
+	if projection.bodyStates["M1"].body != nil {
+		t.Fatal("shredded body was reinstalled by the completing cold load")
 	}
 }
 
@@ -245,7 +375,7 @@ func TestRoomTimelineSnapshotKeepsColdBucketPayloadOut(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	snapshot := &corev1.RoomTimelineProjectionSnapshotV3{}
+	snapshot := &corev1.RoomTimelineProjectionSnapshot{}
 	if err := proto.Unmarshal(payload, snapshot); err != nil {
 		t.Fatal(err)
 	}
@@ -254,5 +384,42 @@ func TestRoomTimelineSnapshotKeepsColdBucketPayloadOut(t *testing.T) {
 	}
 	if snapshot.GetEntries()[0].GetResidentEvent() != nil || snapshot.GetBodies()[0].GetResidentBody() != nil {
 		t.Fatal("historical payload leaked into snapshot")
+	}
+}
+
+func TestRoomTimelineSnapshotRejectsMissingResidentBody(t *testing.T) {
+	for _, includePost := range []bool{false, true} {
+		t.Run(map[bool]string{false: "body before post", true: "posted message"}[includePost], func(t *testing.T) {
+			at := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
+			body, post := bucketTestMessageEvents(at, "B1", "M1")
+			projection := NewRoomTimelineProjection()
+			if err := projection.Apply(body, 10); err != nil {
+				t.Fatal(err)
+			}
+			if includePost {
+				if err := projection.Apply(post, 11); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			payload, err := projection.Snapshot()
+			if err != nil {
+				t.Fatal(err)
+			}
+			snapshot := &corev1.RoomTimelineProjectionSnapshot{}
+			if err := proto.Unmarshal(payload, snapshot); err != nil {
+				t.Fatal(err)
+			}
+			snapshot.Bodies[0].ResidentBody = nil
+			payload, err = proto.Marshal(snapshot)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			restored := NewRoomTimelineProjection()
+			if err := restored.Restore(payload); err == nil {
+				t.Fatal("Restore() accepted a resident bucket without its current body")
+			}
+		})
 	}
 }

--- a/cli/internal/core/room_timeline_buckets_test.go
+++ b/cli/internal/core/room_timeline_buckets_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -105,6 +106,51 @@ func bucketTestMessageEvents(at time.Time, bodyID, messageID string) (*corev1.Ev
 	return body, post
 }
 
+func TestTimelineBucketEventReferencesRoundTripCompactly(t *testing.T) {
+	bucket := &timelineBucket{}
+	for _, ref := range []timelineBucketEventRef{
+		{sequence: 1001, optionalBody: true},
+		{sequence: 1003},
+		{sequence: 1010, optionalBody: true},
+	} {
+		if err := appendTimelineBucketEventRef(bucket, ref.sequence, ref.optionalBody); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := decodeTimelineBucketEventRefs(bucket.encodedRefs, bucket.referenceCount)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []timelineBucketEventRef{
+		{sequence: 1001, optionalBody: true},
+		{sequence: 1003},
+		{sequence: 1010, optionalBody: true},
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("decoded references = %#v, want %#v", got, want)
+	}
+	if bucket.referenceCount != len(want) || bucket.lastSequence != 1010 {
+		t.Fatalf("bucket reference metadata = count %d, last %d", bucket.referenceCount, bucket.lastSequence)
+	}
+	if len(bucket.encodedRefs) >= len(want)*16 {
+		t.Fatalf("encoded references use %d bytes, want less than former %d-byte representation", len(bucket.encodedRefs), len(want)*16)
+	}
+}
+
+func TestTimelineBucketEventReferencesRejectInvalidEncoding(t *testing.T) {
+	for name, encoded := range map[string][]byte{
+		"truncated varint": {0x80},
+		"zero delta":       {0x01},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := decodeTimelineBucketEventRefs(encoded, 0); err == nil {
+				t.Fatal("invalid references unexpectedly decoded")
+			}
+		})
+	}
+}
+
 func TestRoomTimelineColdBucketLoadsFromExactEVTReferences(t *testing.T) {
 	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
 	body, post := bucketTestMessageEvents(at, "B1", "M1")
@@ -128,7 +174,7 @@ func TestRoomTimelineColdBucketLoadsFromExactEVTReferences(t *testing.T) {
 	}
 	state := projection.bodyStates["M1"]
 	bucket := projection.buckets[state.bucket]
-	if state.body != nil || bucket == nil || bucket.resident || len(bucket.refs) != 2 {
+	if state.body != nil || bucket == nil || bucket.resident || bucket.referenceCount != 2 {
 		t.Fatalf("cold body/bucket = %#v / %#v", state, bucket)
 	}
 	projection.RUnlock()
@@ -446,8 +492,42 @@ func TestRoomTimelineSnapshotKeepsColdBucketPayloadOut(t *testing.T) {
 	if len(snapshot.GetBuckets()) != 1 || snapshot.GetBuckets()[0].GetPayloadResident() {
 		t.Fatalf("snapshot buckets = %#v, want cold metadata", snapshot.GetBuckets())
 	}
+	refs, err := decodeTimelineBucketEventRefs(snapshot.GetBuckets()[0].GetEncodedEventReferences(), 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 2 || refs[0].sequence != 10 || !refs[0].optionalBody || refs[1].sequence != 11 || refs[1].optionalBody {
+		t.Fatalf("snapshot references = %#v", refs)
+	}
 	if snapshot.GetEntries()[0].GetResidentEvent() != nil || snapshot.GetBodies()[0].GetResidentBody() != nil {
 		t.Fatal("historical payload leaked into snapshot")
+	}
+}
+
+func TestRoomTimelineSnapshotRejectsInvalidEncodedReferences(t *testing.T) {
+	at := time.Date(2026, time.July, 24, 12, 0, 0, 0, time.UTC)
+	_, post := bucketTestMessageEvents(at, "B1", "M1")
+	projection := NewRoomTimelineProjection()
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := projection.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &corev1.RoomTimelineProjectionSnapshot{}
+	if err := proto.Unmarshal(payload, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	snapshot.Buckets[0].EncodedEventReferences = []byte{1}
+	payload, err = proto.Marshal(snapshot)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := NewRoomTimelineProjection().Restore(payload); err == nil {
+		t.Fatal("Restore() accepted invalid bucket reference encoding")
 	}
 }
 

--- a/cli/internal/core/room_timeline_buckets_test.go
+++ b/cli/internal/core/room_timeline_buckets_test.go
@@ -5,13 +5,16 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"runtime"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -147,6 +150,67 @@ func TestRoomTimelineColdBucketLoadsFromExactEVTReferences(t *testing.T) {
 	if loader.callCount() != 1 {
 		t.Fatalf("EVT loads = %d, want one bucket load", loader.callCount())
 	}
+}
+
+func TestRoomTimelineColdBucketLoggingLevels(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	now := func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) }
+
+	t.Run("successful load stays below info", func(t *testing.T) {
+		body, post := bucketTestMessageEvents(at, "B1", "M1")
+		var output bytes.Buffer
+		logger := log.New(&output)
+		logger.SetLevel(log.InfoLevel)
+		projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+			eventLoader: &fakeRoomTimelineEventLoader{events: map[uint64]*corev1.Event{10: body, 11: post}},
+			hotWindow:   7 * 24 * time.Hour,
+			now:         now,
+			logger:      logger,
+		})
+		if err := projection.Apply(body, 10); err != nil {
+			t.Fatal(err)
+		}
+		if err := projection.Apply(post, 11); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := projection.GetContext(context.Background(), "M1"); err != nil {
+			t.Fatal(err)
+		}
+		if output.Len() != 0 {
+			t.Fatalf("successful cold load logged at INFO or beyond: %s", output.String())
+		}
+	})
+
+	t.Run("failed load warns once", func(t *testing.T) {
+		body, post := bucketTestMessageEvents(at, "B1", "M1")
+		var output bytes.Buffer
+		logger := log.New(&output)
+		logger.SetLevel(log.InfoLevel)
+		projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+			eventLoader: &fakeRoomTimelineEventLoader{events: map[uint64]*corev1.Event{10: body}},
+			hotWindow:   7 * 24 * time.Hour,
+			now:         now,
+			logger:      logger,
+		})
+		if err := projection.Apply(body, 10); err != nil {
+			t.Fatal(err)
+		}
+		if err := projection.Apply(post, 11); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := projection.GetContext(context.Background(), "M1"); err == nil {
+			t.Fatal("cold load unexpectedly succeeded")
+		}
+		got := output.String()
+		if strings.Count(got, "Failed to load cold Room Timeline bucket") != 1 {
+			t.Fatalf("failure log = %q, want one warning", got)
+		}
+		for _, field := range []string{"room_id", "bucket_start", "event_references", "duration"} {
+			if !strings.Contains(got, field) {
+				t.Errorf("failure log %q does not contain %q", got, field)
+			}
+		}
+	})
 }
 
 func TestRoomTimelineColdBucketSharesConcurrentLoad(t *testing.T) {

--- a/cli/internal/core/room_timeline_buckets_test.go
+++ b/cli/internal/core/room_timeline_buckets_test.go
@@ -1,0 +1,258 @@
+// SPDX-FileCopyrightText: 2026 Chatto contributors
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+package core
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type fakeRoomTimelineEventLoader struct {
+	mu      sync.Mutex
+	events  map[uint64]*corev1.Event
+	calls   int
+	started chan struct{}
+	release chan struct{}
+}
+
+func (l *fakeRoomTimelineEventLoader) loadRoomTimelineEvents(_ context.Context, refs []timelineBucketEventRef) ([]*corev1.Event, error) {
+	l.mu.Lock()
+	l.calls++
+	if l.started != nil && l.calls == 1 {
+		close(l.started)
+	}
+	l.mu.Unlock()
+	if l.release != nil {
+		<-l.release
+	}
+	out := make([]*corev1.Event, len(refs))
+	for index, ref := range refs {
+		if event := l.events[ref.sequence]; event != nil {
+			out[index] = proto.Clone(event).(*corev1.Event)
+			continue
+		}
+		if !ref.optionalBody {
+			return nil, errors.New("required event missing")
+		}
+	}
+	return out, nil
+}
+
+func (l *fakeRoomTimelineEventLoader) callCount() int {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.calls
+}
+
+func bucketTestMessageEvents(at time.Time, bodyID, messageID string) (*corev1.Event, *corev1.Event) {
+	body := &corev1.Event{
+		Id:        bodyID,
+		CreatedAt: timestamppb.New(at),
+		Event: &corev1.Event_MessageBody{MessageBody: &corev1.MessageBodyEvent{
+			RoomId:  "R1",
+			EventId: messageID,
+			Body: &corev1.MessageBody{
+				AuthorId:      "U1",
+				BodyEventId:   bodyID,
+				EncryptedBody: []byte("ciphertext"),
+			},
+		}},
+	}
+	post := &corev1.Event{
+		Id:        messageID,
+		ActorId:   "U1",
+		CreatedAt: timestamppb.New(at),
+		Event: &corev1.Event_MessagePosted{MessagePosted: &corev1.MessagePostedEvent{
+			RoomId: "R1",
+		}},
+	}
+	return body, post
+}
+
+func TestRoomTimelineColdBucketLoadsFromExactEVTReferences(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	body, post := bucketTestMessageEvents(at, "B1", "M1")
+	loader := &fakeRoomTimelineEventLoader{events: map[uint64]*corev1.Event{10: body, 11: post}}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   14 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+
+	if err := projection.Apply(body, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+	projection.RLock()
+	entry, ok := projection.entryByEventIDLocked("M1")
+	if !ok || entry.Event != nil {
+		t.Fatalf("cold entry = %#v, want metadata without payload", entry)
+	}
+	state := projection.bodyStates["M1"]
+	bucket := projection.buckets[state.bucket]
+	if state.body != nil || bucket == nil || bucket.resident || len(bucket.refs) != 2 {
+		t.Fatalf("cold body/bucket = %#v / %#v", state, bucket)
+	}
+	projection.RUnlock()
+
+	loadedEntry, ok, err := projection.GetContext(context.Background(), "M1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || loadedEntry.Event.GetId() != "M1" {
+		t.Fatalf("loaded entry = %#v", loadedEntry)
+	}
+	loadedBody, retracted, known, err := projection.LatestBodyContext(context.Background(), "M1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !known || retracted || loadedBody.GetBodyEventId() != "B1" {
+		t.Fatalf("loaded body = %#v, retracted=%v known=%v", loadedBody, retracted, known)
+	}
+	if loader.callCount() != 1 {
+		t.Fatalf("EVT loads = %d, want one bucket load", loader.callCount())
+	}
+}
+
+func TestRoomTimelineColdBucketSharesConcurrentLoad(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	body, post := bucketTestMessageEvents(at, "B1", "M1")
+	loader := &fakeRoomTimelineEventLoader{
+		events:  map[uint64]*corev1.Event{10: body, 11: post},
+		started: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   7 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+	if err := projection.Apply(body, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	errs := make(chan error, 8)
+	for range 8 {
+		go func() {
+			_, _, err := projection.GetContext(context.Background(), "M1")
+			errs <- err
+		}()
+	}
+	<-loader.started
+	close(loader.release)
+	for range 8 {
+		if err := <-errs; err != nil {
+			t.Fatal(err)
+		}
+	}
+	if loader.callCount() != 1 {
+		t.Fatalf("EVT loads = %d, want one shared load", loader.callCount())
+	}
+}
+
+func TestRoomTimelineColdBucketInstallIsTransactional(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	body, post := bucketTestMessageEvents(at, "B1", "M1")
+	wrongPost := proto.Clone(post).(*corev1.Event)
+	wrongPost.Id = "OTHER"
+	loader := &fakeRoomTimelineEventLoader{events: map[uint64]*corev1.Event{10: body, 11: wrongPost}}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   7 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+	if err := projection.Apply(body, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := projection.GetContext(context.Background(), "M1"); err == nil {
+		t.Fatal("cold load unexpectedly succeeded")
+	}
+	projection.RLock()
+	defer projection.RUnlock()
+	entry, _ := projection.entryByEventIDLocked("M1")
+	if entry.Event != nil || projection.bodyStates["M1"].body != nil || projection.buckets[entry.bucket].resident {
+		t.Fatal("failed bucket load installed partial payload")
+	}
+}
+
+func TestRoomTimelineColdBucketAllowsSecurelyDeletedObsoleteBody(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	firstBody, post := bucketTestMessageEvents(at, "B1", "M1")
+	secondBody, _ := bucketTestMessageEvents(at.Add(time.Hour), "B2", "M1")
+	loader := &fakeRoomTimelineEventLoader{events: map[uint64]*corev1.Event{
+		11: secondBody,
+		12: post,
+	}}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   7 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+	for index, event := range []*corev1.Event{firstBody, secondBody, post} {
+		if err := projection.Apply(event, uint64(10+index)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	body, retracted, known, err := projection.LatestBodyContext(context.Background(), "M1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !known || retracted || body.GetBodyEventId() != "B2" {
+		t.Fatalf("body = %#v, retracted=%v known=%v", body, retracted, known)
+	}
+}
+
+func TestRoomTimelineSnapshotKeepsColdBucketPayloadOut(t *testing.T) {
+	at := time.Date(2026, time.March, 3, 12, 0, 0, 0, time.UTC)
+	body, post := bucketTestMessageEvents(at, "B1", "M1")
+	loader := &fakeRoomTimelineEventLoader{events: map[uint64]*corev1.Event{10: body, 11: post}}
+	projection := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: loader,
+		hotWindow:   7 * 24 * time.Hour,
+		now:         func() time.Time { return time.Date(2026, time.July, 24, 0, 0, 0, 0, time.UTC) },
+	})
+	if err := projection.Apply(body, 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(post, 11); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := projection.GetContext(context.Background(), "M1"); err != nil {
+		t.Fatal(err)
+	}
+
+	payload, err := projection.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot := &corev1.RoomTimelineProjectionSnapshotV3{}
+	if err := proto.Unmarshal(payload, snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.GetBuckets()) != 1 || snapshot.GetBuckets()[0].GetPayloadResident() {
+		t.Fatalf("snapshot buckets = %#v, want cold metadata", snapshot.GetBuckets())
+	}
+	if snapshot.GetEntries()[0].GetResidentEvent() != nil || snapshot.GetBodies()[0].GetResidentBody() != nil {
+		t.Fatal("historical payload leaked into snapshot")
+	}
+}

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -2,8 +2,10 @@ package core
 
 import (
 	"context"
+	"io"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"google.golang.org/protobuf/proto"
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -57,6 +59,7 @@ type RoomTimelineProjection struct {
 	hotWindow   time.Duration
 	now         func() time.Time
 	retainAll   bool
+	logger      *log.Logger
 }
 
 // TimelineEntry is one event's position in a room timeline. Event is present
@@ -140,12 +143,17 @@ type roomTimelineProjectionOptions struct {
 	hotWindow   time.Duration
 	now         func() time.Time
 	retainAll   bool
+	logger      *log.Logger
 }
 
 func newRoomTimelineProjection(options roomTimelineProjectionOptions) *RoomTimelineProjection {
 	now := options.now
 	if now == nil {
 		now = time.Now
+	}
+	logger := options.logger
+	if logger == nil {
+		logger = log.New(io.Discard)
 	}
 	return &RoomTimelineProjection{
 		byRoom:                     make(map[string][]int),
@@ -166,6 +174,7 @@ func newRoomTimelineProjection(options roomTimelineProjectionOptions) *RoomTimel
 		hotWindow:                  options.hotWindow,
 		now:                        now,
 		retainAll:                  options.retainAll,
+		logger:                     logger,
 	}
 }
 

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -50,15 +51,27 @@ type RoomTimelineProjection struct {
 	// without deleting the original thread reply's content.
 	hiddenEchoes  map[string]struct{}
 	shreddedUsers map[string]struct{}
+
+	buckets     map[timelineBucketKey]*timelineBucket
+	eventLoader roomTimelineEventLoader
+	hotWindow   time.Duration
+	now         func() time.Time
+	retainAll   bool
 }
 
-// TimelineEntry is one event's position in a room timeline. Carries
-// the full immutable event proto verbatim — payload, envelope, actor,
-// created_at, oneof variant — so resolvers don't need to consult
-// the projection's internal state to render.
+// TimelineEntry is one event's position in a room timeline. Event is present
+// while the entry's weekly bucket is resident; the remaining fields form the
+// lightweight directory used to locate and materialize a cold bucket.
 type TimelineEntry struct {
 	StreamSeq uint64
 	Event     *corev1.Event
+
+	eventID        string
+	roomID         string
+	authorID       string
+	echoOriginalID string
+	bucket         timelineBucketKey
+	messagePosted  bool
 }
 
 type projectedRoomAttachmentMessage struct {
@@ -70,11 +83,31 @@ type timelineBodyState struct {
 	body                *corev1.MessageBody
 	currentSequence     uint64
 	supersededSequences []uint64
+	bucket              timelineBucketKey
+	hasAttachments      bool
 }
 
 func (p *RoomTimelineProjection) appendEntryLocked(seq uint64, event *corev1.Event) int {
+	return p.appendEntryForBucketLocked(seq, event, p.bucketForEventLocked(event))
+}
+
+func (p *RoomTimelineProjection) appendEntryForBucketLocked(seq uint64, event *corev1.Event, bucket timelineBucketKey) int {
 	idx := len(p.entries)
-	p.entries = append(p.entries, TimelineEntry{StreamSeq: seq, Event: event})
+	entry := TimelineEntry{
+		StreamSeq: seq,
+		Event:     event,
+		bucket:    bucket,
+	}
+	if event != nil {
+		entry.eventID = event.GetId()
+		entry.roomID = roomIDOfEvent(event)
+		entry.authorID = messageAuthorID(event)
+		entry.messagePosted = event.GetMessagePosted() != nil
+		if posted := event.GetMessagePosted(); posted != nil {
+			entry.echoOriginalID = posted.GetEchoOfEventId()
+		}
+	}
+	p.entries = append(p.entries, entry)
 	return idx
 }
 
@@ -99,6 +132,21 @@ func (p *RoomTimelineProjection) entryByEventIDLocked(eventID string) (*Timeline
 
 // NewRoomTimelineProjection returns an empty projection.
 func NewRoomTimelineProjection() *RoomTimelineProjection {
+	return newRoomTimelineProjection(roomTimelineProjectionOptions{retainAll: true})
+}
+
+type roomTimelineProjectionOptions struct {
+	eventLoader roomTimelineEventLoader
+	hotWindow   time.Duration
+	now         func() time.Time
+	retainAll   bool
+}
+
+func newRoomTimelineProjection(options roomTimelineProjectionOptions) *RoomTimelineProjection {
+	now := options.now
+	if now == nil {
+		now = time.Now
+	}
 	return &RoomTimelineProjection{
 		byRoom:                     make(map[string][]int),
 		byEventID:                  make(map[string]int),
@@ -113,6 +161,11 @@ func NewRoomTimelineProjection() *RoomTimelineProjection {
 		echoLinks:                  make(map[string][]string),
 		hiddenEchoes:               make(map[string]struct{}),
 		shreddedUsers:              make(map[string]struct{}),
+		buckets:                    make(map[timelineBucketKey]*timelineBucket),
+		eventLoader:                options.eventLoader,
+		hotWindow:                  options.hotWindow,
+		now:                        now,
+		retainAll:                  options.retainAll,
 	}
 }
 
@@ -169,6 +222,9 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 				return nil
 			}
 			if authorID := body.GetAuthorId(); authorID != "" {
+				bucket := p.messageBucketLocked(targetID, roomID, event)
+				p.recordBucketRefLocked(bucket, seq, true)
+				resident := p.bucketResidentLocked(bucket)
 				if _, shredded := p.shreddedUsers[authorID]; shredded {
 					p.clearBodyLocked(targetID)
 					p.retractedFlags[targetID] = struct{}{}
@@ -179,18 +235,29 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 					if body.GetBodyEventId() == "" {
 						body.BodyEventId = event.GetId()
 					}
-					p.setCurrentBodyLocked(targetID, body, seq)
+					p.setCurrentBodyLocked(targetID, body, seq, bucket, resident)
 					delete(p.retractedFlags, targetID)
-					p.refreshAttachmentMessageLocked(roomID, targetID, body)
+					p.refreshAttachmentMessageMetadataLocked(roomID, targetID, body)
 				}
 			}
 		}
 		return nil
 	}
 
+	bucket := p.bucketForMutationLocked(event, roomID)
+	p.recordBucketRefLocked(bucket, seq, false)
+	resident := p.bucketResidentLocked(bucket)
+	retainedEvent := event
+	if !resident {
+		retainedEvent = nil
+	}
 	entryIdx := -1
 	if shouldIndexRoomTimelineEvent(event) {
-		entryIdx = p.appendEntryLocked(seq, event)
+		entryIdx = p.appendEntryForBucketLocked(seq, event, bucket)
+		p.entries[entryIdx].Event = retainedEvent
+		if retainedEvent != nil {
+			p.buckets[bucket].residentBytes += int64(proto.Size(retainedEvent))
+		}
 		if eid := event.GetId(); eid != "" {
 			p.byEventID[eid] = entryIdx
 		}
@@ -222,8 +289,8 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 				p.removeAttachmentMessageLocked(targetID)
 			}
 		}
-		if state, ok := p.bodyStates[targetID]; ok && state.body != nil {
-			p.refreshAttachmentMessageLocked(roomID, targetID, state.body)
+		if state, ok := p.bodyStates[targetID]; ok && state.hasAttachments {
+			p.addAttachmentMessageLocked(roomID, targetID, p.entries[entryIdx].StreamSeq)
 		}
 		// Track echo links so edits on either side can fan out to the
 		// other, and so original retractions can be reflected when
@@ -280,14 +347,13 @@ func (p *RoomTimelineProjection) applyUserKeyShreddedLocked(userID string, at ti
 	}
 	for eventID, idx := range p.byEventID {
 		entry := p.entryAtLocked(idx)
-		if entry == nil || entry.Event == nil {
+		if entry == nil {
 			continue
 		}
-		posted := entry.Event.GetMessagePosted()
-		if posted == nil {
+		if !entry.messagePosted {
 			continue
 		}
-		if messageAuthorID(entry.Event) != userID {
+		if entry.authorID != userID {
 			continue
 		}
 		p.clearBodyLocked(eventID)
@@ -297,13 +363,27 @@ func (p *RoomTimelineProjection) applyUserKeyShreddedLocked(userID string, at ti
 	}
 }
 
-func (p *RoomTimelineProjection) setCurrentBodyLocked(eventID string, body *corev1.MessageBody, sequence uint64) {
+func (p *RoomTimelineProjection) setCurrentBodyLocked(eventID string, body *corev1.MessageBody, sequence uint64, bucket timelineBucketKey, resident bool) {
 	state, exists := p.bodyStates[eventID]
 	if exists {
 		state.supersededSequences = append(state.supersededSequences, state.currentSequence)
+		if state.body != nil {
+			if oldBucket := p.buckets[state.bucket]; oldBucket != nil {
+				oldBucket.residentBytes -= int64(proto.Size(state.body))
+			}
+		}
 	}
-	state.body = body
+	if resident {
+		state.body = body
+		if targetBucket := p.buckets[bucket]; targetBucket != nil {
+			targetBucket.residentBytes += int64(proto.Size(body))
+		}
+	} else {
+		state.body = nil
+	}
 	state.currentSequence = sequence
+	state.bucket = bucket
+	state.hasAttachments = messageBodyReferencesAttachments(body)
 	p.bodyStates[eventID] = state
 }
 
@@ -311,6 +391,11 @@ func (p *RoomTimelineProjection) clearBodyLocked(eventID string) {
 	state, exists := p.bodyStates[eventID]
 	if !exists {
 		return
+	}
+	if state.body != nil {
+		if bucket := p.buckets[state.bucket]; bucket != nil {
+			bucket.residentBytes -= int64(proto.Size(state.body))
+		}
 	}
 	state.body = nil
 	p.bodyStates[eventID] = state
@@ -328,33 +413,52 @@ func (p *RoomTimelineProjection) setTombstonedAtLocked(eventID string, at time.T
 // RoomEvents returns up to `limit` entries from a room's timeline in
 // newest-first order, optionally bounded by an exclusive
 // stream-sequence cursor (beforeStreamSeq == 0 means "from the
-// newest"). Returns a fresh slice; entries and event payloads are immutable
-// and must be treated as read-only by callers.
+// newest"). It materializes any cold bucket needed by the page. Returns a
+// fresh slice; entries and event payloads are immutable and must be treated as
+// read-only by callers.
 //
 // Entries are the room-visible timeline; folded state such as edits, reactions,
 // thread replies, asset processing, and directly hidden echoes is excluded.
 func (p *RoomTimelineProjection) RoomEvents(roomID string, limit int, beforeStreamSeq uint64) []*TimelineEntry {
+	entries, _ := p.RoomEventsContext(context.Background(), roomID, limit, beforeStreamSeq)
+	return entries
+}
+
+func (p *RoomTimelineProjection) RoomEventsContext(ctx context.Context, roomID string, limit int, beforeStreamSeq uint64) ([]*TimelineEntry, error) {
 	if limit <= 0 {
-		return nil
+		return nil, nil
 	}
 	p.RLock()
-	defer p.RUnlock()
 	entryIndexes := p.byRoom[roomID]
 	if len(entryIndexes) == 0 {
-		return nil
+		p.RUnlock()
+		return nil, nil
 	}
-	out := make([]*TimelineEntry, 0, limit)
-	for i := len(entryIndexes) - 1; i >= 0 && len(out) < limit; i-- {
-		e := p.entryAtLocked(entryIndexes[i])
+	selected := make([]int, 0, limit)
+	for i := len(entryIndexes) - 1; i >= 0 && len(selected) < limit; i-- {
+		idx := entryIndexes[i]
+		e := p.entryAtLocked(idx)
 		if e == nil {
 			continue
 		}
 		if beforeStreamSeq > 0 && e.StreamSeq >= beforeStreamSeq {
 			continue
 		}
-		out = append(out, e)
+		selected = append(selected, idx)
 	}
-	return out
+	p.RUnlock()
+	if err := p.ensureEntryIndexes(ctx, selected); err != nil {
+		return nil, err
+	}
+	p.RLock()
+	out := make([]*TimelineEntry, 0, len(selected))
+	for _, idx := range selected {
+		if entry := p.entryAtLocked(idx); entry != nil {
+			out = append(out, entry)
+		}
+	}
+	p.RUnlock()
+	return out, nil
 }
 
 // RoomEventCount returns the total number of non-hidden visible timeline
@@ -409,16 +513,50 @@ func shouldIndexRoomTimelineEvent(event *corev1.Event) bool {
 // Get returns a single timeline entry by its envelope id, or
 // (nil, false) if no such event has been projected.
 func (p *RoomTimelineProjection) Get(eventID string) (*TimelineEntry, bool) {
+	entry, ok, _ := p.GetContext(context.Background(), eventID)
+	return entry, ok
+}
+
+// EventSequence returns an event's EVT stream position without materializing
+// its bucket payload.
+func (p *RoomTimelineProjection) EventSequence(eventID string) (uint64, bool) {
 	p.RLock()
 	defer p.RUnlock()
-	return p.entryByEventIDLocked(eventID)
+
+	entry, ok := p.entryByEventIDLocked(eventID)
+	if !ok {
+		return 0, false
+	}
+	return entry.StreamSeq, true
+}
+
+func (p *RoomTimelineProjection) GetContext(ctx context.Context, eventID string) (*TimelineEntry, bool, error) {
+	p.RLock()
+	entry, ok := p.entryByEventIDLocked(eventID)
+	if !ok {
+		p.RUnlock()
+		return nil, false, nil
+	}
+	bucket := entry.bucket
+	p.RUnlock()
+	if err := p.ensureBucket(ctx, bucket); err != nil {
+		return nil, false, err
+	}
+	p.RLock()
+	entry, ok = p.entryByEventIDLocked(eventID)
+	p.RUnlock()
+	return entry, ok, nil
 }
 
 // LastRoomMessageEntry returns the newest non-hidden MessagePostedEvent in a
 // room, including thread replies that are intentionally absent from byRoom.
 func (p *RoomTimelineProjection) LastRoomMessageEntry(roomID string) (*TimelineEntry, bool) {
+	entry, ok, _ := p.LastRoomMessageEntryContext(context.Background(), roomID)
+	return entry, ok
+}
+
+func (p *RoomTimelineProjection) LastRoomMessageEntryContext(ctx context.Context, roomID string) (*TimelineEntry, bool, error) {
 	p.RLock()
-	defer p.RUnlock()
 	entryIndexes := p.messagePostsByRoom[roomID]
 	for i := len(entryIndexes) - 1; i >= 0; i-- {
 		e := p.entryAtLocked(entryIndexes[i])
@@ -428,9 +566,18 @@ func (p *RoomTimelineProjection) LastRoomMessageEntry(roomID string) (*TimelineE
 		if p.isHiddenEchoEntryLocked(e) {
 			continue
 		}
-		return e, true
+		index := entryIndexes[i]
+		p.RUnlock()
+		if err := p.ensureEntryIndexes(ctx, []int{index}); err != nil {
+			return nil, false, err
+		}
+		p.RLock()
+		e = p.entryAtLocked(index)
+		p.RUnlock()
+		return e, true, nil
 	}
-	return nil, false
+	p.RUnlock()
+	return nil, false, nil
 }
 
 // LatestBody returns the current MessageBodyEvent body for a message, or nil +
@@ -442,41 +589,86 @@ func (p *RoomTimelineProjection) LastRoomMessageEntry(roomID string) (*TimelineE
 // O(1): consults the derived bodyStates / retractedFlags indexes
 // that Apply keeps in lockstep with byRoom.
 func (p *RoomTimelineProjection) LatestBody(eventID string) (body *corev1.MessageBody, retracted bool, ok bool) {
+	body, retracted, ok, _ = p.LatestBodyContext(context.Background(), eventID)
+	return body, retracted, ok
+}
+
+func (p *RoomTimelineProjection) LatestBodyContext(ctx context.Context, eventID string) (body *corev1.MessageBody, retracted bool, ok bool, err error) {
 	p.RLock()
-	defer p.RUnlock()
 	if eventID == "" {
-		return nil, false, false
+		p.RUnlock()
+		return nil, false, false, nil
 	}
 	if _, exists := p.byEventID[eventID]; !exists {
-		return nil, false, false
+		p.RUnlock()
+		return nil, false, false, nil
 	}
 	if _, hidden := p.hiddenEchoes[eventID]; hidden {
-		return nil, true, true
+		p.RUnlock()
+		return nil, true, true, nil
 	}
 	if _, isRetracted := p.retractedFlags[eventID]; isRetracted {
-		return nil, true, true
+		p.RUnlock()
+		return nil, true, true, nil
 	}
 	if origID := p.echoOriginalIDLocked(eventID); origID != "" {
 		if _, originalRetracted := p.retractedFlags[origID]; originalRetracted {
-			return nil, true, true
+			p.RUnlock()
+			return nil, true, true, nil
 		}
 	}
-	if state, has := p.bodyStates[eventID]; has && state.body != nil {
-		return cloneMessageBody(state.body), false, true
+	state, has := p.bodyStates[eventID]
+	if !has {
+		p.RUnlock()
+		return nil, false, true, nil
 	}
-	return nil, false, true
+	bucket := state.bucket
+	if state.body != nil {
+		body = cloneMessageBody(state.body)
+		p.RUnlock()
+		return body, false, true, nil
+	}
+	p.RUnlock()
+	if err := p.ensureBucket(ctx, bucket); err != nil {
+		return nil, false, false, err
+	}
+	p.RLock()
+	defer p.RUnlock()
+	if state, has := p.bodyStates[eventID]; has && state.body != nil {
+		return cloneMessageBody(state.body), false, true, nil
+	}
+	return nil, false, true, nil
 }
 
 // CurrentRoomAttachmentMessages returns current, visible messages whose latest
 // body references attachments. Results are newest message first.
 func (p *RoomTimelineProjection) CurrentRoomAttachmentMessages(roomID string) []projectedRoomAttachmentMessage {
+	messages, _ := p.CurrentRoomAttachmentMessagesContext(context.Background(), roomID)
+	return messages
+}
+
+func (p *RoomTimelineProjection) CurrentRoomAttachmentMessagesContext(ctx context.Context, roomID string) ([]projectedRoomAttachmentMessage, error) {
+	p.RLock()
+
+	ids := append([]string(nil), p.attachmentMessageIDsByRoom[roomID]...)
+	if len(ids) == 0 {
+		p.RUnlock()
+		return nil, nil
+	}
+	keys := make(map[timelineBucketKey]struct{})
+	for _, eventID := range ids {
+		if state, ok := p.bodyStates[eventID]; ok {
+			keys[state.bucket] = struct{}{}
+		}
+	}
+	p.RUnlock()
+	for key := range keys {
+		if err := p.ensureBucket(ctx, key); err != nil {
+			return nil, err
+		}
+	}
 	p.RLock()
 	defer p.RUnlock()
-
-	ids := p.attachmentMessageIDsByRoom[roomID]
-	if len(ids) == 0 {
-		return nil
-	}
 
 	out := make([]projectedRoomAttachmentMessage, 0, len(ids))
 	for i := len(ids) - 1; i >= 0; i-- {
@@ -502,7 +694,20 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessages(roomID string) []
 			Body:  cloneMessageBody(body),
 		})
 	}
-	return out
+	return out, nil
+}
+
+func (p *RoomTimelineProjection) refreshAttachmentMessageMetadataLocked(roomID, eventID string, body *corev1.MessageBody) {
+	state := p.bodyStates[eventID]
+	state.hasAttachments = messageBodyReferencesAttachments(body)
+	p.bodyStates[eventID] = state
+	if !state.hasAttachments {
+		p.removeAttachmentMessageLocked(eventID)
+		return
+	}
+	if entry, ok := p.entryByEventIDLocked(eventID); ok {
+		p.addAttachmentMessageLocked(roomID, eventID, entry.StreamSeq)
+	}
 }
 
 func (p *RoomTimelineProjection) refreshAttachmentMessageLocked(roomID, eventID string, body *corev1.MessageBody) {
@@ -514,7 +719,7 @@ func (p *RoomTimelineProjection) refreshAttachmentMessageLocked(roomID, eventID 
 		return
 	}
 	entry, _ := p.entryByEventIDLocked(eventID)
-	if entry == nil || entry.Event == nil || p.isHiddenEchoEntryLocked(entry) {
+	if entry == nil || p.isHiddenEchoEntryLocked(entry) {
 		return
 	}
 	p.addAttachmentMessageLocked(roomID, eventID, entry.StreamSeq)
@@ -652,14 +857,13 @@ func appendBodySequences(dst []uint64, state timelineBodyState) []uint64 {
 
 func (p *RoomTimelineProjection) echoOriginalIDLocked(eventID string) string {
 	entry, ok := p.entryByEventIDLocked(eventID)
-	if !ok || entry == nil || entry.Event == nil {
+	if !ok || entry == nil {
 		return ""
 	}
-	posted := entry.Event.GetMessagePosted()
-	if posted == nil {
+	if !entry.messagePosted {
 		return ""
 	}
-	return posted.GetEchoOfEventId()
+	return entry.echoOriginalID
 }
 
 // IsEcho reports whether eventID is a MessagePostedEvent echo.
@@ -667,6 +871,16 @@ func (p *RoomTimelineProjection) IsEcho(eventID string) bool {
 	p.RLock()
 	defer p.RUnlock()
 	return p.echoOriginalIDLocked(eventID) != ""
+}
+
+func (p *RoomTimelineProjection) messageLocator(eventID string) (roomID, echoOriginalID string, ok bool) {
+	p.RLock()
+	defer p.RUnlock()
+	entry, ok := p.entryByEventIDLocked(eventID)
+	if !ok || entry == nil || !entry.messagePosted {
+		return "", "", false
+	}
+	return entry.roomID, entry.echoOriginalID, true
 }
 
 // IsHiddenEcho reports whether an echo has been directly retracted from the
@@ -811,8 +1025,8 @@ func (p *RoomTimelineProjection) LinkedEventIDs(eventID string) []string {
 
 	// Backward: if this event IS an echo, include the original.
 	if entry, ok := p.entryByEventIDLocked(eventID); ok {
-		if posted := entry.Event.GetMessagePosted(); posted != nil {
-			if origID := posted.GetEchoOfEventId(); origID != "" && origID != eventID {
+		if entry.messagePosted {
+			if origID := entry.echoOriginalID; origID != "" && origID != eventID {
 				linked = append(linked, origID)
 				// Also include any sibling echoes of the same original
 				// (rare, but possible if "also send to channel" was
@@ -837,23 +1051,45 @@ func (p *RoomTimelineProjection) LastVisibleRoomEntry(
 	roomID string,
 	visible func(*corev1.Event) bool,
 ) (*TimelineEntry, bool) {
+	entry, ok, _ := p.LastVisibleRoomEntryContext(context.Background(), roomID, visible)
+	return entry, ok
+}
+
+func (p *RoomTimelineProjection) LastVisibleRoomEntryContext(
+	ctx context.Context,
+	roomID string,
+	visible func(*corev1.Event) bool,
+) (*TimelineEntry, bool, error) {
 	p.RLock()
-	defer p.RUnlock()
-	entryIndexes := p.byRoom[roomID]
+	entryIndexes := append([]int(nil), p.byRoom[roomID]...)
+	p.RUnlock()
 	for i := len(entryIndexes) - 1; i >= 0; i-- {
-		e := p.entryAtLocked(entryIndexes[i])
+		idx := entryIndexes[i]
+		p.RLock()
+		e := p.entryAtLocked(idx)
 		if e == nil {
+			p.RUnlock()
 			continue
 		}
 		if p.isHiddenEchoEntryLocked(e) {
+			p.RUnlock()
 			continue
 		}
+		bucket := e.bucket
+		p.RUnlock()
+		if err := p.ensureBucket(ctx, bucket); err != nil {
+			return nil, false, err
+		}
+		p.RLock()
+		e = p.entryAtLocked(idx)
 		if visible != nil && !visible(e.Event) {
+			p.RUnlock()
 			continue
 		}
-		return e, true
+		p.RUnlock()
+		return e, true, nil
 	}
-	return nil, false
+	return nil, false, nil
 }
 
 // VisibleRoomTimeline walks the room's visible timeline newest-first, applying
@@ -873,30 +1109,55 @@ func (p *RoomTimelineProjection) VisibleRoomTimeline(
 	beforeStreamSeq uint64,
 	visible func(*corev1.Event) bool,
 ) []*TimelineEntry {
+	entries, _ := p.VisibleRoomTimelineContext(context.Background(), roomID, limit, beforeStreamSeq, visible)
+	return entries
+}
+
+func (p *RoomTimelineProjection) VisibleRoomTimelineContext(
+	ctx context.Context,
+	roomID string,
+	limit int,
+	beforeStreamSeq uint64,
+	visible func(*corev1.Event) bool,
+) ([]*TimelineEntry, error) {
 	if limit <= 0 {
-		return nil
+		return nil, nil
 	}
 	p.RLock()
-	defer p.RUnlock()
-	entryIndexes := p.byRoom[roomID]
+	entryIndexes := append([]int(nil), p.byRoom[roomID]...)
+	p.RUnlock()
 	out := make([]*TimelineEntry, 0, limit)
 	for i := len(entryIndexes) - 1; i >= 0 && len(out) < limit; i-- {
-		e := p.entryAtLocked(entryIndexes[i])
+		idx := entryIndexes[i]
+		p.RLock()
+		e := p.entryAtLocked(idx)
 		if e == nil {
+			p.RUnlock()
 			continue
 		}
 		if beforeStreamSeq > 0 && e.StreamSeq >= beforeStreamSeq {
+			p.RUnlock()
 			continue
 		}
 		if p.isHiddenEchoEntryLocked(e) {
+			p.RUnlock()
 			continue
 		}
+		bucket := e.bucket
+		p.RUnlock()
+		if err := p.ensureBucket(ctx, bucket); err != nil {
+			return nil, err
+		}
+		p.RLock()
+		e = p.entryAtLocked(idx)
 		if visible != nil && !visible(e.Event) {
+			p.RUnlock()
 			continue
 		}
 		out = append(out, e)
+		p.RUnlock()
 	}
-	return out
+	return out, nil
 }
 
 // VisibleRoomTimelineAfter walks the room's timeline oldest-first,
@@ -909,33 +1170,57 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAfter(
 	afterStreamSeq uint64,
 	visible func(*corev1.Event) bool,
 ) []*TimelineEntry {
+	entries, _ := p.VisibleRoomTimelineAfterContext(context.Background(), roomID, limit, afterStreamSeq, visible)
+	return entries
+}
+
+func (p *RoomTimelineProjection) VisibleRoomTimelineAfterContext(
+	ctx context.Context,
+	roomID string,
+	limit int,
+	afterStreamSeq uint64,
+	visible func(*corev1.Event) bool,
+) ([]*TimelineEntry, error) {
 	if limit <= 0 {
-		return nil
+		return nil, nil
 	}
 	p.RLock()
-	defer p.RUnlock()
-	entryIndexes := p.byRoom[roomID]
+	entryIndexes := append([]int(nil), p.byRoom[roomID]...)
+	p.RUnlock()
 	out := make([]*TimelineEntry, 0, limit)
 	for _, idx := range entryIndexes {
+		p.RLock()
 		e := p.entryAtLocked(idx)
 		if e == nil {
+			p.RUnlock()
 			continue
 		}
 		if e.StreamSeq <= afterStreamSeq {
+			p.RUnlock()
 			continue
 		}
 		if p.isHiddenEchoEntryLocked(e) {
+			p.RUnlock()
 			continue
 		}
+		bucket := e.bucket
+		p.RUnlock()
+		if err := p.ensureBucket(ctx, bucket); err != nil {
+			return nil, err
+		}
+		p.RLock()
+		e = p.entryAtLocked(idx)
 		if visible != nil && !visible(e.Event) {
+			p.RUnlock()
 			continue
 		}
 		out = append(out, e)
+		p.RUnlock()
 		if len(out) >= limit {
 			break
 		}
 	}
-	return out
+	return out, nil
 }
 
 // VisibleRoomTimelineAround returns a room-visible window centered on eventID
@@ -947,11 +1232,20 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 	eventID string,
 	limit int,
 ) (entries []*TimelineEntry, targetIndex int, hasOlder bool, hasNewer bool, ok bool) {
+	entries, targetIndex, hasOlder, hasNewer, ok, _ = p.VisibleRoomTimelineAroundContext(context.Background(), roomID, eventID, limit)
+	return entries, targetIndex, hasOlder, hasNewer, ok
+}
+
+func (p *RoomTimelineProjection) VisibleRoomTimelineAroundContext(
+	ctx context.Context,
+	roomID string,
+	eventID string,
+	limit int,
+) (entries []*TimelineEntry, targetIndex int, hasOlder bool, hasNewer bool, ok bool, err error) {
 	if limit <= 0 || eventID == "" {
-		return nil, 0, false, false, false
+		return nil, 0, false, false, false, nil
 	}
 	p.RLock()
-	defer p.RUnlock()
 	roomEntries := p.byRoom[roomID]
 	targetVisibleIndex := -1
 	visibleCount := 0
@@ -960,13 +1254,14 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 		if p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}
-		if entry != nil && entry.Event != nil && entry.Event.GetId() == eventID {
+		if entry != nil && entry.eventID == eventID {
 			targetVisibleIndex = visibleCount
 		}
 		visibleCount++
 	}
 	if targetVisibleIndex == -1 {
-		return nil, 0, false, false, false
+		p.RUnlock()
+		return nil, 0, false, false, false, nil
 	}
 
 	start := targetVisibleIndex - (limit-1)/2
@@ -982,7 +1277,7 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 		}
 	}
 
-	out := make([]*TimelineEntry, 0, end-start)
+	selected := make([]int, 0, end-start)
 	visibleIndex := 0
 	for _, idx := range roomEntries {
 		entry := p.entryAtLocked(idx)
@@ -990,20 +1285,32 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAround(
 			continue
 		}
 		if visibleIndex >= start && visibleIndex < end {
-			out = append(out, entry)
+			selected = append(selected, idx)
 		}
 		visibleIndex++
 		if visibleIndex >= end {
 			break
 		}
 	}
-	return out, targetVisibleIndex - start, start > 0, end < visibleCount, true
+	p.RUnlock()
+	if err := p.ensureEntryIndexes(ctx, selected); err != nil {
+		return nil, 0, false, false, false, err
+	}
+	p.RLock()
+	out := make([]*TimelineEntry, 0, len(selected))
+	for _, idx := range selected {
+		if entry := p.entryAtLocked(idx); entry != nil {
+			out = append(out, entry)
+		}
+	}
+	p.RUnlock()
+	return out, targetVisibleIndex - start, start > 0, end < visibleCount, true, nil
 }
 
 func (p *RoomTimelineProjection) isHiddenEchoEntryLocked(entry *TimelineEntry) bool {
-	if entry == nil || entry.Event == nil {
+	if entry == nil {
 		return false
 	}
-	_, hidden := p.hiddenEchoes[entry.Event.GetId()]
+	_, hidden := p.hiddenEchoes[entry.eventID]
 	return hidden
 }

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -634,6 +634,20 @@ func (p *RoomTimelineProjection) LatestBodyContext(ctx context.Context, eventID 
 	}
 	p.RLock()
 	defer p.RUnlock()
+	if _, exists := p.byEventID[eventID]; !exists {
+		return nil, false, false, nil
+	}
+	if _, hidden := p.hiddenEchoes[eventID]; hidden {
+		return nil, true, true, nil
+	}
+	if _, isRetracted := p.retractedFlags[eventID]; isRetracted {
+		return nil, true, true, nil
+	}
+	if origID := p.echoOriginalIDLocked(eventID); origID != "" {
+		if _, originalRetracted := p.retractedFlags[origID]; originalRetracted {
+			return nil, true, true, nil
+		}
+	}
 	if state, has := p.bodyStates[eventID]; has && state.body != nil {
 		return cloneMessageBody(state.body), false, true, nil
 	}
@@ -708,21 +722,6 @@ func (p *RoomTimelineProjection) refreshAttachmentMessageMetadataLocked(roomID, 
 	if entry, ok := p.entryByEventIDLocked(eventID); ok {
 		p.addAttachmentMessageLocked(roomID, eventID, entry.StreamSeq)
 	}
-}
-
-func (p *RoomTimelineProjection) refreshAttachmentMessageLocked(roomID, eventID string, body *corev1.MessageBody) {
-	if roomID == "" || eventID == "" {
-		return
-	}
-	if !messageBodyReferencesAttachments(body) {
-		p.removeAttachmentMessageLocked(eventID)
-		return
-	}
-	entry, _ := p.entryByEventIDLocked(eventID)
-	if entry == nil || p.isHiddenEchoEntryLocked(entry) {
-		return
-	}
-	p.addAttachmentMessageLocked(roomID, eventID, entry.StreamSeq)
 }
 
 func (p *RoomTimelineProjection) addAttachmentMessageLocked(roomID, eventID string, streamSeq uint64) {

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -21,38 +21,43 @@ import (
 type RoomTimelineProjection struct {
 	events.MemoryProjection
 	entries            []TimelineEntry
-	byRoom             map[string][]int
-	byEventID          map[string]int
-	messagePostsByRoom map[string][]int
+	eventIDs           projectionStringTable
+	roomIDs            projectionStringTable
+	userIDs            projectionStringTable
+	entryByEvent       []int32
+	byRoom             map[timelineRoomRef][]timelineEntryRef
+	messagePostsByRoom map[timelineRoomRef][]timelineEntryRef
 	replayGuard        projectionReplayGuard
-	// bodyStates keeps the current encrypted body and its EVT lifecycle in one
-	// entry per message. supersededSequences stays nil until the first edit,
-	// avoiding a slice allocation for the common single-body case.
-	bodyStates     map[string]timelineBodyState
-	retractedFlags map[string]struct{}
+	// bodyStates keeps compact lifecycle and bucket coordinates in one dense
+	// row per retained ID. Decoded current bodies and the uncommon superseded
+	// sequence lists live separately so cold, never-edited messages pay for
+	// neither pointer-heavy shape.
+	bodyStates              []timelineBodyState
+	currentBodies           []*corev1.MessageBody
+	supersededBodySequences map[timelineEventRef][]uint64
 	// tombstonedAt records when message content first became unavailable
 	// through a durable retraction or user key-shred fact. It deliberately does
 	// not cover missing/corrupt body payloads so clients can distinguish those
 	// states from deletions.
-	tombstonedAt map[string]time.Time
-	shreddedAt   map[string]time.Time
-	// attachmentMessageIDsByRoom tracks messages whose current body contains
+	tombstonedAt map[timelineEventRef]time.Time
+	shreddedAt   map[timelineUserRef]time.Time
+	// attachmentMessagesByRoom tracks messages whose current body contains
 	// attachment/asset references. It lets room file reads page over current
 	// file-bearing messages instead of decrypting every message body in a room.
-	attachmentMessageIDsByRoom map[string][]string
-	attachmentMessageRoom      map[string]string
+	attachmentMessagesByRoom map[timelineRoomRef][]timelineEventRef
+	attachmentMessageRoom    []timelineRoomRef
 	// echoLinks maps an original message's event_id to the event_ids
 	// of any echoes pointing at it. Maintained as MessagePostedEvents
 	// with EchoOfEventId arrive. Used by EditMessage / DeleteMessage
 	// to fan mutations across linked messages. Each echo has its own
 	// projected body payload, so edits and retractions need explicit
 	// propagation.
-	echoLinks map[string][]string
-	// hiddenEchoes tracks echo MessagePostedEvents that were directly
-	// retracted. A direct echo retract removes the room-timeline copy
-	// without deleting the original thread reply's content.
-	hiddenEchoes  map[string]struct{}
-	shreddedUsers map[string]struct{}
+	echoLinks map[timelineEventRef][]timelineEventRef
+	// messageFlags packs retracted and directly hidden-echo state by event
+	// handle. A direct echo retract removes the room-timeline copy without
+	// deleting the original thread reply's content.
+	messageFlags  []timelineMessageFlags
+	shreddedUsers []bool
 
 	buckets     map[timelineBucketKey]*timelineBucket
 	eventLoader roomTimelineEventLoader
@@ -62,6 +67,20 @@ type RoomTimelineProjection struct {
 	logger      *log.Logger
 }
 
+type timelineEventRef uint32
+type timelineRoomRef uint32
+type timelineUserRef uint32
+type timelineEntryRef uint32
+
+const missingTimelineEntry = int32(-1)
+
+type timelineMessageFlags uint8
+
+const (
+	timelineMessageRetracted timelineMessageFlags = 1 << iota
+	timelineMessageHiddenEcho
+)
+
 // TimelineEntry is one event's position in a room timeline. Event is present
 // while the entry's weekly bucket is resident; the remaining fields form the
 // lightweight directory used to locate and materialize a cold bucket.
@@ -69,10 +88,10 @@ type TimelineEntry struct {
 	StreamSeq uint64
 	Event     *corev1.Event
 
-	eventID        string
-	roomID         string
-	authorID       string
-	echoOriginalID string
+	eventID        timelineEventRef
+	roomID         timelineRoomRef
+	authorID       timelineUserRef
+	echoOriginalID timelineEventRef
 	bucket         timelineBucketKey
 	messagePosted  bool
 }
@@ -83,11 +102,10 @@ type projectedRoomAttachmentMessage struct {
 }
 
 type timelineBodyState struct {
-	body                *corev1.MessageBody
-	currentSequence     uint64
-	supersededSequences []uint64
-	bucket              timelineBucketKey
-	hasAttachments      bool
+	currentSequence uint64
+	bucket          timelineBucketKey
+	hasAttachments  bool
+	known           bool
 }
 
 func (p *RoomTimelineProjection) appendEntryLocked(seq uint64, event *corev1.Event) int {
@@ -102,35 +120,122 @@ func (p *RoomTimelineProjection) appendEntryForBucketLocked(seq uint64, event *c
 		bucket:    bucket,
 	}
 	if event != nil {
-		entry.eventID = event.GetId()
-		entry.roomID = roomIDOfEvent(event)
-		entry.authorID = messageAuthorID(event)
+		entry.eventID = p.internEventIDLocked(event.GetId())
+		entry.roomID = p.internRoomIDLocked(roomIDOfEvent(event))
+		entry.authorID = p.internUserIDLocked(messageAuthorID(event))
 		entry.messagePosted = event.GetMessagePosted() != nil
 		if posted := event.GetMessagePosted(); posted != nil {
-			entry.echoOriginalID = posted.GetEchoOfEventId()
+			entry.echoOriginalID = p.internEventIDLocked(posted.GetEchoOfEventId())
 		}
 	}
 	p.entries = append(p.entries, entry)
 	return idx
 }
 
-func (p *RoomTimelineProjection) entryAtLocked(idx int) *TimelineEntry {
-	if idx < 0 || idx >= len(p.entries) {
+func (p *RoomTimelineProjection) entryAtLocked(ref timelineEntryRef) *TimelineEntry {
+	if int(ref) >= len(p.entries) {
 		return nil
 	}
-	return &p.entries[idx]
+	return &p.entries[ref]
 }
 
 func (p *RoomTimelineProjection) entryByEventIDLocked(eventID string) (*TimelineEntry, bool) {
-	idx, ok := p.byEventID[eventID]
-	if !ok {
+	raw, ok := p.eventIDs.lookup(eventID)
+	if !ok || int(raw) >= len(p.entryByEvent) {
 		return nil, false
 	}
-	entry := p.entryAtLocked(idx)
+	idx := p.entryByEvent[raw]
+	if idx == missingTimelineEntry {
+		return nil, false
+	}
+	entry := p.entryAtLocked(timelineEntryRef(idx))
 	if entry == nil {
 		return nil, false
 	}
 	return entry, true
+}
+
+func (p *RoomTimelineProjection) internEventIDLocked(id string) timelineEventRef {
+	ref := timelineEventRef(p.eventIDs.intern(id))
+	for len(p.entryByEvent) <= int(ref) {
+		p.entryByEvent = append(p.entryByEvent, missingTimelineEntry)
+	}
+	p.bodyStates = growProjectionSlice(p.bodyStates, uint32(ref))
+	p.currentBodies = growProjectionSlice(p.currentBodies, uint32(ref))
+	p.messageFlags = growProjectionSlice(p.messageFlags, uint32(ref))
+	for i := len(p.attachmentMessageRoom); i <= int(ref); i++ {
+		p.attachmentMessageRoom = append(p.attachmentMessageRoom, 0)
+	}
+	return ref
+}
+
+func (p *RoomTimelineProjection) internRoomIDLocked(id string) timelineRoomRef {
+	return timelineRoomRef(p.roomIDs.intern(id))
+}
+
+func (p *RoomTimelineProjection) internUserIDLocked(id string) timelineUserRef {
+	ref := timelineUserRef(p.userIDs.intern(id))
+	p.shreddedUsers = growProjectionSlice(p.shreddedUsers, uint32(ref))
+	return ref
+}
+
+func (p *RoomTimelineProjection) eventIDLocked(ref timelineEventRef) string {
+	return p.eventIDs.value(uint32(ref))
+}
+
+func (p *RoomTimelineProjection) roomIDLocked(ref timelineRoomRef) string {
+	return p.roomIDs.value(uint32(ref))
+}
+
+func (p *RoomTimelineProjection) userIDLocked(ref timelineUserRef) string {
+	return p.userIDs.value(uint32(ref))
+}
+
+func (p *RoomTimelineProjection) eventRefLocked(id string) (timelineEventRef, bool) {
+	ref, ok := p.eventIDs.lookup(id)
+	return timelineEventRef(ref), ok
+}
+
+func (p *RoomTimelineProjection) roomRefLocked(id string) (timelineRoomRef, bool) {
+	ref, ok := p.roomIDs.lookup(id)
+	return timelineRoomRef(ref), ok
+}
+
+func (p *RoomTimelineProjection) bodyStateByEventIDLocked(id string) (timelineBodyState, bool) {
+	ref, ok := p.eventRefLocked(id)
+	if !ok || int(ref) >= len(p.bodyStates) || !p.bodyStates[ref].known {
+		return timelineBodyState{}, false
+	}
+	return p.bodyStates[ref], true
+}
+
+func (p *RoomTimelineProjection) currentBodyByEventIDLocked(id string) *corev1.MessageBody {
+	ref, ok := p.eventRefLocked(id)
+	if !ok || int(ref) >= len(p.currentBodies) {
+		return nil
+	}
+	return p.currentBodies[ref]
+}
+
+func (p *RoomTimelineProjection) supersededBodySequencesByEventIDLocked(id string) []uint64 {
+	ref, ok := p.eventRefLocked(id)
+	if !ok {
+		return nil
+	}
+	return p.supersededBodySequences[ref]
+}
+
+func (p *RoomTimelineProjection) messageFlagLocked(ref timelineEventRef, flag timelineMessageFlags) bool {
+	return int(ref) < len(p.messageFlags) && p.messageFlags[ref]&flag != 0
+}
+
+func (p *RoomTimelineProjection) setMessageFlagLocked(ref timelineEventRef, flag timelineMessageFlags, enabled bool) {
+	p.messageFlags = growProjectionSlice(p.messageFlags, uint32(ref))
+	if enabled {
+		p.messageFlags[ref] |= flag
+	} else {
+		p.messageFlags[ref] &^= flag
+	}
 }
 
 // NewRoomTimelineProjection returns an empty projection.
@@ -156,25 +261,29 @@ func newRoomTimelineProjection(options roomTimelineProjectionOptions) *RoomTimel
 		logger = log.New(io.Discard)
 	}
 	return &RoomTimelineProjection{
-		byRoom:                     make(map[string][]int),
-		byEventID:                  make(map[string]int),
-		messagePostsByRoom:         make(map[string][]int),
-		replayGuard:                newProjectionReplayGuard(),
-		bodyStates:                 make(map[string]timelineBodyState),
-		retractedFlags:             make(map[string]struct{}),
-		tombstonedAt:               make(map[string]time.Time),
-		shreddedAt:                 make(map[string]time.Time),
-		attachmentMessageIDsByRoom: make(map[string][]string),
-		attachmentMessageRoom:      make(map[string]string),
-		echoLinks:                  make(map[string][]string),
-		hiddenEchoes:               make(map[string]struct{}),
-		shreddedUsers:              make(map[string]struct{}),
-		buckets:                    make(map[timelineBucketKey]*timelineBucket),
-		eventLoader:                options.eventLoader,
-		hotWindow:                  options.hotWindow,
-		now:                        now,
-		retainAll:                  options.retainAll,
-		logger:                     logger,
+		eventIDs:                 newProjectionStringTable(),
+		roomIDs:                  newProjectionStringTable(),
+		userIDs:                  newProjectionStringTable(),
+		entryByEvent:             []int32{missingTimelineEntry},
+		byRoom:                   make(map[timelineRoomRef][]timelineEntryRef),
+		messagePostsByRoom:       make(map[timelineRoomRef][]timelineEntryRef),
+		replayGuard:              newProjectionReplayGuard(),
+		bodyStates:               make([]timelineBodyState, 1),
+		currentBodies:            make([]*corev1.MessageBody, 1),
+		supersededBodySequences:  make(map[timelineEventRef][]uint64),
+		tombstonedAt:             make(map[timelineEventRef]time.Time),
+		shreddedAt:               make(map[timelineUserRef]time.Time),
+		attachmentMessagesByRoom: make(map[timelineRoomRef][]timelineEventRef),
+		attachmentMessageRoom:    make([]timelineRoomRef, 1),
+		echoLinks:                make(map[timelineEventRef][]timelineEventRef),
+		messageFlags:             make([]timelineMessageFlags, 1),
+		shreddedUsers:            make([]bool, 1),
+		buckets:                  make(map[timelineBucketKey]*timelineBucket),
+		eventLoader:              options.eventLoader,
+		hotWindow:                options.hotWindow,
+		now:                      now,
+		retainAll:                options.retainAll,
+		logger:                   logger,
 	}
 }
 
@@ -231,15 +340,17 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 				return nil
 			}
 			if authorID := body.GetAuthorId(); authorID != "" {
+				targetRef := p.internEventIDLocked(targetID)
+				authorRef := p.internUserIDLocked(authorID)
 				bucket := p.messageBucketLocked(targetID, roomID, event)
 				if err := p.recordBucketRefLocked(bucket, seq, true); err != nil {
 					return err
 				}
 				resident := p.bucketResidentLocked(bucket)
-				if _, shredded := p.shreddedUsers[authorID]; shredded {
+				if p.shreddedUsers[authorRef] {
 					p.clearBodyLocked(targetID)
-					p.retractedFlags[targetID] = struct{}{}
-					p.setTombstonedAtLocked(targetID, p.shreddedAt[authorID])
+					p.setMessageFlagLocked(targetRef, timelineMessageRetracted, true)
+					p.setTombstonedAtLocked(targetID, p.shreddedAt[authorRef])
 					p.removeAttachmentMessageLocked(targetID)
 				} else {
 					body = cloneMessageBody(body)
@@ -247,7 +358,7 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 						body.BodyEventId = event.GetId()
 					}
 					p.setCurrentBodyLocked(targetID, body, seq, bucket, resident)
-					delete(p.retractedFlags, targetID)
+					p.setMessageFlagLocked(targetRef, timelineMessageRetracted, false)
 					p.refreshAttachmentMessageMetadataLocked(roomID, targetID, body)
 				}
 			}
@@ -264,28 +375,30 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 	if !resident {
 		retainedEvent = nil
 	}
-	entryIdx := -1
+	entryIdx := int32(-1)
 	if shouldIndexRoomTimelineEvent(event) {
-		entryIdx = p.appendEntryForBucketLocked(seq, event, bucket)
+		entryIdx = int32(p.appendEntryForBucketLocked(seq, event, bucket))
 		p.entries[entryIdx].Event = retainedEvent
 		if retainedEvent != nil {
 			p.buckets[bucket].residentBytes += int64(proto.Size(retainedEvent))
 		}
-		if eid := event.GetId(); eid != "" {
-			p.byEventID[eid] = entryIdx
+		if eventRef := p.entries[entryIdx].eventID; eventRef != 0 {
+			p.entryByEvent[eventRef] = entryIdx
 		}
 	}
 	if event.GetMessagePosted() != nil {
 		if entryIdx < 0 {
-			entryIdx = p.appendEntryLocked(seq, event)
+			entryIdx = int32(p.appendEntryLocked(seq, event))
 		}
-		p.messagePostsByRoom[roomID] = append(p.messagePostsByRoom[roomID], entryIdx)
+		roomRef := p.internRoomIDLocked(roomID)
+		p.messagePostsByRoom[roomRef] = append(p.messagePostsByRoom[roomRef], timelineEntryRef(entryIdx))
 	}
 	if isVisibleRoomTimelineEntry(event) {
 		if entryIdx < 0 {
-			entryIdx = p.appendEntryLocked(seq, event)
+			entryIdx = int32(p.appendEntryLocked(seq, event))
 		}
-		p.byRoom[roomID] = append(p.byRoom[roomID], entryIdx)
+		roomRef := p.internRoomIDLocked(roomID)
+		p.byRoom[roomRef] = append(p.byRoom[roomRef], timelineEntryRef(entryIdx))
 	}
 
 	// Maintain the latest-body / retracted-flag derived index so
@@ -293,38 +406,42 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 	switch ev := event.GetEvent().(type) {
 	case *corev1.Event_MessagePosted:
 		targetID := event.GetId()
+		targetRef := p.internEventIDLocked(targetID)
 		if targetID != "" {
-			authorID := messageAuthorID(event)
-			if _, shredded := p.shreddedUsers[authorID]; shredded {
+			authorRef := p.internUserIDLocked(messageAuthorID(event))
+			if p.shreddedUsers[authorRef] {
 				p.clearBodyLocked(targetID)
-				p.retractedFlags[targetID] = struct{}{}
-				p.setTombstonedAtLocked(targetID, p.shreddedAt[authorID])
+				p.setMessageFlagLocked(targetRef, timelineMessageRetracted, true)
+				p.setTombstonedAtLocked(targetID, p.shreddedAt[authorRef])
 				p.removeAttachmentMessageLocked(targetID)
 			}
 		}
-		if state, ok := p.bodyStates[targetID]; ok && state.hasAttachments {
+		if state := p.bodyStates[targetRef]; state.known && state.hasAttachments {
 			p.addAttachmentMessageLocked(roomID, targetID, p.entries[entryIdx].StreamSeq)
 		}
 		// Track echo links so edits on either side can fan out to the
 		// other, and so original retractions can be reflected when
 		// rendering echoes.
 		if origID := ev.MessagePosted.GetEchoOfEventId(); origID != "" && targetID != "" {
-			p.echoLinks[origID] = append(p.echoLinks[origID], targetID)
+			origRef := p.internEventIDLocked(origID)
+			p.echoLinks[origRef] = append(p.echoLinks[origRef], targetRef)
 		}
 	case *corev1.Event_MessageRetracted:
 		targetID := ev.MessageRetracted.GetEventId()
 		if targetID != "" {
+			targetRef := p.internEventIDLocked(targetID)
 			p.setTombstonedAtLocked(targetID, eventCreatedAt(event))
 			if origID := p.echoOriginalIDLocked(targetID); origID != "" {
-				if _, originalRetracted := p.retractedFlags[origID]; !originalRetracted {
+				origRef, _ := p.eventRefLocked(origID)
+				if !p.messageFlagLocked(origRef, timelineMessageRetracted) {
 					p.clearBodyLocked(targetID)
-					p.hiddenEchoes[targetID] = struct{}{}
+					p.setMessageFlagLocked(targetRef, timelineMessageHiddenEcho, true)
 					p.removeAttachmentMessageLocked(targetID)
 					return nil
 				}
 			}
 			p.clearBodyLocked(targetID)
-			p.retractedFlags[targetID] = struct{}{}
+			p.setMessageFlagLocked(targetRef, timelineMessageRetracted, true)
 			p.removeAttachmentMessageLocked(targetID)
 		}
 	}
@@ -351,75 +468,84 @@ func (p *RoomTimelineProjection) applyUserKeyShreddedLocked(userID string, at ti
 	if userID == "" {
 		return
 	}
-	p.shreddedUsers[userID] = struct{}{}
+	userRef := p.internUserIDLocked(userID)
+	p.shreddedUsers[userRef] = true
 	if !at.IsZero() {
-		if existing, ok := p.shreddedAt[userID]; !ok || at.Before(existing) {
-			p.shreddedAt[userID] = at
+		if existing, ok := p.shreddedAt[userRef]; !ok || at.Before(existing) {
+			p.shreddedAt[userRef] = at
 		}
-		at = p.shreddedAt[userID]
+		at = p.shreddedAt[userRef]
 	}
-	for eventID, idx := range p.byEventID {
-		entry := p.entryAtLocked(idx)
+	for idx := range p.entries {
+		entry := &p.entries[idx]
 		if entry == nil {
 			continue
 		}
 		if !entry.messagePosted {
 			continue
 		}
-		if entry.authorID != userID {
+		if entry.authorID != userRef {
 			continue
 		}
+		eventRef := entry.eventID
+		eventID := p.eventIDLocked(eventRef)
 		p.clearBodyLocked(eventID)
-		p.retractedFlags[eventID] = struct{}{}
+		p.setMessageFlagLocked(eventRef, timelineMessageRetracted, true)
 		p.setTombstonedAtLocked(eventID, at)
 		p.removeAttachmentMessageLocked(eventID)
 	}
 }
 
 func (p *RoomTimelineProjection) setCurrentBodyLocked(eventID string, body *corev1.MessageBody, sequence uint64, bucket timelineBucketKey, resident bool) {
-	state, exists := p.bodyStates[eventID]
-	if exists {
-		state.supersededSequences = append(state.supersededSequences, state.currentSequence)
-		if state.body != nil {
+	eventRef := p.internEventIDLocked(eventID)
+	state := p.bodyStates[eventRef]
+	if state.known {
+		p.supersededBodySequences[eventRef] = append(p.supersededBodySequences[eventRef], state.currentSequence)
+		if p.currentBodies[eventRef] != nil {
 			if oldBucket := p.buckets[state.bucket]; oldBucket != nil {
-				oldBucket.residentBytes -= int64(proto.Size(state.body))
+				oldBucket.residentBytes -= int64(proto.Size(p.currentBodies[eventRef]))
 			}
 		}
 	}
 	if resident {
-		state.body = body
+		p.currentBodies[eventRef] = body
 		if targetBucket := p.buckets[bucket]; targetBucket != nil {
 			targetBucket.residentBytes += int64(proto.Size(body))
 		}
 	} else {
-		state.body = nil
+		p.currentBodies[eventRef] = nil
 	}
 	state.currentSequence = sequence
 	state.bucket = bucket
 	state.hasAttachments = messageBodyReferencesAttachments(body)
-	p.bodyStates[eventID] = state
+	state.known = true
+	p.bodyStates[eventRef] = state
 }
 
 func (p *RoomTimelineProjection) clearBodyLocked(eventID string) {
-	state, exists := p.bodyStates[eventID]
+	eventRef, exists := p.eventRefLocked(eventID)
 	if !exists {
 		return
 	}
-	if state.body != nil {
+	state := p.bodyStates[eventRef]
+	if !state.known {
+		return
+	}
+	if p.currentBodies[eventRef] != nil {
 		if bucket := p.buckets[state.bucket]; bucket != nil {
-			bucket.residentBytes -= int64(proto.Size(state.body))
+			bucket.residentBytes -= int64(proto.Size(p.currentBodies[eventRef]))
 		}
 	}
-	state.body = nil
-	p.bodyStates[eventID] = state
+	p.currentBodies[eventRef] = nil
 }
 
 func (p *RoomTimelineProjection) setTombstonedAtLocked(eventID string, at time.Time) {
 	if eventID == "" || at.IsZero() {
 		return
 	}
-	if existing, ok := p.tombstonedAt[eventID]; !ok || at.Before(existing) {
-		p.tombstonedAt[eventID] = at
+	eventRef := p.internEventIDLocked(eventID)
+	if existing, ok := p.tombstonedAt[eventRef]; !ok || at.Before(existing) {
+		p.tombstonedAt[eventRef] = at
 	}
 }
 
@@ -442,12 +568,17 @@ func (p *RoomTimelineProjection) RoomEventsContext(ctx context.Context, roomID s
 		return nil, nil
 	}
 	p.RLock()
-	entryIndexes := p.byRoom[roomID]
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		p.RUnlock()
+		return nil, nil
+	}
+	entryIndexes := p.byRoom[roomRef]
 	if len(entryIndexes) == 0 {
 		p.RUnlock()
 		return nil, nil
 	}
-	selected := make([]int, 0, limit)
+	selected := make([]timelineEntryRef, 0, limit)
 	for i := len(entryIndexes) - 1; i >= 0 && len(selected) < limit; i-- {
 		idx := entryIndexes[i]
 		e := p.entryAtLocked(idx)
@@ -486,8 +617,12 @@ func (p *RoomTimelineProjection) RoomEventCount(roomID string) int {
 func (p *RoomTimelineProjection) VisibleRoomEventCount(roomID string) int {
 	p.RLock()
 	defer p.RUnlock()
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		return 0
+	}
 	n := 0
-	for _, idx := range p.byRoom[roomID] {
+	for _, idx := range p.byRoom[roomRef] {
 		entry := p.entryAtLocked(idx)
 		if p.isHiddenEchoEntryLocked(entry) {
 			continue
@@ -570,7 +705,12 @@ func (p *RoomTimelineProjection) LastRoomMessageEntry(roomID string) (*TimelineE
 
 func (p *RoomTimelineProjection) LastRoomMessageEntryContext(ctx context.Context, roomID string) (*TimelineEntry, bool, error) {
 	p.RLock()
-	entryIndexes := p.messagePostsByRoom[roomID]
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		p.RUnlock()
+		return nil, false, nil
+	}
+	entryIndexes := p.messagePostsByRoom[roomRef]
 	for i := len(entryIndexes) - 1; i >= 0; i-- {
 		e := p.entryAtLocked(entryIndexes[i])
 		if e == nil {
@@ -581,7 +721,7 @@ func (p *RoomTimelineProjection) LastRoomMessageEntryContext(ctx context.Context
 		}
 		index := entryIndexes[i]
 		p.RUnlock()
-		if err := p.ensureEntryIndexes(ctx, []int{index}); err != nil {
+		if err := p.ensureEntryIndexes(ctx, []timelineEntryRef{index}); err != nil {
 			return nil, false, err
 		}
 		p.RLock()
@@ -599,7 +739,7 @@ func (p *RoomTimelineProjection) LastRoomMessageEntryContext(ctx context.Context
 // Returns (nil, false, false) if the event_id isn't known to the
 // projection (caller can treat as "not found yet").
 //
-// O(1): consults the derived bodyStates / retractedFlags indexes
+// O(1): consults the dense body-state / message-flag indexes
 // that Apply keeps in lockstep with byRoom.
 func (p *RoomTimelineProjection) LatestBody(eventID string) (body *corev1.MessageBody, retracted bool, ok bool) {
 	body, retracted, ok, _ = p.LatestBodyContext(context.Background(), eventID)
@@ -612,32 +752,34 @@ func (p *RoomTimelineProjection) LatestBodyContext(ctx context.Context, eventID 
 		p.RUnlock()
 		return nil, false, false, nil
 	}
-	if _, exists := p.byEventID[eventID]; !exists {
+	eventRef, exists := p.eventRefLocked(eventID)
+	if !exists || int(eventRef) >= len(p.entryByEvent) || p.entryByEvent[eventRef] == missingTimelineEntry {
 		p.RUnlock()
 		return nil, false, false, nil
 	}
-	if _, hidden := p.hiddenEchoes[eventID]; hidden {
+	if p.messageFlagLocked(eventRef, timelineMessageHiddenEcho) {
 		p.RUnlock()
 		return nil, true, true, nil
 	}
-	if _, isRetracted := p.retractedFlags[eventID]; isRetracted {
+	if p.messageFlagLocked(eventRef, timelineMessageRetracted) {
 		p.RUnlock()
 		return nil, true, true, nil
 	}
 	if origID := p.echoOriginalIDLocked(eventID); origID != "" {
-		if _, originalRetracted := p.retractedFlags[origID]; originalRetracted {
+		origRef, _ := p.eventRefLocked(origID)
+		if p.messageFlagLocked(origRef, timelineMessageRetracted) {
 			p.RUnlock()
 			return nil, true, true, nil
 		}
 	}
-	state, has := p.bodyStates[eventID]
-	if !has {
+	state := p.bodyStates[eventRef]
+	if !state.known {
 		p.RUnlock()
 		return nil, false, true, nil
 	}
 	bucket := state.bucket
-	if state.body != nil {
-		body = cloneMessageBody(state.body)
+	if currentBody := p.currentBodies[eventRef]; currentBody != nil {
+		body = cloneMessageBody(currentBody)
 		p.RUnlock()
 		return body, false, true, nil
 	}
@@ -647,22 +789,24 @@ func (p *RoomTimelineProjection) LatestBodyContext(ctx context.Context, eventID 
 	}
 	p.RLock()
 	defer p.RUnlock()
-	if _, exists := p.byEventID[eventID]; !exists {
+	eventRef, exists = p.eventRefLocked(eventID)
+	if !exists || int(eventRef) >= len(p.entryByEvent) || p.entryByEvent[eventRef] == missingTimelineEntry {
 		return nil, false, false, nil
 	}
-	if _, hidden := p.hiddenEchoes[eventID]; hidden {
+	if p.messageFlagLocked(eventRef, timelineMessageHiddenEcho) {
 		return nil, true, true, nil
 	}
-	if _, isRetracted := p.retractedFlags[eventID]; isRetracted {
+	if p.messageFlagLocked(eventRef, timelineMessageRetracted) {
 		return nil, true, true, nil
 	}
 	if origID := p.echoOriginalIDLocked(eventID); origID != "" {
-		if _, originalRetracted := p.retractedFlags[origID]; originalRetracted {
+		origRef, _ := p.eventRefLocked(origID)
+		if p.messageFlagLocked(origRef, timelineMessageRetracted) {
 			return nil, true, true, nil
 		}
 	}
-	if state, has := p.bodyStates[eventID]; has && state.body != nil {
-		return cloneMessageBody(state.body), false, true, nil
+	if state := p.bodyStates[eventRef]; state.known && p.currentBodies[eventRef] != nil {
+		return cloneMessageBody(p.currentBodies[eventRef]), false, true, nil
 	}
 	return nil, false, true, nil
 }
@@ -677,14 +821,19 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessages(roomID string) []
 func (p *RoomTimelineProjection) CurrentRoomAttachmentMessagesContext(ctx context.Context, roomID string) ([]projectedRoomAttachmentMessage, error) {
 	p.RLock()
 
-	ids := append([]string(nil), p.attachmentMessageIDsByRoom[roomID]...)
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		p.RUnlock()
+		return nil, nil
+	}
+	ids := append([]timelineEventRef(nil), p.attachmentMessagesByRoom[roomRef]...)
 	if len(ids) == 0 {
 		p.RUnlock()
 		return nil, nil
 	}
 	keys := make(map[timelineBucketKey]struct{})
-	for _, eventID := range ids {
-		if state, ok := p.bodyStates[eventID]; ok {
+	for _, eventRef := range ids {
+		if state := p.bodyStates[eventRef]; state.known {
 			keys[state.bucket] = struct{}{}
 		}
 	}
@@ -699,20 +848,22 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessagesContext(ctx contex
 
 	out := make([]projectedRoomAttachmentMessage, 0, len(ids))
 	for i := len(ids) - 1; i >= 0; i-- {
-		eventID := ids[i]
+		eventRef := ids[i]
+		eventID := p.eventIDLocked(eventRef)
 		entry, _ := p.entryByEventIDLocked(eventID)
 		if entry == nil || entry.Event == nil || p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}
-		if _, retracted := p.retractedFlags[eventID]; retracted {
+		if p.messageFlagLocked(eventRef, timelineMessageRetracted) {
 			continue
 		}
 		if origID := p.echoOriginalIDLocked(eventID); origID != "" {
-			if _, originalRetracted := p.retractedFlags[origID]; originalRetracted {
+			origRef, _ := p.eventRefLocked(origID)
+			if p.messageFlagLocked(origRef, timelineMessageRetracted) {
 				continue
 			}
 		}
-		body := p.bodyStates[eventID].body
+		body := p.currentBodies[eventRef]
 		if !messageBodyReferencesAttachments(body) {
 			continue
 		}
@@ -725,9 +876,10 @@ func (p *RoomTimelineProjection) CurrentRoomAttachmentMessagesContext(ctx contex
 }
 
 func (p *RoomTimelineProjection) refreshAttachmentMessageMetadataLocked(roomID, eventID string, body *corev1.MessageBody) {
-	state := p.bodyStates[eventID]
+	eventRef := p.internEventIDLocked(eventID)
+	state := p.bodyStates[eventRef]
 	state.hasAttachments = messageBodyReferencesAttachments(body)
-	p.bodyStates[eventID] = state
+	p.bodyStates[eventRef] = state
 	if !state.hasAttachments {
 		p.removeAttachmentMessageLocked(eventID)
 		return
@@ -741,57 +893,63 @@ func (p *RoomTimelineProjection) addAttachmentMessageLocked(roomID, eventID stri
 	if roomID == "" || eventID == "" {
 		return
 	}
-	if existingRoom := p.attachmentMessageRoom[eventID]; existingRoom != "" {
-		if existingRoom == roomID {
+	roomRef := p.internRoomIDLocked(roomID)
+	eventRef := p.internEventIDLocked(eventID)
+	if existingRoom := p.attachmentMessageRoom[eventRef]; existingRoom != 0 {
+		if existingRoom == roomRef {
 			return
 		}
 		p.removeAttachmentMessageLocked(eventID)
 	}
 
-	ids := p.attachmentMessageIDsByRoom[roomID]
+	ids := p.attachmentMessagesByRoom[roomRef]
 	insertAt := len(ids)
 	if len(ids) > 0 {
-		last, _ := p.entryByEventIDLocked(ids[len(ids)-1])
+		last, _ := p.entryByEventIDLocked(p.eventIDLocked(ids[len(ids)-1]))
 		if last != nil && last.StreamSeq <= streamSeq {
-			ids = append(ids, eventID)
-			p.attachmentMessageIDsByRoom[roomID] = ids
-			p.attachmentMessageRoom[eventID] = roomID
+			ids = append(ids, eventRef)
+			p.attachmentMessagesByRoom[roomRef] = ids
+			p.attachmentMessageRoom[eventRef] = roomRef
 			return
 		}
-		for i, existingID := range ids {
-			existing, _ := p.entryByEventIDLocked(existingID)
+		for i, existingRef := range ids {
+			existing, _ := p.entryByEventIDLocked(p.eventIDLocked(existingRef))
 			if existing == nil || existing.StreamSeq > streamSeq {
 				insertAt = i
 				break
 			}
 		}
 	}
-	ids = append(ids, "")
+	ids = append(ids, 0)
 	copy(ids[insertAt+1:], ids[insertAt:])
-	ids[insertAt] = eventID
-	p.attachmentMessageIDsByRoom[roomID] = ids
-	p.attachmentMessageRoom[eventID] = roomID
+	ids[insertAt] = eventRef
+	p.attachmentMessagesByRoom[roomRef] = ids
+	p.attachmentMessageRoom[eventRef] = roomRef
 }
 
 func (p *RoomTimelineProjection) removeAttachmentMessageLocked(eventID string) {
-	roomID := p.attachmentMessageRoom[eventID]
-	if roomID == "" {
+	eventRef, ok := p.eventRefLocked(eventID)
+	if !ok || int(eventRef) >= len(p.attachmentMessageRoom) {
 		return
 	}
-	ids := p.attachmentMessageIDsByRoom[roomID]
-	for i, existingID := range ids {
-		if existingID != eventID {
+	roomRef := p.attachmentMessageRoom[eventRef]
+	if roomRef == 0 {
+		return
+	}
+	ids := p.attachmentMessagesByRoom[roomRef]
+	for i, existingRef := range ids {
+		if existingRef != eventRef {
 			continue
 		}
 		ids = append(ids[:i], ids[i+1:]...)
 		break
 	}
 	if len(ids) == 0 {
-		delete(p.attachmentMessageIDsByRoom, roomID)
+		delete(p.attachmentMessagesByRoom, roomRef)
 	} else {
-		p.attachmentMessageIDsByRoom[roomID] = ids
+		p.attachmentMessagesByRoom[roomRef] = ids
 	}
-	delete(p.attachmentMessageRoom, eventID)
+	p.attachmentMessageRoom[eventRef] = 0
 }
 
 func messageBodyReferencesAttachments(body *corev1.MessageBody) bool {
@@ -806,15 +964,17 @@ func (p *RoomTimelineProjection) BodyEventSeqs(eventID string) (seqs []uint64, c
 	if eventID == "" {
 		return nil, 0, false
 	}
-	if _, exists := p.byEventID[eventID]; !exists {
+	eventRef, exists := p.eventRefLocked(eventID)
+	if !exists || int(eventRef) >= len(p.entryByEvent) || p.entryByEvent[eventRef] == missingTimelineEntry {
 		return nil, 0, false
 	}
-	state, hasBodyState := p.bodyStates[eventID]
-	if !hasBodyState {
+	state := p.bodyStates[eventRef]
+	if !state.known {
 		return nil, 0, true
 	}
-	seqs = make([]uint64, 0, len(state.supersededSequences)+1)
-	seqs = append(seqs, state.supersededSequences...)
+	superseded := p.supersededBodySequences[eventRef]
+	seqs = make([]uint64, 0, len(superseded)+1)
+	seqs = append(seqs, superseded...)
 	seqs = append(seqs, state.currentSequence)
 	return seqs, state.currentSequence, true
 }
@@ -829,17 +989,21 @@ func (p *RoomTimelineProjection) ObsoleteBodyEventSeqs(eventID string) []uint64 
 	if eventID == "" {
 		return nil
 	}
-	state, ok := p.bodyStates[eventID]
+	eventRef, ok := p.eventRefLocked(eventID)
 	if !ok {
 		return nil
 	}
-	if _, retracted := p.retractedFlags[eventID]; retracted {
-		return appendBodySequences(nil, state)
+	state := p.bodyStates[eventRef]
+	if !state.known {
+		return nil
 	}
-	if _, hidden := p.hiddenEchoes[eventID]; hidden {
-		return appendBodySequences(nil, state)
+	if p.messageFlagLocked(eventRef, timelineMessageRetracted) {
+		return p.appendBodySequencesLocked(nil, eventRef, state)
 	}
-	return append([]uint64(nil), state.supersededSequences...)
+	if p.messageFlagLocked(eventRef, timelineMessageHiddenEcho) {
+		return p.appendBodySequencesLocked(nil, eventRef, state)
+	}
+	return append([]uint64(nil), p.supersededBodySequences[eventRef]...)
 }
 
 // AllObsoleteBodyEventSeqs returns every projected MessageBodyEvent seq
@@ -848,22 +1012,26 @@ func (p *RoomTimelineProjection) AllObsoleteBodyEventSeqs() []uint64 {
 	p.RLock()
 	defer p.RUnlock()
 	var out []uint64
-	for eventID, state := range p.bodyStates {
-		if _, retracted := p.retractedFlags[eventID]; retracted {
-			out = appendBodySequences(out, state)
+	for eventRef, state := range p.bodyStates {
+		if !state.known {
 			continue
 		}
-		if _, hidden := p.hiddenEchoes[eventID]; hidden {
-			out = appendBodySequences(out, state)
+		ref := timelineEventRef(eventRef)
+		if p.messageFlagLocked(ref, timelineMessageRetracted) {
+			out = p.appendBodySequencesLocked(out, ref, state)
 			continue
 		}
-		out = append(out, state.supersededSequences...)
+		if p.messageFlagLocked(ref, timelineMessageHiddenEcho) {
+			out = p.appendBodySequencesLocked(out, ref, state)
+			continue
+		}
+		out = append(out, p.supersededBodySequences[ref]...)
 	}
 	return out
 }
 
-func appendBodySequences(dst []uint64, state timelineBodyState) []uint64 {
-	dst = append(dst, state.supersededSequences...)
+func (p *RoomTimelineProjection) appendBodySequencesLocked(dst []uint64, ref timelineEventRef, state timelineBodyState) []uint64 {
+	dst = append(dst, p.supersededBodySequences[ref]...)
 	return append(dst, state.currentSequence)
 }
 
@@ -875,7 +1043,7 @@ func (p *RoomTimelineProjection) echoOriginalIDLocked(eventID string) string {
 	if !entry.messagePosted {
 		return ""
 	}
-	return entry.echoOriginalID
+	return p.eventIDLocked(entry.echoOriginalID)
 }
 
 // IsEcho reports whether eventID is a MessagePostedEvent echo.
@@ -892,7 +1060,7 @@ func (p *RoomTimelineProjection) messageLocator(eventID string) (roomID, echoOri
 	if !ok || entry == nil || !entry.messagePosted {
 		return "", "", false
 	}
-	return entry.roomID, entry.echoOriginalID, true
+	return p.roomIDLocked(entry.roomID), p.eventIDLocked(entry.echoOriginalID), true
 }
 
 // IsHiddenEcho reports whether an echo has been directly retracted from the
@@ -900,8 +1068,8 @@ func (p *RoomTimelineProjection) messageLocator(eventID string) (roomID, echoOri
 func (p *RoomTimelineProjection) IsHiddenEcho(eventID string) bool {
 	p.RLock()
 	defer p.RUnlock()
-	_, ok := p.hiddenEchoes[eventID]
-	return ok
+	ref, ok := p.eventRefLocked(eventID)
+	return ok && p.messageFlagLocked(ref, timelineMessageHiddenEcho)
 }
 
 // ChannelEchoEventID returns the first visible echo event for an original
@@ -912,16 +1080,21 @@ func (p *RoomTimelineProjection) ChannelEchoEventID(originalEventID string) (str
 	if originalEventID == "" {
 		return "", false
 	}
-	for _, echoID := range p.echoLinks[originalEventID] {
-		if echoID == "" {
+	originalRef, ok := p.eventRefLocked(originalEventID)
+	if !ok {
+		return "", false
+	}
+	for _, echoRef := range p.echoLinks[originalRef] {
+		if echoRef == 0 {
 			continue
 		}
-		if _, hidden := p.hiddenEchoes[echoID]; hidden {
+		if p.messageFlagLocked(echoRef, timelineMessageHiddenEcho) {
 			continue
 		}
-		if _, retracted := p.retractedFlags[echoID]; retracted {
+		if p.messageFlagLocked(echoRef, timelineMessageRetracted) {
 			continue
 		}
+		echoID := p.eventIDLocked(echoRef)
 		if _, ok := p.entryByEventIDLocked(echoID); !ok {
 			continue
 		}
@@ -941,13 +1114,18 @@ func (p *RoomTimelineProjection) LinkedChannelEchoEventID(originalEventID string
 	if originalEventID == "" {
 		return "", false
 	}
-	for _, echoID := range p.echoLinks[originalEventID] {
-		if echoID == "" {
+	originalRef, ok := p.eventRefLocked(originalEventID)
+	if !ok {
+		return "", false
+	}
+	for _, echoRef := range p.echoLinks[originalRef] {
+		if echoRef == 0 {
 			continue
 		}
-		if _, hidden := p.hiddenEchoes[echoID]; hidden {
+		if p.messageFlagLocked(echoRef, timelineMessageHiddenEcho) {
 			continue
 		}
+		echoID := p.eventIDLocked(echoRef)
 		if _, ok := p.entryByEventIDLocked(echoID); !ok {
 			continue
 		}
@@ -961,8 +1139,8 @@ func (p *RoomTimelineProjection) LinkedChannelEchoEventID(originalEventID string
 func (p *RoomTimelineProjection) MessageTombstoned(eventID string) bool {
 	p.RLock()
 	defer p.RUnlock()
-	_, ok := p.retractedFlags[eventID]
-	return ok
+	ref, ok := p.eventRefLocked(eventID)
+	return ok && p.messageFlagLocked(ref, timelineMessageRetracted)
 }
 
 // MessageDeletedAt returns when the message first became unavailable through
@@ -975,12 +1153,16 @@ func (p *RoomTimelineProjection) MessageDeletedAt(eventID string) (time.Time, bo
 }
 
 func (p *RoomTimelineProjection) messageTombstonedAtLocked(eventID string) (time.Time, bool) {
-	if at, ok := p.tombstonedAt[eventID]; ok {
-		return at, true
+	ref, ok := p.eventRefLocked(eventID)
+	if ok {
+		if at, exists := p.tombstonedAt[ref]; exists {
+			return at, true
+		}
 	}
 	if origID := p.echoOriginalIDLocked(eventID); origID != "" {
-		at, ok := p.tombstonedAt[origID]
-		return at, ok
+		origRef, exists := p.eventRefLocked(origID)
+		at, found := p.tombstonedAt[origRef]
+		return at, exists && found
 	}
 	return time.Time{}, false
 }
@@ -1027,25 +1209,30 @@ func (p *RoomTimelineProjection) LinkedEventIDs(eventID string) []string {
 		return nil
 	}
 	linked := make([]string, 0, 2)
+	eventRef, exists := p.eventRefLocked(eventID)
+	if !exists {
+		return nil
+	}
 
 	// Forward: echoes pointing at this event.
-	for _, echoID := range p.echoLinks[eventID] {
-		if echoID != eventID {
-			linked = append(linked, echoID)
+	for _, echoRef := range p.echoLinks[eventRef] {
+		if echoRef != eventRef {
+			linked = append(linked, p.eventIDLocked(echoRef))
 		}
 	}
 
 	// Backward: if this event IS an echo, include the original.
 	if entry, ok := p.entryByEventIDLocked(eventID); ok {
 		if entry.messagePosted {
-			if origID := entry.echoOriginalID; origID != "" && origID != eventID {
+			if origRef := entry.echoOriginalID; origRef != 0 && origRef != eventRef {
+				origID := p.eventIDLocked(origRef)
 				linked = append(linked, origID)
 				// Also include any sibling echoes of the same original
 				// (rare, but possible if "also send to channel" was
 				// invoked twice — keep semantics consistent).
-				for _, siblingID := range p.echoLinks[origID] {
-					if siblingID != eventID && siblingID != origID {
-						linked = append(linked, siblingID)
+				for _, siblingRef := range p.echoLinks[origRef] {
+					if siblingRef != eventRef && siblingRef != origRef {
+						linked = append(linked, p.eventIDLocked(siblingRef))
 					}
 				}
 			}
@@ -1073,7 +1260,12 @@ func (p *RoomTimelineProjection) LastVisibleRoomEntryContext(
 	visible func(*corev1.Event) bool,
 ) (*TimelineEntry, bool, error) {
 	p.RLock()
-	entryIndexes := append([]int(nil), p.byRoom[roomID]...)
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		p.RUnlock()
+		return nil, false, nil
+	}
+	entryIndexes := append([]timelineEntryRef(nil), p.byRoom[roomRef]...)
 	p.RUnlock()
 	for i := len(entryIndexes) - 1; i >= 0; i-- {
 		idx := entryIndexes[i]
@@ -1136,7 +1328,12 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineContext(
 		return nil, nil
 	}
 	p.RLock()
-	entryIndexes := append([]int(nil), p.byRoom[roomID]...)
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		p.RUnlock()
+		return nil, nil
+	}
+	entryIndexes := append([]timelineEntryRef(nil), p.byRoom[roomRef]...)
 	p.RUnlock()
 	out := make([]*TimelineEntry, 0, limit)
 	for i := len(entryIndexes) - 1; i >= 0 && len(out) < limit; i-- {
@@ -1197,7 +1394,12 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAfterContext(
 		return nil, nil
 	}
 	p.RLock()
-	entryIndexes := append([]int(nil), p.byRoom[roomID]...)
+	roomRef, ok := p.roomRefLocked(roomID)
+	if !ok {
+		p.RUnlock()
+		return nil, nil
+	}
+	entryIndexes := append([]timelineEntryRef(nil), p.byRoom[roomRef]...)
 	p.RUnlock()
 	out := make([]*TimelineEntry, 0, limit)
 	for _, idx := range entryIndexes {
@@ -1258,7 +1460,17 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAroundContext(
 		return nil, 0, false, false, false, nil
 	}
 	p.RLock()
-	roomEntries := p.byRoom[roomID]
+	roomRef, roomKnown := p.roomRefLocked(roomID)
+	if !roomKnown {
+		p.RUnlock()
+		return nil, 0, false, false, false, nil
+	}
+	targetRef, targetKnown := p.eventRefLocked(eventID)
+	if !targetKnown {
+		p.RUnlock()
+		return nil, 0, false, false, false, nil
+	}
+	roomEntries := p.byRoom[roomRef]
 	targetVisibleIndex := -1
 	visibleCount := 0
 	for _, idx := range roomEntries {
@@ -1266,7 +1478,7 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAroundContext(
 		if p.isHiddenEchoEntryLocked(entry) {
 			continue
 		}
-		if entry != nil && entry.eventID == eventID {
+		if entry != nil && entry.eventID == targetRef {
 			targetVisibleIndex = visibleCount
 		}
 		visibleCount++
@@ -1289,7 +1501,7 @@ func (p *RoomTimelineProjection) VisibleRoomTimelineAroundContext(
 		}
 	}
 
-	selected := make([]int, 0, end-start)
+	selected := make([]timelineEntryRef, 0, end-start)
 	visibleIndex := 0
 	for _, idx := range roomEntries {
 		entry := p.entryAtLocked(idx)
@@ -1323,6 +1535,5 @@ func (p *RoomTimelineProjection) isHiddenEchoEntryLocked(entry *TimelineEntry) b
 	if entry == nil {
 		return false
 	}
-	_, hidden := p.hiddenEchoes[entry.eventID]
-	return hidden
+	return p.messageFlagLocked(entry.eventID, timelineMessageHiddenEcho)
 }

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -232,7 +232,9 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 			}
 			if authorID := body.GetAuthorId(); authorID != "" {
 				bucket := p.messageBucketLocked(targetID, roomID, event)
-				p.recordBucketRefLocked(bucket, seq, true)
+				if err := p.recordBucketRefLocked(bucket, seq, true); err != nil {
+					return err
+				}
 				resident := p.bucketResidentLocked(bucket)
 				if _, shredded := p.shreddedUsers[authorID]; shredded {
 					p.clearBodyLocked(targetID)
@@ -254,7 +256,9 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 	}
 
 	bucket := p.bucketForMutationLocked(event, roomID)
-	p.recordBucketRefLocked(bucket, seq, false)
+	if err := p.recordBucketRefLocked(bucket, seq, false); err != nil {
+		return err
+	}
 	resident := p.bucketResidentLocked(bucket)
 	retainedEvent := event
 	if !resident {

--- a/cli/internal/core/room_timeline_projection_snapshot.go
+++ b/cli/internal/core/room_timeline_projection_snapshot.go
@@ -21,12 +21,23 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 	p.RLock()
 	defer p.RUnlock()
 
-	snapshot := &corev1.RoomTimelineProjectionSnapshot{
-		ReplayGuard:        snapshotReplayGuard(p.replayGuard),
-		RetractedEventIds:  sortedMapKeys(p.retractedFlags),
-		HiddenEchoEventIds: sortedMapKeys(p.hiddenEchoes),
-		ShreddedUserIds:    sortedMapKeys(p.shreddedUsers),
+	snapshot := &corev1.RoomTimelineProjectionSnapshot{ReplayGuard: snapshotReplayGuard(p.replayGuard)}
+	for ref := timelineEventRef(1); int(ref) < len(p.messageFlags); ref++ {
+		if p.messageFlagLocked(ref, timelineMessageRetracted) {
+			snapshot.RetractedEventIds = append(snapshot.RetractedEventIds, p.eventIDLocked(ref))
+		}
+		if p.messageFlagLocked(ref, timelineMessageHiddenEcho) {
+			snapshot.HiddenEchoEventIds = append(snapshot.HiddenEchoEventIds, p.eventIDLocked(ref))
+		}
 	}
+	for ref := timelineUserRef(1); int(ref) < len(p.shreddedUsers); ref++ {
+		if p.shreddedUsers[ref] {
+			snapshot.ShreddedUserIds = append(snapshot.ShreddedUserIds, p.userIDLocked(ref))
+		}
+	}
+	sort.Strings(snapshot.RetractedEventIds)
+	sort.Strings(snapshot.HiddenEchoEventIds)
+	sort.Strings(snapshot.ShreddedUserIds)
 	residentBuckets := make(map[timelineBucketKey]bool, len(p.buckets))
 	bucketKeys := make([]timelineBucketKey, 0, len(p.buckets))
 	for key := range p.buckets {
@@ -51,7 +62,7 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 		snapshot.Buckets = append(snapshot.Buckets, row)
 	}
 
-	visibleIndexes := make(map[int]struct{})
+	visibleIndexes := make(map[timelineEntryRef]struct{})
 	for _, indexes := range p.byRoom {
 		for _, idx := range indexes {
 			visibleIndexes[idx] = struct{}{}
@@ -61,45 +72,62 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 		entry := &p.entries[index]
 		row := &corev1.TimelineEntryMetadataSnapshot{
 			StreamSequence:      entry.StreamSeq,
-			EventId:             entry.eventID,
-			RoomId:              entry.roomID,
-			AuthorId:            entry.authorID,
-			EchoOriginalEventId: entry.echoOriginalID,
+			EventId:             p.eventIDLocked(entry.eventID),
+			RoomId:              p.roomIDLocked(entry.roomID),
+			AuthorId:            p.userIDLocked(entry.authorID),
+			EchoOriginalEventId: p.eventIDLocked(entry.echoOriginalID),
 			WeekStartUnix:       entry.bucket.weekStart,
 			MessagePosted:       entry.messagePosted,
 		}
-		_, row.RoomVisible = visibleIndexes[index]
+		_, row.RoomVisible = visibleIndexes[timelineEntryRef(index)]
 		if residentBuckets[entry.bucket] && entry.Event != nil {
 			row.ResidentEvent = proto.Clone(entry.Event).(*corev1.Event)
 		}
 		snapshot.Entries = append(snapshot.Entries, row)
 	}
-	for _, id := range sortedMapKeys(p.bodyStates) {
-		state := p.bodyStates[id]
+	for ref := timelineEventRef(1); int(ref) < len(p.bodyStates); ref++ {
+		state := p.bodyStates[ref]
+		if !state.known {
+			continue
+		}
 		row := &corev1.TimelineBodyMetadataSnapshot{
-			MessageEventId:      id,
-			BodyEventSequences:  appendBodySequences(nil, state),
+			MessageEventId:      p.eventIDLocked(ref),
+			BodyEventSequences:  p.appendBodySequencesLocked(nil, ref, state),
 			CurrentBodySequence: state.currentSequence,
 			RoomId:              state.bucket.roomID,
 			WeekStartUnix:       state.bucket.weekStart,
 			HasAttachments:      state.hasAttachments,
 		}
-		if residentBuckets[state.bucket] && state.body != nil {
-			row.ResidentBody = cloneMessageBody(state.body)
+		if residentBuckets[state.bucket] && p.currentBodies[ref] != nil {
+			row.ResidentBody = cloneMessageBody(p.currentBodies[ref])
 		}
 		snapshot.Bodies = append(snapshot.Bodies, row)
 	}
-	appendTimes := func(values map[string]time.Time) []*corev1.StringTimestampSnapshot {
+	sort.Slice(snapshot.Bodies, func(i, j int) bool {
+		return snapshot.Bodies[i].GetMessageEventId() < snapshot.Bodies[j].GetMessageEventId()
+	})
+	appendEventTimes := func(values map[timelineEventRef]time.Time) []*corev1.StringTimestampSnapshot {
 		rows := make([]*corev1.StringTimestampSnapshot, 0, len(values))
-		for _, key := range sortedMapKeys(values) {
-			if !values[key].IsZero() {
-				rows = append(rows, &corev1.StringTimestampSnapshot{Key: key, Value: timestamppb.New(values[key])})
+		for key, value := range values {
+			if !value.IsZero() {
+				rows = append(rows, &corev1.StringTimestampSnapshot{Key: p.eventIDLocked(key), Value: timestamppb.New(value)})
 			}
 		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].GetKey() < rows[j].GetKey() })
 		return rows
 	}
-	snapshot.TombstonedAt = appendTimes(p.tombstonedAt)
-	snapshot.ShreddedAt = appendTimes(p.shreddedAt)
+	appendUserTimes := func(values map[timelineUserRef]time.Time) []*corev1.StringTimestampSnapshot {
+		rows := make([]*corev1.StringTimestampSnapshot, 0, len(values))
+		for key, value := range values {
+			if !value.IsZero() {
+				rows = append(rows, &corev1.StringTimestampSnapshot{Key: p.userIDLocked(key), Value: timestamppb.New(value)})
+			}
+		}
+		sort.Slice(rows, func(i, j int) bool { return rows[i].GetKey() < rows[j].GetKey() })
+		return rows
+	}
+	snapshot.TombstonedAt = appendEventTimes(p.tombstonedAt)
+	snapshot.ShreddedAt = appendUserTimes(p.shreddedAt)
 	return proto.MarshalOptions{Deterministic: true}.Marshal(snapshot)
 }
 
@@ -152,35 +180,36 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 		if row.GetStreamSequence() == 0 || row.GetEventId() == "" || !bucketExists {
 			return fmt.Errorf("room timeline snapshot has invalid timeline entry")
 		}
+		eventRef := restored.internEventIDLocked(row.GetEventId())
+		if restored.entryByEvent[eventRef] != missingTimelineEntry {
+			return fmt.Errorf("room timeline snapshot repeats event %q", row.GetEventId())
+		}
 		entry := TimelineEntry{
 			StreamSeq:      row.GetStreamSequence(),
-			eventID:        row.GetEventId(),
-			roomID:         row.GetRoomId(),
-			authorID:       row.GetAuthorId(),
-			echoOriginalID: row.GetEchoOriginalEventId(),
+			eventID:        eventRef,
+			roomID:         restored.internRoomIDLocked(row.GetRoomId()),
+			authorID:       restored.internUserIDLocked(row.GetAuthorId()),
+			echoOriginalID: restored.internEventIDLocked(row.GetEchoOriginalEventId()),
 			bucket:         key,
 			messagePosted:  row.GetMessagePosted(),
 		}
 		if bucket.resident {
-			if row.GetResidentEvent() == nil || row.GetResidentEvent().GetId() != entry.eventID {
-				return fmt.Errorf("room timeline snapshot resident bucket %s/%d is missing event %q", key.roomID, key.weekStart, entry.eventID)
+			if row.GetResidentEvent() == nil || row.GetResidentEvent().GetId() != row.GetEventId() {
+				return fmt.Errorf("room timeline snapshot resident bucket %s/%d is missing event %q", key.roomID, key.weekStart, row.GetEventId())
 			}
 			entry.Event = proto.Clone(row.GetResidentEvent()).(*corev1.Event)
 		}
 		index := len(restored.entries)
 		restored.entries = append(restored.entries, entry)
-		if _, duplicate := restored.byEventID[entry.eventID]; duplicate {
-			return fmt.Errorf("room timeline snapshot repeats event %q", entry.eventID)
-		}
-		restored.byEventID[entry.eventID] = index
+		restored.entryByEvent[eventRef] = int32(index)
 		if entry.messagePosted {
-			restored.messagePostsByRoom[entry.roomID] = append(restored.messagePostsByRoom[entry.roomID], index)
-			if entry.echoOriginalID != "" {
+			restored.messagePostsByRoom[entry.roomID] = append(restored.messagePostsByRoom[entry.roomID], timelineEntryRef(index))
+			if entry.echoOriginalID != 0 {
 				restored.echoLinks[entry.echoOriginalID] = append(restored.echoLinks[entry.echoOriginalID], entry.eventID)
 			}
 		}
 		if row.GetRoomVisible() {
-			restored.byRoom[entry.roomID] = append(restored.byRoom[entry.roomID], index)
+			restored.byRoom[entry.roomID] = append(restored.byRoom[entry.roomID], timelineEntryRef(index))
 		}
 	}
 
@@ -191,7 +220,8 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 		if id == "" || !bucketExists {
 			return fmt.Errorf("room timeline snapshot has invalid body metadata")
 		}
-		if _, duplicate := restored.bodyStates[id]; duplicate {
+		eventRef := restored.internEventIDLocked(id)
+		if restored.bodyStates[eventRef].known {
 			return fmt.Errorf("room timeline snapshot repeats body %q", id)
 		}
 		sequences := row.GetBodyEventSequences()
@@ -199,88 +229,110 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 			return fmt.Errorf("room timeline snapshot body %q has inconsistent sequence history", id)
 		}
 		state := timelineBodyState{
-			currentSequence:     row.GetCurrentBodySequence(),
-			supersededSequences: append([]uint64(nil), sequences[:len(sequences)-1]...),
-			bucket:              key,
-			hasAttachments:      row.GetHasAttachments(),
+			currentSequence: row.GetCurrentBodySequence(),
+			bucket:          key,
+			hasAttachments:  row.GetHasAttachments(),
+			known:           true,
 		}
 		if bucket.resident && row.GetResidentBody() != nil {
-			state.body = cloneMessageBody(row.GetResidentBody())
+			restored.currentBodies[eventRef] = cloneMessageBody(row.GetResidentBody())
 		}
-		restored.bodyStates[id] = state
+		restored.bodyStates[eventRef] = state
+		if len(sequences) > 1 {
+			restored.supersededBodySequences[eventRef] = append([]uint64(nil), sequences[:len(sequences)-1]...)
+		}
 	}
 
-	restoreTimes := func(rows []*corev1.StringTimestampSnapshot) (map[string]time.Time, error) {
-		values := make(map[string]time.Time, len(rows))
+	restoreEventTimes := func(rows []*corev1.StringTimestampSnapshot) (map[timelineEventRef]time.Time, error) {
+		values := make(map[timelineEventRef]time.Time, len(rows))
 		for _, row := range rows {
 			if row.GetKey() == "" || row.GetValue() == nil {
 				return nil, fmt.Errorf("room timeline snapshot has invalid timestamp mapping")
 			}
-			if _, duplicate := values[row.GetKey()]; duplicate {
+			ref := restored.internEventIDLocked(row.GetKey())
+			if _, duplicate := values[ref]; duplicate {
 				return nil, fmt.Errorf("room timeline snapshot repeats timestamp key %q", row.GetKey())
 			}
 			value, err := snapshotTime(row.GetValue())
 			if err != nil {
 				return nil, err
 			}
-			values[row.GetKey()] = value
+			values[ref] = value
 		}
 		return values, nil
 	}
-	restored.tombstonedAt, err = restoreTimes(snapshot.GetTombstonedAt())
+	restoreUserTimes := func(rows []*corev1.StringTimestampSnapshot) (map[timelineUserRef]time.Time, error) {
+		values := make(map[timelineUserRef]time.Time, len(rows))
+		for _, row := range rows {
+			if row.GetKey() == "" || row.GetValue() == nil {
+				return nil, fmt.Errorf("room timeline snapshot has invalid timestamp mapping")
+			}
+			ref := restored.internUserIDLocked(row.GetKey())
+			if _, duplicate := values[ref]; duplicate {
+				return nil, fmt.Errorf("room timeline snapshot repeats timestamp key %q", row.GetKey())
+			}
+			value, err := snapshotTime(row.GetValue())
+			if err != nil {
+				return nil, err
+			}
+			values[ref] = value
+		}
+		return values, nil
+	}
+	restored.tombstonedAt, err = restoreEventTimes(snapshot.GetTombstonedAt())
 	if err != nil {
 		return fmt.Errorf("room timeline tombstones: %w", err)
 	}
-	restored.shreddedAt, err = restoreTimes(snapshot.GetShreddedAt())
+	restored.shreddedAt, err = restoreUserTimes(snapshot.GetShreddedAt())
 	if err != nil {
 		return fmt.Errorf("room timeline shred timestamps: %w", err)
 	}
-	fillSet := func(values []string) (map[string]struct{}, error) {
-		set := make(map[string]struct{}, len(values))
-		for _, value := range values {
-			if value == "" {
-				return nil, fmt.Errorf("empty set value")
-			}
-			if _, duplicate := set[value]; duplicate {
-				return nil, fmt.Errorf("repeated set value %q", value)
-			}
-			set[value] = struct{}{}
+	for _, id := range snapshot.GetRetractedEventIds() {
+		ref := restored.internEventIDLocked(id)
+		if restored.messageFlagLocked(ref, timelineMessageRetracted) {
+			return fmt.Errorf("room timeline retracted IDs: repeated set value %q", id)
 		}
-		return set, nil
+		restored.setMessageFlagLocked(ref, timelineMessageRetracted, true)
 	}
-	restored.retractedFlags, err = fillSet(snapshot.GetRetractedEventIds())
-	if err != nil {
-		return fmt.Errorf("room timeline retracted IDs: %w", err)
+	for _, id := range snapshot.GetHiddenEchoEventIds() {
+		ref := restored.internEventIDLocked(id)
+		if restored.messageFlagLocked(ref, timelineMessageHiddenEcho) {
+			return fmt.Errorf("room timeline hidden echoes: repeated set value %q", id)
+		}
+		restored.setMessageFlagLocked(ref, timelineMessageHiddenEcho, true)
 	}
-	restored.hiddenEchoes, err = fillSet(snapshot.GetHiddenEchoEventIds())
-	if err != nil {
-		return fmt.Errorf("room timeline hidden echoes: %w", err)
-	}
-	restored.shreddedUsers, err = fillSet(snapshot.GetShreddedUserIds())
-	if err != nil {
-		return fmt.Errorf("room timeline shredded users: %w", err)
+	for _, id := range snapshot.GetShreddedUserIds() {
+		ref := restored.internUserIDLocked(id)
+		if restored.shreddedUsers[ref] {
+			return fmt.Errorf("room timeline shredded users: repeated set value %q", id)
+		}
+		restored.shreddedUsers[ref] = true
 	}
 
-	for messageID, state := range restored.bodyStates {
+	for eventIndex, state := range restored.bodyStates {
+		if !state.known {
+			continue
+		}
+		eventRef := timelineEventRef(eventIndex)
+		messageID := restored.eventIDLocked(eventRef)
 		entry, entryExists := restored.entryByEventIDLocked(messageID)
-		_, retracted := restored.retractedFlags[messageID]
-		_, hidden := restored.hiddenEchoes[messageID]
+		retracted := restored.messageFlagLocked(eventRef, timelineMessageRetracted)
+		hidden := restored.messageFlagLocked(eventRef, timelineMessageHiddenEcho)
 		shredded := false
 		if entryExists {
-			_, shredded = restored.shreddedUsers[entry.authorID]
+			shredded = restored.shreddedUsers[entry.authorID]
 		}
-		if restored.buckets[state.bucket].resident && state.body == nil && !retracted && !hidden && !shredded {
+		if restored.buckets[state.bucket].resident && restored.currentBodies[eventRef] == nil && !retracted && !hidden && !shredded {
 			return fmt.Errorf("room timeline snapshot resident bucket %s/%d is missing body %q", state.bucket.roomID, state.bucket.weekStart, messageID)
 		}
 		if !entryExists {
 			continue
 		}
 		if state.hasAttachments && !retracted && !hidden && !shredded {
-			restored.addAttachmentMessageLocked(entry.roomID, messageID, entry.StreamSeq)
+			restored.addAttachmentMessageLocked(restored.roomIDLocked(entry.roomID), messageID, entry.StreamSeq)
 		}
 		if retracted || hidden || shredded {
-			state.body = nil
-			restored.bodyStates[messageID] = state
+			restored.currentBodies[eventRef] = nil
 		}
 	}
 	for index := range restored.entries {
@@ -289,26 +341,30 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 			restored.buckets[entry.bucket].residentBytes += int64(proto.Size(entry.Event))
 		}
 	}
-	for _, state := range restored.bodyStates {
-		if state.body != nil {
-			restored.buckets[state.bucket].residentBytes += int64(proto.Size(state.body))
+	for eventIndex, state := range restored.bodyStates {
+		if state.known && restored.currentBodies[eventIndex] != nil {
+			restored.buckets[state.bucket].residentBytes += int64(proto.Size(restored.currentBodies[eventIndex]))
 		}
 	}
 
 	p.Lock()
 	p.entries = restored.entries
+	p.eventIDs = restored.eventIDs
+	p.roomIDs = restored.roomIDs
+	p.userIDs = restored.userIDs
+	p.entryByEvent = restored.entryByEvent
 	p.byRoom = restored.byRoom
-	p.byEventID = restored.byEventID
 	p.messagePostsByRoom = restored.messagePostsByRoom
 	p.replayGuard = restored.replayGuard
 	p.bodyStates = restored.bodyStates
-	p.retractedFlags = restored.retractedFlags
+	p.currentBodies = restored.currentBodies
+	p.supersededBodySequences = restored.supersededBodySequences
 	p.tombstonedAt = restored.tombstonedAt
 	p.shreddedAt = restored.shreddedAt
-	p.attachmentMessageIDsByRoom = restored.attachmentMessageIDsByRoom
+	p.attachmentMessagesByRoom = restored.attachmentMessagesByRoom
 	p.attachmentMessageRoom = restored.attachmentMessageRoom
 	p.echoLinks = restored.echoLinks
-	p.hiddenEchoes = restored.hiddenEchoes
+	p.messageFlags = restored.messageFlags
 	p.shreddedUsers = restored.shreddedUsers
 	p.buckets = restored.buckets
 	p.Unlock()

--- a/cli/internal/core/room_timeline_projection_snapshot.go
+++ b/cli/internal/core/room_timeline_projection_snapshot.go
@@ -43,15 +43,10 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 		payloadResident := bucket.resident && p.bucketIsHotLocked(key)
 		residentBuckets[key] = payloadResident
 		row := &corev1.TimelineBucketSnapshot{
-			RoomId:          key.roomID,
-			WeekStartUnix:   key.weekStart,
-			PayloadResident: payloadResident,
-		}
-		for _, ref := range bucket.refs {
-			row.EventReferences = append(row.EventReferences, &corev1.TimelineBucketEventReferenceSnapshot{
-				StreamSequence: ref.sequence,
-				OptionalBody:   ref.optionalBody,
-			})
+			RoomId:                 key.roomID,
+			WeekStartUnix:          key.weekStart,
+			EncodedEventReferences: append([]byte(nil), bucket.encodedRefs...),
+			PayloadResident:        payloadResident,
 		}
 		snapshot.Buckets = append(snapshot.Buckets, row)
 	}
@@ -138,17 +133,15 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 		bucket := &timelineBucket{
 			resident: row.GetPayloadResident() && restored.bucketIsHotLocked(key),
 		}
+		referenceCount, lastSequence, err := inspectTimelineBucketEventRefs(row.GetEncodedEventReferences())
+		if err != nil {
+			return fmt.Errorf("room timeline snapshot bucket %s/%d references: %w", key.roomID, key.weekStart, err)
+		}
+		bucket.encodedRefs = append([]byte(nil), row.GetEncodedEventReferences()...)
+		bucket.referenceCount = referenceCount
+		bucket.lastSequence = lastSequence
 		if bucket.resident {
 			bucket.lastAccess = restored.now()
-		}
-		for _, ref := range row.GetEventReferences() {
-			if ref.GetStreamSequence() == 0 {
-				return fmt.Errorf("room timeline snapshot bucket %s/%d has zero sequence", key.roomID, key.weekStart)
-			}
-			bucket.refs = append(bucket.refs, timelineBucketEventRef{
-				sequence:     ref.GetStreamSequence(),
-				optionalBody: ref.GetOptionalBody(),
-			})
 		}
 		restored.buckets[key] = bucket
 	}

--- a/cli/internal/core/room_timeline_projection_snapshot.go
+++ b/cli/internal/core/room_timeline_projection_snapshot.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -10,7 +11,7 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-var roomTimelineSnapshotContractID = snapshotContractID("v2", &corev1.RoomTimelineProjectionSnapshot{})
+var roomTimelineSnapshotContractID = snapshotContractID("v3", &corev1.RoomTimelineProjectionSnapshotV3{})
 
 func (*RoomTimelineProjection) SnapshotContractID() string {
 	return roomTimelineSnapshotContractID
@@ -19,19 +20,77 @@ func (*RoomTimelineProjection) SnapshotContractID() string {
 func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 	p.RLock()
 	defer p.RUnlock()
-	snapshot := &corev1.RoomTimelineProjectionSnapshot{ReplayGuard: snapshotReplayGuard(p.replayGuard), RetractedEventIds: sortedMapKeys(p.retractedFlags), HiddenEchoEventIds: sortedMapKeys(p.hiddenEchoes), ShreddedUserIds: sortedMapKeys(p.shreddedUsers)}
-	for _, entry := range p.entries {
-		snapshot.Entries = append(snapshot.Entries, &corev1.TimelineEntrySnapshot{StreamSequence: entry.StreamSeq, Event: proto.Clone(entry.Event).(*corev1.Event)})
+
+	snapshot := &corev1.RoomTimelineProjectionSnapshotV3{
+		ReplayGuard:        snapshotReplayGuard(p.replayGuard),
+		RetractedEventIds:  sortedMapKeys(p.retractedFlags),
+		HiddenEchoEventIds: sortedMapKeys(p.hiddenEchoes),
+		ShreddedUserIds:    sortedMapKeys(p.shreddedUsers),
+	}
+	residentBuckets := make(map[timelineBucketKey]bool, len(p.buckets))
+	bucketKeys := make([]timelineBucketKey, 0, len(p.buckets))
+	for key := range p.buckets {
+		bucketKeys = append(bucketKeys, key)
+	}
+	sort.Slice(bucketKeys, func(i, j int) bool {
+		if bucketKeys[i].roomID != bucketKeys[j].roomID {
+			return bucketKeys[i].roomID < bucketKeys[j].roomID
+		}
+		return bucketKeys[i].weekStart < bucketKeys[j].weekStart
+	})
+	for _, key := range bucketKeys {
+		bucket := p.buckets[key]
+		payloadResident := bucket.resident && p.bucketIsHotLocked(key)
+		residentBuckets[key] = payloadResident
+		row := &corev1.TimelineBucketSnapshot{
+			RoomId:          key.roomID,
+			WeekStartUnix:   key.weekStart,
+			PayloadResident: payloadResident,
+		}
+		for _, ref := range bucket.refs {
+			row.EventReferences = append(row.EventReferences, &corev1.TimelineBucketEventReferenceSnapshot{
+				StreamSequence: ref.sequence,
+				OptionalBody:   ref.optionalBody,
+			})
+		}
+		snapshot.Buckets = append(snapshot.Buckets, row)
+	}
+
+	visibleIndexes := make(map[int]struct{})
+	for _, indexes := range p.byRoom {
+		for _, idx := range indexes {
+			visibleIndexes[idx] = struct{}{}
+		}
+	}
+	for index := range p.entries {
+		entry := &p.entries[index]
+		row := &corev1.TimelineEntryMetadataSnapshot{
+			StreamSequence:      entry.StreamSeq,
+			EventId:             entry.eventID,
+			RoomId:              entry.roomID,
+			AuthorId:            entry.authorID,
+			EchoOriginalEventId: entry.echoOriginalID,
+			WeekStartUnix:       entry.bucket.weekStart,
+			MessagePosted:       entry.messagePosted,
+		}
+		_, row.RoomVisible = visibleIndexes[index]
+		if residentBuckets[entry.bucket] && entry.Event != nil {
+			row.ResidentEvent = proto.Clone(entry.Event).(*corev1.Event)
+		}
+		snapshot.Entries = append(snapshot.Entries, row)
 	}
 	for _, id := range sortedMapKeys(p.bodyStates) {
 		state := p.bodyStates[id]
-		row := &corev1.TimelineBodySnapshot{
+		row := &corev1.TimelineBodyMetadataSnapshot{
 			MessageEventId:      id,
 			BodyEventSequences:  appendBodySequences(nil, state),
 			CurrentBodySequence: state.currentSequence,
+			RoomId:              state.bucket.roomID,
+			WeekStartUnix:       state.bucket.weekStart,
+			HasAttachments:      state.hasAttachments,
 		}
-		if state.body != nil {
-			row.Body = cloneMessageBody(state.body)
+		if residentBuckets[state.bucket] && state.body != nil {
+			row.ResidentBody = cloneMessageBody(state.body)
 		}
 		snapshot.Bodies = append(snapshot.Bodies, row)
 	}
@@ -50,7 +109,7 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 }
 
 func (p *RoomTimelineProjection) Restore(data []byte) error {
-	snapshot := &corev1.RoomTimelineProjectionSnapshot{}
+	snapshot := &corev1.RoomTimelineProjectionSnapshotV3{}
 	if len(data) > 0 {
 		if err := proto.Unmarshal(data, snapshot); err != nil {
 			return fmt.Errorf("unmarshal room timeline snapshot: %w", err)
@@ -60,41 +119,84 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("room timeline snapshot replay guard: %w", err)
 	}
-	restored := NewRoomTimelineProjection()
+	restored := newRoomTimelineProjection(roomTimelineProjectionOptions{
+		eventLoader: p.eventLoader,
+		hotWindow:   p.hotWindow,
+		now:         p.now,
+		retainAll:   p.retainAll,
+	})
 	restored.replayGuard = guard
+
+	for _, row := range snapshot.GetBuckets() {
+		key := timelineBucketKey{roomID: row.GetRoomId(), weekStart: row.GetWeekStartUnix()}
+		if key.roomID == "" {
+			return fmt.Errorf("room timeline snapshot has bucket without room")
+		}
+		if _, duplicate := restored.buckets[key]; duplicate {
+			return fmt.Errorf("room timeline snapshot repeats bucket %s/%d", key.roomID, key.weekStart)
+		}
+		bucket := &timelineBucket{
+			resident: row.GetPayloadResident() && restored.bucketIsHotLocked(key),
+		}
+		if bucket.resident {
+			bucket.lastAccess = restored.now()
+		}
+		for _, ref := range row.GetEventReferences() {
+			if ref.GetStreamSequence() == 0 {
+				return fmt.Errorf("room timeline snapshot bucket %s/%d has zero sequence", key.roomID, key.weekStart)
+			}
+			bucket.refs = append(bucket.refs, timelineBucketEventRef{
+				sequence:     ref.GetStreamSequence(),
+				optionalBody: ref.GetOptionalBody(),
+			})
+		}
+		restored.buckets[key] = bucket
+	}
+
 	for _, row := range snapshot.GetEntries() {
-		if row.GetStreamSequence() == 0 || row.GetEvent().GetId() == "" {
+		key := timelineBucketKey{roomID: row.GetRoomId(), weekStart: row.GetWeekStartUnix()}
+		bucket, bucketExists := restored.buckets[key]
+		if row.GetStreamSequence() == 0 || row.GetEventId() == "" || !bucketExists {
 			return fmt.Errorf("room timeline snapshot has invalid timeline entry")
 		}
-		event := proto.Clone(row.GetEvent()).(*corev1.Event)
-		index := restored.appendEntryLocked(row.GetStreamSequence(), event)
-		if _, duplicate := restored.byEventID[event.GetId()]; duplicate {
-			return fmt.Errorf("room timeline snapshot repeats event %q", event.GetId())
+		entry := TimelineEntry{
+			StreamSeq:      row.GetStreamSequence(),
+			eventID:        row.GetEventId(),
+			roomID:         row.GetRoomId(),
+			authorID:       row.GetAuthorId(),
+			echoOriginalID: row.GetEchoOriginalEventId(),
+			bucket:         key,
+			messagePosted:  row.GetMessagePosted(),
 		}
-		if shouldIndexRoomTimelineEvent(event) {
-			restored.byEventID[event.GetId()] = index
+		if bucket.resident {
+			if row.GetResidentEvent() == nil || row.GetResidentEvent().GetId() != entry.eventID {
+				return fmt.Errorf("room timeline snapshot resident bucket %s/%d is missing event %q", key.roomID, key.weekStart, entry.eventID)
+			}
+			entry.Event = proto.Clone(row.GetResidentEvent()).(*corev1.Event)
 		}
-		roomID := roomIDOfEvent(event)
-		if event.GetMessagePosted() != nil {
-			if roomID == "" {
-				return fmt.Errorf("room timeline snapshot message %q has no room", event.GetId())
-			}
-			restored.messagePostsByRoom[roomID] = append(restored.messagePostsByRoom[roomID], index)
-			if originalID := event.GetMessagePosted().GetEchoOfEventId(); originalID != "" {
-				restored.echoLinks[originalID] = append(restored.echoLinks[originalID], event.GetId())
+		index := len(restored.entries)
+		restored.entries = append(restored.entries, entry)
+		if _, duplicate := restored.byEventID[entry.eventID]; duplicate {
+			return fmt.Errorf("room timeline snapshot repeats event %q", entry.eventID)
+		}
+		restored.byEventID[entry.eventID] = index
+		if entry.messagePosted {
+			restored.messagePostsByRoom[entry.roomID] = append(restored.messagePostsByRoom[entry.roomID], index)
+			if entry.echoOriginalID != "" {
+				restored.echoLinks[entry.echoOriginalID] = append(restored.echoLinks[entry.echoOriginalID], entry.eventID)
 			}
 		}
-		if isVisibleRoomTimelineEntry(event) {
-			if roomID == "" {
-				return fmt.Errorf("room timeline snapshot event %q has no room", event.GetId())
-			}
-			restored.byRoom[roomID] = append(restored.byRoom[roomID], index)
+		if row.GetRoomVisible() {
+			restored.byRoom[entry.roomID] = append(restored.byRoom[entry.roomID], index)
 		}
 	}
+
 	for _, row := range snapshot.GetBodies() {
 		id := row.GetMessageEventId()
-		if id == "" {
-			return fmt.Errorf("room timeline snapshot has empty body message ID")
+		key := timelineBucketKey{roomID: row.GetRoomId(), weekStart: row.GetWeekStartUnix()}
+		bucket, bucketExists := restored.buckets[key]
+		if id == "" || !bucketExists {
+			return fmt.Errorf("room timeline snapshot has invalid body metadata")
 		}
 		if _, duplicate := restored.bodyStates[id]; duplicate {
 			return fmt.Errorf("room timeline snapshot repeats body %q", id)
@@ -103,12 +205,18 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 		if len(sequences) == 0 || sequences[len(sequences)-1] != row.GetCurrentBodySequence() {
 			return fmt.Errorf("room timeline snapshot body %q has inconsistent sequence history", id)
 		}
-		restored.bodyStates[id] = timelineBodyState{
-			body:                cloneMessageBody(row.GetBody()),
+		state := timelineBodyState{
 			currentSequence:     row.GetCurrentBodySequence(),
 			supersededSequences: append([]uint64(nil), sequences[:len(sequences)-1]...),
+			bucket:              key,
+			hasAttachments:      row.GetHasAttachments(),
 		}
+		if bucket.resident && row.GetResidentBody() != nil {
+			state.body = cloneMessageBody(row.GetResidentBody())
+		}
+		restored.bodyStates[id] = state
 	}
+
 	restoreTimes := func(rows []*corev1.StringTimestampSnapshot) (map[string]time.Time, error) {
 		values := make(map[string]time.Time, len(rows))
 		for _, row := range rows {
@@ -159,16 +267,48 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 	if err != nil {
 		return fmt.Errorf("room timeline shredded users: %w", err)
 	}
+
 	for messageID, state := range restored.bodyStates {
 		entry, ok := restored.entryByEventIDLocked(messageID)
-		if !ok || entry.Event == nil || state.body == nil {
+		if !ok {
 			continue
 		}
-		roomID := roomIDOfEvent(entry.Event)
-		restored.refreshAttachmentMessageLocked(roomID, messageID, state.body)
+		if state.hasAttachments {
+			restored.addAttachmentMessageLocked(entry.roomID, messageID, entry.StreamSeq)
+		}
+		if _, retracted := restored.retractedFlags[messageID]; retracted {
+			state.body = nil
+			restored.bodyStates[messageID] = state
+		}
 	}
+	for index := range restored.entries {
+		entry := &restored.entries[index]
+		if entry.Event != nil {
+			restored.buckets[entry.bucket].residentBytes += int64(proto.Size(entry.Event))
+		}
+	}
+	for _, state := range restored.bodyStates {
+		if state.body != nil {
+			restored.buckets[state.bucket].residentBytes += int64(proto.Size(state.body))
+		}
+	}
+
 	p.Lock()
-	p.entries, p.byRoom, p.byEventID, p.messagePostsByRoom, p.replayGuard, p.bodyStates, p.retractedFlags, p.tombstonedAt, p.shreddedAt, p.attachmentMessageIDsByRoom, p.attachmentMessageRoom, p.echoLinks, p.hiddenEchoes, p.shreddedUsers = restored.entries, restored.byRoom, restored.byEventID, restored.messagePostsByRoom, restored.replayGuard, restored.bodyStates, restored.retractedFlags, restored.tombstonedAt, restored.shreddedAt, restored.attachmentMessageIDsByRoom, restored.attachmentMessageRoom, restored.echoLinks, restored.hiddenEchoes, restored.shreddedUsers
+	p.entries = restored.entries
+	p.byRoom = restored.byRoom
+	p.byEventID = restored.byEventID
+	p.messagePostsByRoom = restored.messagePostsByRoom
+	p.replayGuard = restored.replayGuard
+	p.bodyStates = restored.bodyStates
+	p.retractedFlags = restored.retractedFlags
+	p.tombstonedAt = restored.tombstonedAt
+	p.shreddedAt = restored.shreddedAt
+	p.attachmentMessageIDsByRoom = restored.attachmentMessageIDsByRoom
+	p.attachmentMessageRoom = restored.attachmentMessageRoom
+	p.echoLinks = restored.echoLinks
+	p.hiddenEchoes = restored.hiddenEchoes
+	p.shreddedUsers = restored.shreddedUsers
+	p.buckets = restored.buckets
 	p.Unlock()
 	return nil
 }

--- a/cli/internal/core/room_timeline_projection_snapshot.go
+++ b/cli/internal/core/room_timeline_projection_snapshot.go
@@ -11,7 +11,7 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-var roomTimelineSnapshotContractID = snapshotContractID("v3", &corev1.RoomTimelineProjectionSnapshotV3{})
+var roomTimelineSnapshotContractID = snapshotContractID("v2", &corev1.RoomTimelineProjectionSnapshot{})
 
 func (*RoomTimelineProjection) SnapshotContractID() string {
 	return roomTimelineSnapshotContractID
@@ -21,7 +21,7 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 	p.RLock()
 	defer p.RUnlock()
 
-	snapshot := &corev1.RoomTimelineProjectionSnapshotV3{
+	snapshot := &corev1.RoomTimelineProjectionSnapshot{
 		ReplayGuard:        snapshotReplayGuard(p.replayGuard),
 		RetractedEventIds:  sortedMapKeys(p.retractedFlags),
 		HiddenEchoEventIds: sortedMapKeys(p.hiddenEchoes),
@@ -109,7 +109,7 @@ func (p *RoomTimelineProjection) Snapshot() ([]byte, error) {
 }
 
 func (p *RoomTimelineProjection) Restore(data []byte) error {
-	snapshot := &corev1.RoomTimelineProjectionSnapshotV3{}
+	snapshot := &corev1.RoomTimelineProjectionSnapshot{}
 	if len(data) > 0 {
 		if err := proto.Unmarshal(data, snapshot); err != nil {
 			return fmt.Errorf("unmarshal room timeline snapshot: %w", err)
@@ -269,14 +269,23 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 	}
 
 	for messageID, state := range restored.bodyStates {
-		entry, ok := restored.entryByEventIDLocked(messageID)
-		if !ok {
+		entry, entryExists := restored.entryByEventIDLocked(messageID)
+		_, retracted := restored.retractedFlags[messageID]
+		_, hidden := restored.hiddenEchoes[messageID]
+		shredded := false
+		if entryExists {
+			_, shredded = restored.shreddedUsers[entry.authorID]
+		}
+		if restored.buckets[state.bucket].resident && state.body == nil && !retracted && !hidden && !shredded {
+			return fmt.Errorf("room timeline snapshot resident bucket %s/%d is missing body %q", state.bucket.roomID, state.bucket.weekStart, messageID)
+		}
+		if !entryExists {
 			continue
 		}
-		if state.hasAttachments {
+		if state.hasAttachments && !retracted && !hidden && !shredded {
 			restored.addAttachmentMessageLocked(entry.roomID, messageID, entry.StreamSeq)
 		}
-		if _, retracted := restored.retractedFlags[messageID]; retracted {
+		if retracted || hidden || shredded {
 			state.body = nil
 			restored.bodyStates[messageID] = state
 		}

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -841,6 +841,7 @@ func TestRoomTimeline_AdminProjectionEstimateCoversDerivedIndexes(t *testing.T) 
 		"message_posts_by_room_index",
 		"applied_event_ids",
 		"body_state_index",
+		"timeline_bucket_event_refs",
 		"superseded_body_event_seqs",
 		"hidden_echoes",
 		"tombstoned_at_index",
@@ -863,6 +864,10 @@ func TestRoomTimeline_AdminProjectionEstimateCoversDerivedIndexes(t *testing.T) 
 	messagePostIndex := projectionMetricByName(metrics, "message_posts_by_room_index")
 	if messagePostIndex.Value != 3 {
 		t.Fatalf("message_posts_by_room_index value = %d, want 3 indexed message posts", messagePostIndex.Value)
+	}
+	bucketRefs := projectionMetricByName(metrics, "timeline_bucket_event_refs")
+	if bucketRefs.Bytes >= bucketRefs.Value*16 {
+		t.Fatalf("timeline_bucket_event_refs bytes = %d for %d references, want less than former struct representation", bucketRefs.Bytes, bucketRefs.Value)
 	}
 }
 

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"bytes"
 	"slices"
 	"testing"
 	"time"
@@ -509,7 +510,7 @@ func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
 	if !ok || current != 1 || len(seqs) != 1 || seqs[0] != 1 {
 		t.Fatalf("BodyEventSeqs = (%v, %d, %v), want ([1], 1, true)", seqs, current, ok)
 	}
-	if got := p.bodyStates["ENV-M1"].supersededSequences; got != nil {
+	if got := p.supersededBodySequencesByEventIDLocked("ENV-M1"); got != nil {
 		t.Fatalf("first body superseded sequences = %v, want nil", got)
 	}
 
@@ -526,7 +527,7 @@ func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
 	if got := p.AllObsoleteBodyEventSeqs(); !slices.Equal(got, []uint64{1}) {
 		t.Fatalf("AllObsoleteBodyEventSeqs active = %v, want [1]", got)
 	}
-	if got := p.bodyStates["ENV-M1"].supersededSequences; !slices.Equal(got, []uint64{1}) {
+	if got := p.supersededBodySequencesByEventIDLocked("ENV-M1"); !slices.Equal(got, []uint64{1}) {
 		t.Fatalf("edited body superseded sequences = %v, want [1]", got)
 	}
 
@@ -568,6 +569,32 @@ func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
 	}
 	if body, retracted, ok := restored.LatestBody("ENV-M1"); body != nil || !retracted || !ok {
 		t.Fatalf("LatestBody after restore = (%v, %v, %v), want retracted", body, retracted, ok)
+	}
+}
+
+func TestRoomTimeline_SnapshotCanonicalAcrossHandleOrders(t *testing.T) {
+	p := NewRoomTimelineProjection()
+	applyAll(t, p, []*corev1.Event{
+		bodyEvent("BODY-Z", "Z-MESSAGE", "R1", "U1", "z", 1),
+		bodyEvent("BODY-A", "A-MESSAGE", "R1", "U1", "a", 2),
+		postedEvent(postedOpts{envelopeID: "A-MESSAGE", roomID: "R1", actorID: "U1", at: 3}),
+		postedEvent(postedOpts{envelopeID: "Z-MESSAGE", roomID: "R1", actorID: "U1", at: 4}),
+	})
+
+	first, err := p.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := NewRoomTimelineProjection()
+	if err := restored.Restore(first); err != nil {
+		t.Fatal(err)
+	}
+	second, err := restored.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("Room Timeline snapshot differs after handles are rebuilt")
 	}
 }
 
@@ -837,13 +864,14 @@ func TestRoomTimeline_AdminProjectionEstimateCoversDerivedIndexes(t *testing.T) 
 		t.Fatalf("adminProjectionEstimate entries=%d bytes=%d, want non-zero", entries, bytes)
 	}
 	for _, name := range []string{
-		"event_id_retained_entries",
+		"event_id_index",
+		"room_entry_index",
 		"message_posts_by_room_index",
 		"applied_event_ids",
 		"body_state_index",
 		"timeline_bucket_event_refs",
 		"superseded_body_event_seqs",
-		"hidden_echoes",
+		"message_flags",
 		"tombstoned_at_index",
 	} {
 		metric := projectionMetricByName(metrics, name)
@@ -856,10 +884,6 @@ func TestRoomTimeline_AdminProjectionEstimateCoversDerivedIndexes(t *testing.T) 
 		if metric.Bytes == 0 {
 			t.Fatalf("metric %q bytes = 0, want non-zero", name)
 		}
-	}
-	retainedEntries := projectionMetricByName(metrics, "event_id_retained_entries")
-	if retainedEntries.Value != 1 {
-		t.Fatalf("event_id_retained_entries value = %d, want 1 thread reply retained only by event ID", retainedEntries.Value)
 	}
 	messagePostIndex := projectionMetricByName(metrics, "message_posts_by_room_index")
 	if messagePostIndex.Value != 3 {
@@ -933,8 +957,8 @@ func TestRoomTimeline_IgnoredRoomEventsDoNotRetainIdempotencyIDs(t *testing.T) {
 	if got := p.RoomEventCount("R1"); got != 0 {
 		t.Fatalf("RoomEventCount after ignored events = %d, want 0", got)
 	}
-	if got := len(p.byEventID); got != 0 {
-		t.Fatalf("byEventID after ignored events = %d, want 0", got)
+	if got := len(p.eventIDs.byValue); got != 0 {
+		t.Fatalf("event ID dictionary after ignored events = %d, want 0", got)
 	}
 }
 

--- a/cli/internal/core/room_unread.go
+++ b/cli/internal/core/room_unread.go
@@ -72,7 +72,10 @@ func (c *ChattoCore) NotifyRoomMarkedAsRead(ctx context.Context, userID string, 
 // value stays correct after #354 phase 4d (which re-publishes messages
 // with fresh JetStream timestamps but leaves the proto payloads intact).
 func (c *ChattoCore) GetRoomLastEvent(ctx context.Context, kind RoomKind, roomID string) (eventID string, ts time.Time, exists bool, err error) {
-	ev := c.getRoomLastRootEvent(roomID)
+	ev, err := c.getRoomLastRootEvent(ctx, roomID)
+	if err != nil {
+		return "", time.Time{}, false, err
+	}
 	if ev == nil {
 		return "", time.Time{}, false, nil
 	}
@@ -249,7 +252,10 @@ func (c *ChattoCore) GetEventTimestamp(ctx context.Context, kind RoomKind, roomI
 	if eventID == "" {
 		return time.Time{}, nil
 	}
-	entry, ok := c.roomModel.timelineEntry(eventID)
+	entry, ok, err := c.roomModel.timelineEntryContext(ctx, eventID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("load room timeline event: %w", err)
+	}
 	if !ok {
 		return time.Time{}, nil
 	}

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -19,34 +19,43 @@ import (
 // (excluding thread replies) in a room, or nil if none have been
 // projected yet. Bounded O(walk-until-found) via the projection's
 // LastVisibleRoomEntry helper.
-func (c *ChattoCore) getRoomLastRootEvent(roomID string) *corev1.Event {
-	entry, ok := c.roomModel.lastVisibleRoomEntry(roomID, func(e *corev1.Event) bool {
+func (c *ChattoCore) getRoomLastRootEvent(ctx context.Context, roomID string) (*corev1.Event, error) {
+	entry, ok, err := c.roomModel.lastVisibleRoomEntryContext(ctx, roomID, func(e *corev1.Event) bool {
 		msg := e.GetMessagePosted()
 		return msg != nil && msg.GetInThread() == ""
 	})
-	if !ok {
-		return nil
+	if err != nil {
+		return nil, err
 	}
-	return entry.Event
+	if !ok {
+		return nil, nil
+	}
+	return entry.Event, nil
 }
 
 // getRoomLastMessageEvent returns the most recent MessagePostedEvent
 // of any kind (root or thread reply) in a room, or nil. It uses the
 // projection's message-post index because thread replies are not part of the
 // visible room timeline.
-func (c *ChattoCore) getRoomLastMessageEvent(roomID string) *corev1.Event {
-	entry, ok := c.roomModel.lastRoomMessageEntry(roomID)
-	if !ok {
-		return nil
+func (c *ChattoCore) getRoomLastMessageEvent(ctx context.Context, roomID string) (*corev1.Event, error) {
+	entry, ok, err := c.RoomTimeline.LastRoomMessageEntryContext(ctx, roomID)
+	if err != nil {
+		return nil, err
 	}
-	return entry.Event
+	if !ok {
+		return nil, nil
+	}
+	return entry.Event, nil
 }
 
 // GetRoomLastMessageAt returns the timestamp of the last message in a
 // room, including thread replies. Reads from the in-memory room
 // timeline projection.
 func (c *ChattoCore) GetRoomLastMessageAt(ctx context.Context, kind RoomKind, roomID string) (time.Time, error) {
-	ev := c.getRoomLastMessageEvent(roomID)
+	ev, err := c.getRoomLastMessageEvent(ctx, roomID)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("load latest room timeline bucket: %w", err)
+	}
 	if ev == nil {
 		return time.Time{}, nil
 	}

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -8,17 +8,19 @@ import (
 )
 
 type threadReplySummary struct {
-	actorID   string
-	createdAt time.Time
-	retracted bool
+	actorID        threadUserRef
+	createdSeconds int64
+	createdNanos   int32
+	hasCreatedAt   bool
+	retracted      bool
+	known          bool
 }
 
 type threadSummary struct {
-	replyIDs          []string
 	replyCount        int
 	lastReplyAt       *time.Time
-	participantIDs    []string
-	participantCounts map[string]int
+	participantIDs    []threadUserRef
+	participantCounts []uint32
 }
 
 type ThreadFollowState string
@@ -34,9 +36,29 @@ type threadFollowRef struct {
 	threadRootEventID string
 }
 
+type threadEventRef uint32
+type threadRoomRef uint32
+type threadUserRef uint32
+
+type threadFollowKey struct {
+	user threadUserRef
+	room threadRoomRef
+	root threadEventRef
+}
+
+type threadTarget struct {
+	room threadRoomRef
+	root threadEventRef
+}
+
 type ThreadTimelineEntry struct {
 	EventID   string
 	StreamSeq uint64
+}
+
+type compactThreadTimelineEntry struct {
+	Event threadEventRef
+	Seq   uint64
 }
 
 // ThreadProjection holds an append-only event log per thread,
@@ -60,30 +82,75 @@ type ThreadTimelineEntry struct {
 // latest-body state instead of being retained as separate thread rows.
 type ThreadProjection struct {
 	events.MemoryProjection
-	byThread        map[string][]ThreadTimelineEntry
-	messageToThread map[string]string // reply event_id → thread root event_id
-	replySummaries  map[string]*threadReplySummary
-	summaryByThread map[string]*threadSummary
-	followState     map[string]ThreadFollowState
-	followers       map[string]map[string]struct{}
-	followedByUser  map[string]map[string]threadFollowRef
+	eventIDs        projectionStringTable
+	roomIDs         projectionStringTable
+	userIDs         projectionStringTable
+	byThread        map[threadEventRef][]compactThreadTimelineEntry
+	messageToThread []threadEventRef
+	replySummaries  []threadReplySummary
+	summaryByThread map[threadEventRef]*threadSummary
+	followState     map[threadFollowKey]uint8
+	followers       map[threadTarget][]threadUserRef
+	followedByUser  map[threadUserRef][]threadTarget
 	replayGuard     projectionReplayGuard
-	shreddedUsers   map[string]struct{}
+	shreddedUsers   []bool
 }
 
 // NewThreadProjection returns an empty projection.
 func NewThreadProjection() *ThreadProjection {
 	return &ThreadProjection{
-		byThread:        make(map[string][]ThreadTimelineEntry),
-		messageToThread: make(map[string]string),
-		replySummaries:  make(map[string]*threadReplySummary),
-		summaryByThread: make(map[string]*threadSummary),
-		followState:     make(map[string]ThreadFollowState),
-		followers:       make(map[string]map[string]struct{}),
-		followedByUser:  make(map[string]map[string]threadFollowRef),
+		eventIDs:        newProjectionStringTable(),
+		roomIDs:         newProjectionStringTable(),
+		userIDs:         newProjectionStringTable(),
+		byThread:        make(map[threadEventRef][]compactThreadTimelineEntry),
+		messageToThread: make([]threadEventRef, 1),
+		replySummaries:  make([]threadReplySummary, 1),
+		summaryByThread: make(map[threadEventRef]*threadSummary),
+		followState:     make(map[threadFollowKey]uint8),
+		followers:       make(map[threadTarget][]threadUserRef),
+		followedByUser:  make(map[threadUserRef][]threadTarget),
 		replayGuard:     newProjectionReplayGuard(),
-		shreddedUsers:   make(map[string]struct{}),
+		shreddedUsers:   make([]bool, 1),
 	}
+}
+
+func (p *ThreadProjection) internEventIDLocked(id string) threadEventRef {
+	ref := threadEventRef(p.eventIDs.intern(id))
+	p.messageToThread = growProjectionSlice(p.messageToThread, uint32(ref))
+	p.replySummaries = growProjectionSlice(p.replySummaries, uint32(ref))
+	return ref
+}
+
+func (p *ThreadProjection) internRoomIDLocked(id string) threadRoomRef {
+	return threadRoomRef(p.roomIDs.intern(id))
+}
+
+func (p *ThreadProjection) internUserIDLocked(id string) threadUserRef {
+	ref := threadUserRef(p.userIDs.intern(id))
+	p.shreddedUsers = growProjectionSlice(p.shreddedUsers, uint32(ref))
+	return ref
+}
+
+func (p *ThreadProjection) eventIDLocked(ref threadEventRef) string {
+	return p.eventIDs.value(uint32(ref))
+}
+
+func (p *ThreadProjection) roomIDLocked(ref threadRoomRef) string {
+	return p.roomIDs.value(uint32(ref))
+}
+
+func (p *ThreadProjection) userIDLocked(ref threadUserRef) string {
+	return p.userIDs.value(uint32(ref))
+}
+
+func (p *ThreadProjection) eventRefLocked(id string) (threadEventRef, bool) {
+	ref, ok := p.eventIDs.lookup(id)
+	return threadEventRef(ref), ok
+}
+
+func (p *ThreadProjection) userRefLocked(id string) (threadUserRef, bool) {
+	ref, ok := p.userIDs.lookup(id)
+	return threadUserRef(ref), ok
 }
 
 // Subjects implements events.Projection. Threads only need thread lifecycle
@@ -141,7 +208,8 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 	switch e := event.GetEvent().(type) {
 	case *corev1.Event_UserKeyShredded:
 		if userID := e.UserKeyShredded.GetUserId(); userID != "" {
-			p.shreddedUsers[userID] = struct{}{}
+			userRef := p.internUserIDLocked(userID)
+			p.shreddedUsers[userRef] = true
 			for threadRoot := range p.summaryByThread {
 				p.recomputeSummaryLocked(threadRoot)
 			}
@@ -153,11 +221,12 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		if threadRoot == "" {
 			return nil
 		}
-		if _, exists := p.byThread[threadRoot]; !exists {
-			p.byThread[threadRoot] = nil
+		rootRef := p.internEventIDLocked(threadRoot)
+		if _, exists := p.byThread[rootRef]; !exists {
+			p.byThread[rootRef] = nil
 		}
-		if _, exists := p.summaryByThread[threadRoot]; !exists {
-			p.summaryByThread[threadRoot] = newThreadSummary()
+		if _, exists := p.summaryByThread[rootRef]; !exists {
+			p.summaryByThread[rootRef] = newThreadSummary()
 		}
 		markApplied()
 
@@ -181,35 +250,47 @@ func (p *ThreadProjection) Apply(event *corev1.Event, seq uint64) error {
 		if replyID == "" {
 			return nil
 		}
-		p.byThread[threadRoot] = append(p.byThread[threadRoot], ThreadTimelineEntry{EventID: replyID, StreamSeq: seq})
-		p.messageToThread[replyID] = threadRoot
-		p.replySummaries[replyID] = &threadReplySummary{
-			actorID:   messageAuthorID(event),
-			createdAt: eventCreatedAt(event),
+		rootRef := p.internEventIDLocked(threadRoot)
+		replyRef := p.internEventIDLocked(replyID)
+		p.byThread[rootRef] = append(p.byThread[rootRef], compactThreadTimelineEntry{Event: replyRef, Seq: seq})
+		p.messageToThread[replyRef] = rootRef
+		createdAt := eventCreatedAt(event)
+		var createdSeconds int64
+		var createdNanos int32
+		if !createdAt.IsZero() {
+			createdSeconds = createdAt.Unix()
+			createdNanos = int32(createdAt.Nanosecond())
 		}
-		summary := p.summaryByThread[threadRoot]
+		p.replySummaries[replyRef] = threadReplySummary{
+			actorID:        p.internUserIDLocked(messageAuthorID(event)),
+			createdSeconds: createdSeconds,
+			createdNanos:   createdNanos,
+			hasCreatedAt:   !createdAt.IsZero(),
+			known:          true,
+		}
+		summary := p.summaryByThread[rootRef]
 		if summary == nil {
 			summary = newThreadSummary()
-			p.summaryByThread[threadRoot] = summary
+			p.summaryByThread[rootRef] = summary
 		}
-		summary.replyIDs = append(summary.replyIDs, replyID)
-		p.applyReplyToSummaryLocked(summary, replyID)
+		p.applyReplyToSummaryLocked(summary, replyRef)
 		markApplied()
 
 	case *corev1.Event_MessageEdited:
-		_, ok := p.messageToThread[e.MessageEdited.GetEventId()]
-		if !ok {
+		replyRef, ok := p.eventRefLocked(e.MessageEdited.GetEventId())
+		if !ok || p.messageToThread[replyRef] == 0 {
 			return nil // target isn't a known thread reply
 		}
 		markApplied()
 
 	case *corev1.Event_MessageRetracted:
 		targetID := e.MessageRetracted.GetEventId()
-		threadRoot, ok := p.messageToThread[targetID]
-		if !ok {
+		replyRef, ok := p.eventRefLocked(targetID)
+		if !ok || p.messageToThread[replyRef] == 0 {
 			return nil
 		}
-		if reply := p.replySummaries[targetID]; reply != nil {
+		threadRoot := p.messageToThread[replyRef]
+		if reply := &p.replySummaries[replyRef]; reply.known {
 			reply.retracted = true
 			// Retractions are rare and can invalidate last-reply or participant
 			// ordering, so recomputing the affected thread keeps the hot reply
@@ -227,59 +308,43 @@ func (p *ThreadProjection) CompleteStartupReplay() {
 	p.replayGuard.completeReplay()
 }
 
-func threadFollowKeyPart(roomID, threadRootEventID string) string {
-	return roomID + "\x00" + threadRootEventID
-}
-
 func (p *ThreadProjection) setThreadFollowStateLocked(userID, roomID, threadRootEventID string, state ThreadFollowState) {
 	if userID == "" || roomID == "" || threadRootEventID == "" {
 		return
 	}
-	key := threadFollowKeyPart(roomID, threadRootEventID)
-	stateKey := userID + "\x00" + key
+	userRef := p.internUserIDLocked(userID)
+	target := threadTarget{room: p.internRoomIDLocked(roomID), root: p.internEventIDLocked(threadRootEventID)}
+	stateKey := threadFollowKey{user: userRef, room: target.room, root: target.root}
+	encodedState := uint8(1)
+	if state == ThreadFollowStateUnfollowed {
+		encodedState = 2
+	}
 	previous := p.followState[stateKey]
-	if previous == state {
+	if previous == encodedState {
 		return
 	}
 
-	if previous == ThreadFollowStateFollowing {
-		if followers := p.followers[key]; followers != nil {
-			delete(followers, userID)
-			if len(followers) == 0 {
-				delete(p.followers, key)
-			}
+	if previous == 1 {
+		p.followers[target] = removeThreadUserRef(p.followers[target], userRef)
+		if len(p.followers[target]) == 0 {
+			delete(p.followers, target)
 		}
-		if followed := p.followedByUser[userID]; followed != nil {
-			delete(followed, key)
-			if len(followed) == 0 {
-				delete(p.followedByUser, userID)
-			}
+		p.followedByUser[userRef] = removeThreadTarget(p.followedByUser[userRef], target)
+		if len(p.followedByUser[userRef]) == 0 {
+			delete(p.followedByUser, userRef)
 		}
 	}
 
-	p.followState[stateKey] = state
+	p.followState[stateKey] = encodedState
 
 	if state == ThreadFollowStateFollowing {
-		followers := p.followers[key]
-		if followers == nil {
-			followers = make(map[string]struct{})
-			p.followers[key] = followers
-		}
-		followers[userID] = struct{}{}
-
-		followed := p.followedByUser[userID]
-		if followed == nil {
-			followed = make(map[string]threadFollowRef)
-			p.followedByUser[userID] = followed
-		}
-		followed[key] = threadFollowRef{roomID: roomID, threadRootEventID: threadRootEventID}
+		p.followers[target] = append(p.followers[target], userRef)
+		p.followedByUser[userRef] = append(p.followedByUser[userRef], target)
 	}
 }
 
 func newThreadSummary() *threadSummary {
-	return &threadSummary{
-		participantCounts: make(map[string]int),
-	}
+	return &threadSummary{}
 }
 
 func eventCreatedAt(event *corev1.Event) time.Time {
@@ -289,52 +354,72 @@ func eventCreatedAt(event *corev1.Event) time.Time {
 	return event.GetCreatedAt().AsTime()
 }
 
-func (p *ThreadProjection) recomputeSummaryLocked(threadRoot string) {
+func (p *ThreadProjection) recomputeSummaryLocked(threadRoot threadEventRef) {
 	summary := p.summaryByThread[threadRoot]
 	if summary == nil {
 		summary = newThreadSummary()
 		p.summaryByThread[threadRoot] = summary
-	} else if summary.participantCounts == nil {
-		summary.participantCounts = make(map[string]int)
 	}
 
 	summary.replyCount = 0
 	summary.lastReplyAt = nil
 	summary.participantIDs = nil
-	clear(summary.participantCounts)
+	summary.participantCounts = nil
 
-	for _, replyID := range summary.replyIDs {
-		p.applyReplyToSummaryLocked(summary, replyID)
+	for _, reply := range p.byThread[threadRoot] {
+		p.applyReplyToSummaryLocked(summary, reply.Event)
 	}
 }
 
-func (p *ThreadProjection) applyReplyToSummaryLocked(summary *threadSummary, replyID string) {
-	if summary == nil || replyID == "" {
+func (p *ThreadProjection) applyReplyToSummaryLocked(summary *threadSummary, replyID threadEventRef) {
+	if summary == nil || replyID == 0 {
 		return
 	}
-	if summary.participantCounts == nil {
-		summary.participantCounts = make(map[string]int)
-	}
-
 	reply := p.replySummaries[replyID]
-	if reply == nil || reply.retracted {
+	if !reply.known || reply.retracted {
 		return
 	}
-	if _, shredded := p.shreddedUsers[reply.actorID]; shredded {
+	if p.shreddedUsers[reply.actorID] {
 		return
 	}
 
 	summary.replyCount++
-	if !reply.createdAt.IsZero() && (summary.lastReplyAt == nil || reply.createdAt.After(*summary.lastReplyAt)) {
-		at := reply.createdAt
-		summary.lastReplyAt = &at
-	}
-	if reply.actorID != "" {
-		summary.participantCounts[reply.actorID]++
-		if summary.participantCounts[reply.actorID] == 1 && len(summary.participantIDs) < maxThreadParticipants {
-			summary.participantIDs = append(summary.participantIDs, reply.actorID)
+	if reply.hasCreatedAt {
+		at := time.Unix(reply.createdSeconds, int64(reply.createdNanos))
+		if summary.lastReplyAt == nil || at.After(*summary.lastReplyAt) {
+			summary.lastReplyAt = &at
 		}
 	}
+	if reply.actorID != 0 {
+		for i, participant := range summary.participantIDs {
+			if participant == reply.actorID {
+				summary.participantCounts[i]++
+				return
+			}
+		}
+		if len(summary.participantIDs) < maxThreadParticipants {
+			summary.participantIDs = append(summary.participantIDs, reply.actorID)
+			summary.participantCounts = append(summary.participantCounts, 1)
+		}
+	}
+}
+
+func removeThreadUserRef(values []threadUserRef, target threadUserRef) []threadUserRef {
+	for i, value := range values {
+		if value == target {
+			return append(values[:i], values[i+1:]...)
+		}
+	}
+	return values
+}
+
+func removeThreadTarget(values []threadTarget, target threadTarget) []threadTarget {
+	for i, value := range values {
+		if value == target {
+			return append(values[:i], values[i+1:]...)
+		}
+	}
+	return values
 }
 
 // ThreadEvents returns reply event references for a thread in stream order.
@@ -346,12 +431,18 @@ func (p *ThreadProjection) applyReplyToSummaryLocked(summary *threadSummary, rep
 func (p *ThreadProjection) ThreadEvents(rootEventID string) []ThreadTimelineEntry {
 	p.RLock()
 	defer p.RUnlock()
-	entries := p.byThread[rootEventID]
+	rootRef, ok := p.eventRefLocked(rootEventID)
+	if !ok {
+		return nil
+	}
+	entries := p.byThread[rootRef]
 	if len(entries) == 0 {
 		return nil
 	}
 	out := make([]ThreadTimelineEntry, len(entries))
-	copy(out, entries)
+	for i, entry := range entries {
+		out[i] = ThreadTimelineEntry{EventID: p.eventIDLocked(entry.Event), StreamSeq: entry.Seq}
+	}
 	return out
 }
 
@@ -361,7 +452,11 @@ func (p *ThreadProjection) ThreadEvents(rootEventID string) []ThreadTimelineEntr
 func (p *ThreadProjection) ReplyCount(rootEventID string) int {
 	p.RLock()
 	defer p.RUnlock()
-	summary := p.summaryByThread[rootEventID]
+	rootRef, ok := p.eventRefLocked(rootEventID)
+	if !ok {
+		return 0
+	}
+	summary := p.summaryByThread[rootRef]
 	if summary == nil {
 		return 0
 	}
@@ -374,13 +469,17 @@ func (p *ThreadProjection) ReplyCount(rootEventID string) int {
 func (p *ThreadProjection) ThreadMetadata(rootEventID string) *ThreadMetadata {
 	p.RLock()
 	defer p.RUnlock()
-	summary := p.summaryByThread[rootEventID]
+	rootRef, ok := p.eventRefLocked(rootEventID)
+	if !ok {
+		return &ThreadMetadata{}
+	}
+	summary := p.summaryByThread[rootRef]
 	if summary == nil {
 		return &ThreadMetadata{}
 	}
-	metadata := &ThreadMetadata{
-		ReplyCount:     summary.replyCount,
-		ParticipantIDs: append([]string(nil), summary.participantIDs...),
+	metadata := &ThreadMetadata{ReplyCount: summary.replyCount, ParticipantIDs: make([]string, len(summary.participantIDs))}
+	for i, participant := range summary.participantIDs {
+		metadata.ParticipantIDs[i] = p.userIDLocked(participant)
 	}
 	if summary.lastReplyAt != nil {
 		at := *summary.lastReplyAt
@@ -392,19 +491,37 @@ func (p *ThreadProjection) ThreadMetadata(rootEventID string) *ThreadMetadata {
 func (p *ThreadProjection) FollowState(userID, roomID, threadRootEventID string) ThreadFollowState {
 	p.RLock()
 	defer p.RUnlock()
-	return p.followState[userID+"\x00"+threadFollowKeyPart(roomID, threadRootEventID)]
+	userRaw, userOK := p.userIDs.lookup(userID)
+	roomRaw, roomOK := p.roomIDs.lookup(roomID)
+	rootRaw, rootOK := p.eventIDs.lookup(threadRootEventID)
+	if !userOK || !roomOK || !rootOK {
+		return ThreadFollowStateNone
+	}
+	switch p.followState[threadFollowKey{user: threadUserRef(userRaw), room: threadRoomRef(roomRaw), root: threadEventRef(rootRaw)}] {
+	case 1:
+		return ThreadFollowStateFollowing
+	case 2:
+		return ThreadFollowStateUnfollowed
+	default:
+		return ThreadFollowStateNone
+	}
 }
 
 func (p *ThreadProjection) ThreadFollowers(roomID, threadRootEventID string) []string {
 	p.RLock()
 	defer p.RUnlock()
-	followers := p.followers[threadFollowKeyPart(roomID, threadRootEventID)]
+	roomRaw, roomOK := p.roomIDs.lookup(roomID)
+	rootRaw, rootOK := p.eventIDs.lookup(threadRootEventID)
+	if !roomOK || !rootOK {
+		return nil
+	}
+	followers := p.followers[threadTarget{room: threadRoomRef(roomRaw), root: threadEventRef(rootRaw)}]
 	if len(followers) == 0 {
 		return nil
 	}
 	userIDs := make([]string, 0, len(followers))
-	for userID := range followers {
-		userIDs = append(userIDs, userID)
+	for _, userRef := range followers {
+		userIDs = append(userIDs, p.userIDLocked(userRef))
 	}
 	return userIDs
 }
@@ -412,13 +529,20 @@ func (p *ThreadProjection) ThreadFollowers(roomID, threadRootEventID string) []s
 func (p *ThreadProjection) FollowedThreadsForUser(userID string) []threadFollowRef {
 	p.RLock()
 	defer p.RUnlock()
-	followed := p.followedByUser[userID]
+	userRef, ok := p.userRefLocked(userID)
+	if !ok {
+		return nil
+	}
+	followed := p.followedByUser[userRef]
 	if len(followed) == 0 {
 		return nil
 	}
 	refs := make([]threadFollowRef, 0, len(followed))
-	for _, ref := range followed {
-		refs = append(refs, ref)
+	for _, target := range followed {
+		refs = append(refs, threadFollowRef{
+			roomID:            p.roomIDLocked(target.room),
+			threadRootEventID: p.eventIDLocked(target.root),
+		})
 	}
 	return refs
 }
@@ -436,7 +560,11 @@ func (p *ThreadProjection) ThreadCount() int {
 func (p *ThreadProjection) ThreadExists(rootEventID string) bool {
 	p.RLock()
 	defer p.RUnlock()
-	_, ok := p.byThread[rootEventID]
+	rootRef, known := p.eventRefLocked(rootEventID)
+	if !known {
+		return false
+	}
+	_, ok := p.byThread[rootRef]
 	return ok
 }
 
@@ -448,7 +576,7 @@ func (p *ThreadProjection) Stats() (threads int, entries int, replies int) {
 	for _, threadEntries := range p.byThread {
 		entries += len(threadEntries)
 		for _, entry := range threadEntries {
-			if entry.EventID != "" {
+			if entry.Event != 0 {
 				replies++
 			}
 		}

--- a/cli/internal/core/thread_projection_snapshot.go
+++ b/cli/internal/core/thread_projection_snapshot.go
@@ -3,7 +3,6 @@ package core
 import (
 	"fmt"
 	"sort"
-	"strings"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -30,50 +29,75 @@ func (p *ThreadProjection) Snapshot() ([]byte, error) {
 		},
 	}
 
-	threadRoots := sortedMapKeys(p.byThread)
+	threadRoots := make([]string, 0, len(p.byThread))
+	for root := range p.byThread {
+		threadRoots = append(threadRoots, p.eventIDLocked(root))
+	}
+	sort.Strings(threadRoots)
 	for _, root := range threadRoots {
 		thread := &corev1.ThreadSnapshot{RootEventId: root}
-		for _, entry := range p.byThread[root] {
+		rootRef, _ := p.eventRefLocked(root)
+		for _, entry := range p.byThread[rootRef] {
 			thread.Entries = append(thread.Entries, &corev1.ThreadTimelineEntrySnapshot{
-				EventId:        entry.EventID,
-				StreamSequence: entry.StreamSeq,
+				EventId:        p.eventIDLocked(entry.Event),
+				StreamSequence: entry.Seq,
 			})
 		}
 		snapshot.Threads = append(snapshot.Threads, thread)
 	}
 
-	replyIDs := sortedMapKeys(p.messageToThread)
-	for _, replyID := range replyIDs {
-		reply := p.replySummaries[replyID]
+	for replyRef := threadEventRef(1); int(replyRef) < len(p.messageToThread); replyRef++ {
+		if p.messageToThread[replyRef] == 0 {
+			continue
+		}
+		replyID := p.eventIDLocked(replyRef)
+		reply := p.replySummaries[replyRef]
 		row := &corev1.ThreadReplySnapshot{
 			EventId:           replyID,
-			ThreadRootEventId: p.messageToThread[replyID],
+			ThreadRootEventId: p.eventIDLocked(p.messageToThread[replyRef]),
 		}
-		if reply != nil {
-			row.ActorId = reply.actorID
+		if reply.known {
+			row.ActorId = p.userIDLocked(reply.actorID)
 			row.Retracted = reply.retracted
-			if !reply.createdAt.IsZero() {
-				row.CreatedAt = timestamppb.New(reply.createdAt)
+			if reply.hasCreatedAt {
+				row.CreatedAt = timestamppb.New(time.Unix(reply.createdSeconds, int64(reply.createdNanos)))
 			}
 		}
 		snapshot.Replies = append(snapshot.Replies, row)
 	}
+	sort.Slice(snapshot.Replies, func(i, j int) bool {
+		return snapshot.Replies[i].GetEventId() < snapshot.Replies[j].GetEventId()
+	})
 
-	followKeys := sortedMapKeys(p.followState)
-	for _, key := range followKeys {
-		parts := strings.SplitN(key, "\x00", 3)
-		if len(parts) != 3 {
-			return nil, fmt.Errorf("invalid thread follow key in projection")
+	for key, state := range p.followState {
+		stateName := ThreadFollowStateFollowing
+		if state == 2 {
+			stateName = ThreadFollowStateUnfollowed
 		}
 		snapshot.Follows = append(snapshot.Follows, &corev1.ThreadFollowSnapshot{
-			UserId:            parts[0],
-			RoomId:            parts[1],
-			ThreadRootEventId: parts[2],
-			State:             string(p.followState[key]),
+			UserId:            p.userIDLocked(key.user),
+			RoomId:            p.roomIDLocked(key.room),
+			ThreadRootEventId: p.eventIDLocked(key.root),
+			State:             string(stateName),
 		})
 	}
+	sort.Slice(snapshot.Follows, func(i, j int) bool {
+		a, b := snapshot.Follows[i], snapshot.Follows[j]
+		if a.GetUserId() != b.GetUserId() {
+			return a.GetUserId() < b.GetUserId()
+		}
+		if a.GetRoomId() != b.GetRoomId() {
+			return a.GetRoomId() < b.GetRoomId()
+		}
+		return a.GetThreadRootEventId() < b.GetThreadRootEventId()
+	})
 
-	snapshot.ShreddedUserIds = sortedMapKeys(p.shreddedUsers)
+	for userRef := threadUserRef(1); int(userRef) < len(p.shreddedUsers); userRef++ {
+		if p.shreddedUsers[userRef] {
+			snapshot.ShreddedUserIds = append(snapshot.ShreddedUserIds, p.userIDLocked(userRef))
+		}
+	}
+	sort.Strings(snapshot.ShreddedUserIds)
 	if p.replayGuard.compatibilityMode {
 		snapshot.ReplayGuard.EventIds = sortedMapKeys(p.replayGuard.eventIDs)
 	}
@@ -84,58 +108,32 @@ func (p *ThreadProjection) Restore(data []byte) (err error) {
 	if len(data) == 0 {
 		return nil
 	}
-	p.Lock()
-	defer p.Unlock()
-
-	previous := struct {
-		byThread        map[string][]ThreadTimelineEntry
-		messageToThread map[string]string
-		replySummaries  map[string]*threadReplySummary
-		summaryByThread map[string]*threadSummary
-		followState     map[string]ThreadFollowState
-		followers       map[string]map[string]struct{}
-		followedByUser  map[string]map[string]threadFollowRef
-		replayGuard     projectionReplayGuard
-		shreddedUsers   map[string]struct{}
-	}{p.byThread, p.messageToThread, p.replySummaries, p.summaryByThread, p.followState, p.followers, p.followedByUser, p.replayGuard, p.shreddedUsers}
-	defer func() {
-		if err == nil {
-			return
-		}
-		p.byThread = previous.byThread
-		p.messageToThread = previous.messageToThread
-		p.replySummaries = previous.replySummaries
-		p.summaryByThread = previous.summaryByThread
-		p.followState = previous.followState
-		p.followers = previous.followers
-		p.followedByUser = previous.followedByUser
-		p.replayGuard = previous.replayGuard
-		p.shreddedUsers = previous.shreddedUsers
-	}()
-
-	p.resetSnapshotStateLocked()
-
 	var snapshot corev1.ThreadProjectionSnapshot
 	if err := proto.Unmarshal(data, &snapshot); err != nil {
 		return fmt.Errorf("unmarshal Thread projection snapshot: %w", err)
 	}
+	restored := NewThreadProjection()
 
 	for _, thread := range snapshot.GetThreads() {
 		root := thread.GetRootEventId()
 		if root == "" {
 			return fmt.Errorf("Thread projection snapshot has empty thread root")
 		}
-		if _, exists := p.byThread[root]; exists {
+		rootRef := restored.internEventIDLocked(root)
+		if _, exists := restored.byThread[rootRef]; exists {
 			return fmt.Errorf("Thread projection snapshot repeats thread %q", root)
 		}
-		entries := make([]ThreadTimelineEntry, 0, len(thread.GetEntries()))
+		entries := make([]compactThreadTimelineEntry, 0, len(thread.GetEntries()))
 		for _, entry := range thread.GetEntries() {
 			if entry.GetEventId() == "" || entry.GetStreamSequence() == 0 {
 				return fmt.Errorf("Thread projection snapshot has invalid entry in thread %q", root)
 			}
-			entries = append(entries, ThreadTimelineEntry{EventID: entry.GetEventId(), StreamSeq: entry.GetStreamSequence()})
+			entries = append(entries, compactThreadTimelineEntry{
+				Event: restored.internEventIDLocked(entry.GetEventId()),
+				Seq:   entry.GetStreamSequence(),
+			})
 		}
-		p.byThread[root] = entries
+		restored.byThread[rootRef] = entries
 	}
 
 	for _, row := range snapshot.GetReplies() {
@@ -144,36 +142,54 @@ func (p *ThreadProjection) Restore(data []byte) (err error) {
 		if replyID == "" || root == "" {
 			return fmt.Errorf("Thread projection snapshot has invalid reply mapping")
 		}
-		if _, exists := p.messageToThread[replyID]; exists {
+		replyRef := restored.internEventIDLocked(replyID)
+		if restored.messageToThread[replyRef] != 0 {
 			return fmt.Errorf("Thread projection snapshot repeats reply %q", replyID)
 		}
-		var createdAt time.Time
+		var createdSeconds int64
+		var createdNanos int32
 		if row.GetCreatedAt() != nil {
 			if err := row.GetCreatedAt().CheckValid(); err != nil {
 				return fmt.Errorf("Thread projection snapshot reply %q timestamp: %w", replyID, err)
 			}
-			createdAt = row.GetCreatedAt().AsTime()
+			at := row.GetCreatedAt().AsTime()
+			createdSeconds = at.Unix()
+			createdNanos = int32(at.Nanosecond())
 		}
-		p.messageToThread[replyID] = root
-		p.replySummaries[replyID] = &threadReplySummary{actorID: row.GetActorId(), createdAt: createdAt, retracted: row.GetRetracted()}
+		restored.messageToThread[replyRef] = restored.internEventIDLocked(root)
+		restored.replySummaries[replyRef] = threadReplySummary{
+			actorID:        restored.internUserIDLocked(row.GetActorId()),
+			createdSeconds: createdSeconds,
+			createdNanos:   createdNanos,
+			hasCreatedAt:   row.GetCreatedAt() != nil,
+			retracted:      row.GetRetracted(),
+			known:          true,
+		}
 	}
 
-	seenEntries := make(map[string]struct{}, len(p.messageToThread))
-	for root, entries := range p.byThread {
+	seenEntries := make(map[threadEventRef]struct{}, len(restored.messageToThread))
+	replyCount := 0
+	for root, entries := range restored.byThread {
 		summary := newThreadSummary()
 		for _, entry := range entries {
-			if _, duplicate := seenEntries[entry.EventID]; duplicate {
-				return fmt.Errorf("Thread projection snapshot repeats timeline entry %q", entry.EventID)
+			if _, duplicate := seenEntries[entry.Event]; duplicate {
+				return fmt.Errorf("Thread projection snapshot repeats timeline entry %q", restored.eventIDLocked(entry.Event))
 			}
-			seenEntries[entry.EventID] = struct{}{}
-			if mappedRoot, ok := p.messageToThread[entry.EventID]; !ok || mappedRoot != root {
-				return fmt.Errorf("Thread projection snapshot entry %q has no matching reply", entry.EventID)
+			seenEntries[entry.Event] = struct{}{}
+			if restored.messageToThread[entry.Event] != root {
+				return fmt.Errorf("Thread projection snapshot entry %q has no matching reply", restored.eventIDLocked(entry.Event))
 			}
-			summary.replyIDs = append(summary.replyIDs, entry.EventID)
+			replyCount++
 		}
-		p.summaryByThread[root] = summary
+		restored.summaryByThread[root] = summary
 	}
-	if len(seenEntries) != len(p.messageToThread) {
+	mappedReplies := 0
+	for _, root := range restored.messageToThread {
+		if root != 0 {
+			mappedReplies++
+		}
+	}
+	if replyCount != mappedReplies {
 		return fmt.Errorf("Thread projection snapshot contains replies outside thread timelines")
 	}
 
@@ -181,13 +197,14 @@ func (p *ThreadProjection) Restore(data []byte) (err error) {
 		if userID == "" {
 			return fmt.Errorf("Thread projection snapshot has empty shredded user id")
 		}
-		if _, duplicate := p.shreddedUsers[userID]; duplicate {
+		userRef := restored.internUserIDLocked(userID)
+		if restored.shreddedUsers[userRef] {
 			return fmt.Errorf("Thread projection snapshot repeats shredded user %q", userID)
 		}
-		p.shreddedUsers[userID] = struct{}{}
+		restored.shreddedUsers[userRef] = true
 	}
-	for root := range p.summaryByThread {
-		p.recomputeSummaryLocked(root)
+	for root := range restored.summaryByThread {
+		restored.recomputeSummaryLocked(root)
 	}
 
 	for _, follow := range snapshot.GetFollows() {
@@ -195,12 +212,16 @@ func (p *ThreadProjection) Restore(data []byte) (err error) {
 		if state != ThreadFollowStateFollowing && state != ThreadFollowStateUnfollowed {
 			return fmt.Errorf("Thread projection snapshot has invalid follow state %q", state)
 		}
-		key := follow.GetUserId() + "\x00" + threadFollowKeyPart(follow.GetRoomId(), follow.GetThreadRootEventId())
-		if _, duplicate := p.followState[key]; duplicate {
+		key := threadFollowKey{
+			user: restored.internUserIDLocked(follow.GetUserId()),
+			room: restored.internRoomIDLocked(follow.GetRoomId()),
+			root: restored.internEventIDLocked(follow.GetThreadRootEventId()),
+		}
+		if _, duplicate := restored.followState[key]; duplicate {
 			return fmt.Errorf("Thread projection snapshot repeats follow state")
 		}
-		p.setThreadFollowStateLocked(follow.GetUserId(), follow.GetRoomId(), follow.GetThreadRootEventId(), state)
-		if _, stored := p.followState[key]; !stored {
+		restored.setThreadFollowStateLocked(follow.GetUserId(), follow.GetRoomId(), follow.GetThreadRootEventId(), state)
+		if _, stored := restored.followState[key]; !stored {
 			return fmt.Errorf("Thread projection snapshot has incomplete follow identity")
 		}
 	}
@@ -209,42 +230,44 @@ func (p *ThreadProjection) Restore(data []byte) (err error) {
 	if guard == nil {
 		return fmt.Errorf("Thread projection snapshot is missing replay guard")
 	}
-	p.replayGuard.highestSeq = guard.GetHighestSequence()
-	p.replayGuard.replayComplete = guard.GetReplayComplete()
-	p.replayGuard.compatibilityMode = guard.GetCompatibilityMode()
-	if p.replayGuard.compatibilityMode {
-		p.replayGuard.eventIDs = make(eventIDSet, len(guard.GetEventIds()))
+	restored.replayGuard.highestSeq = guard.GetHighestSequence()
+	restored.replayGuard.replayComplete = guard.GetReplayComplete()
+	restored.replayGuard.compatibilityMode = guard.GetCompatibilityMode()
+	if restored.replayGuard.compatibilityMode {
+		restored.replayGuard.eventIDs = make(eventIDSet, len(guard.GetEventIds()))
 		for _, eventID := range guard.GetEventIds() {
 			if eventID == "" {
 				return fmt.Errorf("Thread projection snapshot has empty compatibility event id")
 			}
-			if _, duplicate := p.replayGuard.eventIDs[eventID]; duplicate {
+			if _, duplicate := restored.replayGuard.eventIDs[eventID]; duplicate {
 				return fmt.Errorf("Thread projection snapshot repeats compatibility event %q", eventID)
 			}
-			p.replayGuard.eventIDs[eventID] = struct{}{}
+			restored.replayGuard.eventIDs[eventID] = struct{}{}
 		}
 	} else {
 		if len(guard.GetEventIds()) != 0 {
 			return fmt.Errorf("Thread projection snapshot has event ids outside compatibility mode")
 		}
-		if p.replayGuard.replayComplete {
-			p.replayGuard.eventIDs = nil
+		if restored.replayGuard.replayComplete {
+			restored.replayGuard.eventIDs = nil
 		}
 	}
 
+	p.Lock()
+	p.eventIDs = restored.eventIDs
+	p.roomIDs = restored.roomIDs
+	p.userIDs = restored.userIDs
+	p.byThread = restored.byThread
+	p.messageToThread = restored.messageToThread
+	p.replySummaries = restored.replySummaries
+	p.summaryByThread = restored.summaryByThread
+	p.followState = restored.followState
+	p.followers = restored.followers
+	p.followedByUser = restored.followedByUser
+	p.replayGuard = restored.replayGuard
+	p.shreddedUsers = restored.shreddedUsers
+	p.Unlock()
 	return nil
-}
-
-func (p *ThreadProjection) resetSnapshotStateLocked() {
-	p.byThread = make(map[string][]ThreadTimelineEntry)
-	p.messageToThread = make(map[string]string)
-	p.replySummaries = make(map[string]*threadReplySummary)
-	p.summaryByThread = make(map[string]*threadSummary)
-	p.followState = make(map[string]ThreadFollowState)
-	p.followers = make(map[string]map[string]struct{})
-	p.followedByUser = make(map[string]map[string]threadFollowRef)
-	p.replayGuard = newProjectionReplayGuard()
-	p.shreddedUsers = make(map[string]struct{})
 }
 
 func sortedMapKeys[V any](values map[string]V) []string {

--- a/cli/internal/core/thread_projection_test.go
+++ b/cli/internal/core/thread_projection_test.go
@@ -5,7 +5,9 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -75,6 +77,30 @@ func TestThreadProjectionSnapshotRoundTripAndTailReplay(t *testing.T) {
 func TestThreadProjectionSnapshotContractID(t *testing.T) {
 	if got := NewThreadProjection().SnapshotContractID(); !strings.HasPrefix(got, "v1-") {
 		t.Fatalf("SnapshotContractID() = %q, want v1 schema contract", got)
+	}
+}
+
+func TestThreadProjectionSnapshotCanonicalAcrossHandleOrders(t *testing.T) {
+	p := NewThreadProjection()
+	applyAll(t, p, []*corev1.Event{
+		postedEvent(postedOpts{envelopeID: "Z-REPLY", roomID: "R1", actorID: "U1", inThread: "Z-ROOT", at: 1}),
+		postedEvent(postedOpts{envelopeID: "A-REPLY", roomID: "R1", actorID: "U1", inThread: "A-ROOT", at: 2}),
+	})
+
+	first, err := p.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := NewThreadProjection()
+	if err := restored.Restore(first); err != nil {
+		t.Fatal(err)
+	}
+	second, err := restored.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(first, second) {
+		t.Fatal("Thread snapshot differs after handles are rebuilt")
 	}
 }
 
@@ -191,6 +217,37 @@ func TestThreadProjection_RepliesAppended(t *testing.T) {
 	}
 	if !slices.Equal(metadata.ParticipantIDs, []string{"U2", "U3"}) {
 		t.Errorf("ThreadMetadata ParticipantIDs = %v, want [U2 U3]", metadata.ParticipantIDs)
+	}
+}
+
+func TestThreadProjection_PreservesUnixEpochReplyTime(t *testing.T) {
+	p := NewThreadProjection()
+	reply := postedEvent(postedOpts{
+		envelopeID: "ENV-R1",
+		eventID:    "REPLY1",
+		roomID:     "R1",
+		actorID:    "U2",
+		inThread:   "ROOT",
+	})
+	reply.CreatedAt = timestamppb.New(time.Unix(0, 0))
+	applyAll(t, p, []*corev1.Event{reply})
+
+	metadata := p.ThreadMetadata("ROOT")
+	if metadata.LastReplyAt == nil || !metadata.LastReplyAt.Equal(time.Unix(0, 0)) {
+		t.Fatalf("LastReplyAt = %v, want Unix epoch", metadata.LastReplyAt)
+	}
+
+	snapshot, err := p.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := NewThreadProjection()
+	if err := restored.Restore(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	metadata = restored.ThreadMetadata("ROOT")
+	if metadata.LastReplyAt == nil || !metadata.LastReplyAt.Equal(time.Unix(0, 0)) {
+		t.Fatalf("LastReplyAt after restore = %v, want Unix epoch", metadata.LastReplyAt)
 	}
 }
 

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -107,11 +107,22 @@ func (c *ChattoCore) GetThreadReplyEvents(ctx context.Context, kind RoomKind, ro
 		return nil, fmt.Errorf("thread root message not found in room %s: event ID %s", roomID, threadRootEventID)
 	}
 
-	entries, err := c.roomModel.threadEventsContext(ctx, threadRootEventID)
-	if err != nil {
-		return nil, fmt.Errorf("load thread replies: %w", err)
-	}
+	refs := c.roomModel.threadEventRefs(threadRootEventID)
 	if afterSeq != nil && *afterSeq > 0 {
+		selected := make([]ThreadTimelineEntry, 0, limit+1)
+		for _, ref := range refs {
+			if ref.StreamSeq <= *afterSeq {
+				continue
+			}
+			selected = append(selected, ref)
+			if len(selected) >= limit+1 {
+				break
+			}
+		}
+		entries, err := c.roomModel.hydrateThreadEventsContext(ctx, selected)
+		if err != nil {
+			return nil, fmt.Errorf("load thread replies: %w", err)
+		}
 		return threadReplyEventsAfter(entries, *afterSeq, limit), nil
 	}
 
@@ -119,14 +130,21 @@ func (c *ChattoCore) GetThreadReplyEvents(ctx context.Context, kind RoomKind, ro
 	if beforeSeq != nil {
 		before = *beforeSeq
 	}
-
-	raw := make([]*RoomEvent, 0, limit+1)
-	for i := len(entries) - 1; i >= 0 && len(raw) < limit+1; i-- {
-		entry := entries[i]
-		if !isThreadReplyEventForPage(entry) {
+	selected := make([]ThreadTimelineEntry, 0, limit+1)
+	for i := len(refs) - 1; i >= 0 && len(selected) < limit+1; i-- {
+		if before > 0 && refs[i].StreamSeq >= before {
 			continue
 		}
-		if before > 0 && entry.StreamSeq >= before {
+		selected = append(selected, refs[i])
+	}
+	entries, err := c.roomModel.hydrateThreadEventsContext(ctx, selected)
+	if err != nil {
+		return nil, fmt.Errorf("load thread replies: %w", err)
+	}
+
+	raw := make([]*RoomEvent, 0, limit+1)
+	for _, entry := range entries {
+		if !isThreadReplyEventForPage(entry) {
 			continue
 		}
 		raw = append(raw, &RoomEvent{Event: entry.Event, Sequence: entry.StreamSeq})
@@ -171,29 +189,22 @@ func (c *ChattoCore) GetThreadReplyEventsAround(ctx context.Context, kind RoomKi
 		return nil, fmt.Errorf("thread root message not found in room %s: event ID %s", roomID, threadRootEventID)
 	}
 
-	entries, err := c.roomModel.threadEventsContext(ctx, threadRootEventID)
-	if err != nil {
-		return nil, fmt.Errorf("load thread replies: %w", err)
-	}
-	replies := make([]*TimelineEntry, 0, len(entries))
+	refs := c.roomModel.threadEventRefs(threadRootEventID)
 	targetIndex := 0
 	foundAnchor := anchorEventID == threadRootEventID
-	for _, entry := range entries {
-		if !isThreadReplyEventForPage(entry) {
-			continue
-		}
-		if entry.Event.GetId() == anchorEventID {
-			targetIndex = len(replies)
+	for index, ref := range refs {
+		if ref.EventID == anchorEventID {
+			targetIndex = index
 			foundAnchor = true
+			break
 		}
-		replies = append(replies, entry)
 	}
 	if !foundAnchor {
 		return nil, ErrMessageNotFound
 	}
 
 	start := 0
-	end := len(replies)
+	end := len(refs)
 	if anchorEventID == threadRootEventID {
 		if end > limit {
 			end = limit
@@ -205,8 +216,8 @@ func (c *ChattoCore) GetThreadReplyEventsAround(ctx context.Context, kind RoomKi
 			start = 0
 		}
 		end = start + limit
-		if end > len(replies) {
-			end = len(replies)
+		if end > len(refs) {
+			end = len(refs)
 			start = end - limit
 			if start < 0 {
 				start = 0
@@ -214,15 +225,19 @@ func (c *ChattoCore) GetThreadReplyEventsAround(ctx context.Context, kind RoomKi
 		}
 	}
 
+	entries, err := c.roomModel.hydrateThreadEventsContext(ctx, refs[start:end])
+	if err != nil {
+		return nil, fmt.Errorf("load thread replies: %w", err)
+	}
 	raw := make([]*RoomEvent, 0, end-start)
-	for _, entry := range replies[start:end] {
+	for _, entry := range entries {
 		raw = append(raw, &RoomEvent{Event: entry.Event, Sequence: entry.StreamSeq})
 	}
 
 	result := &RoomEventsResult{
 		Events:   raw,
 		HasOlder: start > 0,
-		HasNewer: end < len(replies),
+		HasNewer: end < len(refs),
 	}
 	setRoomEventsResultCursors(result)
 	return result, nil
@@ -563,10 +578,7 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 // SetThreadLastOpened records the latest current reply in the thread as read.
 // Returns the previous marker time (zero if never opened before).
 func (c *ChattoCore) SetThreadLastOpened(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (time.Time, error) {
-	latestID, err := c.latestThreadMessageEventID(ctx, threadRootEventID)
-	if err != nil {
-		return time.Time{}, err
-	}
+	latestID := c.latestThreadMessageEventID(threadRootEventID)
 	if latestID == "" {
 		return time.Time{}, nil
 	}
@@ -585,21 +597,12 @@ func (c *ChattoCore) threadReadMarkerTime(ctx context.Context, kind RoomKind, ro
 	return c.GetEventTimestamp(ctx, kind, roomID, eventID)
 }
 
-func (c *ChattoCore) latestThreadMessageEventID(ctx context.Context, threadRootEventID string) (string, error) {
-	entries, err := c.roomModel.threadEventsContext(ctx, threadRootEventID)
-	if err != nil {
-		return "", fmt.Errorf("load thread timeline buckets: %w", err)
+func (c *ChattoCore) latestThreadMessageEventID(threadRootEventID string) string {
+	refs := c.roomModel.threadEventRefs(threadRootEventID)
+	if len(refs) > 0 && refs[len(refs)-1].EventID != "" {
+		return refs[len(refs)-1].EventID
 	}
-	for i := len(entries) - 1; i >= 0; i-- {
-		event := entries[i].Event
-		if event == nil || event.GetMessagePosted() == nil {
-			continue
-		}
-		if id := event.GetId(); id != "" {
-			return id, nil
-		}
-	}
-	return threadRootEventID, nil
+	return threadRootEventID
 }
 
 func (c *ChattoCore) threadFollowState(ctx context.Context, userID, roomID, threadRootEventID string) (ThreadFollowState, error) {

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -57,7 +57,10 @@ const maxThreadParticipants = 50
 //
 // Authorization: caller must verify room membership before calling.
 func (c *ChattoCore) GetThreadEvents(ctx context.Context, kind RoomKind, room_id string, threadRootEventId string) ([]*corev1.Event, error) {
-	rootEntry, ok := c.roomModel.timelineEntry(threadRootEventId)
+	rootEntry, ok, err := c.roomModel.timelineEntryContext(ctx, threadRootEventId)
+	if err != nil {
+		return nil, fmt.Errorf("load thread root: %w", err)
+	}
 	if !ok {
 		return nil, fmt.Errorf("thread root message not found: event ID %s", threadRootEventId)
 	}
@@ -65,7 +68,10 @@ func (c *ChattoCore) GetThreadEvents(ctx context.Context, kind RoomKind, room_id
 		return nil, fmt.Errorf("event ID %s is not a message event", threadRootEventId)
 	}
 
-	replies := c.roomModel.threadEvents(threadRootEventId)
+	replies, err := c.roomModel.threadEventsContext(ctx, threadRootEventId)
+	if err != nil {
+		return nil, fmt.Errorf("load thread replies: %w", err)
+	}
 	events := make([]*corev1.Event, 0, 1+len(replies))
 	events = append(events, rootEntry.Event)
 	for _, r := range replies {
@@ -87,7 +93,10 @@ func (c *ChattoCore) GetThreadEvents(ctx context.Context, kind RoomKind, room_id
 func (c *ChattoCore) GetThreadReplyEvents(ctx context.Context, kind RoomKind, roomID, threadRootEventID string, limit int, beforeSeq *uint64, afterSeq *uint64) (*RoomEventsResult, error) {
 	limit = clampHistoricalMessageLimit(limit)
 
-	rootEntry, ok := c.roomModel.timelineEntry(threadRootEventID)
+	rootEntry, ok, err := c.roomModel.timelineEntryContext(ctx, threadRootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("load thread root: %w", err)
+	}
 	if !ok {
 		return nil, fmt.Errorf("thread root message not found: event ID %s", threadRootEventID)
 	}
@@ -98,7 +107,10 @@ func (c *ChattoCore) GetThreadReplyEvents(ctx context.Context, kind RoomKind, ro
 		return nil, fmt.Errorf("thread root message not found in room %s: event ID %s", roomID, threadRootEventID)
 	}
 
-	entries := c.roomModel.threadEvents(threadRootEventID)
+	entries, err := c.roomModel.threadEventsContext(ctx, threadRootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("load thread replies: %w", err)
+	}
 	if afterSeq != nil && *afterSeq > 0 {
 		return threadReplyEventsAfter(entries, *afterSeq, limit), nil
 	}
@@ -145,7 +157,10 @@ func (c *ChattoCore) GetThreadReplyEvents(ctx context.Context, kind RoomKind, ro
 func (c *ChattoCore) GetThreadReplyEventsAround(ctx context.Context, kind RoomKind, roomID, threadRootEventID, anchorEventID string, limit int) (*RoomEventsResult, error) {
 	limit = clampHistoricalMessageLimit(limit)
 
-	rootEntry, ok := c.roomModel.timelineEntry(threadRootEventID)
+	rootEntry, ok, err := c.roomModel.timelineEntryContext(ctx, threadRootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("load thread root: %w", err)
+	}
 	if !ok {
 		return nil, fmt.Errorf("thread root message not found: event ID %s", threadRootEventID)
 	}
@@ -156,7 +171,10 @@ func (c *ChattoCore) GetThreadReplyEventsAround(ctx context.Context, kind RoomKi
 		return nil, fmt.Errorf("thread root message not found in room %s: event ID %s", roomID, threadRootEventID)
 	}
 
-	entries := c.roomModel.threadEvents(threadRootEventID)
+	entries, err := c.roomModel.threadEventsContext(ctx, threadRootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("load thread replies: %w", err)
+	}
 	replies := make([]*TimelineEntry, 0, len(entries))
 	targetIndex := 0
 	foundAnchor := anchorEventID == threadRootEventID
@@ -545,7 +563,10 @@ func (c *ChattoCore) SetThreadLastOpenedAt(ctx context.Context, kind RoomKind, u
 // SetThreadLastOpened records the latest current reply in the thread as read.
 // Returns the previous marker time (zero if never opened before).
 func (c *ChattoCore) SetThreadLastOpened(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID string) (time.Time, error) {
-	latestID := c.latestThreadMessageEventID(threadRootEventID)
+	latestID, err := c.latestThreadMessageEventID(ctx, threadRootEventID)
+	if err != nil {
+		return time.Time{}, err
+	}
 	if latestID == "" {
 		return time.Time{}, nil
 	}
@@ -564,18 +585,21 @@ func (c *ChattoCore) threadReadMarkerTime(ctx context.Context, kind RoomKind, ro
 	return c.GetEventTimestamp(ctx, kind, roomID, eventID)
 }
 
-func (c *ChattoCore) latestThreadMessageEventID(threadRootEventID string) string {
-	entries := c.roomModel.threadEvents(threadRootEventID)
+func (c *ChattoCore) latestThreadMessageEventID(ctx context.Context, threadRootEventID string) (string, error) {
+	entries, err := c.roomModel.threadEventsContext(ctx, threadRootEventID)
+	if err != nil {
+		return "", fmt.Errorf("load thread timeline buckets: %w", err)
+	}
 	for i := len(entries) - 1; i >= 0; i-- {
 		event := entries[i].Event
 		if event == nil || event.GetMessagePosted() == nil {
 			continue
 		}
 		if id := event.GetId(); id != "" {
-			return id
+			return id, nil
 		}
 	}
-	return threadRootEventID
+	return threadRootEventID, nil
 }
 
 func (c *ChattoCore) threadFollowState(ctx context.Context, userID, roomID, threadRootEventID string) (ThreadFollowState, error) {

--- a/cli/internal/pb/chatto/core/v1/projection_snapshots.pb.go
+++ b/cli/internal/pb/chatto/core/v1/projection_snapshots.pb.go
@@ -2934,6 +2934,436 @@ func (x *TimelineBodySnapshot) GetCurrentBodySequence() uint64 {
 	return 0
 }
 
+// RoomTimelineProjectionSnapshotV3 stores the always-resident timeline
+// directory separately from optional decoded bucket payloads.
+type RoomTimelineProjectionSnapshotV3 struct {
+	state              protoimpl.MessageState           `protogen:"open.v1"`
+	Entries            []*TimelineEntryMetadataSnapshot `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	Bodies             []*TimelineBodyMetadataSnapshot  `protobuf:"bytes,2,rep,name=bodies,proto3" json:"bodies,omitempty"`
+	Buckets            []*TimelineBucketSnapshot        `protobuf:"bytes,3,rep,name=buckets,proto3" json:"buckets,omitempty"`
+	TombstonedAt       []*StringTimestampSnapshot       `protobuf:"bytes,4,rep,name=tombstoned_at,json=tombstonedAt,proto3" json:"tombstoned_at,omitempty"`
+	ShreddedAt         []*StringTimestampSnapshot       `protobuf:"bytes,5,rep,name=shredded_at,json=shreddedAt,proto3" json:"shredded_at,omitempty"`
+	RetractedEventIds  []string                         `protobuf:"bytes,6,rep,name=retracted_event_ids,json=retractedEventIds,proto3" json:"retracted_event_ids,omitempty"`
+	HiddenEchoEventIds []string                         `protobuf:"bytes,7,rep,name=hidden_echo_event_ids,json=hiddenEchoEventIds,proto3" json:"hidden_echo_event_ids,omitempty"`
+	ShreddedUserIds    []string                         `protobuf:"bytes,8,rep,name=shredded_user_ids,json=shreddedUserIds,proto3" json:"shredded_user_ids,omitempty"`
+	ReplayGuard        *ProjectionReplayGuardSnapshot   `protobuf:"bytes,9,opt,name=replay_guard,json=replayGuard,proto3" json:"replay_guard,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) Reset() {
+	*x = RoomTimelineProjectionSnapshotV3{}
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RoomTimelineProjectionSnapshotV3) ProtoMessage() {}
+
+func (x *RoomTimelineProjectionSnapshotV3) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RoomTimelineProjectionSnapshotV3.ProtoReflect.Descriptor instead.
+func (*RoomTimelineProjectionSnapshotV3) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{42}
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetEntries() []*TimelineEntryMetadataSnapshot {
+	if x != nil {
+		return x.Entries
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetBodies() []*TimelineBodyMetadataSnapshot {
+	if x != nil {
+		return x.Bodies
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetBuckets() []*TimelineBucketSnapshot {
+	if x != nil {
+		return x.Buckets
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetTombstonedAt() []*StringTimestampSnapshot {
+	if x != nil {
+		return x.TombstonedAt
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetShreddedAt() []*StringTimestampSnapshot {
+	if x != nil {
+		return x.ShreddedAt
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetRetractedEventIds() []string {
+	if x != nil {
+		return x.RetractedEventIds
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetHiddenEchoEventIds() []string {
+	if x != nil {
+		return x.HiddenEchoEventIds
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetShreddedUserIds() []string {
+	if x != nil {
+		return x.ShreddedUserIds
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshotV3) GetReplayGuard() *ProjectionReplayGuardSnapshot {
+	if x != nil {
+		return x.ReplayGuard
+	}
+	return nil
+}
+
+type TimelineEntryMetadataSnapshot struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	StreamSequence      uint64                 `protobuf:"varint,1,opt,name=stream_sequence,json=streamSequence,proto3" json:"stream_sequence,omitempty"`
+	EventId             string                 `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
+	RoomId              string                 `protobuf:"bytes,3,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	AuthorId            string                 `protobuf:"bytes,4,opt,name=author_id,json=authorId,proto3" json:"author_id,omitempty"`
+	EchoOriginalEventId string                 `protobuf:"bytes,5,opt,name=echo_original_event_id,json=echoOriginalEventId,proto3" json:"echo_original_event_id,omitempty"`
+	WeekStartUnix       int64                  `protobuf:"varint,6,opt,name=week_start_unix,json=weekStartUnix,proto3" json:"week_start_unix,omitempty"`
+	MessagePosted       bool                   `protobuf:"varint,7,opt,name=message_posted,json=messagePosted,proto3" json:"message_posted,omitempty"`
+	RoomVisible         bool                   `protobuf:"varint,8,opt,name=room_visible,json=roomVisible,proto3" json:"room_visible,omitempty"`
+	ResidentEvent       *Event                 `protobuf:"bytes,9,opt,name=resident_event,json=residentEvent,proto3" json:"resident_event,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *TimelineEntryMetadataSnapshot) Reset() {
+	*x = TimelineEntryMetadataSnapshot{}
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimelineEntryMetadataSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimelineEntryMetadataSnapshot) ProtoMessage() {}
+
+func (x *TimelineEntryMetadataSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimelineEntryMetadataSnapshot.ProtoReflect.Descriptor instead.
+func (*TimelineEntryMetadataSnapshot) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{43}
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetStreamSequence() uint64 {
+	if x != nil {
+		return x.StreamSequence
+	}
+	return 0
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetEventId() string {
+	if x != nil {
+		return x.EventId
+	}
+	return ""
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetAuthorId() string {
+	if x != nil {
+		return x.AuthorId
+	}
+	return ""
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetEchoOriginalEventId() string {
+	if x != nil {
+		return x.EchoOriginalEventId
+	}
+	return ""
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetWeekStartUnix() int64 {
+	if x != nil {
+		return x.WeekStartUnix
+	}
+	return 0
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetMessagePosted() bool {
+	if x != nil {
+		return x.MessagePosted
+	}
+	return false
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetRoomVisible() bool {
+	if x != nil {
+		return x.RoomVisible
+	}
+	return false
+}
+
+func (x *TimelineEntryMetadataSnapshot) GetResidentEvent() *Event {
+	if x != nil {
+		return x.ResidentEvent
+	}
+	return nil
+}
+
+type TimelineBodyMetadataSnapshot struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	MessageEventId      string                 `protobuf:"bytes,1,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
+	BodyEventSequences  []uint64               `protobuf:"varint,2,rep,packed,name=body_event_sequences,json=bodyEventSequences,proto3" json:"body_event_sequences,omitempty"`
+	CurrentBodySequence uint64                 `protobuf:"varint,3,opt,name=current_body_sequence,json=currentBodySequence,proto3" json:"current_body_sequence,omitempty"`
+	RoomId              string                 `protobuf:"bytes,4,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	WeekStartUnix       int64                  `protobuf:"varint,5,opt,name=week_start_unix,json=weekStartUnix,proto3" json:"week_start_unix,omitempty"`
+	HasAttachments      bool                   `protobuf:"varint,6,opt,name=has_attachments,json=hasAttachments,proto3" json:"has_attachments,omitempty"`
+	ResidentBody        *MessageBody           `protobuf:"bytes,7,opt,name=resident_body,json=residentBody,proto3" json:"resident_body,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *TimelineBodyMetadataSnapshot) Reset() {
+	*x = TimelineBodyMetadataSnapshot{}
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimelineBodyMetadataSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimelineBodyMetadataSnapshot) ProtoMessage() {}
+
+func (x *TimelineBodyMetadataSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimelineBodyMetadataSnapshot.ProtoReflect.Descriptor instead.
+func (*TimelineBodyMetadataSnapshot) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{44}
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetMessageEventId() string {
+	if x != nil {
+		return x.MessageEventId
+	}
+	return ""
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetBodyEventSequences() []uint64 {
+	if x != nil {
+		return x.BodyEventSequences
+	}
+	return nil
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetCurrentBodySequence() uint64 {
+	if x != nil {
+		return x.CurrentBodySequence
+	}
+	return 0
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetWeekStartUnix() int64 {
+	if x != nil {
+		return x.WeekStartUnix
+	}
+	return 0
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetHasAttachments() bool {
+	if x != nil {
+		return x.HasAttachments
+	}
+	return false
+}
+
+func (x *TimelineBodyMetadataSnapshot) GetResidentBody() *MessageBody {
+	if x != nil {
+		return x.ResidentBody
+	}
+	return nil
+}
+
+type TimelineBucketSnapshot struct {
+	state           protoimpl.MessageState                  `protogen:"open.v1"`
+	RoomId          string                                  `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	WeekStartUnix   int64                                   `protobuf:"varint,2,opt,name=week_start_unix,json=weekStartUnix,proto3" json:"week_start_unix,omitempty"`
+	EventReferences []*TimelineBucketEventReferenceSnapshot `protobuf:"bytes,3,rep,name=event_references,json=eventReferences,proto3" json:"event_references,omitempty"`
+	PayloadResident bool                                    `protobuf:"varint,4,opt,name=payload_resident,json=payloadResident,proto3" json:"payload_resident,omitempty"`
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *TimelineBucketSnapshot) Reset() {
+	*x = TimelineBucketSnapshot{}
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimelineBucketSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimelineBucketSnapshot) ProtoMessage() {}
+
+func (x *TimelineBucketSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimelineBucketSnapshot.ProtoReflect.Descriptor instead.
+func (*TimelineBucketSnapshot) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{45}
+}
+
+func (x *TimelineBucketSnapshot) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *TimelineBucketSnapshot) GetWeekStartUnix() int64 {
+	if x != nil {
+		return x.WeekStartUnix
+	}
+	return 0
+}
+
+func (x *TimelineBucketSnapshot) GetEventReferences() []*TimelineBucketEventReferenceSnapshot {
+	if x != nil {
+		return x.EventReferences
+	}
+	return nil
+}
+
+func (x *TimelineBucketSnapshot) GetPayloadResident() bool {
+	if x != nil {
+		return x.PayloadResident
+	}
+	return false
+}
+
+type TimelineBucketEventReferenceSnapshot struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	StreamSequence uint64                 `protobuf:"varint,1,opt,name=stream_sequence,json=streamSequence,proto3" json:"stream_sequence,omitempty"`
+	OptionalBody   bool                   `protobuf:"varint,2,opt,name=optional_body,json=optionalBody,proto3" json:"optional_body,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *TimelineBucketEventReferenceSnapshot) Reset() {
+	*x = TimelineBucketEventReferenceSnapshot{}
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[46]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TimelineBucketEventReferenceSnapshot) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TimelineBucketEventReferenceSnapshot) ProtoMessage() {}
+
+func (x *TimelineBucketEventReferenceSnapshot) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[46]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TimelineBucketEventReferenceSnapshot.ProtoReflect.Descriptor instead.
+func (*TimelineBucketEventReferenceSnapshot) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{46}
+}
+
+func (x *TimelineBucketEventReferenceSnapshot) GetStreamSequence() uint64 {
+	if x != nil {
+		return x.StreamSequence
+	}
+	return 0
+}
+
+func (x *TimelineBucketEventReferenceSnapshot) GetOptionalBody() bool {
+	if x != nil {
+		return x.OptionalBody
+	}
+	return false
+}
+
 type StringTimestampSnapshot struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -2944,7 +3374,7 @@ type StringTimestampSnapshot struct {
 
 func (x *StringTimestampSnapshot) Reset() {
 	*x = StringTimestampSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2956,7 +3386,7 @@ func (x *StringTimestampSnapshot) String() string {
 func (*StringTimestampSnapshot) ProtoMessage() {}
 
 func (x *StringTimestampSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2969,7 +3399,7 @@ func (x *StringTimestampSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StringTimestampSnapshot.ProtoReflect.Descriptor instead.
 func (*StringTimestampSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{42}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *StringTimestampSnapshot) GetKey() string {
@@ -2998,7 +3428,7 @@ type AssetMessageOwnerSnapshot struct {
 
 func (x *AssetMessageOwnerSnapshot) Reset() {
 	*x = AssetMessageOwnerSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3010,7 +3440,7 @@ func (x *AssetMessageOwnerSnapshot) String() string {
 func (*AssetMessageOwnerSnapshot) ProtoMessage() {}
 
 func (x *AssetMessageOwnerSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3023,7 +3453,7 @@ func (x *AssetMessageOwnerSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetMessageOwnerSnapshot.ProtoReflect.Descriptor instead.
 func (*AssetMessageOwnerSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{43}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *AssetMessageOwnerSnapshot) GetAssetId() string {
@@ -3300,7 +3730,44 @@ const file_chatto_core_v1_projection_snapshots_proto_rawDesc = "" +
 	"\x10message_event_id\x18\x01 \x01(\tR\x0emessageEventId\x12/\n" +
 	"\x04body\x18\x02 \x01(\v2\x1b.chatto.core.v1.MessageBodyR\x04body\x120\n" +
 	"\x14body_event_sequences\x18\x03 \x03(\x04R\x12bodyEventSequences\x122\n" +
-	"\x15current_body_sequence\x18\x04 \x01(\x04R\x13currentBodySequence\"]\n" +
+	"\x15current_body_sequence\x18\x04 \x01(\x04R\x13currentBodySequence\"\xec\x04\n" +
+	" RoomTimelineProjectionSnapshotV3\x12G\n" +
+	"\aentries\x18\x01 \x03(\v2-.chatto.core.v1.TimelineEntryMetadataSnapshotR\aentries\x12D\n" +
+	"\x06bodies\x18\x02 \x03(\v2,.chatto.core.v1.TimelineBodyMetadataSnapshotR\x06bodies\x12@\n" +
+	"\abuckets\x18\x03 \x03(\v2&.chatto.core.v1.TimelineBucketSnapshotR\abuckets\x12L\n" +
+	"\rtombstoned_at\x18\x04 \x03(\v2'.chatto.core.v1.StringTimestampSnapshotR\ftombstonedAt\x12H\n" +
+	"\vshredded_at\x18\x05 \x03(\v2'.chatto.core.v1.StringTimestampSnapshotR\n" +
+	"shreddedAt\x12.\n" +
+	"\x13retracted_event_ids\x18\x06 \x03(\tR\x11retractedEventIds\x121\n" +
+	"\x15hidden_echo_event_ids\x18\a \x03(\tR\x12hiddenEchoEventIds\x12*\n" +
+	"\x11shredded_user_ids\x18\b \x03(\tR\x0fshreddedUserIds\x12P\n" +
+	"\freplay_guard\x18\t \x01(\v2-.chatto.core.v1.ProjectionReplayGuardSnapshotR\vreplayGuard\"\xfe\x02\n" +
+	"\x1dTimelineEntryMetadataSnapshot\x12'\n" +
+	"\x0fstream_sequence\x18\x01 \x01(\x04R\x0estreamSequence\x12\x19\n" +
+	"\bevent_id\x18\x02 \x01(\tR\aeventId\x12\x17\n" +
+	"\aroom_id\x18\x03 \x01(\tR\x06roomId\x12\x1b\n" +
+	"\tauthor_id\x18\x04 \x01(\tR\bauthorId\x123\n" +
+	"\x16echo_original_event_id\x18\x05 \x01(\tR\x13echoOriginalEventId\x12&\n" +
+	"\x0fweek_start_unix\x18\x06 \x01(\x03R\rweekStartUnix\x12%\n" +
+	"\x0emessage_posted\x18\a \x01(\bR\rmessagePosted\x12!\n" +
+	"\froom_visible\x18\b \x01(\bR\vroomVisible\x12<\n" +
+	"\x0eresident_event\x18\t \x01(\v2\x15.chatto.core.v1.EventR\rresidentEvent\"\xda\x02\n" +
+	"\x1cTimelineBodyMetadataSnapshot\x12(\n" +
+	"\x10message_event_id\x18\x01 \x01(\tR\x0emessageEventId\x120\n" +
+	"\x14body_event_sequences\x18\x02 \x03(\x04R\x12bodyEventSequences\x122\n" +
+	"\x15current_body_sequence\x18\x03 \x01(\x04R\x13currentBodySequence\x12\x17\n" +
+	"\aroom_id\x18\x04 \x01(\tR\x06roomId\x12&\n" +
+	"\x0fweek_start_unix\x18\x05 \x01(\x03R\rweekStartUnix\x12'\n" +
+	"\x0fhas_attachments\x18\x06 \x01(\bR\x0ehasAttachments\x12@\n" +
+	"\rresident_body\x18\a \x01(\v2\x1b.chatto.core.v1.MessageBodyR\fresidentBody\"\xe5\x01\n" +
+	"\x16TimelineBucketSnapshot\x12\x17\n" +
+	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12&\n" +
+	"\x0fweek_start_unix\x18\x02 \x01(\x03R\rweekStartUnix\x12_\n" +
+	"\x10event_references\x18\x03 \x03(\v24.chatto.core.v1.TimelineBucketEventReferenceSnapshotR\x0feventReferences\x12)\n" +
+	"\x10payload_resident\x18\x04 \x01(\bR\x0fpayloadResident\"t\n" +
+	"$TimelineBucketEventReferenceSnapshot\x12'\n" +
+	"\x0fstream_sequence\x18\x01 \x01(\x04R\x0estreamSequence\x12#\n" +
+	"\roptional_body\x18\x02 \x01(\bR\foptionalBody\"]\n" +
 	"\x17StringTimestampSnapshot\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x05value\"\x96\x01\n" +
@@ -3323,7 +3790,7 @@ func file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_projection_snapshots_proto_rawDescData
 }
 
-var file_chatto_core_v1_projection_snapshots_proto_msgTypes = make([]protoimpl.MessageInfo, 44)
+var file_chatto_core_v1_projection_snapshots_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
 var file_chatto_core_v1_projection_snapshots_proto_goTypes = []any{
 	(*ProjectionSnapshotGeneration)(nil),         // 0: chatto.core.v1.ProjectionSnapshotGeneration
 	(*ProjectionSnapshotPointer)(nil),            // 1: chatto.core.v1.ProjectionSnapshotPointer
@@ -3367,73 +3834,78 @@ var file_chatto_core_v1_projection_snapshots_proto_goTypes = []any{
 	(*RoomTimelineProjectionSnapshot)(nil),       // 39: chatto.core.v1.RoomTimelineProjectionSnapshot
 	(*TimelineEntrySnapshot)(nil),                // 40: chatto.core.v1.TimelineEntrySnapshot
 	(*TimelineBodySnapshot)(nil),                 // 41: chatto.core.v1.TimelineBodySnapshot
-	(*StringTimestampSnapshot)(nil),              // 42: chatto.core.v1.StringTimestampSnapshot
-	(*AssetMessageOwnerSnapshot)(nil),            // 43: chatto.core.v1.AssetMessageOwnerSnapshot
-	(*timestamppb.Timestamp)(nil),                // 44: google.protobuf.Timestamp
-	(*Room)(nil),                                 // 45: chatto.core.v1.Room
-	(*RoomGroup)(nil),                            // 46: chatto.core.v1.RoomGroup
-	(CallParticipantEventSource)(0),              // 47: chatto.core.v1.CallParticipantEventSource
-	(*UserDEKGeneratedEvent)(nil),                // 48: chatto.core.v1.UserDEKGeneratedEvent
-	(*Role)(nil),                                 // 49: chatto.core.v1.Role
-	(RbacPermissionSubjectKind)(0),               // 50: chatto.core.v1.RbacPermissionSubjectKind
-	(*AssetRecord)(nil),                          // 51: chatto.core.v1.AssetRecord
-	(TimeFormat)(0),                              // 52: chatto.core.v1.TimeFormat
-	(NotificationLevel)(0),                       // 53: chatto.core.v1.NotificationLevel
-	(*AssetCreatedEvent)(nil),                    // 54: chatto.core.v1.AssetCreatedEvent
-	(*AssetProcessingStartedEvent)(nil),          // 55: chatto.core.v1.AssetProcessingStartedEvent
-	(*AssetProcessingSucceededEvent)(nil),        // 56: chatto.core.v1.AssetProcessingSucceededEvent
-	(*AssetProcessingFailedEvent)(nil),           // 57: chatto.core.v1.AssetProcessingFailedEvent
-	(*Event)(nil),                                // 58: chatto.core.v1.Event
-	(*User)(nil),                                 // 59: chatto.core.v1.User
-	(*ServerUserPreferences)(nil),                // 60: chatto.core.v1.ServerUserPreferences
-	(*EncryptedUserString)(nil),                  // 61: chatto.core.v1.EncryptedUserString
-	(*MessageBody)(nil),                          // 62: chatto.core.v1.MessageBody
+	(*RoomTimelineProjectionSnapshotV3)(nil),     // 42: chatto.core.v1.RoomTimelineProjectionSnapshotV3
+	(*TimelineEntryMetadataSnapshot)(nil),        // 43: chatto.core.v1.TimelineEntryMetadataSnapshot
+	(*TimelineBodyMetadataSnapshot)(nil),         // 44: chatto.core.v1.TimelineBodyMetadataSnapshot
+	(*TimelineBucketSnapshot)(nil),               // 45: chatto.core.v1.TimelineBucketSnapshot
+	(*TimelineBucketEventReferenceSnapshot)(nil), // 46: chatto.core.v1.TimelineBucketEventReferenceSnapshot
+	(*StringTimestampSnapshot)(nil),              // 47: chatto.core.v1.StringTimestampSnapshot
+	(*AssetMessageOwnerSnapshot)(nil),            // 48: chatto.core.v1.AssetMessageOwnerSnapshot
+	(*timestamppb.Timestamp)(nil),                // 49: google.protobuf.Timestamp
+	(*Room)(nil),                                 // 50: chatto.core.v1.Room
+	(*RoomGroup)(nil),                            // 51: chatto.core.v1.RoomGroup
+	(CallParticipantEventSource)(0),              // 52: chatto.core.v1.CallParticipantEventSource
+	(*UserDEKGeneratedEvent)(nil),                // 53: chatto.core.v1.UserDEKGeneratedEvent
+	(*Role)(nil),                                 // 54: chatto.core.v1.Role
+	(RbacPermissionSubjectKind)(0),               // 55: chatto.core.v1.RbacPermissionSubjectKind
+	(*AssetRecord)(nil),                          // 56: chatto.core.v1.AssetRecord
+	(TimeFormat)(0),                              // 57: chatto.core.v1.TimeFormat
+	(NotificationLevel)(0),                       // 58: chatto.core.v1.NotificationLevel
+	(*AssetCreatedEvent)(nil),                    // 59: chatto.core.v1.AssetCreatedEvent
+	(*AssetProcessingStartedEvent)(nil),          // 60: chatto.core.v1.AssetProcessingStartedEvent
+	(*AssetProcessingSucceededEvent)(nil),        // 61: chatto.core.v1.AssetProcessingSucceededEvent
+	(*AssetProcessingFailedEvent)(nil),           // 62: chatto.core.v1.AssetProcessingFailedEvent
+	(*Event)(nil),                                // 63: chatto.core.v1.Event
+	(*User)(nil),                                 // 64: chatto.core.v1.User
+	(*ServerUserPreferences)(nil),                // 65: chatto.core.v1.ServerUserPreferences
+	(*EncryptedUserString)(nil),                  // 66: chatto.core.v1.EncryptedUserString
+	(*MessageBody)(nil),                          // 67: chatto.core.v1.MessageBody
 }
 var file_chatto_core_v1_projection_snapshots_proto_depIdxs = []int32{
-	44, // 0: chatto.core.v1.ProjectionSnapshotGeneration.created_at:type_name -> google.protobuf.Timestamp
-	44, // 1: chatto.core.v1.ProjectionSnapshotPointer.current_created_at:type_name -> google.protobuf.Timestamp
-	44, // 2: chatto.core.v1.ProjectionSnapshotPointer.previous_created_at:type_name -> google.protobuf.Timestamp
+	49, // 0: chatto.core.v1.ProjectionSnapshotGeneration.created_at:type_name -> google.protobuf.Timestamp
+	49, // 1: chatto.core.v1.ProjectionSnapshotPointer.current_created_at:type_name -> google.protobuf.Timestamp
+	49, // 2: chatto.core.v1.ProjectionSnapshotPointer.previous_created_at:type_name -> google.protobuf.Timestamp
 	3,  // 3: chatto.core.v1.ThreadProjectionSnapshot.threads:type_name -> chatto.core.v1.ThreadSnapshot
 	5,  // 4: chatto.core.v1.ThreadProjectionSnapshot.replies:type_name -> chatto.core.v1.ThreadReplySnapshot
 	6,  // 5: chatto.core.v1.ThreadProjectionSnapshot.follows:type_name -> chatto.core.v1.ThreadFollowSnapshot
 	7,  // 6: chatto.core.v1.ThreadProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	4,  // 7: chatto.core.v1.ThreadSnapshot.entries:type_name -> chatto.core.v1.ThreadTimelineEntrySnapshot
-	44, // 8: chatto.core.v1.ThreadReplySnapshot.created_at:type_name -> google.protobuf.Timestamp
-	45, // 9: chatto.core.v1.RoomDirectoryProjectionSnapshot.rooms:type_name -> chatto.core.v1.Room
+	49, // 8: chatto.core.v1.ThreadReplySnapshot.created_at:type_name -> google.protobuf.Timestamp
+	50, // 9: chatto.core.v1.RoomDirectoryProjectionSnapshot.rooms:type_name -> chatto.core.v1.Room
 	9,  // 10: chatto.core.v1.RoomDirectoryProjectionSnapshot.memberships:type_name -> chatto.core.v1.RoomMembershipSnapshot
 	10, // 11: chatto.core.v1.RoomDirectoryProjectionSnapshot.bans:type_name -> chatto.core.v1.RoomBanSnapshot
-	44, // 12: chatto.core.v1.RoomBanSnapshot.created_at:type_name -> google.protobuf.Timestamp
-	44, // 13: chatto.core.v1.RoomBanSnapshot.expires_at:type_name -> google.protobuf.Timestamp
+	49, // 12: chatto.core.v1.RoomBanSnapshot.created_at:type_name -> google.protobuf.Timestamp
+	49, // 13: chatto.core.v1.RoomBanSnapshot.expires_at:type_name -> google.protobuf.Timestamp
 	12, // 14: chatto.core.v1.RoomGroupLayoutProjectionSnapshot.groups:type_name -> chatto.core.v1.RoomGroupStateSnapshot
-	46, // 15: chatto.core.v1.RoomGroupStateSnapshot.group:type_name -> chatto.core.v1.RoomGroup
+	51, // 15: chatto.core.v1.RoomGroupStateSnapshot.group:type_name -> chatto.core.v1.RoomGroup
 	14, // 16: chatto.core.v1.CallStateProjectionSnapshot.rooms:type_name -> chatto.core.v1.CallRoomStateSnapshot
 	15, // 17: chatto.core.v1.CallRoomStateSnapshot.call:type_name -> chatto.core.v1.CallSessionSnapshot
 	16, // 18: chatto.core.v1.CallRoomStateSnapshot.participants:type_name -> chatto.core.v1.CallParticipantSnapshot
-	47, // 19: chatto.core.v1.CallSessionSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
-	47, // 20: chatto.core.v1.CallParticipantSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
-	48, // 21: chatto.core.v1.ContentKeyProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	52, // 19: chatto.core.v1.CallSessionSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
+	52, // 20: chatto.core.v1.CallParticipantSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
+	53, // 21: chatto.core.v1.ContentKeyProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	7,  // 22: chatto.core.v1.ContentKeyProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	49, // 23: chatto.core.v1.RBACProjectionSnapshot.roles:type_name -> chatto.core.v1.Role
+	54, // 23: chatto.core.v1.RBACProjectionSnapshot.roles:type_name -> chatto.core.v1.Role
 	19, // 24: chatto.core.v1.RBACProjectionSnapshot.assignments:type_name -> chatto.core.v1.RBACAssignmentSnapshot
 	20, // 25: chatto.core.v1.RBACProjectionSnapshot.decisions:type_name -> chatto.core.v1.RBACDecisionSnapshot
 	7,  // 26: chatto.core.v1.RBACProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	50, // 27: chatto.core.v1.RBACDecisionSnapshot.subject_kind:type_name -> chatto.core.v1.RbacPermissionSubjectKind
-	51, // 28: chatto.core.v1.ConfigProjectionSnapshot.logo:type_name -> chatto.core.v1.AssetRecord
-	51, // 29: chatto.core.v1.ConfigProjectionSnapshot.banner:type_name -> chatto.core.v1.AssetRecord
+	55, // 27: chatto.core.v1.RBACDecisionSnapshot.subject_kind:type_name -> chatto.core.v1.RbacPermissionSubjectKind
+	56, // 28: chatto.core.v1.ConfigProjectionSnapshot.logo:type_name -> chatto.core.v1.AssetRecord
+	56, // 29: chatto.core.v1.ConfigProjectionSnapshot.banner:type_name -> chatto.core.v1.AssetRecord
 	22, // 30: chatto.core.v1.ConfigProjectionSnapshot.users:type_name -> chatto.core.v1.UserConfigSnapshot
-	52, // 31: chatto.core.v1.UserConfigSnapshot.time_format:type_name -> chatto.core.v1.TimeFormat
-	53, // 32: chatto.core.v1.UserConfigSnapshot.server_notification_level:type_name -> chatto.core.v1.NotificationLevel
+	57, // 31: chatto.core.v1.UserConfigSnapshot.time_format:type_name -> chatto.core.v1.TimeFormat
+	58, // 32: chatto.core.v1.UserConfigSnapshot.server_notification_level:type_name -> chatto.core.v1.NotificationLevel
 	23, // 33: chatto.core.v1.UserConfigSnapshot.room_notification_levels:type_name -> chatto.core.v1.RoomNotificationLevelSnapshot
-	53, // 34: chatto.core.v1.RoomNotificationLevelSnapshot.level:type_name -> chatto.core.v1.NotificationLevel
-	54, // 35: chatto.core.v1.AssetProjectionSnapshot.creations:type_name -> chatto.core.v1.AssetCreatedEvent
+	58, // 34: chatto.core.v1.RoomNotificationLevelSnapshot.level:type_name -> chatto.core.v1.NotificationLevel
+	59, // 35: chatto.core.v1.AssetProjectionSnapshot.creations:type_name -> chatto.core.v1.AssetCreatedEvent
 	25, // 36: chatto.core.v1.AssetProjectionSnapshot.children:type_name -> chatto.core.v1.AssetChildrenSnapshot
 	26, // 37: chatto.core.v1.AssetProjectionSnapshot.manifests:type_name -> chatto.core.v1.AssetManifestSnapshot
 	27, // 38: chatto.core.v1.AssetProjectionSnapshot.deleted_assets:type_name -> chatto.core.v1.DeletedAssetSnapshot
 	7,  // 39: chatto.core.v1.AssetProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	43, // 40: chatto.core.v1.AssetProjectionSnapshot.message_owners:type_name -> chatto.core.v1.AssetMessageOwnerSnapshot
-	55, // 41: chatto.core.v1.AssetManifestSnapshot.started:type_name -> chatto.core.v1.AssetProcessingStartedEvent
-	56, // 42: chatto.core.v1.AssetManifestSnapshot.succeeded:type_name -> chatto.core.v1.AssetProcessingSucceededEvent
-	57, // 43: chatto.core.v1.AssetManifestSnapshot.failed:type_name -> chatto.core.v1.AssetProcessingFailedEvent
+	48, // 40: chatto.core.v1.AssetProjectionSnapshot.message_owners:type_name -> chatto.core.v1.AssetMessageOwnerSnapshot
+	60, // 41: chatto.core.v1.AssetManifestSnapshot.started:type_name -> chatto.core.v1.AssetProcessingStartedEvent
+	61, // 42: chatto.core.v1.AssetManifestSnapshot.succeeded:type_name -> chatto.core.v1.AssetProcessingSucceededEvent
+	62, // 43: chatto.core.v1.AssetManifestSnapshot.failed:type_name -> chatto.core.v1.AssetProcessingFailedEvent
 	29, // 44: chatto.core.v1.ReactionProjectionSnapshot.messages:type_name -> chatto.core.v1.MessageReactionsSnapshot
 	32, // 45: chatto.core.v1.ReactionProjectionSnapshot.room_sequences:type_name -> chatto.core.v1.StringUint64Snapshot
 	33, // 46: chatto.core.v1.ReactionProjectionSnapshot.message_rooms:type_name -> chatto.core.v1.StringStringSnapshot
@@ -3442,36 +3914,45 @@ var file_chatto_core_v1_projection_snapshots_proto_depIdxs = []int32{
 	7,  // 49: chatto.core.v1.ReactionProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	30, // 50: chatto.core.v1.MessageReactionsSnapshot.emojis:type_name -> chatto.core.v1.EmojiReactionsSnapshot
 	31, // 51: chatto.core.v1.EmojiReactionsSnapshot.users:type_name -> chatto.core.v1.UserReactionSnapshot
-	58, // 52: chatto.core.v1.MentionablesProjectionSnapshot.user_login_sources:type_name -> chatto.core.v1.Event
-	48, // 53: chatto.core.v1.MentionablesProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	63, // 52: chatto.core.v1.MentionablesProjectionSnapshot.user_login_sources:type_name -> chatto.core.v1.Event
+	53, // 53: chatto.core.v1.MentionablesProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	36, // 54: chatto.core.v1.UserProfileProjectionSnapshot.users:type_name -> chatto.core.v1.ProjectedUserProfileSnapshot
-	48, // 55: chatto.core.v1.UserProfileProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	53, // 55: chatto.core.v1.UserProfileProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	7,  // 56: chatto.core.v1.UserProfileProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	33, // 57: chatto.core.v1.UserProfileProjectionSnapshot.login_index:type_name -> chatto.core.v1.StringStringSnapshot
 	33, // 58: chatto.core.v1.UserProfileProjectionSnapshot.email_index:type_name -> chatto.core.v1.StringStringSnapshot
-	59, // 59: chatto.core.v1.ProjectedUserProfileSnapshot.user:type_name -> chatto.core.v1.User
+	64, // 59: chatto.core.v1.ProjectedUserProfileSnapshot.user:type_name -> chatto.core.v1.User
 	37, // 60: chatto.core.v1.ProjectedUserProfileSnapshot.login:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
 	37, // 61: chatto.core.v1.ProjectedUserProfileSnapshot.display_name:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
-	51, // 62: chatto.core.v1.ProjectedUserProfileSnapshot.avatar:type_name -> chatto.core.v1.AssetRecord
+	56, // 62: chatto.core.v1.ProjectedUserProfileSnapshot.avatar:type_name -> chatto.core.v1.AssetRecord
 	38, // 63: chatto.core.v1.ProjectedUserProfileSnapshot.verified_emails:type_name -> chatto.core.v1.ProjectedVerifiedEmailSnapshot
-	60, // 64: chatto.core.v1.ProjectedUserProfileSnapshot.preferences:type_name -> chatto.core.v1.ServerUserPreferences
-	44, // 65: chatto.core.v1.ProjectedUserProfileSnapshot.login_changed_at:type_name -> google.protobuf.Timestamp
-	61, // 66: chatto.core.v1.ProjectedEncryptedUserStringSnapshot.encrypted:type_name -> chatto.core.v1.EncryptedUserString
+	65, // 64: chatto.core.v1.ProjectedUserProfileSnapshot.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	49, // 65: chatto.core.v1.ProjectedUserProfileSnapshot.login_changed_at:type_name -> google.protobuf.Timestamp
+	66, // 66: chatto.core.v1.ProjectedEncryptedUserStringSnapshot.encrypted:type_name -> chatto.core.v1.EncryptedUserString
 	37, // 67: chatto.core.v1.ProjectedVerifiedEmailSnapshot.value:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
-	44, // 68: chatto.core.v1.ProjectedVerifiedEmailSnapshot.verified_at:type_name -> google.protobuf.Timestamp
+	49, // 68: chatto.core.v1.ProjectedVerifiedEmailSnapshot.verified_at:type_name -> google.protobuf.Timestamp
 	40, // 69: chatto.core.v1.RoomTimelineProjectionSnapshot.entries:type_name -> chatto.core.v1.TimelineEntrySnapshot
 	41, // 70: chatto.core.v1.RoomTimelineProjectionSnapshot.bodies:type_name -> chatto.core.v1.TimelineBodySnapshot
-	42, // 71: chatto.core.v1.RoomTimelineProjectionSnapshot.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
-	42, // 72: chatto.core.v1.RoomTimelineProjectionSnapshot.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	47, // 71: chatto.core.v1.RoomTimelineProjectionSnapshot.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	47, // 72: chatto.core.v1.RoomTimelineProjectionSnapshot.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
 	7,  // 73: chatto.core.v1.RoomTimelineProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	58, // 74: chatto.core.v1.TimelineEntrySnapshot.event:type_name -> chatto.core.v1.Event
-	62, // 75: chatto.core.v1.TimelineBodySnapshot.body:type_name -> chatto.core.v1.MessageBody
-	44, // 76: chatto.core.v1.StringTimestampSnapshot.value:type_name -> google.protobuf.Timestamp
-	77, // [77:77] is the sub-list for method output_type
-	77, // [77:77] is the sub-list for method input_type
-	77, // [77:77] is the sub-list for extension type_name
-	77, // [77:77] is the sub-list for extension extendee
-	0,  // [0:77] is the sub-list for field type_name
+	63, // 74: chatto.core.v1.TimelineEntrySnapshot.event:type_name -> chatto.core.v1.Event
+	67, // 75: chatto.core.v1.TimelineBodySnapshot.body:type_name -> chatto.core.v1.MessageBody
+	43, // 76: chatto.core.v1.RoomTimelineProjectionSnapshotV3.entries:type_name -> chatto.core.v1.TimelineEntryMetadataSnapshot
+	44, // 77: chatto.core.v1.RoomTimelineProjectionSnapshotV3.bodies:type_name -> chatto.core.v1.TimelineBodyMetadataSnapshot
+	45, // 78: chatto.core.v1.RoomTimelineProjectionSnapshotV3.buckets:type_name -> chatto.core.v1.TimelineBucketSnapshot
+	47, // 79: chatto.core.v1.RoomTimelineProjectionSnapshotV3.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	47, // 80: chatto.core.v1.RoomTimelineProjectionSnapshotV3.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	7,  // 81: chatto.core.v1.RoomTimelineProjectionSnapshotV3.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
+	63, // 82: chatto.core.v1.TimelineEntryMetadataSnapshot.resident_event:type_name -> chatto.core.v1.Event
+	67, // 83: chatto.core.v1.TimelineBodyMetadataSnapshot.resident_body:type_name -> chatto.core.v1.MessageBody
+	46, // 84: chatto.core.v1.TimelineBucketSnapshot.event_references:type_name -> chatto.core.v1.TimelineBucketEventReferenceSnapshot
+	49, // 85: chatto.core.v1.StringTimestampSnapshot.value:type_name -> google.protobuf.Timestamp
+	86, // [86:86] is the sub-list for method output_type
+	86, // [86:86] is the sub-list for method input_type
+	86, // [86:86] is the sub-list for extension type_name
+	86, // [86:86] is the sub-list for extension extendee
+	0,  // [0:86] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_projection_snapshots_proto_init() }
@@ -3494,7 +3975,7 @@ func file_chatto_core_v1_projection_snapshots_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_projection_snapshots_proto_rawDesc), len(file_chatto_core_v1_projection_snapshots_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   44,
+			NumMessages:   49,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/core/v1/projection_snapshots.pb.go
+++ b/cli/internal/pb/chatto/core/v1/projection_snapshots.pb.go
@@ -2714,16 +2714,19 @@ func (x *ProjectedVerifiedEmailSnapshot) GetVerifiedAt() *timestamppb.Timestamp 
 	return nil
 }
 
+// RoomTimelineProjectionSnapshot stores the always-resident timeline
+// directory separately from optional decoded bucket payloads.
 type RoomTimelineProjectionSnapshot struct {
-	state              protoimpl.MessageState         `protogen:"open.v1"`
-	Entries            []*TimelineEntrySnapshot       `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
-	Bodies             []*TimelineBodySnapshot        `protobuf:"bytes,2,rep,name=bodies,proto3" json:"bodies,omitempty"`
-	TombstonedAt       []*StringTimestampSnapshot     `protobuf:"bytes,3,rep,name=tombstoned_at,json=tombstonedAt,proto3" json:"tombstoned_at,omitempty"`
-	ShreddedAt         []*StringTimestampSnapshot     `protobuf:"bytes,4,rep,name=shredded_at,json=shreddedAt,proto3" json:"shredded_at,omitempty"`
-	RetractedEventIds  []string                       `protobuf:"bytes,5,rep,name=retracted_event_ids,json=retractedEventIds,proto3" json:"retracted_event_ids,omitempty"`
-	HiddenEchoEventIds []string                       `protobuf:"bytes,6,rep,name=hidden_echo_event_ids,json=hiddenEchoEventIds,proto3" json:"hidden_echo_event_ids,omitempty"`
-	ShreddedUserIds    []string                       `protobuf:"bytes,7,rep,name=shredded_user_ids,json=shreddedUserIds,proto3" json:"shredded_user_ids,omitempty"`
-	ReplayGuard        *ProjectionReplayGuardSnapshot `protobuf:"bytes,8,opt,name=replay_guard,json=replayGuard,proto3" json:"replay_guard,omitempty"`
+	state              protoimpl.MessageState           `protogen:"open.v1"`
+	Entries            []*TimelineEntryMetadataSnapshot `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
+	Bodies             []*TimelineBodyMetadataSnapshot  `protobuf:"bytes,2,rep,name=bodies,proto3" json:"bodies,omitempty"`
+	Buckets            []*TimelineBucketSnapshot        `protobuf:"bytes,3,rep,name=buckets,proto3" json:"buckets,omitempty"`
+	TombstonedAt       []*StringTimestampSnapshot       `protobuf:"bytes,4,rep,name=tombstoned_at,json=tombstonedAt,proto3" json:"tombstoned_at,omitempty"`
+	ShreddedAt         []*StringTimestampSnapshot       `protobuf:"bytes,5,rep,name=shredded_at,json=shreddedAt,proto3" json:"shredded_at,omitempty"`
+	RetractedEventIds  []string                         `protobuf:"bytes,6,rep,name=retracted_event_ids,json=retractedEventIds,proto3" json:"retracted_event_ids,omitempty"`
+	HiddenEchoEventIds []string                         `protobuf:"bytes,7,rep,name=hidden_echo_event_ids,json=hiddenEchoEventIds,proto3" json:"hidden_echo_event_ids,omitempty"`
+	ShreddedUserIds    []string                         `protobuf:"bytes,8,rep,name=shredded_user_ids,json=shreddedUserIds,proto3" json:"shredded_user_ids,omitempty"`
+	ReplayGuard        *ProjectionReplayGuardSnapshot   `protobuf:"bytes,9,opt,name=replay_guard,json=replayGuard,proto3" json:"replay_guard,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache
 }
@@ -2758,16 +2761,23 @@ func (*RoomTimelineProjectionSnapshot) Descriptor() ([]byte, []int) {
 	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{39}
 }
 
-func (x *RoomTimelineProjectionSnapshot) GetEntries() []*TimelineEntrySnapshot {
+func (x *RoomTimelineProjectionSnapshot) GetEntries() []*TimelineEntryMetadataSnapshot {
 	if x != nil {
 		return x.Entries
 	}
 	return nil
 }
 
-func (x *RoomTimelineProjectionSnapshot) GetBodies() []*TimelineBodySnapshot {
+func (x *RoomTimelineProjectionSnapshot) GetBodies() []*TimelineBodyMetadataSnapshot {
 	if x != nil {
 		return x.Bodies
+	}
+	return nil
+}
+
+func (x *RoomTimelineProjectionSnapshot) GetBuckets() []*TimelineBucketSnapshot {
+	if x != nil {
+		return x.Buckets
 	}
 	return nil
 }
@@ -2814,236 +2824,6 @@ func (x *RoomTimelineProjectionSnapshot) GetReplayGuard() *ProjectionReplayGuard
 	return nil
 }
 
-type TimelineEntrySnapshot struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	StreamSequence uint64                 `protobuf:"varint,1,opt,name=stream_sequence,json=streamSequence,proto3" json:"stream_sequence,omitempty"`
-	Event          *Event                 `protobuf:"bytes,2,opt,name=event,proto3" json:"event,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
-}
-
-func (x *TimelineEntrySnapshot) Reset() {
-	*x = TimelineEntrySnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[40]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TimelineEntrySnapshot) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TimelineEntrySnapshot) ProtoMessage() {}
-
-func (x *TimelineEntrySnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[40]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TimelineEntrySnapshot.ProtoReflect.Descriptor instead.
-func (*TimelineEntrySnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{40}
-}
-
-func (x *TimelineEntrySnapshot) GetStreamSequence() uint64 {
-	if x != nil {
-		return x.StreamSequence
-	}
-	return 0
-}
-
-func (x *TimelineEntrySnapshot) GetEvent() *Event {
-	if x != nil {
-		return x.Event
-	}
-	return nil
-}
-
-type TimelineBodySnapshot struct {
-	state               protoimpl.MessageState `protogen:"open.v1"`
-	MessageEventId      string                 `protobuf:"bytes,1,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
-	Body                *MessageBody           `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
-	BodyEventSequences  []uint64               `protobuf:"varint,3,rep,packed,name=body_event_sequences,json=bodyEventSequences,proto3" json:"body_event_sequences,omitempty"`
-	CurrentBodySequence uint64                 `protobuf:"varint,4,opt,name=current_body_sequence,json=currentBodySequence,proto3" json:"current_body_sequence,omitempty"`
-	unknownFields       protoimpl.UnknownFields
-	sizeCache           protoimpl.SizeCache
-}
-
-func (x *TimelineBodySnapshot) Reset() {
-	*x = TimelineBodySnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[41]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TimelineBodySnapshot) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TimelineBodySnapshot) ProtoMessage() {}
-
-func (x *TimelineBodySnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[41]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TimelineBodySnapshot.ProtoReflect.Descriptor instead.
-func (*TimelineBodySnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{41}
-}
-
-func (x *TimelineBodySnapshot) GetMessageEventId() string {
-	if x != nil {
-		return x.MessageEventId
-	}
-	return ""
-}
-
-func (x *TimelineBodySnapshot) GetBody() *MessageBody {
-	if x != nil {
-		return x.Body
-	}
-	return nil
-}
-
-func (x *TimelineBodySnapshot) GetBodyEventSequences() []uint64 {
-	if x != nil {
-		return x.BodyEventSequences
-	}
-	return nil
-}
-
-func (x *TimelineBodySnapshot) GetCurrentBodySequence() uint64 {
-	if x != nil {
-		return x.CurrentBodySequence
-	}
-	return 0
-}
-
-// RoomTimelineProjectionSnapshotV3 stores the always-resident timeline
-// directory separately from optional decoded bucket payloads.
-type RoomTimelineProjectionSnapshotV3 struct {
-	state              protoimpl.MessageState           `protogen:"open.v1"`
-	Entries            []*TimelineEntryMetadataSnapshot `protobuf:"bytes,1,rep,name=entries,proto3" json:"entries,omitempty"`
-	Bodies             []*TimelineBodyMetadataSnapshot  `protobuf:"bytes,2,rep,name=bodies,proto3" json:"bodies,omitempty"`
-	Buckets            []*TimelineBucketSnapshot        `protobuf:"bytes,3,rep,name=buckets,proto3" json:"buckets,omitempty"`
-	TombstonedAt       []*StringTimestampSnapshot       `protobuf:"bytes,4,rep,name=tombstoned_at,json=tombstonedAt,proto3" json:"tombstoned_at,omitempty"`
-	ShreddedAt         []*StringTimestampSnapshot       `protobuf:"bytes,5,rep,name=shredded_at,json=shreddedAt,proto3" json:"shredded_at,omitempty"`
-	RetractedEventIds  []string                         `protobuf:"bytes,6,rep,name=retracted_event_ids,json=retractedEventIds,proto3" json:"retracted_event_ids,omitempty"`
-	HiddenEchoEventIds []string                         `protobuf:"bytes,7,rep,name=hidden_echo_event_ids,json=hiddenEchoEventIds,proto3" json:"hidden_echo_event_ids,omitempty"`
-	ShreddedUserIds    []string                         `protobuf:"bytes,8,rep,name=shredded_user_ids,json=shreddedUserIds,proto3" json:"shredded_user_ids,omitempty"`
-	ReplayGuard        *ProjectionReplayGuardSnapshot   `protobuf:"bytes,9,opt,name=replay_guard,json=replayGuard,proto3" json:"replay_guard,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) Reset() {
-	*x = RoomTimelineProjectionSnapshotV3{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*RoomTimelineProjectionSnapshotV3) ProtoMessage() {}
-
-func (x *RoomTimelineProjectionSnapshotV3) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use RoomTimelineProjectionSnapshotV3.ProtoReflect.Descriptor instead.
-func (*RoomTimelineProjectionSnapshotV3) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{42}
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetEntries() []*TimelineEntryMetadataSnapshot {
-	if x != nil {
-		return x.Entries
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetBodies() []*TimelineBodyMetadataSnapshot {
-	if x != nil {
-		return x.Bodies
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetBuckets() []*TimelineBucketSnapshot {
-	if x != nil {
-		return x.Buckets
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetTombstonedAt() []*StringTimestampSnapshot {
-	if x != nil {
-		return x.TombstonedAt
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetShreddedAt() []*StringTimestampSnapshot {
-	if x != nil {
-		return x.ShreddedAt
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetRetractedEventIds() []string {
-	if x != nil {
-		return x.RetractedEventIds
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetHiddenEchoEventIds() []string {
-	if x != nil {
-		return x.HiddenEchoEventIds
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetShreddedUserIds() []string {
-	if x != nil {
-		return x.ShreddedUserIds
-	}
-	return nil
-}
-
-func (x *RoomTimelineProjectionSnapshotV3) GetReplayGuard() *ProjectionReplayGuardSnapshot {
-	if x != nil {
-		return x.ReplayGuard
-	}
-	return nil
-}
-
 type TimelineEntryMetadataSnapshot struct {
 	state               protoimpl.MessageState `protogen:"open.v1"`
 	StreamSequence      uint64                 `protobuf:"varint,1,opt,name=stream_sequence,json=streamSequence,proto3" json:"stream_sequence,omitempty"`
@@ -3061,7 +2841,7 @@ type TimelineEntryMetadataSnapshot struct {
 
 func (x *TimelineEntryMetadataSnapshot) Reset() {
 	*x = TimelineEntryMetadataSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3073,7 +2853,7 @@ func (x *TimelineEntryMetadataSnapshot) String() string {
 func (*TimelineEntryMetadataSnapshot) ProtoMessage() {}
 
 func (x *TimelineEntryMetadataSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3086,7 +2866,7 @@ func (x *TimelineEntryMetadataSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineEntryMetadataSnapshot.ProtoReflect.Descriptor instead.
 func (*TimelineEntryMetadataSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{43}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *TimelineEntryMetadataSnapshot) GetStreamSequence() uint64 {
@@ -3167,7 +2947,7 @@ type TimelineBodyMetadataSnapshot struct {
 
 func (x *TimelineBodyMetadataSnapshot) Reset() {
 	*x = TimelineBodyMetadataSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3179,7 +2959,7 @@ func (x *TimelineBodyMetadataSnapshot) String() string {
 func (*TimelineBodyMetadataSnapshot) ProtoMessage() {}
 
 func (x *TimelineBodyMetadataSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3192,7 +2972,7 @@ func (x *TimelineBodyMetadataSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineBodyMetadataSnapshot.ProtoReflect.Descriptor instead.
 func (*TimelineBodyMetadataSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{44}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *TimelineBodyMetadataSnapshot) GetMessageEventId() string {
@@ -3256,7 +3036,7 @@ type TimelineBucketSnapshot struct {
 
 func (x *TimelineBucketSnapshot) Reset() {
 	*x = TimelineBucketSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3268,7 +3048,7 @@ func (x *TimelineBucketSnapshot) String() string {
 func (*TimelineBucketSnapshot) ProtoMessage() {}
 
 func (x *TimelineBucketSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3281,7 +3061,7 @@ func (x *TimelineBucketSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TimelineBucketSnapshot.ProtoReflect.Descriptor instead.
 func (*TimelineBucketSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{45}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *TimelineBucketSnapshot) GetRoomId() string {
@@ -3322,7 +3102,7 @@ type TimelineBucketEventReferenceSnapshot struct {
 
 func (x *TimelineBucketEventReferenceSnapshot) Reset() {
 	*x = TimelineBucketEventReferenceSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3334,7 +3114,7 @@ func (x *TimelineBucketEventReferenceSnapshot) String() string {
 func (*TimelineBucketEventReferenceSnapshot) ProtoMessage() {}
 
 func (x *TimelineBucketEventReferenceSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[46]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3347,7 +3127,7 @@ func (x *TimelineBucketEventReferenceSnapshot) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use TimelineBucketEventReferenceSnapshot.ProtoReflect.Descriptor instead.
 func (*TimelineBucketEventReferenceSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{46}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *TimelineBucketEventReferenceSnapshot) GetStreamSequence() uint64 {
@@ -3374,7 +3154,7 @@ type StringTimestampSnapshot struct {
 
 func (x *StringTimestampSnapshot) Reset() {
 	*x = StringTimestampSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3386,7 +3166,7 @@ func (x *StringTimestampSnapshot) String() string {
 func (*StringTimestampSnapshot) ProtoMessage() {}
 
 func (x *StringTimestampSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[47]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3399,7 +3179,7 @@ func (x *StringTimestampSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StringTimestampSnapshot.ProtoReflect.Descriptor instead.
 func (*StringTimestampSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{47}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *StringTimestampSnapshot) GetKey() string {
@@ -3428,7 +3208,7 @@ type AssetMessageOwnerSnapshot struct {
 
 func (x *AssetMessageOwnerSnapshot) Reset() {
 	*x = AssetMessageOwnerSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[48]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3440,7 +3220,7 @@ func (x *AssetMessageOwnerSnapshot) String() string {
 func (*AssetMessageOwnerSnapshot) ProtoMessage() {}
 
 func (x *AssetMessageOwnerSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[48]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3453,7 +3233,7 @@ func (x *AssetMessageOwnerSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetMessageOwnerSnapshot.ProtoReflect.Descriptor instead.
 func (*AssetMessageOwnerSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{48}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *AssetMessageOwnerSnapshot) GetAssetId() string {
@@ -3712,26 +3492,8 @@ const file_chatto_core_v1_projection_snapshots_proto_rawDesc = "" +
 	"\x06digest\x18\x01 \x01(\tR\x06digest\x12J\n" +
 	"\x05value\x18\x02 \x01(\v24.chatto.core.v1.ProjectedEncryptedUserStringSnapshotR\x05value\x12;\n" +
 	"\vverified_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"verifiedAt\"\x98\x04\n" +
-	"\x1eRoomTimelineProjectionSnapshot\x12?\n" +
-	"\aentries\x18\x01 \x03(\v2%.chatto.core.v1.TimelineEntrySnapshotR\aentries\x12<\n" +
-	"\x06bodies\x18\x02 \x03(\v2$.chatto.core.v1.TimelineBodySnapshotR\x06bodies\x12L\n" +
-	"\rtombstoned_at\x18\x03 \x03(\v2'.chatto.core.v1.StringTimestampSnapshotR\ftombstonedAt\x12H\n" +
-	"\vshredded_at\x18\x04 \x03(\v2'.chatto.core.v1.StringTimestampSnapshotR\n" +
-	"shreddedAt\x12.\n" +
-	"\x13retracted_event_ids\x18\x05 \x03(\tR\x11retractedEventIds\x121\n" +
-	"\x15hidden_echo_event_ids\x18\x06 \x03(\tR\x12hiddenEchoEventIds\x12*\n" +
-	"\x11shredded_user_ids\x18\a \x03(\tR\x0fshreddedUserIds\x12P\n" +
-	"\freplay_guard\x18\b \x01(\v2-.chatto.core.v1.ProjectionReplayGuardSnapshotR\vreplayGuard\"m\n" +
-	"\x15TimelineEntrySnapshot\x12'\n" +
-	"\x0fstream_sequence\x18\x01 \x01(\x04R\x0estreamSequence\x12+\n" +
-	"\x05event\x18\x02 \x01(\v2\x15.chatto.core.v1.EventR\x05event\"\xd7\x01\n" +
-	"\x14TimelineBodySnapshot\x12(\n" +
-	"\x10message_event_id\x18\x01 \x01(\tR\x0emessageEventId\x12/\n" +
-	"\x04body\x18\x02 \x01(\v2\x1b.chatto.core.v1.MessageBodyR\x04body\x120\n" +
-	"\x14body_event_sequences\x18\x03 \x03(\x04R\x12bodyEventSequences\x122\n" +
-	"\x15current_body_sequence\x18\x04 \x01(\x04R\x13currentBodySequence\"\xec\x04\n" +
-	" RoomTimelineProjectionSnapshotV3\x12G\n" +
+	"verifiedAt\"\xea\x04\n" +
+	"\x1eRoomTimelineProjectionSnapshot\x12G\n" +
 	"\aentries\x18\x01 \x03(\v2-.chatto.core.v1.TimelineEntryMetadataSnapshotR\aentries\x12D\n" +
 	"\x06bodies\x18\x02 \x03(\v2,.chatto.core.v1.TimelineBodyMetadataSnapshotR\x06bodies\x12@\n" +
 	"\abuckets\x18\x03 \x03(\v2&.chatto.core.v1.TimelineBucketSnapshotR\abuckets\x12L\n" +
@@ -3790,7 +3552,7 @@ func file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_projection_snapshots_proto_rawDescData
 }
 
-var file_chatto_core_v1_projection_snapshots_proto_msgTypes = make([]protoimpl.MessageInfo, 49)
+var file_chatto_core_v1_projection_snapshots_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
 var file_chatto_core_v1_projection_snapshots_proto_goTypes = []any{
 	(*ProjectionSnapshotGeneration)(nil),         // 0: chatto.core.v1.ProjectionSnapshotGeneration
 	(*ProjectionSnapshotPointer)(nil),            // 1: chatto.core.v1.ProjectionSnapshotPointer
@@ -3832,80 +3594,77 @@ var file_chatto_core_v1_projection_snapshots_proto_goTypes = []any{
 	(*ProjectedEncryptedUserStringSnapshot)(nil), // 37: chatto.core.v1.ProjectedEncryptedUserStringSnapshot
 	(*ProjectedVerifiedEmailSnapshot)(nil),       // 38: chatto.core.v1.ProjectedVerifiedEmailSnapshot
 	(*RoomTimelineProjectionSnapshot)(nil),       // 39: chatto.core.v1.RoomTimelineProjectionSnapshot
-	(*TimelineEntrySnapshot)(nil),                // 40: chatto.core.v1.TimelineEntrySnapshot
-	(*TimelineBodySnapshot)(nil),                 // 41: chatto.core.v1.TimelineBodySnapshot
-	(*RoomTimelineProjectionSnapshotV3)(nil),     // 42: chatto.core.v1.RoomTimelineProjectionSnapshotV3
-	(*TimelineEntryMetadataSnapshot)(nil),        // 43: chatto.core.v1.TimelineEntryMetadataSnapshot
-	(*TimelineBodyMetadataSnapshot)(nil),         // 44: chatto.core.v1.TimelineBodyMetadataSnapshot
-	(*TimelineBucketSnapshot)(nil),               // 45: chatto.core.v1.TimelineBucketSnapshot
-	(*TimelineBucketEventReferenceSnapshot)(nil), // 46: chatto.core.v1.TimelineBucketEventReferenceSnapshot
-	(*StringTimestampSnapshot)(nil),              // 47: chatto.core.v1.StringTimestampSnapshot
-	(*AssetMessageOwnerSnapshot)(nil),            // 48: chatto.core.v1.AssetMessageOwnerSnapshot
-	(*timestamppb.Timestamp)(nil),                // 49: google.protobuf.Timestamp
-	(*Room)(nil),                                 // 50: chatto.core.v1.Room
-	(*RoomGroup)(nil),                            // 51: chatto.core.v1.RoomGroup
-	(CallParticipantEventSource)(0),              // 52: chatto.core.v1.CallParticipantEventSource
-	(*UserDEKGeneratedEvent)(nil),                // 53: chatto.core.v1.UserDEKGeneratedEvent
-	(*Role)(nil),                                 // 54: chatto.core.v1.Role
-	(RbacPermissionSubjectKind)(0),               // 55: chatto.core.v1.RbacPermissionSubjectKind
-	(*AssetRecord)(nil),                          // 56: chatto.core.v1.AssetRecord
-	(TimeFormat)(0),                              // 57: chatto.core.v1.TimeFormat
-	(NotificationLevel)(0),                       // 58: chatto.core.v1.NotificationLevel
-	(*AssetCreatedEvent)(nil),                    // 59: chatto.core.v1.AssetCreatedEvent
-	(*AssetProcessingStartedEvent)(nil),          // 60: chatto.core.v1.AssetProcessingStartedEvent
-	(*AssetProcessingSucceededEvent)(nil),        // 61: chatto.core.v1.AssetProcessingSucceededEvent
-	(*AssetProcessingFailedEvent)(nil),           // 62: chatto.core.v1.AssetProcessingFailedEvent
-	(*Event)(nil),                                // 63: chatto.core.v1.Event
-	(*User)(nil),                                 // 64: chatto.core.v1.User
-	(*ServerUserPreferences)(nil),                // 65: chatto.core.v1.ServerUserPreferences
-	(*EncryptedUserString)(nil),                  // 66: chatto.core.v1.EncryptedUserString
-	(*MessageBody)(nil),                          // 67: chatto.core.v1.MessageBody
+	(*TimelineEntryMetadataSnapshot)(nil),        // 40: chatto.core.v1.TimelineEntryMetadataSnapshot
+	(*TimelineBodyMetadataSnapshot)(nil),         // 41: chatto.core.v1.TimelineBodyMetadataSnapshot
+	(*TimelineBucketSnapshot)(nil),               // 42: chatto.core.v1.TimelineBucketSnapshot
+	(*TimelineBucketEventReferenceSnapshot)(nil), // 43: chatto.core.v1.TimelineBucketEventReferenceSnapshot
+	(*StringTimestampSnapshot)(nil),              // 44: chatto.core.v1.StringTimestampSnapshot
+	(*AssetMessageOwnerSnapshot)(nil),            // 45: chatto.core.v1.AssetMessageOwnerSnapshot
+	(*timestamppb.Timestamp)(nil),                // 46: google.protobuf.Timestamp
+	(*Room)(nil),                                 // 47: chatto.core.v1.Room
+	(*RoomGroup)(nil),                            // 48: chatto.core.v1.RoomGroup
+	(CallParticipantEventSource)(0),              // 49: chatto.core.v1.CallParticipantEventSource
+	(*UserDEKGeneratedEvent)(nil),                // 50: chatto.core.v1.UserDEKGeneratedEvent
+	(*Role)(nil),                                 // 51: chatto.core.v1.Role
+	(RbacPermissionSubjectKind)(0),               // 52: chatto.core.v1.RbacPermissionSubjectKind
+	(*AssetRecord)(nil),                          // 53: chatto.core.v1.AssetRecord
+	(TimeFormat)(0),                              // 54: chatto.core.v1.TimeFormat
+	(NotificationLevel)(0),                       // 55: chatto.core.v1.NotificationLevel
+	(*AssetCreatedEvent)(nil),                    // 56: chatto.core.v1.AssetCreatedEvent
+	(*AssetProcessingStartedEvent)(nil),          // 57: chatto.core.v1.AssetProcessingStartedEvent
+	(*AssetProcessingSucceededEvent)(nil),        // 58: chatto.core.v1.AssetProcessingSucceededEvent
+	(*AssetProcessingFailedEvent)(nil),           // 59: chatto.core.v1.AssetProcessingFailedEvent
+	(*Event)(nil),                                // 60: chatto.core.v1.Event
+	(*User)(nil),                                 // 61: chatto.core.v1.User
+	(*ServerUserPreferences)(nil),                // 62: chatto.core.v1.ServerUserPreferences
+	(*EncryptedUserString)(nil),                  // 63: chatto.core.v1.EncryptedUserString
+	(*MessageBody)(nil),                          // 64: chatto.core.v1.MessageBody
 }
 var file_chatto_core_v1_projection_snapshots_proto_depIdxs = []int32{
-	49, // 0: chatto.core.v1.ProjectionSnapshotGeneration.created_at:type_name -> google.protobuf.Timestamp
-	49, // 1: chatto.core.v1.ProjectionSnapshotPointer.current_created_at:type_name -> google.protobuf.Timestamp
-	49, // 2: chatto.core.v1.ProjectionSnapshotPointer.previous_created_at:type_name -> google.protobuf.Timestamp
+	46, // 0: chatto.core.v1.ProjectionSnapshotGeneration.created_at:type_name -> google.protobuf.Timestamp
+	46, // 1: chatto.core.v1.ProjectionSnapshotPointer.current_created_at:type_name -> google.protobuf.Timestamp
+	46, // 2: chatto.core.v1.ProjectionSnapshotPointer.previous_created_at:type_name -> google.protobuf.Timestamp
 	3,  // 3: chatto.core.v1.ThreadProjectionSnapshot.threads:type_name -> chatto.core.v1.ThreadSnapshot
 	5,  // 4: chatto.core.v1.ThreadProjectionSnapshot.replies:type_name -> chatto.core.v1.ThreadReplySnapshot
 	6,  // 5: chatto.core.v1.ThreadProjectionSnapshot.follows:type_name -> chatto.core.v1.ThreadFollowSnapshot
 	7,  // 6: chatto.core.v1.ThreadProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	4,  // 7: chatto.core.v1.ThreadSnapshot.entries:type_name -> chatto.core.v1.ThreadTimelineEntrySnapshot
-	49, // 8: chatto.core.v1.ThreadReplySnapshot.created_at:type_name -> google.protobuf.Timestamp
-	50, // 9: chatto.core.v1.RoomDirectoryProjectionSnapshot.rooms:type_name -> chatto.core.v1.Room
+	46, // 8: chatto.core.v1.ThreadReplySnapshot.created_at:type_name -> google.protobuf.Timestamp
+	47, // 9: chatto.core.v1.RoomDirectoryProjectionSnapshot.rooms:type_name -> chatto.core.v1.Room
 	9,  // 10: chatto.core.v1.RoomDirectoryProjectionSnapshot.memberships:type_name -> chatto.core.v1.RoomMembershipSnapshot
 	10, // 11: chatto.core.v1.RoomDirectoryProjectionSnapshot.bans:type_name -> chatto.core.v1.RoomBanSnapshot
-	49, // 12: chatto.core.v1.RoomBanSnapshot.created_at:type_name -> google.protobuf.Timestamp
-	49, // 13: chatto.core.v1.RoomBanSnapshot.expires_at:type_name -> google.protobuf.Timestamp
+	46, // 12: chatto.core.v1.RoomBanSnapshot.created_at:type_name -> google.protobuf.Timestamp
+	46, // 13: chatto.core.v1.RoomBanSnapshot.expires_at:type_name -> google.protobuf.Timestamp
 	12, // 14: chatto.core.v1.RoomGroupLayoutProjectionSnapshot.groups:type_name -> chatto.core.v1.RoomGroupStateSnapshot
-	51, // 15: chatto.core.v1.RoomGroupStateSnapshot.group:type_name -> chatto.core.v1.RoomGroup
+	48, // 15: chatto.core.v1.RoomGroupStateSnapshot.group:type_name -> chatto.core.v1.RoomGroup
 	14, // 16: chatto.core.v1.CallStateProjectionSnapshot.rooms:type_name -> chatto.core.v1.CallRoomStateSnapshot
 	15, // 17: chatto.core.v1.CallRoomStateSnapshot.call:type_name -> chatto.core.v1.CallSessionSnapshot
 	16, // 18: chatto.core.v1.CallRoomStateSnapshot.participants:type_name -> chatto.core.v1.CallParticipantSnapshot
-	52, // 19: chatto.core.v1.CallSessionSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
-	52, // 20: chatto.core.v1.CallParticipantSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
-	53, // 21: chatto.core.v1.ContentKeyProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	49, // 19: chatto.core.v1.CallSessionSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
+	49, // 20: chatto.core.v1.CallParticipantSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
+	50, // 21: chatto.core.v1.ContentKeyProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	7,  // 22: chatto.core.v1.ContentKeyProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	54, // 23: chatto.core.v1.RBACProjectionSnapshot.roles:type_name -> chatto.core.v1.Role
+	51, // 23: chatto.core.v1.RBACProjectionSnapshot.roles:type_name -> chatto.core.v1.Role
 	19, // 24: chatto.core.v1.RBACProjectionSnapshot.assignments:type_name -> chatto.core.v1.RBACAssignmentSnapshot
 	20, // 25: chatto.core.v1.RBACProjectionSnapshot.decisions:type_name -> chatto.core.v1.RBACDecisionSnapshot
 	7,  // 26: chatto.core.v1.RBACProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	55, // 27: chatto.core.v1.RBACDecisionSnapshot.subject_kind:type_name -> chatto.core.v1.RbacPermissionSubjectKind
-	56, // 28: chatto.core.v1.ConfigProjectionSnapshot.logo:type_name -> chatto.core.v1.AssetRecord
-	56, // 29: chatto.core.v1.ConfigProjectionSnapshot.banner:type_name -> chatto.core.v1.AssetRecord
+	52, // 27: chatto.core.v1.RBACDecisionSnapshot.subject_kind:type_name -> chatto.core.v1.RbacPermissionSubjectKind
+	53, // 28: chatto.core.v1.ConfigProjectionSnapshot.logo:type_name -> chatto.core.v1.AssetRecord
+	53, // 29: chatto.core.v1.ConfigProjectionSnapshot.banner:type_name -> chatto.core.v1.AssetRecord
 	22, // 30: chatto.core.v1.ConfigProjectionSnapshot.users:type_name -> chatto.core.v1.UserConfigSnapshot
-	57, // 31: chatto.core.v1.UserConfigSnapshot.time_format:type_name -> chatto.core.v1.TimeFormat
-	58, // 32: chatto.core.v1.UserConfigSnapshot.server_notification_level:type_name -> chatto.core.v1.NotificationLevel
+	54, // 31: chatto.core.v1.UserConfigSnapshot.time_format:type_name -> chatto.core.v1.TimeFormat
+	55, // 32: chatto.core.v1.UserConfigSnapshot.server_notification_level:type_name -> chatto.core.v1.NotificationLevel
 	23, // 33: chatto.core.v1.UserConfigSnapshot.room_notification_levels:type_name -> chatto.core.v1.RoomNotificationLevelSnapshot
-	58, // 34: chatto.core.v1.RoomNotificationLevelSnapshot.level:type_name -> chatto.core.v1.NotificationLevel
-	59, // 35: chatto.core.v1.AssetProjectionSnapshot.creations:type_name -> chatto.core.v1.AssetCreatedEvent
+	55, // 34: chatto.core.v1.RoomNotificationLevelSnapshot.level:type_name -> chatto.core.v1.NotificationLevel
+	56, // 35: chatto.core.v1.AssetProjectionSnapshot.creations:type_name -> chatto.core.v1.AssetCreatedEvent
 	25, // 36: chatto.core.v1.AssetProjectionSnapshot.children:type_name -> chatto.core.v1.AssetChildrenSnapshot
 	26, // 37: chatto.core.v1.AssetProjectionSnapshot.manifests:type_name -> chatto.core.v1.AssetManifestSnapshot
 	27, // 38: chatto.core.v1.AssetProjectionSnapshot.deleted_assets:type_name -> chatto.core.v1.DeletedAssetSnapshot
 	7,  // 39: chatto.core.v1.AssetProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	48, // 40: chatto.core.v1.AssetProjectionSnapshot.message_owners:type_name -> chatto.core.v1.AssetMessageOwnerSnapshot
-	60, // 41: chatto.core.v1.AssetManifestSnapshot.started:type_name -> chatto.core.v1.AssetProcessingStartedEvent
-	61, // 42: chatto.core.v1.AssetManifestSnapshot.succeeded:type_name -> chatto.core.v1.AssetProcessingSucceededEvent
-	62, // 43: chatto.core.v1.AssetManifestSnapshot.failed:type_name -> chatto.core.v1.AssetProcessingFailedEvent
+	45, // 40: chatto.core.v1.AssetProjectionSnapshot.message_owners:type_name -> chatto.core.v1.AssetMessageOwnerSnapshot
+	57, // 41: chatto.core.v1.AssetManifestSnapshot.started:type_name -> chatto.core.v1.AssetProcessingStartedEvent
+	58, // 42: chatto.core.v1.AssetManifestSnapshot.succeeded:type_name -> chatto.core.v1.AssetProcessingSucceededEvent
+	59, // 43: chatto.core.v1.AssetManifestSnapshot.failed:type_name -> chatto.core.v1.AssetProcessingFailedEvent
 	29, // 44: chatto.core.v1.ReactionProjectionSnapshot.messages:type_name -> chatto.core.v1.MessageReactionsSnapshot
 	32, // 45: chatto.core.v1.ReactionProjectionSnapshot.room_sequences:type_name -> chatto.core.v1.StringUint64Snapshot
 	33, // 46: chatto.core.v1.ReactionProjectionSnapshot.message_rooms:type_name -> chatto.core.v1.StringStringSnapshot
@@ -3914,45 +3673,38 @@ var file_chatto_core_v1_projection_snapshots_proto_depIdxs = []int32{
 	7,  // 49: chatto.core.v1.ReactionProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	30, // 50: chatto.core.v1.MessageReactionsSnapshot.emojis:type_name -> chatto.core.v1.EmojiReactionsSnapshot
 	31, // 51: chatto.core.v1.EmojiReactionsSnapshot.users:type_name -> chatto.core.v1.UserReactionSnapshot
-	63, // 52: chatto.core.v1.MentionablesProjectionSnapshot.user_login_sources:type_name -> chatto.core.v1.Event
-	53, // 53: chatto.core.v1.MentionablesProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	60, // 52: chatto.core.v1.MentionablesProjectionSnapshot.user_login_sources:type_name -> chatto.core.v1.Event
+	50, // 53: chatto.core.v1.MentionablesProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	36, // 54: chatto.core.v1.UserProfileProjectionSnapshot.users:type_name -> chatto.core.v1.ProjectedUserProfileSnapshot
-	53, // 55: chatto.core.v1.UserProfileProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	50, // 55: chatto.core.v1.UserProfileProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	7,  // 56: chatto.core.v1.UserProfileProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	33, // 57: chatto.core.v1.UserProfileProjectionSnapshot.login_index:type_name -> chatto.core.v1.StringStringSnapshot
 	33, // 58: chatto.core.v1.UserProfileProjectionSnapshot.email_index:type_name -> chatto.core.v1.StringStringSnapshot
-	64, // 59: chatto.core.v1.ProjectedUserProfileSnapshot.user:type_name -> chatto.core.v1.User
+	61, // 59: chatto.core.v1.ProjectedUserProfileSnapshot.user:type_name -> chatto.core.v1.User
 	37, // 60: chatto.core.v1.ProjectedUserProfileSnapshot.login:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
 	37, // 61: chatto.core.v1.ProjectedUserProfileSnapshot.display_name:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
-	56, // 62: chatto.core.v1.ProjectedUserProfileSnapshot.avatar:type_name -> chatto.core.v1.AssetRecord
+	53, // 62: chatto.core.v1.ProjectedUserProfileSnapshot.avatar:type_name -> chatto.core.v1.AssetRecord
 	38, // 63: chatto.core.v1.ProjectedUserProfileSnapshot.verified_emails:type_name -> chatto.core.v1.ProjectedVerifiedEmailSnapshot
-	65, // 64: chatto.core.v1.ProjectedUserProfileSnapshot.preferences:type_name -> chatto.core.v1.ServerUserPreferences
-	49, // 65: chatto.core.v1.ProjectedUserProfileSnapshot.login_changed_at:type_name -> google.protobuf.Timestamp
-	66, // 66: chatto.core.v1.ProjectedEncryptedUserStringSnapshot.encrypted:type_name -> chatto.core.v1.EncryptedUserString
+	62, // 64: chatto.core.v1.ProjectedUserProfileSnapshot.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	46, // 65: chatto.core.v1.ProjectedUserProfileSnapshot.login_changed_at:type_name -> google.protobuf.Timestamp
+	63, // 66: chatto.core.v1.ProjectedEncryptedUserStringSnapshot.encrypted:type_name -> chatto.core.v1.EncryptedUserString
 	37, // 67: chatto.core.v1.ProjectedVerifiedEmailSnapshot.value:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
-	49, // 68: chatto.core.v1.ProjectedVerifiedEmailSnapshot.verified_at:type_name -> google.protobuf.Timestamp
-	40, // 69: chatto.core.v1.RoomTimelineProjectionSnapshot.entries:type_name -> chatto.core.v1.TimelineEntrySnapshot
-	41, // 70: chatto.core.v1.RoomTimelineProjectionSnapshot.bodies:type_name -> chatto.core.v1.TimelineBodySnapshot
-	47, // 71: chatto.core.v1.RoomTimelineProjectionSnapshot.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
-	47, // 72: chatto.core.v1.RoomTimelineProjectionSnapshot.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
-	7,  // 73: chatto.core.v1.RoomTimelineProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	63, // 74: chatto.core.v1.TimelineEntrySnapshot.event:type_name -> chatto.core.v1.Event
-	67, // 75: chatto.core.v1.TimelineBodySnapshot.body:type_name -> chatto.core.v1.MessageBody
-	43, // 76: chatto.core.v1.RoomTimelineProjectionSnapshotV3.entries:type_name -> chatto.core.v1.TimelineEntryMetadataSnapshot
-	44, // 77: chatto.core.v1.RoomTimelineProjectionSnapshotV3.bodies:type_name -> chatto.core.v1.TimelineBodyMetadataSnapshot
-	45, // 78: chatto.core.v1.RoomTimelineProjectionSnapshotV3.buckets:type_name -> chatto.core.v1.TimelineBucketSnapshot
-	47, // 79: chatto.core.v1.RoomTimelineProjectionSnapshotV3.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
-	47, // 80: chatto.core.v1.RoomTimelineProjectionSnapshotV3.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
-	7,  // 81: chatto.core.v1.RoomTimelineProjectionSnapshotV3.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	63, // 82: chatto.core.v1.TimelineEntryMetadataSnapshot.resident_event:type_name -> chatto.core.v1.Event
-	67, // 83: chatto.core.v1.TimelineBodyMetadataSnapshot.resident_body:type_name -> chatto.core.v1.MessageBody
-	46, // 84: chatto.core.v1.TimelineBucketSnapshot.event_references:type_name -> chatto.core.v1.TimelineBucketEventReferenceSnapshot
-	49, // 85: chatto.core.v1.StringTimestampSnapshot.value:type_name -> google.protobuf.Timestamp
-	86, // [86:86] is the sub-list for method output_type
-	86, // [86:86] is the sub-list for method input_type
-	86, // [86:86] is the sub-list for extension type_name
-	86, // [86:86] is the sub-list for extension extendee
-	0,  // [0:86] is the sub-list for field type_name
+	46, // 68: chatto.core.v1.ProjectedVerifiedEmailSnapshot.verified_at:type_name -> google.protobuf.Timestamp
+	40, // 69: chatto.core.v1.RoomTimelineProjectionSnapshot.entries:type_name -> chatto.core.v1.TimelineEntryMetadataSnapshot
+	41, // 70: chatto.core.v1.RoomTimelineProjectionSnapshot.bodies:type_name -> chatto.core.v1.TimelineBodyMetadataSnapshot
+	42, // 71: chatto.core.v1.RoomTimelineProjectionSnapshot.buckets:type_name -> chatto.core.v1.TimelineBucketSnapshot
+	44, // 72: chatto.core.v1.RoomTimelineProjectionSnapshot.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	44, // 73: chatto.core.v1.RoomTimelineProjectionSnapshot.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	7,  // 74: chatto.core.v1.RoomTimelineProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
+	60, // 75: chatto.core.v1.TimelineEntryMetadataSnapshot.resident_event:type_name -> chatto.core.v1.Event
+	64, // 76: chatto.core.v1.TimelineBodyMetadataSnapshot.resident_body:type_name -> chatto.core.v1.MessageBody
+	43, // 77: chatto.core.v1.TimelineBucketSnapshot.event_references:type_name -> chatto.core.v1.TimelineBucketEventReferenceSnapshot
+	46, // 78: chatto.core.v1.StringTimestampSnapshot.value:type_name -> google.protobuf.Timestamp
+	79, // [79:79] is the sub-list for method output_type
+	79, // [79:79] is the sub-list for method input_type
+	79, // [79:79] is the sub-list for extension type_name
+	79, // [79:79] is the sub-list for extension extendee
+	0,  // [0:79] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_projection_snapshots_proto_init() }
@@ -3975,7 +3727,7 @@ func file_chatto_core_v1_projection_snapshots_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_projection_snapshots_proto_rawDesc), len(file_chatto_core_v1_projection_snapshots_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   49,
+			NumMessages:   46,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/core/v1/projection_snapshots.pb.go
+++ b/cli/internal/pb/chatto/core/v1/projection_snapshots.pb.go
@@ -3025,13 +3025,15 @@ func (x *TimelineBodyMetadataSnapshot) GetResidentBody() *MessageBody {
 }
 
 type TimelineBucketSnapshot struct {
-	state           protoimpl.MessageState                  `protogen:"open.v1"`
-	RoomId          string                                  `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	WeekStartUnix   int64                                   `protobuf:"varint,2,opt,name=week_start_unix,json=weekStartUnix,proto3" json:"week_start_unix,omitempty"`
-	EventReferences []*TimelineBucketEventReferenceSnapshot `protobuf:"bytes,3,rep,name=event_references,json=eventReferences,proto3" json:"event_references,omitempty"`
-	PayloadResident bool                                    `protobuf:"varint,4,opt,name=payload_resident,json=payloadResident,proto3" json:"payload_resident,omitempty"`
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	RoomId        string                 `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	WeekStartUnix int64                  `protobuf:"varint,2,opt,name=week_start_unix,json=weekStartUnix,proto3" json:"week_start_unix,omitempty"`
+	// Delta-varint encoded EVT stream sequences. The low bit records whether a
+	// securely deleted obsolete message body may be absent.
+	EncodedEventReferences []byte `protobuf:"bytes,3,opt,name=encoded_event_references,json=encodedEventReferences,proto3" json:"encoded_event_references,omitempty"`
+	PayloadResident        bool   `protobuf:"varint,4,opt,name=payload_resident,json=payloadResident,proto3" json:"payload_resident,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
 }
 
 func (x *TimelineBucketSnapshot) Reset() {
@@ -3078,9 +3080,9 @@ func (x *TimelineBucketSnapshot) GetWeekStartUnix() int64 {
 	return 0
 }
 
-func (x *TimelineBucketSnapshot) GetEventReferences() []*TimelineBucketEventReferenceSnapshot {
+func (x *TimelineBucketSnapshot) GetEncodedEventReferences() []byte {
 	if x != nil {
-		return x.EventReferences
+		return x.EncodedEventReferences
 	}
 	return nil
 }
@@ -3088,58 +3090,6 @@ func (x *TimelineBucketSnapshot) GetEventReferences() []*TimelineBucketEventRefe
 func (x *TimelineBucketSnapshot) GetPayloadResident() bool {
 	if x != nil {
 		return x.PayloadResident
-	}
-	return false
-}
-
-type TimelineBucketEventReferenceSnapshot struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	StreamSequence uint64                 `protobuf:"varint,1,opt,name=stream_sequence,json=streamSequence,proto3" json:"stream_sequence,omitempty"`
-	OptionalBody   bool                   `protobuf:"varint,2,opt,name=optional_body,json=optionalBody,proto3" json:"optional_body,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
-}
-
-func (x *TimelineBucketEventReferenceSnapshot) Reset() {
-	*x = TimelineBucketEventReferenceSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *TimelineBucketEventReferenceSnapshot) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*TimelineBucketEventReferenceSnapshot) ProtoMessage() {}
-
-func (x *TimelineBucketEventReferenceSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use TimelineBucketEventReferenceSnapshot.ProtoReflect.Descriptor instead.
-func (*TimelineBucketEventReferenceSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{43}
-}
-
-func (x *TimelineBucketEventReferenceSnapshot) GetStreamSequence() uint64 {
-	if x != nil {
-		return x.StreamSequence
-	}
-	return 0
-}
-
-func (x *TimelineBucketEventReferenceSnapshot) GetOptionalBody() bool {
-	if x != nil {
-		return x.OptionalBody
 	}
 	return false
 }
@@ -3154,7 +3104,7 @@ type StringTimestampSnapshot struct {
 
 func (x *StringTimestampSnapshot) Reset() {
 	*x = StringTimestampSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3166,7 +3116,7 @@ func (x *StringTimestampSnapshot) String() string {
 func (*StringTimestampSnapshot) ProtoMessage() {}
 
 func (x *StringTimestampSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3179,7 +3129,7 @@ func (x *StringTimestampSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StringTimestampSnapshot.ProtoReflect.Descriptor instead.
 func (*StringTimestampSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{44}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *StringTimestampSnapshot) GetKey() string {
@@ -3208,7 +3158,7 @@ type AssetMessageOwnerSnapshot struct {
 
 func (x *AssetMessageOwnerSnapshot) Reset() {
 	*x = AssetMessageOwnerSnapshot{}
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3220,7 +3170,7 @@ func (x *AssetMessageOwnerSnapshot) String() string {
 func (*AssetMessageOwnerSnapshot) ProtoMessage() {}
 
 func (x *AssetMessageOwnerSnapshot) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[45]
+	mi := &file_chatto_core_v1_projection_snapshots_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3233,7 +3183,7 @@ func (x *AssetMessageOwnerSnapshot) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AssetMessageOwnerSnapshot.ProtoReflect.Descriptor instead.
 func (*AssetMessageOwnerSnapshot) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{45}
+	return file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *AssetMessageOwnerSnapshot) GetAssetId() string {
@@ -3521,15 +3471,12 @@ const file_chatto_core_v1_projection_snapshots_proto_rawDesc = "" +
 	"\aroom_id\x18\x04 \x01(\tR\x06roomId\x12&\n" +
 	"\x0fweek_start_unix\x18\x05 \x01(\x03R\rweekStartUnix\x12'\n" +
 	"\x0fhas_attachments\x18\x06 \x01(\bR\x0ehasAttachments\x12@\n" +
-	"\rresident_body\x18\a \x01(\v2\x1b.chatto.core.v1.MessageBodyR\fresidentBody\"\xe5\x01\n" +
+	"\rresident_body\x18\a \x01(\v2\x1b.chatto.core.v1.MessageBodyR\fresidentBody\"\xbe\x01\n" +
 	"\x16TimelineBucketSnapshot\x12\x17\n" +
 	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12&\n" +
-	"\x0fweek_start_unix\x18\x02 \x01(\x03R\rweekStartUnix\x12_\n" +
-	"\x10event_references\x18\x03 \x03(\v24.chatto.core.v1.TimelineBucketEventReferenceSnapshotR\x0feventReferences\x12)\n" +
-	"\x10payload_resident\x18\x04 \x01(\bR\x0fpayloadResident\"t\n" +
-	"$TimelineBucketEventReferenceSnapshot\x12'\n" +
-	"\x0fstream_sequence\x18\x01 \x01(\x04R\x0estreamSequence\x12#\n" +
-	"\roptional_body\x18\x02 \x01(\bR\foptionalBody\"]\n" +
+	"\x0fweek_start_unix\x18\x02 \x01(\x03R\rweekStartUnix\x128\n" +
+	"\x18encoded_event_references\x18\x03 \x01(\fR\x16encodedEventReferences\x12)\n" +
+	"\x10payload_resident\x18\x04 \x01(\bR\x0fpayloadResident\"]\n" +
 	"\x17StringTimestampSnapshot\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x120\n" +
 	"\x05value\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x05value\"\x96\x01\n" +
@@ -3552,7 +3499,7 @@ func file_chatto_core_v1_projection_snapshots_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_projection_snapshots_proto_rawDescData
 }
 
-var file_chatto_core_v1_projection_snapshots_proto_msgTypes = make([]protoimpl.MessageInfo, 46)
+var file_chatto_core_v1_projection_snapshots_proto_msgTypes = make([]protoimpl.MessageInfo, 45)
 var file_chatto_core_v1_projection_snapshots_proto_goTypes = []any{
 	(*ProjectionSnapshotGeneration)(nil),         // 0: chatto.core.v1.ProjectionSnapshotGeneration
 	(*ProjectionSnapshotPointer)(nil),            // 1: chatto.core.v1.ProjectionSnapshotPointer
@@ -3597,74 +3544,73 @@ var file_chatto_core_v1_projection_snapshots_proto_goTypes = []any{
 	(*TimelineEntryMetadataSnapshot)(nil),        // 40: chatto.core.v1.TimelineEntryMetadataSnapshot
 	(*TimelineBodyMetadataSnapshot)(nil),         // 41: chatto.core.v1.TimelineBodyMetadataSnapshot
 	(*TimelineBucketSnapshot)(nil),               // 42: chatto.core.v1.TimelineBucketSnapshot
-	(*TimelineBucketEventReferenceSnapshot)(nil), // 43: chatto.core.v1.TimelineBucketEventReferenceSnapshot
-	(*StringTimestampSnapshot)(nil),              // 44: chatto.core.v1.StringTimestampSnapshot
-	(*AssetMessageOwnerSnapshot)(nil),            // 45: chatto.core.v1.AssetMessageOwnerSnapshot
-	(*timestamppb.Timestamp)(nil),                // 46: google.protobuf.Timestamp
-	(*Room)(nil),                                 // 47: chatto.core.v1.Room
-	(*RoomGroup)(nil),                            // 48: chatto.core.v1.RoomGroup
-	(CallParticipantEventSource)(0),              // 49: chatto.core.v1.CallParticipantEventSource
-	(*UserDEKGeneratedEvent)(nil),                // 50: chatto.core.v1.UserDEKGeneratedEvent
-	(*Role)(nil),                                 // 51: chatto.core.v1.Role
-	(RbacPermissionSubjectKind)(0),               // 52: chatto.core.v1.RbacPermissionSubjectKind
-	(*AssetRecord)(nil),                          // 53: chatto.core.v1.AssetRecord
-	(TimeFormat)(0),                              // 54: chatto.core.v1.TimeFormat
-	(NotificationLevel)(0),                       // 55: chatto.core.v1.NotificationLevel
-	(*AssetCreatedEvent)(nil),                    // 56: chatto.core.v1.AssetCreatedEvent
-	(*AssetProcessingStartedEvent)(nil),          // 57: chatto.core.v1.AssetProcessingStartedEvent
-	(*AssetProcessingSucceededEvent)(nil),        // 58: chatto.core.v1.AssetProcessingSucceededEvent
-	(*AssetProcessingFailedEvent)(nil),           // 59: chatto.core.v1.AssetProcessingFailedEvent
-	(*Event)(nil),                                // 60: chatto.core.v1.Event
-	(*User)(nil),                                 // 61: chatto.core.v1.User
-	(*ServerUserPreferences)(nil),                // 62: chatto.core.v1.ServerUserPreferences
-	(*EncryptedUserString)(nil),                  // 63: chatto.core.v1.EncryptedUserString
-	(*MessageBody)(nil),                          // 64: chatto.core.v1.MessageBody
+	(*StringTimestampSnapshot)(nil),              // 43: chatto.core.v1.StringTimestampSnapshot
+	(*AssetMessageOwnerSnapshot)(nil),            // 44: chatto.core.v1.AssetMessageOwnerSnapshot
+	(*timestamppb.Timestamp)(nil),                // 45: google.protobuf.Timestamp
+	(*Room)(nil),                                 // 46: chatto.core.v1.Room
+	(*RoomGroup)(nil),                            // 47: chatto.core.v1.RoomGroup
+	(CallParticipantEventSource)(0),              // 48: chatto.core.v1.CallParticipantEventSource
+	(*UserDEKGeneratedEvent)(nil),                // 49: chatto.core.v1.UserDEKGeneratedEvent
+	(*Role)(nil),                                 // 50: chatto.core.v1.Role
+	(RbacPermissionSubjectKind)(0),               // 51: chatto.core.v1.RbacPermissionSubjectKind
+	(*AssetRecord)(nil),                          // 52: chatto.core.v1.AssetRecord
+	(TimeFormat)(0),                              // 53: chatto.core.v1.TimeFormat
+	(NotificationLevel)(0),                       // 54: chatto.core.v1.NotificationLevel
+	(*AssetCreatedEvent)(nil),                    // 55: chatto.core.v1.AssetCreatedEvent
+	(*AssetProcessingStartedEvent)(nil),          // 56: chatto.core.v1.AssetProcessingStartedEvent
+	(*AssetProcessingSucceededEvent)(nil),        // 57: chatto.core.v1.AssetProcessingSucceededEvent
+	(*AssetProcessingFailedEvent)(nil),           // 58: chatto.core.v1.AssetProcessingFailedEvent
+	(*Event)(nil),                                // 59: chatto.core.v1.Event
+	(*User)(nil),                                 // 60: chatto.core.v1.User
+	(*ServerUserPreferences)(nil),                // 61: chatto.core.v1.ServerUserPreferences
+	(*EncryptedUserString)(nil),                  // 62: chatto.core.v1.EncryptedUserString
+	(*MessageBody)(nil),                          // 63: chatto.core.v1.MessageBody
 }
 var file_chatto_core_v1_projection_snapshots_proto_depIdxs = []int32{
-	46, // 0: chatto.core.v1.ProjectionSnapshotGeneration.created_at:type_name -> google.protobuf.Timestamp
-	46, // 1: chatto.core.v1.ProjectionSnapshotPointer.current_created_at:type_name -> google.protobuf.Timestamp
-	46, // 2: chatto.core.v1.ProjectionSnapshotPointer.previous_created_at:type_name -> google.protobuf.Timestamp
+	45, // 0: chatto.core.v1.ProjectionSnapshotGeneration.created_at:type_name -> google.protobuf.Timestamp
+	45, // 1: chatto.core.v1.ProjectionSnapshotPointer.current_created_at:type_name -> google.protobuf.Timestamp
+	45, // 2: chatto.core.v1.ProjectionSnapshotPointer.previous_created_at:type_name -> google.protobuf.Timestamp
 	3,  // 3: chatto.core.v1.ThreadProjectionSnapshot.threads:type_name -> chatto.core.v1.ThreadSnapshot
 	5,  // 4: chatto.core.v1.ThreadProjectionSnapshot.replies:type_name -> chatto.core.v1.ThreadReplySnapshot
 	6,  // 5: chatto.core.v1.ThreadProjectionSnapshot.follows:type_name -> chatto.core.v1.ThreadFollowSnapshot
 	7,  // 6: chatto.core.v1.ThreadProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	4,  // 7: chatto.core.v1.ThreadSnapshot.entries:type_name -> chatto.core.v1.ThreadTimelineEntrySnapshot
-	46, // 8: chatto.core.v1.ThreadReplySnapshot.created_at:type_name -> google.protobuf.Timestamp
-	47, // 9: chatto.core.v1.RoomDirectoryProjectionSnapshot.rooms:type_name -> chatto.core.v1.Room
+	45, // 8: chatto.core.v1.ThreadReplySnapshot.created_at:type_name -> google.protobuf.Timestamp
+	46, // 9: chatto.core.v1.RoomDirectoryProjectionSnapshot.rooms:type_name -> chatto.core.v1.Room
 	9,  // 10: chatto.core.v1.RoomDirectoryProjectionSnapshot.memberships:type_name -> chatto.core.v1.RoomMembershipSnapshot
 	10, // 11: chatto.core.v1.RoomDirectoryProjectionSnapshot.bans:type_name -> chatto.core.v1.RoomBanSnapshot
-	46, // 12: chatto.core.v1.RoomBanSnapshot.created_at:type_name -> google.protobuf.Timestamp
-	46, // 13: chatto.core.v1.RoomBanSnapshot.expires_at:type_name -> google.protobuf.Timestamp
+	45, // 12: chatto.core.v1.RoomBanSnapshot.created_at:type_name -> google.protobuf.Timestamp
+	45, // 13: chatto.core.v1.RoomBanSnapshot.expires_at:type_name -> google.protobuf.Timestamp
 	12, // 14: chatto.core.v1.RoomGroupLayoutProjectionSnapshot.groups:type_name -> chatto.core.v1.RoomGroupStateSnapshot
-	48, // 15: chatto.core.v1.RoomGroupStateSnapshot.group:type_name -> chatto.core.v1.RoomGroup
+	47, // 15: chatto.core.v1.RoomGroupStateSnapshot.group:type_name -> chatto.core.v1.RoomGroup
 	14, // 16: chatto.core.v1.CallStateProjectionSnapshot.rooms:type_name -> chatto.core.v1.CallRoomStateSnapshot
 	15, // 17: chatto.core.v1.CallRoomStateSnapshot.call:type_name -> chatto.core.v1.CallSessionSnapshot
 	16, // 18: chatto.core.v1.CallRoomStateSnapshot.participants:type_name -> chatto.core.v1.CallParticipantSnapshot
-	49, // 19: chatto.core.v1.CallSessionSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
-	49, // 20: chatto.core.v1.CallParticipantSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
-	50, // 21: chatto.core.v1.ContentKeyProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	48, // 19: chatto.core.v1.CallSessionSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
+	48, // 20: chatto.core.v1.CallParticipantSnapshot.source:type_name -> chatto.core.v1.CallParticipantEventSource
+	49, // 21: chatto.core.v1.ContentKeyProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	7,  // 22: chatto.core.v1.ContentKeyProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	51, // 23: chatto.core.v1.RBACProjectionSnapshot.roles:type_name -> chatto.core.v1.Role
+	50, // 23: chatto.core.v1.RBACProjectionSnapshot.roles:type_name -> chatto.core.v1.Role
 	19, // 24: chatto.core.v1.RBACProjectionSnapshot.assignments:type_name -> chatto.core.v1.RBACAssignmentSnapshot
 	20, // 25: chatto.core.v1.RBACProjectionSnapshot.decisions:type_name -> chatto.core.v1.RBACDecisionSnapshot
 	7,  // 26: chatto.core.v1.RBACProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	52, // 27: chatto.core.v1.RBACDecisionSnapshot.subject_kind:type_name -> chatto.core.v1.RbacPermissionSubjectKind
-	53, // 28: chatto.core.v1.ConfigProjectionSnapshot.logo:type_name -> chatto.core.v1.AssetRecord
-	53, // 29: chatto.core.v1.ConfigProjectionSnapshot.banner:type_name -> chatto.core.v1.AssetRecord
+	51, // 27: chatto.core.v1.RBACDecisionSnapshot.subject_kind:type_name -> chatto.core.v1.RbacPermissionSubjectKind
+	52, // 28: chatto.core.v1.ConfigProjectionSnapshot.logo:type_name -> chatto.core.v1.AssetRecord
+	52, // 29: chatto.core.v1.ConfigProjectionSnapshot.banner:type_name -> chatto.core.v1.AssetRecord
 	22, // 30: chatto.core.v1.ConfigProjectionSnapshot.users:type_name -> chatto.core.v1.UserConfigSnapshot
-	54, // 31: chatto.core.v1.UserConfigSnapshot.time_format:type_name -> chatto.core.v1.TimeFormat
-	55, // 32: chatto.core.v1.UserConfigSnapshot.server_notification_level:type_name -> chatto.core.v1.NotificationLevel
+	53, // 31: chatto.core.v1.UserConfigSnapshot.time_format:type_name -> chatto.core.v1.TimeFormat
+	54, // 32: chatto.core.v1.UserConfigSnapshot.server_notification_level:type_name -> chatto.core.v1.NotificationLevel
 	23, // 33: chatto.core.v1.UserConfigSnapshot.room_notification_levels:type_name -> chatto.core.v1.RoomNotificationLevelSnapshot
-	55, // 34: chatto.core.v1.RoomNotificationLevelSnapshot.level:type_name -> chatto.core.v1.NotificationLevel
-	56, // 35: chatto.core.v1.AssetProjectionSnapshot.creations:type_name -> chatto.core.v1.AssetCreatedEvent
+	54, // 34: chatto.core.v1.RoomNotificationLevelSnapshot.level:type_name -> chatto.core.v1.NotificationLevel
+	55, // 35: chatto.core.v1.AssetProjectionSnapshot.creations:type_name -> chatto.core.v1.AssetCreatedEvent
 	25, // 36: chatto.core.v1.AssetProjectionSnapshot.children:type_name -> chatto.core.v1.AssetChildrenSnapshot
 	26, // 37: chatto.core.v1.AssetProjectionSnapshot.manifests:type_name -> chatto.core.v1.AssetManifestSnapshot
 	27, // 38: chatto.core.v1.AssetProjectionSnapshot.deleted_assets:type_name -> chatto.core.v1.DeletedAssetSnapshot
 	7,  // 39: chatto.core.v1.AssetProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	45, // 40: chatto.core.v1.AssetProjectionSnapshot.message_owners:type_name -> chatto.core.v1.AssetMessageOwnerSnapshot
-	57, // 41: chatto.core.v1.AssetManifestSnapshot.started:type_name -> chatto.core.v1.AssetProcessingStartedEvent
-	58, // 42: chatto.core.v1.AssetManifestSnapshot.succeeded:type_name -> chatto.core.v1.AssetProcessingSucceededEvent
-	59, // 43: chatto.core.v1.AssetManifestSnapshot.failed:type_name -> chatto.core.v1.AssetProcessingFailedEvent
+	44, // 40: chatto.core.v1.AssetProjectionSnapshot.message_owners:type_name -> chatto.core.v1.AssetMessageOwnerSnapshot
+	56, // 41: chatto.core.v1.AssetManifestSnapshot.started:type_name -> chatto.core.v1.AssetProcessingStartedEvent
+	57, // 42: chatto.core.v1.AssetManifestSnapshot.succeeded:type_name -> chatto.core.v1.AssetProcessingSucceededEvent
+	58, // 43: chatto.core.v1.AssetManifestSnapshot.failed:type_name -> chatto.core.v1.AssetProcessingFailedEvent
 	29, // 44: chatto.core.v1.ReactionProjectionSnapshot.messages:type_name -> chatto.core.v1.MessageReactionsSnapshot
 	32, // 45: chatto.core.v1.ReactionProjectionSnapshot.room_sequences:type_name -> chatto.core.v1.StringUint64Snapshot
 	33, // 46: chatto.core.v1.ReactionProjectionSnapshot.message_rooms:type_name -> chatto.core.v1.StringStringSnapshot
@@ -3673,38 +3619,37 @@ var file_chatto_core_v1_projection_snapshots_proto_depIdxs = []int32{
 	7,  // 49: chatto.core.v1.ReactionProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	30, // 50: chatto.core.v1.MessageReactionsSnapshot.emojis:type_name -> chatto.core.v1.EmojiReactionsSnapshot
 	31, // 51: chatto.core.v1.EmojiReactionsSnapshot.users:type_name -> chatto.core.v1.UserReactionSnapshot
-	60, // 52: chatto.core.v1.MentionablesProjectionSnapshot.user_login_sources:type_name -> chatto.core.v1.Event
-	50, // 53: chatto.core.v1.MentionablesProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	59, // 52: chatto.core.v1.MentionablesProjectionSnapshot.user_login_sources:type_name -> chatto.core.v1.Event
+	49, // 53: chatto.core.v1.MentionablesProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	36, // 54: chatto.core.v1.UserProfileProjectionSnapshot.users:type_name -> chatto.core.v1.ProjectedUserProfileSnapshot
-	50, // 55: chatto.core.v1.UserProfileProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
+	49, // 55: chatto.core.v1.UserProfileProjectionSnapshot.keys:type_name -> chatto.core.v1.UserDEKGeneratedEvent
 	7,  // 56: chatto.core.v1.UserProfileProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
 	33, // 57: chatto.core.v1.UserProfileProjectionSnapshot.login_index:type_name -> chatto.core.v1.StringStringSnapshot
 	33, // 58: chatto.core.v1.UserProfileProjectionSnapshot.email_index:type_name -> chatto.core.v1.StringStringSnapshot
-	61, // 59: chatto.core.v1.ProjectedUserProfileSnapshot.user:type_name -> chatto.core.v1.User
+	60, // 59: chatto.core.v1.ProjectedUserProfileSnapshot.user:type_name -> chatto.core.v1.User
 	37, // 60: chatto.core.v1.ProjectedUserProfileSnapshot.login:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
 	37, // 61: chatto.core.v1.ProjectedUserProfileSnapshot.display_name:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
-	53, // 62: chatto.core.v1.ProjectedUserProfileSnapshot.avatar:type_name -> chatto.core.v1.AssetRecord
+	52, // 62: chatto.core.v1.ProjectedUserProfileSnapshot.avatar:type_name -> chatto.core.v1.AssetRecord
 	38, // 63: chatto.core.v1.ProjectedUserProfileSnapshot.verified_emails:type_name -> chatto.core.v1.ProjectedVerifiedEmailSnapshot
-	62, // 64: chatto.core.v1.ProjectedUserProfileSnapshot.preferences:type_name -> chatto.core.v1.ServerUserPreferences
-	46, // 65: chatto.core.v1.ProjectedUserProfileSnapshot.login_changed_at:type_name -> google.protobuf.Timestamp
-	63, // 66: chatto.core.v1.ProjectedEncryptedUserStringSnapshot.encrypted:type_name -> chatto.core.v1.EncryptedUserString
+	61, // 64: chatto.core.v1.ProjectedUserProfileSnapshot.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	45, // 65: chatto.core.v1.ProjectedUserProfileSnapshot.login_changed_at:type_name -> google.protobuf.Timestamp
+	62, // 66: chatto.core.v1.ProjectedEncryptedUserStringSnapshot.encrypted:type_name -> chatto.core.v1.EncryptedUserString
 	37, // 67: chatto.core.v1.ProjectedVerifiedEmailSnapshot.value:type_name -> chatto.core.v1.ProjectedEncryptedUserStringSnapshot
-	46, // 68: chatto.core.v1.ProjectedVerifiedEmailSnapshot.verified_at:type_name -> google.protobuf.Timestamp
+	45, // 68: chatto.core.v1.ProjectedVerifiedEmailSnapshot.verified_at:type_name -> google.protobuf.Timestamp
 	40, // 69: chatto.core.v1.RoomTimelineProjectionSnapshot.entries:type_name -> chatto.core.v1.TimelineEntryMetadataSnapshot
 	41, // 70: chatto.core.v1.RoomTimelineProjectionSnapshot.bodies:type_name -> chatto.core.v1.TimelineBodyMetadataSnapshot
 	42, // 71: chatto.core.v1.RoomTimelineProjectionSnapshot.buckets:type_name -> chatto.core.v1.TimelineBucketSnapshot
-	44, // 72: chatto.core.v1.RoomTimelineProjectionSnapshot.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
-	44, // 73: chatto.core.v1.RoomTimelineProjectionSnapshot.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	43, // 72: chatto.core.v1.RoomTimelineProjectionSnapshot.tombstoned_at:type_name -> chatto.core.v1.StringTimestampSnapshot
+	43, // 73: chatto.core.v1.RoomTimelineProjectionSnapshot.shredded_at:type_name -> chatto.core.v1.StringTimestampSnapshot
 	7,  // 74: chatto.core.v1.RoomTimelineProjectionSnapshot.replay_guard:type_name -> chatto.core.v1.ProjectionReplayGuardSnapshot
-	60, // 75: chatto.core.v1.TimelineEntryMetadataSnapshot.resident_event:type_name -> chatto.core.v1.Event
-	64, // 76: chatto.core.v1.TimelineBodyMetadataSnapshot.resident_body:type_name -> chatto.core.v1.MessageBody
-	43, // 77: chatto.core.v1.TimelineBucketSnapshot.event_references:type_name -> chatto.core.v1.TimelineBucketEventReferenceSnapshot
-	46, // 78: chatto.core.v1.StringTimestampSnapshot.value:type_name -> google.protobuf.Timestamp
-	79, // [79:79] is the sub-list for method output_type
-	79, // [79:79] is the sub-list for method input_type
-	79, // [79:79] is the sub-list for extension type_name
-	79, // [79:79] is the sub-list for extension extendee
-	0,  // [0:79] is the sub-list for field type_name
+	59, // 75: chatto.core.v1.TimelineEntryMetadataSnapshot.resident_event:type_name -> chatto.core.v1.Event
+	63, // 76: chatto.core.v1.TimelineBodyMetadataSnapshot.resident_body:type_name -> chatto.core.v1.MessageBody
+	45, // 77: chatto.core.v1.StringTimestampSnapshot.value:type_name -> google.protobuf.Timestamp
+	78, // [78:78] is the sub-list for method output_type
+	78, // [78:78] is the sub-list for method input_type
+	78, // [78:78] is the sub-list for extension type_name
+	78, // [78:78] is the sub-list for extension extendee
+	0,  // [0:78] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_projection_snapshots_proto_init() }
@@ -3727,7 +3672,7 @@ func file_chatto_core_v1_projection_snapshots_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_projection_snapshots_proto_rawDesc), len(file_chatto_core_v1_projection_snapshots_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   46,
+			NumMessages:   45,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/docs/adr/ADR-056-bucketed-room-timeline-payloads.md
+++ b/docs/adr/ADR-056-bucketed-room-timeline-payloads.md
@@ -1,0 +1,88 @@
+# ADR-056: Bucket Room Timeline Payloads by UTC Week
+
+**Date:** 2026-07-24
+
+## Context
+
+The Room Timeline projection currently retains every projected event and every
+current message body as decoded protobufs for the lifetime of the process. Its
+indexes are efficient, but its resident payload memory grows with all room
+history even when operators and members only read recent messages.
+
+Room and thread timeline cursors use EVT stream sequences. Search returns
+message identifiers that Chatto must authorize and hydrate against current
+projection state. Any memory reduction therefore needs to preserve exact
+pagination, thread, deletion, attachment, echo, and search semantics without
+introducing a shared replay consumer or a second durable source of truth.
+
+A benchmark against a 53,763-event production-derived EVT backup found 41,612
+Room Timeline events. UTC-week buckets produced 375 room buckets; the largest
+cold bucket held 1,963 events and 338 KB of encoded payload. UTC-month buckets
+produced 269 room buckets, but the largest held 4,562 events and 783 KB. Exact
+sequence loading of the largest weekly bucket took about 18 ms with bounded
+concurrency, versus about 42 ms for the monthly bucket. The additional weekly
+metadata was negligible compared with retained protobuf payloads.
+
+## Decision
+
+Keep one Room Timeline projection and its existing independent ordered EVT
+consumer. Partition only its decoded payload cache into fixed UTC-week buckets.
+Bucket geometry is deliberately not configurable because changing it would
+invalidate snapshot layout and make operational behavior harder to compare.
+
+The projection always retains lightweight metadata: timeline ordering,
+event-to-bucket locators, message-body sequence history, visibility and
+retraction state, and the exact EVT sequences required to reconstruct each
+bucket. Recent buckets retain their decoded event and current-body protobufs.
+The operator configures the recent hot window in days; it defaults to 30 days.
+
+When a read needs a cold bucket, the projection loads its referenced messages
+directly from EVT with bounded concurrency, validates and decodes them, and
+installs the reconstructed payload atomically. Concurrent readers share the
+same load. Missing sequences are errors except for message-body facts that
+Chatto may have securely deleted after they became obsolete. Search candidate
+hydration uses the same loading boundary as timeline and thread reads.
+
+The first version does not evict a bucket after it has been loaded. Its bucket
+state records access and resident size so a later LRU policy can be added
+without changing the storage model or read APIs. This deliberately accepts
+process-lifetime cache growth from historical reads while removing the
+unconditional cold-boot cost.
+
+Room Timeline snapshots use a new codec contract. They retain the complete
+lightweight directory and exact EVT references, plus decoded payloads only for
+buckets inside the configured hot window. Incompatible or missing snapshots
+cold-replay EVT as before. A changed hot-window setting changes cache residency,
+not projected behavior or bucket identity.
+
+Use event `created_at` to assign a fixed UTC week. A message's first projected
+body or post establishes its bucket, which handles the durable ordering where
+an initial `MessageBodyEvent` precedes its `MessagePostedEvent`. Later edits and
+retractions follow the established message bucket. Events without a usable
+timestamp use a deterministic timeless bucket rather than wall-clock time.
+
+ThreadProjection remains independently consumed and retains its lightweight
+reply references. Resolving a thread root or reply materializes the owning Room
+Timeline bucket. Bucketing ThreadProjection's own metadata is deferred until
+measurements show that it is worthwhile.
+
+## Consequences
+
+Normal startup and recent-room reads retain only recent decoded Room Timeline
+payloads while preserving existing global cursors, authorization, and event
+ordering. Historical reads pay an explicit EVT load and protobuf decode cost
+once per process and bucket.
+
+EVT remains required for cold bucket materialization. Operators must not prune
+non-obsolete Room Timeline facts independently of the projection. Secure
+deletion of obsolete body facts remains supported because the directory marks
+those references as optional during reconstruction.
+
+Exact sequence references cost eight bytes per referenced fact before Go
+container overhead. This is intentionally simpler than compressed ranges,
+which perform poorly when a room's events are interleaved with other rooms and
+would make missing-fact handling more complex.
+
+The parent projection still retains metadata proportional to history. A future
+LRU bounds decoded cache residency; a separate archive projection remains an
+alternative if metadata itself becomes material.

--- a/docs/adr/ADR-056-bucketed-room-timeline-payloads.md
+++ b/docs/adr/ADR-056-bucketed-room-timeline-payloads.md
@@ -32,9 +32,11 @@ invalidate snapshot layout and make operational behavior harder to compare.
 
 The projection always retains lightweight metadata: timeline ordering,
 event-to-bucket locators, message-body sequence history, visibility and
-retraction state, and the exact EVT sequences required to reconstruct each
-bucket. Recent buckets retain their decoded event and current-body protobufs.
-The operator configures the recent hot window in days; it defaults to 30 days.
+retraction state, and compact delta-varint encoded EVT sequences required to
+reconstruct each bucket. The encoding folds the optional-obsolete-body marker
+into each sequence delta. Recent buckets retain their decoded event and
+current-body protobufs. The operator configures the recent hot window in days;
+it defaults to 30 days.
 
 When a read needs a cold bucket, the projection loads its referenced messages
 directly from EVT with bounded concurrency, validates and decodes them, and
@@ -50,10 +52,10 @@ process-lifetime cache growth from historical reads while removing the
 unconditional cold-boot cost.
 
 Room Timeline snapshots use a new codec contract. They retain the complete
-lightweight directory and exact EVT references, plus decoded payloads only for
-buckets inside the configured hot window. Incompatible or missing snapshots
-cold-replay EVT as before. A changed hot-window setting changes cache residency,
-not projected behavior or bucket identity.
+lightweight directory and the same compact EVT references, plus decoded
+payloads only for buckets inside the configured hot window. Incompatible or
+missing snapshots cold-replay EVT as before. A changed hot-window setting
+changes cache residency, not projected behavior or bucket identity.
 
 Use event `created_at` to assign a fixed UTC week. A message's first projected
 body or post establishes its bucket, which handles the durable ordering where
@@ -78,10 +80,11 @@ non-obsolete Room Timeline facts independently of the projection. Secure
 deletion of obsolete body facts remains supported because the directory marks
 those references as optional during reconstruction.
 
-Exact sequence references cost eight bytes per referenced fact before Go
-container overhead. This is intentionally simpler than compressed ranges,
-which perform poorly when a room's events are interleaved with other rooms and
-would make missing-fact handling more complex.
+Exact sequence references are stored as monotonically increasing delta varints,
+typically using one to three bytes per referenced fact. This is intentionally
+simpler than ranges, which perform poorly when a room's events are interleaved
+with other rooms and would make missing-fact handling more complex. Hydration
+temporarily expands only the requested bucket into ordinary sequence records.
 
 The parent projection still retains metadata proportional to history. A future
 LRU bounds decoded cache residency; a separate archive projection remains an

--- a/docs/adr/ADR-056-bucketed-room-timeline-payloads.md
+++ b/docs/adr/ADR-056-bucketed-room-timeline-payloads.md
@@ -33,10 +33,16 @@ invalidate snapshot layout and make operational behavior harder to compare.
 The projection always retains lightweight metadata: timeline ordering,
 event-to-bucket locators, message-body sequence history, visibility and
 retraction state, and compact delta-varint encoded EVT sequences required to
-reconstruct each bucket. The encoding folds the optional-obsolete-body marker
-into each sequence delta. Recent buckets retain their decoded event and
-current-body protobufs. The operator configures the recent hot window in days;
-it defaults to 30 days.
+reconstruct each bucket. Stable event, room, and user IDs are interned once;
+dense metadata rows and posting lists refer to them through projection-local
+32-bit handles. Retraction and hidden-echo state is packed by handle, while
+decoded bodies and uncommon superseded body sequences live outside the common
+body row.
+
+The sequence encoding folds the optional-obsolete-body marker into each
+sequence delta. Recent buckets retain their decoded event and current-body
+protobufs. The operator configures the recent hot window in days; it defaults
+to 30 days.
 
 When a read needs a cold bucket, the projection loads its referenced messages
 directly from EVT with bounded concurrency, validates and decodes them, and
@@ -63,10 +69,11 @@ an initial `MessageBodyEvent` precedes its `MessagePostedEvent`. Later edits and
 retractions follow the established message bucket. Events without a usable
 timestamp use a deterministic timeless bucket rather than wall-clock time.
 
-ThreadProjection remains independently consumed and retains its lightweight
-reply references. Resolving a thread root or reply materializes the owning Room
-Timeline bucket. Bucketing ThreadProjection's own metadata is deferred until
-measurements show that it is worthwhile.
+ThreadProjection remains independently consumed and owns an independent handle
+space so its replay, readiness, and snapshots do not depend on Room Timeline
+apply order. Thread roots, replies, users, rooms, follow targets, summaries,
+and reverse indexes use compact handles. Resolving a thread root or reply still
+materializes the owning Room Timeline bucket.
 
 ## Consequences
 
@@ -85,6 +92,12 @@ typically using one to three bytes per referenced fact. This is intentionally
 simpler than ranges, which perform poorly when a room's events are interleaved
 with other rooms and would make missing-fact handling more complex. Hydration
 temporarily expands only the requested bucket into ordinary sequence records.
+
+Projection handles are not durable identities and never cross an API,
+snapshot, or projection boundary. Snapshot codecs continue to store stable IDs
+and EVT sequences, then rebuild each projection's dictionaries and handles on
+restore. This keeps the existing snapshot contracts replay-equivalent and
+allows rolling deploys and rollbacks to restore their own snapshot generations.
 
 The parent projection still retains metadata proportional to history. A future
 LRU bounds decoded cache residency; a separate archive projection remains an

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -67,3 +67,4 @@ replace part of their original design.
 | [ADR-053](ADR-053-versioned-nats-service-namespaces.md) | Versioned NATS Service Namespaces | Accepted | 2026-07-20 |
 | [ADR-054](ADR-054-optional-projection-persistence.md) | Projection Persistence Is Optional | Accepted | 2026-07-20 |
 | [ADR-055](ADR-055-pluggable-message-search-over-nats.md) | Pluggable Message Search over NATS | Accepted | 2026-07-21 |
+| [ADR-056](ADR-056-bucketed-room-timeline-payloads.md) | Bucket Room Timeline Payloads by UTC Week | Accepted | 2026-07-24 |

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -42,7 +42,30 @@ Related decisions: [ADR-007](../adr/ADR-007-per-user-encryption-with-crypto-shre
 [ADR-033](../adr/ADR-033-event-sourced-state-with-projections.md),
 [ADR-050](../adr/ADR-050-ephemeral-encrypted-projection-snapshots.md),
 [ADR-054](../adr/ADR-054-optional-projection-persistence.md), and
-[ADR-055](../adr/ADR-055-pluggable-message-search-over-nats.md).
+[ADR-055](../adr/ADR-055-pluggable-message-search-over-nats.md), and
+[ADR-056](../adr/ADR-056-bucketed-room-timeline-payloads.md).
+
+## Room Timeline payload buckets
+
+Room Timeline keeps one projector and ordered EVT consumer. Its ordering,
+event-ID, message-body sequence, visibility, retraction, echo, and attachment
+metadata remains resident. Decoded event and current-body protobufs are grouped
+by room and fixed UTC week.
+
+Buckets intersecting `core.room_timeline_hot_window` remain decoded during EVT
+replay; the window defaults to 30 days. Older buckets retain exact EVT sequence
+references and load through bounded direct stream reads when a room page,
+thread, attachment page, direct message lookup, or search candidate needs
+them. One concurrent load owns a bucket and other readers wait for it. Loaded
+historical buckets remain resident for the rest of the process; eviction is not
+implemented yet.
+
+Every message body reference is marked optional because secure cleanup may
+have deleted obsolete body facts. Missing current-body or indexed-event facts
+fail the bucket load. A message's first body or post establishes its bucket, so
+the normal body-before-post write order does not require a second replay lane.
+ThreadProjection continues to retain lightweight reply references and resolves
+their payload through Room Timeline.
 
 ## Local checkpoint support
 
@@ -105,7 +128,8 @@ generation prefix. The contract covers serialized state, replay semantics,
 consumed event families, and cutoff meaning. Each ID combines a manual semantic
 token with a fingerprint of the codec's reachable protobuf schema, so a schema
 change automatically starts a new contract namespace. Most contracts use
-semantic token `v1`; Assets, Room Timeline, and user profile use `v2`.
+semantic token `v1`; Assets and user profile use `v2`, while Room Timeline uses
+`v3`.
 
 Snapshot loads and replay frontiers are projection-local. A successful restore
 starts that projection's ordered consumer at one greater than its cutoff. A
@@ -116,10 +140,11 @@ state is owned by `UserAuthProjection` and cold-replays from eight focused user
 event families.
 
 The projector framework atomically captures each projection's explicit
-protobuf state with its latest applied logical EVT sequence. Room Timeline
-retains one body-state entry per message: the current encrypted envelope and
-EVT sequence are inline, while a sequence slice is allocated only after an
-edit. Its snapshot codec preserves the complete body-event sequence history.
+protobuf state with its latest applied logical EVT sequence. Room Timeline's
+snapshot retains its lightweight bucket directory, entry/body metadata, exact
+EVT references, and complete body-event sequence history. It includes decoded
+payload only for buckets inside the hot window, even when a historical bucket
+was loaded after boot.
 Mentionables
 retains encrypted login source events and wrapped DEK records rather than
 plaintext handles or lookup digests. The Users codec retains encrypted login,
@@ -162,7 +187,8 @@ reconstruction. Legacy cohort paths remain outside application S3 expiry.
 | Projection | Contract | Payload store | Pointer store | Publication |
 | ---------- | -------- | ------------- | ------------- | ----------- |
 | Threads, Room Directory, Server Config, Room Group Layout, Call State, Reactions, Content Keys, RBAC, Mentionables | `v1` per projection | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Elected publisher checks hourly; cold/delta replay publishes immediately and unchanged state refreshes at 23 hours |
-| Room Timeline, Assets | `v2` per projection | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; `v1` snapshots remain independently addressable during rollout and rollback |
+| Assets | `v2` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; `v1` snapshots remain independently addressable during rollout and rollback |
+| Room Timeline | `v3` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; earlier contracts remain independently addressable during rollout and rollback |
 | Users (profile state only) | `v2` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher |
 
 ## Registered projections
@@ -171,7 +197,7 @@ reconstruction. Legacy cohort paths remain outside application S3 expiry.
 | ------------------ | -------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
 | Room directory     | Room Directory       | `evt.room.>`                                               | `RoomCatalogProjection`, `RoomMembershipProjection`, `RoomBanProjection`; room/member queries, room authorization, and Universal-room effective membership |
 | Room organization  | Room Group Layout    | `evt.group.>`, `evt.layout.>`                              | `RoomGroupProjection`, `RoomLayoutProjection`; sidebar groups, sidebar links, and mixed sidebar item ordering |
-| Room timeline      | Room Timeline        | `evt.room.>`, `evt.user.*.user_key_shredded`               | Visible room timeline, latest message bodies, tombstone timestamps, hidden echoes, current attachment-bearing message index, and direct message-post lookup |
+| Room timeline      | Room Timeline        | `evt.room.>`, `evt.user.*.user_key_shredded`               | Resident timeline/body metadata plus hot or lazily EVT-loaded weekly payload buckets; visible room timeline, latest message bodies, tombstone timestamps, hidden echoes, current attachment-bearing message index, search hydration, and direct message-post lookup |
 | Assets             | Assets               | `evt.asset.>`, legacy `evt.room.*.asset_*`, `evt.room.*.message_body` | Asset creation metadata, room scope, processing manifests, derivative graph, deletion state, message ownership/author references, public link-preview image references, and legacy room-asset compatibility |
 | Threads            | Threads              | `evt.room.*.thread_created`, `evt.room.*.thread_followed`, `evt.room.*.thread_unfollowed`, `evt.room.*.message_posted`, `evt.room.*.message_edited`, `evt.room.*.message_retracted`, `evt.user.*.user_key_shredded` | Per-thread reply logs, summaries, participants, reply counts, and follow state             |
 | Reactions          | Reactions            | `evt.room.>`                                               | Current canonical per-message reaction sets, echo-to-original reaction aliases, and room-scoped snapshot OCC positions; intentionally broad so reaction writes can OCC against the room tail |

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -53,12 +53,12 @@ metadata remains resident. Decoded event and current-body protobufs are grouped
 by room and fixed UTC week.
 
 Buckets intersecting `core.room_timeline_hot_window` remain decoded during EVT
-replay; the window defaults to 30 days. Older buckets retain exact EVT sequence
-references and load through bounded direct stream reads when a room page,
-thread, attachment page, direct message lookup, or search candidate needs
-them. One concurrent load owns a bucket and other readers wait for it. Loaded
-historical buckets remain resident for the rest of the process; eviction is not
-implemented yet.
+replay; the window defaults to 30 days. Older buckets retain exact EVT
+sequences as compact delta varints and expand only the requested bucket for
+bounded direct stream reads when a room page, thread, attachment page, direct
+message lookup, or search candidate needs them. One concurrent load owns a
+bucket and other readers wait for it. Loaded historical buckets remain resident
+for the rest of the process; eviction is not implemented yet.
 
 Every message body reference is marked optional because secure cleanup may
 have deleted obsolete body facts. Missing current-body or indexed-event facts

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -128,8 +128,7 @@ generation prefix. The contract covers serialized state, replay semantics,
 consumed event families, and cutoff meaning. Each ID combines a manual semantic
 token with a fingerprint of the codec's reachable protobuf schema, so a schema
 change automatically starts a new contract namespace. Most contracts use
-semantic token `v1`; Assets and user profile use `v2`, while Room Timeline uses
-`v3`.
+semantic token `v1`; Assets, Room Timeline, and user profile use `v2`.
 
 Snapshot loads and replay frontiers are projection-local. A successful restore
 starts that projection's ordered consumer at one greater than its cutoff. A
@@ -187,8 +186,7 @@ reconstruction. Legacy cohort paths remain outside application S3 expiry.
 | Projection | Contract | Payload store | Pointer store | Publication |
 | ---------- | -------- | ------------- | ------------- | ----------- |
 | Threads, Room Directory, Server Config, Room Group Layout, Call State, Reactions, Content Keys, RBAC, Mentionables | `v1` per projection | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Elected publisher checks hourly; cold/delta replay publishes immediately and unchanged state refreshes at 23 hours |
-| Assets | `v2` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; `v1` snapshots remain independently addressable during rollout and rollback |
-| Room Timeline | `v3` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; earlier contracts remain independently addressable during rollout and rollback |
+| Room Timeline, Assets | `v2` per projection | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; earlier schema-fingerprinted contracts remain independently addressable during rollout and rollback |
 | Users (profile state only) | `v2` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher |
 
 ## Registered projections

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -52,6 +52,13 @@ event-ID, message-body sequence, visibility, retraction, echo, and attachment
 metadata remains resident. Decoded event and current-body protobufs are grouped
 by room and fixed UTC week.
 
+Resident metadata uses projection-local dictionary encoding. Stable event,
+room, and user IDs are retained once, while dense metadata rows, room posting
+lists, body state, attachment locators, echo links, and packed visibility flags
+refer to 32-bit handles. Current decoded bodies and edited-message sequence
+history are separate sparse payloads. Handles never leave the projection;
+snapshots persist stable IDs and rebuild the dictionaries during restore.
+
 Buckets intersecting `core.room_timeline_hot_window` remain decoded during EVT
 replay; the window defaults to 30 days. Older buckets retain exact EVT
 sequences as compact delta varints and expand only the requested bucket for
@@ -65,7 +72,9 @@ have deleted obsolete body facts. Missing current-body or indexed-event facts
 fail the bucket load. A message's first body or post establishes its bucket, so
 the normal body-before-post write order does not require a second replay lane.
 ThreadProjection continues to retain lightweight reply references and resolves
-their payload through Room Timeline.
+their payload through Room Timeline. It owns a separate handle space and
+compacts thread roots, reply mappings, summaries, participants, follows, rooms,
+and users without coupling its replay or snapshot lifecycle to Room Timeline.
 
 ## Local checkpoint support
 
@@ -144,6 +153,7 @@ snapshot retains its lightweight bucket directory, entry/body metadata, exact
 EVT references, and complete body-event sequence history. It includes decoded
 payload only for buckets inside the hot window, even when a historical bucket
 was loaded after boot.
+
 Mentionables
 retains encrypted login source events and wrapped DEK records rather than
 plaintext handles or lookup digests. The Users codec retains encrypted login,

--- a/docs/fdr/FDR-014-jump-to-present.md
+++ b/docs/fdr/FDR-014-jump-to-present.md
@@ -1,7 +1,7 @@
 # FDR-014: Jump to Present
 
 **Status:** Active
-**Last reviewed:** 2026-05-19
+**Last reviewed:** 2026-07-24
 
 ## Overview
 
@@ -50,6 +50,19 @@ When a user is reading older messages in a room — either because they scrolled
 **Why:** Without it, the virtualized list's adjustments after a measurement update could be interpreted as the user scrolling down, immediately dismissing the button after the user just scrolled up. The lock filters out those self-induced movements.
 **Tradeoff:** Real user scroll-down within the lock window is briefly ignored. The window is short enough that this is imperceptible.
 
+### 6. Historical windows may materialize a timeline bucket
+
+**Decision:** Jumped-mode and older-page reads use the same Room Timeline read
+boundary as ordinary pages. The server may reconstruct the target UTC-week
+bucket from exact EVT sequences before returning the page.
+**Why:** Historical navigation must not require every room's complete decoded
+history to remain in RAM. Keeping cursor and authorization behavior behind one
+boundary makes the storage optimization invisible to clients.
+**Tradeoff:** The first read of a cold historical week has additional EVT and
+decode latency; later reads in the same process use the resident bucket. See
+ADR-056.
+
 ## Related
 
+- **ADRs:** ADR-056 (Bucket Room Timeline Payloads by UTC Week)
 - **FDRs:** FDR-002 (Replies & Threads), FDR-012 (Notifications)

--- a/docs/fdr/FDR-033-message-search.md
+++ b/docs/fdr/FDR-033-message-search.md
@@ -1,7 +1,7 @@
 # FDR-033: Message Search
 
 **Status:** Experimental
-**Last reviewed:** 2026-07-21
+**Last reviewed:** 2026-07-24
 
 ## Overview
 
@@ -62,7 +62,9 @@ each result is checked again against current message state before delivery.
 content visibility changes. Search cannot become an alternative path around
 the room privacy boundary.
 **Tradeoff:** Authorization and hydration add work after text matching, and
-stale provider hits may be discarded before a page is returned.
+stale provider hits may be discarded before a page is returned. Hydrating a
+historical candidate can materialize its Room Timeline UTC-week bucket from
+EVT; candidates in the same bucket share the resulting resident payload.
 
 ### 3. Only current message bodies are searchable
 
@@ -122,7 +124,7 @@ search is retained in memory so browser Back can restore it.
   (event-sourced state with projections), ADR-041 (runtime units), ADR-045
   (public API stability tiers), ADR-053 (versioned NATS service namespaces),
   ADR-054 (optional projection persistence), ADR-055 (pluggable message search
-  over NATS)
+  over NATS), ADR-056 (bucketed Room Timeline payloads)
 - **FDRs:** FDR-004 (Message Editing & Deletion), FDR-014 (Jump to Present),
   FDR-015 (Quick Switcher), FDR-019 (Room Lifecycle), FDR-032 (Message
   Formatting)

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -23,7 +23,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-07-18 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-07-20 |
 | [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-20 |
-| [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
+| [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-07-24 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-07-20 |
@@ -42,4 +42,4 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-030](FDR-030-inline-message-timestamps.md) | Inline Message Timestamps | Active | 2026-07-12 |
 | [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-07-16 |
 | [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-07-19 |
-| [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-07-21 |
+| [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-07-24 |

--- a/proto/chatto/core/v1/projection_snapshots.proto
+++ b/proto/chatto/core/v1/projection_snapshots.proto
@@ -335,13 +335,10 @@ message TimelineBodyMetadataSnapshot {
 message TimelineBucketSnapshot {
   string room_id = 1;
   int64 week_start_unix = 2;
-  repeated TimelineBucketEventReferenceSnapshot event_references = 3;
+  // Delta-varint encoded EVT stream sequences. The low bit records whether a
+  // securely deleted obsolete message body may be absent.
+  bytes encoded_event_references = 3;
   bool payload_resident = 4;
-}
-
-message TimelineBucketEventReferenceSnapshot {
-  uint64 stream_sequence = 1;
-  bool optional_body = 2;
 }
 
 message StringTimestampSnapshot {

--- a/proto/chatto/core/v1/projection_snapshots.proto
+++ b/proto/chatto/core/v1/projection_snapshots.proto
@@ -296,32 +296,9 @@ message ProjectedVerifiedEmailSnapshot {
   google.protobuf.Timestamp verified_at = 3;
 }
 
-message RoomTimelineProjectionSnapshot {
-  repeated TimelineEntrySnapshot entries = 1;
-  repeated TimelineBodySnapshot bodies = 2;
-  repeated StringTimestampSnapshot tombstoned_at = 3;
-  repeated StringTimestampSnapshot shredded_at = 4;
-  repeated string retracted_event_ids = 5;
-  repeated string hidden_echo_event_ids = 6;
-  repeated string shredded_user_ids = 7;
-  ProjectionReplayGuardSnapshot replay_guard = 8;
-}
-
-message TimelineEntrySnapshot {
-  uint64 stream_sequence = 1;
-  Event event = 2;
-}
-
-message TimelineBodySnapshot {
-  string message_event_id = 1;
-  MessageBody body = 2;
-  repeated uint64 body_event_sequences = 3;
-  uint64 current_body_sequence = 4;
-}
-
-// RoomTimelineProjectionSnapshotV3 stores the always-resident timeline
+// RoomTimelineProjectionSnapshot stores the always-resident timeline
 // directory separately from optional decoded bucket payloads.
-message RoomTimelineProjectionSnapshotV3 {
+message RoomTimelineProjectionSnapshot {
   repeated TimelineEntryMetadataSnapshot entries = 1;
   repeated TimelineBodyMetadataSnapshot bodies = 2;
   repeated TimelineBucketSnapshot buckets = 3;

--- a/proto/chatto/core/v1/projection_snapshots.proto
+++ b/proto/chatto/core/v1/projection_snapshots.proto
@@ -319,6 +319,54 @@ message TimelineBodySnapshot {
   uint64 current_body_sequence = 4;
 }
 
+// RoomTimelineProjectionSnapshotV3 stores the always-resident timeline
+// directory separately from optional decoded bucket payloads.
+message RoomTimelineProjectionSnapshotV3 {
+  repeated TimelineEntryMetadataSnapshot entries = 1;
+  repeated TimelineBodyMetadataSnapshot bodies = 2;
+  repeated TimelineBucketSnapshot buckets = 3;
+  repeated StringTimestampSnapshot tombstoned_at = 4;
+  repeated StringTimestampSnapshot shredded_at = 5;
+  repeated string retracted_event_ids = 6;
+  repeated string hidden_echo_event_ids = 7;
+  repeated string shredded_user_ids = 8;
+  ProjectionReplayGuardSnapshot replay_guard = 9;
+}
+
+message TimelineEntryMetadataSnapshot {
+  uint64 stream_sequence = 1;
+  string event_id = 2;
+  string room_id = 3;
+  string author_id = 4;
+  string echo_original_event_id = 5;
+  int64 week_start_unix = 6;
+  bool message_posted = 7;
+  bool room_visible = 8;
+  Event resident_event = 9;
+}
+
+message TimelineBodyMetadataSnapshot {
+  string message_event_id = 1;
+  repeated uint64 body_event_sequences = 2;
+  uint64 current_body_sequence = 3;
+  string room_id = 4;
+  int64 week_start_unix = 5;
+  bool has_attachments = 6;
+  MessageBody resident_body = 7;
+}
+
+message TimelineBucketSnapshot {
+  string room_id = 1;
+  int64 week_start_unix = 2;
+  repeated TimelineBucketEventReferenceSnapshot event_references = 3;
+  bool payload_resident = 4;
+}
+
+message TimelineBucketEventReferenceSnapshot {
+  uint64 stream_sequence = 1;
+  bool optional_body = 2;
+}
+
 message StringTimestampSnapshot {
   string key = 1;
   google.protobuf.Timestamp value = 2;


### PR DESCRIPTION
## Why

Room Timeline retained decoded protobuf payloads and string-heavy metadata for
every room and every point in history. Threads independently duplicated many of
the same stable IDs in maps and summaries. Their RAM cost therefore grew with
the complete retained message history.

Closes #1721.

## What changed

- Partition Room Timeline payloads into fixed per-room UTC-week buckets while
  preserving its one ordered EVT consumer and lightweight global indexes.
- Keep a configurable recent window decoded in RAM
  (`core.room_timeline_hot_window` /
  `CHATTO_CORE_ROOM_TIMELINE_HOT_WINDOW`, default `30d`).
- Reconstruct cold buckets from exact EVT sequence references with 16 bounded
  direct reads, atomic installation, shared concurrent success/failure results,
  and context-aware errors.
- Select paginated thread references before hydration so opening one page of a
  long-lived thread does not load its complete history.
- Intern stable event, room, and user IDs once per projection, then represent
  timeline rows, posting lists, body state, echo/attachment indexes, thread
  mappings, summaries, participants, and follows with 32-bit handles, dense
  slices, and packed flags.
- Keep Room Timeline and Threads handle spaces independent, so replay,
  readiness, snapshots, and failure remain independently owned.
- Store only stable IDs and sequences at snapshot boundaries. Restore rebuilds
  process-local handles, with canonical stable-ID ordering and byte-identical
  round-trip coverage.
- Add operator diagnostics, retained-heap benchmarks, cold-load/race/snapshot
  tests, ADR-056, architecture/FDR updates, and operator configuration docs.

## Results

- The deterministic 50k-message benchmark drops cold Room Timeline from 1,251
  to 276 retained heap bytes/message across the full PR (77.9%).
- Compared with the already-bucketed branch, compact indexing drops cold Room
  Timeline from 432.2 to 276.0 bytes/message (36.1%), Threads from 311.3 to
  118.1 bytes/message (62.1%), and their combined retained metadata from 743.5
  to 394.1 bytes/message (47.0%).
- A snapshot-disabled cold boot against the imported production-derived
  53,763-event history replayed Room Timeline in 1.14 seconds and Threads in
  1.14 seconds.
- On that same history, whole Go heap after forced GC fell from 45.14 MB on the
  already-bucketed branch to 34.66 MB with compact indexes (23.2%). The
  projection-specific diagnostics were also corrected to account for compact
  slice capacity instead of charging map overhead per element.
- Historical buckets remain resident after their first read in this version.
  Access timestamps and resident-byte accounting prepare a later bounded LRU.

## Compatibility and rollout

- No public API, realtime protocol, or persisted EVT contract changes.
- The bucketed Room Timeline snapshot uses its schema-fingerprinted `v2`
  contract. The indexed representation preserves that stable protobuf shape;
  handles never cross the snapshot boundary.
- Threads preserves its existing `v1` snapshot contract and likewise rebuilds
  its independent handles during restore.
- Pre-bucketing Room Timeline snapshots use a different contract fingerprint
  and safely cold-replay EVT once. Rolling back uses the old binary's
  independent contract namespace.
- Privacy boundaries are rechecked after lazy loads, so a concurrent
  retraction or user-key shred cannot reintroduce or return deleted content.

## Test plan

- `mise codegen-proto`
- targeted Room Timeline, Thread, handle-table, and snapshot tests
- targeted race tests for cold hydration, snapshots, and adversarial
  handle-order restore
- repeated byte-identical snapshot round trips
- `mise test-cli`
- `mise lint`
- `mise license-check`
- architecture-inventory source-link and paragraph-length validation
- snapshot-disabled replay and forced-GC measurement against 53,763 retained
  production-derived EVT messages
- deterministic retained-heap benchmark at 50,000 logical messages / 124,478
  events
- adversarial code-review loop; both findings fixed, no remaining findings
