### PR TITLE
refactor(frontend): use protobuf-native render enums

### DIFF
--- a/apps/frontend/e2e/notification-level.test.ts
+++ b/apps/frontend/e2e/notification-level.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { createAndLoginTestUser } from './fixtures/testUser';
 import {
   getRoomIdByNameViaConnect,
@@ -90,10 +91,10 @@ test.describe('Notification Level - Notifications Settings', () => {
     const select = generalRow.locator('select');
 
     // Default should be selected initially
-    await expect(select).toHaveValue('DEFAULT');
+    await expect(select).toHaveValue(String(NotificationLevel.DEFAULT));
 
     // Change to MUTED
-    await select.selectOption('MUTED');
+    await select.selectOption(String(NotificationLevel.MUTED));
 
     // Wait for success toast
     await expect(page.getByText('Room notification level updated')).toBeVisible({
@@ -104,7 +105,9 @@ test.describe('Notification Level - Notifications Settings', () => {
     await page.reload();
     await expect(page.getByRole('heading', { name: 'Notifications' })).toBeVisible();
     const generalRowAfterReload = page.getByTestId('room-notification-general');
-    await expect(generalRowAfterReload.locator('select')).toHaveValue('MUTED');
+    await expect(generalRowAfterReload.locator('select')).toHaveValue(
+      String(NotificationLevel.MUTED)
+    );
   });
 
   test('notification levels are available from settings sidebar', async ({ page, chatPage }) => {

--- a/apps/frontend/e2e/notifications.test.ts
+++ b/apps/frontend/e2e/notifications.test.ts
@@ -1,4 +1,5 @@
 import { expect } from '@playwright/test';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { test } from './setup';
 import { ChatPage, NotificationsPage } from './pages';
 import { createAndLoginTestUser, loginAsAdmin, loginTestUser } from './fixtures/testUser';
@@ -158,7 +159,9 @@ test.describe('All Messages Notifications', () => {
 
     const generalNotificationRow = page.getByTestId('room-notification-general');
     await expect(generalNotificationRow).toBeVisible();
-    await generalNotificationRow.locator('select').selectOption('ALL_MESSAGES');
+    await generalNotificationRow
+      .locator('select')
+      .selectOption(String(NotificationLevel.ALL_MESSAGES));
     await expect(page.getByText('Room notification level updated')).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });

--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -1,10 +1,10 @@
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
 import Harness from './RoomDirectoryTestHarness.svelte';
 import { RoomDirectoryStore, type DirectoryRoom } from '$lib/state/server/roomDirectory.svelte';
 import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
-import { RoomType } from '$lib/render/types';
 
 const room = (id: string, overrides: Partial<DirectoryRoom> = {}): DirectoryRoom => ({
   id,
@@ -18,7 +18,7 @@ const room = (id: string, overrides: Partial<DirectoryRoom> = {}): DirectoryRoom
 const listedRoom = (id: string, overrides: Partial<RoomsListItem> = {}): RoomsListItem => ({
   id,
   name: overrides.name ?? id,
-  type: overrides.type ?? RoomType.Channel,
+  type: overrides.type ?? RoomKind.CHANNEL,
   isUniversal: overrides.isUniversal ?? false,
   viewerIsMember: overrides.viewerIsMember ?? true,
   viewerCanJoinRoom: overrides.viewerCanJoinRoom ?? true,

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -5,6 +5,8 @@ Renders the room list in the server sidebar. When a room layout is configured,
 rooms are organized into collapsible sections. Otherwise, rooms display alphabetically.
 -->
 <script lang="ts">
+  import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { goto, pushState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
@@ -24,7 +26,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     setRoomSidebarPanel
   } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
-  import { PresenceStatus, RoomType, type UserAvatarUserView } from '$lib/render/types';
+  import { type UserAvatarUserView } from '$lib/render/types';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import NotificationBadge from '$lib/ui/NotificationBadge.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
@@ -146,9 +148,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // Channels and DMs are stored together, but rendered as separate groups.
   // Room sets only apply to channels — DM rooms always render in their
   // own group below.
-  let channels = $derived(roomsStore.rooms.filter((r) => r.type === RoomType.Channel));
+  let channels = $derived(roomsStore.rooms.filter((r) => r.type === RoomKind.CHANNEL));
   let dmRooms = $derived(
-    roomsStore.rooms.filter((r) => r.type === RoomType.Dm && isNavigationVisibleRoom(r))
+    roomsStore.rooms.filter((r) => r.type === RoomKind.DM && isNavigationVisibleRoom(r))
   );
 
   let channelMap = $derived(new Map(channels.map((r) => [r.id, r])));
@@ -209,7 +211,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       displayName: participant.displayName,
       deleted: false,
       avatarUrl: participant.avatarUrl,
-      presenceStatus: PresenceStatus.Offline
+      presenceStatus: PresenceStatus.OFFLINE
     };
   }
 
@@ -222,7 +224,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     if (room.id === activeRoomId) return true;
     if (activeCallRooms.has(room.id)) return true;
     if (roomUnreadStore.roomIsUnread(room.id)) return true;
-    if (room.type === RoomType.Dm) {
+    if (room.type === RoomKind.DM) {
       return room.viewerNotificationCount > 0;
     }
     return room.viewerNotificationCount > 0;
@@ -569,8 +571,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       canJoin={contextRoom.viewerCanJoinRoom}
       canMarkRead={roomUnreadStore.roomIsUnread(contextRoom.id) ||
         contextRoom.viewerNotificationCount > 0}
-      canConfigure={contextRoom.viewerCanManageRoom && contextRoom.type !== RoomType.Dm}
-      canLeave={!contextRoom.isUniversal && contextRoom.type !== RoomType.Dm}
+      canConfigure={contextRoom.viewerCanManageRoom && contextRoom.type !== RoomKind.DM}
+      canLeave={!contextRoom.isUniversal && contextRoom.type !== RoomKind.DM}
       onJoin={() => void handleJoinRoom(contextRoom)}
       onMarkRead={() => handleMarkRoomRead(contextRoom)}
       onConfigure={() => handleConfigureRoom(contextRoom)}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -1,7 +1,8 @@
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
-import { RoomType } from '$lib/render/types';
+
 import { NotificationItemKind } from '$lib/api-client/notifications';
 import { serverStorageKey } from '$lib/storage/serverStorage';
 import {
@@ -189,7 +190,7 @@ function setRooms() {
     {
       id: 'channel-1',
       name: 'general',
-      type: RoomType.Channel,
+      type: RoomKind.CHANNEL,
       isUniversal: false,
       viewerIsMember: true,
       viewerCanJoinRoom: true,
@@ -200,7 +201,7 @@ function setRooms() {
     {
       id: 'joinable-channel',
       name: 'joinable',
-      type: RoomType.Channel,
+      type: RoomKind.CHANNEL,
       isUniversal: false,
       viewerIsMember: false,
       viewerCanJoinRoom: true,
@@ -211,7 +212,7 @@ function setRooms() {
     {
       id: 'restricted-channel',
       name: 'restricted',
-      type: RoomType.Channel,
+      type: RoomKind.CHANNEL,
       isUniversal: false,
       viewerIsMember: false,
       viewerCanJoinRoom: false,
@@ -222,7 +223,7 @@ function setRooms() {
     {
       id: 'dm-with-participants',
       name: '',
-      type: RoomType.Dm,
+      type: RoomKind.DM,
       isUniversal: false,
       viewerIsMember: true,
       viewerCanJoinRoom: true,
@@ -233,7 +234,7 @@ function setRooms() {
     {
       id: 'dm-phone-only',
       name: '',
-      type: RoomType.Dm,
+      type: RoomKind.DM,
       isUniversal: false,
       viewerIsMember: true,
       viewerCanJoinRoom: true,

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -1,6 +1,8 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
-import { NotificationLevel, PresenceStatus } from '$lib/render/types';
+
 import { NotificationItemKind } from '$lib/api-client/notifications';
 import { q } from '$lib/test-utils';
 
@@ -169,7 +171,7 @@ function viewerState(overrides: Record<string, unknown> = {}) {
       id: 'user-1',
       login: 'alice',
       displayName: 'Alice',
-      presenceStatus: PresenceStatus.Online,
+      presenceStatus: PresenceStatus.ONLINE,
       hasVerifiedEmail: true
     },
     canViewAdmin: false,
@@ -182,8 +184,8 @@ function viewerState(overrides: Record<string, unknown> = {}) {
     canAdminViewSystem: false,
     canAdminViewAudit: false,
     serverNotificationPreference: {
-      level: NotificationLevel.Default,
-      effectiveLevel: NotificationLevel.Normal
+      level: NotificationLevel.DEFAULT,
+      effectiveLevel: NotificationLevel.NORMAL
     },
     roomNotificationPreferences: [],
     ...overrides
@@ -331,10 +333,12 @@ describe('ServerSidebarEntry', () => {
       .toBeInTheDocument();
 
     const icon = q(container, '[data-testid="server-icon"]') as HTMLAnchorElement;
-    await expect.element(icon).toHaveAttribute(
-      'title',
-      'Loaded Remote — This server must be upgraded to Chatto 0.5 or newer before this app can connect.'
-    );
+    await expect
+      .element(icon)
+      .toHaveAttribute(
+        'title',
+        'Loaded Remote — This server must be upgraded to Chatto 0.5 or newer before this app can connect.'
+      );
     icon.dispatchEvent(
       new MouseEvent('contextmenu', {
         bubbles: true,
@@ -351,10 +355,7 @@ describe('ServerSidebarEntry', () => {
     );
     expect(document.body.textContent).toContain('Version 0.4.12');
 
-    const compatibilitySection = q(
-      document.body,
-      '[data-testid="server-compatibility-section"]'
-    );
+    const compatibilitySection = q(document.body, '[data-testid="server-compatibility-section"]');
     expect(compatibilitySection!.classList).toContain('text-sm');
     expect(compatibilitySection!.querySelector('.text-xs')).toBeNull();
     expect(compatibilitySection!.closest('.w-80')).not.toBeNull();
@@ -480,5 +481,4 @@ describe('ServerSidebarEntry', () => {
       expect(mocks.goto).toHaveBeenCalledWith('/chat/remote.example.com/room-1/thread-1');
     });
   });
-
 });

--- a/apps/frontend/src/lib/api-client-tests/attachments.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/attachments.spec.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureApiClientHooks } from '$lib/api-client/hooks';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { Timestamp } from '@bufbuild/protobuf';
-import { FitMode } from '$lib/api-client/renderTypes';
+
 import {
   Asset,
   BatchGetAssetsResponse,
@@ -117,7 +117,7 @@ describe('createAttachmentAPI', () => {
       roomId: 'room_1',
       limit: 50,
       offset: 0,
-      thumbnail: { width: 120, height: 120, fit: FitMode.Cover }
+      thumbnail: { width: 120, height: 120, fit: ImageFitMode.COVER }
     });
 
     expect(mocks.createConnectTransport).toHaveBeenCalledWith({
@@ -191,7 +191,7 @@ describe('createAttachmentAPI', () => {
     const urls = await api.refreshAssetUrls('room_1', ['att_1'], {
       width: 960,
       height: 800,
-      fit: FitMode.Contain
+      fit: ImageFitMode.CONTAIN
     });
 
     expect(mocks.batchGetAssets).toHaveBeenCalledWith(
@@ -240,7 +240,7 @@ describe('createAttachmentAPI', () => {
     const urls = await api.refreshAssetUrls('room_1', ['att_1'], {
       width: 960,
       height: 800,
-      fit: FitMode.Contain
+      fit: ImageFitMode.CONTAIN
     });
 
     expect(urls.get('att_1')?.assetUrl).toBeNull();
@@ -269,7 +269,7 @@ describe('createAttachmentAPI', () => {
     const urls = await api.refreshAssetUrls('room_1', ['att_1', 'missing'], {
       width: 120,
       height: 120,
-      fit: FitMode.Cover
+      fit: ImageFitMode.COVER
     });
 
     expect(mocks.batchGetAssets).toHaveBeenCalledWith(
@@ -320,7 +320,7 @@ describe('createAttachmentAPI', () => {
       roomId: 'room_1',
       limit: 50,
       offset: 0,
-      thumbnail: { width: 120, height: 120, fit: FitMode.Cover }
+      thumbnail: { width: 120, height: 120, fit: ImageFitMode.COVER }
     });
 
     expect(page.items[0]?.attachment.assetUrl).toBeNull();
@@ -343,7 +343,7 @@ describe('createAttachmentAPI', () => {
         roomId: 'room_1',
         limit: 50,
         offset: 0,
-        thumbnail: { width: 120, height: 120, fit: FitMode.Cover }
+        thumbnail: { width: 120, height: 120, fit: ImageFitMode.COVER }
       })
     ).rejects.toBeInstanceOf(ConnectError);
     expect(mocks.handleAuthenticationRequired).toHaveBeenCalledWith('server_1');

--- a/apps/frontend/src/lib/api-client-tests/enumDefaults.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/enumDefaults.spec.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import {
+  imageFitModeOrCover,
+  notificationLevelOrDefault,
+  presenceStatusOrOffline,
+  roomKindOrChannel
+} from '$lib/api-client/enumDefaults';
+
+describe('protobuf enum defaults', () => {
+  it('preserves supported values', () => {
+    expect(notificationLevelOrDefault(NotificationLevel.ALL_MESSAGES)).toBe(
+      NotificationLevel.ALL_MESSAGES
+    );
+    expect(presenceStatusOrOffline(PresenceStatus.AWAY)).toBe(PresenceStatus.AWAY);
+    expect(roomKindOrChannel(RoomKind.DM)).toBe(RoomKind.DM);
+    expect(imageFitModeOrCover(ImageFitMode.CONTAIN)).toBe(ImageFitMode.CONTAIN);
+  });
+
+  it('uses safe defaults for unspecified values', () => {
+    expect(notificationLevelOrDefault(NotificationLevel.UNSPECIFIED)).toBe(
+      NotificationLevel.DEFAULT
+    );
+    expect(presenceStatusOrOffline(PresenceStatus.UNSPECIFIED)).toBe(PresenceStatus.OFFLINE);
+    expect(roomKindOrChannel(RoomKind.UNSPECIFIED)).toBe(RoomKind.CHANNEL);
+    expect(imageFitModeOrCover(ImageFitMode.UNSPECIFIED)).toBe(ImageFitMode.COVER);
+  });
+
+  it('uses safe defaults for unknown future values', () => {
+    expect(notificationLevelOrDefault(99 as NotificationLevel)).toBe(NotificationLevel.DEFAULT);
+    expect(presenceStatusOrOffline(99 as PresenceStatus)).toBe(PresenceStatus.OFFLINE);
+    expect(roomKindOrChannel(99 as RoomKind)).toBe(RoomKind.CHANNEL);
+    expect(imageFitModeOrCover(99 as ImageFitMode)).toBe(ImageFitMode.COVER);
+  });
+});

--- a/apps/frontend/src/lib/api-client-tests/memberDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/memberDirectory.spec.ts
@@ -1,7 +1,8 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { Timestamp } from '@bufbuild/protobuf';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PresenceStatus } from '$lib/api-client/renderTypes';
+
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 
@@ -89,7 +90,7 @@ describe('createMemberDirectoryAPI', () => {
           displayName: 'Alice',
           deleted: false,
           avatarUrl: 'https://cdn/avatar.webp',
-          presenceStatus: PresenceStatus.Away,
+          presenceStatus: PresenceStatus.AWAY,
           customStatus: {
             emoji: ':seedling:',
             text: 'Focus',
@@ -134,15 +135,13 @@ describe('createMemberDirectoryAPI', () => {
 
     await expect(api.getUser('U1')).resolves.toMatchObject({
       id: 'U1',
-      presenceStatus: PresenceStatus.Online
+      presenceStatus: PresenceStatus.ONLINE
     });
     await expect(api.getUserByLogin('alice')).resolves.toMatchObject({
       id: 'U1',
-      presenceStatus: PresenceStatus.Online
+      presenceStatus: PresenceStatus.ONLINE
     });
-    await expect(api.batchGetUsers(['U1', 'missing'])).resolves.toMatchObject([
-      { id: 'U1' }
-    ]);
+    await expect(api.batchGetUsers(['U1', 'missing'])).resolves.toMatchObject([{ id: 'U1' }]);
 
     expect(mocks.getUser).toHaveBeenNthCalledWith(
       1,
@@ -187,7 +186,7 @@ describe('createMemberDirectoryAPI', () => {
           displayName: 'Bob',
           deleted: false,
           avatarUrl: null,
-          presenceStatus: PresenceStatus.DoNotDisturb,
+          presenceStatus: PresenceStatus.DO_NOT_DISTURB,
           customStatus: null,
           roles: [],
           createdAt: null
@@ -274,20 +273,20 @@ describe('createMemberDirectoryAPI', () => {
       users: [
         {
           user: {
-              id: 'U3',
-              login: 'carol',
-              displayName: 'Carol',
-              deleted: false,
+            id: 'U3',
+            login: 'carol',
+            displayName: 'Carol',
+            deleted: false,
             presenceStatus: APIPresenceStatus.OFFLINE
           },
           roles: []
         },
         {
           user: {
-              id: 'U4',
-              login: 'dave',
-              displayName: 'Dave',
-              deleted: false,
+            id: 'U4',
+            login: 'dave',
+            displayName: 'Dave',
+            deleted: false,
             presenceStatus: APIPresenceStatus.UNSPECIFIED
           },
           roles: []
@@ -300,8 +299,8 @@ describe('createMemberDirectoryAPI', () => {
 
     await expect(api.listUsers()).resolves.toMatchObject({
       members: [
-        { id: 'U3', presenceStatus: PresenceStatus.Offline },
-        { id: 'U4', presenceStatus: PresenceStatus.Offline }
+        { id: 'U3', presenceStatus: PresenceStatus.OFFLINE },
+        { id: 'U4', presenceStatus: PresenceStatus.OFFLINE }
       ]
     });
   });

--- a/apps/frontend/src/lib/api-client-tests/notifications.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/notifications.spec.ts
@@ -1,7 +1,8 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { Timestamp } from '@bufbuild/protobuf';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { PresenceStatus } from '$lib/api-client/renderTypes';
+
 import { createNotificationAPI, NotificationItemKind } from '$lib/api-client/notifications';
 
 const mocks = vi.hoisted(() => ({
@@ -100,7 +101,7 @@ describe('createNotificationAPI', () => {
             displayName: 'Alice',
             deleted: false,
             avatarUrl: 'https://cdn/avatar.webp',
-            presenceStatus: PresenceStatus.Offline,
+            presenceStatus: PresenceStatus.OFFLINE,
             customStatus: null
           },
           summary: 'Alice mentioned you',
@@ -157,5 +158,4 @@ describe('createNotificationAPI', () => {
       { headers: undefined }
     );
   });
-
 });

--- a/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
@@ -1,8 +1,9 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { Code, ConnectError } from '@connectrpc/connect';
 import { Timestamp } from '@bufbuild/protobuf';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureApiClientHooks } from '$lib/api-client/hooks';
-import { PresenceStatus } from '$lib/api-client/renderTypes';
+
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { createRoomCommandAPI } from '$lib/api-client/rooms';
 
@@ -206,7 +207,7 @@ describe('createRoomCommandAPI', () => {
       id: 'user-1',
       login: 'alice',
       displayName: 'Alice',
-      presenceStatus: PresenceStatus.Online
+      presenceStatus: PresenceStatus.ONLINE
     });
     await expect(api.removeMember({ roomId: 'room-1', userId: 'user-1' })).resolves.toBe(true);
     await expect(api.joinGroup('group-1')).resolves.toEqual(['room-1', 'room-2']);
@@ -354,7 +355,7 @@ describe('createRoomCommandAPI', () => {
             displayName: 'Alice',
             deleted: false,
             avatarUrl: 'https://cdn/avatar.webp',
-            presenceStatus: PresenceStatus.Away,
+            presenceStatus: PresenceStatus.AWAY,
             customStatus: null,
             roles: [],
             createdAt: '2026-01-01T09:00:00.000Z'
@@ -366,7 +367,7 @@ describe('createRoomCommandAPI', () => {
             displayName: 'Moderator',
             deleted: false,
             avatarUrl: null,
-            presenceStatus: PresenceStatus.Offline,
+            presenceStatus: PresenceStatus.OFFLINE,
             customStatus: null,
             roles: [],
             createdAt: null

--- a/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
@@ -1,9 +1,11 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { Timestamp } from '@bufbuild/protobuf';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotificationLevel as APINotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
-import { NotificationLevel, PresenceStatus } from '$lib/api-client/renderTypes';
+
 import { getCurrentUserViaConnect, getViewerStateViaConnect } from '$lib/api-client/viewer';
 
 const mocks = vi.hoisted(() => ({
@@ -83,7 +85,7 @@ describe('getCurrentUserViaConnect', () => {
         text: 'here',
         expiresAt: '2026-06-01T12:00:00.000Z'
       },
-      presenceStatus: PresenceStatus.Away,
+      presenceStatus: PresenceStatus.AWAY,
       hasVerifiedEmail: true,
       hasPassword: true,
       viewerCanDeleteAccount: true,
@@ -116,7 +118,7 @@ describe('getCurrentUserViaConnect', () => {
     });
 
     expect(mocks.getViewer).toHaveBeenCalledWith({}, { headers: undefined });
-    expect(user.presenceStatus).toBe(PresenceStatus.Offline);
+    expect(user.presenceStatus).toBe(PresenceStatus.OFFLINE);
     expect(user.settings?.timeFormat).toBe(TimeFormat.TIME_FORMAT_AUTO);
     expect(user.customStatus).toBeNull();
     expect(user.hasPassword).toBe(false);
@@ -189,19 +191,19 @@ describe('getCurrentUserViaConnect', () => {
         canAdminViewAudit: true,
         canManageUserPermissions: true,
         serverNotificationPreference: {
-          level: NotificationLevel.AllMessages,
-          effectiveLevel: NotificationLevel.AllMessages
+          level: NotificationLevel.ALL_MESSAGES,
+          effectiveLevel: NotificationLevel.ALL_MESSAGES
         },
         roomNotificationPreferences: [
           {
             roomId: 'room-1',
-            level: NotificationLevel.Muted,
-            effectiveLevel: NotificationLevel.Muted
+            level: NotificationLevel.MUTED,
+            effectiveLevel: NotificationLevel.MUTED
           },
           {
             roomId: 'room-2',
-            level: NotificationLevel.Default,
-            effectiveLevel: NotificationLevel.Normal
+            level: NotificationLevel.DEFAULT,
+            effectiveLevel: NotificationLevel.NORMAL
           }
         ]
       })

--- a/apps/frontend/src/lib/api-client/attachments.ts
+++ b/apps/frontend/src/lib/api-client/attachments.ts
@@ -1,7 +1,7 @@
 import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
-import { FitMode } from './renderTypes.js';
 import type { ExpiringAssetUrl, RefreshedAttachmentUrls } from './attachmentUrls.js';
 import { ImageFitMode, ImageTransformOptions } from '@chatto/api-types/api/v1/common_pb';
+import { imageFitModeOrCover } from './enumDefaults.js';
 import { AssetService } from '@chatto/api-types/api/v1/attachments_connect';
 import type { Asset } from '@chatto/api-types/api/v1/attachments_pb';
 import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
@@ -23,7 +23,7 @@ export type AttachmentAPIConfig = {
 export type AttachmentRefreshOptions = {
   width: number;
   height: number;
-  fit: FitMode;
+  fit: ImageFitMode;
 };
 
 export type RoomFileItem = {
@@ -146,7 +146,7 @@ function thumbnailOptions(options: AttachmentRefreshOptions): ImageTransformOpti
   return new ImageTransformOptions({
     width: options.width,
     height: options.height,
-    fit: options.fit === FitMode.Contain ? ImageFitMode.CONTAIN : ImageFitMode.COVER
+    fit: imageFitModeOrCover(options.fit)
   });
 }
 

--- a/apps/frontend/src/lib/api-client/enumDefaults.ts
+++ b/apps/frontend/src/lib/api-client/enumDefaults.ts
@@ -1,0 +1,44 @@
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+
+/** Preserve the frontend's default when a notification level is absent or unknown. */
+export function notificationLevelOrDefault(
+  level: NotificationLevel | undefined
+): NotificationLevel {
+  switch (level) {
+    case NotificationLevel.MUTED:
+    case NotificationLevel.NORMAL:
+    case NotificationLevel.ALL_MESSAGES:
+    case NotificationLevel.DEFAULT:
+      return level;
+    case NotificationLevel.UNSPECIFIED:
+    default:
+      return NotificationLevel.DEFAULT;
+  }
+}
+
+/** Treat absent or unknown presence values as offline instead of implying availability. */
+export function presenceStatusOrOffline(status: PresenceStatus): PresenceStatus {
+  switch (status) {
+    case PresenceStatus.AWAY:
+    case PresenceStatus.DO_NOT_DISTURB:
+    case PresenceStatus.ONLINE:
+    case PresenceStatus.OFFLINE:
+      return status;
+    case PresenceStatus.UNSPECIFIED:
+    default:
+      return PresenceStatus.OFFLINE;
+  }
+}
+
+/** Keep unspecified or unknown room kinds on the non-DM path. */
+export function roomKindOrChannel(kind: RoomKind): RoomKind {
+  return kind === RoomKind.DM ? RoomKind.DM : RoomKind.CHANNEL;
+}
+
+/** Preserve the historical cover fallback for unsupported image-fit values. */
+export function imageFitModeOrCover(fit: ImageFitMode): ImageFitMode {
+  return fit === ImageFitMode.CONTAIN ? ImageFitMode.CONTAIN : ImageFitMode.COVER;
+}

--- a/apps/frontend/src/lib/api-client/events.ts
+++ b/apps/frontend/src/lib/api-client/events.ts
@@ -1,5 +1,4 @@
-import type { RoomEventView } from "./renderTypes.js";
-
+import type { RoomEventView } from './renderTypes.js';
 export type RawEvent = RoomEventView;
 
 export type EventConnectionPage = {

--- a/apps/frontend/src/lib/api-client/linkPreviews.ts
+++ b/apps/frontend/src/lib/api-client/linkPreviews.ts
@@ -2,7 +2,6 @@ import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
 import { MessageService } from '@chatto/api-types/api/v1/messages_connect';
 import type { LinkPreview } from '@chatto/api-types/api/v1/link_previews_pb';
 import type { SocialPostPreviewView } from './renderTypes.js';
-
 export type LinkPreviewAPIConfig = {
   serverId?: string;
   baseUrl: string;

--- a/apps/frontend/src/lib/api-client/memberDirectory.ts
+++ b/apps/frontend/src/lib/api-client/memberDirectory.ts
@@ -8,8 +8,10 @@ import {
 import { UserService } from "@chatto/api-types/api/v1/member_directory_connect";
 import { RoomService } from "@chatto/api-types/api/v1/rooms_connect";
 import type { DirectoryMember as APIDirectoryMember } from "@chatto/api-types/api/v1/member_directory_pb";
-import { PresenceStatus as APIPresenceStatus } from "@chatto/api-types/api/v1/presence_pb";
-import { PresenceStatus } from "./renderTypes.js";
+import { PresenceStatus } from "@chatto/api-types/api/v1/presence_pb";
+import { presenceStatusOrOffline } from "./enumDefaults.js";
+
+export { presenceStatusOrOffline as apiPresenceStatus } from "./enumDefaults.js";
 
 export type MemberDirectoryAPIConfig = ConnectAPIConfig;
 
@@ -155,8 +157,8 @@ export function mapDirectoryMember(
     displayName: user?.displayName ?? "",
     deleted: user?.deleted ?? false,
     avatarUrl: user?.avatarUrl ?? null,
-    presenceStatus: apiPresenceStatus(
-      user?.presenceStatus ?? APIPresenceStatus.UNSPECIFIED,
+    presenceStatus: presenceStatusOrOffline(
+      user?.presenceStatus ?? PresenceStatus.UNSPECIFIED,
     ),
     customStatus: user?.customStatus
       ? {
@@ -169,19 +171,4 @@ export function mapDirectoryMember(
     roles: [...member.roles],
     createdAt: member.createdAt?.toDate().toISOString() ?? null,
   };
-}
-
-export function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
-  switch (status) {
-    case APIPresenceStatus.AWAY:
-      return PresenceStatus.Away;
-    case APIPresenceStatus.DO_NOT_DISTURB:
-      return PresenceStatus.DoNotDisturb;
-    case APIPresenceStatus.ONLINE:
-      return PresenceStatus.Online;
-    case APIPresenceStatus.OFFLINE:
-    case APIPresenceStatus.UNSPECIFIED:
-    default:
-      return PresenceStatus.Offline;
-  }
 }

--- a/apps/frontend/src/lib/api-client/notifications.ts
+++ b/apps/frontend/src/lib/api-client/notifications.ts
@@ -1,3 +1,4 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { authHeaders, createChattoClient } from './connect.js';
 import { NotificationService } from '@chatto/api-types/api/v1/notifications_connect';
 import type {
@@ -6,9 +7,7 @@ import type {
   NotificationItem as APINotificationItem
 } from '@chatto/api-types/api/v1/notifications_pb';
 import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
-import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { PresenceStatus } from './renderTypes.js';
-
+import { presenceStatusOrOffline } from './enumDefaults.js';
 export type NotificationAPIConfig = {
   baseUrl: string;
   bearerToken: string | null;
@@ -224,7 +223,7 @@ function notificationActor(actor: APIUser | undefined): NotificationActor | null
     displayName: actor.displayName,
     deleted: actor.deleted,
     avatarUrl: actor.avatarUrl ?? null,
-    presenceStatus: apiPresenceStatus(actor.presenceStatus),
+    presenceStatus: presenceStatusOrOffline(actor.presenceStatus),
     customStatus: actor.customStatus
       ? {
           emoji: actor.customStatus.emoji,
@@ -233,19 +232,4 @@ function notificationActor(actor: APIUser | undefined): NotificationActor | null
         }
       : null
   };
-}
-
-function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
-  switch (status) {
-    case APIPresenceStatus.AWAY:
-      return PresenceStatus.Away;
-    case APIPresenceStatus.DO_NOT_DISTURB:
-      return PresenceStatus.DoNotDisturb;
-    case APIPresenceStatus.ONLINE:
-      return PresenceStatus.Online;
-    case APIPresenceStatus.OFFLINE:
-    case APIPresenceStatus.UNSPECIFIED:
-    default:
-      return PresenceStatus.Offline;
-  }
 }

--- a/apps/frontend/src/lib/api-client/renderTypes.ts
+++ b/apps/frontend/src/lib/api-client/renderTypes.ts
@@ -4,31 +4,7 @@
  *
  * This file is hand-owned. Do not regenerate it from the retired legacy schema.
  */
-
-export enum FitMode {
-  Contain = 'CONTAIN',
-  Cover = 'COVER',
-  Exact = 'EXACT'
-}
-
-export enum NotificationLevel {
-  AllMessages = 'ALL_MESSAGES',
-  Default = 'DEFAULT',
-  Muted = 'MUTED',
-  Normal = 'NORMAL'
-}
-
-export enum PresenceStatus {
-  Away = 'AWAY',
-  DoNotDisturb = 'DO_NOT_DISTURB',
-  Offline = 'OFFLINE',
-  Online = 'ONLINE'
-}
-
-export enum RoomType {
-  Channel = 'CHANNEL',
-  Dm = 'DM'
-}
+import type { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 
 export enum VideoProcessingStatus {
   Completed = 'COMPLETED',

--- a/apps/frontend/src/lib/api-client/roomTimeline.ts
+++ b/apps/frontend/src/lib/api-client/roomTimeline.ts
@@ -1,8 +1,9 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { notifyUserSummaries } from './hooks.js';
 import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
 import type { RawEvent, EventConnectionPage, UserSummaryForCache } from './events.js';
 import { RoomEventKind } from './eventKinds.js';
-import { PresenceStatus, type RoomEventView, type SocialPostPreviewView } from './renderTypes.js';
+import { type RoomEventView, type SocialPostPreviewView } from './renderTypes.js';
 import { MessageService } from '@chatto/api-types/api/v1/messages_connect';
 import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
 import { ThreadService } from '@chatto/api-types/api/v1/threads_connect';
@@ -364,7 +365,7 @@ function userView(userId: string, users: Record<string, User>) {
       displayName: 'Deleted User',
       deleted: true,
       avatarUrl: null,
-      presenceStatus: PresenceStatus.Offline
+      presenceStatus: PresenceStatus.OFFLINE
     };
   }
   return {
@@ -373,7 +374,7 @@ function userView(userId: string, users: Record<string, User>) {
     displayName: user.displayName,
     deleted: user.deleted,
     avatarUrl: user.avatarUrl || null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -1,9 +1,9 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { authHeaders, createChattoClient } from './connect.js';
 import { ViewerService } from '@chatto/api-types/api/v1/viewer_connect';
-import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { NotificationLevel as APINotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { TimeFormat, type GetViewerResponse } from '@chatto/api-types/api/v1/viewer_pb';
-import { NotificationLevel, PresenceStatus } from './renderTypes.js';
+import { notificationLevelOrDefault, presenceStatusOrOffline } from './enumDefaults.js';
 import { timeFormatOrAuto } from './timeFormat.js';
 
 export type ViewerAPIConfig = {
@@ -112,7 +112,7 @@ export function viewerResponseToState(response: GetViewerResponse): ViewerState 
             expiresAt: user.customStatus.expiresAt?.toDate().toISOString() ?? null
           }
         : null,
-      presenceStatus: apiPresenceStatus(user.presenceStatus),
+      presenceStatus: presenceStatusOrOffline(user.presenceStatus),
       hasVerifiedEmail: response.user.hasVerifiedEmail,
       hasPassword: response.user.hasPassword ?? false,
       viewerCanDeleteAccount: response.user.viewerCanDeleteAccount ?? false,
@@ -137,8 +137,10 @@ export function viewerResponseToState(response: GetViewerResponse): ViewerState 
     viewerPermissions,
     viewerHasUnreadRooms: response.viewerState?.hasUnreadRooms ?? false,
     serverNotificationPreference: {
-      level: apiNotificationLevel(response.serverNotificationPreference?.level),
-      effectiveLevel: apiNotificationLevel(response.serverNotificationPreference?.effectiveLevel)
+      level: notificationLevelOrDefault(response.serverNotificationPreference?.level),
+      effectiveLevel: notificationLevelOrDefault(
+        response.serverNotificationPreference?.effectiveLevel
+      )
     },
     roomNotificationPreferences: response.roomNotificationPreferences.map(
       roomNotificationPreference
@@ -165,8 +167,8 @@ export async function getCurrentUserViaConnect(config: ViewerAPIConfig): Promise
 function roomNotificationPreference(pref: {
   roomId: string;
   preference?: {
-    level: APINotificationLevel;
-    effectiveLevel: APINotificationLevel;
+    level: NotificationLevel;
+    effectiveLevel: NotificationLevel;
   };
 }): RoomNotificationPreference {
   if (!pref.preference) {
@@ -174,37 +176,7 @@ function roomNotificationPreference(pref: {
   }
   return {
     roomId: pref.roomId,
-    level: apiNotificationLevel(pref.preference.level),
-    effectiveLevel: apiNotificationLevel(pref.preference.effectiveLevel)
+    level: notificationLevelOrDefault(pref.preference.level),
+    effectiveLevel: notificationLevelOrDefault(pref.preference.effectiveLevel)
   };
-}
-
-function apiNotificationLevel(level: APINotificationLevel | undefined): NotificationLevel {
-  switch (level) {
-    case APINotificationLevel.MUTED:
-      return NotificationLevel.Muted;
-    case APINotificationLevel.NORMAL:
-      return NotificationLevel.Normal;
-    case APINotificationLevel.ALL_MESSAGES:
-      return NotificationLevel.AllMessages;
-    case APINotificationLevel.DEFAULT:
-    case APINotificationLevel.UNSPECIFIED:
-    default:
-      return NotificationLevel.Default;
-  }
-}
-
-function apiPresenceStatus(status: APIPresenceStatus): PresenceStatus {
-  switch (status) {
-    case APIPresenceStatus.AWAY:
-      return PresenceStatus.Away;
-    case APIPresenceStatus.DO_NOT_DISTURB:
-      return PresenceStatus.DoNotDisturb;
-    case APIPresenceStatus.ONLINE:
-      return PresenceStatus.Online;
-    case APIPresenceStatus.OFFLINE:
-    case APIPresenceStatus.UNSPECIFIED:
-    default:
-      return PresenceStatus.Offline;
-  }
 }

--- a/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
@@ -1,5 +1,6 @@
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { describe, expect, it, vi } from 'vitest';
-import { FitMode } from '$lib/render/types';
+
 import type { AttachmentAPI } from '$lib/api-client/attachments';
 import {
   ASSET_URL_REFRESH_LEAD_MS,
@@ -69,7 +70,7 @@ describe('refreshAttachmentUrlsForAssets', () => {
     expect(refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1', 'att_2'], {
       width: 960,
       height: 400,
-      fit: FitMode.Contain
+      fit: ImageFitMode.CONTAIN
     });
     expect(urls.get('att_1')?.assetUrl?.url).toBe('https://cdn.example.com/fresh-1.jpg');
     expect(urls.get('att_1')?.videoThumbnailAssetUrl?.url).toBe(
@@ -87,13 +88,13 @@ describe('refreshAttachmentUrlsForAssets', () => {
     await refreshAttachmentUrlsForAssets(apiWithRefresh(refreshAssetUrls), 'room_1', ['att_1'], {
       width: 120,
       height: 120,
-      fit: FitMode.Cover
+      fit: ImageFitMode.COVER
     });
 
     expect(refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1'], {
       width: 120,
       height: 120,
-      fit: FitMode.Cover
+      fit: ImageFitMode.COVER
     });
   });
 

--- a/apps/frontend/src/lib/attachments/attachmentUrls.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.ts
@@ -1,4 +1,5 @@
-import { FitMode } from '$lib/render/types';
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
+
 import type { AttachmentAPI } from '$lib/api-client/attachments';
 
 export type ExpiringAssetUrl = {
@@ -17,19 +18,19 @@ export type RefreshedAttachmentUrls = {
 export type AttachmentThumbnailRefreshOptions = {
   width: number;
   height: number;
-  fit: FitMode;
+  fit: ImageFitMode;
 };
 
 export const DEFAULT_ATTACHMENT_THUMBNAIL_REFRESH: AttachmentThumbnailRefreshOptions = {
   width: 960,
   height: 400,
-  fit: FitMode.Contain
+  fit: ImageFitMode.CONTAIN
 };
 
 export const LIGHTBOX_ATTACHMENT_IMAGE_REFRESH: AttachmentThumbnailRefreshOptions = {
   width: 2048,
   height: 2048,
-  fit: FitMode.Contain
+  fit: ImageFitMode.CONTAIN
 };
 
 export const ASSET_URL_REFRESH_LEAD_MS = 2 * 60_000;

--- a/apps/frontend/src/lib/auth/currentUser.spec.ts
+++ b/apps/frontend/src/lib/auth/currentUser.spec.ts
@@ -1,6 +1,6 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { CurrentUserState } from './currentUser.svelte';
-import { PresenceStatus } from '$lib/render/types';
 
 const { clearCachedUserMock } = vi.hoisted(() => ({
   clearCachedUserMock: vi.fn()
@@ -63,7 +63,7 @@ describe('CurrentUserState', () => {
       login: 'alice',
       displayName: 'Alice',
       avatarUrl: null,
-      presenceStatus: PresenceStatus.Online,
+      presenceStatus: PresenceStatus.ONLINE,
       hasVerifiedEmail: true,
       viewerCanDeleteAccount: false,
       hasPassword: true,

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -6,6 +6,8 @@ sidebar. Shows the avatar with presence and the live display name, and links
 to the user settings page for the active server.
 -->
 <script lang="ts">
+  import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { resolve } from '$app/paths';
   import { goto } from '$app/navigation';
   import { serverIdToSegment } from '$lib/navigation';
@@ -16,7 +18,7 @@ to the user settings page for the active server.
   import { getLiveDisplayName, type CustomUserStatus } from '$lib/state/userProfiles.svelte';
   import { setPresenceMode } from '$lib/presenceTracking';
   import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
-  import { PresenceStatus, RoomType } from '$lib/render/types';
+
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import {
     roomSidebarPanelStorageSuffix,
@@ -62,7 +64,7 @@ to the user settings page for the active server.
   const activeCallRoomName = $derived.by(() => {
     const room = activeCallRoom;
     if (!room) return m['common.current_call']();
-    if (room.type === RoomType.Dm) {
+    if (room.type === RoomKind.DM) {
       const meId = roomsStore?.currentUserId;
       const others = room.members.filter((member) => member.id !== meId);
       if (others.length === 0) return m['common.you']();
@@ -78,7 +80,7 @@ to the user settings page for the active server.
   const useSheetDialog = prefersTouchActions() && !supportsHoverActions();
   const presenceModes: PresenceMode[] = ['auto', 'away', 'doNotDisturb', 'invisible'];
   const currentPresence = $derived.by(() => {
-    if (!activeServerUser) return PresenceStatus.Offline;
+    if (!activeServerUser) return PresenceStatus.OFFLINE;
     return presenceCache.get(
       { serverId: activeServerId, userId: activeServerUser.id },
       activeServerUser.presenceStatus
@@ -117,11 +119,11 @@ to the user settings page for the active server.
 
   function presenceStatusLabel(status: PresenceStatus): string {
     switch (status) {
-      case PresenceStatus.Away:
+      case PresenceStatus.AWAY:
         return m['settings.profile.presence.away']();
-      case PresenceStatus.DoNotDisturb:
+      case PresenceStatus.DO_NOT_DISTURB:
         return m['settings.profile.presence.do_not_disturb']();
-      case PresenceStatus.Offline:
+      case PresenceStatus.OFFLINE:
         return m['settings.profile.presence.offline']();
       default:
         return m['settings.profile.presence.auto']();

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -1,8 +1,10 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import '../../app.css';
 import { q } from '$lib/test-utils';
-import { PresenceStatus } from '$lib/render/types';
+
 import { presencePreference } from '$lib/state/presencePreference.svelte';
 import {
   consumePendingRoomSidebarPanel,
@@ -32,7 +34,7 @@ type MockRoomMember = {
 type MockRoom = {
   id: string;
   name: string;
-  type: 'CHANNEL' | 'DM';
+  type: RoomKind;
   members: MockRoomMember[];
 };
 
@@ -73,7 +75,8 @@ const { currentUserState, voiceCallState, roomsState } = vi.hoisted(() => ({
       {
         id: 'room-1',
         name: 'general',
-        type: 'CHANNEL',
+        // RoomKind.CHANNEL; vi.hoisted cannot reference module imports.
+        type: 1 as RoomKind,
         members: []
       }
     ] as MockRoom[]
@@ -126,13 +129,13 @@ describe('CurrentUserBar', () => {
       login: 'alice',
       displayName: 'Alice',
       avatarUrl: null,
-      presenceStatus: PresenceStatus.Offline,
+      presenceStatus: PresenceStatus.OFFLINE,
       customStatus: null,
       hasVerifiedEmail: true,
       settings: null
     };
     presencePreference.mode = 'auto';
-    presencePreference.effectiveStatus = PresenceStatus.Online;
+    presencePreference.effectiveStatus = PresenceStatus.ONLINE;
     voiceCallState.connected = false;
     voiceCallState.roomId = null;
     voiceCallState.isMuted = false;
@@ -151,7 +154,7 @@ describe('CurrentUserBar', () => {
       {
         id: 'room-1',
         name: 'general',
-        type: 'CHANNEL',
+        type: RoomKind.CHANNEL,
         members: []
       }
     ];
@@ -172,7 +175,7 @@ describe('CurrentUserBar', () => {
   });
 
   it('uses the presence cache instead of local presence preference for the current user dot', () => {
-    presencePreference.effectiveStatus = PresenceStatus.Away;
+    presencePreference.effectiveStatus = PresenceStatus.AWAY;
 
     const { container } = render(CurrentUserBarTestHarness);
 
@@ -186,10 +189,10 @@ describe('CurrentUserBar', () => {
   });
 
   it('renders the current user dot from the seeded away presence cache value', () => {
-    presencePreference.effectiveStatus = PresenceStatus.Online;
+    presencePreference.effectiveStatus = PresenceStatus.ONLINE;
 
     const { container } = render(CurrentUserBarTestHarness, {
-      cachedPresence: PresenceStatus.Away
+      cachedPresence: PresenceStatus.AWAY
     });
 
     expect(q(container, '[aria-label="Presence: Away"]')).toBeTruthy();
@@ -444,8 +447,9 @@ describe('CurrentUserBar', () => {
     const identityCard = q(container, '[data-testid="current-user-identity-card"]')!;
     const callCardRect = callCard.getBoundingClientRect();
     const identityCardRect = identityCard.getBoundingClientRect();
-    const controlWidths = Array.from(callCard.children, (control) =>
-      control.getBoundingClientRect().width
+    const controlWidths = Array.from(
+      callCard.children,
+      (control) => control.getBoundingClientRect().width
     );
 
     expect(callCardRect.left).toBe(identityCardRect.left);
@@ -505,21 +509,21 @@ describe('CurrentUserBar', () => {
       {
         id: 'dm-1',
         name: 'dm-1',
-        type: 'DM',
+        type: RoomKind.DM,
         members: [
           {
             id: 'user-1',
             login: 'alice',
             displayName: 'Alice',
             avatarUrl: null,
-            presenceStatus: PresenceStatus.Online
+            presenceStatus: PresenceStatus.ONLINE
           },
           {
             id: 'user-2',
             login: 'bob',
             displayName: 'Bob',
             avatarUrl: null,
-            presenceStatus: PresenceStatus.Online
+            presenceStatus: PresenceStatus.ONLINE
           }
         ]
       }

--- a/apps/frontend/src/lib/components/CurrentUserBarTestHarness.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBarTestHarness.svelte
@@ -5,11 +5,12 @@ Test-only wrapper for `CurrentUserBar`. Creates the presence-cache context
 before the bar mounts so specs can exercise first-login presence fallbacks.
 -->
 <script lang="ts">
-  import { PresenceStatus } from '$lib/render/types';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import CurrentUserBar from './CurrentUserBar.svelte';
 
-  let { cachedPresence = PresenceStatus.Online }: { cachedPresence?: PresenceStatus } = $props();
+  let { cachedPresence = PresenceStatus.ONLINE }: { cachedPresence?: PresenceStatus } = $props();
 
   const presenceCache = createPresenceCache();
   // svelte-ignore state_referenced_locally

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -4,7 +4,8 @@ import { render } from 'vitest-browser-svelte';
 import '../../app.css';
 import { q } from '$lib/test-utils';
 import type { RoomMember } from '$lib/mentions';
-import { PresenceStatus } from '$lib/render/types';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
 import type { TimeFormatSettings } from '$lib/utils/formatTime';
 
 const mocks = vi.hoisted(() => ({
@@ -77,7 +78,7 @@ function member(login: string): RoomMember {
     login,
     displayName: login,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -12,10 +12,11 @@ unknown instance) the component renders nothing.
 - `showDismiss` — Whether to show the dismiss button (default: true).
 -->
 <script lang="ts">
+  import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import type { MessageLink } from '$lib/messageLinks';
-  import { FitMode, type MessageAttachmentView, type UserAvatarUserView } from '$lib/render/types';
+  import { type MessageAttachmentView, type UserAvatarUserView } from '$lib/render/types';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { serverIdToSegment } from '$lib/navigation';
   import * as m from '$lib/i18n/messages';
@@ -75,7 +76,7 @@ unknown instance) the component renders nothing.
   const PREVIEW_THUMBNAIL_REFRESH = {
     width: 120,
     height: 120,
-    fit: FitMode.Cover
+    fit: ImageFitMode.COVER
   };
 
   function connectBaseUrl(serverUrl: string): string {

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -1,18 +1,17 @@
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import MessagePreviewCard from './MessagePreviewCard.svelte';
 import type { MessageLink } from '$lib/messageLinks';
-import { FitMode } from '$lib/render/types';
+
 import { RoomEventKind } from '$lib/render/eventKinds';
 import type { RefreshedAttachmentUrls } from '$lib/attachments/attachmentUrls';
 
-const { getRoomEventsAroundMock, timelineResults, refreshAssetUrlsMock } = vi.hoisted(
-  () => ({
-    getRoomEventsAroundMock: vi.fn(),
-    timelineResults: [] as unknown[],
-    refreshAssetUrlsMock: vi.fn()
-  })
-);
+const { getRoomEventsAroundMock, timelineResults, refreshAssetUrlsMock } = vi.hoisted(() => ({
+  getRoomEventsAroundMock: vi.fn(),
+  timelineResults: [] as unknown[],
+  refreshAssetUrlsMock: vi.fn()
+}));
 
 function testImageUrl(label: string): string {
   return `/icons/favicon.png?label=${label}`;
@@ -260,7 +259,7 @@ describe('MessagePreviewCard', () => {
     expect(refreshAssetUrlsMock).toHaveBeenCalledWith('room_1', ['att_1'], {
       width: 120,
       height: 120,
-      fit: FitMode.Cover
+      fit: ImageFitMode.COVER
     });
   });
 

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { untrack } from 'svelte';
@@ -11,7 +12,7 @@
   import { getGradientForName } from '$lib/utils/gradients';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
-  import { RoomType } from '$lib/render/types';
+
   import { isNavigationVisibleRoom } from '$lib/state/server/rooms.svelte';
   import * as m from '$lib/i18n/messages';
   import { toast } from '$lib/ui/toast';
@@ -81,7 +82,7 @@
       });
 
       for (const room of store?.rooms.rooms ?? []) {
-        if (room.type === RoomType.Dm) {
+        if (room.type === RoomKind.DM) {
           if (!isNavigationVisibleRoom(room)) continue;
           const participants = room.members.map(avatarUser);
           items.push({

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -1,8 +1,9 @@
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import { q } from '$lib/test-utils';
-import { RoomType } from '$lib/render/types';
+
 import { quickSwitcher } from '$lib/state/globals.svelte';
 
 const mocks = vi.hoisted(() => ({
@@ -44,7 +45,7 @@ const mocks = vi.hoisted(() => ({
       rooms: [] as Array<{
         id: string;
         name: string;
-        type: RoomType;
+        type: RoomKind;
         viewerIsMember: boolean;
         hasMessageHistory?: boolean | null;
         members: User[];
@@ -166,28 +167,28 @@ function installQueryMocks() {
     {
       id: 'room-general',
       name: 'general',
-      type: RoomType.Channel,
+      type: RoomKind.CHANNEL,
       viewerIsMember: true,
       members: []
     },
     {
       id: 'room-xylophone',
       name: 'xylophone-chat',
-      type: RoomType.Channel,
+      type: RoomKind.CHANNEL,
       viewerIsMember: true,
       members: []
     },
     {
       id: 'dm-existing',
       name: '',
-      type: RoomType.Dm,
+      type: RoomKind.DM,
       viewerIsMember: true,
       members: [currentUser, teammate]
     },
     {
       id: 'dm-empty',
       name: '',
-      type: RoomType.Dm,
+      type: RoomKind.DM,
       viewerIsMember: true,
       hasMessageHistory: false,
       members: [currentUser, user('user-empty', 'empty', 'Empty Conversation')]

--- a/apps/frontend/src/lib/components/UserAvatar.stories.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.stories.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { defineMeta } from '@storybook/addon-svelte-csf';
-  import { PresenceStatus, type UserAvatarUserView } from '$lib/render/types';
+  import { type UserAvatarUserView } from '$lib/render/types';
   import UserAvatar from './UserAvatar.svelte';
 
   const { Story } = defineMeta({
@@ -32,10 +33,10 @@
     };
   }
 
-  const onlineUser = user('online', 'Online User', PresenceStatus.Online);
-  const awayUser = user('away', 'Away User', PresenceStatus.Away);
-  const dndUser = user('dnd', 'DND User', PresenceStatus.DoNotDisturb);
-  const offlineUser = user('offline', 'Offline User', PresenceStatus.Offline);
+  const onlineUser = user('online', 'Online User', PresenceStatus.ONLINE);
+  const awayUser = user('away', 'Away User', PresenceStatus.AWAY);
+  const dndUser = user('dnd', 'DND User', PresenceStatus.DO_NOT_DISTURB);
+  const offlineUser = user('offline', 'Offline User', PresenceStatus.OFFLINE);
 </script>
 
 <script lang="ts">

--- a/apps/frontend/src/lib/components/UserAvatar.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { PresenceStatus, type UserAvatarUserView } from '$lib/render/types';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+  import { type UserAvatarUserView } from '$lib/render/types';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { getLiveAvatarUrl, getLiveCustomStatus } from '$lib/state/userProfiles.svelte';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
@@ -29,10 +30,11 @@
   };
 
   const presenceDotColorClasses: Record<PresenceStatus, string> = {
-    [PresenceStatus.Online]: 'bg-presence-online',
-    [PresenceStatus.Away]: 'bg-presence-away',
-    [PresenceStatus.DoNotDisturb]: 'bg-presence-do-not-disturb',
-    [PresenceStatus.Offline]: 'bg-presence-offline'
+    [PresenceStatus.UNSPECIFIED]: 'bg-presence-offline',
+    [PresenceStatus.ONLINE]: 'bg-presence-online',
+    [PresenceStatus.AWAY]: 'bg-presence-away',
+    [PresenceStatus.DO_NOT_DISTURB]: 'bg-presence-do-not-disturb',
+    [PresenceStatus.OFFLINE]: 'bg-presence-offline'
   };
 
   const presenceDotSizeClasses: Record<Size, string> = {
@@ -118,11 +120,11 @@
   );
 
   const presenceLabel = $derived(
-    presence === 'ONLINE'
+    presence === PresenceStatus.ONLINE
       ? 'Online'
-      : presence === 'AWAY'
+      : presence === PresenceStatus.AWAY
         ? 'Away'
-        : presence === 'DO_NOT_DISTURB'
+        : presence === PresenceStatus.DO_NOT_DISTURB
           ? 'Do not disturb'
           : 'Offline'
   );

--- a/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
@@ -1,7 +1,8 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import '../../app.css';
-import { PresenceStatus } from '$lib/render/types';
+
 import { q } from '$lib/test-utils';
 import UserAvatarTestHarness from './UserAvatarTestHarness.svelte';
 
@@ -59,7 +60,7 @@ describe('UserAvatar', () => {
     const { container } = render(UserAvatarTestHarness, {
       size: 'md',
       showPresence: true,
-      presenceStatus: PresenceStatus.Away
+      presenceStatus: PresenceStatus.AWAY
     });
     const presenceDot = q(container, '[aria-label="Away"] span')!;
     const yellow500 = window

--- a/apps/frontend/src/lib/components/UserAvatarTestHarness.svelte
+++ b/apps/frontend/src/lib/components/UserAvatarTestHarness.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { PresenceStatus, type UserAvatarUserView } from '$lib/render/types';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+  import { type UserAvatarUserView } from '$lib/render/types';
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
   import UserAvatar from './UserAvatar.svelte';
@@ -10,7 +11,7 @@
     size = 'md',
     showPresence = false,
     showStatus = false,
-    presenceStatus = PresenceStatus.Online
+    presenceStatus = PresenceStatus.ONLINE
   }: {
     size?: Size;
     showPresence?: boolean;

--- a/apps/frontend/src/lib/components/composer/MentionAutocomplete.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MentionAutocomplete.svelte.spec.ts
@@ -1,9 +1,9 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import MentionAutocomplete from './MentionAutocomplete.svelte';
 import type { RoomMember } from '$lib/state/room';
-import { PresenceStatus } from '$lib/render/types';
 
 function member(login: string, displayName?: string, deleted = false): RoomMember {
   return {
@@ -12,7 +12,7 @@ function member(login: string, displayName?: string, deleted = false): RoomMembe
     displayName: displayName ?? login,
     deleted,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -6,7 +6,8 @@ import MessageComposer, { type MessageComposerApi } from './MessageComposer.svel
 import { q } from '$lib/test-utils';
 import { getToasts, toast } from '$lib/ui/toast';
 import type { QuoteInsertionContent, RoomMember } from '$lib/state/room';
-import { PresenceStatus } from '$lib/render/types';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
 import { RoomEventKind } from '$lib/render/eventKinds';
 import { renderMarkdown } from '$lib/markdown';
 import type { CreateMessageInput } from '$lib/api-client/messages';
@@ -219,7 +220,7 @@ function roomMember(login: string, displayName = login): RoomMember {
     login,
     displayName,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/autocomplete.svelte.spec.ts
@@ -1,5 +1,6 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, it, expect } from 'vitest';
-import { PresenceStatus } from '$lib/render/types';
+
 import type { RoomMember } from '$lib/state/room';
 import type { TipTapEditorApi } from './TipTapEditor.svelte';
 import { AutocompleteState } from './autocomplete.svelte';
@@ -11,7 +12,7 @@ function member(login: string, displayName = login, deleted = false): RoomMember
     displayName,
     deleted,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
@@ -16,7 +16,8 @@ ContextMenu, which handles both modes automatically.
 - `onClose` - Callback to close the popover/sheet
 -->
 <script lang="ts">
-  import type { PresenceStatus } from '$lib/render/types';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import UserCustomStatusBadge from '$lib/components/UserCustomStatusBadge.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
@@ -1,6 +1,7 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
-import { PresenceStatus } from '$lib/render/types';
+
 import { q } from '$lib/test-utils';
 import UserContextMenu from './UserContextMenu.svelte';
 
@@ -22,7 +23,7 @@ const user = {
   login: 'alice',
   displayName: 'Alice Example',
   avatarUrl: null,
-  presenceStatus: PresenceStatus.Online,
+  presenceStatus: PresenceStatus.ONLINE,
   customStatus: null
 };
 
@@ -72,9 +73,9 @@ describe('UserContextMenu', () => {
     });
 
     await expect.element(q(container, '[role="dialog"]')).toBeInTheDocument();
-    expect(
-      container.querySelector('[role="dialog"] .flex-1 > .font-semibold')?.textContent
-    ).toBe('Alice Example');
+    expect(container.querySelector('[role="dialog"] .flex-1 > .font-semibold')?.textContent).toBe(
+      'Alice Example'
+    );
     expect(q(container, '[aria-label="🍜 Out for lunch"]')).toBeTruthy();
     expect(container.textContent).toContain('Out for lunch');
   });
@@ -85,9 +86,7 @@ describe('UserContextMenu', () => {
     hidden.unmount();
 
     const visible = renderMenu({ canSendMessage: true });
-    await expect
-      .element(q(visible.container, 'button'))
-      .toHaveTextContent('Send Message');
+    await expect.element(q(visible.container, 'button')).toHaveTextContent('Send Message');
   });
 
   it('calls send and close callbacks when sending a message', () => {

--- a/apps/frontend/src/lib/components/moderation/BanRoomMemberModal.svelte
+++ b/apps/frontend/src/lib/components/moderation/BanRoomMemberModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { PresenceStatus } from '$lib/render/types';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import { getLiveDisplayName, getLiveLogin } from '$lib/state/userProfiles.svelte';
   import FormDialog from '$lib/ui/FormDialog.svelte';

--- a/apps/frontend/src/lib/components/moderation/UnbanRoomMemberModal.svelte
+++ b/apps/frontend/src/lib/components/moderation/UnbanRoomMemberModal.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import type { PresenceStatus } from '$lib/render/types';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import FormDialog from '$lib/ui/FormDialog.svelte';
   import { TextArea } from '$lib/ui/form';

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -5,10 +5,12 @@ Server-wide and per-room notification level settings for the current user.
 These preferences are server-side and sync across devices.
 -->
 <script lang="ts">
+  import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
+  import { notificationLevelOrDefault } from '$lib/api-client/enumDefaults';
   import { onMount } from 'svelte';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { NotificationLevel } from '$lib/render/types';
+
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { ChoiceRow, FormSection } from '$lib/ui';
   import { FormError } from '$lib/ui/form';
@@ -21,14 +23,13 @@ These preferences are server-side and sync across devices.
   } from '$lib/api-client/notificationPreferences';
   import { createRoomDirectoryAPI, RoomDirectoryScope } from '$lib/api-client/roomDirectory';
   import { getViewerStateViaConnect } from '$lib/api-client/viewer';
-  import { NotificationLevel as ApiNotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 
   const serverId = getActiveServer();
   const notificationLevelStore = serverRegistry.getStore(serverId).notificationLevels;
   const connection = useConnection();
 
-  let serverLevel = $state<NotificationLevel>(NotificationLevel.Default);
-  let serverEffectiveLevel = $state<NotificationLevel>(NotificationLevel.Normal);
+  let serverLevel = $state<NotificationLevel>(NotificationLevel.DEFAULT);
+  let serverEffectiveLevel = $state<NotificationLevel>(NotificationLevel.NORMAL);
 
   let rooms = $state<
     Array<{
@@ -67,8 +68,8 @@ These preferences are server-side and sync across devices.
 
       const mappedServerPref = notificationPreferenceFromAPI(serverPref);
       serverLevel =
-        mappedServerPref.level === NotificationLevel.Default
-          ? NotificationLevel.Normal
+        mappedServerPref.level === NotificationLevel.DEFAULT
+          ? NotificationLevel.NORMAL
           : mappedServerPref.level;
       serverEffectiveLevel = mappedServerPref.effectiveLevel;
       notificationLevelStore.setServerPreference(
@@ -84,8 +85,8 @@ These preferences are server-side and sync across devices.
         return {
           id: room.id,
           name: room.name,
-          level: pref?.level ?? NotificationLevel.Default,
-          effectiveLevel: pref?.effectiveLevel ?? NotificationLevel.Normal
+          level: pref?.level ?? NotificationLevel.DEFAULT,
+          effectiveLevel: pref?.effectiveLevel ?? NotificationLevel.NORMAL
         };
       });
 
@@ -104,7 +105,7 @@ These preferences are server-side and sync across devices.
 
     try {
       const pref = notificationPreferenceFromAPI(
-        await updateServerNotificationPreference(connectConfig(), notificationLevelToAPI(newLevel))
+        await updateServerNotificationPreference(connectConfig(), newLevel)
       );
       serverLevel = pref.level;
       serverEffectiveLevel = pref.effectiveLevel;
@@ -146,22 +147,22 @@ These preferences are server-side and sync across devices.
     Array<{ value: NotificationLevel; label: string; description: string }>
   >([
     {
-      value: NotificationLevel.Default,
+      value: NotificationLevel.DEFAULT,
       label: m['settings.notifications.levels.default.label'](),
       description: m['settings.notifications.levels.default.description']()
     },
     {
-      value: NotificationLevel.Muted,
+      value: NotificationLevel.MUTED,
       label: m['settings.notifications.levels.muted.label'](),
       description: m['settings.notifications.levels.muted.description']()
     },
     {
-      value: NotificationLevel.Normal,
+      value: NotificationLevel.NORMAL,
       label: m['settings.notifications.levels.normal.label'](),
       description: m['settings.notifications.levels.normal.description']()
     },
     {
-      value: NotificationLevel.AllMessages,
+      value: NotificationLevel.ALL_MESSAGES,
       label: m['settings.notifications.levels.all_messages.label'](),
       description: m['settings.notifications.levels.all_messages.description']()
     }
@@ -171,11 +172,7 @@ These preferences are server-side and sync across devices.
     roomId: string,
     newLevel: NotificationLevel
   ): Promise<NotificationPreference> {
-    const pref = await updateRoomNotificationPreference(
-      connectConfig(),
-      roomId,
-      notificationLevelToAPI(newLevel)
-    );
+    const pref = await updateRoomNotificationPreference(connectConfig(), roomId, newLevel);
     return notificationPreferenceFromAPI(pref);
   }
 
@@ -189,50 +186,21 @@ These preferences are server-side and sync across devices.
   }
 
   function notificationPreferenceFromAPI(pref: {
-    level: ApiNotificationLevel;
-    effectiveLevel: ApiNotificationLevel;
+    level: NotificationLevel;
+    effectiveLevel: NotificationLevel;
   }): NotificationPreference {
     return {
-      level: notificationLevelFromAPI(pref.level),
-      effectiveLevel: notificationLevelFromAPI(pref.effectiveLevel)
+      level: notificationLevelOrDefault(pref.level),
+      effectiveLevel: notificationLevelOrDefault(pref.effectiveLevel)
     };
   }
 
   const serverLevelOptions = $derived(
-    levelOptions.filter((o) => o.value !== NotificationLevel.Default)
+    levelOptions.filter((o) => o.value !== NotificationLevel.DEFAULT)
   );
 
   function levelLabel(level: NotificationLevel): string {
-    return levelOptions.find((o) => o.value === level)?.label ?? level;
-  }
-
-  function notificationLevelToAPI(level: NotificationLevel): ApiNotificationLevel {
-    switch (level) {
-      case NotificationLevel.Muted:
-        return ApiNotificationLevel.MUTED;
-      case NotificationLevel.Normal:
-        return ApiNotificationLevel.NORMAL;
-      case NotificationLevel.AllMessages:
-        return ApiNotificationLevel.ALL_MESSAGES;
-      case NotificationLevel.Default:
-      default:
-        return ApiNotificationLevel.DEFAULT;
-    }
-  }
-
-  function notificationLevelFromAPI(level: ApiNotificationLevel): NotificationLevel {
-    switch (level) {
-      case ApiNotificationLevel.MUTED:
-        return NotificationLevel.Muted;
-      case ApiNotificationLevel.NORMAL:
-        return NotificationLevel.Normal;
-      case ApiNotificationLevel.ALL_MESSAGES:
-        return NotificationLevel.AllMessages;
-      case ApiNotificationLevel.DEFAULT:
-      case ApiNotificationLevel.UNSPECIFIED:
-      default:
-        return NotificationLevel.Default;
-    }
+    return levelOptions.find((o) => o.value === level)?.label ?? String(level);
   }
 </script>
 
@@ -285,7 +253,7 @@ These preferences are server-side and sync across devices.
             data-testid={`room-notification-${room.name}`}
             class={[
               'flex items-center justify-between gap-3 rounded-lg border border-border px-3 py-2',
-              room.effectiveLevel === NotificationLevel.Muted ? 'opacity-60' : ''
+              room.effectiveLevel === NotificationLevel.MUTED ? 'opacity-60' : ''
             ]}
           >
             <div class="min-w-0">
@@ -293,7 +261,7 @@ These preferences are server-side and sync across devices.
                 <span class="text-muted">#</span>
                 <span class="truncate font-medium">{room.name}</span>
               </div>
-              {#if room.level !== NotificationLevel.Default}
+              {#if room.level !== NotificationLevel.DEFAULT}
                 <div class="text-xs text-muted">
                   {m['settings.notifications.levels.effective']({
                     level: levelLabel(room.effectiveLevel)
@@ -303,17 +271,17 @@ These preferences are server-side and sync across devices.
             </div>
             <select
               aria-label={m['settings.notifications.levels.room_level_label']({ room: room.name })}
-              value={room.level}
+              value={String(room.level)}
               disabled={isSaving}
               onchange={(e) =>
                 handleRoomLevelChange(
                   room.id,
-                  (e.target as HTMLSelectElement).value as NotificationLevel
+                  Number((e.target as HTMLSelectElement).value) as NotificationLevel
                 )}
               class={['input w-auto min-w-[120px] text-sm', isSaving ? 'opacity-50' : '']}
             >
               {#each levelOptions as option (option.value)}
-                <option value={option.value}>{option.label}</option>
+                <option value={String(option.value)}>{option.label}</option>
               {/each}
             </select>
           </div>

--- a/apps/frontend/src/lib/components/voice/VideoThumbnail.stories.svelte
+++ b/apps/frontend/src/lib/components/voice/VideoThumbnail.stories.svelte
@@ -1,7 +1,8 @@
 <script module lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import VideoThumbnail from './VideoThumbnail.svelte';
-  import { PresenceStatus } from '$lib/render/types';
+
   import type { Track } from 'livekit-client';
 
   const { Story } = defineMeta({
@@ -22,7 +23,7 @@
     login: 'alice',
     displayName: 'Alice',
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Online
+    presenceStatus: PresenceStatus.ONLINE
   } as const;
 
   function posterTrack(svg: string): Track {

--- a/apps/frontend/src/lib/components/voice/VideoThumbnail.svelte
+++ b/apps/frontend/src/lib/components/voice/VideoThumbnail.svelte
@@ -23,7 +23,7 @@ resolution to request for sidebar-width tiles.
 <script lang="ts">
 	import { onDestroy } from 'svelte';
 	import type { Track } from 'livekit-client';
-	import type { PresenceStatus } from '$lib/render/types';
+	import type { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 	import UserAvatar from '$lib/components/UserAvatar.svelte';
 
 	let {

--- a/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -14,6 +14,7 @@ Room sidebar panel for voice/video calls.
 - `livekitUrl` - The LiveKit server WebSocket URL (needed for joining)
 -->
 <script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -22,7 +23,7 @@ Room sidebar panel for voice/video calls.
   const stores = serverRegistry.getStore(getActiveServer());
   const voiceCallState = stores.voiceCall;
   const activeCallRooms = stores.activeCallRooms;
-  import type { PresenceStatus } from '$lib/render/types';
+
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import VideoThumbnail from './VideoThumbnail.svelte';
   import AudioDeviceMenu from './AudioDeviceMenu.svelte';
@@ -83,7 +84,7 @@ Room sidebar panel for voice/video calls.
           login: p.login,
           displayName: p.name,
           avatarUrl: p.avatarUrl,
-          presenceStatus: 'ONLINE' as PresenceStatus
+          presenceStatus: PresenceStatus.ONLINE
         },
         isMuted: p.isMuted,
         isLocal: p.isLocal,
@@ -104,7 +105,7 @@ Room sidebar panel for voice/video calls.
         login: p.login,
         displayName: p.displayName,
         avatarUrl: p.avatarUrl,
-        presenceStatus: 'ONLINE' as PresenceStatus
+        presenceStatus: PresenceStatus.ONLINE
       },
       isMuted: false,
       isLocal: false,

--- a/apps/frontend/src/lib/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/eventBus.svelte.ts
@@ -10,7 +10,7 @@
 
 import { createContext } from 'svelte';
 import { SvelteSet } from 'svelte/reactivity';
-import type { PresenceStatus } from './render/types';
+import type { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { eventBusManager } from './state/server/eventBus.svelte';
 import type { RealtimeProjectionEvent } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { RoomEventKind, roomEventKind } from '$lib/render/eventKinds';

--- a/apps/frontend/src/lib/hooks/useEvent.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useEvent.svelte.ts
@@ -1,10 +1,10 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import {
   onProjectionEvent,
   onPresenceChange,
   onSessionTerminated,
   type ProjectionHandler
 } from '$lib/eventBus.svelte';
-import type { PresenceStatus } from '$lib/render/types';
 
 /** Subscribe to canonical projection operations on the active server. */
 export function useProjectionEvent(handler: ProjectionHandler) {

--- a/apps/frontend/src/lib/hooks/useRoomData.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useRoomData.svelte.spec.ts
@@ -1,7 +1,8 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { flushSync } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { PresenceStatus } from '$lib/render/types';
+
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { useRoomData } from './useRoomData.svelte';
 
@@ -62,7 +63,7 @@ function member(id: string) {
     displayName: `User ${id}`,
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Online
+    presenceStatus: PresenceStatus.ONLINE
   };
 }
 

--- a/apps/frontend/src/lib/mentions.svelte.test.ts
+++ b/apps/frontend/src/lib/mentions.svelte.test.ts
@@ -1,10 +1,10 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 /**
  * Browser tests for wrapValidMentions (requires DOMParser).
  * Pure function tests are in mentions.test.ts.
  */
 import { describe, it, expect } from 'vitest';
 import { wrapValidMentions, type RoomMember } from './mentions';
-import type { PresenceStatus } from '$lib/render/types';
 
 // Helper to create test members
 function member(login: string, displayName?: string): RoomMember {
@@ -13,7 +13,7 @@ function member(login: string, displayName?: string): RoomMember {
     login,
     displayName: displayName ?? login,
     avatarUrl: null,
-    presenceStatus: 'OFFLINE' as PresenceStatus
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/mentions.test.ts
+++ b/apps/frontend/src/lib/mentions.test.ts
@@ -1,3 +1,4 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 /**
  * Unit tests for mention parsing utilities (pure functions).
  * Tests for wrapValidMentions are in mentions.svelte.test.ts (requires browser APIs).
@@ -10,7 +11,6 @@ import {
   isUserMentioned,
   type RoomMember
 } from './mentions';
-import type { PresenceStatus } from '$lib/render/types';
 
 // Helper to create test members
 function member(login: string, displayName?: string): RoomMember {
@@ -19,7 +19,7 @@ function member(login: string, displayName?: string): RoomMember {
     login,
     displayName: displayName ?? login,
     avatarUrl: null,
-    presenceStatus: 'OFFLINE' as PresenceStatus
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
+++ b/apps/frontend/src/lib/navigation/roomLinkAccess.spec.ts
@@ -1,5 +1,6 @@
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { describe, expect, it } from 'vitest';
-import { RoomType } from '$lib/render/types';
+
 import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
 import { roomRouteAccess } from './roomLinkAccess';
 
@@ -7,7 +8,7 @@ function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
   return {
     id: 'room-1',
     name: 'general',
-    type: RoomType.Channel,
+    type: RoomKind.CHANNEL,
     isUniversal: false,
     viewerIsMember: true,
     viewerCanJoinRoom: true,

--- a/apps/frontend/src/lib/presenceTracking.spec.ts
+++ b/apps/frontend/src/lib/presenceTracking.spec.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 import { APIPresenceStatus } from '$lib/api-client/presence';
-import { PresenceStatus } from '$lib/render/types';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { presencePreference } from '$lib/state/presencePreference.svelte';
 import { __presenceTrackingTest, initPresenceTracking, setPresenceMode } from './presenceTracking';
 
@@ -118,7 +118,7 @@ describe('initPresenceTracking', () => {
 		vi.advanceTimersByTime(4 * 60 * 1000 + 59 * 1000);
 
 		expect(sentStatuses()).not.toContain(APIPresenceStatus.AWAY);
-		expect(onStatusChange).not.toHaveBeenCalledWith(PresenceStatus.Away);
+		expect(onStatusChange).not.toHaveBeenCalledWith(PresenceStatus.AWAY);
 	});
 
 	it('reconciles local status to the server-accepted presence', async () => {
@@ -133,12 +133,12 @@ describe('initPresenceTracking', () => {
 		startTracking();
 
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Online);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
 
 		await Promise.resolve();
 
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.DoNotDisturb);
-		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.DoNotDisturb);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.DO_NOT_DISTURB);
+		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.DO_NOT_DISTURB);
 
 		vi.advanceTimersByTime(30_000);
 
@@ -154,12 +154,12 @@ describe('initPresenceTracking', () => {
 
 		vi.advanceTimersByTime(5 * 60 * 1000);
 		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Away);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
 
 		dispatchDocumentEvent('pointermove');
 
 		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.ONLINE);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Online);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
 	});
 
 	it('reports away after the hidden delay and returns online when visible again in auto mode', () => {
@@ -171,7 +171,7 @@ describe('initPresenceTracking', () => {
 
 		vi.advanceTimersByTime(1);
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE, APIPresenceStatus.AWAY]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Away);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
 
 		setVisibility('visible');
 
@@ -180,7 +180,7 @@ describe('initPresenceTracking', () => {
 			APIPresenceStatus.AWAY,
 			APIPresenceStatus.ONLINE
 		]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Online);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
 	});
 
 	it('does not auto-return from explicit away on activity', () => {
@@ -194,7 +194,7 @@ describe('initPresenceTracking', () => {
 		expect(sentStatuses()).toContain(APIPresenceStatus.AWAY);
 		expect(sentStatuses().slice(1)).not.toContain(APIPresenceStatus.ONLINE);
 		expect(sentUserSelectedFlags().at(1)).toBe(true);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Away);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
 	});
 
 	it('returns online when another tab clears explicit away while this tab is hidden', () => {
@@ -204,14 +204,14 @@ describe('initPresenceTracking', () => {
 		dispatchStorageMode('away');
 
 		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Away);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
 
 		dispatchStorageMode('auto');
 
 		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.ONLINE);
 		expect(sentUserSelectedFlags().at(-1)).toBe(true);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Online);
-		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.Online);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
+		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.ONLINE);
 	});
 
 	it('keeps do not disturb through activity and refreshes it', () => {
@@ -227,7 +227,7 @@ describe('initPresenceTracking', () => {
 			APIPresenceStatus.DO_NOT_DISTURB
 		]);
 		expect(sentUserSelectedFlags()).toEqual([false, true, true]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.DoNotDisturb);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.DO_NOT_DISTURB);
 	});
 
 	it('does not update presence while invisible and returns online when automatic mode resumes', () => {
@@ -237,7 +237,7 @@ describe('initPresenceTracking', () => {
 		dispatchDocumentEvent('pointermove');
 
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Offline);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.OFFLINE);
 
 		setPresenceMode('auto');
 
@@ -252,6 +252,6 @@ describe('initPresenceTracking', () => {
 		vi.advanceTimersByTime(60_000);
 
 		expect(sentStatuses()).toEqual([]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.Offline);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.OFFLINE);
 	});
 });

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -1,5 +1,5 @@
 import { createPresenceAPI, APIPresenceStatus, type PresenceAPIConfig } from '$lib/api-client/presence';
-import { PresenceStatus } from '$lib/render/types';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
@@ -18,19 +18,19 @@ let applyModeFromUI: ((mode: PresenceMode) => void) | null = null;
 function apiStatusToPresenceStatus(status: APIPresenceStatus): PresenceStatus {
 	switch (status) {
 		case APIPresenceStatus.AWAY:
-			return PresenceStatus.Away;
+			return PresenceStatus.AWAY;
 		case APIPresenceStatus.DO_NOT_DISTURB:
-			return PresenceStatus.DoNotDisturb;
+			return PresenceStatus.DO_NOT_DISTURB;
 		default:
-			return PresenceStatus.Online;
+			return PresenceStatus.ONLINE;
 	}
 }
 
 function presenceStatusToAPIStatus(status: PresenceStatus): APIPresenceStatus {
 	switch (status) {
-		case PresenceStatus.Away:
+		case PresenceStatus.AWAY:
 			return APIPresenceStatus.AWAY;
-		case PresenceStatus.DoNotDisturb:
+		case PresenceStatus.DO_NOT_DISTURB:
 			return APIPresenceStatus.DO_NOT_DISTURB;
 		default:
 			return APIPresenceStatus.ONLINE;
@@ -40,11 +40,11 @@ function presenceStatusToAPIStatus(status: PresenceStatus): APIPresenceStatus {
 function modeToExplicitStatus(mode: PresenceMode): PresenceStatus | null {
 	switch (mode) {
 		case 'away':
-			return PresenceStatus.Away;
+			return PresenceStatus.AWAY;
 		case 'doNotDisturb':
-			return PresenceStatus.DoNotDisturb;
+			return PresenceStatus.DO_NOT_DISTURB;
 		case 'invisible':
-			return PresenceStatus.Offline;
+			return PresenceStatus.OFFLINE;
 		default:
 			return null;
 	}
@@ -146,7 +146,7 @@ export function initPresenceTracking(
 	}
 
 	function statusForAutoState(state: ActivityState): PresenceStatus {
-		return state === 'active' ? PresenceStatus.Online : PresenceStatus.Away;
+		return state === 'active' ? PresenceStatus.ONLINE : PresenceStatus.AWAY;
 	}
 
 	function applyMode(mode: PresenceMode, persist = false, syncedFromStorage = false) {
@@ -158,7 +158,7 @@ export function initPresenceTracking(
 			clearRefreshTimer();
 			reportRevision++;
 			currentVisibleStatus = null;
-			emitLocalStatus(PresenceStatus.Offline);
+			emitLocalStatus(PresenceStatus.OFFLINE);
 			return;
 		}
 
@@ -166,7 +166,7 @@ export function initPresenceTracking(
 			currentState = document.visibilityState === 'hidden' ? 'hidden' : 'active';
 			const userSelected = persist || syncedFromStorage;
 			reportStatus(
-				userSelected ? PresenceStatus.Online : statusForAutoState(currentState),
+				userSelected ? PresenceStatus.ONLINE : statusForAutoState(currentState),
 				userSelected
 			);
 			ensureRefreshTimer();

--- a/apps/frontend/src/lib/realtimeEventMapper.ts
+++ b/apps/frontend/src/lib/realtimeEventMapper.ts
@@ -1,26 +1,10 @@
-import { PresenceStatus as GqlPresenceStatus } from '$lib/render/types';
 import { RoomEventKind } from '$lib/render/eventKinds';
 import { RealtimeEventEnvelope } from '@chatto/api-types/realtime/v1/realtime_pb';
-import { PresenceStatus as ApiPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { presenceStatusOrOffline } from '$lib/api-client/enumDefaults';
 import type { EventEnvelope } from '$lib/eventBus.svelte';
 
 function timestampToISO(value: { toDate(): Date } | undefined): string {
   return value?.toDate().toISOString() ?? new Date().toISOString();
-}
-
-function presenceStatus(status: ApiPresenceStatus): GqlPresenceStatus {
-  switch (status) {
-    case ApiPresenceStatus.AWAY:
-      return GqlPresenceStatus.Away;
-    case ApiPresenceStatus.DO_NOT_DISTURB:
-      return GqlPresenceStatus.DoNotDisturb;
-    case ApiPresenceStatus.ONLINE:
-      return GqlPresenceStatus.Online;
-    case ApiPresenceStatus.OFFLINE:
-    case ApiPresenceStatus.UNSPECIFIED:
-    default:
-      return GqlPresenceStatus.Offline;
-  }
 }
 
 export function realtimeEventToEventEnvelope(frame: RealtimeEventEnvelope): EventEnvelope | null {
@@ -48,7 +32,7 @@ export function realtimeEventToEventEnvelope(frame: RealtimeEventEnvelope): Even
         actorId: frame.event.value.userId || base.actorId,
         event: {
           kind: RoomEventKind.PresenceChanged,
-          status: presenceStatus(frame.event.value.status)
+          status: presenceStatusOrOffline(frame.event.value.status)
         }
       };
     case 'mentionNotification': {

--- a/apps/frontend/src/lib/state/presenceCache.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/presenceCache.svelte.spec.ts
@@ -1,5 +1,6 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, expect, it } from 'vitest';
-import { PresenceStatus } from '$lib/render/types';
+
 import {
   authenticatedCurrentUserPresenceEntries,
   PresenceCache,
@@ -9,54 +10,54 @@ import {
 describe('PresenceCache', () => {
   it('replaces one server snapshot without disturbing another server', () => {
     const cache = new PresenceCache();
-    cache.update({ serverId: 'origin', userId: 'old' }, PresenceStatus.Online);
-    cache.update({ serverId: 'remote', userId: 'same' }, PresenceStatus.Away);
+    cache.update({ serverId: 'origin', userId: 'old' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'remote', userId: 'same' }, PresenceStatus.AWAY);
 
     cache.replaceServer(
       'origin',
       new Map([
-        ['same', PresenceStatus.DoNotDisturb],
-        ['offline', PresenceStatus.Offline]
+        ['same', PresenceStatus.DO_NOT_DISTURB],
+        ['offline', PresenceStatus.OFFLINE]
       ])
     );
 
-    expect(cache.get({ serverId: 'origin', userId: 'old' }, PresenceStatus.Offline)).toBe(
-      PresenceStatus.Offline
+    expect(cache.get({ serverId: 'origin', userId: 'old' }, PresenceStatus.OFFLINE)).toBe(
+      PresenceStatus.OFFLINE
     );
-    expect(cache.get({ serverId: 'origin', userId: 'same' }, PresenceStatus.Offline)).toBe(
-      PresenceStatus.DoNotDisturb
+    expect(cache.get({ serverId: 'origin', userId: 'same' }, PresenceStatus.OFFLINE)).toBe(
+      PresenceStatus.DO_NOT_DISTURB
     );
-    expect(cache.get({ serverId: 'remote', userId: 'same' }, PresenceStatus.Offline)).toBe(
-      PresenceStatus.Away
+    expect(cache.get({ serverId: 'remote', userId: 'same' }, PresenceStatus.OFFLINE)).toBe(
+      PresenceStatus.AWAY
     );
   });
 
   it('isolates entries by server id and user id', () => {
     const cache = new PresenceCache();
 
-    cache.update({ serverId: 'origin', userId: 'same-user-id' }, PresenceStatus.Away);
-    cache.update({ serverId: 'remote', userId: 'same-user-id' }, PresenceStatus.DoNotDisturb);
+    cache.update({ serverId: 'origin', userId: 'same-user-id' }, PresenceStatus.AWAY);
+    cache.update({ serverId: 'remote', userId: 'same-user-id' }, PresenceStatus.DO_NOT_DISTURB);
 
-    expect(cache.get({ serverId: 'origin', userId: 'same-user-id' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.Away
+    expect(cache.get({ serverId: 'origin', userId: 'same-user-id' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.AWAY
     );
-    expect(cache.get({ serverId: 'remote', userId: 'same-user-id' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.DoNotDisturb
+    expect(cache.get({ serverId: 'remote', userId: 'same-user-id' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.DO_NOT_DISTURB
     );
   });
 
   it('clears stale entries while retaining provided current-user presence', () => {
     const cache = new PresenceCache();
-    cache.update({ serverId: 'origin', userId: 'current-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Away);
+    cache.update({ serverId: 'origin', userId: 'current-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.AWAY);
 
-    cache.clear([[{ serverId: 'origin', userId: 'current-user' }, PresenceStatus.DoNotDisturb]]);
+    cache.clear([[{ serverId: 'origin', userId: 'current-user' }, PresenceStatus.DO_NOT_DISTURB]]);
 
-    expect(cache.get({ serverId: 'origin', userId: 'current-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.DoNotDisturb
+    expect(cache.get({ serverId: 'origin', userId: 'current-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.DO_NOT_DISTURB
     );
-    expect(cache.get({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.Online
+    expect(cache.get({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.ONLINE
     );
   });
 
@@ -67,10 +68,10 @@ describe('PresenceCache', () => {
       isAuthenticated: true,
       currentUser: { user: null as { id: string } | null }
     };
-    cache.update({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Online);
+    cache.update({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.ONLINE);
 
     updateAuthenticatedCurrentUserPresenceEntries(
       cache,
@@ -92,28 +93,28 @@ describe('PresenceCache', () => {
         },
         lateStore
       ],
-      PresenceStatus.Offline
+      PresenceStatus.OFFLINE
     );
 
-    expect(cache.get({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.Offline
+    expect(cache.get({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.OFFLINE
     );
-    expect(cache.get({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.Offline
+    expect(cache.get({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.OFFLINE
     );
     expect(
-      cache.get({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.Away)
-    ).toBe(PresenceStatus.Online);
+      cache.get({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.AWAY)
+    ).toBe(PresenceStatus.ONLINE);
     expect(
-      cache.get({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Away)
-    ).toBe(PresenceStatus.Online);
+      cache.get({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.AWAY)
+    ).toBe(PresenceStatus.ONLINE);
 
     lateStore.currentUser.user = { id: 'late-remote-user' };
-    updateAuthenticatedCurrentUserPresenceEntries(cache, [lateStore], PresenceStatus.Offline);
+    updateAuthenticatedCurrentUserPresenceEntries(cache, [lateStore], PresenceStatus.OFFLINE);
 
     expect(
-      cache.get({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.Online)
-    ).toBe(PresenceStatus.Offline);
+      cache.get({ serverId: 'late-remote', userId: 'late-remote-user' }, PresenceStatus.ONLINE)
+    ).toBe(PresenceStatus.OFFLINE);
   });
 
   it('retains all authenticated current-user entries when clearing stale presence', () => {
@@ -136,24 +137,24 @@ describe('PresenceCache', () => {
       }
     ];
 
-    cache.update({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Online);
-    cache.update({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Away);
+    cache.update({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.ONLINE);
+    cache.update({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.AWAY);
 
-    cache.clear(authenticatedCurrentUserPresenceEntries(stores, PresenceStatus.DoNotDisturb));
+    cache.clear(authenticatedCurrentUserPresenceEntries(stores, PresenceStatus.DO_NOT_DISTURB));
 
-    expect(cache.get({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.DoNotDisturb
+    expect(cache.get({ serverId: 'origin', userId: 'origin-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.DO_NOT_DISTURB
     );
-    expect(cache.get({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.DoNotDisturb
+    expect(cache.get({ serverId: 'remote', userId: 'remote-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.DO_NOT_DISTURB
     );
     expect(
-      cache.get({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.Away)
-    ).toBe(PresenceStatus.Away);
-    expect(cache.get({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.Online)).toBe(
-      PresenceStatus.Online
+      cache.get({ serverId: 'signed-out', userId: 'signed-out-user' }, PresenceStatus.AWAY)
+    ).toBe(PresenceStatus.AWAY);
+    expect(cache.get({ serverId: 'origin', userId: 'other-user' }, PresenceStatus.ONLINE)).toBe(
+      PresenceStatus.ONLINE
     );
   });
 });

--- a/apps/frontend/src/lib/state/presenceCache.svelte.ts
+++ b/apps/frontend/src/lib/state/presenceCache.svelte.ts
@@ -1,6 +1,6 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { createContext, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
-import type { PresenceStatus } from '$lib/render/types';
 
 export type PresenceCacheScope = {
   serverId: string;

--- a/apps/frontend/src/lib/state/presencePreference.svelte.ts
+++ b/apps/frontend/src/lib/state/presencePreference.svelte.ts
@@ -1,10 +1,10 @@
-import { PresenceStatus } from '$lib/render/types';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 
 export type PresenceMode = 'auto' | 'away' | 'doNotDisturb' | 'invisible';
 
 class PresencePreference {
-	mode = $state<PresenceMode>('auto');
-	effectiveStatus = $state<PresenceStatus>(PresenceStatus.Online);
+  mode = $state<PresenceMode>('auto');
+  effectiveStatus = $state<PresenceStatus>(PresenceStatus.ONLINE);
 }
 
 export const presencePreference = new PresencePreference();

--- a/apps/frontend/src/lib/state/room/files.svelte.ts
+++ b/apps/frontend/src/lib/state/room/files.svelte.ts
@@ -1,5 +1,6 @@
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
-import { FitMode } from '$lib/render/types';
+
 import type { ExpiringAssetUrl, RefreshedAttachmentUrls } from '$lib/attachments/attachmentUrls';
 import {
   assetUrlNeedsRefresh,
@@ -210,13 +211,7 @@ export class RoomFilesStore {
   }
 
   async loadMore(): Promise<void> {
-    if (
-      this.hydrationPromise ||
-      this.isLoadingMore ||
-      !this.hasMore ||
-      !this.hydrated
-    )
-      return;
+    if (this.hydrationPromise || this.isLoadingMore || !this.hasMore || !this.hydrated) return;
     const roomId = this.roomId;
     const requestEpoch = this.requestEpoch;
     const paginationEpoch = this.paginationEpoch;
@@ -309,16 +304,14 @@ export class RoomFilesStore {
           {
             width: 120,
             height: 120,
-            fit: FitMode.Cover
+            fit: ImageFitMode.COVER
           }
         );
         if (this.roomId !== roomId || this.requestEpoch !== requestEpoch) return;
         for (const assetId of assetIds) this.pendingUrlRefreshAssetIds.delete(assetId);
 
         const fresh = new SvelteMap<string, RefreshedAttachmentUrls>();
-        const currentAssetIds = new SvelteSet(
-          this.items.map((item) => item.attachment.id)
-        );
+        const currentAssetIds = new SvelteSet(this.items.map((item) => item.attachment.id));
         for (const [attachmentId, urls] of freshMap) {
           if (
             !currentAssetIds.has(attachmentId) ||
@@ -396,7 +389,7 @@ export class RoomFilesStore {
         thumbnail: {
           width: 120,
           height: 120,
-          fit: FitMode.Cover
+          fit: ImageFitMode.COVER
         }
       });
     } catch (error) {

--- a/apps/frontend/src/lib/state/room/members.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.spec.ts
@@ -1,5 +1,6 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, expect, it, vi } from 'vitest';
-import { PresenceStatus } from '$lib/render/types';
+
 import type { MemberDirectoryAPI, MemberDirectoryPage } from '$lib/api-client/memberDirectory';
 import { ROOM_MEMBERS_PAGE_SIZE, RoomMembersStore } from './members.svelte';
 
@@ -43,7 +44,7 @@ function user(id: string, login = id) {
     displayName: login,
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Online,
+    presenceStatus: PresenceStatus.ONLINE,
     customStatus: null,
     roles: [],
     createdAt: null

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -1,6 +1,7 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { createContext } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
-import { type PresenceStatus } from '$lib/render/types';
+
 import {
   createMemberDirectoryAPI,
   type DirectoryMember,

--- a/apps/frontend/src/lib/state/room/messages/filters.ts
+++ b/apps/frontend/src/lib/state/room/messages/filters.ts
@@ -1,6 +1,5 @@
 import { isMessagePostedEvent, roomEventKind, RoomEventKind } from '$lib/render/eventKinds';
 import type { RoomEventView } from '$lib/render/types';
-
 export function isRootRoomEvent(event: RoomEventView): boolean {
   const eventData = event.event;
   if (!eventData) return false;

--- a/apps/frontend/src/lib/state/room/messages/helpers.ts
+++ b/apps/frontend/src/lib/state/room/messages/helpers.ts
@@ -1,5 +1,4 @@
 import type { RoomEventView } from '$lib/render/types';
-
 export type RawEvent = RoomEventView;
 
 export type EventConnectionPage = {

--- a/apps/frontend/src/lib/state/server/notificationLevel.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notificationLevel.svelte.ts
@@ -1,3 +1,4 @@
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 /**
  * Server-level and per-room notification level preferences.
  *
@@ -10,13 +11,12 @@
  */
 
 import { SvelteMap } from 'svelte/reactivity';
-import { NotificationLevel } from '$lib/render/types';
 
 export class NotificationLevelStore {
   /** Server-level preference. */
   private server = $state<{ level: NotificationLevel; effectiveLevel: NotificationLevel }>({
-    level: NotificationLevel.Default,
-    effectiveLevel: NotificationLevel.Normal
+    level: NotificationLevel.DEFAULT,
+    effectiveLevel: NotificationLevel.NORMAL
   });
 
   /** Room-level preferences: roomId -> { level, effectiveLevel } */
@@ -55,13 +55,14 @@ export class NotificationLevelStore {
    * Get the viewer's notification preference for a room.
    * Returns DEFAULT with the server's effective level if not set.
    */
-  getRoomPreference(
-    roomId: string
-  ): { level: NotificationLevel; effectiveLevel: NotificationLevel } {
+  getRoomPreference(roomId: string): {
+    level: NotificationLevel;
+    effectiveLevel: NotificationLevel;
+  } {
     const roomPref = this.roomLevels.get(roomId);
     if (roomPref) return roomPref;
     return {
-      level: NotificationLevel.Default,
+      level: NotificationLevel.DEFAULT,
       effectiveLevel: this.server.effectiveLevel
     };
   }
@@ -78,14 +79,14 @@ export class NotificationLevelStore {
    * Check if a room is muted (no notifications, no unread markers).
    */
   isRoomMuted(roomId: string): boolean {
-    return this.getEffectiveLevel(roomId) === NotificationLevel.Muted;
+    return this.getEffectiveLevel(roomId) === NotificationLevel.MUTED;
   }
 
   /**
    * Check if the server is fully muted (server-level muted, no room overrides).
    */
   isServerMuted(): boolean {
-    return this.server.effectiveLevel === NotificationLevel.Muted;
+    return this.server.effectiveLevel === NotificationLevel.MUTED;
   }
 
   /**
@@ -93,8 +94,8 @@ export class NotificationLevelStore {
    */
   clear(): void {
     this.server = {
-      level: NotificationLevel.Default,
-      effectiveLevel: NotificationLevel.Normal
+      level: NotificationLevel.DEFAULT,
+      effectiveLevel: NotificationLevel.NORMAL
     };
     this.roomLevels.clear();
   }

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
@@ -1,3 +1,4 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, it, expect, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import {
@@ -6,7 +7,7 @@ import {
   type DirectoryRoomSummary,
   type RoomDirectoryAPI
 } from '$lib/api-client/roomDirectory';
-import { PresenceStatus } from '$lib/api-client/renderTypes';
+
 import type { MemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 import { RoomDirectoryStore, type DirectoryRoom } from './roomDirectory.svelte';
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
@@ -113,7 +114,7 @@ describe('RoomDirectoryStore - join preview', () => {
           displayName: 'Alice',
           deleted: false,
           avatarUrl: null,
-          presenceStatus: PresenceStatus.Offline,
+          presenceStatus: PresenceStatus.OFFLINE,
           customStatus: null,
           roles: [],
           createdAt: null

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -1,11 +1,8 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { describe, it, expect, vi } from 'vitest';
 import { flushSync } from 'svelte';
-import {
-  NotificationLevel,
-  PresenceStatus,
-  RoomType,
-  type UserAvatarUserView
-} from '$lib/render/types';
+import { type UserAvatarUserView } from '$lib/render/types';
 import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
 import {
   RoomDirectoryScope,
@@ -56,7 +53,7 @@ function makeMember(id: string, overrides: Partial<DirectoryMember> = {}): Direc
     displayName: overrides.displayName ?? id,
     deleted: overrides.deleted ?? false,
     avatarUrl: overrides.avatarUrl ?? null,
-    presenceStatus: overrides.presenceStatus ?? PresenceStatus.Online,
+    presenceStatus: overrides.presenceStatus ?? PresenceStatus.ONLINE,
     customStatus: overrides.customStatus ?? null,
     roles: overrides.roles ?? [],
     createdAt: overrides.createdAt ?? null
@@ -71,7 +68,7 @@ function makeViewer(overrides: Partial<ViewerState> = {}): ViewerState {
       displayName: 'Alice',
       avatarUrl: null,
       customStatus: null,
-      presenceStatus: PresenceStatus.Online,
+      presenceStatus: PresenceStatus.ONLINE,
       hasVerifiedEmail: true,
       hasPassword: true,
       viewerCanDeleteAccount: true,
@@ -89,8 +86,8 @@ function makeViewer(overrides: Partial<ViewerState> = {}): ViewerState {
     canAdminViewAudit: false,
     canManageUserPermissions: false,
     serverNotificationPreference: {
-      level: NotificationLevel.Default,
-      effectiveLevel: NotificationLevel.Normal
+      level: NotificationLevel.DEFAULT,
+      effectiveLevel: NotificationLevel.NORMAL
     },
     roomNotificationPreferences: [],
     viewerPermissions: {},
@@ -198,7 +195,7 @@ describe('RoomsStore - refresh', () => {
     expect(store.rooms).toMatchObject([
       {
         id: 'public',
-        type: RoomType.Channel,
+        type: RoomKind.CHANNEL,
         isUniversal: false,
         viewerIsMember: false,
         viewerCanJoinRoom: true,
@@ -206,7 +203,7 @@ describe('RoomsStore - refresh', () => {
       },
       {
         id: 'dm-1',
-        type: RoomType.Dm,
+        type: RoomKind.DM,
         isUniversal: false,
         viewerIsMember: true,
         members: [{ id: 'U1', displayName: 'Alice' }]
@@ -242,14 +239,14 @@ describe('RoomsStore - refresh', () => {
             id: 'U2'
           },
           serverNotificationPreference: {
-            level: NotificationLevel.Muted,
-            effectiveLevel: NotificationLevel.Muted
+            level: NotificationLevel.MUTED,
+            effectiveLevel: NotificationLevel.MUTED
           },
           roomNotificationPreferences: [
             {
               roomId: 'general',
-              level: NotificationLevel.AllMessages,
-              effectiveLevel: NotificationLevel.AllMessages
+              level: NotificationLevel.ALL_MESSAGES,
+              effectiveLevel: NotificationLevel.ALL_MESSAGES
             }
           ]
         })
@@ -260,12 +257,12 @@ describe('RoomsStore - refresh', () => {
 
     expect(store.currentUserId).toBe('U2');
     expect(notificationLevels.getServerPreference()).toEqual({
-      level: NotificationLevel.Muted,
-      effectiveLevel: NotificationLevel.Muted
+      level: NotificationLevel.MUTED,
+      effectiveLevel: NotificationLevel.MUTED
     });
     expect(notificationLevels.getRoomPreference('general')).toEqual({
-      level: NotificationLevel.AllMessages,
-      effectiveLevel: NotificationLevel.AllMessages
+      level: NotificationLevel.ALL_MESSAGES,
+      effectiveLevel: NotificationLevel.ALL_MESSAGES
     });
   });
 
@@ -623,7 +620,7 @@ describe('RoomsStore - refresh', () => {
         displayName: 'Bob',
         deleted: false,
         avatarUrl: null,
-        presenceStatus: PresenceStatus.Online,
+        presenceStatus: PresenceStatus.ONLINE,
         customStatus: {
           emoji: ':wave:',
           text: 'Hi',

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -1,6 +1,6 @@
 import { untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
-import { RoomType, type UserAvatarUserView } from '$lib/render/types';
+import { type UserAvatarUserView } from '$lib/render/types';
 import type {
   DirectoryRoomGroup,
   DirectoryRoomGroupItem,
@@ -8,6 +8,7 @@ import type {
   RoomDirectoryAPI
 } from '$lib/api-client/roomDirectory';
 import { RoomDirectoryScope, RoomKind } from '$lib/api-client/roomDirectory';
+import { roomKindOrChannel } from '$lib/api-client/enumDefaults';
 import type { MemberDirectoryAPI, DirectoryMember } from '$lib/api-client/memberDirectory';
 import type { ViewerState } from '$lib/api-client/viewer';
 import type { NotificationLevelStore } from '$lib/state/server/notificationLevel.svelte';
@@ -19,7 +20,7 @@ export type RoomsListItem = {
   id: string;
   name: string;
   description?: string | null;
-  type: RoomType;
+  type: RoomKind;
   isUniversal: boolean;
   viewerIsMember: boolean;
   viewerCanJoinRoom: boolean;
@@ -33,7 +34,7 @@ export type RoomsListItem = {
 };
 
 export function isNavigationVisibleRoom(room: RoomsListItem): boolean {
-  return room.type !== RoomType.Dm || room.hasMessageHistory !== false;
+  return room.type !== RoomKind.DM || room.hasMessageHistory !== false;
 }
 
 export type RoomsListGroup = {
@@ -71,10 +72,6 @@ function uniqueById<T extends { id: string }>(items: readonly T[] | null | undef
     seen[item.id] = true;
     return true;
   });
-}
-
-function roomType(kind: RoomKind): RoomType {
-  return kind === RoomKind.DM ? RoomType.Dm : RoomType.Channel;
 }
 
 export function avatarUserFromDirectoryMember(member: DirectoryMember): UserAvatarUserView {
@@ -343,7 +340,7 @@ export class RoomsStore {
       id: room.id,
       name: room.name,
       description: room.description,
-      type: roomType(room.kind),
+      type: roomKindOrChannel(room.kind),
       isUniversal: room.isUniversal,
       viewerIsMember: room.isMember,
       viewerCanJoinRoom: room.canJoinRoom,

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { onDestroy, type Snippet } from 'svelte';
   import type { CurrentUser } from '$lib/auth/loadAuth';
-  import { PresenceStatus } from '$lib/render/types';
+
   import {
     updateAuthenticatedCurrentUserPresenceEntries,
     type PresenceCache
@@ -64,7 +65,7 @@
   }
   const currentUserState = serverRegistry.getStore(originServer.id).currentUser;
   // svelte-ignore state_referenced_locally
-  currentUserState.user = { ...user, presenceStatus: PresenceStatus.Online };
+  currentUserState.user = { ...user, presenceStatus: PresenceStatus.ONLINE };
   currentUserState.loading = false;
   onDestroy(() => {
     if (currentUserState.user?.id === user.id) {
@@ -73,7 +74,7 @@
     }
   });
   // svelte-ignore state_referenced_locally
-  presenceCache.update({ serverId: originServer.id, userId: user.id }, PresenceStatus.Online);
+  presenceCache.update({ serverId: originServer.id, userId: user.id }, PresenceStatus.ONLINE);
 
   // Initialize user settings from the user's settings data
   // svelte-ignore state_referenced_locally

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListRoomEventMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListRoomEventMock.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import type { RoomEventView } from '$lib/render/types';
-
   let { event }: { event: RoomEventView } = $props();
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventListTestHarness.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { RoomEventKind } from '$lib/render/eventKinds';
-  import { PresenceStatus, type RoomEventView } from '$lib/render/types';
+  import { type RoomEventView } from '$lib/render/types';
   import {
     createComposerContext,
     createRoomPermissions,
@@ -51,7 +52,7 @@
           displayName: `User ${id}`,
           deleted: false,
           avatarUrl: null,
-          presenceStatus: PresenceStatus.Offline
+          presenceStatus: PresenceStatus.OFFLINE
         }
       };
       if (eventKind === 'join') {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/LocaleDateMetadataHarness.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { getLocale } from '$lib/i18n/runtime';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import type { RoomEventView } from '$lib/render/types';
   import { RoomEventKind } from '$lib/render/eventKinds';
   import type { UserSettingsState } from '$lib/state/userSettings.svelte';
@@ -24,7 +25,7 @@
         login: 'alice',
         displayName: 'Alice',
         deleted: false,
-        presenceStatus: 'ONLINE',
+        presenceStatus: PresenceStatus.ONLINE,
         avatarUrl: null
       },
       event: {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -1,11 +1,8 @@
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import MessageAttachments from './MessageAttachments.svelte';
-import {
-  FitMode,
-  VideoProcessingStatus,
-  type MessageAttachmentView
-} from '$lib/render/types';
+import { VideoProcessingStatus, type MessageAttachmentView } from '$lib/render/types';
 import type { RefreshedAttachmentUrls } from '$lib/attachments/attachmentUrls';
 
 const attachmentMocks = vi.hoisted(() => ({
@@ -253,7 +250,7 @@ describe('MessageAttachments', () => {
             }
           ]
         ])
-    );
+      );
     const { container } = renderAttachment(hlsVideoAttachment());
 
     const player = container.querySelector<HTMLButtonElement>(
@@ -343,7 +340,7 @@ describe('MessageAttachments', () => {
       expect(attachmentMocks.refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1'], {
         width: 2048,
         height: 2048,
-        fit: FitMode.Contain
+        fit: ImageFitMode.CONTAIN
       });
       expect(attachmentMocks.pushState).toHaveBeenCalledWith('', {
         modal: {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
@@ -1,15 +1,11 @@
 <script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import MessageMetaBar from './MessageMetaBar.svelte';
   import { ServerConnection } from '$lib/state/server/serverConnection.svelte';
   import { provideConnection } from '$lib/state/server/connection.svelte';
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
-  import {
-    PresenceStatus,
-    type ReactionSummaryView,
-    type UserAvatarUserView
-  } from '$lib/render/types';
-
+  import { type ReactionSummaryView, type UserAvatarUserView } from '$lib/render/types';
   type Variant =
     | 'reactions'
     | 'replies-and-reactions'
@@ -42,7 +38,7 @@
     displayName: 'Alice',
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Online
+    presenceStatus: PresenceStatus.ONLINE
   };
   const jordan: UserAvatarUserView = {
     id: 'user-jordan',
@@ -50,7 +46,7 @@
     displayName: 'Jordan',
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Away
+    presenceStatus: PresenceStatus.AWAY
   };
   const mika: UserAvatarUserView = {
     id: 'user-mika',
@@ -58,7 +54,7 @@
     displayName: 'Mika',
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 
   const reactions: ReactionSummaryView[] = [

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte
@@ -1,16 +1,12 @@
 <script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import MessageMetaBar from './MessageMetaBar.svelte';
   import MessageView from '$lib/components/messages/MessageView.svelte';
   import { ServerConnection } from '$lib/state/server/serverConnection.svelte';
   import { provideConnection } from '$lib/state/server/connection.svelte';
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
-  import {
-    PresenceStatus,
-    type ReactionSummaryView,
-    type UserAvatarUserView
-  } from '$lib/render/types';
-
+  import { type ReactionSummaryView, type UserAvatarUserView } from '$lib/render/types';
   type Variant =
     | 'plain'
     | 'with-meta-bar'
@@ -43,7 +39,7 @@
       displayName: 'Alice',
       deleted: false,
       avatarUrl: null,
-      presenceStatus: PresenceStatus.Online
+      presenceStatus: PresenceStatus.ONLINE
     },
     {
       id: 'user-jordan',
@@ -51,7 +47,7 @@
       displayName: 'Jordan',
       deleted: false,
       avatarUrl: null,
-      presenceStatus: PresenceStatus.Away
+      presenceStatus: PresenceStatus.AWAY
     }
   ];
   const alice = threadParticipants[0];
@@ -61,7 +57,7 @@
     displayName: 'Bea',
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 
   const reactions: ReactionSummaryView[] = [

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -7,6 +7,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
 "UI" section of `docs/GLOSSARY.md`.
 -->
 <script module lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   export type RoomSidebarPanel = 'members' | 'files' | 'call';
 </script>
 
@@ -18,7 +19,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
   import UserCustomStatusBadge from '$lib/components/UserCustomStatusBadge.svelte';
   import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
-  import type { PresenceStatus } from '$lib/render/types';
+
   import type { RoomFilesStore, RoomMember, RoomMembersStore } from '$lib/state/room';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import {
@@ -140,7 +141,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
 
   // Check if a presence status counts as "online" (connected to the system)
   function isOnlineStatus(status: PresenceStatus): boolean {
-    return status !== 'OFFLINE';
+    return status !== PresenceStatus.OFFLINE && status !== PresenceStatus.UNSPECIFIED;
   }
 
   // Sort names once when membership/search/profile data changes. Presence updates only repartition

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -1,3 +1,5 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
@@ -7,7 +9,7 @@ import { setReactiveLocale } from '$lib/i18n/state.svelte';
 import { ROOM_MEMBERS_PAGE_SIZE, type RoomMember } from '$lib/state/room/members.svelte';
 import type { PresenceCache } from '$lib/state/presenceCache.svelte';
 import type { RoomData } from '$lib/hooks/useRoomData.svelte';
-import { PresenceStatus } from '$lib/render/types';
+
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import RoomSidebarTestHarness from './RoomSidebarTestHarness.svelte';
 
@@ -72,9 +74,7 @@ const callStore = vi.hoisted(() => ({
     }>,
     has: vi.fn(() => callStore.activeCallRooms.active),
     getParticipants: vi.fn(() => callStore.activeCallRooms.participants),
-    getParticipantCallPresenceInAnyRoom: vi.fn(
-      (_userId: string): 'voice' | 'video' | null => null
-    )
+    getParticipantCallPresenceInAnyRoom: vi.fn((_userId: string): 'voice' | 'video' | null => null)
   },
   rooms: {
     currentUserId: 'viewer'
@@ -181,7 +181,7 @@ function member(index: number): RoomMember {
     login: `user${index}`,
     displayName: `User ${index}`,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Online
+    presenceStatus: PresenceStatus.ONLINE
   };
 }
 
@@ -373,7 +373,10 @@ describe('RoomSidebar', () => {
     callStore.voiceCall.toggleParticipantLocalMute.mockClear();
     callStore.voiceCall.refreshDevices.mockClear();
     callStore.voiceCall.getAudioLevel.mockClear();
-    callStore.voiceCall.getAudioLevel.mockImplementation(() => ({ isSpeaking: false, audioLevel: 0 }));
+    callStore.voiceCall.getAudioLevel.mockImplementation(() => ({
+      isSpeaking: false,
+      audioLevel: 0
+    }));
     callStore.activeCallRooms.active = false;
     callStore.activeCallRooms.participants = [];
     callStore.activeCallRooms.has.mockClear();
@@ -462,7 +465,9 @@ describe('RoomSidebar', () => {
     await vi.waitFor(() => {
       expect(q(container, '[data-testid="member-call-presence-voice"]')).toBeTruthy();
     });
-    expect(callStore.activeCallRooms.getParticipantCallPresenceInAnyRoom).toHaveBeenCalledWith('user-2');
+    expect(callStore.activeCallRooms.getParticipantCallPresenceInAnyRoom).toHaveBeenCalledWith(
+      'user-2'
+    );
   });
 
   it('renders the call tab empty state and starts a call', async () => {
@@ -634,12 +639,8 @@ describe('RoomSidebar', () => {
       }
     });
 
-    expect(q(container, '[data-testid="call-mute-toggle"]')!.className).toContain(
-      'btn-secondary'
-    );
-    expect(q(container, '[data-testid="call-camera-toggle"]')!.className).toContain(
-      'btn-success'
-    );
+    expect(q(container, '[data-testid="call-mute-toggle"]')!.className).toContain('btn-secondary');
+    expect(q(container, '[data-testid="call-camera-toggle"]')!.className).toContain('btn-success');
     expect(q(container, '[data-testid="call-screen-share-toggle"]')!.className).toContain(
       'btn-success'
     );
@@ -683,7 +684,9 @@ describe('RoomSidebar', () => {
     await vi.waitFor(() => {
       expect(callStore.voiceCall.getAudioLevel).toHaveBeenCalledWith('viewer');
       expect(card.dataset.callSpeaking).toBe('true');
-      expect(Number(card.style.getPropertyValue('--call-speaking-ring-opacity'))).toBeGreaterThan(0);
+      expect(Number(card.style.getPropertyValue('--call-speaking-ring-opacity'))).toBeGreaterThan(
+        0
+      );
     });
     expect(card.className).toContain('call-speaking-card');
     expect(q(card, '[data-testid="call-speaking-indicator"]')).toBeFalsy();
@@ -955,8 +958,14 @@ describe('RoomSidebar', () => {
 
     const featured = q(container, '[data-testid="call-featured-stage-card"]')!;
     const mediaActions = q(featured, '[data-testid="call-media-actions"]')!;
-    const fullscreenButton = q(featured, '[data-testid="call-feed-fullscreen-button"]') as HTMLButtonElement;
-    const localMuteButton = q(featured, '[data-testid="call-feed-local-mute-button"]') as HTMLButtonElement;
+    const fullscreenButton = q(
+      featured,
+      '[data-testid="call-feed-fullscreen-button"]'
+    ) as HTMLButtonElement;
+    const localMuteButton = q(
+      featured,
+      '[data-testid="call-feed-local-mute-button"]'
+    ) as HTMLButtonElement;
 
     expect(mediaActions.className).toContain('border-text/10');
     expect(mediaActions.className).toContain('bg-surface');
@@ -1078,9 +1087,9 @@ describe('RoomSidebar', () => {
     await vi.waitFor(() => {
       expect(callStore.voiceCall.getAudioLevel).toHaveBeenCalledWith('viewer');
       expect(featured!.dataset.callSpeaking).toBe('true');
-      expect(Number(featured!.style.getPropertyValue('--call-speaking-ring-opacity'))).toBeGreaterThan(
-        0
-      );
+      expect(
+        Number(featured!.style.getPropertyValue('--call-speaking-ring-opacity'))
+      ).toBeGreaterThan(0);
     });
     expect(featured!.hasAttribute('data-speaking-ring')).toBe(true);
     expect(q(featured!, '[aria-label="Poor connection"]')).toBeTruthy();
@@ -1321,13 +1330,13 @@ describe('RoomSidebar', () => {
     await vi.waitFor(() => {
       expect(presenceCache).toBeTruthy();
     });
-    presenceCache!.update({ serverId: 'test-server', userId: user.id }, PresenceStatus.Away);
+    presenceCache!.update({ serverId: 'test-server', userId: user.id }, PresenceStatus.AWAY);
     await tick();
 
     expect(presenceBadge(container, 'Away')).toBeTruthy();
     expect(buttonByText(container, 'Online (1)')).toBeTruthy();
 
-    presenceCache!.update({ serverId: 'test-server', userId: user.id }, PresenceStatus.Online);
+    presenceCache!.update({ serverId: 'test-server', userId: user.id }, PresenceStatus.ONLINE);
     await tick();
 
     expect(presenceBadge(container, 'Online')).toBeTruthy();
@@ -1403,7 +1412,9 @@ describe('RoomSidebar', () => {
     ) as HTMLButtonElement | null;
     expect(minimizeButton).toBeTruthy();
     expect(minimizeButton!.querySelector('.mdi--arrow-collapse-right')).toBeTruthy();
-    const fullscreenButton = container.querySelector('[aria-label="Fullscreen call"]') as HTMLButtonElement | null;
+    const fullscreenButton = container.querySelector(
+      '[aria-label="Fullscreen call"]'
+    ) as HTMLButtonElement | null;
     expect(fullscreenButton).toBeTruthy();
     expect(fullscreenButton!.querySelector('.mdi--monitor-share')).toBeTruthy();
 
@@ -1564,7 +1575,7 @@ describe('RoomSidebar', () => {
         thumbnail: {
           width: 120,
           height: 120,
-          fit: 'COVER'
+          fit: ImageFitMode.COVER
         }
       });
       expect(container.textContent).toContain('thread.txt');
@@ -1667,12 +1678,11 @@ describe('RoomSidebar', () => {
   });
 
   it('falls back to a file icon when a video thumbnail fails to load', async () => {
-    attachmentMocks.listRoomAttachments
-      .mockResolvedValueOnce({
-        items: [roomVideoFile('clip.mp4')],
-        totalCount: 1,
-        hasMore: false
-      });
+    attachmentMocks.listRoomAttachments.mockResolvedValueOnce({
+      items: [roomVideoFile('clip.mp4')],
+      totalCount: 1,
+      hasMore: false
+    });
     attachmentMocks.refreshAssetUrls.mockResolvedValueOnce(new Map());
 
     const { container } = render(RoomSidebarTestHarness, {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPaneTestStore.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPaneTestStore.svelte.ts
@@ -1,5 +1,4 @@
 import type { RoomEventView } from '$lib/render/types';
-
 /** Reactive test double for exercising thread data that resolves after mount. */
 export class ThreadPaneTestStore {
   threadEvents = $state<RoomEventView[]>([]);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageGrouping.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageGrouping.spec.ts
@@ -5,6 +5,7 @@ import { RoomEventKind } from '$lib/render/eventKinds';
 import type { UserSettingsState } from '$lib/state/userSettings.svelte';
 import { loadLocaleMessages } from '$lib/i18n/messages';
 import { setReactiveLocale } from '$lib/i18n/state.svelte';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 
 // Mock settings with explicit UTC timezone so tests are deterministic regardless of host TZ
 const defaultSettings = {
@@ -37,7 +38,7 @@ function createMockEvent(
       login: 'testuser',
       displayName: 'Test User',
       deleted: false,
-      presenceStatus: 'ONLINE',
+      presenceStatus: PresenceStatus.ONLINE,
       avatarUrl: null
     }
   };

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageMentionHighlight.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageMentionHighlight.spec.ts
@@ -1,5 +1,6 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, expect, it } from 'vitest';
-import { PresenceStatus } from '$lib/render/types';
+
 import type { RoomMember } from '$lib/mentions';
 import { shouldHighlightCurrentUserMention } from './messageMentionHighlight';
 
@@ -9,7 +10,7 @@ function member(id: string, login: string, displayName = login): RoomMember {
     login,
     displayName,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline
+    presenceStatus: PresenceStatus.OFFLINE
   };
 }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -1,8 +1,10 @@
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q, testSnippet } from '$lib/test-utils';
-import { PresenceStatus, RoomType } from '$lib/render/types';
+
 import type { RoomsListItem } from '$lib/state/server/rooms.svelte';
 
 const { mocks } = vi.hoisted(() => ({
@@ -110,7 +112,7 @@ function room(overrides: Partial<RoomsListItem> = {}): RoomsListItem {
   return {
     id: 'room-1',
     name: 'development',
-    type: RoomType.Channel,
+    type: RoomKind.CHANNEL,
     isUniversal: false,
     viewerIsMember: true,
     viewerCanJoinRoom: true,
@@ -225,7 +227,7 @@ describe('room route layout access handling', () => {
           displayName: 'Alice',
           deleted: false,
           avatarUrl: null,
-          presenceStatus: PresenceStatus.Offline,
+          presenceStatus: PresenceStatus.OFFLINE,
           customStatus: null
         },
         {
@@ -234,7 +236,7 @@ describe('room route layout access handling', () => {
           displayName: 'Bob',
           deleted: false,
           avatarUrl: null,
-          presenceStatus: PresenceStatus.Online,
+          presenceStatus: PresenceStatus.ONLINE,
           customStatus: null
         }
       ]

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/tombstoneVisibility.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/tombstoneVisibility.ts
@@ -1,6 +1,5 @@
 import { isMessagePostedEvent } from '$lib/render/eventKinds';
 import type { RoomEventView } from '$lib/render/types';
-
 export const MESSAGE_TOMBSTONE_GRACE_MS = 60 * 60 * 1000;
 
 /**

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMemberManagementStore.svelte.spec.ts
@@ -1,10 +1,11 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { describe, expect, it, vi } from 'vitest';
 import type {
   DirectoryMember,
   MemberDirectoryAPI,
   MemberDirectoryPage
 } from '$lib/api-client/memberDirectory';
-import { PresenceStatus } from '$lib/api-client/renderTypes';
+
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
 import {
   ROOM_MEMBER_MANAGEMENT_PAGE_SIZE,
@@ -19,7 +20,7 @@ function member(id: string): DirectoryMember {
     displayName: id.toUpperCase(),
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline,
+    presenceStatus: PresenceStatus.OFFLINE,
     customStatus: null,
     roles: ['everyone'],
     createdAt: null

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte.spec.ts
@@ -1,3 +1,4 @@
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
@@ -11,7 +12,7 @@ import type {
   MemberDirectoryAPI,
   MemberDirectoryPage
 } from '$lib/api-client/memberDirectory';
-import { PresenceStatus } from '$lib/api-client/renderTypes';
+
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
 import RoomMembersPanel from './RoomMembersPanel.svelte';
 import {
@@ -49,7 +50,7 @@ function member(id: string, displayName = id.toUpperCase()): DirectoryMember {
     displayName,
     deleted: false,
     avatarUrl: null,
-    presenceStatus: PresenceStatus.Offline,
+    presenceStatus: PresenceStatus.OFFLINE,
     customStatus: null,
     roles: ['everyone'],
     createdAt: null

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -5,13 +5,14 @@ Server-local message search. Query text and hydrated results remain transient
 in the active server store so browser Back can restore the current search.
 -->
 <script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import type { Attachment } from 'svelte/attachments';
   import { tick } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { Panel } from '$lib/components/admin';
   import MessageView from '$lib/components/messages/MessageView.svelte';
-  import { PresenceStatus, type UserAvatarUserView } from '$lib/render/types';
+  import { type UserAvatarUserView } from '$lib/render/types';
   import type { MessageSearchResult } from '$lib/api-client/messageSearch';
   import { RoomKind } from '$lib/api-client/roomDirectory';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -77,7 +78,7 @@ in the active server store so browser Back can restore the current search.
     if (!result.actor) return null;
     return {
       ...result.actor,
-      presenceStatus: PresenceStatus.Offline
+      presenceStatus: PresenceStatus.OFFLINE
     };
   }
 
@@ -230,10 +231,7 @@ in the active server store so browser Back can restore the current search.
                 <EmptyState icon="uil--exclamation-triangle" title={m['search.error.title']()}>
                   {m['search.error.description']()}
                 </EmptyState>
-              {:else if store.hasSearched &&
-                !store.loading &&
-                store.results.length === 0 &&
-                !store.nextCursor}
+              {:else if store.hasSearched && !store.loading && store.results.length === 0 && !store.nextCursor}
                 <EmptyState icon="uil--search-minus" title={m['search.no_results.title']()}>
                   {m['search.no_results.description']()}
                 </EmptyState>
@@ -249,7 +247,7 @@ in the active server store so browser Back can restore the current search.
                         role="link"
                         tabindex="0"
                         data-search-result-id={result.id}
-                        class="selectable-list-item cursor-pointer"
+                        class="cursor-pointer selectable-list-item"
                         onclick={(event) => openResult(event, result)}
                         onkeydown={(event) => openResultFromKeyboard(event, result)}
                       >

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -1,8 +1,9 @@
+import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import NotificationsPage from './+page.svelte';
-import { NotificationLevel } from '$lib/render/types';
+
 import { NotificationLevel as ApiNotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
 import { RoomDirectoryScope } from '@chatto/api-types/api/v1/room_directory_pb';
 import { q } from '$lib/test-utils';
@@ -172,13 +173,13 @@ describe('Notification settings page', () => {
       roomNotificationPreferences: [
         {
           roomId: 'room-1',
-          level: NotificationLevel.Default,
-          effectiveLevel: NotificationLevel.Normal
+          level: NotificationLevel.DEFAULT,
+          effectiveLevel: NotificationLevel.NORMAL
         },
         {
           roomId: 'dm-1',
-          level: NotificationLevel.Muted,
-          effectiveLevel: NotificationLevel.Muted
+          level: NotificationLevel.MUTED,
+          effectiveLevel: NotificationLevel.MUTED
         }
       ]
     });
@@ -269,7 +270,7 @@ describe('Notification settings page', () => {
       container,
       '[data-testid="room-notification-general"] select'
     ) as HTMLSelectElement;
-    select.value = NotificationLevel.Muted;
+    select.value = String(NotificationLevel.MUTED);
     select.dispatchEvent(new Event('change', { bubbles: true }));
     await settle();
 
@@ -285,8 +286,8 @@ describe('Notification settings page', () => {
     expect(mocks.mutation).not.toHaveBeenCalled();
     expect(mocks.notificationLevels.setRoomPreference).toHaveBeenLastCalledWith(
       'room-1',
-      NotificationLevel.Muted,
-      NotificationLevel.Muted
+      NotificationLevel.MUTED,
+      NotificationLevel.MUTED
     );
   });
 
@@ -307,8 +308,8 @@ describe('Notification settings page', () => {
     );
     expect(mocks.mutation).not.toHaveBeenCalled();
     expect(mocks.notificationLevels.setServerPreference).toHaveBeenCalledWith(
-      NotificationLevel.AllMessages,
-      NotificationLevel.AllMessages
+      NotificationLevel.ALL_MESSAGES,
+      NotificationLevel.ALL_MESSAGES
     );
   });
 


### PR DESCRIPTION
## Why

The frontend still carried four hand-written compatibility enums that duplicate
the generated protobuf API types. Keeping both representations required
repetitive mapping code and allowed fixtures to drift away from the real wire
values.

## What changed

- use generated `NotificationLevel`, `RoomKind`, `PresenceStatus`, and
  `ImageFitMode` values throughout frontend state, render DTOs, components, and
  tests
- centralize the established safe defaults for unspecified and unknown values:
  `DEFAULT`, `CHANNEL`, `OFFLINE`, and `COVER`
- serialize numeric notification enum values explicitly at the room preference
  `<select>` boundary
- remove redundant API-to-render enum mappers
- retain the custom `VideoProcessingStatus`, whose frontend-only `Pending`
  state has no one-to-one protobuf equivalent

This is an internal frontend representation cleanup. It does not change public
protobufs, server behavior, stored data, user-visible behavior, or rollout
requirements.

## Test plan

- `mise lint-frontend` — passed with 0 Svelte errors and 0 warnings
- focused enum/API/component tests — 70 passed
- `mise test-frontend` — 292 files and 2,480 tests passed
- focused post-review tests — 21 passed
- targeted notification e2e tests — 40 passed
- official Svelte autofixer and repository CLI autofixer — no migration-related
  issues
- `mise license-check` — passed
- independent adversarial review — clean after addressing one stale fixture

Closes #1734.
