### PR TITLE
refactor(frontend): stop mirroring projected navigation state

### DIFF
--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -7,12 +7,9 @@ are compact rows with a join / joined / restricted indicator. The
 header carries a "Join all" affordance when there's at least one
 joinable, non-joined room left in the group.
 
-Both stores are passed in as props — the active server's `directory`
-(`RoomDirectoryStore`) owns the all-rooms listing and optimistic
-join/leave state, and the active server's `roomsStore` (`RoomsStore`)
-supplies the joined-membership set. Explicit props keep the component
-testable without context stubs and decoupled from the multi-server
-registry.
+The active server's command store is passed as a prop. Directory rows and
+membership are read through its projection-backed navigation view, while the
+store owns only optimistic join/leave state.
 -->
 <script lang="ts">
   import { resolve } from '$app/paths';
@@ -21,16 +18,10 @@ registry.
   import { Button } from '$lib/ui/form';
   import Dialog from '$lib/ui/Dialog.svelte';
   import { Panel } from '$lib/components/admin';
-  import type { RoomsStore } from '$lib/state/server/rooms.svelte';
   import type { RoomDirectoryStore, DirectoryRoom } from '$lib/state/server/roomDirectory.svelte';
 
-  let {
-    directory,
-    roomsStore,
-    serverSegment
-  }: {
+  let { directory, serverSegment }: {
     directory: RoomDirectoryStore;
-    roomsStore: RoomsStore;
     serverSegment: string;
   } = $props();
 
@@ -40,10 +31,7 @@ registry.
 
   // --- Derived data ---
 
-  const joinedRoomIds = $derived(
-    new Set(roomsStore.rooms.filter((r) => r.viewerIsMember).map((r) => r.id))
-  );
-  const roomGroups = $derived(roomsStore.roomGroups);
+  const roomGroups = $derived(directory.roomGroups);
   const visibleRooms = $derived(directory.allRooms.filter((room) => !room.archived));
 
   function matchesSearch(room: DirectoryRoom): boolean {
@@ -119,7 +107,7 @@ registry.
       (r) =>
         r.viewerCanJoinRoom &&
         !r.isUniversal &&
-        !directory.isJoined(r.id, joinedRoomIds) &&
+        !directory.isJoined(r.id) &&
         !directory.joiningIds.has(r.id)
     );
   }
@@ -181,7 +169,7 @@ registry.
 </script>
 
 {#snippet roomRow(room: DirectoryRoom)}
-  {@const joined = directory.isJoined(room.id, joinedRoomIds)}
+  {@const joined = directory.isJoined(room.id)}
   {@const joining = directory.joiningIds.has(room.id)}
   {@const leaving = directory.leavingIds.has(room.id)}
   <!--

--- a/apps/frontend/src/lib/RoomDirectoryTestHarness.svelte
+++ b/apps/frontend/src/lib/RoomDirectoryTestHarness.svelte
@@ -1,15 +1,12 @@
 <!--
 @component
 
-Test-only wrapper around `RoomDirectory`. Constructs a real
-`RoomDirectoryStore` with stubbed APIs, seeds the rooms list, and
-passes a duck-typed rooms-store stub as the prop — so component-level
-tests can exercise the rendered view without standing up the full
-chat-event tree or registering a server in the global registry.
+Test-only wrapper around `RoomDirectory`. Constructs a real command store over
+a fixture navigation view so component tests do not need a realtime transport.
 -->
 <script lang="ts">
-  import { untrack } from 'svelte';
-  import type { RoomsListItem, RoomsListGroup, RoomsStore } from '$lib/state/server/rooms.svelte';
+  import { RoomKind } from '$lib/api-client/roomDirectory';
+  import type { RoomsListItem, RoomsListGroup } from '$lib/state/server/rooms.svelte';
   import { RoomDirectoryStore, type DirectoryRoom } from '$lib/state/server/roomDirectory.svelte';
   import RoomDirectory from './RoomDirectory.svelte';
 
@@ -28,30 +25,38 @@ chat-event tree or registering a server in the global registry.
     leaveRoom: async () => true,
     joinGroup: async () => []
   };
-  const stubRoomDirectoryAPI = {
-    // The harness seeds `allRooms` directly, so this in-flight load should
-    // never replace the fixture data.
-    listRooms: () => new Promise<never>(() => {})
-  };
   const stubMemberDirectoryAPI = {
     listRoomMembers: async () => ({ members: [], totalCount: 0, hasMore: false })
   };
 
+  const navigation = {
+    get rooms() {
+      const joinedById = new Map(joinedRooms.map((room) => [room.id, room]));
+      return initialRooms
+        .filter((room) => !room.archived)
+        .map((room): RoomsListItem => {
+          const listed = joinedById.get(room.id);
+          return {
+            ...room,
+            type: RoomKind.CHANNEL,
+            viewerIsMember: listed?.viewerIsMember ?? false,
+            viewerCanManageRoom: listed?.viewerCanManageRoom ?? false,
+            viewerNotificationCount: 0,
+            hasMessageHistory: null,
+            members: []
+          };
+        });
+    },
+    get roomGroups() {
+      return roomGroups ?? [];
+    },
+    isInitialLoading: false
+  };
   const directory = new RoomDirectoryStore(
-    stubRoomDirectoryAPI,
+    navigation,
     stubMemberDirectoryAPI,
     stubRoomAPI
   );
-  directory.allRooms = untrack(() => initialRooms);
-  directory.isLoading = false;
-
-  // Rooms-store stub: only the fields RoomDirectory reads need to be
-  // populated. A full constructor isn't viable here without dragging in
-  // notification/roomUnread mocks; a duck-typed object is good enough.
-  const roomsStoreStub = {
-    rooms: untrack(() => joinedRooms),
-    roomGroups: untrack(() => roomGroups)
-  } as unknown as RoomsStore;
 </script>
 
-<RoomDirectory {directory} roomsStore={roomsStoreStub} serverSegment="-" />
+<RoomDirectory {directory} serverSegment="-" />

--- a/apps/frontend/src/lib/RoomDirectoryTestHarness.svelte
+++ b/apps/frontend/src/lib/RoomDirectoryTestHarness.svelte
@@ -50,7 +50,10 @@ a fixture navigation view so component tests do not need a realtime transport.
     get roomGroups() {
       return roomGroups ?? [];
     },
-    isInitialLoading: false
+    isInitialLoading: false,
+    isRoomMember(roomId: string) {
+      return this.rooms.some((room) => room.id === roomId && room.viewerIsMember);
+    }
   };
   const directory = new RoomDirectoryStore(
     navigation,

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -65,7 +65,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   const activeCallRooms = $derived(stores.activeCallRooms);
   const appUi = getAppUiState();
 
-  const roomsStore = $derived(stores.rooms);
+  const navigation = $derived(stores.navigation);
   const roomUnreadStore = $derived(stores.roomUnread);
 
   let activeRoomId = $derived(page.params.roomId);
@@ -148,9 +148,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // Channels and DMs are stored together, but rendered as separate groups.
   // Room sets only apply to channels — DM rooms always render in their
   // own group below.
-  let channels = $derived(roomsStore.rooms.filter((r) => r.type === RoomKind.CHANNEL));
+  let channels = $derived(navigation.rooms.filter((r) => r.type === RoomKind.CHANNEL));
   let dmRooms = $derived(
-    roomsStore.rooms.filter((r) => r.type === RoomKind.DM && isNavigationVisibleRoom(r))
+    navigation.rooms.filter((r) => r.type === RoomKind.DM && isNavigationVisibleRoom(r))
   );
 
   let channelMap = $derived(new Map(channels.map((r) => [r.id, r])));
@@ -169,8 +169,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // Keep manageable groups discoverable even when none of their rooms are
   // visible to the viewer.
   let visibleSets = $derived.by(() => {
-    const sets = roomsStore.roomGroups;
-    if (!sets) return [];
+    const sets = navigation.roomGroups;
     return sets.filter((s) => s.viewerCanManageGroup || getSetItems(s).length > 0);
   });
 
@@ -180,22 +179,21 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // DM display name: comma-joined participants other than the current user
   // (or "You" for self-DMs).
   //
-  // `meId` comes from `roomsStore.currentUserId`, which is captured from the
-  // same `viewer { user { id, rooms { members } } }` query that produced `room.members`.
+  // `meId` and DM members come from the same server projection prefix.
   // Reading the viewer ID from a global auth context here is unsafe — the
   // [serverId] layout intentionally renders children while the per-instance
   // CurrentUserState is still loading, so `currentUserState.user?.id` can be
   // undefined for the first render and the filter would include self in the
   // label/avatars (e.g. a 1:1 with Teal rendering as "Teal, hmans").
   function dmDisplayName(room: RoomsListItem): string {
-    const meId = roomsStore.currentUserId;
+    const meId = navigation.currentUserId;
     const others = room.members.filter((m) => m.id !== meId);
     if (others.length === 0) return m['common.you']();
     return others.map((m) => getLiveDisplayName(m.id, m.displayName || m.login)).join(', ');
   }
 
   function dmAvatarParticipants(room: RoomsListItem) {
-    const meId = roomsStore.currentUserId;
+    const meId = navigation.currentUserId;
     const others = room.members.filter((m) => m.id !== meId);
     if (others.length === 0) {
       // Self-DM: show own avatar
@@ -278,9 +276,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     const notification = lookup.notification;
 
     if (!notification) {
-      if (lookup.ok && lookup.totalCount === 0) {
-        roomsStore.clearUnreadNotifications(roomId);
-      } else {
+      if (!lookup.ok || lookup.totalCount !== 0) {
         await goto(resolve('/chat/notifications'));
       }
       return;
@@ -291,14 +287,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     if (target.eventId && target.roomId) {
       stores.pendingHighlights.set(target.roomId, target.threadRootId, target.eventId);
     }
-    roomsStore.decrementUnreadNotification(roomId);
-    void notificationStore.dismiss(notification.id).then((dismissed) => {
-      if (!dismissed) {
-        roomsStore.incrementUnreadNotification(roomId);
-        return;
-      }
-      void roomsStore.refreshNotificationCounts();
-    });
+    void notificationStore.dismiss(notification.id);
 
     const path = notificationStore.getCleanPath(getActiveServer(), notification);
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- path from getCleanPath() is already resolved
@@ -485,7 +474,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   {/if}
 {/snippet}
 
-{#if channels.length === 0 && dmRooms.length === 0 && visibleSets.length === 0 && !roomsStore.isInitialLoading}
+{#if channels.length === 0 && dmRooms.length === 0 && visibleSets.length === 0 && !navigation.isInitialLoading}
   <EmptyState icon="uil--comments" title={m['room_list.empty_title']()}>
     {m['room_list.empty_prefix']()}
     <a href={resolve('/chat/[serverId]/overview', { serverId: serverSegment })} class="link"
@@ -495,7 +484,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   </EmptyState>
 {:else}
   <nav class="room-list sidebar-nav p-2 md:w-full">
-    {#if roomsStore.roomGroups && roomsStore.roomGroups.length > 0}
+    {#if navigation.roomGroups.length > 0}
       <!-- Room-set layout -->
       {#each visibleSets as set, i (set.id)}
         <CollapsibleGroup

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -66,16 +66,11 @@ const { mocks } = vi.hoisted(() => ({
       serverInfo: {
         livekitUrl: null
       },
-      rooms: {
+      navigation: {
         rooms: [],
-        roomGroups: null as RoomsListGroup[] | null,
+        roomGroups: [] as RoomsListGroup[],
         isInitialLoading: false,
-        currentUserId: 'me',
-        bumpRoom: vi.fn(),
-        clearUnreadNotifications: vi.fn(),
-        decrementUnreadNotification: vi.fn(),
-        incrementUnreadNotification: vi.fn(),
-        refreshNotificationCounts: vi.fn().mockResolvedValue(undefined)
+        currentUserId: 'me'
       },
       roomDirectory: {
         joinRoom: vi.fn()
@@ -186,7 +181,7 @@ function user(id: string, login: string, displayName: string) {
 }
 
 function setRooms() {
-  mocks.store.rooms.rooms = [
+  mocks.store.navigation.rooms = [
     {
       id: 'channel-1',
       name: 'general',
@@ -246,7 +241,7 @@ function setRooms() {
 }
 
 function setRoomNotificationCount(roomId: string, count: number) {
-  const rooms = mocks.store.rooms.rooms as Array<{
+  const rooms = mocks.store.navigation.rooms as Array<{
     id: string;
     viewerNotificationCount: number;
   }>;
@@ -266,9 +261,9 @@ beforeEach(() => {
   mocks.activeCallRoomIds = new Set();
   mocks.projectedCallParticipants = new Map();
   mocks.unreadRoomIds = new Set();
-  mocks.store.rooms.roomGroups = null;
-  mocks.store.rooms.isInitialLoading = false;
-  mocks.store.rooms.currentUserId = 'me';
+  mocks.store.navigation.roomGroups = [];
+  mocks.store.navigation.isInitialLoading = false;
+  mocks.store.navigation.currentUserId = 'me';
   setRooms();
   vi.clearAllMocks();
   mocks.store.notifications.fetchRoomNotification.mockResolvedValue({
@@ -282,14 +277,13 @@ beforeEach(() => {
     notification: null
   });
   mocks.store.notifications.getCleanPath.mockReturnValue('/chat/-/room');
-  mocks.store.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
   mocks.store.roomDirectory.joinRoom.mockResolvedValue({ ok: true });
   mocks.markNavigationRoomAsRead.mockResolvedValue(true);
 });
 
 describe('RoomList', () => {
   it('hides only DMs explicitly projected without message history', async () => {
-    const empty = mocks.store.rooms.rooms.find(
+    const empty = mocks.store.navigation.rooms.find(
       (room: { id: string }) => room.id === 'dm-with-participants'
     ) as unknown as { hasMessageHistory?: boolean };
     empty.hasMessageHistory = false;
@@ -353,7 +347,7 @@ describe('RoomList', () => {
   });
 
   it('offers room settings to a non-member room manager alongside Join', async () => {
-    const rooms = mocks.store.rooms.rooms as Array<{
+    const rooms = mocks.store.navigation.rooms as Array<{
       id: string;
       viewerCanManageRoom: boolean;
     }>;
@@ -532,7 +526,7 @@ describe('RoomList', () => {
   });
 
   it('hides room settings without room.manage', async () => {
-    const rooms = mocks.store.rooms.rooms as Array<{
+    const rooms = mocks.store.navigation.rooms as Array<{
       id: string;
       viewerCanManageRoom: boolean;
     }>;
@@ -768,7 +762,7 @@ describe('RoomList', () => {
   });
 
   it('renders server-local sidebar links as same-tab anchors resolved against the active server', async () => {
-    mocks.store.rooms.roomGroups = [
+    mocks.store.navigation.roomGroups = [
       {
         id: 'g1',
         name: 'Links',
@@ -794,8 +788,8 @@ describe('RoomList', () => {
   });
 
   it('keeps an empty manageable group visible and opens its settings from a context menu', async () => {
-    mocks.store.rooms.rooms = [];
-    mocks.store.rooms.roomGroups = [
+    mocks.store.navigation.rooms = [];
+    mocks.store.navigation.roomGroups = [
       {
         id: 'private-group',
         name: 'Private Group',
@@ -830,7 +824,7 @@ describe('RoomList', () => {
   });
 
   it('renders active-server host sidebar links as same-tab anchors', async () => {
-    mocks.store.rooms.roomGroups = [
+    mocks.store.navigation.roomGroups = [
       {
         id: 'g1',
         name: 'Links',
@@ -859,7 +853,7 @@ describe('RoomList', () => {
   });
 
   it('renders external sidebar links as new-tab anchors', async () => {
-    mocks.store.rooms.roomGroups = [
+    mocks.store.navigation.roomGroups = [
       {
         id: 'g1',
         name: 'Links',
@@ -917,9 +911,7 @@ describe('RoomList', () => {
       expect(mocks.appUi.disableRoomCallWideFor.mock.invocationCallOrder[0]).toBeLessThan(
         mocks.goto.mock.invocationCallOrder[0]
       );
-      expect(mocks.store.rooms.decrementUnreadNotification).toHaveBeenCalledWith('channel-1');
       expect(mocks.store.notifications.dismiss).toHaveBeenCalledWith('mention-1');
-      expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1/thread-1');
     });
   });
@@ -946,9 +938,6 @@ describe('RoomList', () => {
         'dm-with-participants',
         { isDM: true }
       );
-      expect(mocks.store.rooms.decrementUnreadNotification).toHaveBeenCalledWith(
-        'dm-with-participants'
-      );
       expect(mocks.appUi.disableRoomCallWideFor).toHaveBeenCalledWith(
         'origin',
         'dm-with-participants'
@@ -957,12 +946,11 @@ describe('RoomList', () => {
         mocks.goto.mock.invocationCallOrder[0]
       );
       expect(mocks.store.notifications.dismiss).toHaveBeenCalledWith('dm-1');
-      expect(mocks.store.rooms.refreshNotificationCounts).toHaveBeenCalledOnce();
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/dm-with-participants');
     });
   });
 
-  it('clears a stale room badge when the room-scoped query returns no notifications', async () => {
+  it('leaves a stale room badge to converge through the authoritative projection', async () => {
     setRoomNotificationCount('channel-1', 1);
     mocks.store.notifications.resolveRoomNotification.mockResolvedValue({
       ok: true,
@@ -980,7 +968,6 @@ describe('RoomList', () => {
       expect(mocks.store.notifications.resolveRoomNotification).toHaveBeenCalledWith('channel-1', {
         isDM: false
       });
-      expect(mocks.store.rooms.clearUnreadNotifications).toHaveBeenCalledWith('channel-1');
       expect(mocks.goto).not.toHaveBeenCalled();
       expect(mocks.store.notifications.dismiss).not.toHaveBeenCalled();
     });

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -41,7 +41,7 @@ to the user settings page for the active server.
   const activeStore = $derived(serverRegistry.tryGetStore(activeServerId));
   const activeServerUser = $derived(activeStore?.currentUser.user);
   const voiceCallState = $derived(activeStore?.voiceCall);
-  const roomsStore = $derived(activeStore?.rooms);
+  const navigation = $derived(activeStore?.navigation);
 
   const displayName = $derived(
     activeServerUser
@@ -58,14 +58,14 @@ to the user settings page for the active server.
   );
   const activeCallRoom = $derived(
     activeCallRoomId
-      ? (roomsStore?.rooms.find((room) => room.id === activeCallRoomId) ?? null)
+      ? (navigation?.rooms.find((room) => room.id === activeCallRoomId) ?? null)
       : null
   );
   const activeCallRoomName = $derived.by(() => {
     const room = activeCallRoom;
     if (!room) return m['common.current_call']();
     if (room.type === RoomKind.DM) {
-      const meId = roomsStore?.currentUserId;
+      const meId = navigation?.currentUserId;
       const others = room.members.filter((member) => member.id !== meId);
       if (others.length === 0) return m['common.you']();
       return others

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -109,7 +109,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
     tryGetStore: () => ({
       currentUser: currentUserState,
       voiceCall: voiceCallState,
-      rooms: roomsState
+      navigation: roomsState
     })
   }
 }));

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -86,7 +86,7 @@ unknown instance) the component renders nothing.
 
   function roomName(serverId: string, roomId: string): string | null {
     return (
-      serverRegistry.tryGetStore(serverId)?.rooms.rooms.find((room) => room.id === roomId)?.name ??
+      serverRegistry.tryGetStore(serverId)?.navigation.rooms.find((room) => room.id === roomId)?.name ??
       null
     );
   }

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -36,7 +36,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
       currentUser: {
         user: { login: 'viewer' }
       },
-      rooms: {
+      navigation: {
         rooms: [{ id: 'room_1', name: 'general' }]
       }
     }),

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -81,7 +81,7 @@
         score: 0
       });
 
-      for (const room of store?.rooms.rooms ?? []) {
+      for (const room of store?.navigation.rooms ?? []) {
         if (room.type === RoomKind.DM) {
           if (!isNavigationVisibleRoom(room)) continue;
           const participants = room.members.map(avatarUser);
@@ -320,8 +320,8 @@
     void serverRegistry.servers;
     for (const instance of serverRegistry.servers) {
       const store = serverRegistry.tryGetStore(instance.id);
-      void store?.rooms.rooms;
-      void store?.rooms.isInitialLoading;
+      void store?.navigation.rooms;
+      void store?.navigation.isInitialLoading;
     }
     untrack(loadAll);
   });

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -41,7 +41,7 @@ const mocks = vi.hoisted(() => ({
         id: 'user-current'
       }
     },
-    rooms: {
+    navigation: {
       rooms: [] as Array<{
         id: string;
         name: string;
@@ -118,12 +118,16 @@ vi.mock('$lib/api-client/rooms', () => ({
   }))
 }));
 
-vi.mock('$lib/api-client/memberDirectory', () => ({
-  createMemberDirectoryAPI: vi.fn(() => ({
-    listRoomMembers: mocks.listRoomMembers,
-    listUsers: mocks.listUsers
-  }))
-}));
+vi.mock('$lib/api-client/memberDirectory', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/api-client/memberDirectory')>();
+  return {
+    ...actual,
+    createMemberDirectoryAPI: vi.fn(() => ({
+      listRoomMembers: mocks.listRoomMembers,
+      listUsers: mocks.listUsers
+    }))
+  };
+});
 
 vi.mock('$lib/api-client/roomDirectory', async (importOriginal) => {
   const actual = await importOriginal<typeof import('$lib/api-client/roomDirectory')>();
@@ -163,7 +167,7 @@ let originalClose: typeof HTMLDialogElement.prototype.close;
 
 function installQueryMocks() {
   mocks.startDM.mockResolvedValue({ id: 'dm-new' });
-  mocks.store.rooms.rooms = [
+  mocks.store.navigation.rooms = [
     {
       id: 'room-general',
       name: 'general',

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -162,12 +162,12 @@
   );
   const managedRoom = $derived(
     page.params.roomId
-      ? (activeStore.rooms.rooms.find((room) => room.id === page.params.roomId) ?? null)
+      ? (activeStore.navigation.rooms.find((room) => room.id === page.params.roomId) ?? null)
       : null
   );
   const managedGroup = $derived(
     page.params.groupId
-      ? (activeStore.rooms.roomGroups?.find((group) => group.id === page.params.groupId) ?? null)
+      ? (activeStore.navigation.roomGroups.find((group) => group.id === page.params.groupId) ?? null)
       : null
   );
   const managementNavItems = $derived(

--- a/apps/frontend/src/lib/components/voice/VoiceCallPanelStoryHarness.svelte
+++ b/apps/frontend/src/lib/components/voice/VoiceCallPanelStoryHarness.svelte
@@ -181,7 +181,6 @@
 		const store = serverRegistry.getStore(server.id);
 
 		store.permissions = permissions;
-		store.rooms.currentUserId = 'viewer';
 		store.voiceCall.roomId = roomId;
 		store.voiceCall.connected = true;
 		store.voiceCall.connecting = false;

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
@@ -25,7 +25,14 @@ function room(id: string, member = false): RoomsListItem {
 }
 
 function makeNavigation(rooms: RoomsListItem[] = [room('R1')]): RoomDirectoryNavigation {
-  return { rooms, roomGroups: [], isInitialLoading: false };
+  return {
+    rooms,
+    roomGroups: [],
+    isInitialLoading: false,
+    isRoomMember(roomId: string) {
+      return this.rooms.some((candidate) => candidate.id === roomId && candidate.viewerIsMember);
+    }
+  };
 }
 
 function memberAPI(): Pick<MemberDirectoryAPI, 'listRoomMembers'> {
@@ -87,14 +94,14 @@ describe('RoomDirectoryStore', () => {
 
     expect((await store.joinRoom('R1')).ok).toBe(true);
     expect(store.isJoined('R1')).toBe(true);
-    store.acknowledgeMembership('R1');
+    store.acknowledgeMembership('R1', true);
     expect(store.isJoined('R1')).toBe(false);
 
     const joinedNavigation = makeNavigation([room('R1', true)]);
     const joinedStore = makeStore(joinedNavigation);
     expect((await joinedStore.leaveRoom('R1')).ok).toBe(true);
     expect(joinedStore.isJoined('R1')).toBe(false);
-    joinedStore.acknowledgeMembership('R1');
+    joinedStore.acknowledgeMembership('R1', false);
     expect(joinedStore.isJoined('R1')).toBe(true);
   });
 
@@ -148,11 +155,56 @@ describe('RoomDirectoryStore', () => {
     );
 
     const joining = store.joinRoom('R1');
-    store.acknowledgeMembership('R1');
+    store.acknowledgeMembership('R1', true);
     resolveJoin();
     await joining;
 
     expect(store.justJoinedIds.size).toBe(0);
+  });
+
+  it('keeps successful overlays until the projection confirms their value', async () => {
+    const store = makeStore();
+
+    await store.joinRoom('R1');
+    store.acknowledgeMembership('R1', false);
+    expect(store.isJoined('R1')).toBe(true);
+    store.acknowledgeMembership('R1', true);
+    expect(store.isJoined('R1')).toBe(false);
+
+    const joinedNavigation = makeNavigation([room('R1', true)]);
+    const joinedStore = makeStore(joinedNavigation);
+    await joinedStore.leaveRoom('R1');
+    joinedStore.acknowledgeMembership('R1', true);
+    expect(joinedStore.isJoined('R1')).toBe(false);
+    joinedStore.acknowledgeMembership('R1', false);
+    expect(joinedStore.isJoined('R1')).toBe(true);
+  });
+
+  it('does not let an older command clear a newer pending marker', async () => {
+    const resolvers: Array<() => void> = [];
+    const store = makeStore(
+      makeNavigation(),
+      commands({
+        joinRoom: vi.fn(
+          () =>
+            new Promise<null>((resolve) => {
+              resolvers.push(() => resolve(null));
+            })
+        )
+      })
+    );
+
+    const oldJoin = store.joinRoom('R1');
+    store.resetOptimisticState();
+    const newJoin = store.joinRoom('R1');
+    resolvers[0]?.();
+    await oldJoin;
+
+    expect(store.joiningIds.has('R1')).toBe(true);
+
+    resolvers[1]?.();
+    await newJoin;
+    expect(store.joiningIds.has('R1')).toBe(false);
   });
 
   it('loads join previews as an explicit best-effort query', async () => {

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
@@ -133,6 +133,28 @@ describe('RoomDirectoryStore', () => {
     expect(store.joiningIds.size).toBe(0);
   });
 
+  it('does not restore an optimistic overlay when projection acknowledgement wins the race', async () => {
+    let resolveJoin!: () => void;
+    const store = makeStore(
+      makeNavigation(),
+      commands({
+        joinRoom: vi.fn(
+          () =>
+            new Promise<null>((resolve) => {
+              resolveJoin = () => resolve(null);
+            })
+        )
+      })
+    );
+
+    const joining = store.joinRoom('R1');
+    store.acknowledgeMembership('R1');
+    resolveJoin();
+    await joining;
+
+    expect(store.justJoinedIds.size).toBe(0);
+  });
+
   it('loads join previews as an explicit best-effort query', async () => {
     const api = memberAPI();
     const store = new RoomDirectoryStore(makeNavigation(), api, commands());

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
@@ -1,47 +1,56 @@
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { describe, it, expect, vi } from 'vitest';
-import { flushSync } from 'svelte';
-import {
-  RoomDirectoryScope,
-  RoomKind,
-  type DirectoryRoomSummary,
-  type RoomDirectoryAPI
-} from '$lib/api-client/roomDirectory';
-
+import { RoomKind } from '$lib/api-client/roomDirectory';
+import { describe, expect, it, vi } from 'vitest';
 import type { MemberDirectoryAPI } from '$lib/api-client/memberDirectory';
-import { RoomDirectoryStore, type DirectoryRoom } from './roomDirectory.svelte';
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
+import type { RoomsListItem } from './rooms.svelte';
+import {
+  RoomDirectoryStore,
+  type RoomDirectoryNavigation
+} from './roomDirectory.svelte';
 
-function makeRoom(id: string, overrides: Partial<DirectoryRoomSummary> = {}): DirectoryRoomSummary {
+function room(id: string, member = false): RoomsListItem {
   return {
     id,
-    name: overrides.name ?? id,
-    description: overrides.description ?? null,
-    kind: overrides.kind ?? RoomKind.CHANNEL,
-    archived: overrides.archived ?? false,
-    isUniversal: overrides.isUniversal ?? false,
-    isMember: overrides.isMember ?? false,
-    hasUnread: overrides.hasUnread ?? false,
-    canJoinRoom: overrides.canJoinRoom ?? true,
-    canManageRoom: overrides.canManageRoom ?? false
+    name: id,
+    description: `${id} description`,
+    type: RoomKind.CHANNEL,
+    isUniversal: false,
+    viewerIsMember: member,
+    viewerCanJoinRoom: true,
+    viewerCanManageRoom: false,
+    viewerNotificationCount: 0,
+    members: []
   };
 }
 
-function makeRoomDirectoryAPI(
-  rooms: DirectoryRoomSummary[] = []
-): Pick<RoomDirectoryAPI, 'listRooms'> {
+function makeNavigation(rooms: RoomsListItem[] = [room('R1')]): RoomDirectoryNavigation {
+  return { rooms, roomGroups: [], isInitialLoading: false };
+}
+
+function memberAPI(): Pick<MemberDirectoryAPI, 'listRoomMembers'> {
   return {
-    listRooms: vi.fn().mockResolvedValue(rooms)
+    listRoomMembers: vi.fn().mockResolvedValue({
+      members: [
+        {
+          id: 'U1',
+          login: 'ada',
+          displayName: 'Ada',
+          deleted: false,
+          avatarUrl: null,
+          presenceStatus: PresenceStatus.ONLINE,
+          customStatus: null,
+          roles: [],
+          createdAt: null
+        }
+      ],
+      totalCount: 7,
+      hasMore: true
+    })
   };
 }
 
-function makeMemberDirectoryAPI(): Pick<MemberDirectoryAPI, 'listRoomMembers'> {
-  return {
-    listRoomMembers: vi.fn().mockResolvedValue({ members: [], totalCount: 0, hasMore: false })
-  };
-}
-
-function roomAPI(
+function commands(
   overrides: Partial<Pick<RoomCommandAPI, 'joinRoom' | 'leaveRoom' | 'joinGroup'>> = {}
 ): Pick<RoomCommandAPI, 'joinRoom' | 'leaveRoom' | 'joinGroup'> {
   return {
@@ -52,263 +61,86 @@ function roomAPI(
   };
 }
 
-function makeStore({
-  roomDirectoryAPI = makeRoomDirectoryAPI(),
-  memberDirectoryAPI = makeMemberDirectoryAPI(),
-  commands = roomAPI()
-}: {
-  roomDirectoryAPI?: Pick<RoomDirectoryAPI, 'listRooms'>;
-  memberDirectoryAPI?: Pick<MemberDirectoryAPI, 'listRoomMembers'>;
-  commands?: Pick<RoomCommandAPI, 'joinRoom' | 'leaveRoom' | 'joinGroup'>;
-} = {}) {
-  return new RoomDirectoryStore(roomDirectoryAPI, memberDirectoryAPI, commands);
+function makeStore(
+  navigation = makeNavigation(),
+  api = commands()
+): RoomDirectoryStore {
+  return new RoomDirectoryStore(navigation, memberAPI(), api);
 }
 
-async function settle() {
-  await Promise.resolve();
-  await Promise.resolve();
-  flushSync();
-}
+describe('RoomDirectoryStore', () => {
+  it('derives directory rows and membership from the navigation projection', () => {
+    const navigation = makeNavigation([room('joined', true), room('open')]);
+    const store = makeStore(navigation);
 
-describe('RoomDirectoryStore - initial load', () => {
-  it('populates allRooms and clears isLoading', async () => {
-    const roomDirectoryAPI = makeRoomDirectoryAPI([
-      makeRoom('r1', { description: 'Lobby' }),
-      makeRoom('r2', { archived: true })
-    ]);
-    const store = makeStore({ roomDirectoryAPI });
+    expect(store.allRooms.map((candidate) => candidate.id)).toEqual(['joined', 'open']);
+    expect(store.isJoined('joined')).toBe(true);
+    expect(store.isJoined('open')).toBe(false);
 
-    expect(store.isLoading).toBe(true);
-    void store.refresh();
-    await settle();
-
-    expect(roomDirectoryAPI.listRooms).toHaveBeenCalledWith(RoomDirectoryScope.CHANNELS);
-    // Both rooms (archived + non-archived) are stored. Filtering is a
-    // presentation concern because Browse Rooms needs archived state.
-    expect(store.allRooms).toMatchObject([
-      { id: 'r1', description: 'Lobby', archived: false },
-      { id: 'r2', archived: true }
-    ]);
-    expect(store.isLoading).toBe(false);
+    navigation.rooms = [room('open', true)];
+    expect(store.allRooms.map((candidate) => candidate.id)).toEqual(['open']);
+    expect(store.isJoined('open')).toBe(true);
   });
 
-  it('replaces allRooms with an empty list when Connect returns no rooms', async () => {
-    const store = makeStore({ roomDirectoryAPI: makeRoomDirectoryAPI([]) });
-    store.allRooms = [directoryRoom('stale')];
-
-    await store.refresh();
-
-    expect(store.allRooms).toEqual([]);
-    expect(store.isLoading).toBe(false);
-  });
-});
-
-describe('RoomDirectoryStore - join preview', () => {
-  it('returns five sampled members and the exact total from ListMembers', async () => {
-    const memberDirectoryAPI = makeMemberDirectoryAPI();
-    vi.mocked(memberDirectoryAPI.listRoomMembers).mockResolvedValue({
-      members: [
-        {
-          id: 'u1',
-          login: 'alice',
-          displayName: 'Alice',
-          deleted: false,
-          avatarUrl: null,
-          presenceStatus: PresenceStatus.OFFLINE,
-          customStatus: null,
-          roles: [],
-          createdAt: null
-        }
-      ],
-      totalCount: 12,
-      hasMore: true
-    });
-    const store = makeStore({ memberDirectoryAPI });
-
-    await expect(store.loadJoinPreview('r1')).resolves.toMatchObject({
-      memberCount: 12,
-      sampleMembers: [{ id: 'u1', displayName: 'Alice' }]
-    });
-    expect(memberDirectoryAPI.listRoomMembers).toHaveBeenCalledWith('r1', '', 5, 0);
-  });
-
-  it('returns no preview when the member listing fails', async () => {
-    const memberDirectoryAPI = makeMemberDirectoryAPI();
-    vi.mocked(memberDirectoryAPI.listRoomMembers).mockRejectedValue(new Error('offline'));
-    const store = makeStore({ memberDirectoryAPI });
-
-    await expect(store.loadJoinPreview('r1')).resolves.toBeNull();
-  });
-});
-
-describe('RoomDirectoryStore - isJoined predicate', () => {
-  it('returns true when the room is in the joined set', async () => {
+  it('keeps successful join and leave state optimistic until projection acknowledgement', async () => {
     const store = makeStore();
-    void store.refresh();
-    await settle();
 
-    expect(store.isJoined('r1', new Set(['r1']))).toBe(true);
-    expect(store.isJoined('r2', new Set(['r1']))).toBe(false);
+    expect((await store.joinRoom('R1')).ok).toBe(true);
+    expect(store.isJoined('R1')).toBe(true);
+    store.acknowledgeMembership('R1');
+    expect(store.isJoined('R1')).toBe(false);
+
+    const joinedNavigation = makeNavigation([room('R1', true)]);
+    const joinedStore = makeStore(joinedNavigation);
+    expect((await joinedStore.leaveRoom('R1')).ok).toBe(true);
+    expect(joinedStore.isJoined('R1')).toBe(false);
+    joinedStore.acknowledgeMembership('R1');
+    expect(joinedStore.isJoined('R1')).toBe(true);
   });
 
-  it('returns true for an optimistically-just-joined room even if not in the joined set yet', async () => {
-    const store = makeStore();
-    void store.refresh();
-    await settle();
+  it('rolls command failures back without changing authoritative membership', async () => {
+    const failure = new Error('nope');
+    const store = makeStore(
+      makeNavigation(),
+      commands({ joinRoom: vi.fn().mockRejectedValue(failure) })
+    );
 
-    store.justJoinedIds.add('r1');
-    expect(store.isJoined('r1', new Set())).toBe(true);
+    expect(await store.joinRoom('R1')).toEqual({ ok: false, error: failure });
+    expect(store.isJoined('R1')).toBe(false);
+    expect(store.joiningIds.size).toBe(0);
   });
 
-  it('returns false for an optimistically-just-left room even if still in the joined set', async () => {
-    const store = makeStore();
-    void store.refresh();
-    await settle();
+  it('fences a late command response across projection reset', async () => {
+    let resolveJoin!: () => void;
+    const store = makeStore(
+      makeNavigation(),
+      commands({
+        joinRoom: vi.fn(
+          () =>
+            new Promise<null>((resolve) => {
+              resolveJoin = () => resolve(null);
+            })
+        )
+      })
+    );
 
-    store.justLeftIds.add('r1');
-    expect(store.isJoined('r1', new Set(['r1']))).toBe(false);
-  });
-
-  it('justLeft takes precedence over justJoined when both are set', async () => {
-    const store = makeStore();
-    void store.refresh();
-    await settle();
-
-    store.justJoinedIds.add('r1');
-    store.justLeftIds.add('r1');
-    expect(store.isJoined('r1', new Set())).toBe(false);
-  });
-});
-
-describe('RoomDirectoryStore - joinRoom', () => {
-  it('marks joining during the request and just-joined on success', async () => {
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('r1', { name: 'general' })])
-    });
-    void store.refresh();
-    await settle();
-
-    const promise = store.joinRoom('r1');
-    expect(store.joiningIds.has('r1')).toBe(true);
-
-    const result = await promise;
-    expect(result.ok).toBe(true);
-    if (result.ok) expect(result.room?.name).toBe('general');
-    expect(store.joiningIds.has('r1')).toBe(false);
-    expect(store.justJoinedIds.has('r1')).toBe(true);
-  });
-
-  it('returns an error result and does not set just-joined when the mutation fails', async () => {
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('r1')]),
-      commands: roomAPI({ joinRoom: vi.fn().mockRejectedValue(new Error('permission denied')) })
-    });
-    void store.refresh();
-    await settle();
-
-    const result = await store.joinRoom('r1');
-    expect(result.ok).toBe(false);
-    if (!result.ok) expect(result.error.message).toBe('permission denied');
-    expect(store.joiningIds.has('r1')).toBe(false);
-    expect(store.justJoinedIds.has('r1')).toBe(false);
-  });
-
-  it('clears a stale justLeft when the user re-joins', async () => {
-    const store = makeStore({ roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('r1')]) });
-    void store.refresh();
-    await settle();
-
-    store.justLeftIds.add('r1');
-    await store.joinRoom('r1');
-
-    expect(store.justJoinedIds.has('r1')).toBe(true);
-    expect(store.justLeftIds.has('r1')).toBe(false);
-  });
-});
-
-describe('RoomDirectoryStore - leaveRoom', () => {
-  it('marks leaving during the request and just-left on success, clearing justJoined', async () => {
-    const store = makeStore({ roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('r1')]) });
-    void store.refresh();
-    await settle();
-
-    store.justJoinedIds.add('r1');
-    const promise = store.leaveRoom('r1');
-    expect(store.leavingIds.has('r1')).toBe(true);
-
-    const result = await promise;
-    expect(result.ok).toBe(true);
-    expect(store.leavingIds.has('r1')).toBe(false);
-    expect(store.justLeftIds.has('r1')).toBe(true);
-    expect(store.justJoinedIds.has('r1')).toBe(false);
-  });
-
-  it('returns an error result on failure', async () => {
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('r1')]),
-      commands: roomAPI({ leaveRoom: vi.fn().mockRejectedValue(new Error('cannot leave')) })
-    });
-    void store.refresh();
-    await settle();
-
-    const result = await store.leaveRoom('r1');
-    expect(result.ok).toBe(false);
-    expect(store.leavingIds.has('r1')).toBe(false);
-    expect(store.justLeftIds.has('r1')).toBe(false);
-  });
-});
-
-describe('RoomDirectoryStore - refresh clears optimistic state', () => {
-  it('refresh clears just-* sets so the authoritative joined membership wins', async () => {
-    const store = makeStore({ roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('r1')]) });
-    void store.refresh();
-    await settle();
-
-    store.justJoinedIds.add('r1');
-    store.justLeftIds.add('r2');
-
-    await store.refresh();
-    await settle();
+    const joining = store.joinRoom('R1');
+    store.resetOptimisticState();
+    resolveJoin();
+    await joining;
 
     expect(store.justJoinedIds.size).toBe(0);
-    expect(store.justLeftIds.size).toBe(0);
+    expect(store.joiningIds.size).toBe(0);
+  });
+
+  it('loads join previews as an explicit best-effort query', async () => {
+    const api = memberAPI();
+    const store = new RoomDirectoryStore(makeNavigation(), api, commands());
+
+    expect(await store.loadJoinPreview('R1')).toMatchObject({
+      memberCount: 7,
+      sampleMembers: [{ id: 'U1', displayName: 'Ada' }]
+    });
+    expect(api.listRoomMembers).toHaveBeenCalledWith('R1', '', 5, 0);
   });
 });
-
-describe('RoomDirectoryStore - concurrent refresh guard', () => {
-  it('discards out-of-order responses', async () => {
-    let resolveFirst!: (value: DirectoryRoomSummary[]) => void;
-    let resolveSecond!: (value: DirectoryRoomSummary[]) => void;
-
-    const listRooms = vi
-      .fn()
-      .mockImplementationOnce(() => new Promise((resolve) => (resolveFirst = resolve)))
-      .mockImplementationOnce(() => new Promise((resolve) => (resolveSecond = resolve)));
-    const roomDirectoryAPI = { listRooms } as unknown as Pick<RoomDirectoryAPI, 'listRooms'>;
-
-    const store = makeStore({ roomDirectoryAPI });
-    void store.refresh();
-    void store.refresh();
-
-    resolveSecond([makeRoom('newer')]);
-    await settle();
-
-    expect(store.allRooms.map((r) => r.id)).toEqual(['newer']);
-
-    resolveFirst([makeRoom('older')]);
-    await settle();
-
-    expect(store.allRooms.map((r) => r.id)).toEqual(['newer']);
-  });
-});
-
-function directoryRoom(id: string): DirectoryRoom {
-  return {
-    id,
-    name: id,
-    description: null,
-    archived: false,
-    isUniversal: false,
-    viewerCanJoinRoom: true
-  };
-}

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.spec.ts
@@ -180,6 +180,18 @@ describe('RoomDirectoryStore', () => {
     expect(joinedStore.isJoined('R1')).toBe(true);
   });
 
+  it('clears every membership overlay when the projected room is removed', async () => {
+    const store = makeStore();
+    await store.joinRoom('R1');
+    expect(store.isJoined('R1')).toBe(true);
+
+    store.removeMembershipProjection('R1');
+
+    expect(store.isJoined('R1')).toBe(false);
+    expect(store.justJoinedIds.size).toBe(0);
+    expect(store.justLeftIds.size).toBe(0);
+  });
+
   it('does not let an older command clear a newer pending marker', async () => {
     const resolvers: Array<() => void> = [];
     const store = makeStore(

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
@@ -51,9 +51,9 @@ export class RoomDirectoryStore {
   #generation = 0;
   #commandToken = 0;
   #membershipRevisions = new SvelteMap<string, number>();
-  #joiningTokens = new Map<string, number>();
-  #leavingTokens = new Map<string, number>();
-  #joiningGroupTokens = new Map<string, number>();
+  #joiningTokens = new SvelteMap<string, number>();
+  #leavingTokens = new SvelteMap<string, number>();
+  #joiningGroupTokens = new SvelteMap<string, number>();
 
   constructor(
     private readonly navigation: RoomDirectoryNavigation,
@@ -128,7 +128,7 @@ export class RoomDirectoryStore {
 
   async joinGroup(groupId: string): Promise<JoinGroupResult> {
     const generation = this.#generation;
-    const membershipRevisions = new Map(
+    const membershipRevisions = new SvelteMap(
       this.navigation.rooms.map((room) => [room.id, this.membershipRevision(room.id)])
     );
     const commandToken = ++this.#commandToken;
@@ -186,6 +186,13 @@ export class RoomDirectoryStore {
     this.#membershipRevisions.set(roomId, this.membershipRevision(roomId) + 1);
     if (isMember === true) this.justJoinedIds.delete(roomId);
     if (isMember === false) this.justLeftIds.delete(roomId);
+  }
+
+  /** A removed room cannot retain either optimistic membership answer. */
+  removeMembershipProjection(roomId: string): void {
+    this.#membershipRevisions.set(roomId, this.membershipRevision(roomId) + 1);
+    this.justJoinedIds.delete(roomId);
+    this.justLeftIds.delete(roomId);
   }
 
   /** Fence late command responses and clear all optimistic state. */

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
@@ -1,10 +1,13 @@
 import { SvelteSet } from 'svelte/reactivity';
-import type { DirectoryRoomSummary, RoomDirectoryAPI } from '$lib/api-client/roomDirectory';
-import { RoomDirectoryScope, RoomKind } from '$lib/api-client/roomDirectory';
+import { RoomKind } from '$lib/api-client/roomDirectory';
 import type { MemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
 import type { UserAvatarUserView } from '$lib/render/users';
-import { avatarUserFromDirectoryMember } from './rooms.svelte';
+import {
+  avatarUserFromDirectoryMember,
+  type RoomsListGroup,
+  type RoomsListItem
+} from './rooms.svelte';
 
 export type DirectoryRoom = {
   id: string;
@@ -24,98 +27,55 @@ export type JoinResult = { ok: true; room?: DirectoryRoom } | { ok: false; error
 export type LeaveResult = { ok: true; room?: DirectoryRoom } | { ok: false; error: Error };
 export type JoinGroupResult = { ok: true; joinedRoomIds: string[] } | { ok: false; error: Error };
 
-function directoryRoom(room: DirectoryRoomSummary): DirectoryRoom {
-  return {
-    id: room.id,
-    name: room.name,
-    description: room.description,
-    archived: room.archived,
-    isUniversal: room.isUniversal,
-    viewerCanJoinRoom: room.canJoinRoom
-  };
-}
+export type RoomDirectoryNavigation = {
+  rooms: RoomsListItem[];
+  roomGroups: RoomsListGroup[];
+  isInitialLoading: boolean;
+};
 
 /**
- * Reactive state for the Browse Rooms directory page.
+ * Command state for room membership changes.
  *
- * Owns the "all rooms" listing (joined or not) plus the optimistic UI state
- * for in-flight join/leave operations (`joiningIds` / `leavingIds`) and the
- * just-completed momentary state (`justJoinedIds` / `justLeftIds`). The
- * actual "which rooms have I joined" answer comes from membership-filtered
- * rows in the active server's rooms store — components combine the two via
- * `isJoined(roomId, joinedSet)` rather than this store duplicating that
- * data.
- *
- * One store per registered server, owned by `ServerStateStore`. The
- * Browse Rooms page reads the active server's store via
- * `serverRegistry.getStore(getServerId()).roomDirectory` and triggers
- * `refresh()` reactively when the active server changes.
- *
- * The page-level component triggers {@link refresh} on mount / server switch
- * and surfaces command feedback.
+ * Directory rows and authoritative membership come directly from the
+ * projection-backed navigation view. This store owns only in-flight and
+ * just-completed optimistic state plus the explicit join-preview query.
  */
 export class RoomDirectoryStore {
-  allRooms = $state<DirectoryRoom[]>([]);
-  isLoading = $state(true);
-
-  // Optimistic UI sets. Public for templates to read; mutated only by methods
-  // on this store.
   joiningIds = new SvelteSet<string>();
   leavingIds = new SvelteSet<string>();
   justJoinedIds = new SvelteSet<string>();
   justLeftIds = new SvelteSet<string>();
-  // Group IDs whose "Join all" action is currently in flight.
   joiningGroupIds = new SvelteSet<string>();
 
-  private loadId = 0;
+  #generation = 0;
 
   constructor(
-    private readonly roomDirectoryAPI: Pick<RoomDirectoryAPI, 'listRooms'>,
+    private readonly navigation: RoomDirectoryNavigation,
     private readonly memberDirectoryAPI: Pick<MemberDirectoryAPI, 'listRoomMembers'>,
     private readonly roomAPI: Pick<RoomCommandAPI, 'joinRoom' | 'leaveRoom' | 'joinGroup'>
   ) {}
 
-  // ---------------------------------------------------------------------------
-  // Loading
-  // ---------------------------------------------------------------------------
-
-  async refresh(): Promise<void> {
-    const thisLoad = ++this.loadId;
-    const rooms = await this.roomDirectoryAPI.listRooms(RoomDirectoryScope.CHANNELS);
-    if (this.loadId !== thisLoad) return;
-
-    this.allRooms = rooms.map(directoryRoom);
-    // A successful refresh confirms what was optimistically applied; clear
-    // the just-* sets so isJoined() falls back on the authoritative joined
-    // membership reported by RoomsStore.
-    this.justJoinedIds.clear();
-    this.justLeftIds.clear();
-    this.isLoading = false;
+  get allRooms(): DirectoryRoom[] {
+    return this.navigation.rooms
+      .filter((room) => room.type === RoomKind.CHANNEL)
+      .map((room) => ({
+        id: room.id,
+        name: room.name,
+        description: room.description,
+        archived: false,
+        isUniversal: room.isUniversal,
+        viewerCanJoinRoom: room.viewerCanJoinRoom
+      }));
   }
 
-  /** Replace the visible channel directory from the realtime projection. */
-  replaceProjection(rooms: DirectoryRoomSummary[]): void {
-    this.loadId++;
-    this.allRooms = rooms.filter((room) => room.kind === RoomKind.CHANNEL).map(directoryRoom);
-    this.justJoinedIds.clear();
-    this.justLeftIds.clear();
-    this.isLoading = false;
+  get isLoading(): boolean {
+    return this.navigation.isInitialLoading;
   }
 
-  /** Invalidate projection-owned directory state during a compacted reset. */
-  resetProjectionState(): void {
-    this.loadId++;
-    this.allRooms = [];
-    this.justJoinedIds.clear();
-    this.justLeftIds.clear();
-    this.isLoading = true;
+  get roomGroups() {
+    return this.navigation.roomGroups;
   }
 
-  /**
-   * Loads the first five alphabetically sorted room members and the exact
-   * total from the ordinary paginated member listing. Availability remains
-   * best-effort so a failed read never prevents the user from joining.
-   */
   async loadJoinPreview(roomId: string): Promise<DirectoryRoomJoinPreview | null> {
     try {
       const page = await this.memberDirectoryAPI.listRoomMembers(roomId, '', 5, 0);
@@ -128,33 +88,22 @@ export class RoomDirectoryStore {
     }
   }
 
-  // ---------------------------------------------------------------------------
-  // Membership predicate
-  // ---------------------------------------------------------------------------
-
-  /**
-   * Whether a room should render as "joined" in the directory UI. Combines
-   * authoritative membership IDs (from `RoomsStore.rooms` rows where
-   * `viewerIsMember` is true, supplied by the caller) with optimistic just-*
-   * state held here.
-   */
-  isJoined(roomId: string, joinedRoomIds: ReadonlySet<string>): boolean {
+  isJoined(roomId: string): boolean {
     if (this.justLeftIds.has(roomId)) return false;
     if (this.justJoinedIds.has(roomId)) return true;
-    return joinedRoomIds.has(roomId);
+    return this.navigation.rooms.some((room) => room.id === roomId && room.viewerIsMember);
   }
 
-  // ---------------------------------------------------------------------------
-  // Mutations
-  // ---------------------------------------------------------------------------
-
   async joinRoom(roomId: string): Promise<JoinResult> {
+    const generation = this.#generation;
     this.joiningIds.add(roomId);
     try {
       await this.roomAPI.joinRoom(roomId);
-      this.justJoinedIds.add(roomId);
-      this.justLeftIds.delete(roomId);
-      return { ok: true, room: this.allRooms.find((r) => r.id === roomId) };
+      if (generation === this.#generation) {
+        this.justJoinedIds.add(roomId);
+        this.justLeftIds.delete(roomId);
+      }
+      return { ok: true, room: this.allRooms.find((room) => room.id === roomId) };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     } finally {
@@ -162,18 +111,16 @@ export class RoomDirectoryStore {
     }
   }
 
-  /**
-   * Join every room in a group that the caller can self-join and hasn't
-   * already joined. Returns the IDs of the rooms that were newly joined;
-   * already-joined and non-joinable rooms are silently skipped server-side.
-   */
   async joinGroup(groupId: string): Promise<JoinGroupResult> {
+    const generation = this.#generation;
     this.joiningGroupIds.add(groupId);
     try {
       const joined = await this.roomAPI.joinGroup(groupId);
-      for (const id of joined) {
-        this.justJoinedIds.add(id);
-        this.justLeftIds.delete(id);
+      if (generation === this.#generation) {
+        for (const id of joined) {
+          this.justJoinedIds.add(id);
+          this.justLeftIds.delete(id);
+        }
       }
       return { ok: true, joinedRoomIds: joined };
     } catch (error) {
@@ -184,16 +131,35 @@ export class RoomDirectoryStore {
   }
 
   async leaveRoom(roomId: string): Promise<LeaveResult> {
+    const generation = this.#generation;
     this.leavingIds.add(roomId);
     try {
       await this.roomAPI.leaveRoom(roomId);
-      this.justLeftIds.add(roomId);
-      this.justJoinedIds.delete(roomId);
-      return { ok: true, room: this.allRooms.find((r) => r.id === roomId) };
+      if (generation === this.#generation) {
+        this.justLeftIds.add(roomId);
+        this.justJoinedIds.delete(roomId);
+      }
+      return { ok: true, room: this.allRooms.find((room) => room.id === roomId) };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     } finally {
       this.leavingIds.delete(roomId);
     }
+  }
+
+  /** The authoritative membership projection supersedes a local overlay. */
+  acknowledgeMembership(roomId: string): void {
+    this.justJoinedIds.delete(roomId);
+    this.justLeftIds.delete(roomId);
+  }
+
+  /** Fence late command responses and clear all optimistic state. */
+  resetOptimisticState(): void {
+    this.#generation++;
+    this.joiningIds.clear();
+    this.leavingIds.clear();
+    this.justJoinedIds.clear();
+    this.justLeftIds.clear();
+    this.joiningGroupIds.clear();
   }
 }

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
@@ -1,4 +1,4 @@
-import { SvelteSet } from 'svelte/reactivity';
+import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { RoomKind } from '$lib/api-client/roomDirectory';
 import type { MemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 import type { RoomCommandAPI } from '$lib/api-client/rooms';
@@ -48,6 +48,7 @@ export class RoomDirectoryStore {
   joiningGroupIds = new SvelteSet<string>();
 
   #generation = 0;
+  #membershipRevisions = new SvelteMap<string, number>();
 
   constructor(
     private readonly navigation: RoomDirectoryNavigation,
@@ -96,10 +97,14 @@ export class RoomDirectoryStore {
 
   async joinRoom(roomId: string): Promise<JoinResult> {
     const generation = this.#generation;
+    const membershipRevision = this.membershipRevision(roomId);
     this.joiningIds.add(roomId);
     try {
       await this.roomAPI.joinRoom(roomId);
-      if (generation === this.#generation) {
+      if (
+        generation === this.#generation &&
+        membershipRevision === this.membershipRevision(roomId)
+      ) {
         this.justJoinedIds.add(roomId);
         this.justLeftIds.delete(roomId);
       }
@@ -113,13 +118,18 @@ export class RoomDirectoryStore {
 
   async joinGroup(groupId: string): Promise<JoinGroupResult> {
     const generation = this.#generation;
+    const membershipRevisions = new Map(
+      this.navigation.rooms.map((room) => [room.id, this.membershipRevision(room.id)])
+    );
     this.joiningGroupIds.add(groupId);
     try {
       const joined = await this.roomAPI.joinGroup(groupId);
       if (generation === this.#generation) {
         for (const id of joined) {
-          this.justJoinedIds.add(id);
-          this.justLeftIds.delete(id);
+          if ((membershipRevisions.get(id) ?? 0) === this.membershipRevision(id)) {
+            this.justJoinedIds.add(id);
+            this.justLeftIds.delete(id);
+          }
         }
       }
       return { ok: true, joinedRoomIds: joined };
@@ -132,10 +142,14 @@ export class RoomDirectoryStore {
 
   async leaveRoom(roomId: string): Promise<LeaveResult> {
     const generation = this.#generation;
+    const membershipRevision = this.membershipRevision(roomId);
     this.leavingIds.add(roomId);
     try {
       await this.roomAPI.leaveRoom(roomId);
-      if (generation === this.#generation) {
+      if (
+        generation === this.#generation &&
+        membershipRevision === this.membershipRevision(roomId)
+      ) {
         this.justLeftIds.add(roomId);
         this.justJoinedIds.delete(roomId);
       }
@@ -149,6 +163,7 @@ export class RoomDirectoryStore {
 
   /** The authoritative membership projection supersedes a local overlay. */
   acknowledgeMembership(roomId: string): void {
+    this.#membershipRevisions.set(roomId, this.membershipRevision(roomId) + 1);
     this.justJoinedIds.delete(roomId);
     this.justLeftIds.delete(roomId);
   }
@@ -156,10 +171,15 @@ export class RoomDirectoryStore {
   /** Fence late command responses and clear all optimistic state. */
   resetOptimisticState(): void {
     this.#generation++;
+    this.#membershipRevisions.clear();
     this.joiningIds.clear();
     this.leavingIds.clear();
     this.justJoinedIds.clear();
     this.justLeftIds.clear();
     this.joiningGroupIds.clear();
+  }
+
+  private membershipRevision(roomId: string): number {
+    return this.#membershipRevisions.get(roomId) ?? 0;
   }
 }

--- a/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomDirectory.svelte.ts
@@ -31,6 +31,7 @@ export type RoomDirectoryNavigation = {
   rooms: RoomsListItem[];
   roomGroups: RoomsListGroup[];
   isInitialLoading: boolean;
+  isRoomMember(roomId: string): boolean;
 };
 
 /**
@@ -48,7 +49,11 @@ export class RoomDirectoryStore {
   joiningGroupIds = new SvelteSet<string>();
 
   #generation = 0;
+  #commandToken = 0;
   #membershipRevisions = new SvelteMap<string, number>();
+  #joiningTokens = new Map<string, number>();
+  #leavingTokens = new Map<string, number>();
+  #joiningGroupTokens = new Map<string, number>();
 
   constructor(
     private readonly navigation: RoomDirectoryNavigation,
@@ -92,12 +97,14 @@ export class RoomDirectoryStore {
   isJoined(roomId: string): boolean {
     if (this.justLeftIds.has(roomId)) return false;
     if (this.justJoinedIds.has(roomId)) return true;
-    return this.navigation.rooms.some((room) => room.id === roomId && room.viewerIsMember);
+    return this.navigation.isRoomMember(roomId);
   }
 
   async joinRoom(roomId: string): Promise<JoinResult> {
     const generation = this.#generation;
     const membershipRevision = this.membershipRevision(roomId);
+    const commandToken = ++this.#commandToken;
+    this.#joiningTokens.set(roomId, commandToken);
     this.joiningIds.add(roomId);
     try {
       await this.roomAPI.joinRoom(roomId);
@@ -112,7 +119,10 @@ export class RoomDirectoryStore {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     } finally {
-      this.joiningIds.delete(roomId);
+      if (this.#joiningTokens.get(roomId) === commandToken) {
+        this.#joiningTokens.delete(roomId);
+        this.joiningIds.delete(roomId);
+      }
     }
   }
 
@@ -121,6 +131,8 @@ export class RoomDirectoryStore {
     const membershipRevisions = new Map(
       this.navigation.rooms.map((room) => [room.id, this.membershipRevision(room.id)])
     );
+    const commandToken = ++this.#commandToken;
+    this.#joiningGroupTokens.set(groupId, commandToken);
     this.joiningGroupIds.add(groupId);
     try {
       const joined = await this.roomAPI.joinGroup(groupId);
@@ -136,13 +148,18 @@ export class RoomDirectoryStore {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     } finally {
-      this.joiningGroupIds.delete(groupId);
+      if (this.#joiningGroupTokens.get(groupId) === commandToken) {
+        this.#joiningGroupTokens.delete(groupId);
+        this.joiningGroupIds.delete(groupId);
+      }
     }
   }
 
   async leaveRoom(roomId: string): Promise<LeaveResult> {
     const generation = this.#generation;
     const membershipRevision = this.membershipRevision(roomId);
+    const commandToken = ++this.#commandToken;
+    this.#leavingTokens.set(roomId, commandToken);
     this.leavingIds.add(roomId);
     try {
       await this.roomAPI.leaveRoom(roomId);
@@ -157,21 +174,27 @@ export class RoomDirectoryStore {
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error : new Error(String(error)) };
     } finally {
-      this.leavingIds.delete(roomId);
+      if (this.#leavingTokens.get(roomId) === commandToken) {
+        this.#leavingTokens.delete(roomId);
+        this.leavingIds.delete(roomId);
+      }
     }
   }
 
-  /** The authoritative membership projection supersedes a local overlay. */
-  acknowledgeMembership(roomId: string): void {
+  /** Clear only the local overlay confirmed by this projected membership. */
+  acknowledgeMembership(roomId: string, isMember: boolean | undefined): void {
     this.#membershipRevisions.set(roomId, this.membershipRevision(roomId) + 1);
-    this.justJoinedIds.delete(roomId);
-    this.justLeftIds.delete(roomId);
+    if (isMember === true) this.justJoinedIds.delete(roomId);
+    if (isMember === false) this.justLeftIds.delete(roomId);
   }
 
   /** Fence late command responses and clear all optimistic state. */
   resetOptimisticState(): void {
     this.#generation++;
     this.#membershipRevisions.clear();
+    this.#joiningTokens.clear();
+    this.#leavingTokens.clear();
+    this.#joiningGroupTokens.clear();
     this.joiningIds.clear();
     this.leavingIds.clear();
     this.justJoinedIds.clear();

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -1,7 +1,38 @@
 import { describe, expect, it } from 'vitest';
+import { RoomViewerState, RoomWithViewerState } from '@chatto/api-types/api/v1/room_directory_pb';
+import { Room } from '@chatto/api-types/api/v1/rooms_pb';
+import { GetViewerResponse, ServerViewerState } from '@chatto/api-types/api/v1/viewer_pb';
+import { RealtimeProjectionRoom } from '@chatto/api-types/realtime/v1/realtime_pb';
+import { ServerProjectionStore } from './projection.svelte';
 import { RoomUnreadStore } from './roomUnread.svelte';
 
 describe('RoomUnreadStore', () => {
+  it('reads authoritative room and aggregate unread state directly from the projection', () => {
+    const projection = new ServerProjectionStore();
+    projection.viewer = new GetViewerResponse({
+      viewerState: new ServerViewerState({ hasUnreadRooms: true })
+    });
+    projection.rooms.set(
+      'room-1',
+      new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({
+          room: new Room({ id: 'room-1' }),
+          viewerState: new RoomViewerState({ hasUnread: true })
+        })
+      })
+    );
+    const store = new RoomUnreadStore(() => projection);
+
+    expect(store.roomIsUnread('room-1')).toBe(true);
+    expect(store.hasAnyUnread).toBe(true);
+
+    projection.rooms.get('room-1')!.room!.viewerState = new RoomViewerState({ hasUnread: false });
+    projection.viewer.viewerState = new ServerViewerState({ hasUnreadRooms: false });
+
+    expect(store.roomIsUnread('room-1')).toBe(false);
+    expect(store.hasAnyUnread).toBe(false);
+  });
+
   it('initializes room unread state from an authoritative directory snapshot', () => {
     const store = new RoomUnreadStore();
 

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -33,6 +33,25 @@ describe('RoomUnreadStore', () => {
     expect(store.hasAnyUnread).toBe(false);
   });
 
+  it('lets concrete projected room state supersede a stale viewer aggregate', () => {
+    const projection = new ServerProjectionStore();
+    projection.viewer = new GetViewerResponse({
+      viewerState: new ServerViewerState({ hasUnreadRooms: true })
+    });
+    projection.rooms.set(
+      'room-1',
+      new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({
+          room: new Room({ id: 'room-1' }),
+          viewerState: new RoomViewerState({ hasUnread: false })
+        })
+      })
+    );
+    const store = new RoomUnreadStore(() => projection);
+
+    expect(store.hasAnyUnread).toBe(false);
+  });
+
   it('initializes room unread state from an authoritative directory snapshot', () => {
     const store = new RoomUnreadStore();
 

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -255,10 +255,13 @@ describe('RoomUnreadStore', () => {
     read.commit();
     expect(store.roomIsUnread('room-1')).toBe(false);
 
+    store.acknowledgeRoomProjection('room-1', true);
+    expect(store.roomIsUnread('room-1')).toBe(true);
+
+    const nextRead = store.beginOptimisticRead('room-1');
     store.acknowledgeRoomProjection('room-1', false);
-    projection.rooms.get('room-1')!.room!.viewerState = new RoomViewerState({
-      hasUnread: false
-    });
+    projection.rooms.get('room-1')!.room!.viewerState = new RoomViewerState({ hasUnread: false });
+    nextRead.commit();
     expect(store.roomIsUnread('room-1')).toBe(false);
   });
 });

--- a/apps/frontend/src/lib/state/server/roomUnread.spec.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.spec.ts
@@ -234,4 +234,31 @@ describe('RoomUnreadStore', () => {
     read.rollback();
     expect(store.roomIsUnread('room-1')).toBe(true);
   });
+
+  it('keeps an optimistic read until the projection confirms the room is read', () => {
+    const projection = new ServerProjectionStore();
+    projection.rooms.set(
+      'room-1',
+      new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({
+          room: new Room({ id: 'room-1' }),
+          viewerState: new RoomViewerState({ hasUnread: true })
+        })
+      })
+    );
+    const store = new RoomUnreadStore(() => projection);
+    const read = store.beginOptimisticRead('room-1');
+
+    store.acknowledgeRoomProjection('room-1', true);
+    expect(store.roomIsUnread('room-1')).toBe(false);
+
+    read.commit();
+    expect(store.roomIsUnread('room-1')).toBe(false);
+
+    store.acknowledgeRoomProjection('room-1', false);
+    projection.rooms.get('room-1')!.room!.viewerState = new RoomViewerState({
+      hasUnread: false
+    });
+    expect(store.roomIsUnread('room-1')).toBe(false);
+  });
 });

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -146,11 +146,11 @@ export class RoomUnreadStore {
 
   /** Clear only local overlays confirmed by this projected unread value. */
   acknowledgeRoomProjection(roomId: string, hasUnread: boolean | undefined): void {
+    if (hasUnread === undefined) return;
+    if (hasUnread && this.optimisticReadRooms.has(roomId)) return;
     this.advanceRoomRevision(roomId);
     if (hasUnread === false) this.invalidateOptimisticRead(roomId);
-    if (hasUnread !== undefined && this.roomOverrides.get(roomId) === hasUnread) {
-      this.roomOverrides.delete(roomId);
-    }
+    this.roomOverrides.delete(roomId);
   }
 
   /** Remove all local state when the projected room itself disappears. */

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -144,8 +144,17 @@ export class RoomUnreadStore {
     }
   }
 
-  /** A room viewer-state operation supersedes every local overlay for it. */
-  acknowledgeRoomProjection(roomId: string): void {
+  /** Clear only local overlays confirmed by this projected unread value. */
+  acknowledgeRoomProjection(roomId: string, hasUnread: boolean | undefined): void {
+    this.advanceRoomRevision(roomId);
+    if (hasUnread === false) this.invalidateOptimisticRead(roomId);
+    if (hasUnread !== undefined && this.roomOverrides.get(roomId) === hasUnread) {
+      this.roomOverrides.delete(roomId);
+    }
+  }
+
+  /** Remove all local state when the projected room itself disappears. */
+  removeRoomProjection(roomId: string): void {
     this.advanceRoomRevision(roomId);
     this.invalidateOptimisticRead(roomId);
     this.roomOverrides.delete(roomId);

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -1,35 +1,30 @@
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { OptimisticMutationRegistry } from '$lib/state/optimisticMutations';
+import type { ServerProjectionStore } from './projection.svelte';
 
 export type OptimisticRoomReadHandle = {
   commit(): void;
   rollback(): void;
 };
 
+type ProjectedUnreadSource = Pick<ServerProjectionStore, 'rooms' | 'viewer'>;
+
 /**
- * Tracks which rooms on the server have unread messages.
+ * Optimistic overlays for projection-owned room unread state.
  *
- * Post-PR(b) the API surface no longer carries `spaceId`, so unread state
- * collapses from "rooms-by-space" to a flat per-room group with a single
- * server-level "unknown unread" sentinel.
- *
- * Updated by:
- * - Root `MessagePostedEvent` for any room on the server → `setRoomUnread(_, true)`
- * - Marking a room as read (posting or entering) → `setRoomUnread(_, false)`
- * - Initial load with full room data → `initRooms`
- * - Initial load with only a server-level signal → `setServerHasUnread`
+ * Authoritative unread answers are read directly from `ServerProjectionStore`.
+ * Local posting/reading actions can temporarily override one room until the
+ * next room viewer-state operation acknowledges that command.
  */
 export class RoomUnreadStore {
-  // Specific rooms authoritatively known to be unread.
-  private unreadRooms = new SvelteSet<string>();
-  // Provisional reads hide the underlying unread fact until they settle.
+  private roomOverrides = new SvelteMap<string, boolean>();
   private optimisticReadRooms = new SvelteSet<string>();
   private optimisticReads = new OptimisticMutationRegistry();
   private roomRevisions = new SvelteMap<string, number>();
   private revision = 0;
-  // Server-level unknown-unread flag (set when we know there's unread but
-  // not which room — e.g. on initial load before rooms are queried).
-  private serverHasUnknownUnread = $state(false);
+  private serverHasUnknownUnreadOverride = $state<boolean | null>(null);
+
+  constructor(private readonly getProjection?: () => ProjectedUnreadSource) {}
 
   private optimisticReadKey(roomId: string): string {
     return `room:${roomId}`;
@@ -49,24 +44,12 @@ export class RoomUnreadStore {
     this.optimisticReadRooms.delete(roomId);
   }
 
-  /**
-   * Set unread status for a specific room.
-   */
   setRoomUnread(roomId: string, unread: boolean): void {
     this.advanceRoomRevision(roomId);
     this.invalidateOptimisticRead(roomId);
-
-    if (unread) {
-      this.unreadRooms.add(roomId);
-    } else {
-      this.unreadRooms.delete(roomId);
-    }
+    this.roomOverrides.set(roomId, unread);
   }
 
-  /**
-   * Provisionally mark a room read while retaining the underlying unread fact.
-   * New room state invalidates the handle so rollback cannot overwrite it.
-   */
   beginOptimisticRead(roomId: string): OptimisticRoomReadHandle {
     const token = this.optimisticReads.createToken();
     const roomRevision = this.roomRevision(roomId);
@@ -79,9 +62,8 @@ export class RoomUnreadStore {
       commit: () => {
         if (!this.optimisticReads.isCurrent(key, token)) return;
         if (this.roomRevision(roomId) !== roomRevision) return;
-
         this.advanceRoomRevision(roomId);
-        this.unreadRooms.delete(roomId);
+        this.roomOverrides.set(roomId, false);
         this.optimisticReads.clear(key);
         this.optimisticReadRooms.delete(roomId);
       },
@@ -93,100 +75,91 @@ export class RoomUnreadStore {
     };
   }
 
-  /**
-   * Check if the server has any unread rooms (or is flagged with unknown unread).
-   */
   get hasAnyUnread(): boolean {
-    for (const roomId of this.unreadRooms) {
-      if (!this.optimisticReadRooms.has(roomId)) return true;
-    }
-    return this.serverHasUnknownUnread;
+    const roomIds = new SvelteSet<string>(this.roomOverrides.keys());
+    for (const roomId of this.getProjection?.().rooms.keys() ?? []) roomIds.add(roomId);
+    for (const roomId of roomIds) if (this.roomIsUnread(roomId)) return true;
+    return (
+      this.serverHasUnknownUnreadOverride ??
+      this.getProjection?.().viewer?.viewerState?.hasUnreadRooms ??
+      false
+    );
   }
 
-  /**
-   * Get the first known unread room ID, or null if only the unknown-unread
-   * flag is set (no specific rooms).
-   */
   getFirstUnreadRoomId(): string | null {
-    for (const roomId of this.unreadRooms) {
-      if (!this.optimisticReadRooms.has(roomId)) return roomId;
-    }
+    const roomIds = new SvelteSet<string>(this.roomOverrides.keys());
+    for (const roomId of this.getProjection?.().rooms.keys() ?? []) roomIds.add(roomId);
+    for (const roomId of roomIds) if (this.roomIsUnread(roomId)) return roomId;
     return null;
   }
 
-  /**
-   * Check if a specific room is unread.
-   */
   roomIsUnread(roomId: string): boolean {
-    return this.unreadRooms.has(roomId) && !this.optimisticReadRooms.has(roomId);
+    if (this.optimisticReadRooms.has(roomId)) return false;
+    const override = this.roomOverrides.get(roomId);
+    if (override !== undefined) return override;
+    return this.getProjection?.().rooms.get(roomId)?.room?.viewerState?.hasUnread ?? false;
   }
 
-  /** Capture before loading a snapshot so newer room events win on arrival. */
   captureSnapshotRevision(): number {
     return this.revision;
   }
 
-  /**
-   * Initialize unread state from room data.
-   * Call this when loading rooms.
-   */
   initRooms(
     rooms: Array<{ id: string; hasUnread: boolean }>,
     serverHasUnknownUnread = false,
     snapshotRevision = this.captureSnapshotRevision()
   ): void {
     const snapshotRoomIds = new SvelteSet(rooms.map((room) => room.id));
-    for (const roomId of this.unreadRooms) {
+    for (const roomId of this.roomOverrides.keys()) {
       if (!snapshotRoomIds.has(roomId) && this.roomRevision(roomId) <= snapshotRevision) {
-        this.unreadRooms.delete(roomId);
+        this.roomOverrides.delete(roomId);
       }
     }
-
     this.updateRooms(rooms, snapshotRevision);
-    this.serverHasUnknownUnread = serverHasUnknownUnread;
+    this.serverHasUnknownUnreadOverride = serverHasUnknownUnread;
   }
 
-  /** Merge an authoritative partial room snapshot without dropping other rooms. */
   updateRooms(
     rooms: Array<{ id: string; hasUnread: boolean }>,
     snapshotRevision = this.captureSnapshotRevision()
   ): void {
     for (const room of rooms) {
       if (this.roomRevision(room.id) > snapshotRevision) continue;
-      if (room.hasUnread) this.unreadRooms.add(room.id);
-      else this.unreadRooms.delete(room.id);
+      this.roomOverrides.set(room.id, room.hasUnread);
     }
   }
 
-  /** Clear the server-level sentinel after all relevant room scopes are known. */
   resolveUnknownUnread(): void {
-    this.serverHasUnknownUnread = false;
+    this.serverHasUnknownUnreadOverride = false;
   }
 
-  /**
-   * Flag (or unflag) the server as having unread when only the server-level
-   * signal is known (initial load, before rooms are queried).
-   */
   setServerHasUnread(hasUnread: boolean): void {
-    if (hasUnread) {
-      this.serverHasUnknownUnread = true;
-    } else {
+    this.serverHasUnknownUnreadOverride = hasUnread;
+    if (!hasUnread) {
       this.optimisticReads.clearAll();
       this.optimisticReadRooms.clear();
-      this.serverHasUnknownUnread = false;
-      this.unreadRooms.clear();
+      this.roomOverrides.clear();
     }
   }
 
-  /**
-   * Clear all unread state.
-   */
+  /** A room viewer-state operation supersedes every local overlay for it. */
+  acknowledgeRoomProjection(roomId: string): void {
+    this.advanceRoomRevision(roomId);
+    this.invalidateOptimisticRead(roomId);
+    this.roomOverrides.delete(roomId);
+  }
+
+  /** A viewer operation supersedes the server-level fallback overlay. */
+  acknowledgeViewerProjection(): void {
+    this.serverHasUnknownUnreadOverride = null;
+  }
+
   clear(): void {
     this.optimisticReads.clearAll();
     this.optimisticReadRooms.clear();
     this.roomRevisions.clear();
     this.revision = 0;
-    this.unreadRooms.clear();
-    this.serverHasUnknownUnread = false;
+    this.roomOverrides.clear();
+    this.serverHasUnknownUnreadOverride = null;
   }
 }

--- a/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
+++ b/apps/frontend/src/lib/state/server/roomUnread.svelte.ts
@@ -79,11 +79,13 @@ export class RoomUnreadStore {
     const roomIds = new SvelteSet<string>(this.roomOverrides.keys());
     for (const roomId of this.getProjection?.().rooms.keys() ?? []) roomIds.add(roomId);
     for (const roomId of roomIds) if (this.roomIsUnread(roomId)) return true;
-    return (
-      this.serverHasUnknownUnreadOverride ??
-      this.getProjection?.().viewer?.viewerState?.hasUnreadRooms ??
-      false
-    );
+    if (this.serverHasUnknownUnreadOverride !== null) {
+      return this.serverHasUnknownUnreadOverride;
+    }
+    const projection = this.getProjection?.();
+    return projection?.rooms.size === 0
+      ? (projection.viewer?.viewerState?.hasUnreadRooms ?? false)
+      : false;
   }
 
   getFirstUnreadRoomId(): string | null {

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -12,7 +12,16 @@ import { User } from '@chatto/api-types/api/v1/users_pb';
 import { GetViewerResponse, ViewerUser } from '@chatto/api-types/api/v1/viewer_pb';
 import { RealtimeProjectionRoom } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { ServerProjectionStore } from './projection.svelte';
+import { RealtimeProjectionSyncState } from './realtimeSync.svelte';
 import { NavigationStore } from './rooms.svelte';
+
+function navigationFor(
+  projection: ServerProjectionStore,
+  sync = new RealtimeProjectionSyncState()
+): { navigation: NavigationStore; sync: RealtimeProjectionSyncState } {
+  sync.markCaughtUp(undefined);
+  return { navigation: new NavigationStore(projection, sync), sync };
+}
 
 function projectedRoom(
   id: string,
@@ -70,7 +79,7 @@ describe('NavigationStore', () => {
     );
     projection.rooms.set('managed', projectedRoom('managed'));
 
-    const navigation = new NavigationStore(projection);
+    const { navigation } = navigationFor(projection);
 
     expect(navigation.currentUserId).toBe('U1');
     expect(navigation.isInitialLoading).toBe(false);
@@ -105,7 +114,7 @@ describe('NavigationStore', () => {
         ]
       })
     ];
-    const navigation = new NavigationStore(projection);
+    const { navigation } = navigationFor(projection);
 
     expect(navigation.rooms.map((room) => room.id)).toEqual(['older', 'newer']);
     expect(navigation.roomGroups).toMatchObject([
@@ -120,12 +129,39 @@ describe('NavigationStore', () => {
     const projection = new ServerProjectionStore();
     projection.viewer = new GetViewerResponse();
     projection.rooms.set('R1', projectedRoom('R1'));
-    const navigation = new NavigationStore(projection);
+    const { navigation, sync } = navigationFor(projection);
 
     projection.reset();
+    sync.acceptProjectionEvent(undefined, true);
 
     expect(navigation.rooms).toEqual([]);
     expect(navigation.roomGroups).toEqual([]);
     expect(navigation.isInitialLoading).toBe(true);
+  });
+
+  it('hides a compacted projection prefix until caught up while retaining stale state', () => {
+    const projection = new ServerProjectionStore();
+    const sync = new RealtimeProjectionSyncState();
+    sync.beginCatchUp();
+    projection.viewer = new GetViewerResponse({
+      user: new ViewerUser({ profile: new User({ id: 'U1' }) })
+    });
+    projection.rooms.set('R1', projectedRoom('R1'));
+    const navigation = new NavigationStore(projection, sync);
+
+    expect(navigation.isInitialLoading).toBe(true);
+    expect(navigation.currentUserId).toBeNull();
+    expect(navigation.rooms).toEqual([]);
+
+    sync.markCaughtUp('cursor');
+
+    expect(navigation.isInitialLoading).toBe(false);
+    expect(navigation.currentUserId).toBe('U1');
+    expect(navigation.rooms.map((room) => room.id)).toEqual(['R1']);
+
+    sync.markStale();
+
+    expect(navigation.isInitialLoading).toBe(false);
+    expect(navigation.rooms.map((room) => room.id)).toEqual(['R1']);
   });
 });

--- a/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.spec.ts
@@ -1,632 +1,131 @@
-import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
-import { describe, it, expect, vi } from 'vitest';
-import { flushSync } from 'svelte';
-import type { UserAvatarUserView } from '$lib/render/users';
-import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
+import { describe, expect, it } from 'vitest';
+import { DirectoryMember } from '@chatto/api-types/api/v1/member_directory_pb';
+import { PermissionGrant } from '@chatto/api-types/api/v1/permissions_pb';
 import {
-  RoomDirectoryScope,
-  RoomKind,
-  type DirectoryRoomGroup,
-  type DirectoryRoomGroupItem,
-  type DirectoryRoomSummary,
-  type RoomDirectoryAPI
-} from '$lib/api-client/roomDirectory';
-import type { DirectoryMember, MemberDirectoryAPI } from '$lib/api-client/memberDirectory';
-import type { NotificationAPI } from '$lib/api-client/notifications';
-import type { ViewerState } from '$lib/api-client/viewer';
-import { NotificationLevelStore } from './notificationLevel.svelte';
-import { RoomUnreadStore } from './roomUnread.svelte';
-import { RoomsStore, type ViewerStateLoader } from './rooms.svelte';
+  RoomGroup,
+  RoomGroupItem,
+  RoomViewerState,
+  RoomWithViewerState
+} from '@chatto/api-types/api/v1/room_directory_pb';
+import { Room, RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { User } from '@chatto/api-types/api/v1/users_pb';
+import { GetViewerResponse, ViewerUser } from '@chatto/api-types/api/v1/viewer_pb';
+import { RealtimeProjectionRoom } from '@chatto/api-types/realtime/v1/realtime_pb';
+import { ServerProjectionStore } from './projection.svelte';
+import { NavigationStore } from './rooms.svelte';
 
-function makeRoom(id: string, overrides: Partial<DirectoryRoomSummary> = {}): DirectoryRoomSummary {
-  return {
-    id,
-    name: overrides.name ?? id,
-    description: overrides.description ?? null,
-    kind: overrides.kind ?? RoomKind.CHANNEL,
-    archived: overrides.archived ?? false,
-    isUniversal: overrides.isUniversal ?? false,
-    isMember: overrides.isMember ?? true,
-    hasUnread: overrides.hasUnread ?? false,
-    canJoinRoom: overrides.canJoinRoom ?? true,
-    canManageRoom: overrides.canManageRoom ?? false
-  };
-}
-
-function makeGroupRoomItem(
+function projectedRoom(
   id: string,
-  overrides: Partial<DirectoryRoomSummary> = {}
-): DirectoryRoomGroupItem {
-  return {
-    id: `room:${id}`,
-    type: 'room',
-    roomId: id,
-    room: makeRoom(id, overrides)
-  };
+  {
+    kind = RoomKind.CHANNEL,
+    member = true,
+    count = 0,
+    memberUserIds = [],
+    hasMessageHistory
+  }: {
+    kind?: RoomKind;
+    member?: boolean;
+    count?: number;
+    memberUserIds?: string[];
+    hasMessageHistory?: boolean;
+  } = {}
+): RealtimeProjectionRoom {
+  return new RealtimeProjectionRoom({
+    room: new RoomWithViewerState({
+      room: new Room({ id, name: id, kind }),
+      viewerState: new RoomViewerState({
+        isMember: member,
+        permissions: [
+          new PermissionGrant({ permission: 'room.join', granted: true }),
+          new PermissionGrant({ permission: 'room.manage', granted: id === 'managed' })
+        ]
+      })
+    }),
+    memberUserIds,
+    viewerNotificationCount: count,
+    hasMessageHistory
+  });
 }
 
-function makeMember(id: string, overrides: Partial<DirectoryMember> = {}): DirectoryMember {
-  return {
-    id,
-    login: overrides.login ?? id.toLowerCase(),
-    displayName: overrides.displayName ?? id,
-    deleted: overrides.deleted ?? false,
-    avatarUrl: overrides.avatarUrl ?? null,
-    presenceStatus: overrides.presenceStatus ?? PresenceStatus.ONLINE,
-    customStatus: overrides.customStatus ?? null,
-    roles: overrides.roles ?? [],
-    createdAt: overrides.createdAt ?? null
-  };
-}
-
-function makeViewer(overrides: Partial<ViewerState> = {}): ViewerState {
-  return {
-    user: {
-      id: 'U1',
-      login: 'alice',
-      displayName: 'Alice',
-      avatarUrl: null,
-      customStatus: null,
-      presenceStatus: PresenceStatus.ONLINE,
-      hasVerifiedEmail: true,
-      hasPassword: true,
-      viewerCanDeleteAccount: true,
-      lastLoginChange: null,
-      settings: null
-    },
-    canViewAdmin: false,
-    canStartDMs: true,
-    canAdminViewUsers: false,
-    canAdminManageAccounts: false,
-    canAssignRoles: false,
-    canAdminViewRoles: false,
-    canAdminManageRoles: false,
-    canAdminViewSystem: false,
-    canAdminViewAudit: false,
-    canManageUserPermissions: false,
-    serverNotificationPreference: {
-      level: NotificationLevel.DEFAULT,
-      effectiveLevel: NotificationLevel.NORMAL
-    },
-    roomNotificationPreferences: [],
-    viewerPermissions: {},
-    viewerHasUnreadRooms: false,
-    ...overrides
-  };
-}
-
-function makeNotificationAPI(counts: Record<string, number> = {}): NotificationAPI {
-  return {
-    listNotifications: vi.fn(),
-    listRoomNotifications: vi.fn(),
-    listRoomNotificationCounts: vi.fn().mockResolvedValue(counts),
-    dismissNotification: vi.fn(),
-    dismissAllNotifications: vi.fn()
-  } as unknown as NotificationAPI;
-}
-
-function makeRoomDirectoryAPI(
-  rooms: DirectoryRoomSummary[] = [],
-  groups: DirectoryRoomGroup[] = []
-): RoomDirectoryAPI {
-  return {
-    listRooms: vi.fn().mockResolvedValue(rooms),
-    listRoomGroups: vi.fn().mockResolvedValue(groups)
-  } as unknown as RoomDirectoryAPI;
-}
-
-function makeMemberDirectoryAPI(
-  membersByRoomId: Record<string, DirectoryMember[]> = {}
-): MemberDirectoryAPI {
-  return {
-    listUsers: vi.fn(),
-    listRoomMembers: vi.fn(async (roomId: string) => ({
-      members: membersByRoomId[roomId] ?? [],
-      totalCount: membersByRoomId[roomId]?.length ?? 0,
-      hasMore: false
-    }))
-  } as unknown as MemberDirectoryAPI;
-}
-
-function makeStore({
-  roomDirectoryAPI = makeRoomDirectoryAPI(),
-  memberDirectoryAPI = makeMemberDirectoryAPI(),
-  viewerStateLoader = vi.fn().mockResolvedValue(makeViewer()),
-  notificationAPI = makeNotificationAPI(),
-  notificationLevels = new NotificationLevelStore(),
-  roomUnread = new RoomUnreadStore()
-}: {
-  roomDirectoryAPI?: RoomDirectoryAPI;
-  memberDirectoryAPI?: MemberDirectoryAPI;
-  viewerStateLoader?: ViewerStateLoader;
-  notificationAPI?: NotificationAPI;
-  notificationLevels?: NotificationLevelStore;
-  roomUnread?: RoomUnreadStore;
-} = {}) {
-  return new RoomsStore(
-    roomDirectoryAPI,
-    memberDirectoryAPI,
-    viewerStateLoader,
-    notificationLevels,
-    roomUnread,
-    notificationAPI
-  );
-}
-
-async function settle() {
-  await Promise.resolve();
-  await Promise.resolve();
-  flushSync();
-}
-
-describe('RoomsStore - refresh', () => {
-  it('loads listable non-member channels from room directory and DMs with members', async () => {
-    const roomDirectoryAPI = makeRoomDirectoryAPI(
-      [
-        makeRoom('public', { isMember: false, canJoinRoom: true }),
-        makeRoom('dm-1', { kind: RoomKind.DM, name: '' })
-      ],
-      [
-        {
-          id: 'g1',
-          name: 'Lobby',
-          canCreateRoom: false,
-          canManageGroup: false,
-          roomIds: ['public'],
-          items: [makeGroupRoomItem('public')]
-        }
-      ]
-    );
-    const memberDirectoryAPI = makeMemberDirectoryAPI({
-      'dm-1': [makeMember('U1', { login: 'alice', displayName: 'Alice' })]
+describe('NavigationStore', () => {
+  it('selects rooms, members, permissions, counts, and viewer identity from the projection', () => {
+    const projection = new ServerProjectionStore();
+    projection.viewer = new GetViewerResponse({
+      user: new ViewerUser({ profile: new User({ id: 'U1' }) })
     });
-    const store = makeStore({ roomDirectoryAPI, memberDirectoryAPI });
-
-    await store.refresh();
-
-    expect(roomDirectoryAPI.listRooms).toHaveBeenCalledWith(RoomDirectoryScope.ALL);
-    expect(memberDirectoryAPI.listRoomMembers).toHaveBeenCalledWith(
-      'dm-1',
-      '',
-      ROOM_MEMBERS_PAGE_SIZE,
-      0
+    projection.users.set(
+      'U2',
+      new DirectoryMember({
+        user: new User({ id: 'U2', login: 'ada', displayName: 'Ada' })
+      })
     );
-    expect(store.rooms).toMatchObject([
+    projection.rooms.set(
+      'dm',
+      projectedRoom('dm', {
+        kind: RoomKind.DM,
+        count: 3,
+        memberUserIds: ['U2'],
+        hasMessageHistory: true
+      })
+    );
+    projection.rooms.set('managed', projectedRoom('managed'));
+
+    const navigation = new NavigationStore(projection);
+
+    expect(navigation.currentUserId).toBe('U1');
+    expect(navigation.isInitialLoading).toBe(false);
+    expect(navigation.rooms).toMatchObject([
       {
-        id: 'public',
-        type: RoomKind.CHANNEL,
-        isUniversal: false,
-        viewerIsMember: false,
-        viewerCanJoinRoom: true,
-        members: []
+        id: 'dm',
+        type: RoomKind.DM,
+        viewerNotificationCount: 3,
+        hasMessageHistory: true,
+        members: [{ id: 'U2', displayName: 'Ada' }]
       },
       {
-        id: 'dm-1',
-        type: RoomKind.DM,
-        isUniversal: false,
-        viewerIsMember: true,
-        members: [{ id: 'U1', displayName: 'Alice' }]
-      }
-    ]);
-    expect(store.roomGroups).toMatchObject([
-      {
-        id: 'g1',
-        items: [{ id: 'room:public', type: 'room', roomId: 'public' }]
+        id: 'managed',
+        viewerCanJoinRoom: true,
+        viewerCanManageRoom: true
       }
     ]);
   });
 
-  it('maps universal channel rooms from the room directory', async () => {
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general', { isUniversal: true })])
-    });
-
-    await store.refresh();
-
-    expect(store.rooms).toMatchObject([{ id: 'general', isUniversal: true }]);
-  });
-
-  it('loads viewer identity and notification preferences from Connect viewer state', async () => {
-    const notificationLevels = new NotificationLevelStore();
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general')]),
-      notificationLevels,
-      viewerStateLoader: vi.fn().mockResolvedValue(
-        makeViewer({
-          user: {
-            ...makeViewer().user,
-            id: 'U2'
-          },
-          serverNotificationPreference: {
-            level: NotificationLevel.MUTED,
-            effectiveLevel: NotificationLevel.MUTED
-          },
-          roomNotificationPreferences: [
-            {
-              roomId: 'general',
-              level: NotificationLevel.ALL_MESSAGES,
-              effectiveLevel: NotificationLevel.ALL_MESSAGES
-            }
-          ]
-        })
-      )
-    });
-
-    await store.refresh();
-
-    expect(store.currentUserId).toBe('U2');
-    expect(notificationLevels.getServerPreference()).toEqual({
-      level: NotificationLevel.MUTED,
-      effectiveLevel: NotificationLevel.MUTED
-    });
-    expect(notificationLevels.getRoomPreference('general')).toEqual({
-      level: NotificationLevel.ALL_MESSAGES,
-      effectiveLevel: NotificationLevel.ALL_MESSAGES
-    });
-  });
-
-  it('discards out-of-order responses', async () => {
-    let resolveFirstRooms!: (value: DirectoryRoomSummary[]) => void;
-    let resolveSecondRooms!: (value: DirectoryRoomSummary[]) => void;
-    const listRooms = vi.fn().mockImplementation(() => {
-      if (listRooms.mock.calls.length === 1) {
-        return new Promise<DirectoryRoomSummary[]>((resolve) => (resolveFirstRooms = resolve));
-      }
-      return new Promise<DirectoryRoomSummary[]>((resolve) => (resolveSecondRooms = resolve));
-    });
-    const listRoomGroups = vi.fn().mockImplementation(() => {
-      if (listRoomGroups.mock.calls.length === 1) {
-        return Promise.resolve([
-          {
-            id: 'g1',
-            name: 'Lobby',
-            roomIds: ['older'],
-            items: [makeGroupRoomItem('older')]
-          }
-        ]);
-      }
-      return Promise.resolve([
-        {
-          id: 'g1',
-          name: 'Lobby',
-          roomIds: ['newer'],
-          items: [makeGroupRoomItem('newer')]
-        }
-      ]);
-    });
-    const roomDirectoryAPI = {
-      listRooms,
-      listRoomGroups
-    } as unknown as RoomDirectoryAPI;
-    const store = makeStore({
-      roomDirectoryAPI,
-      notificationAPI: makeNotificationAPI({ newer: 4 })
-    });
-
-    void store.refresh();
-    void store.refresh();
-
-    resolveSecondRooms([makeRoom('newer')]);
-    await settle();
-
-    expect(store.rooms.map((room) => room.id)).toEqual(['newer']);
-    expect(store.roomGroups).toEqual([
-      {
-        id: 'g1',
-        name: 'Lobby',
-        roomIds: ['newer'],
-        items: [{ id: 'room:newer', type: 'room', roomId: 'newer' }]
-      }
-    ]);
-    await vi.waitFor(() => {
-      expect(store.rooms.find((room) => room.id === 'newer')?.viewerNotificationCount).toBe(4);
-    });
-
-    resolveFirstRooms([makeRoom('older')]);
-    await settle();
-
-    expect(store.rooms.map((room) => room.id)).toEqual(['newer']);
-    expect(store.roomGroups).toEqual([
-      {
-        id: 'g1',
-        name: 'Lobby',
-        roomIds: ['newer'],
-        items: [{ id: 'room:newer', type: 'room', roomId: 'newer' }]
-      }
-    ]);
-  });
-
-  it('patches notification counts from Connect', async () => {
-    let resolveCounts!: (value: Record<string, number>) => void;
-    const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listRoomNotificationCounts).mockImplementation(
-      () => new Promise((resolve) => (resolveCounts = resolve))
-    );
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general')]),
-      notificationAPI
-    });
-
-    await store.refresh();
-
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
-    resolveCounts({ general: 7 });
-
-    await vi.waitFor(() => {
-      expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 7 }]);
-    });
-  });
-
-  it('refreshes notification counts for an already-loaded room list', async () => {
-    let countQueries = 0;
-    const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listRoomNotificationCounts).mockImplementation(async () => {
-      countQueries++;
-      return { general: countQueries === 1 ? 1 : 0 };
-    });
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general')]),
-      notificationAPI
-    });
-
-    await store.refresh();
-    await vi.waitFor(() => {
-      expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 1 }]);
-    });
-
-    await store.refreshNotificationCounts();
-
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
-  });
-
-  it('preserves unchanged room rows and array identity during refresh', async () => {
-    const roomDirectoryAPI = makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]);
-    const store = makeStore({
-      roomDirectoryAPI,
-      notificationAPI: makeNotificationAPI({ general: 1, random: 0 })
-    });
-
-    await store.refresh();
-    await vi.waitFor(() => {
-      expect(store.rooms[0]?.viewerNotificationCount).toBe(1);
-    });
-
-    const rooms = store.rooms;
-    const general = store.rooms[0];
-    const random = store.rooms[1];
-    vi.mocked(roomDirectoryAPI.listRooms).mockResolvedValue([
-      makeRoom('general'),
-      makeRoom('random')
-    ]);
-
-    await store.refresh();
-    await settle();
-
-    expect(store.rooms).toBe(rooms);
-    expect(store.rooms[0]).toBe(general);
-    expect(store.rooms[1]).toBe(random);
-  });
-
-  it('refreshes unread state without replacing room rows', async () => {
-    const roomDirectoryAPI = makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]);
-    const roomUnread = new RoomUnreadStore();
-    const store = makeStore({
-      roomDirectoryAPI,
-      notificationAPI: makeNotificationAPI(),
-      roomUnread
-    });
-
-    await store.refresh();
-    await settle();
-
-    const general = store.rooms[0];
-    const random = store.rooms[1];
-    vi.mocked(roomDirectoryAPI.listRooms).mockResolvedValue([
-      makeRoom('general'),
-      makeRoom('random', { hasUnread: true })
-    ]);
-
-    await store.refresh();
-    await settle();
-
-    expect(store.rooms[0]).toBe(general);
-    expect(store.rooms[1]).toBe(random);
-    expect(roomUnread.roomIsUnread('random')).toBe(true);
-  });
-
-  it('does not cancel an optimistic read when an older refresh completes', async () => {
-    let resolveRooms!: (value: DirectoryRoomSummary[]) => void;
-    const roomDirectoryAPI = {
-      listRooms: vi.fn(
-        () => new Promise<DirectoryRoomSummary[]>((resolve) => (resolveRooms = resolve))
-      ),
-      listRoomGroups: vi.fn().mockResolvedValue([])
-    } as unknown as RoomDirectoryAPI;
-    const roomUnread = new RoomUnreadStore();
-    roomUnread.setRoomUnread('general', true);
-    const store = makeStore({ roomDirectoryAPI, roomUnread });
-
-    const refresh = store.refresh();
-    const read = roomUnread.beginOptimisticRead('general');
-    resolveRooms([makeRoom('general', { hasUnread: true })]);
-    await refresh;
-
-    expect(roomUnread.roomIsUnread('general')).toBe(false);
-
-    read.commit();
-
-    expect(roomUnread.roomIsUnread('general')).toBe(false);
-  });
-
-  it('only replaces rooms whose notification counts changed', async () => {
-    const notificationAPI = makeNotificationAPI({ general: 1, random: 0 });
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general'), makeRoom('random')]),
-      notificationAPI
-    });
-
-    await store.refresh();
-    await vi.waitFor(() => {
-      expect(store.rooms[0]?.viewerNotificationCount).toBe(1);
-    });
-
-    const rooms = store.rooms;
-    const general = store.rooms[0];
-    const random = store.rooms[1];
-
-    await store.refreshNotificationCounts();
-
-    expect(store.rooms).toBe(rooms);
-    expect(store.rooms[0]).toBe(general);
-    expect(store.rooms[1]).toBe(random);
-
-    vi.mocked(notificationAPI.listRoomNotificationCounts).mockResolvedValue({
-      general: 1,
-      random: 3
-    });
-
-    await store.refreshNotificationCounts();
-
-    expect(store.rooms).not.toBe(rooms);
-    expect(store.rooms[0]).toBe(general);
-    expect(store.rooms[1]).not.toBe(random);
-    expect(store.rooms[1]).toMatchObject({ id: 'random', viewerNotificationCount: 3 });
-  });
-
-  it('treats projected notification counts as authoritative replacements', () => {
-    const store = makeStore();
-    const room = makeRoom('general');
-
-    store.replaceProjection(makeViewer(), [room], [], new Map(), new Map([['general', 1]]));
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 1 }]);
-
-    store.replaceProjection(makeViewer(), [room], [], new Map(), new Map());
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
-  });
-
-  it('discards out-of-order notification count refresh responses', async () => {
-    let countQueries = 0;
-    let resolveOlder!: (value: Record<string, number>) => void;
-    let resolveNewer!: (value: Record<string, number>) => void;
-    const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listRoomNotificationCounts).mockImplementation(() => {
-      countQueries++;
-      if (countQueries === 1) return Promise.resolve({ general: 0 });
-      if (countQueries === 2) return new Promise((resolve) => (resolveOlder = resolve));
-      return new Promise((resolve) => (resolveNewer = resolve));
-    });
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general')]),
-      notificationAPI
-    });
-
-    await store.refresh();
-    await vi.waitFor(() => {
-      expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
-    });
-
-    const olderRefresh = store.refreshNotificationCounts();
-    const newerRefresh = store.refreshNotificationCounts();
-
-    resolveNewer({ general: 2 });
-    await newerRefresh;
-
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 2 }]);
-
-    resolveOlder({ general: 1 });
-    await olderRefresh;
-
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 2 }]);
-  });
-
-  it('keeps rooms visible when notification count loading fails', async () => {
-    const notificationAPI = makeNotificationAPI();
-    vi.mocked(notificationAPI.listRoomNotificationCounts).mockRejectedValue(
-      new Error('server too old')
-    );
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('general')]),
-      notificationAPI
-    });
-
-    await store.refresh();
-    await settle();
-
-    expect(store.rooms).toMatchObject([{ id: 'general', viewerNotificationCount: 0 }]);
-  });
-
-  it('maps mixed sidebar group items from the room directory', async () => {
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI(
-        [makeRoom('general')],
-        [
-          {
-            id: 'g1',
-            name: 'Lobby',
-            canCreateRoom: false,
-            canManageGroup: false,
-            roomIds: ['general'],
-            items: [
-              {
-                id: 'link:docs',
-                type: 'link',
-                link: { id: 'docs', label: 'Docs', url: 'https://example.com/docs' }
-              },
-              makeGroupRoomItem('general')
-            ]
-          }
-        ]
-      )
-    });
-
-    await store.refresh();
-
-    expect(store.roomGroups).toEqual([
-      {
-        id: 'g1',
-        name: 'Lobby',
-        viewerCanManageGroup: false,
-        roomIds: ['general'],
+  it('preserves projection ordering and derives room groups without retaining copies', () => {
+    const projection = new ServerProjectionStore();
+    projection.rooms.set('older', projectedRoom('older'));
+    projection.rooms.set('newer', projectedRoom('newer'));
+    projection.roomGroups = [
+      new RoomGroup({
+        id: 'G1',
+        name: 'Projects',
         items: [
-          {
-            id: 'link:docs',
-            type: 'link',
-            link: { id: 'docs', label: 'Docs', url: 'https://example.com/docs' }
-          },
-          { id: 'room:general', type: 'room', roomId: 'general' }
+          new RoomGroupItem({
+            item: { case: 'room', value: projectedRoom('newer').room! }
+          })
         ]
-      }
+      })
+    ];
+    const navigation = new NavigationStore(projection);
+
+    expect(navigation.rooms.map((room) => room.id)).toEqual(['older', 'newer']);
+    expect(navigation.roomGroups).toMatchObject([
+      { id: 'G1', name: 'Projects', roomIds: ['newer'] }
     ]);
+
+    projection.rooms.delete('older');
+    expect(navigation.rooms.map((room) => room.id)).toEqual(['newer']);
   });
 
-  it('preserves the avatar shape expected by sidebar DM rows', async () => {
-    const member: DirectoryMember = makeMember('U2', {
-      login: 'bob',
-      displayName: 'Bob',
-      customStatus: { emoji: ':wave:', text: 'Hi', expiresAt: null }
-    });
-    const store = makeStore({
-      roomDirectoryAPI: makeRoomDirectoryAPI([makeRoom('dm-1', { kind: RoomKind.DM })]),
-      memberDirectoryAPI: makeMemberDirectoryAPI({ 'dm-1': [member] })
-    });
+  it('becomes empty immediately when the canonical projection resets', () => {
+    const projection = new ServerProjectionStore();
+    projection.viewer = new GetViewerResponse();
+    projection.rooms.set('R1', projectedRoom('R1'));
+    const navigation = new NavigationStore(projection);
 
-    await store.refresh();
+    projection.reset();
 
-    expect(store.rooms[0]?.members).toEqual<UserAvatarUserView[]>([
-      {
-        id: 'U2',
-        login: 'bob',
-        displayName: 'Bob',
-        deleted: false,
-        avatarUrl: null,
-        presenceStatus: PresenceStatus.ONLINE,
-        customStatus: {
-          emoji: ':wave:',
-          text: 'Hi',
-          expiresAt: null
-        }
-      }
-    ]);
+    expect(navigation.rooms).toEqual([]);
+    expect(navigation.roomGroups).toEqual([]);
+    expect(navigation.isInitialLoading).toBe(true);
   });
 });

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -1,20 +1,9 @@
-import { untrack } from 'svelte';
-import { SvelteMap } from 'svelte/reactivity';
-import type { UserAvatarUserView } from '$lib/render/users';
-import type {
-  DirectoryRoomGroup,
-  DirectoryRoomGroupItem,
-  DirectoryRoomSummary,
-  RoomDirectoryAPI
-} from '$lib/api-client/roomDirectory';
-import { RoomDirectoryScope, RoomKind } from '$lib/api-client/roomDirectory';
+import { RoomKind } from '$lib/api-client/roomDirectory';
 import { roomKindOrChannel } from '$lib/api-client/enumDefaults';
-import type { MemberDirectoryAPI, DirectoryMember } from '$lib/api-client/memberDirectory';
-import type { ViewerState } from '$lib/api-client/viewer';
-import type { NotificationLevelStore } from '$lib/state/server/notificationLevel.svelte';
-import type { RoomUnreadStore } from '$lib/state/server/roomUnread.svelte';
-import type { NotificationAPI } from '$lib/api-client/notifications';
-import { ROOM_MEMBERS_PAGE_SIZE } from '$lib/state/room/members.svelte';
+import { mapDirectoryRoom, mapRoomGroup } from '$lib/api-client/roomDirectory';
+import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
+import type { UserAvatarUserView } from '$lib/render/users';
+import type { ServerProjectionStore } from './projection.svelte';
 
 export type RoomsListItem = {
   id: string;
@@ -26,10 +15,7 @@ export type RoomsListItem = {
   viewerCanJoinRoom: boolean;
   viewerCanManageRoom: boolean;
   viewerNotificationCount: number;
-  // Null means the connected server predates projection support for this
-  // distinction; only an explicit false hides an empty DM from navigation.
   hasMessageHistory?: boolean | null;
-  // Populated for DM rooms only — used to derive the display name in the sidebar.
   members: UserAvatarUserView[];
 };
 
@@ -63,18 +49,9 @@ export type RoomsListGroupItem =
       link: SidebarLinkListItem;
     };
 
-export type ViewerStateLoader = () => Promise<ViewerState>;
-
-function uniqueById<T extends { id: string }>(items: readonly T[] | null | undefined): T[] {
-  const seen: Record<string, true> = Object.create(null);
-  return (items ?? []).filter((item) => {
-    if (seen[item.id]) return false;
-    seen[item.id] = true;
-    return true;
-  });
-}
-
-export function avatarUserFromDirectoryMember(member: DirectoryMember): UserAvatarUserView {
+export function avatarUserFromDirectoryMember(
+  member: ReturnType<typeof mapDirectoryMember>
+): UserAvatarUserView {
   return {
     id: member.id,
     login: member.login,
@@ -92,380 +69,65 @@ export function avatarUserFromDirectoryMember(member: DirectoryMember): UserAvat
   };
 }
 
-function sameStringArray(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => value === b[index]);
-}
-
-function sameAvatarUser(a: UserAvatarUserView, b: UserAvatarUserView): boolean {
-  return (
-    a.id === b.id &&
-    a.login === b.login &&
-    a.displayName === b.displayName &&
-    a.deleted === b.deleted &&
-    a.avatarUrl === b.avatarUrl &&
-    a.presenceStatus === b.presenceStatus &&
-    a.customStatus?.emoji === b.customStatus?.emoji &&
-    a.customStatus?.text === b.customStatus?.text &&
-    a.customStatus?.expiresAt === b.customStatus?.expiresAt
-  );
-}
-
-function sameAvatarUsers(
-  a: readonly UserAvatarUserView[],
-  b: readonly UserAvatarUserView[]
-): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => {
-    const other = b[index];
-    return other !== undefined && sameAvatarUser(value, other);
-  });
-}
-
-function sameRoomListItem(a: RoomsListItem, b: RoomsListItem): boolean {
-  return (
-    a.id === b.id &&
-    a.name === b.name &&
-    a.description === b.description &&
-    a.type === b.type &&
-    a.isUniversal === b.isUniversal &&
-    a.viewerIsMember === b.viewerIsMember &&
-    a.viewerCanJoinRoom === b.viewerCanJoinRoom &&
-    a.viewerCanManageRoom === b.viewerCanManageRoom &&
-    a.viewerNotificationCount === b.viewerNotificationCount &&
-    a.hasMessageHistory === b.hasMessageHistory &&
-    sameAvatarUsers(a.members, b.members)
-  );
-}
-
-function sameSidebarLink(a: SidebarLinkListItem, b: SidebarLinkListItem): boolean {
-  return a.id === b.id && a.label === b.label && a.url === b.url;
-}
-
-function sameRoomGroupItem(a: RoomsListGroupItem, b: RoomsListGroupItem): boolean {
-  if (a.type !== b.type || a.id !== b.id) return false;
-  if (a.type === 'room' && b.type === 'room') return a.roomId === b.roomId;
-  if (a.type === 'link' && b.type === 'link') return sameSidebarLink(a.link, b.link);
-  return false;
-}
-
-function sameRoomGroupItems(
-  a: readonly RoomsListGroupItem[],
-  b: readonly RoomsListGroupItem[]
-): boolean {
-  if (a.length !== b.length) return false;
-  return a.every((value, index) => {
-    const other = b[index];
-    return other !== undefined && sameRoomGroupItem(value, other);
-  });
-}
-
-function sameRoomGroup(a: RoomsListGroup, b: RoomsListGroup): boolean {
-  return (
-    a.id === b.id &&
-    a.name === b.name &&
-    a.viewerCanManageGroup === b.viewerCanManageGroup &&
-    sameStringArray(a.roomIds, b.roomIds) &&
-    sameRoomGroupItems(a.items ?? [], b.items ?? [])
-  );
-}
-
-function sameRoomGroups(
-  a: readonly RoomsListGroup[] | null,
-  b: readonly RoomsListGroup[]
-): boolean {
-  if (!a || a.length !== b.length) return false;
-  return a.every((value, index) => {
-    const other = b[index];
-    return other !== undefined && sameRoomGroup(value, other);
-  });
-}
-
 /**
- * Reactive store for a server's joined-room list, layout, and per-room
- * notification counts. One store per registered server, owned by
- * `ServerStateStore` — consumers (RoomList sidebar, the `/[serverId]` redirect
- * page, etc.) reach the active server's store via
- * `serverRegistry.getStore(activeServerId).rooms`, so the reactivity follows
- * the URL automatically when the user switches servers.
+ * Read-only navigation view over the canonical realtime server projection.
  *
- * Room read state is owned separately by `RoomUnreadStore` so the room list
- * and server indicator cannot maintain competing unread projections.
- *
- * Canonical room and viewer state is replaced by the server projection; the
- * Connect API remains available for explicit paginated reads and commands.
+ * The view owns no server-derived room, membership, group, profile, ordering,
+ * or notification state. Getters translate the current protobuf projection at
+ * the presentation boundary.
  */
-export class RoomsStore {
-  rooms = $state<RoomsListItem[]>([]);
-  roomGroups = $state<RoomsListGroup[] | null>(null);
-  isInitialLoading = $state(true);
-  // The viewer's user ID, captured from the same sidebar bootstrap query that
-  // produced DM `room.members`. Use this in preference to a global auth
-  // context when filtering self out of DM labels and avatars.
-  currentUserId = $state<string | null>(null);
+export class NavigationStore {
+  constructor(private readonly projection: ServerProjectionStore) {}
 
-  private loadId = 0;
-  private notificationCountsLoadId = 0;
-
-  constructor(
-    private readonly roomDirectoryAPI: RoomDirectoryAPI,
-    private readonly memberDirectoryAPI: MemberDirectoryAPI,
-    private readonly viewerStateLoader: ViewerStateLoader,
-    private readonly notificationLevels: NotificationLevelStore,
-    private readonly roomUnread: RoomUnreadStore,
-    private readonly notificationAPI: NotificationAPI
-  ) {}
-
-  // -------------------------------------------------------------------------
-  // Loading
-  // -------------------------------------------------------------------------
-
-  async refresh(): Promise<void> {
-    const thisLoad = ++this.loadId;
-    const unreadSnapshotRevision = this.roomUnread.captureSnapshotRevision();
-    const [viewer, rooms, roomGroups] = await Promise.all([
-      this.viewerStateLoader(),
-      this.roomDirectoryAPI.listRooms(RoomDirectoryScope.ALL),
-      this.roomDirectoryAPI.listRoomGroups()
-    ]);
-    if (this.loadId !== thisLoad) return;
-
-    this.currentUserId = viewer.user.id;
-    this.notificationLevels.setServerPreference(
-      viewer.serverNotificationPreference.level,
-      viewer.serverNotificationPreference.effectiveLevel
-    );
-    for (const pref of viewer.roomNotificationPreferences) {
-      this.notificationLevels.setRoomPreference(pref.roomId, pref.level, pref.effectiveLevel);
-    }
-
-    const channelRooms = uniqueById(rooms.filter((room) => room.kind === RoomKind.CHANNEL));
-    const dmRooms = uniqueById(rooms.filter((room) => room.kind === RoomKind.DM));
-    const visibleChannels = channelRooms.filter((room) => !room.archived);
-    const visibleDms = dmRooms.filter((room) => !room.archived);
-    const dmMembersByRoomId = new SvelteMap<string, UserAvatarUserView[]>(
-      await Promise.all(
-        visibleDms.map(
-          async (room) =>
-            [
-              room.id,
-              (
-                await this.memberDirectoryAPI.listRoomMembers(
-                  room.id,
-                  '',
-                  ROOM_MEMBERS_PAGE_SIZE,
-                  0
-                )
-              ).members.map(avatarUserFromDirectoryMember)
-            ] as const
-        )
-      )
-    );
-    if (this.loadId !== thisLoad) return;
-
-    const nextRooms = [
-      ...visibleChannels.map((room) => this.roomListItem(room, [])),
-      ...visibleDms.map((room) => this.roomListItem(room, dmMembersByRoomId.get(room.id) ?? []))
-    ];
-    this.applyRooms(nextRooms);
-    this.roomUnread.initRooms([...visibleChannels, ...visibleDms], false, unreadSnapshotRevision);
-    void this.refreshNotificationCounts();
-
-    const nextRoomGroups = roomGroups.map((group) => ({
-      id: group.id,
-      name: group.name,
-      viewerCanManageGroup: group.canManageGroup,
-      roomIds: group.roomIds,
-      items: group.items.map(roomGroupItem)
-    }));
-    if (!sameRoomGroups(this.roomGroups, nextRoomGroups)) {
-      this.roomGroups = nextRoomGroups;
-    }
-
-    this.isInitialLoading = false;
-  }
-
-  /** Replace navigation state from the server-wide realtime projection. */
-  replaceProjection(
-    viewer: ViewerState,
-    rooms: DirectoryRoomSummary[],
-    roomGroups: DirectoryRoomGroup[],
-    membersByRoomId: ReadonlyMap<string, UserAvatarUserView[]> = new SvelteMap(),
-    notificationCountsByRoomId: ReadonlyMap<string, number> = new SvelteMap(),
-    messageHistoryByRoomId: ReadonlyMap<string, boolean | null> = new SvelteMap()
-  ): void {
-    this.loadId++;
-    this.currentUserId = viewer.user.id;
-    this.notificationLevels.setServerPreference(
-      viewer.serverNotificationPreference.level,
-      viewer.serverNotificationPreference.effectiveLevel
-    );
-    for (const pref of viewer.roomNotificationPreferences) {
-      this.notificationLevels.setRoomPreference(pref.roomId, pref.level, pref.effectiveLevel);
-    }
-
-    const visibleRooms = uniqueById(rooms.filter((room) => !room.archived));
-    this.applyRooms(
-      visibleRooms.map((room) => ({
-        ...this.roomListItem(room, membersByRoomId.get(room.id) ?? []),
-        viewerNotificationCount: notificationCountsByRoomId.get(room.id) ?? 0,
-        hasMessageHistory:
-          room.kind === RoomKind.DM ? (messageHistoryByRoomId.get(room.id) ?? null) : null
-      })),
-      false
-    );
-    this.roomUnread.initRooms(visibleRooms);
-    this.roomGroups = roomGroups.map((group) => ({
-      id: group.id,
-      name: group.name,
-      viewerCanManageGroup: group.canManageGroup,
-      roomIds: group.roomIds,
-      items: group.items.map(roomGroupItem)
-    }));
-    this.isInitialLoading = false;
-  }
-
-  /** Invalidate all projection-owned navigation state during a reset. */
-  resetProjectionState(): void {
-    this.loadId++;
-    this.notificationCountsLoadId++;
-    this.rooms = [];
-    this.roomGroups = [];
-    this.currentUserId = null;
-    this.isInitialLoading = true;
-  }
-
-  private roomListItem(room: DirectoryRoomSummary, members: UserAvatarUserView[]): RoomsListItem {
-    return {
-      id: room.id,
-      name: room.name,
-      description: room.description,
-      type: roomKindOrChannel(room.kind),
-      isUniversal: room.isUniversal,
-      viewerIsMember: room.isMember,
-      viewerCanJoinRoom: room.canJoinRoom,
-      viewerCanManageRoom: room.canManageRoom,
-      viewerNotificationCount: 0,
-      hasMessageHistory: room.kind === RoomKind.DM ? true : null,
-      members
-    };
-  }
-
-  private applyRooms(nextRooms: RoomsListItem[], preserveNotificationCounts = true): void {
-    const previousById = new SvelteMap(this.rooms.map((room) => [room.id, room]));
-    let changed = this.rooms.length !== nextRooms.length;
-    const merged = nextRooms.map((room, index) => {
-      const previous = previousById.get(room.id);
-      const next = {
-        ...room,
-        viewerNotificationCount: preserveNotificationCounts
-          ? (previous?.viewerNotificationCount ?? room.viewerNotificationCount)
-          : room.viewerNotificationCount
-      };
-      if (!previous) {
-        changed = true;
-        return next;
-      }
-      if (this.rooms[index]?.id !== room.id || !sameRoomListItem(previous, next)) {
-        changed = true;
-        return next;
-      }
-      return previous;
-    });
-
-    if (changed) {
-      this.rooms = merged;
-    }
-  }
-
-  async refreshNotificationCounts(): Promise<void> {
-    const loadId = this.loadId;
-    const notificationCountsLoadId = ++this.notificationCountsLoadId;
-
-    try {
-      const countsByRoomId = await this.notificationAPI.listRoomNotificationCounts();
-      if (this.loadId !== loadId || this.notificationCountsLoadId !== notificationCountsLoadId) {
-        return;
-      }
-
-      untrack(() => {
-        let changed = false;
-        const rooms = this.rooms.map((room) => {
-          const viewerNotificationCount = countsByRoomId[room.id] ?? 0;
-          if (room.viewerNotificationCount === viewerNotificationCount) return room;
-          changed = true;
-          return { ...room, viewerNotificationCount };
-        });
-        if (changed) this.rooms = rooms;
+  get rooms(): RoomsListItem[] {
+    return [...this.projection.rooms.values()].flatMap((entry) => {
+      const room = entry.room ? mapDirectoryRoom(entry.room) : null;
+      if (!room || room.archived) return [];
+      const members = entry.memberUserIds.flatMap((userId) => {
+        const member = this.projection.users.get(userId);
+        return member ? [avatarUserFromDirectoryMember(mapDirectoryMember(member))] : [];
       });
-    } catch (err) {
-      if (this.loadId === loadId && this.notificationCountsLoadId === notificationCountsLoadId) {
-        console.warn('failed to load room notification counts', err);
-      }
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Per-room flag mutations
-  // -------------------------------------------------------------------------
-
-  incrementUnreadNotification(roomId: string): void {
-    const room = this.rooms.find((r) => r.id === roomId);
-    if (!room) return;
-    this.patchRoom(roomId, { viewerNotificationCount: room.viewerNotificationCount + 1 });
-  }
-
-  decrementUnreadNotification(roomId: string, amount = 1): void {
-    const room = this.rooms.find((r) => r.id === roomId);
-    if (!room) return;
-    this.patchRoom(roomId, {
-      viewerNotificationCount: Math.max(0, room.viewerNotificationCount - amount)
+      return [
+        {
+          id: room.id,
+          name: room.name,
+          description: room.description,
+          type: roomKindOrChannel(room.kind),
+          isUniversal: room.isUniversal,
+          viewerIsMember: room.isMember,
+          viewerCanJoinRoom: room.canJoinRoom,
+          viewerCanManageRoom: room.canManageRoom,
+          viewerNotificationCount: entry.viewerNotificationCount,
+          hasMessageHistory: room.kind === RoomKind.DM ? (entry.hasMessageHistory ?? null) : null,
+          members
+        }
+      ];
     });
   }
 
-  clearUnreadNotifications(roomId: string): void {
-    this.patchRoom(roomId, { viewerNotificationCount: 0 });
-  }
-
-  clearAllUnreadNotifications(): void {
-    untrack(() => {
-      this.rooms = this.rooms.map((room) => ({
-        ...room,
-        viewerNotificationCount: 0
-      }));
+  get roomGroups(): RoomsListGroup[] {
+    return this.projection.roomGroups.map((group) => {
+      const mapped = mapRoomGroup(group);
+      return {
+        id: mapped.id,
+        name: mapped.name,
+        viewerCanManageGroup: mapped.canManageGroup,
+        roomIds: mapped.roomIds,
+        items: mapped.items.map((item) =>
+          item.type === 'room'
+            ? { id: item.id, type: 'room' as const, roomId: item.roomId }
+            : { id: item.id, type: 'link' as const, link: item.link }
+        )
+      };
     });
   }
 
-  /**
-   * Move a room to the front of the rooms array. RoomList renders DMs in
-   * their store-array order, so this is what makes a freshly-active DM jump
-   * to the top of the Direct Messages section. Channels render alphabetically
-   * regardless of array order, so a bump is a no-op for them visually.
-   */
-  bumpRoom(roomId: string): void {
-    untrack(() => {
-      const idx = this.rooms.findIndex((r) => r.id === roomId);
-      if (idx <= 0) return;
-      const room = this.rooms[idx];
-      this.rooms = [room, ...this.rooms.slice(0, idx), ...this.rooms.slice(idx + 1)];
-    });
+  get currentUserId(): string | null {
+    return this.projection.viewer?.user?.profile?.id ?? null;
   }
 
-  private patchRoom(roomId: string, patch: Partial<RoomsListItem>): void {
-    // Wrapped in untrack so callers can invoke from within a $effect without
-    // creating a read+write loop on `rooms`. Reactivity for other consumers
-    // still fires from the assignment.
-    untrack(() => {
-      const idx = this.rooms.findIndex((r) => r.id === roomId);
-      if (idx === -1) return;
-      this.rooms[idx] = { ...this.rooms[idx], ...patch };
-    });
+  get isInitialLoading(): boolean {
+    return this.projection.viewer === null;
   }
-}
 
-function roomGroupItem(item: DirectoryRoomGroupItem): RoomsListGroupItem {
-  if (item.type === 'room') {
-    return { id: item.id, type: 'room', roomId: item.roomId };
-  }
-  return { id: item.id, type: 'link', link: item.link };
 }

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -4,6 +4,7 @@ import { mapDirectoryRoom, mapRoomGroup } from '$lib/api-client/roomDirectory';
 import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
 import type { UserAvatarUserView } from '$lib/render/users';
 import type { ServerProjectionStore } from './projection.svelte';
+import { SvelteSet } from 'svelte/reactivity';
 
 type ProjectionReadiness = {
   hasUsableProjection: boolean;
@@ -127,7 +128,7 @@ export class NavigationStore {
   });
 
   readonly #memberRoomIds = $derived.by(
-    () => new Set(this.#rooms.filter((room) => room.viewerIsMember).map((room) => room.id))
+    () => new SvelteSet(this.#rooms.filter((room) => room.viewerIsMember).map((room) => room.id))
   );
 
   constructor(

--- a/apps/frontend/src/lib/state/server/rooms.svelte.ts
+++ b/apps/frontend/src/lib/state/server/rooms.svelte.ts
@@ -5,6 +5,10 @@ import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
 import type { UserAvatarUserView } from '$lib/render/users';
 import type { ServerProjectionStore } from './projection.svelte';
 
+type ProjectionReadiness = {
+  hasUsableProjection: boolean;
+};
+
 export type RoomsListItem = {
   id: string;
   name: string;
@@ -77,9 +81,8 @@ export function avatarUserFromDirectoryMember(
  * the presentation boundary.
  */
 export class NavigationStore {
-  constructor(private readonly projection: ServerProjectionStore) {}
-
-  get rooms(): RoomsListItem[] {
+  readonly #rooms = $derived.by((): RoomsListItem[] => {
+    if (!this.readiness.hasUsableProjection) return [];
     return [...this.projection.rooms.values()].flatMap((entry) => {
       const room = entry.room ? mapDirectoryRoom(entry.room) : null;
       if (!room || room.archived) return [];
@@ -103,9 +106,10 @@ export class NavigationStore {
         }
       ];
     });
-  }
+  });
 
-  get roomGroups(): RoomsListGroup[] {
+  readonly #roomGroups = $derived.by((): RoomsListGroup[] => {
+    if (!this.readiness.hasUsableProjection) return [];
     return this.projection.roomGroups.map((group) => {
       const mapped = mapRoomGroup(group);
       return {
@@ -120,14 +124,35 @@ export class NavigationStore {
         )
       };
     });
+  });
+
+  readonly #memberRoomIds = $derived.by(
+    () => new Set(this.#rooms.filter((room) => room.viewerIsMember).map((room) => room.id))
+  );
+
+  constructor(
+    private readonly projection: ServerProjectionStore,
+    private readonly readiness: ProjectionReadiness
+  ) {}
+
+  get rooms(): RoomsListItem[] {
+    return this.#rooms;
+  }
+
+  get roomGroups(): RoomsListGroup[] {
+    return this.#roomGroups;
   }
 
   get currentUserId(): string | null {
+    if (!this.readiness.hasUsableProjection) return null;
     return this.projection.viewer?.user?.profile?.id ?? null;
   }
 
   get isInitialLoading(): boolean {
-    return this.projection.viewer === null;
+    return !this.readiness.hasUsableProjection;
   }
 
+  isRoomMember(roomId: string): boolean {
+    return this.#memberRoomIds.has(roomId);
+  }
 }

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -12,9 +12,11 @@ import { DirectoryMember } from '@chatto/api-types/api/v1/member_directory_pb';
 import { Message, MessageAttachment } from '@chatto/api-types/api/v1/message_types_pb';
 import { Room } from '@chatto/api-types/api/v1/rooms_pb';
 import {
+  RoomGroup,
   RoomViewerState,
   RoomWithViewerState
 } from '@chatto/api-types/api/v1/room_directory_pb';
+import { GetViewerResponse, ViewerUser } from '@chatto/api-types/api/v1/viewer_pb';
 import {
   RoomMessagePosted,
   RoomTimelineEvent,
@@ -632,11 +634,16 @@ describe('ServerStateStore live server updates', () => {
         })
       })
     );
-    store.rooms.rooms = [{ id: 'R1' } as never];
-    store.rooms.roomGroups = [{ id: 'G1' } as never];
-    store.rooms.isInitialLoading = false;
-    store.roomDirectory.allRooms = [{ id: 'R1' } as never];
-    store.roomDirectory.isLoading = false;
+    store.projection.viewer = new GetViewerResponse({
+      user: new ViewerUser({ profile: new User({ id: 'U1' }) })
+    });
+    store.projection.rooms.set(
+      'R1',
+      new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({ room: new Room({ id: 'R1' }) })
+      })
+    );
+    store.projection.roomGroups = [new RoomGroup({ id: 'G1' })];
     store.currentUser.loading = false;
 
     for (const handler of bus.projectionHandlers) {
@@ -662,9 +669,9 @@ describe('ServerStateStore live server updates', () => {
     expect(store.serverInfo.motd).toBeNull();
     expect(store.serverInfo.pushNotificationsEnabled).toBe(false);
     expect(store.serverInfo.livekitUrl).toBeNull();
-    expect(store.rooms.rooms).toEqual([]);
-    expect(store.rooms.roomGroups).toEqual([]);
-    expect(store.rooms.isInitialLoading).toBe(true);
+    expect(store.navigation.rooms).toEqual([]);
+    expect(store.navigation.roomGroups).toEqual([]);
+    expect(store.navigation.isInitialLoading).toBe(true);
     expect(store.roomDirectory.allRooms).toEqual([]);
     expect(store.roomDirectory.isLoading).toBe(true);
     expect(store.currentUser.loading).toBe(true);
@@ -737,8 +744,6 @@ describe('ServerStateStore live server updates', () => {
         memberUserIds: ['U2']
       })
     );
-    const replaceNavigation = vi.spyOn(store.rooms, 'replaceProjection');
-
     eventBusManager.startBus(registered.id, fake as unknown as ServerConnection);
     flushSync();
     const bus = eventBusManager.getBus(registered.id)!;
@@ -759,9 +764,7 @@ describe('ServerStateStore live server updates', () => {
 
     expect(store.projection.users.has('U2')).toBe(false);
     expect(store.projection.rooms.get('R1')?.memberUserIds).toEqual([]);
-    expect(replaceNavigation).toHaveBeenCalled();
-    const membersByRoom = replaceNavigation.mock.calls.at(-1)?.[3];
-    expect(membersByRoom?.get('R1')).toEqual([]);
+    expect(store.navigation.rooms[0]?.members).toEqual([]);
     expect(messages.events[0]).toMatchObject({ actorId: 'U2', actor: null });
   });
 
@@ -1270,11 +1273,10 @@ describe('ServerStateStore live server updates', () => {
     release();
   });
 
-  it('does not inject an old mutation outside the retained room window or bump the room', () => {
+  it('does not inject an old mutation outside the retained room window', () => {
     const fake = new FakeServerConnection([]);
     const store = makeStore(fake);
     const messages = store.messagesForRoom('R1');
-    const bumpRoom = vi.spyOn(store.rooms, 'bumpRoom');
     const retained = Array.from({ length: 50 }, (_, index) =>
       projectedMessage(`M${index}`, new Date(Date.UTC(2026, 0, 1, 0, 0, index)))
     );
@@ -1332,13 +1334,23 @@ describe('ServerStateStore live server updates', () => {
     );
     expect(messages.events).toHaveLength(50);
     expect(messages.events.some(({ id }) => id === 'OLD-ROOT')).toBe(false);
-    expect(bumpRoom).not.toHaveBeenCalled();
   });
 
-  it('bumps an unretained room when lightweight activity arrives', () => {
+  it('derives unretained-room activity ordering directly from the projection', () => {
     const fake = new FakeServerConnection([]);
     const store = makeStore(fake);
-    const bumpRoom = vi.spyOn(store.rooms, 'bumpRoom');
+    store.projection.rooms.set(
+      'R1',
+      new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({ room: new Room({ id: 'R1' }) })
+      })
+    );
+    store.projection.rooms.set(
+      'R2',
+      new RealtimeProjectionRoom({
+        room: new RoomWithViewerState({ room: new Room({ id: 'R2' }) })
+      })
+    );
 
     eventBusManager.startBus(registered.id, fake as unknown as ServerConnection);
     flushSync();
@@ -1359,14 +1371,14 @@ describe('ServerStateStore live server updates', () => {
       );
     }
 
-    expect(bumpRoom).toHaveBeenCalledWith('R2');
+    expect([...store.projection.rooms.keys()]).toEqual(['R2', 'R1']);
     expect(store.projection.timelines.has('R2')).toBe(false);
   });
 
   it('derives call join and leave effects from active-call projection replacements', () => {
     const fake = new FakeServerConnection([]);
     const store = makeStore(fake);
-    store.rooms.currentUserId = 'U1';
+    store.currentUser.user = { id: 'U1' } as never;
     const shouldPlay = vi
       .spyOn(store.voiceCall, 'callTransitionSoundDecision')
       .mockReturnValue('play');

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -744,6 +744,7 @@ describe('ServerStateStore live server updates', () => {
         memberUserIds: ['U2']
       })
     );
+    store.realtimeSync.markCaughtUp(undefined);
     eventBusManager.startBus(registered.id, fake as unknown as ServerConnection);
     flushSync();
     const bus = eventBusManager.getBus(registered.id)!;

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -374,7 +374,7 @@ export class ServerStateStore {
         case 'roomRemove': {
           adminRoomLayoutChanged = true;
           const roomId = operation.operation.value.roomId;
-          this.roomDirectory.acknowledgeMembership(roomId, false);
+          this.roomDirectory.removeMembershipProjection(roomId);
           this.roomUnread.removeRoomProjection(roomId);
           this.messageSearch.revokeRoom(roomId);
           this.clearRoomAccess(roomId, true);

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -13,31 +13,29 @@ import { NotificationLevelStore } from './notificationLevel.svelte';
 import { PendingHighlightStore } from './pendingHighlight.svelte';
 import { VoiceCallState } from './voiceCall.svelte';
 import { ActiveCallRoomsState } from './activeCallRooms.svelte';
-import { RoomsStore } from './rooms.svelte';
+import { NavigationStore } from './rooms.svelte';
 import { RoomDirectoryStore } from './roomDirectory.svelte';
 import { AdminRoomLayoutStore } from './adminRoomLayout.svelte';
 import { AdminEventLogStore } from './adminEventLog.svelte';
 import { createRoomCommandAPI } from '$lib/api-client/rooms';
 import { createNotificationAPI } from '$lib/api-client/notifications';
 import { createVoiceCallAPI } from '$lib/api-client/voiceCalls';
-import { createRoomDirectoryAPI } from '$lib/api-client/roomDirectory';
 import { createAdminRoomLayoutAPI } from '$lib/api-client/adminRoomLayout';
 import { createAdminEventLogAPI } from '$lib/api-client/adminEventLog';
 import { createMessageSearchAPI } from '$lib/api-client/messageSearch';
 import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 import { createRoleAPI } from '$lib/api-client/roles';
-import { getViewerStateViaConnect } from '$lib/api-client/viewer';
 import { eventBusManager } from './eventBus.svelte';
 import type { ProjectionHandler } from '$lib/eventBus.svelte';
 import type { ServerConnection } from './serverConnection.svelte';
 import type { RegisteredServer } from './registry.svelte';
 import { playCallSound } from '$lib/audio/callSounds';
-import { SvelteMap, SvelteSet } from 'svelte/reactivity';
+import { SvelteSet } from 'svelte/reactivity';
 import { ServerProjectionStore } from './projection.svelte';
 import { MessagesStore, RoomFilesStore } from '$lib/state/room';
 import type { RoomMember } from '$lib/state/room';
 import type { RealtimeProjectionEvent } from '@chatto/api-types/realtime/v1/realtime_pb';
-import { mapDirectoryRoom, mapRoomGroup, RoomKind } from '$lib/api-client/roomDirectory';
+import { mapDirectoryRoom, RoomKind } from '$lib/api-client/roomDirectory';
 import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
 import { viewerResponseToState, type ViewerState } from '$lib/api-client/viewer';
 import { notifyUserSummaries } from '$lib/api-client/hooks';
@@ -83,7 +81,7 @@ export class ServerStateStore {
   readonly pendingHighlights: PendingHighlightStore;
   readonly voiceCall: VoiceCallState;
   readonly activeCallRooms: ActiveCallRoomsState;
-  readonly rooms: RoomsStore;
+  readonly navigation: NavigationStore;
   readonly roomDirectory: RoomDirectoryStore;
   readonly adminRoomLayout: AdminRoomLayoutStore;
   readonly adminEventLog: AdminEventLogStore;
@@ -133,7 +131,6 @@ export class ServerStateStore {
     };
     const notificationAPI = createNotificationAPI(connectAPIConfig);
     const voiceCallAPI = createVoiceCallAPI(connectAPIConfig);
-    const roomDirectoryAPI = createRoomDirectoryAPI(connectAPIConfig);
     const adminRoomLayoutAPI = createAdminRoomLayoutAPI(connectAPIConfig);
     const adminEventLogAPI = createAdminEventLogAPI(connectAPIConfig);
     const messageSearchAPI = createMessageSearchAPI(connectAPIConfig);
@@ -147,7 +144,7 @@ export class ServerStateStore {
     );
     this.serverInfo = new ServerInfoState(registered.url, publicServerInfoLoader);
     this.notifications = new NotificationStore(notificationAPI);
-    this.roomUnread = new RoomUnreadStore();
+    this.roomUnread = new RoomUnreadStore(() => this.projection);
     this.notificationLevels = new NotificationLevelStore();
     const roomCommandAPI = createRoomCommandAPI({
       serverId: serverConnection.serverId ?? registered.id,
@@ -157,16 +154,9 @@ export class ServerStateStore {
     this.pendingHighlights = new PendingHighlightStore();
     this.voiceCall = new VoiceCallState(voiceCallAPI);
     this.activeCallRooms = new ActiveCallRoomsState(this.voiceCall);
-    this.rooms = new RoomsStore(
-      roomDirectoryAPI,
-      memberDirectoryAPI,
-      () => getViewerStateViaConnect(connectAPIConfig),
-      this.notificationLevels,
-      this.roomUnread,
-      notificationAPI
-    );
+    this.navigation = new NavigationStore(this.projection);
     this.roomDirectory = new RoomDirectoryStore(
-      roomDirectoryAPI,
+      this.navigation,
       memberDirectoryAPI,
       roomCommandAPI
     );
@@ -230,8 +220,6 @@ export class ServerStateStore {
     const room = this.projection.rooms.get(roomId)?.room;
     const clearMembership = room ? mapDirectoryRoom(room)?.kind !== RoomKind.DM : false;
     this.projection.evictRoomTimeline(roomId, clearMembership);
-    const viewer = this.projection.viewer;
-    if (viewer) this.synchronizeProjectedNavigation(viewerResponseToState(viewer));
     this.#roomMessages[roomId]?.dispose();
     delete this.#roomMessages[roomId];
     for (const [key, threadStore] of Object.entries(this.#threadMessages)) {
@@ -344,16 +332,14 @@ export class ServerStateStore {
           this.currentUser.user = viewer.user;
           this.currentUser.loading = false;
           this.setPermissions(viewer);
-          this.synchronizeProjectedNavigation(viewer);
+          this.applyViewerPreferences(viewer);
+          this.roomUnread.acknowledgeViewerProjection();
           break;
         }
         case 'userUpsert': {
           const member = mapDirectoryMember(operation.operation.value);
           if (!member.id) break;
           notifyUserSummaries(this.serverId, [member]);
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse)
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
           break;
         }
         case 'userRemove': {
@@ -368,19 +354,14 @@ export class ServerStateStore {
           for (const store of Object.values(this.#threadMessages)) {
             store.scrubUserReferences(userId);
           }
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse) {
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
-          }
           break;
         }
         case 'roomUpsert': {
           adminRoomLayoutChanged = true;
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse)
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
           const roomId = operation.operation.value.room?.room?.id;
           if (!roomId) break;
+          this.roomDirectory.acknowledgeMembership(roomId);
+          this.roomUnread.acknowledgeRoomProjection(roomId);
           if (operation.operation.value.room?.viewerState?.isMember === false) {
             this.messageSearch.revokeRoom(roomId);
             this.clearRoomAccess(roomId);
@@ -392,18 +373,14 @@ export class ServerStateStore {
         case 'roomRemove': {
           adminRoomLayoutChanged = true;
           const roomId = operation.operation.value.roomId;
+          this.roomDirectory.acknowledgeMembership(roomId);
+          this.roomUnread.acknowledgeRoomProjection(roomId);
           this.messageSearch.revokeRoom(roomId);
           this.clearRoomAccess(roomId, true);
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse)
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
           break;
         }
         case 'roomGroupsReplace': {
           adminRoomLayoutChanged = true;
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse)
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
           break;
         }
         case 'roomTimelineReplace': {
@@ -459,23 +436,17 @@ export class ServerStateStore {
           if (replacement.page) {
             this.notifications.replaceProjection(mapNotificationPage(replacement.page));
           }
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse) {
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
-          }
           break;
         }
         case 'roomViewerStateReplace': {
           const replacement = operation.operation.value;
+          this.roomDirectory.acknowledgeMembership(replacement.roomId);
+          this.roomUnread.acknowledgeRoomProjection(replacement.roomId);
           if (replacement.viewerState?.isMember === false) {
             this.messageSearch.revokeRoom(replacement.roomId);
             this.clearRoomAccess(replacement.roomId);
           } else if (replacement.viewerState?.isMember === true) {
             this.restoreRoomAccess(replacement.roomId);
-          }
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse) {
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
           }
           break;
         }
@@ -486,10 +457,6 @@ export class ServerStateStore {
           break;
         }
         case 'presencesReplace': {
-          const viewerResponse = this.projection.viewer;
-          if (viewerResponse) {
-            this.synchronizeProjectedNavigation(viewerResponseToState(viewerResponse));
-          }
           break;
         }
         case 'threadViewerStatesReplace': {
@@ -528,7 +495,6 @@ export class ServerStateStore {
           break;
         }
         case 'roomActivity':
-          this.rooms.bumpRoom(operation.operation.value.roomId);
           break;
         case undefined:
           // ServerProjectionStore validates the whole event before either
@@ -558,38 +524,18 @@ export class ServerStateStore {
     };
   }
 
-  private synchronizeProjectedNavigation(viewer: ViewerState): void {
-    const rooms = [...this.projection.rooms.values()].flatMap((entry) => {
-      const room = entry.room ? mapDirectoryRoom(entry.room) : null;
-      return room ? [room] : [];
-    });
-    const groups = this.projection.roomGroups.map(mapRoomGroup);
-    const membersByRoomId = new SvelteMap<
-      string,
-      ReturnType<typeof avatarUserFromDirectoryMember>[]
-    >();
-    const notificationCountsByRoomId = new SvelteMap<string, number>();
-    const messageHistoryByRoomId = new SvelteMap<string, boolean | null>();
-    for (const entry of this.projection.rooms.values()) {
-      const roomId = entry.room?.room?.id;
-      if (!roomId) continue;
-      const members = entry.memberUserIds.flatMap((userId) => {
-        const user = this.projection.users.get(userId);
-        return user ? [avatarUserFromDirectoryMember(mapDirectoryMember(user))] : [];
-      });
-      membersByRoomId.set(roomId, members);
-      notificationCountsByRoomId.set(roomId, entry.viewerNotificationCount);
-      messageHistoryByRoomId.set(roomId, entry.hasMessageHistory ?? null);
-    }
-    this.rooms.replaceProjection(
-      viewer,
-      rooms,
-      groups,
-      membersByRoomId,
-      notificationCountsByRoomId,
-      messageHistoryByRoomId
+  private applyViewerPreferences(viewer: ViewerState): void {
+    this.notificationLevels.setServerPreference(
+      viewer.serverNotificationPreference.level,
+      viewer.serverNotificationPreference.effectiveLevel
     );
-    this.roomDirectory.replaceProjection(rooms);
+    for (const preference of viewer.roomNotificationPreferences) {
+      this.notificationLevels.setRoomPreference(
+        preference.roomId,
+        preference.level,
+        preference.effectiveLevel
+      );
+    }
   }
 
   /** Clear every mirror whose authority was invalidated by a reset frame. */
@@ -600,8 +546,7 @@ export class ServerStateStore {
     for (const store of Object.values(this.#roomFiles)) {
       store.reset({ rehydrateRetained: true });
     }
-    this.rooms.resetProjectionState();
-    this.roomDirectory.resetProjectionState();
+    this.roomDirectory.resetOptimisticState();
     this.notifications.resetProjectionState();
     this.notificationLevels.clear();
     this.roomUnread.clear();
@@ -768,12 +713,12 @@ export class ServerStateStore {
   }
 
   private currentUserId(): string | null {
-    return this.rooms.currentUserId ?? this.currentUser.user?.id ?? this.#registered.userId;
+    return this.navigation.currentUserId ?? this.currentUser.user?.id ?? this.#registered.userId;
   }
 
   /** Remove optimistic call UI state after a local join attempt fails. */
   handleVoiceCallJoinFailed(roomId: string): void {
-    const currentUserId = this.rooms.currentUserId;
+    const currentUserId = this.navigation.currentUserId;
     this.activeCallRooms.handleLeave(roomId, null, currentUserId);
   }
 

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -154,7 +154,7 @@ export class ServerStateStore {
     this.pendingHighlights = new PendingHighlightStore();
     this.voiceCall = new VoiceCallState(voiceCallAPI);
     this.activeCallRooms = new ActiveCallRoomsState(this.voiceCall);
-    this.navigation = new NavigationStore(this.projection);
+    this.navigation = new NavigationStore(this.projection, this.realtimeSync);
     this.roomDirectory = new RoomDirectoryStore(
       this.navigation,
       memberDirectoryAPI,
@@ -360,12 +360,13 @@ export class ServerStateStore {
           adminRoomLayoutChanged = true;
           const roomId = operation.operation.value.room?.room?.id;
           if (!roomId) break;
-          this.roomDirectory.acknowledgeMembership(roomId);
-          this.roomUnread.acknowledgeRoomProjection(roomId);
-          if (operation.operation.value.room?.viewerState?.isMember === false) {
+          const viewerState = operation.operation.value.room?.viewerState;
+          this.roomDirectory.acknowledgeMembership(roomId, viewerState?.isMember);
+          this.roomUnread.acknowledgeRoomProjection(roomId, viewerState?.hasUnread);
+          if (viewerState?.isMember === false) {
             this.messageSearch.revokeRoom(roomId);
             this.clearRoomAccess(roomId);
-          } else if (operation.operation.value.room?.viewerState?.isMember === true) {
+          } else if (viewerState?.isMember === true) {
             this.restoreRoomAccess(roomId);
           }
           break;
@@ -373,8 +374,8 @@ export class ServerStateStore {
         case 'roomRemove': {
           adminRoomLayoutChanged = true;
           const roomId = operation.operation.value.roomId;
-          this.roomDirectory.acknowledgeMembership(roomId);
-          this.roomUnread.acknowledgeRoomProjection(roomId);
+          this.roomDirectory.acknowledgeMembership(roomId, false);
+          this.roomUnread.removeRoomProjection(roomId);
           this.messageSearch.revokeRoom(roomId);
           this.clearRoomAccess(roomId, true);
           break;
@@ -440,8 +441,14 @@ export class ServerStateStore {
         }
         case 'roomViewerStateReplace': {
           const replacement = operation.operation.value;
-          this.roomDirectory.acknowledgeMembership(replacement.roomId);
-          this.roomUnread.acknowledgeRoomProjection(replacement.roomId);
+          this.roomDirectory.acknowledgeMembership(
+            replacement.roomId,
+            replacement.viewerState?.isMember
+          );
+          this.roomUnread.acknowledgeRoomProjection(
+            replacement.roomId,
+            replacement.viewerState?.hasUnread
+          );
           if (replacement.viewerState?.isMember === false) {
             this.messageSearch.revokeRoom(replacement.roomId);
             this.clearRoomAccess(replacement.roomId);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
@@ -12,16 +12,14 @@
 
   const activeServerId = $derived(getActiveServer());
 
-  // Wait for the active server's merged rooms store (channels + DMs) to
-  // settle before letting children mount. Without this, a freshly-loaded
-  // room page can fire queries against the URL roomId before the store has
-  // decided whether the room exists, briefly showing the not-found redirect.
+  // Wait for the active server projection to contain its viewer prefix before
+  // treating room absence as authoritative.
   const serverStore = $derived(serverRegistry.getStore(activeServerId));
-  const roomsStore = $derived(serverStore.rooms);
+  const navigation = $derived(serverStore.navigation);
   const ready = $derived(
-    !roomsStore.isInitialLoading &&
+    !navigation.isInitialLoading &&
       !!serverStore.currentUser.user?.id &&
-      roomsStore.currentUserId === serverStore.currentUser.user.id
+      navigation.currentUserId === serverStore.currentUser.user.id
   );
 
   let threadId = $derived(page.params.threadId);
@@ -30,7 +28,7 @@
   const roomAccess = $derived.by(() => {
     if (!ready || !roomId) return { kind: 'unknown' } as const;
     return roomRouteAccess({
-      rooms: roomsStore.rooms,
+      rooms: navigation.rooms,
       roomId
     });
   });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -68,10 +68,6 @@ const { mocks } = vi.hoisted(() => {
         dismissRoomReplyNotifications: vi.fn().mockResolvedValue({ byRoom: {} }),
         dismissRoomMessageNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
       },
-      rooms: {
-        decrementUnreadNotification: vi.fn(),
-        refreshNotificationCounts: vi.fn().mockResolvedValue(undefined)
-      },
       messagesForRoom: vi.fn(),
       restoreProjectedRoomWindow: vi.fn(),
       projectedMembersForRoom: vi.fn(() => []),
@@ -197,7 +193,6 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
       voiceCall: {
         isInCall: vi.fn((roomId: string) => mocks.joinedCallRoomIds.has(roomId))
       },
-      rooms: mocks.rooms,
       mentionRoles: mocks.mentionRoles,
       messagesForRoom: mocks.messagesForRoom,
       filesForRoom: () => ({ retain: mocks.roomFilesRetain }),
@@ -371,7 +366,6 @@ beforeEach(() => {
   mocks.notifications.dismissMentionNotifications.mockResolvedValue({ byRoom: {} });
   mocks.notifications.dismissRoomReplyNotifications.mockResolvedValue({ byRoom: {} });
   mocks.notifications.dismissRoomMessageNotifications.mockResolvedValue({ byRoom: {} });
-  mocks.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
   stubMatchMedia(true);
 });
 
@@ -751,7 +745,6 @@ describe('Room local message echo', () => {
     expect(mocks.notifications.dismissMentionNotifications).not.toHaveBeenCalled();
     expect(mocks.notifications.dismissRoomReplyNotifications).not.toHaveBeenCalled();
     expect(mocks.notifications.dismissRoomMessageNotifications).not.toHaveBeenCalled();
-    expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
   });
 
   it('refreshes the visible room window after a local link-preview deletion succeeds', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomJoinScreen.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomJoinScreen.svelte
@@ -23,7 +23,7 @@
   const title = $derived(`#${room.name}`);
   let joining = $state(false);
   const groupName = $derived(
-    stores.rooms.roomGroups?.find((group) => group.roomIds.includes(room.id))?.name ?? null
+    stores.navigation.roomGroups.find((group) => group.roomIds.includes(room.id))?.name ?? null
   );
   const description = $derived(room.description?.trim() || null);
 
@@ -45,7 +45,6 @@
           ? m['room.join.success']({ room: result.room.name })
           : m['room.join.success_generic']()
       );
-      await stores.rooms.refresh();
     } finally {
       joining = false;
     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -29,9 +29,6 @@ const { mocks } = vi.hoisted(() => {
       notifications: {
         dismissThreadNotifications: vi.fn().mockResolvedValue({ byRoom: {} })
       },
-      rooms: {
-        decrementUnreadNotification: vi.fn()
-      },
       appState: {
         isPresent: true
       },
@@ -89,7 +86,6 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
     getStore: () => ({
       currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
       notifications: mocks.notifications,
-      rooms: mocks.rooms,
       retainMessagesForThread: mocks.retainMessagesForThread,
       releaseMessagesForThread: mocks.releaseMessagesForThread,
       messagesForThread: () =>
@@ -205,7 +201,6 @@ describe('ThreadPane', () => {
 
     expect(mocks.setThread).toHaveBeenCalledWith('room-1', 'thread-root');
     expect(mocks.notifications.dismissThreadNotifications).not.toHaveBeenCalled();
-    expect(mocks.rooms.decrementUnreadNotification).not.toHaveBeenCalled();
   });
 
   it('retains decrypted thread history only for the mounted pane lifetime', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/m/[messageId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/m/[messageId]/+page.svelte
@@ -71,13 +71,13 @@
   const connection = useConnection();
   const stores = $derived(serverRegistry.getStore(getActiveServer()));
 
-  // Wait for the active server's rooms store to settle before redirecting,
+  // Wait for the active server projection to settle before redirecting,
   // so a deep-link to a DM doesn't briefly resolve as a missing channel
   // room and trigger the not-found redirect.
-  const roomsStore = $derived(stores.rooms);
+  const navigation = $derived(stores.navigation);
 
   $effect(() => {
-    if (roomsStore.isInitialLoading) return;
+    if (navigation.isInitialLoading) return;
     const conn = connection();
     resolveAndRedirect(
       {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -25,7 +25,6 @@ const { mocks } = vi.hoisted(() => ({
     currentUserId: 'viewer-1',
     joinRoom: vi.fn(),
     loadJoinPreview: vi.fn(),
-    refreshRooms: vi.fn(),
     toastSuccess: vi.fn(),
     toastError: vi.fn()
   }
@@ -66,7 +65,7 @@ vi.mock('$lib/state/userProfiles.svelte', () => ({
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     getStore: () => ({
-      rooms: {
+      navigation: {
         get rooms() {
           return mocks.roomsStore.rooms;
         },
@@ -78,8 +77,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
         },
         get currentUserId() {
           return mocks.roomsStore.currentUserId;
-        },
-        refresh: mocks.refreshRooms
+        }
       },
       currentUser: {
         get user() {
@@ -151,7 +149,6 @@ beforeEach(() => {
   mocks.currentUserId = 'viewer-1';
   mocks.loadJoinPreview.mockResolvedValue(null);
   mocks.joinRoom.mockResolvedValue({ ok: true, room: { id: 'room-1', name: 'development' } });
-  mocks.refreshRooms.mockResolvedValue(undefined);
 });
 
 describe('room route layout access handling', () => {
@@ -290,7 +287,7 @@ describe('room route layout access handling', () => {
     await expect.element(q(container, 'button')).toHaveTextContent('Join Room');
   });
 
-  it('joins a nonmember room inline and refreshes room membership without changing URLs', async () => {
+  it('joins a nonmember room inline and waits for projected membership without changing URLs', async () => {
     mocks.roomsStore.rooms = [room({ viewerIsMember: false })];
 
     const { container } = renderLayout();
@@ -299,7 +296,6 @@ describe('room route layout access handling', () => {
     await vi.waitFor(() => {
       expect(mocks.joinRoom).toHaveBeenCalledWith('room-1');
       expect(mocks.toastSuccess).toHaveBeenCalledWith('Joined #development');
-      expect(mocks.refreshRooms).toHaveBeenCalledOnce();
     });
     expect(mocks.goto).not.toHaveBeenCalled();
   });

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/+page.svelte
@@ -14,14 +14,10 @@
   // The effect owns an external realtime subscription for this mounted route.
   $effect(() => stores.activateAdminRoomLayout());
 
-  function refreshServerRoomState() {
-    void stores.rooms.refresh();
-    void stores.roomDirectory.refresh();
-  }
 </script>
 
 <PageTitle
   title={m['admin.common.server_admin_page_title']({ title: m['admin.rooms_admin.title']() })}
 />
 
-<AdminRoomLayoutEditor {layout} {serverSegment} onroomcreated={refreshServerRoomState} />
+<AdminRoomLayoutEditor {layout} {serverSegment} />

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -263,7 +263,6 @@
           archived: updated.archived
         });
       }
-      void serverRegistry.getStore(activeServerId).rooms.refresh();
       toast.success(m['admin.rooms_admin.room_updated']());
     } catch (error) {
       if (!isCurrentIdentity(target)) return;

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -19,7 +19,6 @@ import {
 const mocks = vi.hoisted(() => ({
   getRoom: vi.fn(),
   projectionHandlers: [] as Array<(event: RealtimeProjectionEvent) => void>,
-  refreshRooms: vi.fn(),
   updateRoom: vi.fn(),
   protocolCapabilities: ['chatto.api.room-manager-member-reads.v1'] as string[]
 }));
@@ -58,7 +57,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
         }
       }
     }),
-    getStore: () => ({ rooms: { refresh: mocks.refreshRooms } })
+    getStore: () => ({})
   }
 }));
 

--- a/apps/frontend/src/routes/chat/[serverId]/overview/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/overview/+page.svelte
@@ -7,13 +7,10 @@
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import PageTitle from '$lib/ui/PageTitle.svelte';
 
-  // Active-server stores. Both substores self-manage refresh and
-  // live-event ingestion from inside `ServerStateStore`, so this page
-  // just reads them. Re-derives reactively when the URL `[serverId]`
-  // changes.
+  // Re-derives reactively when the URL `[serverId]` changes. Directory rows
+  // and membership are selected directly from that server's projection.
   const stores = $derived(serverRegistry.getStore(getActiveServer()));
   const directory = $derived(stores.roomDirectory);
-  const roomsStore = $derived(stores.rooms);
   const serverSegment = $derived(serverIdToSegment(getActiveServer()));
 </script>
 
@@ -26,7 +23,7 @@
     <div class="mx-auto flex max-w-6xl flex-col gap-8 p-6">
       <section class="flex flex-col gap-3">
         <h2 class="text-lg font-semibold">{m['common.rooms']()}</h2>
-        <RoomDirectory {directory} {roomsStore} {serverSegment} />
+        <RoomDirectory {directory} {serverSegment} />
       </section>
     </div>
   </div>

--- a/apps/frontend/src/routes/chat/notifications/+page.svelte
+++ b/apps/frontend/src/routes/chat/notifications/+page.svelte
@@ -105,12 +105,7 @@
     if (target.eventId && target.roomId) {
       stores.pendingHighlights.set(target.roomId, target.threadRootId, target.eventId);
     }
-    void store.dismiss(item.notification.id).then((dismissed) => {
-      if (dismissed && target.roomId) {
-        stores.rooms.decrementUnreadNotification(target.roomId);
-        void stores.rooms.refreshNotificationCounts();
-      }
-    });
+    void store.dismiss(item.notification.id);
 
     const path = store.getCleanPath(item.serverId, item.notification);
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- path from getCleanPath() is already resolved
@@ -120,12 +115,7 @@
   async function handleDismiss(e: Event, item: ServerNotification) {
     e.stopPropagation();
     const stores = serverRegistry.getStore(item.serverId);
-    const target = notificationTarget(item.notification);
-    const dismissed = await stores.notifications.dismiss(item.notification.id);
-    if (dismissed && target.roomId) {
-      stores.rooms.decrementUnreadNotification(target.roomId);
-      void stores.rooms.refreshNotificationCounts();
-    }
+    await stores.notifications.dismiss(item.notification.id);
   }
 
   async function handleClearAll() {
@@ -133,15 +123,7 @@
     for (const instance of serverRegistry.servers) {
       const stores = serverRegistry.getStore(instance.id);
       if (!stores.isAuthenticated) continue;
-      const hadNotifications = stores.notifications.unreadNotificationCount > 0;
-      clears.push(
-        stores.notifications.dismissAll().then((dismissed) => {
-          if (hadNotifications || dismissed > 0) {
-            stores.rooms.clearAllUnreadNotifications();
-            void stores.rooms.refreshNotificationCounts();
-          }
-        })
-      );
+      clears.push(stores.notifications.dismissAll().then(() => undefined));
     }
     await Promise.allSettled(clears);
   }

--- a/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
@@ -36,11 +36,6 @@ const { mocks } = vi.hoisted(() => ({
       },
       pendingHighlights: {
         set: vi.fn()
-      },
-      rooms: {
-        decrementUnreadNotification: vi.fn(),
-        refreshNotificationCounts: vi.fn().mockResolvedValue(undefined),
-        clearAllUnreadNotifications: vi.fn()
       }
     }
   }
@@ -79,7 +74,6 @@ describe('notifications page', () => {
     mocks.store.notifications.dismiss.mockResolvedValue(true);
     mocks.store.notifications.getCleanPath.mockReturnValue('/chat/-/room-1/thread-1');
     mocks.store.notifications.getLocationString.mockReturnValue('#general in Test Server');
-    mocks.store.rooms.refreshNotificationCounts.mockResolvedValue(undefined);
   });
 
   it('reveals the target room before navigating from a notification row', async () => {


### PR DESCRIPTION
## Why

The frontend maintained query-backed room, membership, group, profile, and
notification mirrors alongside the canonical realtime projection. Keeping
those copies synchronized required refresh-after-command calls and central
reconciliation code, while still leaving room for stale or conflicting UI
state.

## What changed

- make the retained realtime projection the sole authoritative source for
  navigation rooms, ordering, membership, groups, member render data, and
  notification counts
- replace the old rooms mirror with memoized, readiness-aware presentation
  selectors that expose data only at a complete projection boundary
- reduce the room directory and unread stores to command/query state plus
  narrowly scoped optimistic overlays
- fence overlapping commands, resets, room removal, and delayed projection
  operations so stale completions cannot clear newer state
- remove query bootstraps, refresh-after-command calls, central navigation
  reconciliation, and obsolete mirror mocks

## Compatibility

This does not change protobufs, ConnectRPC or realtime wire behaviour, public
API semantics, persistence, or capability discovery. The bundled frontend
continues to require `chatto.realtime.projection.v1` as established by
ADR-051; there is no older-server fallback or migration step.

## Test plan

- `mise lint-frontend` — passed
- `mise test-frontend` — 292 files and 2,494 tests passed
- targeted projection/navigation store suite — 48 tests passed
- `playwright test e2e/realtime-sync.test.ts e2e/browse-rooms-direct-nav.test.ts --retries=0` — 10 tests passed
- Svelte analyzer — no actionable findings
- committed code-review loop — no significant findings remain

Closes #1740.
