### PR TITLE
refactor(frontend): remove notification compatibility aliases

### DIFF
--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -122,7 +122,7 @@
   // notifications when both are present.
   async function handleServerNotificationClick() {
     const notification =
-      notificationStore.getSpaceNotification() ?? notificationStore.getDMNotification();
+      notificationStore.getNonDMNotification() ?? notificationStore.getDMNotification();
     if (!notification) {
       await goto(resolve('/chat/notifications'));
       return;

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -38,7 +38,7 @@ const { mocks } = vi.hoisted(() => {
           fetch: vi.fn().mockResolvedValue(undefined),
           setUnreadNotificationCount: vi.fn(),
           unreadNotificationCount: 0,
-          getSpaceNotification: vi.fn().mockReturnValue(null),
+          getNonDMNotification: vi.fn().mockReturnValue(null),
           getDMNotification: vi.fn().mockReturnValue(null),
           dismiss: vi.fn(),
           getCleanPath: vi.fn().mockReturnValue('/chat/remote.example.com/room-1')
@@ -218,7 +218,7 @@ describe('ServerSidebarEntry', () => {
     mocks.store.notifications.fetch.mockResolvedValue(undefined);
     mocks.store.notifications.setUnreadNotificationCount.mockClear();
     mocks.store.notifications.unreadNotificationCount = 0;
-    mocks.store.notifications.getSpaceNotification.mockReturnValue(null);
+    mocks.store.notifications.getNonDMNotification.mockReturnValue(null);
     mocks.store.notifications.getDMNotification.mockReturnValue(null);
     mocks.store.notifications.dismiss.mockClear();
     mocks.store.notifications.getCleanPath.mockReturnValue('/chat/remote.example.com/room-1');
@@ -450,7 +450,7 @@ describe('ServerSidebarEntry', () => {
     };
     mocks.store.serverIndicator.mockReturnValue('notification');
     mocks.store.notifications.unreadNotificationCount = 1;
-    mocks.store.notifications.getSpaceNotification.mockReturnValue(notification);
+    mocks.store.notifications.getNonDMNotification.mockReturnValue(notification);
     mocks.store.notifications.getCleanPath.mockReturnValue(
       '/chat/remote.example.com/room-1/thread-1'
     );

--- a/apps/frontend/src/lib/api-client-tests/notifications.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/notifications.spec.ts
@@ -9,7 +9,6 @@ const mocks = vi.hoisted(() => ({
   createConnectTransport: vi.fn(),
   listNotifications: vi.fn(),
   listRoomNotifications: vi.fn(),
-  hasNotifications: vi.fn(),
   listRoomNotificationCounts: vi.fn(),
   dismissNotification: vi.fn(),
   dismissAllNotifications: vi.fn()
@@ -33,7 +32,6 @@ describe('createNotificationAPI', () => {
     mocks.createConnectTransport.mockReset();
     mocks.listNotifications.mockReset();
     mocks.listRoomNotifications.mockReset();
-    mocks.hasNotifications.mockReset();
     mocks.listRoomNotificationCounts.mockReset();
     mocks.dismissNotification.mockReset();
     mocks.dismissAllNotifications.mockReset();
@@ -41,7 +39,6 @@ describe('createNotificationAPI', () => {
     mocks.createClient.mockReturnValue({
       listNotifications: mocks.listNotifications,
       listRoomNotifications: mocks.listRoomNotifications,
-      hasNotifications: mocks.hasNotifications,
       listRoomNotificationCounts: mocks.listRoomNotificationCounts,
       dismissNotification: mocks.dismissNotification,
       dismissAllNotifications: mocks.dismissAllNotifications
@@ -128,7 +125,6 @@ describe('createNotificationAPI', () => {
         }
       ]
     });
-    mocks.hasNotifications.mockResolvedValue({ hasNotifications: true });
     mocks.listRoomNotificationCounts.mockResolvedValue({
       roomCounts: [
         { roomId: 'room-1', totalCount: 2 },
@@ -149,8 +145,10 @@ describe('createNotificationAPI', () => {
         }
       ]
     });
-    await expect(api.hasNotifications()).resolves.toBe(true);
-    await expect(api.listNotificationCounts()).resolves.toEqual({ 'room-1': 2, 'dm-1': 1 });
+    await expect(api.listRoomNotificationCounts()).resolves.toEqual({
+      'room-1': 2,
+      'dm-1': 1
+    });
     await expect(api.dismissNotification('n2')).resolves.toBe(true);
     await expect(api.dismissAllNotifications()).resolves.toBe(3);
 

--- a/apps/frontend/src/lib/api-client/notifications.ts
+++ b/apps/frontend/src/lib/api-client/notifications.ts
@@ -118,15 +118,7 @@ export function createNotificationAPI(config: NotificationAPIConfig) {
       );
     },
 
-    async hasNotifications(): Promise<boolean> {
-      return (await client.hasNotifications({}, { headers: headers() })).hasNotifications;
-    },
-
     async listRoomNotificationCounts(): Promise<Record<string, number>> {
-      return listRoomNotificationCounts();
-    },
-
-    async listNotificationCounts(): Promise<Record<string, number>> {
       return listRoomNotificationCounts();
     },
 

--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -13,9 +13,7 @@ import {
 type MockNotificationAPI = NotificationAPI & {
   listNotifications: ReturnType<typeof vi.fn>;
   listRoomNotifications: ReturnType<typeof vi.fn>;
-  hasNotifications: ReturnType<typeof vi.fn>;
   listRoomNotificationCounts: ReturnType<typeof vi.fn>;
-  listNotificationCounts: ReturnType<typeof vi.fn>;
   dismissNotification: ReturnType<typeof vi.fn>;
   dismissAllNotifications: ReturnType<typeof vi.fn>;
 };
@@ -55,9 +53,7 @@ function makeAPI(
       if (options.roomNotificationsError) throw options.roomNotificationsError;
       return options.roomNotifications ?? page([]);
     }),
-    hasNotifications: vi.fn().mockResolvedValue(false),
     listRoomNotificationCounts: vi.fn().mockResolvedValue({}),
-    listNotificationCounts: vi.fn().mockResolvedValue({}),
     dismissNotification: vi
       .fn()
       .mockImplementation(async (notificationId: string) =>

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -20,7 +20,6 @@ export type { NotificationItem };
  */
 export type NotificationTarget = {
   isDM: boolean;
-  spaceName: string | null;
   roomId: string | null;
   roomName: string | null;
   eventId: string | null;
@@ -70,7 +69,6 @@ export function notificationTarget(n: NotificationItem): NotificationTarget {
   if (isDMNotification(n)) {
     return {
       isDM: true,
-      spaceName: null,
       roomId: n.room.id,
       roomName: null,
       eventId: null,
@@ -80,7 +78,6 @@ export function notificationTarget(n: NotificationItem): NotificationTarget {
   if (isMentionNotification(n)) {
     return {
       isDM: false,
-      spaceName: null,
       roomId: n.mentionRoom?.id ?? null,
       roomName: n.mentionRoom?.name ?? null,
       eventId: n.mentionEventId ?? null,
@@ -90,7 +87,6 @@ export function notificationTarget(n: NotificationItem): NotificationTarget {
   if (isReplyNotification(n)) {
     return {
       isDM: false,
-      spaceName: null,
       roomId: n.replyRoom?.id ?? null,
       roomName: n.replyRoom?.name ?? null,
       eventId: n.replyEventId ?? null,
@@ -100,7 +96,6 @@ export function notificationTarget(n: NotificationItem): NotificationTarget {
   if (isRoomMessageNotification(n)) {
     return {
       isDM: false,
-      spaceName: null,
       roomId: n.roomMsgRoom?.id ?? null,
       roomName: n.roomMsgRoom?.name ?? null,
       eventId: n.roomMsgEventId ?? null,
@@ -109,7 +104,6 @@ export function notificationTarget(n: NotificationItem): NotificationTarget {
   }
   return {
     isDM: false,
-    spaceName: null,
     roomId: null,
     roomName: null,
     eventId: null,
@@ -133,11 +127,6 @@ export class NotificationStore {
 
   constructor(api: NotificationAPI) {
     this.#api = api;
-  }
-
-  // Derived properties
-  get hasNotifications() {
-    return this.notifications.length > 0;
   }
 
   get count() {
@@ -236,22 +225,16 @@ export class NotificationStore {
     });
   }
 
-  /**
-   * Check if the server has any pending notifications.
-   *
-   * Post-PR(b) the API surface has only one server, so this collapses to
-   * "any non-DM notification exists." The signature keeps a `_spaceId`
-   * parameter for call-site compatibility — it's ignored.
-   */
-  hasSpaceNotification(_spaceId?: string): boolean {
+  /** Check if the server has any pending non-DM notifications. */
+  hasNonDMNotifications(): boolean {
     return this.notifications.some((n) => !notificationTarget(n).isDM);
   }
 
   /**
-   * Get the most recent server notification.
+   * Get the most recent non-DM notification.
    * Notifications are sorted most-recent-first, so .find returns the freshest.
    */
-  getSpaceNotification(_spaceId?: string): NotificationItem | undefined {
+  getNonDMNotification(): NotificationItem | undefined {
     return this.notifications.find((n) => !notificationTarget(n).isDM);
   }
 
@@ -376,18 +359,6 @@ export class NotificationStore {
       return { ok: true, totalCount: null, notification: cached };
     }
     return this.fetchRoomNotification(roomId);
-  }
-
-  /**
-   * Check if user has any notifications (lightweight check for bell icon).
-   */
-  async checkHasNotifications(): Promise<boolean> {
-    try {
-      return await this.#api.hasNotifications();
-    } catch (e) {
-      console.error('Failed to check notifications:', e);
-      return false;
-    }
   }
 
   /**

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -103,9 +103,7 @@ function makeNotificationAPI(counts: Record<string, number> = {}): NotificationA
   return {
     listNotifications: vi.fn(),
     listRoomNotifications: vi.fn(),
-    hasNotifications: vi.fn(),
     listRoomNotificationCounts: vi.fn().mockResolvedValue(counts),
-    listNotificationCounts: vi.fn().mockResolvedValue(counts),
     dismissNotification: vi.fn(),
     dismissAllNotifications: vi.fn()
   } as unknown as NotificationAPI;
@@ -345,7 +343,7 @@ describe('RoomsStore - refresh', () => {
   it('patches notification counts from Connect', async () => {
     let resolveCounts!: (value: Record<string, number>) => void;
     const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listNotificationCounts).mockImplementation(
+    vi.mocked(notificationAPI.listRoomNotificationCounts).mockImplementation(
       () => new Promise((resolve) => (resolveCounts = resolve))
     );
     const store = makeStore({
@@ -366,7 +364,7 @@ describe('RoomsStore - refresh', () => {
   it('refreshes notification counts for an already-loaded room list', async () => {
     let countQueries = 0;
     const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listNotificationCounts).mockImplementation(async () => {
+    vi.mocked(notificationAPI.listRoomNotificationCounts).mockImplementation(async () => {
       countQueries++;
       return { general: countQueries === 1 ? 1 : 0 };
     });
@@ -486,7 +484,10 @@ describe('RoomsStore - refresh', () => {
     expect(store.rooms[0]).toBe(general);
     expect(store.rooms[1]).toBe(random);
 
-    vi.mocked(notificationAPI.listNotificationCounts).mockResolvedValue({ general: 1, random: 3 });
+    vi.mocked(notificationAPI.listRoomNotificationCounts).mockResolvedValue({
+      general: 1,
+      random: 3
+    });
 
     await store.refreshNotificationCounts();
 
@@ -512,7 +513,7 @@ describe('RoomsStore - refresh', () => {
     let resolveOlder!: (value: Record<string, number>) => void;
     let resolveNewer!: (value: Record<string, number>) => void;
     const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listNotificationCounts).mockImplementation(() => {
+    vi.mocked(notificationAPI.listRoomNotificationCounts).mockImplementation(() => {
       countQueries++;
       if (countQueries === 1) return Promise.resolve({ general: 0 });
       if (countQueries === 2) return new Promise((resolve) => (resolveOlder = resolve));
@@ -544,7 +545,7 @@ describe('RoomsStore - refresh', () => {
 
   it('keeps rooms visible when notification count loading fails', async () => {
     const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listNotificationCounts).mockRejectedValue(
+    vi.mocked(notificationAPI.listRoomNotificationCounts).mockRejectedValue(
       new Error('server too old')
     );
     const store = makeStore({

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -386,7 +386,7 @@ export class RoomsStore {
     const notificationCountsLoadId = ++this.notificationCountsLoadId;
 
     try {
-      const countsByRoomId = await this.notificationAPI.listNotificationCounts();
+      const countsByRoomId = await this.notificationAPI.listRoomNotificationCounts();
       if (this.loadId !== loadId || this.notificationCountsLoadId !== notificationCountsLoadId) {
         return;
       }

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -54,7 +54,7 @@ const { soundMocks, apiMocks } = vi.hoisted(() => ({
     joinCall: vi.fn(() => Promise.resolve(true)),
     getCallToken: vi.fn(() => Promise.resolve(null)),
     leaveCall: vi.fn(() => Promise.resolve(true)),
-    listNotificationCounts: vi.fn(() => Promise.resolve({})),
+    listRoomNotificationCounts: vi.fn(() => Promise.resolve({})),
     listNotifications: vi.fn(() =>
       Promise.resolve({
         items: [],
@@ -223,8 +223,7 @@ vi.mock('$lib/api-client/notifications', () => ({
   createNotificationAPI: vi.fn(() => ({
     listNotifications: apiMocks.listNotifications,
     listRoomNotifications: vi.fn(),
-    hasNotifications: vi.fn(),
-    listNotificationCounts: apiMocks.listNotificationCounts,
+    listRoomNotificationCounts: apiMocks.listRoomNotificationCounts,
     dismissNotification: vi.fn(),
     dismissAllNotifications: vi.fn()
   }))
@@ -416,7 +415,7 @@ beforeEach(() => {
   apiMocks.joinCall.mockResolvedValue(true);
   apiMocks.getCallToken.mockResolvedValue(null);
   apiMocks.leaveCall.mockResolvedValue(true);
-  apiMocks.listNotificationCounts.mockResolvedValue({});
+  apiMocks.listRoomNotificationCounts.mockResolvedValue({});
   apiMocks.listNotifications.mockResolvedValue({
     items: [],
     unreadCount: 0

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -668,7 +668,7 @@ export class ServerStateStore {
   serverIndicator(): ServerIndicator {
     // Channel + DM activity both roll up to the single server indicator.
     if (this.notifications.unreadNotificationCount > 0) return 'notification';
-    if (this.notifications.hasSpaceNotification()) return 'notification';
+    if (this.notifications.hasNonDMNotifications()) return 'notification';
     if (this.notifications.hasDMNotifications()) return 'notification';
     if (this.roomUnread.hasAnyUnread) return 'unread';
     return null;


### PR DESCRIPTION
## Why

The frontend notification layer retained dead aliases and space-shaped compatibility fields that obscured the active model and enlarged mocks and tests.

## What changed

Removed unused notification queries, consolidated room-count reads on `listRoomNotificationCounts()`, removed the always-null target `spaceName`, and replaced retired space selectors with explicit non-DM terminology while preserving notification behaviour.

Closes #1730.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: unchanged.

## Test plan

- Focused notification/store/sidebar tests: 60 passed across 5 files.
- `mise lint-frontend`: passed with zero Svelte errors or warnings.
- `mise test-frontend`: 2,475 tests passed across 290 files.
- `mise knip`: completed successfully with only existing unrelated findings.
- Official Svelte analysis and independent review found no actionable issues.
