### PR TITLE
refactor(frontend): use protobuf-native time format

### DIFF
--- a/apps/frontend/src/lib/api-client-tests/account.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/account.spec.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { TimeFormat as APITimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
-import { TimeFormat } from '$lib/api-client/renderTypes';
+import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
 import { createAccountAPI } from '$lib/api-client/account';
 
 const mocks = vi.hoisted(() => ({
@@ -131,7 +130,7 @@ describe('createAccountAPI', () => {
     mocks.updateSettings.mockResolvedValue({
       settings: {
         timezone: 'Europe/Berlin',
-        timeFormat: APITimeFormat.TIME_FORMAT_24_HOUR
+        timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
       }
     });
 
@@ -143,17 +142,17 @@ describe('createAccountAPI', () => {
     await expect(
       api.updateSettings({
         timezone: 'Europe/Berlin',
-        timeFormat: TimeFormat.TwentyFourHour
+        timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
       })
     ).resolves.toEqual({
       timezone: 'Europe/Berlin',
-      timeFormat: TimeFormat.TwentyFourHour
+      timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
     });
 
     expect(mocks.updateSettings).toHaveBeenCalledWith(
       {
         timezone: 'Europe/Berlin',
-        timeFormat: APITimeFormat.TIME_FORMAT_24_HOUR
+        timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
       },
       { headers: undefined }
     );
@@ -180,7 +179,7 @@ describe('createAccountAPI', () => {
   it('sends empty timezone when clearing settings', async () => {
     mocks.updateSettings.mockResolvedValue({
       settings: {
-        timeFormat: APITimeFormat.TIME_FORMAT_AUTO
+        timeFormat: TimeFormat.TIME_FORMAT_AUTO
       }
     });
 
@@ -191,7 +190,7 @@ describe('createAccountAPI', () => {
 
     await expect(api.updateSettings({ timezone: null })).resolves.toEqual({
       timezone: null,
-      timeFormat: TimeFormat.Auto
+      timeFormat: TimeFormat.TIME_FORMAT_AUTO
     });
 
     expect(mocks.updateSettings).toHaveBeenCalledWith(

--- a/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
@@ -2,8 +2,8 @@ import { Timestamp } from '@bufbuild/protobuf';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationLevel as APINotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { TimeFormat as APITimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
-import { NotificationLevel, PresenceStatus, TimeFormat } from '$lib/api-client/renderTypes';
+import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
+import { NotificationLevel, PresenceStatus } from '$lib/api-client/renderTypes';
 import { getCurrentUserViaConnect, getViewerStateViaConnect } from '$lib/api-client/viewer';
 
 const mocks = vi.hoisted(() => ({
@@ -54,7 +54,7 @@ describe('getCurrentUserViaConnect', () => {
         lastLoginChange: Timestamp.fromDate(new Date('2026-05-20T09:30:00Z')),
         settings: {
           timezone: 'Europe/Berlin',
-          timeFormat: APITimeFormat.TIME_FORMAT_24_HOUR
+          timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
         }
       },
       roomNotificationPreferences: []
@@ -90,7 +90,7 @@ describe('getCurrentUserViaConnect', () => {
       lastLoginChange: '2026-05-20T09:30:00.000Z',
       settings: {
         timezone: 'Europe/Berlin',
-        timeFormat: TimeFormat.TwentyFourHour
+        timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
       }
     });
   });
@@ -105,7 +105,7 @@ describe('getCurrentUserViaConnect', () => {
           presenceStatus: APIPresenceStatus.UNSPECIFIED
         },
         hasVerifiedEmail: false,
-        settings: { timeFormat: APITimeFormat.TIME_FORMAT_UNSPECIFIED }
+        settings: { timeFormat: TimeFormat.TIME_FORMAT_UNSPECIFIED }
       },
       roomNotificationPreferences: []
     });
@@ -117,7 +117,7 @@ describe('getCurrentUserViaConnect', () => {
 
     expect(mocks.getViewer).toHaveBeenCalledWith({}, { headers: undefined });
     expect(user.presenceStatus).toBe(PresenceStatus.Offline);
-    expect(user.settings?.timeFormat).toBe(TimeFormat.Auto);
+    expect(user.settings?.timeFormat).toBe(TimeFormat.TIME_FORMAT_AUTO);
     expect(user.customStatus).toBeNull();
     expect(user.hasPassword).toBe(false);
     expect(user.viewerCanDeleteAccount).toBe(false);

--- a/apps/frontend/src/lib/api-client/account.ts
+++ b/apps/frontend/src/lib/api-client/account.ts
@@ -2,10 +2,10 @@ import { authHeaders, createChattoClient } from './connect.js';
 import { MyAccountService } from '@chatto/api-types/api/v1/account_connect';
 import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
 import {
-  TimeFormat as APITimeFormat,
+  TimeFormat,
   type UserSettings as APIUserSettings
 } from '@chatto/api-types/api/v1/viewer_pb';
-import { TimeFormat } from './renderTypes.js';
+import { timeFormatOrAuto } from './timeFormat.js';
 
 export type AccountAPIConfig = {
   baseUrl: string;
@@ -82,7 +82,8 @@ export function createAccountAPI(config: AccountAPIConfig) {
       const response = await client.updateSettings(
         {
           timezone: input.timezone === null ? '' : input.timezone,
-          timeFormat: input.timeFormat === undefined ? undefined : timeFormatToAPI(input.timeFormat)
+          timeFormat:
+            input.timeFormat === undefined ? undefined : timeFormatOrAuto(input.timeFormat)
         },
         { headers: headers() }
       );
@@ -123,31 +124,6 @@ function accountUser(user: APIUser | undefined): AccountUser {
 function userSettings(settings: APIUserSettings | undefined): AccountUserSettings {
   return {
     timezone: settings?.timezone ?? null,
-    timeFormat: settings ? apiTimeFormat(settings.timeFormat) : TimeFormat.Auto
+    timeFormat: timeFormatOrAuto(settings?.timeFormat)
   };
-}
-
-function timeFormatToAPI(format: TimeFormat): APITimeFormat {
-  switch (format) {
-    case TimeFormat.TwelveHour:
-      return APITimeFormat.TIME_FORMAT_12_HOUR;
-    case TimeFormat.TwentyFourHour:
-      return APITimeFormat.TIME_FORMAT_24_HOUR;
-    case TimeFormat.Auto:
-    default:
-      return APITimeFormat.TIME_FORMAT_AUTO;
-  }
-}
-
-function apiTimeFormat(format: APITimeFormat): TimeFormat {
-  switch (format) {
-    case APITimeFormat.TIME_FORMAT_12_HOUR:
-      return TimeFormat.TwelveHour;
-    case APITimeFormat.TIME_FORMAT_24_HOUR:
-      return TimeFormat.TwentyFourHour;
-    case APITimeFormat.TIME_FORMAT_AUTO:
-    case APITimeFormat.TIME_FORMAT_UNSPECIFIED:
-    default:
-      return TimeFormat.Auto;
-  }
 }

--- a/apps/frontend/src/lib/api-client/renderTypes.ts
+++ b/apps/frontend/src/lib/api-client/renderTypes.ts
@@ -30,12 +30,6 @@ export enum RoomType {
   Dm = 'DM'
 }
 
-export enum TimeFormat {
-  Auto = 'AUTO',
-  TwelveHour = 'TWELVE_HOUR',
-  TwentyFourHour = 'TWENTY_FOUR_HOUR'
-}
-
 export enum VideoProcessingStatus {
   Completed = 'COMPLETED',
   Failed = 'FAILED',

--- a/apps/frontend/src/lib/api-client/timeFormat.ts
+++ b/apps/frontend/src/lib/api-client/timeFormat.ts
@@ -1,0 +1,14 @@
+import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
+
+/** Return a concrete client preference for absent or unknown wire values. */
+export function timeFormatOrAuto(timeFormat: TimeFormat | null | undefined): TimeFormat {
+  switch (timeFormat) {
+    case TimeFormat.TIME_FORMAT_AUTO:
+    case TimeFormat.TIME_FORMAT_12_HOUR:
+    case TimeFormat.TIME_FORMAT_24_HOUR:
+      return timeFormat;
+    case TimeFormat.TIME_FORMAT_UNSPECIFIED:
+    default:
+      return TimeFormat.TIME_FORMAT_AUTO;
+  }
+}

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -2,9 +2,9 @@ import { authHeaders, createChattoClient } from './connect.js';
 import { ViewerService } from '@chatto/api-types/api/v1/viewer_connect';
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { NotificationLevel as APINotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
-import { TimeFormat as APITimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
-import type { GetViewerResponse } from '@chatto/api-types/api/v1/viewer_pb';
-import { NotificationLevel, PresenceStatus, TimeFormat } from './renderTypes.js';
+import { TimeFormat, type GetViewerResponse } from '@chatto/api-types/api/v1/viewer_pb';
+import { NotificationLevel, PresenceStatus } from './renderTypes.js';
+import { timeFormatOrAuto } from './timeFormat.js';
 
 export type ViewerAPIConfig = {
   serverId?: string;
@@ -120,7 +120,7 @@ export function viewerResponseToState(response: GetViewerResponse): ViewerState 
       settings: response.user.settings
         ? {
             timezone: response.user.settings.timezone ?? null,
-            timeFormat: apiTimeFormat(response.user.settings.timeFormat)
+            timeFormat: timeFormatOrAuto(response.user.settings.timeFormat)
           }
         : null
     },
@@ -206,18 +206,5 @@ function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
     case APIPresenceStatus.UNSPECIFIED:
     default:
       return PresenceStatus.Offline;
-  }
-}
-
-function apiTimeFormat(format: APITimeFormat): TimeFormat {
-  switch (format) {
-    case APITimeFormat.TIME_FORMAT_12_HOUR:
-      return TimeFormat.TwelveHour;
-    case APITimeFormat.TIME_FORMAT_24_HOUR:
-      return TimeFormat.TwentyFourHour;
-    case APITimeFormat.TIME_FORMAT_AUTO:
-    case APITimeFormat.TIME_FORMAT_UNSPECIFIED:
-    default:
-      return TimeFormat.Auto;
   }
 }

--- a/apps/frontend/src/lib/state/userSettings.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/userSettings.svelte.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
+import { hour12ForTimeFormat, UserSettingsState } from './userSettings.svelte';
+
+describe('hour12ForTimeFormat', () => {
+  it('maps explicit clock formats and leaves automatic formats to the locale', () => {
+    expect(hour12ForTimeFormat(TimeFormat.TIME_FORMAT_12_HOUR)).toBe(true);
+    expect(hour12ForTimeFormat(TimeFormat.TIME_FORMAT_24_HOUR)).toBe(false);
+    expect(hour12ForTimeFormat(TimeFormat.TIME_FORMAT_AUTO)).toBeUndefined();
+  });
+});
+
+describe('UserSettingsState', () => {
+  it('stores protobuf-native settings and resets to automatic defaults', () => {
+    const settings = new UserSettingsState();
+
+    settings.updateFromData({
+      timezone: 'Europe/Berlin',
+      timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
+    });
+
+    expect(settings.timezone).toBe('Europe/Berlin');
+    expect(settings.timeFormat).toBe(TimeFormat.TIME_FORMAT_24_HOUR);
+    expect(settings.effectiveHour12).toBe(false);
+
+    settings.updateFromData(null);
+
+    expect(settings.timezone).toBeNull();
+    expect(settings.timeFormat).toBe(TimeFormat.TIME_FORMAT_AUTO);
+    expect(settings.effectiveHour12).toBeUndefined();
+  });
+});

--- a/apps/frontend/src/lib/state/userSettings.svelte.ts
+++ b/apps/frontend/src/lib/state/userSettings.svelte.ts
@@ -6,11 +6,11 @@
  */
 
 import { createContext } from 'svelte';
-import { TimeFormat } from '$lib/render/types';
+import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
 
 export function hour12ForTimeFormat(timeFormat: TimeFormat): boolean | undefined {
-  if (timeFormat === TimeFormat.TwelveHour) return true;
-  if (timeFormat === TimeFormat.TwentyFourHour) return false;
+  if (timeFormat === TimeFormat.TIME_FORMAT_12_HOUR) return true;
+  if (timeFormat === TimeFormat.TIME_FORMAT_24_HOUR) return false;
   return undefined;
 }
 
@@ -19,7 +19,7 @@ export class UserSettingsState {
   timezone = $state<string | null>(null);
 
   /** Time display format preference. */
-  timeFormat = $state<TimeFormat>(TimeFormat.Auto);
+  timeFormat = $state<TimeFormat>(TimeFormat.TIME_FORMAT_AUTO);
 
   /**
    * Effective timezone for Intl.DateTimeFormat.
@@ -46,7 +46,7 @@ export class UserSettingsState {
       this.timeFormat = settings.timeFormat;
     } else {
       this.timezone = null;
-      this.timeFormat = TimeFormat.Auto;
+      this.timeFormat = TimeFormat.TIME_FORMAT_AUTO;
     }
   }
 }

--- a/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -4,7 +4,7 @@
   import { getLocale, setLocale, type Locale } from '$lib/i18n/runtime';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { createAccountAPI } from '$lib/api-client/account';
-  import { TimeFormat } from '$lib/render/types';
+  import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
   import { getUserSettings, hour12ForTimeFormat } from '$lib/state/userSettings.svelte';
   import { userPreferences, type DisplayTheme } from '$lib/state/userPreferences.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -145,17 +145,17 @@
 
   const timeFormatOptions = $derived([
     {
-      value: TimeFormat.Auto,
+      value: TimeFormat.TIME_FORMAT_AUTO,
       label: m['settings.preferences.time_format.browser_default.label'](),
       description: m['settings.preferences.time_format.browser_default.description']()
     },
     {
-      value: TimeFormat.TwelveHour,
+      value: TimeFormat.TIME_FORMAT_12_HOUR,
       label: m['settings.preferences.time_format.12h.label'](),
       description: m['settings.preferences.time_format.12h.description']()
     },
     {
-      value: TimeFormat.TwentyFourHour,
+      value: TimeFormat.TIME_FORMAT_24_HOUR,
       label: m['settings.preferences.time_format.24h.label'](),
       description: m['settings.preferences.time_format.24h.description']()
     }


### PR DESCRIPTION
## Why

The frontend maintained a string `TimeFormat` enum beside the generated public API enum, requiring duplicate transport mappings and two representations of the same setting.

## What changed

Account and viewer clients, reactive settings state, and the preferences page now share the generated `chatto.api.v1.TimeFormat`; a small boundary helper preserves the established `UNSPECIFIED` or unknown value fallback to automatic formatting.

Closes #1732.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: unchanged.

## Test plan

- Focused account/viewer/user-settings tests: 11 passed across 3 files.
- `mise lint-frontend`: passed with zero Svelte errors or warnings.
- `mise test-frontend`: 2,477 tests passed across 291 files.
- `mise knip`: completed successfully with only existing unrelated findings.
- `mise license-check`: passed.
- Official Svelte CLI and MCP analysis found no issues or suggestions.
