### PR TITLE
chore(frontend): remove dead compatibility surfaces

### DIFF
--- a/apps/frontend/src/lib/components/ConnectionIndicator.svelte
+++ b/apps/frontend/src/lib/components/ConnectionIndicator.svelte
@@ -1,1 +1,0 @@
-<!-- Connection indicator moved to AppHeader - this component is kept for backwards compatibility -->

--- a/apps/frontend/src/lib/components/MessageContent.svelte
+++ b/apps/frontend/src/lib/components/MessageContent.svelte
@@ -1,6 +1,6 @@
 <script lang="ts" module>
   // Re-export for tests
-  export { rendererReady, renderMarkdown } from '$lib/markdown';
+  export { renderMarkdown } from '$lib/markdown';
 </script>
 
 <script lang="ts">

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -49,7 +49,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
   }
 }));
 
-import MessageContent, { renderMarkdown, rendererReady } from './MessageContent.svelte';
+import MessageContent, { renderMarkdown } from './MessageContent.svelte';
 
 const channelRoomId = 'R123456789abcde';
 const dmRoomId = 'abcdef12345678';
@@ -131,11 +131,6 @@ afterAll(() => {
 });
 
 describe('renderMarkdown', () => {
-  // Wait for the markdown renderer to initialize before running tests
-  beforeAll(async () => {
-    await rendererReady;
-  });
-
   describe('allowed syntax', () => {
     it('renders bold text with **', async () => {
       const html = await renderMarkdown('**bold**');
@@ -393,11 +388,6 @@ describe('MessageContent component', () => {
     const content = q(container, '.prose')!;
     expect(content.textContent).not.toContain('&nbsp;');
     expect(content.clientHeight).toBeLessThan(500);
-  });
-
-  // Wait for the markdown renderer to initialize before running tests
-  beforeAll(async () => {
-    await rendererReady;
   });
 
   it('renders markdown content', async () => {

--- a/apps/frontend/src/lib/markdown.ts
+++ b/apps/frontend/src/lib/markdown.ts
@@ -488,19 +488,6 @@ function initialize(): void {
 }
 
 /**
- * Returns true if the renderer has been initialized.
- */
-export function isRendererReady(): boolean {
-  return md !== null;
-}
-
-/**
- * Promise that resolves when the markdown renderer is ready.
- * Kept for backwards compatibility - initializes the renderer.
- */
-export const rendererReady = Promise.resolve().then(initialize);
-
-/**
  * Renders markdown to HTML.
  */
 export async function renderMarkdown(body: string): Promise<string> {

--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -218,8 +218,7 @@ describe('NotificationStore', () => {
     expect(api.listRoomNotifications).not.toHaveBeenCalled();
   });
 
-  it('routes notification targets to the same room/thread/event used by push payloads', () => {
-    const store = new NotificationStore(makeAPI());
+  it('normalizes the room, thread, and event used by push payloads', () => {
     const threadMention = {
       kind: NotificationItemKind.Mention,
       id: 'thread-mention',
@@ -274,27 +273,17 @@ describe('NotificationStore', () => {
       eventId: 'mention-event',
       threadRootId: 'thread-root'
     });
-    expect(store.getNavigationPath('origin', threadMention)).toBe(
-      '/chat/-/room-2/thread-root?highlight=mention-event'
-    );
-
     expect(notificationTarget(threadReply)).toMatchObject({
       roomId: 'room-2',
       eventId: 'reply-event',
       threadRootId: 'thread-root'
     });
-    expect(store.getNavigationPath('origin', threadReply)).toBe(
-      '/chat/-/room-2/thread-root?highlight=reply-event'
-    );
 
     expect(notificationTarget(roomMessage)).toMatchObject({
       roomId: 'room-news',
       eventId: 'room-event',
       threadRootId: null
     });
-    expect(store.getNavigationPath('origin', roomMessage)).toBe(
-      '/chat/-/room-news?highlight=room-event'
-    );
   });
 
   it('routes notifications using notification item kind', () => {

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -541,51 +541,6 @@ export class NotificationStore {
     });
   }
 
-  /**
-   * Get navigation info for a notification.
-   * Returns the path to navigate to when acting on the notification, with
-   * `?highlight=<eventId>` for messages.
-   *
-   * @deprecated Prefer `getCleanPath` + `PendingHighlightStore.set`. The
-   *   `?highlight=` URL param survives refresh and re-fires; the transient
-   *   store delivers the intent one-shot. Kept for permalink-style call sites
-   *   that genuinely want the URL to encode the highlight.
-   */
-  getNavigationPath(serverId: string, notification: NotificationItem): string {
-    const seg = serverIdToSegment(serverId);
-    const t = notificationTarget(notification);
-
-    if (t.isDM && t.roomId) {
-      // DMs are now rooms on the Server (#330 phase 3) — use the standard
-      // room URL rather than the legacy /chat/dm/... path.
-      return resolve('/chat/[serverId]/[roomId]', {
-        serverId: seg,
-        roomId: t.roomId
-      });
-    }
-
-    if (!t.roomId) {
-      return resolve('/chat/[serverId]', { serverId: seg });
-    }
-
-    if (t.threadRootId && t.eventId) {
-      return (
-        resolve('/chat/[serverId]/[roomId]/[threadId]', {
-          serverId: seg,
-          roomId: t.roomId,
-          threadId: t.threadRootId
-        }) +
-        '?highlight=' +
-        t.eventId
-      );
-    }
-
-    const roomPath = resolve('/chat/[serverId]/[roomId]', {
-      serverId: seg,
-      roomId: t.roomId
-    });
-    return t.eventId ? `${roomPath}?highlight=${t.eventId}` : roomPath;
-  }
 }
 
 function redactedNotificationSummary(kind: NotificationItemKind): string {

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -710,11 +710,6 @@ export class VoiceCallState {
     }
   }
 
-  /** @deprecated Use refreshDevices() instead */
-  async refreshAudioDevices(): Promise<void> {
-    return this.refreshDevices();
-  }
-
   /**
    * Switch to a different audio input device.
    */

--- a/apps/frontend/src/lib/storage/serverStorage.spec.ts
+++ b/apps/frontend/src/lib/storage/serverStorage.spec.ts
@@ -1,19 +1,5 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { serverStorageKey, migrateStorageKey } from './serverStorage';
-
-// Provide a minimal localStorage stub for the Node test environment
-const storage = new Map<string, string>();
-const localStorageMock: Storage = {
-	getItem: (key: string) => storage.get(key) ?? null,
-	setItem: (key: string, value: string) => storage.set(key, value),
-	removeItem: (key: string) => storage.delete(key),
-	clear: () => storage.clear(),
-	get length() {
-		return storage.size;
-	},
-	key: (index: number) => [...storage.keys()][index] ?? null
-};
-vi.stubGlobal('localStorage', localStorageMock);
+import { describe, it, expect } from 'vitest';
+import { serverStorageKey } from './serverStorage';
 
 describe('serverStorageKey', () => {
 	it('produces a namespaced key', () => {
@@ -30,37 +16,5 @@ describe('serverStorageKey', () => {
 		expect(serverStorageKey('my-instance', 'space:abc:collapsed-sections')).toBe(
 			'chatto:i:my-instance:space:abc:collapsed-sections'
 		);
-	});
-});
-
-describe('migrateStorageKey', () => {
-	beforeEach(() => {
-		localStorage.clear();
-	});
-
-	it('moves value from legacy key to namespaced key', () => {
-		localStorage.setItem('chatto:lastRooms', '{"space1":"room1"}');
-
-		migrateStorageKey('my-instance', 'chatto:lastRooms', 'lastRooms');
-
-		expect(localStorage.getItem('chatto:i:my-instance:lastRooms')).toBe('{"space1":"room1"}');
-		expect(localStorage.getItem('chatto:lastRooms')).toBeNull();
-	});
-
-	it('is a no-op if the new key already exists', () => {
-		localStorage.setItem('chatto:lastRooms', '{"old":"data"}');
-		localStorage.setItem('chatto:i:my-instance:lastRooms', '{"new":"data"}');
-
-		migrateStorageKey('my-instance', 'chatto:lastRooms', 'lastRooms');
-
-		// New key keeps its value, old key is not removed
-		expect(localStorage.getItem('chatto:i:my-instance:lastRooms')).toBe('{"new":"data"}');
-		expect(localStorage.getItem('chatto:lastRooms')).toBe('{"old":"data"}');
-	});
-
-	it('is a no-op if the old key does not exist', () => {
-		migrateStorageKey('my-instance', 'chatto:lastRooms', 'lastRooms');
-
-		expect(localStorage.getItem('chatto:i:my-instance:lastRooms')).toBeNull();
 	});
 });

--- a/apps/frontend/src/lib/storage/serverStorage.ts
+++ b/apps/frontend/src/lib/storage/serverStorage.ts
@@ -11,33 +11,3 @@
 export function serverStorageKey(serverId: string, key: string): string {
 	return `chatto:i:${serverId}:${key}`;
 }
-
-/**
- * Migrate a legacy (un-namespaced) localStorage key to a namespaced key.
- * No-op if the new key already exists or the old key is absent.
- *
- * @param serverId - The instance to migrate to
- * @param legacyKey - The old un-namespaced key (e.g., "chatto:lastRooms")
- * @param newKeySuffix - The suffix for the new key (e.g., "lastRooms")
- */
-export function migrateStorageKey(serverId: string, legacyKey: string, newKeySuffix: string): void {
-	try {
-		const newKey = serverStorageKey(serverId, newKeySuffix);
-
-		// Don't overwrite if namespaced key already exists
-		if (localStorage.getItem(newKey) !== null) {
-			return;
-		}
-
-		const oldValue = localStorage.getItem(legacyKey);
-		if (oldValue === null) {
-			return;
-		}
-
-		// Copy to new key, remove old key
-		localStorage.setItem(newKey, oldValue);
-		localStorage.removeItem(legacyKey);
-	} catch {
-		// Ignore storage errors (quota, security, etc.)
-	}
-}

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -5,7 +5,6 @@
   import { onNotificationClick } from '$lib/notifications/pushNotifications';
   import { prepareUiForNotificationPath } from '$lib/notifications/notificationNavigationUi';
   import { setAuthServerInfo } from '$lib/components/authServerInfo';
-  import ConnectionIndicator from '$lib/components/ConnectionIndicator.svelte';
   import ConnectionProvider from '$lib/components/ConnectionProvider.svelte';
   import GlobalKeyboardShortcuts from '$lib/components/GlobalKeyboardShortcuts.svelte';
   import IdleTracker from '$lib/components/IdleTracker.svelte';
@@ -91,8 +90,6 @@
     use:sidebarSwipe
     class="flex h-full w-full flex-col overscroll-y-contain bg-surface pt-[env(safe-area-inset-top,0px)] md:p-3 md:pt-0"
   >
-    <ConnectionIndicator />
-
     <AppHeader />
 
     <Frame class="relative flex-col">


### PR DESCRIPTION
## Why

The frontend retained several compatibility surfaces with no production
callers. One was an empty Svelte component still mounted in the root layout;
the others were deprecated methods, exports, or helpers covered only by tests.
Removing them makes the current architecture easier to read without changing
behaviour.

## What changed

- removed the empty root-level `ConnectionIndicator`
- removed unused notification and voice-call compatibility methods
- removed unused markdown readiness exports and redundant test waits
- removed an unused local-storage migration helper and its dedicated tests
- retained active notification normalisation coverage and all live legacy
  routes and migrations

## Test plan

- Svelte autofixer on both touched components: no issues
- targeted Vitest run: 5 files and 124 tests passed
- `mise lint-frontend`: passed, including design-system checks, Svelte checking
  with zero errors or warnings, and ESLint
- `mise knip`: completed with only pre-existing repository findings
- independent committed-diff review: no findings

## Compatibility

No public API, protocol, persisted-data, rollout, security, or operational
behaviour changes. The removed surfaces had no repository callers.

Closes https://github.com/chattocorp/chatto/issues/1724.
