### PR TITLE
refactor(frontend): centralize mention-role state

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -4,7 +4,6 @@
   import type { RoomEventView } from '$lib/render/types';
   import { createMessageAPI, type AttachmentUploadUpdate } from '$lib/api-client/messages';
   import { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
-  import { createRoleAPI } from '$lib/api-client/roles';
   import * as m from '$lib/i18n/messages';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -93,6 +92,7 @@
   const stores = serverRegistry.getStore(getActiveServer());
   const serverInfo = stores.serverInfo;
   const roomUnreadStore = stores.roomUnread;
+  const mentionRolesStore = stores.mentionRoles;
 
   export type MessageComposerApi = {
     addFiles: (files: File[]) => void;
@@ -197,10 +197,7 @@
     () => mentionCandidateMembers,
     () => mentionRoles
   );
-  let mentionRoles = $state<MentionRole[]>([]);
-  let mentionRolesLoadComplete = $state(false);
-  let mentionRolesLoadFailed = $state(false);
-  let mentionRolesLoadPromise: Promise<boolean> | null = null;
+  const mentionRoles = $derived<MentionRole[]>(mentionRolesStore.roles);
 
   $effect(() => {
     const query = autocomplete.mention?.query ?? null;
@@ -306,45 +303,7 @@
   });
 
   $effect(() => {
-    const conn = connection();
-    const api = createRoleAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
-    let cancelled = false;
-    mentionRoles = [];
-    mentionRolesLoadComplete = false;
-    mentionRolesLoadFailed = false;
-
-    async function loadMentionRoles() {
-      let roles;
-      try {
-        roles = (await api.listRoles()).roles;
-      } catch {
-        if (!cancelled) {
-          mentionRoles = [];
-          mentionRolesLoadFailed = true;
-          mentionRolesLoadComplete = true;
-        }
-        return false;
-      }
-      if (cancelled) return false;
-      mentionRoles =
-        roles.map((role) => ({
-          name: role.name,
-          isSystem: role.isSystem,
-          position: role.position,
-          pingable: role.pingable
-        })) ?? [];
-      mentionRolesLoadFailed = false;
-      mentionRolesLoadComplete = true;
-      return true;
-    }
-
-    mentionRolesLoadPromise = loadMentionRoles();
-    return () => {
-      cancelled = true;
-    };
+    void mentionRolesStore.load();
   });
 
   let loading = $state(false);
@@ -681,14 +640,14 @@
   let roleMentionConfirmationLoading = $state(false);
 
   async function ensureMentionRolesLoadedForConfirmation(): Promise<boolean> {
-    if (mentionRolesLoadComplete) return !mentionRolesLoadFailed;
-    return (await mentionRolesLoadPromise) ?? false;
+    if (mentionRolesStore.status === 'failed') return false;
+    return mentionRolesStore.load();
   }
 
   function postMentionsRoleOrVirtualTarget(post: PreparedPost, rolesAvailable: boolean): boolean {
     const hasKnownRoleOrVirtualMention = hasRoleOrVirtualMention(
       post.bodyToSend,
-      mentionRoles.filter((role) => role.name !== 'everyone').map((role) => role.name)
+      mentionRoles.map((role) => role.name)
     );
     if (hasKnownRoleOrVirtualMention) return true;
     if (rolesAvailable) return false;
@@ -820,8 +779,13 @@
       alsoSendToChannel
     };
 
-    let rolesAvailable = mentionRolesLoadComplete && !mentionRolesLoadFailed;
-    if (hasBody && bodyToSend.includes('@') && !mentionRolesLoadComplete) {
+    let rolesAvailable = mentionRolesStore.status === 'ready';
+    if (
+      hasBody &&
+      bodyToSend.includes('@') &&
+      mentionRolesStore.status !== 'ready' &&
+      mentionRolesStore.status !== 'failed'
+    ) {
       roleMentionCheckLoading = true;
       try {
         rolesAvailable = await ensureMentionRolesLoadedForConfirmation();

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -10,6 +10,7 @@ import { PresenceStatus } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
 import { renderMarkdown } from '$lib/markdown';
 import type { CreateMessageInput } from '$lib/api-client/messages';
+import { MentionRolesStore } from '$lib/state/server/mentionRoles.svelte';
 
 function postedMessageEvent(
   id = 'msg_123',
@@ -79,6 +80,7 @@ const roomStateMock = vi.hoisted(() => ({
 }));
 
 // Mock instance state
+let mentionRolesStore = new MentionRolesStore({ listRoles: listRolesConnectMock });
 const mockInstanceStores = {
   currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
   serverInfo: {
@@ -88,6 +90,9 @@ const mockInstanceStores = {
   },
   roomUnread: {
     setRoomUnread: vi.fn()
+  },
+  get mentionRoles() {
+    return mentionRolesStore;
   }
 };
 
@@ -404,6 +409,7 @@ describe('MessageComposer', () => {
     fetchLinkPreviewConnectMock.mockResolvedValue(null);
     listRolesConnectMock.mockReset();
     listRolesConnectMock.mockResolvedValue({ roles: [] });
+    mentionRolesStore = new MentionRolesStore({ listRoles: listRolesConnectMock });
     queryMock.mockReset();
     queryMock.mockResolvedValue({ data: null, error: null });
     sessionStorage.clear();

--- a/apps/frontend/src/lib/state/room/index.ts
+++ b/apps/frontend/src/lib/state/room/index.ts
@@ -28,7 +28,7 @@ export {
 } from './members.svelte';
 export type { RoomMember, RoomMembersPage } from './members.svelte';
 export { createMentionRoles, getMentionRoles } from './mentionRoles.svelte';
-export type { MentionRole, MentionRolesState } from './mentionRoles.svelte';
+export type { MentionRole } from './mentionRoles.svelte';
 export {
   createRoomPermissions,
   getRoomPermissions,

--- a/apps/frontend/src/lib/state/room/mentionRoles.svelte.ts
+++ b/apps/frontend/src/lib/state/room/mentionRoles.svelte.ts
@@ -7,33 +7,12 @@ export type MentionRole = {
   pingable: boolean;
 };
 
-export type MentionRolesState = {
-  roles: MentionRole[];
-};
+const [getMentionRolesState, setMentionRolesState] = createContext<() => MentionRole[]>();
 
-const [getMentionRolesState, setMentionRolesState] = createContext<{
-  current: MentionRolesState;
-}>();
-
-export function createMentionRoles() {
-  const state = $state<{ current: MentionRolesState }>({
-    current: {
-      roles: []
-    }
-  });
-  setMentionRolesState(state);
-
-  return {
-    setRoles(roles: MentionRole[]) {
-      state.current.roles = roles;
-    },
-
-    clear() {
-      state.current.roles = [];
-    }
-  };
+export function createMentionRoles(getRoles: () => MentionRole[] = () => []) {
+  setMentionRolesState(getRoles);
 }
 
 export function getMentionRoles(): MentionRole[] {
-  return getMentionRolesState().current.roles;
+  return getMentionRolesState()();
 }

--- a/apps/frontend/src/lib/state/server/mentionRoles.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/mentionRoles.svelte.spec.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { MentionRolesStore } from './mentionRoles.svelte';
+
+function role(name: string) {
+  return {
+    name,
+    displayName: name,
+    description: '',
+    permissions: [],
+    permissionDenials: [],
+    isSystem: false,
+    position: 1,
+    pingable: true
+  };
+}
+
+describe('MentionRolesStore', () => {
+  it('maps and caches the public role catalogue', async () => {
+    const listRoles = vi.fn().mockResolvedValue({
+      roles: [role('everyone'), role('moderator')],
+      viewerCanManageRoles: false,
+      viewerCanAssignRoles: false
+    });
+    const store = new MentionRolesStore({ listRoles });
+
+    await expect(store.load()).resolves.toBe(true);
+    await expect(store.load()).resolves.toBe(true);
+
+    expect(listRoles).toHaveBeenCalledOnce();
+    expect(store.status).toBe('ready');
+    expect(store.roles).toEqual([
+      {
+        name: 'moderator',
+        isSystem: false,
+        position: 1,
+        pingable: true
+      }
+    ]);
+  });
+
+  it('coalesces concurrent loads', async () => {
+    let resolveList: ((value: ReturnType<typeof catalog>) => void) | undefined;
+    const listRoles = vi.fn(
+      () =>
+        new Promise<ReturnType<typeof catalog>>((resolve) => {
+          resolveList = resolve;
+        })
+    );
+    const store = new MentionRolesStore({ listRoles });
+
+    const first = store.load();
+    const second = store.refresh();
+    resolveList?.(catalog());
+
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true]);
+    expect(listRoles).toHaveBeenCalledOnce();
+  });
+
+  it('clears failed data and retries on the next load', async () => {
+    const listRoles = vi
+      .fn()
+      .mockResolvedValueOnce(catalog('moderator'))
+      .mockRejectedValueOnce(new Error('unavailable'))
+      .mockResolvedValueOnce(catalog('support'));
+    const store = new MentionRolesStore({ listRoles });
+
+    await store.load();
+    await expect(store.refresh()).resolves.toBe(false);
+    expect(store.status).toBe('failed');
+    expect(store.roles).toEqual([]);
+
+    await expect(store.load()).resolves.toBe(true);
+    expect(store.status).toBe('ready');
+    expect(store.roles.map(({ name }) => name)).toEqual(['support']);
+  });
+});
+
+function catalog(name = 'moderator') {
+  return {
+    roles: [role(name)],
+    viewerCanManageRoles: false,
+    viewerCanAssignRoles: false
+  };
+}

--- a/apps/frontend/src/lib/state/server/mentionRoles.svelte.ts
+++ b/apps/frontend/src/lib/state/server/mentionRoles.svelte.ts
@@ -1,0 +1,57 @@
+import type { RoleAPI } from '$lib/api-client/roles';
+import type { MentionRole } from '$lib/state/room';
+
+type MentionRoleAPI = Pick<RoleAPI, 'listRoles'>;
+
+export type MentionRolesStatus = 'idle' | 'loading' | 'ready' | 'failed';
+
+/** Shared public role catalogue used by message rendering and composers. */
+export class MentionRolesStore {
+  roles = $state.raw<MentionRole[]>([]);
+  status = $state<MentionRolesStatus>('idle');
+
+  readonly #api: MentionRoleAPI;
+  #loadPromise: Promise<boolean> | null = null;
+
+  constructor(api: MentionRoleAPI) {
+    this.#api = api;
+  }
+
+  /** Ensure the catalogue has loaded, coalescing concurrent consumers. */
+  load(): Promise<boolean> {
+    if (this.status === 'ready') return Promise.resolve(true);
+    return this.refresh();
+  }
+
+  /** Reload the catalogue while coalescing with any request already in flight. */
+  refresh(): Promise<boolean> {
+    if (this.#loadPromise) return this.#loadPromise;
+
+    this.status = 'loading';
+    const request = this.#api
+      .listRoles()
+      .then(({ roles }) => {
+        this.roles = roles
+          .filter(({ name }) => name !== 'everyone')
+          .map(({ name, isSystem, position, pingable }) => ({
+            name,
+            isSystem,
+            position,
+            pingable
+          }));
+        this.status = 'ready';
+        return true;
+      })
+      .catch(() => {
+        this.roles = [];
+        this.status = 'failed';
+        return false;
+      })
+      .finally(() => {
+        if (this.#loadPromise === request) this.#loadPromise = null;
+      });
+
+    this.#loadPromise = request;
+    return request;
+  }
+}

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -162,7 +162,14 @@ const { soundMocks, apiMocks } = vi.hoisted(() => ({
     listRoomAttachments: vi.fn<
       () => Promise<{ items: RoomFileItem[]; totalCount: number; hasMore: boolean }>
     >(() => Promise.resolve({ items: [], totalCount: 0, hasMore: false })),
-    refreshAssetUrls: vi.fn(() => Promise.resolve(new Map()))
+    refreshAssetUrls: vi.fn(() => Promise.resolve(new Map())),
+    listRoles: vi.fn(() =>
+      Promise.resolve({
+        roles: [],
+        viewerCanManageRoles: false,
+        viewerCanAssignRoles: false
+      })
+    )
   }
 }));
 
@@ -220,6 +227,12 @@ vi.mock('$lib/api-client/notifications', () => ({
     listNotificationCounts: apiMocks.listNotificationCounts,
     dismissNotification: vi.fn(),
     dismissAllNotifications: vi.fn()
+  }))
+}));
+
+vi.mock('$lib/api-client/roles', () => ({
+  createRoleAPI: vi.fn(() => ({
+    listRoles: apiMocks.listRoles
   }))
 }));
 

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -25,6 +25,7 @@ import { createAdminRoomLayoutAPI } from '$lib/api-client/adminRoomLayout';
 import { createAdminEventLogAPI } from '$lib/api-client/adminEventLog';
 import { createMessageSearchAPI } from '$lib/api-client/messageSearch';
 import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
+import { createRoleAPI } from '$lib/api-client/roles';
 import { getViewerStateViaConnect } from '$lib/api-client/viewer';
 import { eventBusManager } from './eventBus.svelte';
 import type { ProjectionHandler } from '$lib/eventBus.svelte';
@@ -49,6 +50,7 @@ import { mapNotificationPage } from '$lib/api-client/notifications';
 import { RealtimeProjectionSyncState } from './realtimeSync.svelte';
 import type { ActiveCall } from '@chatto/api-types/api/v1/voice_calls_pb';
 import { MessageSearchStore } from './messageSearch.svelte';
+import { MentionRolesStore } from './mentionRoles.svelte';
 
 /**
  * What kind of indicator a server (or the DM area) should display.
@@ -86,6 +88,7 @@ export class ServerStateStore {
   readonly adminRoomLayout: AdminRoomLayoutStore;
   readonly adminEventLog: AdminEventLogStore;
   readonly messageSearch: MessageSearchStore;
+  readonly mentionRoles: MentionRolesStore;
   readonly projection = new ServerProjectionStore();
   /** Readiness and opaque resume position for this retained projection. */
   readonly realtimeSync = new RealtimeProjectionSyncState();
@@ -135,6 +138,7 @@ export class ServerStateStore {
     const adminEventLogAPI = createAdminEventLogAPI(connectAPIConfig);
     const messageSearchAPI = createMessageSearchAPI(connectAPIConfig);
     const memberDirectoryAPI = createMemberDirectoryAPI(connectAPIConfig);
+    const roleAPI = createRoleAPI(connectAPIConfig);
     this.currentUser = new CurrentUserState(
       cookieAuth,
       connectAPIConfig,
@@ -169,6 +173,7 @@ export class ServerStateStore {
     this.adminRoomLayout = new AdminRoomLayoutStore(adminRoomLayoutAPI, roomCommandAPI);
     this.adminEventLog = new AdminEventLogStore(adminEventLogAPI);
     this.messageSearch = new MessageSearchStore(messageSearchAPI);
+    this.mentionRoles = new MentionRolesStore(roleAPI);
 
     // Apply the canonical projection delivered by this server's bus. Transient
     // envelopes are consumed only by components that need one-shot signals.

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -9,7 +9,6 @@
   import MessageComposer, {
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
-  import { createRoleAPI } from '$lib/api-client/roles';
   import {
     useRoomData,
     useRoomUnread,
@@ -109,7 +108,7 @@
 
   // Create context-based state (must be synchronous, before children render)
   const composerContext = createComposerContext({ scroll: true });
-  const mentionRoles = createMentionRoles();
+  createMentionRoles(() => stores.mentionRoles.roles);
   const replyState = composerContext.replyState;
   let replyStateRoomId: string | null = null;
   const jumpState = composerContext.jumpState;
@@ -155,40 +154,7 @@
   });
 
   $effect(() => {
-    const conn = connection();
-    const api = createRoleAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
-    let cancelled = false;
-
-    async function loadMentionRoles() {
-      let roles;
-      try {
-        roles = (await api.listRoles()).roles;
-      } catch {
-        if (!cancelled) {
-          mentionRoles.clear();
-        }
-        return;
-      }
-      if (cancelled) return;
-      mentionRoles.setRoles(
-        roles
-          ?.filter((role) => role.name !== 'everyone')
-          .map((role) => ({
-            name: role.name,
-            isSystem: role.isSystem,
-            position: role.position,
-            pingable: role.pingable
-          })) ?? []
-      );
-    }
-
-    void loadMentionRoles();
-    return () => {
-      cancelled = true;
-    };
+    void stores.mentionRoles.refresh();
   });
 
   const unread = useRoomUnread(() => ({ roomId }));

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -75,7 +75,11 @@ const { mocks } = vi.hoisted(() => {
       messagesForRoom: vi.fn(),
       restoreProjectedRoomWindow: vi.fn(),
       projectedMembersForRoom: vi.fn(() => []),
-      hasCompleteProjectedRoomMembership: vi.fn(() => true)
+      hasCompleteProjectedRoomMembership: vi.fn(() => true),
+      mentionRoles: {
+        roles: [],
+        refresh: vi.fn().mockResolvedValue(true)
+      }
     }
   };
 });
@@ -194,6 +198,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
         isInCall: vi.fn((roomId: string) => mocks.joinedCallRoomIds.has(roomId))
       },
       rooms: mocks.rooms,
+      mentionRoles: mocks.mentionRoles,
       messagesForRoom: mocks.messagesForRoom,
       filesForRoom: () => ({ retain: mocks.roomFilesRetain }),
       restoreProjectedRoomWindow: mocks.restoreProjectedRoomWindow,

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -30,19 +30,24 @@
     createMentionRoles
   } from '$lib/state/room';
 
-  // Provide stub room contexts so MessageEvent can render in read-only mode.
+  const connection = useConnection();
+  const serverStore = serverRegistry.getStore(getActiveServer());
+
+  // Provide room contexts so MessageEvent can render in read-only mode.
   // All permissions are false (no editing, deleting, reacting from this view),
-  // members list is empty (no mention highlighting), composer context is a no-op.
+  // and the members list is empty; role highlighting uses server reference data.
   createRoomPermissions(() => DEFAULT_ROOM_PERMISSIONS);
   createRoomMembers();
   createComposerContext();
-  createMentionRoles();
+  createMentionRoles(() => serverStore.mentionRoles.roles);
 
-  const connection = useConnection();
-  const serverStore = serverRegistry.getStore(getActiveServer());
   const userSettings = getUserSettings();
   const activeLocale = $derived(getLocale());
   const PAGE_SIZE = 20;
+
+  $effect(() => {
+    void serverStore.mentionRoles.refresh();
+  });
 
   type FollowedThreadItem = {
     roomId: string;


### PR DESCRIPTION
## Why

Mention-role reference data had three different frontend ownership paths:
rooms loaded it for message rendering, each composer loaded another copy for
autocomplete and send confirmation, and followed threads installed an empty
catalogue. That duplicated requests, mapping, loading state, and failure
handling for server-scoped data.

## What changed

- Add a lazy `MentionRolesStore` owned by `ServerStateStore`.
- Coalesce concurrent role-catalogue loads from rooms and composers.
- Keep failed loads retryable while preserving conservative mention
  confirmation when the catalogue is unavailable.
- Feed the shared reactive catalogue through the existing room context.
- Refresh the catalogue on room and followed-thread surface entry.
- Give followed-thread message rendering real role handles instead of an empty
  placeholder.
- Remove the duplicate room- and composer-local API clients, mapping, request
  cancellation, and loading flags.

## Test plan

- Official Svelte autofixer: no issues in all changed Svelte files.
- Targeted Vitest: 4 files, 170 tests passed.
- `mise test-frontend`: 290 files, 2,475 tests passed.
- `mise lint-frontend`: passed, including design checks, Svelte type checks,
  and ESLint.
- `mise knip`: completed with only pre-existing repository findings.
- Independent adversarial review: no actionable findings.

## Compatibility and operations

This is an internal frontend state-ownership refactor. It does not change
public APIs, persistence, permissions, user-visible copy, deployment, or
mixed-version behavior.

Closes https://github.com/chattocorp/chatto/issues/1726.
