### PR TITLE
feat(rooms): support Unicode room names

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -45,7 +45,7 @@ Request to create a channel room.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `name` | `string` | Required. Name of the new channel room. |
+| `name` | `string` | Required. NFC-normalized name of the new channel room. Names accept Unicode letters, decimal digits, hyphens, and underscores. |
 | `description` | `string` | Optional room description. |
 | `group_id` | `string` | Required. Room group that should contain the new channel. |
 | `universal` | `bool` | Whether the new channel should grant effective membership to eligible server members. |
@@ -82,7 +82,7 @@ Request to update a room's editable metadata.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room to update. |
-| `name` | `optional string` | New room name, when changing it. |
+| `name` | `optional string` | New NFC-normalized room name, when changing it. Names accept Unicode letters, decimal digits, hyphens, and underscores. |
 | `description` | `optional string` | New room description, when changing it. Empty clears the description. |
 | `universal` | `optional bool` | New universal membership state, when changing it. Direct-message rooms cannot be universal. |
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1463,7 +1463,7 @@ Request to create a channel room.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `name` | `string` | Required. Name of the new channel room. |
+| `name` | `string` | Required. NFC-normalized name of the new channel room. Names accept Unicode letters, decimal digits, hyphens, and underscores. |
 | `description` | `string` | Optional room description. |
 | `group_id` | `string` | Required. Room group that should contain the new channel. |
 | `universal` | `bool` | Whether the new channel should grant effective membership to eligible server members. |
@@ -1500,7 +1500,7 @@ Request to update a room's editable metadata.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room to update. |
-| `name` | `optional string` | New room name, when changing it. |
+| `name` | `optional string` | New NFC-normalized room name, when changing it. Names accept Unicode letters, decimal digits, hyphens, and underscores. |
 | `description` | `optional string` | New room description, when changing it. Empty clears the description. |
 | `universal` | `optional bool` | New universal membership state, when changing it. Direct-message rooms cannot be universal. |
 

--- a/apps/frontend/src/lib/CreateRoom.svelte
+++ b/apps/frontend/src/lib/CreateRoom.svelte
@@ -2,6 +2,7 @@
   import { useConnection } from '$lib/state/server/connection.svelte';
   import * as m from '$lib/i18n/messages';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
+  import { normalizeRoomName } from '$lib/utils/roomName';
   import {
     TextInput,
     TextArea,
@@ -57,7 +58,7 @@
         bearerToken: conn.bearerToken
       });
       const created = await api.createRoom({
-        name: values.name.trim(),
+        name: normalizeRoomName(values.name),
         description: values.description.trim() || null,
         groupId: targetGroupId,
         universal: values.isUniversal

--- a/apps/frontend/src/lib/CreateRoom.svelte.spec.ts
+++ b/apps/frontend/src/lib/CreateRoom.svelte.spec.ts
@@ -79,4 +79,22 @@ describe('CreateRoom', () => {
       universal: true
     });
   });
+
+  it('normalizes Unicode room names before creation', async () => {
+    const { container } = render(CreateRoom, {
+      groupId: 'group-1',
+      onroomcreated: mocks.onroomcreated
+    });
+
+    await fillNameAndSubmit(container, 'Ku\u0308che');
+
+    await vi.waitFor(() => {
+      expect(mocks.createRoom).toHaveBeenCalledWith({
+        name: 'Küche',
+        description: null,
+        groupId: 'group-1',
+        universal: false
+      });
+    });
+  });
 });

--- a/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
@@ -33,14 +33,48 @@ const mocks = vi.hoisted(() => ({
 describe('room name helpers', () => {
   it('normalizes Unicode names and counts code points', () => {
     expect(normalizeRoomName('  Ku\u0308che  ')).toBe('Küche');
+    expect(normalizeRoomName('は\u3099')).toBe('ば');
+    expect(normalizeRoomName('Pho\u0300ng')).toBe('Phòng');
     expect(roomNameCharacterCount('繁體中文')).toBe(4);
+    expect(roomNameCharacterCount('𐐀'.repeat(30))).toBe(30);
+    expect(roomNameCharacterCount('𐐀'.repeat(31))).toBe(31);
   });
 
-  it('accepts Unicode letters and decimal digits but rejects other characters', () => {
-    expect(hasValidRoomNameCharacters('繁體中文')).toBe(true);
-    expect(hasValidRoomNameCharacters('Küche_123')).toBe(true);
-    expect(hasValidRoomNameCharacters('room name')).toBe(false);
-    expect(hasValidRoomNameCharacters('room💬')).toBe(false);
+  it.each([
+    ['Arabic with Arabic-Indic digits', 'غرفة_١٢٣'],
+    ['Armenian', 'սենյակ'],
+    ['Chinese', '聊天室'],
+    ['Cyrillic', 'Комната'],
+    ['Deseret supplementary-plane letters', '𐐀𐐨'],
+    ['Ethiopic', 'ክፍል'],
+    ['Georgian', 'ოთახი'],
+    ['Greek', 'Δωμάτιο'],
+    ['Hebrew', 'חדר'],
+    ['Japanese hiragana', 'ひらがな'],
+    ['Japanese kanji', '会議室'],
+    ['Japanese katakana', 'カタカナ'],
+    ['Korean Hangul', '회의실'],
+    ['Latin with Vietnamese diacritics', 'Phòng'],
+    ['Turkish dotted capital I', 'İstanbul'],
+    ['Devanagari decimal digits', 'room_१२३'],
+    ['fullwidth decimal digits', '部屋１２３'],
+    ['mixed scripts with allowed separators', 'Küche_聊天室-١٢٣']
+  ])('accepts %s', (_description, name) => {
+    expect(hasValidRoomNameCharacters(name)).toBe(true);
+  });
+
+  // NFC runs before validation, but surviving marks and formatting characters
+  // are intentionally outside the current letters-and-decimal-digits rule.
+  it.each([
+    ['combining mark that remains after NFC', 'room\u0338'],
+    ['Devanagari vowel mark', 'कमरा'],
+    ['emoji sequence', 'room👩‍💻'],
+    ['left-to-right formatting mark', 'room\u200ename'],
+    ['non-decimal superscript number', 'room²'],
+    ['Thai combining mark', 'ห้อง'],
+    ['zero-width joiner', 'room\u200dname']
+  ])('rejects %s', (_description, name) => {
+    expect(hasValidRoomNameCharacters(normalizeRoomName(name))).toBe(false);
   });
 });
 
@@ -432,7 +466,7 @@ describe('createRoomCommandAPI', () => {
 
     await expect(
       api.createRoom({
-        name: 'a'.repeat(31),
+        name: '𐐀'.repeat(31),
         description: null,
         groupId: 'group-1'
       })

--- a/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
@@ -6,6 +6,11 @@ import { configureApiClientHooks } from '$lib/api-client/hooks';
 
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { createRoomCommandAPI } from '$lib/api-client/rooms';
+import {
+  hasValidRoomNameCharacters,
+  normalizeRoomName,
+  roomNameCharacterCount
+} from '$lib/utils/roomName';
 
 const mocks = vi.hoisted(() => ({
   createClient: vi.fn(),
@@ -24,6 +29,20 @@ const mocks = vi.hoisted(() => ({
   banMember: vi.fn(),
   unbanMember: vi.fn()
 }));
+
+describe('room name helpers', () => {
+  it('normalizes Unicode names and counts code points', () => {
+    expect(normalizeRoomName('  Ku\u0308che  ')).toBe('Küche');
+    expect(roomNameCharacterCount('繁體中文')).toBe(4);
+  });
+
+  it('accepts Unicode letters and decimal digits but rejects other characters', () => {
+    expect(hasValidRoomNameCharacters('繁體中文')).toBe(true);
+    expect(hasValidRoomNameCharacters('Küche_123')).toBe(true);
+    expect(hasValidRoomNameCharacters('room name')).toBe(false);
+    expect(hasValidRoomNameCharacters('room💬')).toBe(false);
+  });
+});
 
 vi.mock('@connectrpc/connect', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@connectrpc/connect')>();

--- a/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
@@ -43,7 +43,7 @@ describe('room name helpers', () => {
   it.each([
     ['Arabic with Arabic-Indic digits', 'غرفة_١٢٣'],
     ['Armenian', 'սենյակ'],
-    ['Chinese', '聊天室'],
+    ['Traditional Chinese (zh-TW)', '繁體中文聊天室'],
     ['Cyrillic', 'Комната'],
     ['Deseret supplementary-plane letters', '𐐀𐐨'],
     ['Ethiopic', 'ክፍል'],

--- a/apps/frontend/src/lib/api-client/rooms.ts
+++ b/apps/frontend/src/lib/api-client/rooms.ts
@@ -10,6 +10,11 @@ import { Timestamp } from '@bufbuild/protobuf';
 import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
 import type { Room, RoomBan as APIRoomBan } from '@chatto/api-types/api/v1/rooms_pb';
 import { mapDirectoryMember, type DirectoryMember } from './memberDirectory.js';
+import {
+  normalizeRoomName,
+  ROOM_NAME_MAX_LENGTH,
+  roomNameCharacterCount
+} from '$lib/utils/roomName';
 
 export type { ConnectAPIConfig } from './connect.js';
 
@@ -43,7 +48,6 @@ export type RoomBanList = {
 
 export type RoomCommandAPI = ReturnType<typeof createRoomCommandAPI>;
 
-const ROOM_NAME_MAX_LENGTH = 30;
 const ROOM_DESCRIPTION_MAX_LENGTH = 500;
 
 function publicRoom(room: Room | undefined): PublicRoom | null {
@@ -76,7 +80,10 @@ function roomBan(ban: APIRoomBan): RoomBanSummary {
 function roomValidationError(err: unknown, input: { name?: string; description?: string | null }) {
   if (!(err instanceof ConnectError) || err.code !== Code.InvalidArgument) return err;
 
-  if (input.name !== undefined && input.name.length > ROOM_NAME_MAX_LENGTH) {
+  if (
+    input.name !== undefined &&
+    roomNameCharacterCount(normalizeRoomName(input.name)) > ROOM_NAME_MAX_LENGTH
+  ) {
     return new Error(`room name must be ${ROOM_NAME_MAX_LENGTH} characters or less`);
   }
   if ((input.description ?? '').length > ROOM_DESCRIPTION_MAX_LENGTH) {

--- a/apps/frontend/src/lib/utils/roomName.ts
+++ b/apps/frontend/src/lib/utils/roomName.ts
@@ -1,0 +1,13 @@
+export const ROOM_NAME_MAX_LENGTH = 30;
+
+export function normalizeRoomName(name: string): string {
+  return name.trim().normalize('NFC');
+}
+
+export function roomNameCharacterCount(name: string): number {
+  return [...name].length;
+}
+
+export function hasValidRoomNameCharacters(name: string): boolean {
+  return /^[\p{L}\p{Nd}_-]+$/u.test(name);
+}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -7,6 +7,12 @@
   import { createRoomDirectoryAPI, type DirectoryRoomDetails } from '$lib/api-client/roomDirectory';
   import { createAdminRoomLayoutAPI, type AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
+  import {
+    hasValidRoomNameCharacters,
+    normalizeRoomName,
+    ROOM_NAME_MAX_LENGTH,
+    roomNameCharacterCount
+  } from '$lib/utils/roomName';
   import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
   import { Code, ConnectError } from '@connectrpc/connect';
   import { getChromePermissions } from '$lib/state/server/chromePermissions.svelte';
@@ -78,18 +84,21 @@
       ? resolve('/chat/[serverId]/manage/rooms', { serverId: serverSegment })
       : resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId })
   );
+  const normalizedName = $derived(normalizeRoomName(name));
   const nameError = $derived.by(() => {
     if (!name) return undefined;
     if (name.trim() === '') return m['admin.rooms_admin.room_name_empty']();
     if (name !== name.trim()) return m['admin.rooms_admin.room_name_trim']();
-    if (!/^[a-zA-Z0-9_-]+$/.test(name.trim())) {
+    if (!hasValidRoomNameCharacters(normalizedName)) {
       return m['admin.rooms_admin.room_name_charset']();
     }
-    if (name.length > 30) return m['admin.rooms_admin.room_name_too_long']();
+    if (roomNameCharacterCount(normalizedName) > ROOM_NAME_MAX_LENGTH) {
+      return m['admin.rooms_admin.room_name_too_long']();
+    }
     return undefined;
   });
   const changed = $derived(
-    name.trim() !== originalName ||
+    normalizedName !== originalName ||
       description.trim() !== originalDescription ||
       universal !== originalUniversal
   );

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -218,6 +218,28 @@ describe('room management page identity and realtime authority', () => {
     expect(container.querySelector('#room-member-picker')).toBeNull();
   });
 
+  it('accepts and normalizes Unicode room names', async () => {
+    mocks.getRoom.mockResolvedValue(managedRoom('general'));
+    const { container } = render(RoomManagementPage);
+    await settle();
+
+    const nameInput = container.querySelector('#room-settings-name') as HTMLInputElement;
+    nameInput.value = 'Ku\u0308che_繁體';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    const submit = container.querySelector('form button[type="submit"]') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+    submit.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.updateRoom).toHaveBeenCalledWith({
+        roomId: 'shared-room',
+        name: 'Küche_繁體'
+      });
+    });
+  });
+
   it('purges room metadata synchronously when realtime removes access', async () => {
     mocks.getRoom.mockResolvedValueOnce(managedRoom('private-room'));
     const pendingReload = deferred<ReturnType<typeof managedRoom>>();

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/roomSettings.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/roomSettings.ts
@@ -1,4 +1,5 @@
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
+import { normalizeRoomName } from '$lib/utils/roomName';
 
 export type RoomSettingsValues = {
   name: string;
@@ -15,7 +16,7 @@ export function buildRoomSettingsUpdate(
   original: RoomSettingsValues
 ): RoomUpdateInput {
   const input: RoomUpdateInput = { roomId };
-  const name = current.name.trim();
+  const name = normalizeRoomName(current.name);
   const description = current.description.trim();
 
   if (name !== original.name) input.name = name;

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -61,6 +61,7 @@ require (
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/term v0.44.0
+	golang.org/x/text v0.38.0
 	google.golang.org/protobuf v1.36.11
 )
 
@@ -220,7 +221,6 @@ require (
 	golang.org/x/arch v0.27.0 // indirect
 	golang.org/x/exp v0.0.0-20260529124908-c761662dc8c9 // indirect
 	golang.org/x/sys v0.46.0 // indirect
-	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/cli/internal/core/message_search_read_model.go
+++ b/cli/internal/core/message_search_read_model.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"slices"
-	"strings"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -200,7 +199,7 @@ func filterSearchRoomsBySelectors(rooms map[string]*corev1.Room, selectors []str
 	result := make(map[string]*corev1.Room)
 	for _, selector := range selectors {
 		for roomID, room := range rooms {
-			if roomID == selector || (room.GetName() != "" && strings.EqualFold(room.GetName(), selector)) {
+			if roomID == selector || (room.GetName() != "" && canonicalRoomName(room.GetName()) == canonicalRoomName(selector)) {
 				result[roomID] = room
 			}
 		}

--- a/cli/internal/core/message_search_read_model_test.go
+++ b/cli/internal/core/message_search_read_model_test.go
@@ -17,9 +17,11 @@ func TestMessageSearchReadModelResolvesAuthorizedScope(t *testing.T) {
 	require.NoError(t, err)
 	archived, err := chattoCore.CreateRoom(ctx, SystemActorID, KindChannel, "", "search-archived", "")
 	require.NoError(t, err)
+	unicodeRoom, err := chattoCore.CreateRoom(ctx, SystemActorID, KindChannel, "", "Küche", "")
+	require.NoError(t, err)
 	hidden, err := chattoCore.CreateRoom(ctx, SystemActorID, KindChannel, "", "search-hidden", "")
 	require.NoError(t, err)
-	for _, roomID := range []string{visible.Id, archived.Id} {
+	for _, roomID := range []string{visible.Id, archived.Id, unicodeRoom.Id} {
 		_, err = chattoCore.JoinRoom(ctx, viewer.Id, KindChannel, viewer.Id, roomID)
 		require.NoError(t, err)
 	}
@@ -32,7 +34,7 @@ func TestMessageSearchReadModelResolvesAuthorizedScope(t *testing.T) {
 
 	scope, err := chattoCore.MessageSearchReads().ResolveScope(ctx, MessageSearchScopeInput{ActorID: viewer.Id})
 	require.NoError(t, err)
-	require.ElementsMatch(t, []string{visible.Id, archived.Id, dm.Id}, scope.RoomIDs)
+	require.ElementsMatch(t, []string{visible.Id, archived.Id, unicodeRoom.Id, dm.Id}, scope.RoomIDs)
 	require.NotContains(t, scope.RoomIDs, hidden.Id)
 
 	scope, err = chattoCore.MessageSearchReads().ResolveScope(ctx, MessageSearchScopeInput{
@@ -41,6 +43,13 @@ func TestMessageSearchReadModelResolvesAuthorizedScope(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []string{archived.Id}, scope.RoomIDs)
 	require.Equal(t, []string{author.Id}, scope.AuthorIDs)
+	require.False(t, scope.NoMatches)
+
+	scope, err = chattoCore.MessageSearchReads().ResolveScope(ctx, MessageSearchScopeInput{
+		ActorID: viewer.Id, RoomSelectors: []string{"KU\u0308CHE"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, []string{unicodeRoom.Id}, scope.RoomIDs)
 	require.False(t, scope.NoMatches)
 
 	scope, err = chattoCore.MessageSearchReads().ResolveScope(ctx, MessageSearchScopeInput{

--- a/cli/internal/core/room_catalog_projection.go
+++ b/cli/internal/core/room_catalog_projection.go
@@ -1,8 +1,6 @@
 package core
 
 import (
-	"strings"
-
 	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/events"
@@ -160,7 +158,7 @@ func (p *RoomCatalogProjection) FindByName(name string) string {
 }
 
 func (p *RoomCatalogProjection) NameClaimSnapshot(name string) RoomNameClaimSnapshot {
-	target := strings.ToLower(strings.TrimSpace(name))
+	target := canonicalRoomName(name)
 	if target == "" {
 		return RoomNameClaimSnapshot{}
 	}
@@ -171,7 +169,7 @@ func (p *RoomCatalogProjection) NameClaimSnapshot(name string) RoomNameClaimSnap
 		if entry.kind != corev1.RoomKind_ROOM_KIND_CHANNEL {
 			continue
 		}
-		if strings.ToLower(entry.name) == target {
+		if canonicalRoomName(entry.name) == target {
 			snapshot.OwnerRoomID = id
 			return snapshot
 		}

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	"github.com/nats-io/nats.go/jetstream"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/unicode/norm"
 
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
@@ -66,34 +69,37 @@ const (
 // ErrRoomNameExists is returned when a room with the same name (case-insensitive) already exists.
 var ErrRoomNameExists = errors.New("a room with this name already exists in this space")
 
+// normalizeRoomName returns the NFC-normalized, whitespace-trimmed room name
+// stored in durable room events and returned through public APIs.
+func normalizeRoomName(name string) string {
+	return norm.NFC.String(strings.TrimSpace(name))
+}
+
+// canonicalRoomName returns the comparison key used for case-insensitive room
+// name uniqueness and lookups. It is not persisted or shown to users.
+func canonicalRoomName(name string) string {
+	return norm.NFC.String(cases.Fold().String(normalizeRoomName(name)))
+}
+
 // ValidateRoomName validates a room name and returns an error if invalid.
-// Room names must be URL-safe: only alphanumeric characters, hyphens, and underscores.
+// Room names allow Unicode letters and decimal digits plus hyphens and
+// underscores.
 func ValidateRoomName(name string) error {
-	trimmed := strings.TrimSpace(name)
-	if len(trimmed) < RoomNameMinLength {
+	normalized := normalizeRoomName(name)
+	if utf8.RuneCountInString(normalized) < RoomNameMinLength {
 		return fmt.Errorf("room name is required")
 	}
-	if len(trimmed) > RoomNameMaxLength {
+	if utf8.RuneCountInString(normalized) > RoomNameMaxLength {
 		return fmt.Errorf("room name must be %d characters or less", RoomNameMaxLength)
 	}
 
-	// Check for URL-safe characters only (alphanumeric, hyphens, underscores)
-	for _, ch := range trimmed {
-		if !isURLSafeChar(ch) {
+	for _, ch := range normalized {
+		if !unicode.IsLetter(ch) && !unicode.IsDigit(ch) && ch != '-' && ch != '_' {
 			return fmt.Errorf("room name must contain only alphanumeric characters, hyphens, and underscores (no spaces or special characters)")
 		}
 	}
 
 	return nil
-}
-
-// urlSafeCharRegex matches URL-safe characters for room names.
-// Allows: a-z, A-Z, 0-9, hyphen (-), and underscore (_)
-var urlSafeCharRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]$`)
-
-// isURLSafeChar returns true if the character is URL-safe for room names.
-func isURLSafeChar(ch rune) bool {
-	return urlSafeCharRegex.MatchString(string(ch))
 }
 
 // ValidateRoomDescription validates a room description and returns an error if invalid.
@@ -179,7 +185,7 @@ func (c *ChattoCore) CreateRoom(ctx context.Context, actorID string, kind RoomKi
 		}
 	}
 
-	name = strings.TrimSpace(name)
+	name = normalizeRoomName(name)
 	room_id := NewRoomID()
 
 	room := &corev1.Room{
@@ -398,7 +404,7 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 		return nil, err
 	}
 
-	name = strings.TrimSpace(name)
+	name = normalizeRoomName(name)
 
 	room, err := c.GetRoom(ctx, kind, room_id)
 	if err != nil {
@@ -408,7 +414,7 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 	// "Rename" here means the case-folded name changed. Case-only
 	// edits (e.g. "general" → "General") don't change the uniqueness
 	// slot and can skip the wildcard OCC dance.
-	renamed := !strings.EqualFold(room.Name, name)
+	renamed := canonicalRoomName(room.Name) != canonicalRoomName(name)
 
 	room.Name = name
 	room.Description = description

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -11,7 +11,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/nats-io/nats.go/jetstream"
-	"golang.org/x/text/cases"
 	"golang.org/x/text/unicode/norm"
 
 	"hmans.de/chatto/internal/events"
@@ -76,9 +75,12 @@ func normalizeRoomName(name string) string {
 }
 
 // canonicalRoomName returns the comparison key used for case-insensitive room
-// name uniqueness and lookups. It is not persisted or shown to users.
+// name uniqueness and lookups. Keep simple-lowercase semantics so old and new
+// replicas agree during rolling upgrades; full Unicode case folding would make
+// pairs such as "Straße" and "STRASSE" collide only on upgraded replicas.
+// The key is not persisted or shown to users.
 func canonicalRoomName(name string) string {
-	return norm.NFC.String(cases.Fold().String(normalizeRoomName(name)))
+	return norm.NFC.String(strings.ToLower(normalizeRoomName(name)))
 }
 
 // ValidateRoomName validates a room name and returns an error if invalid.
@@ -411,7 +413,7 @@ func (c *ChattoCore) UpdateRoom(ctx context.Context, actorID string, kind RoomKi
 		return nil, err
 	}
 
-	// "Rename" here means the case-folded name changed. Case-only
+	// "Rename" here means the normalized, lowercased name changed. Case-only
 	// edits (e.g. "general" → "General") don't change the uniqueness
 	// slot and can skip the wildcard OCC dance.
 	renamed := canonicalRoomName(room.Name) != canonicalRoomName(name)

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -283,6 +283,85 @@ func TestValidateRoomName(t *testing.T) {
 	}
 }
 
+func TestValidateRoomNameInternationalScripts(t *testing.T) {
+	validNames := map[string]string{
+		"Arabic with Arabic-Indic digits":       "غرفة_١٢٣",
+		"Armenian":                              "սենյակ",
+		"Chinese":                               "聊天室",
+		"Cyrillic":                              "Комната",
+		"Deseret supplementary-plane letters":   "𐐀𐐨",
+		"Ethiopic":                              "ክፍል",
+		"Georgian":                              "ოთახი",
+		"Greek":                                 "Δωμάτιο",
+		"Hebrew":                                "חדר",
+		"Japanese hiragana":                     "ひらがな",
+		"Japanese kanji":                        "会議室",
+		"Japanese katakana":                     "カタカナ",
+		"Korean Hangul":                         "회의실",
+		"Latin with Vietnamese diacritics":      "Phòng",
+		"Turkish dotted capital I":              "İstanbul",
+		"Devanagari decimal digits":             "room_१२३",
+		"fullwidth decimal digits":              "部屋１２３",
+		"30 supplementary-plane code points":    strings.Repeat("𐐀", RoomNameMaxLength),
+		"mixed scripts with allowed separators": "Küche_聊天室-١٢٣",
+	}
+	for name, input := range validNames {
+		t.Run("accepts "+name, func(t *testing.T) {
+			if err := ValidateRoomName(input); err != nil {
+				t.Errorf("ValidateRoomName(%q) = %v, want nil", input, err)
+			}
+		})
+	}
+
+	// Document the Unicode-category boundary explicitly: NFC runs first, but
+	// marks that remain separate and formatting characters are not letters or
+	// decimal digits under the current room-name rule.
+	const invalidCharacterError = "room name must contain only alphanumeric characters, hyphens, and underscores (no spaces or special characters)"
+	invalidNames := map[string]string{
+		"combining mark that remains after NFC": "room\u0338",
+		"Devanagari vowel mark":                 "कमरा",
+		"emoji sequence":                        "room👩‍💻",
+		"left-to-right formatting mark":         "room\u200ename",
+		"non-decimal superscript number":        "room²",
+		"Thai combining mark":                   "ห้อง",
+		"zero-width joiner":                     "room\u200dname",
+	}
+	for name, input := range invalidNames {
+		t.Run("rejects "+name, func(t *testing.T) {
+			err := ValidateRoomName(input)
+			if err == nil || err.Error() != invalidCharacterError {
+				t.Errorf("ValidateRoomName(%q) = %v, want %q", input, err, invalidCharacterError)
+			}
+		})
+	}
+
+	t.Run("rejects 31 supplementary-plane code points", func(t *testing.T) {
+		input := strings.Repeat("𐐀", RoomNameMaxLength+1)
+		err := ValidateRoomName(input)
+		if err == nil || err.Error() != "room name must be 30 characters or less" {
+			t.Errorf("ValidateRoomName(%q) = %v, want length error", input, err)
+		}
+	})
+}
+
+func TestNormalizeRoomNameInternationalComposition(t *testing.T) {
+	tests := map[string]struct {
+		input string
+		want  string
+	}{
+		"German umlaut":      {input: "Ku\u0308che", want: "Küche"},
+		"Japanese dakuten":   {input: "は\u3099", want: "ば"},
+		"Vietnamese accents": {input: "Pho\u0300ng", want: "Phòng"},
+	}
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := normalizeRoomName(tt.input); got != tt.want {
+				t.Errorf("normalizeRoomName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestValidateRoomDescription(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -234,7 +234,7 @@ func TestValidateRoomName(t *testing.T) {
 		{"valid name with underscore", "general_discussion", ""},
 		{"valid mixed case", "GeneralDiscussion", ""},
 		{"valid with numbers", "room123", ""},
-		{"valid Traditional Chinese", "繁體中文", ""},
+		{"valid Traditional Chinese (zh-TW)", "繁體中文", ""},
 		{"valid German umlauts", "Küche_Über", ""},
 		{"valid decomposed umlaut after normalization", "Ku\u0308che", ""},
 		{"valid single char", "A", ""},
@@ -287,7 +287,7 @@ func TestValidateRoomNameInternationalScripts(t *testing.T) {
 	validNames := map[string]string{
 		"Arabic with Arabic-Indic digits":       "غرفة_١٢٣",
 		"Armenian":                              "սենյակ",
-		"Chinese":                               "聊天室",
+		"Traditional Chinese (zh-TW)":           "繁體中文聊天室",
 		"Cyrillic":                              "Комната",
 		"Deseret supplementary-plane letters":   "𐐀𐐨",
 		"Ethiopic":                              "ክፍል",

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -159,6 +160,31 @@ func TestChattoCore_CreateRoom_Validation(t *testing.T) {
 		}
 	})
 
+	t.Run("valid Unicode name at max length", func(t *testing.T) {
+		maxName := strings.Repeat("室", RoomNameMaxLength)
+		room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", maxName, "Description")
+		if err != nil {
+			t.Errorf("Expected success for Unicode room name at max length, got: %v", err)
+		}
+		if room == nil {
+			t.Error("Expected room to be created")
+		}
+	})
+
+	t.Run("Unicode name over max length", func(t *testing.T) {
+		_, err := core.CreateRoom(
+			ctx,
+			"test-user",
+			KindChannel,
+			"",
+			strings.Repeat("室", RoomNameMaxLength+1),
+			"Description",
+		)
+		if err == nil || err.Error() != "room name must be 30 characters or less" {
+			t.Errorf("Expected Unicode room name length error, got: %v", err)
+		}
+	})
+
 	t.Run("valid description at max length", func(t *testing.T) {
 		maxDesc := string(make([]byte, 500)) // exactly 500 characters
 		for i := range maxDesc {
@@ -182,6 +208,16 @@ func TestChattoCore_CreateRoom_Validation(t *testing.T) {
 			t.Errorf("Expected name to be trimmed, got: %s", room.Name)
 		}
 	})
+
+	t.Run("name is NFC-normalized", func(t *testing.T) {
+		room, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Ku\u0308che", "Description")
+		if err != nil {
+			t.Errorf("Expected success, got: %v", err)
+		}
+		if room.Name != "Küche" {
+			t.Errorf("Expected NFC-normalized name, got: %q", room.Name)
+		}
+	})
 }
 
 func TestValidateRoomName(t *testing.T) {
@@ -198,6 +234,9 @@ func TestValidateRoomName(t *testing.T) {
 		{"valid name with underscore", "general_discussion", ""},
 		{"valid mixed case", "GeneralDiscussion", ""},
 		{"valid with numbers", "room123", ""},
+		{"valid Traditional Chinese", "繁體中文", ""},
+		{"valid German umlauts", "Küche_Über", ""},
+		{"valid decomposed umlaut after normalization", "Ku\u0308che", ""},
 		{"valid single char", "A", ""},
 		{"valid 30 chars", string(make([]byte, 30)), ""}, // will be replaced below
 		{"too long 31 chars", string(make([]byte, 31)), "room name must be 30 characters or less"},
@@ -397,6 +436,23 @@ func TestChattoCore_CreateRoom_DuplicateName_CaseInsensitive(t *testing.T) {
 	_, err = core.CreateRoom(ctx, "test-user", KindChannel, "", "GENERAL", "General discussion allcaps")
 	if !errors.Is(err, ErrRoomNameExists) {
 		t.Errorf("Expected ErrRoomNameExists for all caps, got: %v", err)
+	}
+}
+
+func TestChattoCore_CreateRoom_DuplicateUnicodeName(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	_, err := core.CreateRoom(ctx, "test-user", KindChannel, "", "Küche", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+
+	for _, duplicate := range []string{"KÜCHE", "Ku\u0308che"} {
+		_, err = core.CreateRoom(ctx, "test-user", KindChannel, "", duplicate, "")
+		if !errors.Is(err, ErrRoomNameExists) {
+			t.Errorf("CreateRoom(%q) error = %v, want ErrRoomNameExists", duplicate, err)
+		}
 	}
 }
 

--- a/cli/internal/core/rooms_test.go
+++ b/cli/internal/core/rooms_test.go
@@ -456,6 +456,20 @@ func TestChattoCore_CreateRoom_DuplicateUnicodeName(t *testing.T) {
 	}
 }
 
+func TestCanonicalRoomNamePreservesRollingUpgradeComparisonSemantics(t *testing.T) {
+	t.Run("normalizes composed and decomposed umlauts", func(t *testing.T) {
+		if canonicalRoomName("KÜCHE") != canonicalRoomName("Ku\u0308che") {
+			t.Fatal("canonicalRoomName should normalize and lowercase equivalent umlauts")
+		}
+	})
+
+	t.Run("does not introduce full case-fold expansions", func(t *testing.T) {
+		if canonicalRoomName("Straße") == canonicalRoomName("STRASSE") {
+			t.Fatal("canonicalRoomName must retain simple-lowercase semantics during mixed-version operation")
+		}
+	})
+}
+
 func TestChattoCore_RoomNameExists(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/pb/chatto/api/v1/rooms.pb.go
+++ b/cli/internal/pb/chatto/api/v1/rooms.pb.go
@@ -245,7 +245,8 @@ func (x *RoomSummary) GetName() string {
 // Request to create a channel room.
 type CreateRoomRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Required. Name of the new channel room.
+	// Required. NFC-normalized name of the new channel room. Names accept
+	// Unicode letters, decimal digits, hyphens, and underscores.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Optional room description.
 	Description string `protobuf:"bytes,2,opt,name=description,proto3" json:"description,omitempty"`
@@ -367,7 +368,8 @@ type UpdateRoomRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. Room to update.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// New room name, when changing it.
+	// New NFC-normalized room name, when changing it. Names accept Unicode
+	// letters, decimal digits, hyphens, and underscores.
 	Name *string `protobuf:"bytes,2,opt,name=name,proto3,oneof" json:"name,omitempty"`
 	// New room description, when changing it. Empty clears the description.
 	Description *string `protobuf:"bytes,3,opt,name=description,proto3,oneof" json:"description,omitempty"`

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -96,7 +96,7 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 ### 12. Room names are Unicode presentation metadata
 
 **Decision:** Channel room names accept Unicode letters and decimal digits plus hyphens and underscores. Names are stored in NFC-normalized form and compared using normalized Unicode simple lowercase for server-wide uniqueness. The immutable room ID, not the mutable name, identifies the room in links and protocols.
-**Why:** Communities can name rooms naturally in scripts such as Traditional Chinese and use letters such as German umlauts without introducing a separate display name or making presentation metadata carry identity semantics.
+**Why:** Communities can use natural room names written in Traditional Chinese (`zh-TW`) or with letters such as German umlauts, without introducing a separate display name or making presentation metadata carry identity semantics.
 **Tradeoff:** Simple lowercase preserves the existing comparison semantics across rolling upgrades but deliberately does not merge multi-character case-fold equivalents such as `Straße` and `STRASSE`. Spaces, emoji, punctuation, and formatting controls remain unavailable in room names. Distinct Unicode characters can still look alike, so authorization and durable references continue to use the immutable room ID.
 
 ## Permissions

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -95,9 +95,9 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 
 ### 12. Room names are Unicode presentation metadata
 
-**Decision:** Channel room names accept Unicode letters and decimal digits plus hyphens and underscores. Names are stored in NFC-normalized form and compared using normalized Unicode case folding for server-wide uniqueness. The immutable room ID, not the mutable name, identifies the room in links and protocols.
+**Decision:** Channel room names accept Unicode letters and decimal digits plus hyphens and underscores. Names are stored in NFC-normalized form and compared using normalized Unicode simple lowercase for server-wide uniqueness. The immutable room ID, not the mutable name, identifies the room in links and protocols.
 **Why:** Communities can name rooms naturally in scripts such as Traditional Chinese and use letters such as German umlauts without introducing a separate display name or making presentation metadata carry identity semantics.
-**Tradeoff:** Spaces, emoji, punctuation, and formatting controls remain unavailable in room names. Distinct Unicode characters can still look alike, so authorization and durable references continue to use the immutable room ID.
+**Tradeoff:** Simple lowercase preserves the existing comparison semantics across rolling upgrades but deliberately does not merge multi-character case-fold equivalents such as `Straße` and `STRASSE`. Spaces, emoji, punctuation, and formatting controls remain unavailable in room names. Distinct Unicode characters can still look alike, so authorization and durable references continue to use the immutable room ID.
 
 ## Permissions
 

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-019: Room Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-07-23
+**Last reviewed:** 2026-07-25
 
 ## Overview
 
@@ -9,7 +9,7 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 
 ## Behavior
 
-- **Create** — server admins (or anyone with `room.create` in the target group) create a channel room by giving it a name (1–30 chars, alphanumeric / hyphen / underscore, case-insensitive unique across the server), an optional description, a room group, and optionally the Universal setting.
+- **Create** — server admins (or anyone with `room.create` in the target group) create a channel room by giving it a name (1–30 Unicode characters; letters, decimal digits, hyphens, and underscores; case-insensitive unique across the server), an optional description, a room group, and optionally the Universal setting.
 - **Edit** — `room.manage` holders can change the name, description, group, Universal setting, and explicit member set of an existing channel room.
 - **Settings access** — a joined room's context menu links `room.manage` holders directly to that room's management page. Effective `room.manage` holders can change general settings; server-wide `role.manage` holders can configure the room's role permission matrix without receiving general room-management authority. The management read can load private-room metadata for either capability and is deliberately separate from the visibility-gated room directory.
 - **Display** — when set, the optional description appears after the channel room name in the desktop room pane header.
@@ -92,6 +92,12 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 **Decision:** Existing room members and effective `room.manage` holders may list a channel room's effective members and hydrate individual member rows. Other channel-room non-members may list members only when both `room.list` and `room.join` allow it at that room. DMs remain membership-only. The pre-join screen requests the first five alphabetically sorted members and uses the list's total count for its compact preview.
 **Why:** Room managers need the same member resource they are authorised to change, even when management authority deliberately does not grant room participation. Room membership remains an existing paginated resource instead of adding a preview- or management-specific shape. Requiring both discovery and join eligibility for other nonmembers limits access to rooms they can knowingly enter.
 **Tradeoff:** A manager or eligible nonmember can paginate the full member directory without joining. Messages, files, activity, and other membership-gated room content remain inaccessible until joining, and DM participant privacy is unchanged.
+
+### 12. Room names are Unicode presentation metadata
+
+**Decision:** Channel room names accept Unicode letters and decimal digits plus hyphens and underscores. Names are stored in NFC-normalized form and compared using normalized Unicode case folding for server-wide uniqueness. The immutable room ID, not the mutable name, identifies the room in links and protocols.
+**Why:** Communities can name rooms naturally in scripts such as Traditional Chinese and use letters such as German umlauts without introducing a separate display name or making presentation metadata carry identity semantics.
+**Tradeoff:** Spaces, emoji, punctuation, and formatting controls remain unavailable in room names. Distinct Unicode characters can still look alike, so authorization and durable references continue to use the immutable room ID.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -28,7 +28,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-07-20 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-07-21 |
-| [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-20 |
+| [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-07-25 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-07-14 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-07-20 |
 | [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-06-23 |

--- a/packages/api-types/src/chatto/api/v1/rooms_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_pb.ts
@@ -199,7 +199,8 @@ export class RoomSummary extends Message<RoomSummary> {
  */
 export class CreateRoomRequest extends Message<CreateRoomRequest> {
   /**
-   * Required. Name of the new channel room.
+   * Required. NFC-normalized name of the new channel room. Names accept
+   * Unicode letters, decimal digits, hyphens, and underscores.
    *
    * @generated from field: string name = 1;
    */
@@ -313,7 +314,8 @@ export class UpdateRoomRequest extends Message<UpdateRoomRequest> {
   roomId = "";
 
   /**
-   * New room name, when changing it.
+   * New NFC-normalized room name, when changing it. Names accept Unicode
+   * letters, decimal digits, hyphens, and underscores.
    *
    * @generated from field: optional string name = 2;
    */

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -53,7 +53,8 @@ message RoomSummary {
 
 // Request to create a channel room.
 message CreateRoomRequest {
-  // Required. Name of the new channel room.
+  // Required. NFC-normalized name of the new channel room. Names accept
+  // Unicode letters, decimal digits, hyphens, and underscores.
   string name = 1 [(buf.validate.field).string = {
     min_len: 1
     max_len: 30
@@ -77,7 +78,8 @@ message CreateRoomResponse {
 message UpdateRoomRequest {
   // Required. Room to update.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
-  // New room name, when changing it.
+  // New NFC-normalized room name, when changing it. Names accept Unicode
+  // letters, decimal digits, hyphens, and underscores.
   optional string name = 2 [(buf.validate.field).string = {
     min_len: 1
     max_len: 30


### PR DESCRIPTION
## Summary

- allow room names to use Unicode letters and decimal digits, including names
  written in Traditional Chinese (`zh-TW`) and names containing German umlauts
- trim and NFC-normalize room names before persistence, while enforcing the existing 30-character limit by Unicode code point
- use normalized Unicode simple lowercase for uniqueness and room-name search
  matching, preserving rolling-upgrade compatibility
- keep the existing single mutable `name` field and immutable room IDs; no display name, slug, or wire-schema change
- add matching backend/frontend test matrices spanning Arabic, Armenian,
  Traditional Chinese (`zh-TW`), Cyrillic, Deseret, Ethiopic, Georgian, Greek,
  Hebrew, Japanese, Korean, Vietnamese, non-ASCII decimal digits, and Unicode
  edge cases
- update generated API artifacts and FDR-019

## Why

The previous ASCII-only validation prevented communities from choosing natural
room names in many languages. This is the smallest behavioural expansion that
supports those names without introducing a second naming concept or constraining
future federation identity design.

## Compatibility

Classification: **behavioural** validation expansion. There is no protobuf
field, RPC, durable event, or persistence-schema change, and no capability is
needed for clients to read the resulting names.

- Old clients with a new server can read Unicode room names, though their local
  validators may prevent creating them.
- New clients with an old server may receive `INVALID_ARGUMENT` when submitting
  a Unicode room name.
- During a rolling server upgrade, old replicas may reject Unicode name writes
  until the rollout completes. Comparison retains the previous simple-lowercase
  semantics so mixed replicas cannot disagree about durable uniqueness.
- Existing ASCII room names retain the same accepted syntax and identity.
- Immutable room IDs remain the durable identity for links and protocols.

## Test plan

- Passed `mise x -- go test ./internal/core` after the expanded international
  test matrix: 58.242s.
- Passed the focused frontend Vitest suite: 22 tests.
- Passed the frontend room API spec: 35 tests.
- Passed `mise x -- pnpm run check:frontend`: 0 errors and 0 warnings.
- Passed targeted ESLint, including the expanded room API spec.
- Passed `mise license-check`.
- Passed `mise codegen-proto`; generated Go, TypeScript, and API docs are committed.
- Passed a browser smoke test creating/rendering `台灣_Über`; the room updated
  successfully with no console warnings or errors.
- GitHub CI passed on the final head: 9 checks green, including backend,
  frontend unit, all four e2e shards, media e2e, codegen drift, and licence
  checks.

## Documentation

- [FDR-019: Room lifecycle](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-019-room-lifecycle.md)

Closes #1738.
