### PR TITLE
refactor(frontend): make timeline viewport transitions explicit

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -34,6 +34,7 @@
     visibleTombstoneEvents,
     visibleUnreadMarkerEventId
   } from './tombstoneVisibility';
+  import { TimelineViewportController } from './TimelineViewportController.svelte';
 
   let {
     roomId,
@@ -125,18 +126,8 @@
     top: number;
   };
 
-  let initialScrollDone = $state(false);
-  let bottomScrollOperation = 0;
-  let userScrollIntentAt = 0;
-  const USER_SCROLL_INTENT_MS = 250;
-
-  // State for smart scroll behavior (when not alwaysScrollToBottom)
-  let shouldScrollToBottom = $state(true);
-  let hasNewMessages = $state(false);
-  let lastSeenNewestId = $state<string | null>(null);
-  let firstVisibleAt = $state<string | null>(null);
+  const viewport = new TimelineViewportController();
   const expandedSystemEventIds = new SvelteSet<string>();
-  let expandedStateRoomId: string | null = null;
 
   function isSystemGroupExpanded(groupEvents: TimelineEventView[]): boolean {
     return groupEvents.some((event) => expandedSystemEventIds.has(event.id));
@@ -152,24 +143,15 @@
     }
   }
 
-  function setShouldScrollToBottom(value: boolean) {
-    shouldScrollToBottom = value;
-    if (value) {
-      hasNewMessages = false;
-      firstVisibleAt = null;
-    }
-  }
-
-  // Track previous scroll offset for direction detection
-  let previousOffset = $state<number | null>(null);
-
   // Get composer context (scrollState may be null - ThreadPane doesn't provide it)
   const composerContext = getComposerContext();
   const scrollState = composerContext.scrollState;
   const userSettings = getUserSettings();
   const activeLocale = $derived(getLocale());
   const firstVisibleDate = $derived(
-    firstVisibleAt ? formatDayLabel(firstVisibleAt, userSettings, activeLocale) : null
+    viewport.firstVisibleAt
+      ? formatDayLabel(viewport.firstVisibleAt, userSettings, activeLocale)
+      : null
   );
 
   // First apply structural timeline filtering. Tombstone expiry is a separate
@@ -215,7 +197,7 @@
     const bottomDistance = distanceFromBottom();
     const wasAtBottom =
       alwaysScrollToBottom ||
-      (bottomDistance === null ? shouldScrollToBottom : bottomDistance < 50);
+      (bottomDistance === null ? viewport.shouldScrollToBottom : bottomDistance < 50);
     const anchor = wasAtBottom ? null : captureRefreshAnchor(atMs);
 
     tombstoneClockVersion += 1;
@@ -269,58 +251,28 @@
     });
   });
 
-  // Reset scroll state when room changes
-  $effect(() => {
-    void roomId;
-
-    cancelBottomScroll();
-    initialScrollDone = false;
-    setShouldScrollToBottom(true);
-    lastSeenNewestId = null;
-    firstVisibleAt = null;
-    previousOffset = null;
-  });
-
+  // Feed projection/component inputs into the controller in one ordered
+  // transition. DOM and virtualizer state are deliberately excluded.
   $effect(() => {
     const currentRoomId = roomId;
-    if (expandedStateRoomId === null) {
-      expandedStateRoomId = currentRoomId;
-      return;
-    }
-    if (currentRoomId === expandedStateRoomId) return;
-    expandedStateRoomId = currentRoomId;
-    // This reset belongs exclusively to room navigation. Reading the reactive
-    // set here would also subscribe the effect to expansion changes.
-    untrack(() => expandedSystemEventIds.clear());
-  });
-
-  // When exiting jumped mode (returning to present), re-enable auto-scroll
-  // so the latest messages are visible at the bottom.
-  let prevJumpedMode: boolean | undefined;
-  $effect(() => {
-    if (prevJumpedMode && !isJumpedMode) {
-      setShouldScrollToBottom(true);
-    }
-    prevJumpedMode = isJumpedMode;
-  });
-
-  // Track new messages arriving while scrolled up (only when indicator is enabled).
-  // Compares the newest event's ID rather than the count, so that loading older
-  // messages via pagination (which prepends to the array) doesn't falsely trigger.
-  $effect(() => {
-    if (!showNewMessagesIndicator || alwaysScrollToBottom) return;
-    if (timelineEvents.length === 0) return;
-    const newestId = timelineEvents[timelineEvents.length - 1].id;
-
-    if (lastSeenNewestId !== null && newestId !== lastSeenNewestId && !shouldScrollToBottom) {
-      hasNewMessages = true;
-    }
-
-    lastSeenNewestId = newestId;
+    const jumped = isJumpedMode;
+    const newestId = timelineEvents.at(-1)?.id ?? null;
+    const newestOptions = {
+      showNewMessagesIndicator,
+      alwaysScrollToBottom
+    };
+    untrack(() => {
+      if (viewport.enterRoom(currentRoomId)) expandedSystemEventIds.clear();
+      viewport.observeJumpedMode(jumped);
+      // Comparing the newest ID rather than the count keeps prepended
+      // pagination rows from looking like newly arrived messages.
+      viewport.observeNewestEvent(newestId, newestOptions);
+    });
   });
 
   // Watch for scroll-to-bottom requests from MessageComposer (after posting a message).
-  // Clears scrollUpLock since posting a message is explicit user intent to see the bottom.
+  // Posting is explicit user intent to see the bottom, so it releases the
+  // controller's short virtualizer-correction lock.
   // Uses scrollContainer.scrollTop instead of scrollToIndex because the user may have
   // been scrolled up — unmeasured items at the bottom have only estimated heights,
   // causing scrollToIndex to undershoot.
@@ -328,14 +280,9 @@
     if (!scrollState || alwaysScrollToBottom) return;
     const counter = scrollState.scrollRequestCounter;
     if (counter > 0) {
-      setShouldScrollToBottom(true);
-      scrollUpLock = false;
-      if (scrollUpLockTimer) {
-        clearTimeout(scrollUpLockTimer);
-        scrollUpLockTimer = null;
-      }
+      viewport.requestComposerBottom();
       tick().then(() => {
-        if (scrollContainer && shouldScrollToBottom) {
+        if (scrollContainer && viewport.shouldScrollToBottom) {
           void requestBottomScroll();
         }
       });
@@ -351,9 +298,7 @@
     const targetEventId = targetId;
 
     // Disable auto-scroll so it doesn't race with the jump scroll.
-    setShouldScrollToBottom(false);
-    // Mark initial scroll as done so pending initial loading state cannot obscure the jump.
-    initialScrollDone = true;
+    viewport.beginJump();
 
     // After a cache replacement, virtua can need several frames before the
     // target item is indexed, measured, and mounted. Retry the full lookup +
@@ -380,7 +325,7 @@
             virtualizerHandle.getScrollSize() -
             virtualizerHandle.getScrollOffset() -
             virtualizerHandle.getViewportSize();
-          if (dist < 50) setShouldScrollToBottom(true);
+          viewport.settleJump(dist);
           completed = true;
           onScrollToEventComplete?.(true);
         }, 200);
@@ -445,23 +390,13 @@
     }
   }
 
-  function cancelBottomScroll() {
-    bottomScrollOperation += 1;
-  }
-
   function requestBottomScroll(): Promise<boolean> | undefined {
     if (!scrollContainer || !virtualizerHandle || virtualItems.length === 0) return undefined;
 
-    const operation = ++bottomScrollOperation;
-    const requestedRoomId = roomId;
-    const intentAtStart = userScrollIntentAt;
+    const token = viewport.beginBottomScroll(roomId);
     return convergeAtBottom({
       continueWhile: () =>
-        operation === bottomScrollOperation &&
-        roomId === requestedRoomId &&
-        userScrollIntentAt === intentAtStart &&
-        !isJumpedMode &&
-        (alwaysScrollToBottom || shouldScrollToBottom) &&
+        viewport.canContinueBottomScroll(token, roomId, isJumpedMode, alwaysScrollToBottom) &&
         Boolean(scrollContainer && virtualizerHandle),
       waitForFrame: async () => {
         await tick();
@@ -485,7 +420,7 @@
         };
       }
     }).then((converged) => {
-      if (operation === bottomScrollOperation) initialScrollDone = true;
+      viewport.completeBottomScroll(token);
       return converged;
     });
   }
@@ -502,7 +437,7 @@
 
   // Keep ScrollState's shouldScroll flag in sync with our local state
   $effect(() => {
-    scrollState?.setShouldScroll(alwaysScrollToBottom || shouldScrollToBottom);
+    scrollState?.setShouldScroll(alwaysScrollToBottom || viewport.shouldScrollToBottom);
   });
 
   // Auto-scroll to bottom when new events arrive or existing events update.
@@ -518,7 +453,9 @@
     if (pendingHighlightId) return;
 
     if (virtualItems.length > 0 && virtualizerHandle) {
-      const shouldScroll = untrack(() => alwaysScrollToBottom || shouldScrollToBottom);
+      const shouldScroll = untrack(
+        () => alwaysScrollToBottom || viewport.shouldScrollToBottom
+      );
       if (shouldScroll) {
         void requestBottomScroll();
       }
@@ -527,7 +464,7 @@
 
   // Scroll to bottom when clicking the new messages indicator
   function scrollToBottom() {
-    setShouldScrollToBottom(true);
+    viewport.followBottom();
     onReachedBottom?.();
     void requestBottomScroll();
   }
@@ -536,24 +473,15 @@
     // The replacement latest window must perform a fresh initial-style bottom
     // scroll. Virtua otherwise preserves the historical window's offset when
     // the keyed data is replaced and can leave the user stranded mid-window.
-    setShouldScrollToBottom(true);
-    initialScrollDone = false;
-    scrollUpLock = false;
+    viewport.prepareJumpToPresent();
     onReachedBottom?.();
     const requestedRoomId = roomId;
-    const intentAtStart = userScrollIntentAt;
+    const intentRevision = viewport.captureIntentRevision();
     if (!(await onJumpToPresent?.())) return;
     await tick();
-    if (roomId !== requestedRoomId || userScrollIntentAt !== intentAtStart) return;
+    if (roomId !== requestedRoomId || !viewport.hasIntentRevision(intentRevision)) return;
     void requestBottomScroll();
   }
-
-  // Lock to prevent virtua's scroll corrections from immediately re-enabling
-  // auto-scroll after we detect a user scroll-up. Without this, $fixScrollJump
-  // can adjust the scroll position back near the bottom within the same frame,
-  // causing handleVirtuaScroll to see distanceFromBottom < 50 and re-enable.
-  let scrollUpLock = false;
-  let scrollUpLockTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Timestamp of the most recent user-driven scroll signal (wheel or touchmove).
   // The scroll-up branch in handleVirtuaScroll only fires when this is recent,
@@ -561,8 +489,7 @@
   // composer-resize-driven scrollTop writes, and browser scroll clamping during
   // layout shifts never get misread as the user scrolling up.
   function markUserScrollIntent() {
-    userScrollIntentAt = Date.now();
-    cancelBottomScroll();
+    viewport.markUserScrollIntent();
   }
 
   function markKeyboardScrollIntent(event: KeyboardEvent) {
@@ -643,13 +570,12 @@
   // drifted off the bottom (which would suppress the Jump to Present button).
   useTabResumeCallback(() => {
     tombstoneClockVersion += 1;
-    if (alwaysScrollToBottom || !shouldScrollToBottom || !initialScrollDone) return;
     if (!virtualizerHandle) return;
     const dist =
       virtualizerHandle.getScrollSize() -
       virtualizerHandle.getScrollOffset() -
       virtualizerHandle.getViewportSize();
-    if (dist > 50) setShouldScrollToBottom(false);
+    viewport.reconcileAfterTabResume(dist, alwaysScrollToBottom);
   });
 
   let forwardLoadInFlight = false;
@@ -658,7 +584,7 @@
   function exitJumpedModeAtPresent(bottomDistance: number): boolean {
     if (!isJumpedMode || !hasReachedEnd || bottomDistance >= 50 || !onReachedPresent) return false;
 
-    setShouldScrollToBottom(true);
+    viewport.followBottom();
     onReachedBottom?.();
     console.debug('[room-refresh] reached present after forward pagination', {
       roomId,
@@ -760,55 +686,25 @@
 
     const scrollSize = virtualizerHandle.getScrollSize();
     const viewportSize = virtualizerHandle.getViewportSize();
-    const distanceFromBottom = scrollSize - offset - viewportSize;
-
-    // Smart scroll: detect user scroll direction
-    if (!alwaysScrollToBottom) {
-      // Re-enable auto-scroll if we're at the bottom (and not locked)
-      if (distanceFromBottom < 10 && !scrollUpLock) {
-        const wasScrolledUp = !shouldScrollToBottom;
-        setShouldScrollToBottom(true);
-        if (wasScrolledUp && Date.now() - userScrollIntentAt < USER_SCROLL_INTENT_MS) {
-          onReachedBottom?.();
-        }
-      }
-      // Disable auto-scroll if user scrolled up (and clearly not near the bottom).
-      // Gated on a recent wheel/touchmove signal so virtua's internal scroll
-      // corrections ($fixScrollJump after re-measuring items), composer-resize
-      // scrollTop writes, and browser scroll-clamping during layout shifts can't
-      // be misread as the user scrolling up. The distanceFromBottom guard is
-      // kept as a second line of defense for the brief window where intent is
-      // still armed from a fling that already settled near the bottom.
-      else if (
-        Date.now() - userScrollIntentAt < USER_SCROLL_INTENT_MS &&
-        previousOffset !== null &&
-        offset < previousOffset - 10 &&
-        distanceFromBottom > 20
-      ) {
-        setShouldScrollToBottom(false);
-        cancelBottomScroll();
-        scrollUpLock = true;
-        if (scrollUpLockTimer) clearTimeout(scrollUpLockTimer);
-        scrollUpLockTimer = setTimeout(() => {
-          scrollUpLock = false;
-        }, 150);
+    let firstVisibleAt: string | null = null;
+    const idx = virtualizerHandle.findItemIndex(offset);
+    for (let i = idx; i < virtualItems.length; i++) {
+      const item = virtualItems[i];
+      if (item.type === 'event') {
+        firstVisibleAt = item.event.createdAt;
+        break;
       }
     }
-
-    previousOffset = offset;
-
-    // Track the date of the first visible event for the "Jump to Present" button
-    if (!shouldScrollToBottom && virtualizerHandle) {
-      const idx = virtualizerHandle.findItemIndex(offset);
-      // Walk forward from the found index to find the first event-type item
-      for (let i = idx; i < virtualItems.length; i++) {
-        const item = virtualItems[i];
-        if (item.type === 'event') {
-          firstVisibleAt = item.event.createdAt;
-          break;
-        }
-      }
-    }
+    const scrollResult = viewport.observeScroll({
+      offset,
+      scrollSize,
+      viewportSize,
+      firstVisibleAt,
+      alwaysScrollToBottom,
+      now: Date.now()
+    });
+    const { distanceFromBottom } = scrollResult;
+    if (scrollResult.reachedBottom) onReachedBottom?.();
 
     // Trigger pagination when scrolled near the top.
     // Guard: only when content actually overflows the viewport (avoids firing in short rooms).
@@ -947,7 +843,7 @@
 
   <TypingIndicator {typingUserIds} members={typingMembers} />
 
-  {#if isJumpedMode && !shouldScrollToBottom && onJumpToPresent}
+  {#if isJumpedMode && !viewport.shouldScrollToBottom && onJumpToPresent}
     <button
       transition:fade={{ duration: 150 }}
       onclick={handleJumpToPresentClick}
@@ -963,7 +859,7 @@
         <span class="iconify uil--arrow-down"></span>
       </div>
     </button>
-  {:else if !alwaysScrollToBottom && !shouldScrollToBottom}
+  {:else if !alwaysScrollToBottom && !viewport.shouldScrollToBottom}
     <button
       transition:fade={{ duration: 150 }}
       onclick={scrollToBottom}
@@ -975,7 +871,11 @@
           <span class="text-muted">{firstVisibleDate}</span>
           <span class="text-muted/40">|</span>
         {/if}
-        <span>{hasNewMessages ? m['room.unread_separator']() : m['room.jump_to_present']()}</span>
+        <span>
+          {viewport.hasNewMessages
+            ? m['room.unread_separator']()
+            : m['room.jump_to_present']()}
+        </span>
         <span class="iconify uil--arrow-down"></span>
       </div>
     </button>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineViewportController.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineViewportController.svelte.spec.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+import { TimelineViewportController } from './TimelineViewportController.svelte';
+
+describe('TimelineViewportController', () => {
+  it('resets viewport intent exactly once when entering a room', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+    controller.stopFollowingBottom();
+    controller.hasNewMessages = true;
+    controller.firstVisibleAt = '2026-01-01T00:00:00Z';
+    controller.initialScrollDone = true;
+
+    expect(controller.enterRoom('R1')).toBe(false);
+    expect(controller.shouldScrollToBottom).toBe(false);
+
+    expect(controller.enterRoom('R2')).toBe(true);
+    expect(controller.shouldScrollToBottom).toBe(true);
+    expect(controller.hasNewMessages).toBe(false);
+    expect(controller.firstVisibleAt).toBeNull();
+    expect(controller.initialScrollDone).toBe(false);
+  });
+
+  it('shows new-message state only when a newer tail arrives while scrolled up', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+    controller.observeNewestEvent('M1', {
+      showNewMessagesIndicator: true,
+      alwaysScrollToBottom: false
+    });
+    controller.stopFollowingBottom();
+
+    controller.observeNewestEvent('M2', {
+      showNewMessagesIndicator: true,
+      alwaysScrollToBottom: false
+    });
+
+    expect(controller.hasNewMessages).toBe(true);
+    controller.followBottom();
+    expect(controller.hasNewMessages).toBe(false);
+  });
+
+  it('distinguishes user scroll-up from virtualizer corrections', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+
+    controller.observeScroll({
+      offset: 700,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: null,
+      alwaysScrollToBottom: false,
+      now: 1_000
+    });
+    controller.observeScroll({
+      offset: 500,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: '2026-01-01T00:00:00Z',
+      alwaysScrollToBottom: false,
+      now: 1_100
+    });
+    expect(controller.shouldScrollToBottom).toBe(true);
+
+    controller.markUserScrollIntent(2_000);
+    controller.observeScroll({
+      offset: 400,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: '2026-01-02T00:00:00Z',
+      alwaysScrollToBottom: false,
+      now: 2_010
+    });
+
+    expect(controller.shouldScrollToBottom).toBe(false);
+    expect(controller.firstVisibleAt).toBe('2026-01-02T00:00:00Z');
+  });
+
+  it('reports a user-driven return to bottom after the scroll-up lock expires', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+    controller.observeScroll({
+      offset: 700,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: null,
+      alwaysScrollToBottom: false,
+      now: 1_000
+    });
+    controller.markUserScrollIntent(2_000);
+    controller.observeScroll({
+      offset: 400,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: null,
+      alwaysScrollToBottom: false,
+      now: 2_010
+    });
+
+    const locked = controller.observeScroll({
+      offset: 700,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: null,
+      alwaysScrollToBottom: false,
+      now: 2_100
+    });
+    expect(locked.reachedBottom).toBe(false);
+    expect(controller.shouldScrollToBottom).toBe(false);
+
+    controller.markUserScrollIntent(2_200);
+    const settled = controller.observeScroll({
+      offset: 700,
+      scrollSize: 1_000,
+      viewportSize: 300,
+      firstVisibleAt: null,
+      alwaysScrollToBottom: false,
+      now: 2_210
+    });
+    expect(settled.reachedBottom).toBe(true);
+    expect(controller.shouldScrollToBottom).toBe(true);
+  });
+
+  it('fences bottom convergence by operation, room, and user intent', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+    const first = controller.beginBottomScroll('R1');
+    const second = controller.beginBottomScroll('R1');
+
+    expect(controller.canContinueBottomScroll(first, 'R1', false, false)).toBe(false);
+    expect(controller.canContinueBottomScroll(second, 'R1', false, false)).toBe(true);
+    expect(controller.canContinueBottomScroll(second, 'R2', false, false)).toBe(false);
+
+    controller.markUserScrollIntent(1_000);
+    expect(controller.canContinueBottomScroll(second, 'R1', false, false)).toBe(false);
+    controller.completeBottomScroll(second);
+    expect(controller.initialScrollDone).toBe(false);
+  });
+
+  it('makes jump and composer transitions explicit', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+
+    controller.beginJump();
+    expect(controller.shouldScrollToBottom).toBe(false);
+    expect(controller.initialScrollDone).toBe(true);
+
+    controller.settleJump(20);
+    expect(controller.shouldScrollToBottom).toBe(true);
+
+    controller.stopFollowingBottom();
+    controller.requestComposerBottom();
+    expect(controller.shouldScrollToBottom).toBe(true);
+
+    controller.prepareJumpToPresent();
+    expect(controller.initialScrollDone).toBe(false);
+  });
+
+  it('follows the latest window when jumped mode ends', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+    controller.observeJumpedMode(true);
+    controller.stopFollowingBottom();
+
+    controller.observeJumpedMode(false);
+
+    expect(controller.shouldScrollToBottom).toBe(true);
+  });
+
+  it('detects bottom drift after a hidden tab resumes', () => {
+    const controller = new TimelineViewportController();
+    controller.enterRoom('R1');
+    const token = controller.beginBottomScroll('R1');
+    controller.completeBottomScroll(token);
+
+    controller.reconcileAfterTabResume(100, false);
+
+    expect(controller.shouldScrollToBottom).toBe(false);
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineViewportController.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/TimelineViewportController.svelte.ts
@@ -1,0 +1,205 @@
+export type BottomScrollToken = {
+  operationId: number;
+  roomId: string;
+  intentRevision: number;
+};
+
+export type TimelineScrollObservation = {
+  offset: number;
+  scrollSize: number;
+  viewportSize: number;
+  firstVisibleAt: string | null;
+  alwaysScrollToBottom: boolean;
+  now: number;
+};
+
+export type TimelineScrollResult = {
+  distanceFromBottom: number;
+  reachedBottom: boolean;
+};
+
+const USER_SCROLL_INTENT_MS = 250;
+const SCROLL_UP_LOCK_MS = 150;
+
+/**
+ * Owns timeline viewport intent independently of DOM and Virtua operations.
+ *
+ * Components report explicit input transitions and use bottom-scroll tokens
+ * to fence async DOM work. Browser measurements, timers, and scrolling remain
+ * at the component boundary.
+ */
+export class TimelineViewportController {
+  initialScrollDone = $state(false);
+  shouldScrollToBottom = $state(true);
+  hasNewMessages = $state(false);
+  firstVisibleAt = $state<string | null>(null);
+
+  #roomId: string | null = null;
+  #lastSeenNewestId: string | null = null;
+  #previousOffset: number | null = null;
+  #userScrollIntentAt = 0;
+  #intentRevision = 0;
+  #scrollUpLockedUntil = 0;
+  #bottomScrollOperation = 0;
+  #wasJumpedMode = false;
+
+  enterRoom(roomId: string): boolean {
+    if (roomId === this.#roomId) return false;
+
+    this.#roomId = roomId;
+    this.cancelBottomScroll();
+    this.initialScrollDone = false;
+    this.followBottom();
+    this.#lastSeenNewestId = null;
+    this.#previousOffset = null;
+    this.#scrollUpLockedUntil = 0;
+    this.#wasJumpedMode = false;
+    return true;
+  }
+
+  followBottom(): void {
+    this.shouldScrollToBottom = true;
+    this.hasNewMessages = false;
+    this.firstVisibleAt = null;
+  }
+
+  stopFollowingBottom(): void {
+    this.shouldScrollToBottom = false;
+  }
+
+  observeJumpedMode(isJumpedMode: boolean): void {
+    if (this.#wasJumpedMode && !isJumpedMode) this.followBottom();
+    this.#wasJumpedMode = isJumpedMode;
+  }
+
+  observeNewestEvent(
+    newestId: string | null,
+    options: { showNewMessagesIndicator: boolean; alwaysScrollToBottom: boolean }
+  ): void {
+    if (!options.showNewMessagesIndicator || options.alwaysScrollToBottom || newestId === null) {
+      return;
+    }
+    if (
+      this.#lastSeenNewestId !== null &&
+      newestId !== this.#lastSeenNewestId &&
+      !this.shouldScrollToBottom
+    ) {
+      this.hasNewMessages = true;
+    }
+    this.#lastSeenNewestId = newestId;
+  }
+
+  requestComposerBottom(): void {
+    this.followBottom();
+    this.unlockScrollUp();
+  }
+
+  beginJump(): void {
+    this.cancelBottomScroll();
+    this.stopFollowingBottom();
+    this.initialScrollDone = true;
+  }
+
+  settleJump(distanceFromBottom: number): void {
+    if (distanceFromBottom < 50) this.followBottom();
+  }
+
+  prepareJumpToPresent(): void {
+    this.cancelBottomScroll();
+    this.followBottom();
+    this.initialScrollDone = false;
+    this.unlockScrollUp();
+  }
+
+  markUserScrollIntent(now = Date.now()): void {
+    this.#userScrollIntentAt = now;
+    this.#intentRevision += 1;
+    this.cancelBottomScroll();
+  }
+
+  captureIntentRevision(): number {
+    return this.#intentRevision;
+  }
+
+  hasIntentRevision(revision: number): boolean {
+    return revision === this.#intentRevision;
+  }
+
+  observeScroll(observation: TimelineScrollObservation): TimelineScrollResult {
+    const distanceFromBottom =
+      observation.scrollSize - observation.offset - observation.viewportSize;
+    let reachedBottom = false;
+
+    if (!observation.alwaysScrollToBottom) {
+      const scrollUpLocked = observation.now < this.#scrollUpLockedUntil;
+      if (distanceFromBottom < 10 && !scrollUpLocked) {
+        const wasScrolledUp = !this.shouldScrollToBottom;
+        this.followBottom();
+        reachedBottom =
+          wasScrolledUp &&
+          observation.now - this.#userScrollIntentAt < USER_SCROLL_INTENT_MS;
+      } else if (
+        observation.now - this.#userScrollIntentAt < USER_SCROLL_INTENT_MS &&
+        this.#previousOffset !== null &&
+        observation.offset < this.#previousOffset - 10 &&
+        distanceFromBottom > 20
+      ) {
+        this.stopFollowingBottom();
+        this.cancelBottomScroll();
+        this.#scrollUpLockedUntil = observation.now + SCROLL_UP_LOCK_MS;
+      }
+    }
+
+    this.#previousOffset = observation.offset;
+    if (!this.shouldScrollToBottom && observation.firstVisibleAt) {
+      this.firstVisibleAt = observation.firstVisibleAt;
+    }
+
+    return { distanceFromBottom, reachedBottom };
+  }
+
+  reconcileAfterTabResume(
+    distanceFromBottom: number,
+    alwaysScrollToBottom: boolean
+  ): void {
+    if (alwaysScrollToBottom || !this.shouldScrollToBottom || !this.initialScrollDone) return;
+    if (distanceFromBottom > 50) this.stopFollowingBottom();
+  }
+
+  beginBottomScroll(roomId: string): BottomScrollToken {
+    return {
+      operationId: ++this.#bottomScrollOperation,
+      roomId,
+      intentRevision: this.#intentRevision
+    };
+  }
+
+  canContinueBottomScroll(
+    token: BottomScrollToken,
+    currentRoomId: string,
+    isJumpedMode: boolean,
+    alwaysScrollToBottom: boolean
+  ): boolean {
+    return (
+      token.operationId === this.#bottomScrollOperation &&
+      token.roomId === currentRoomId &&
+      token.intentRevision === this.#intentRevision &&
+      !isJumpedMode &&
+      (alwaysScrollToBottom || this.shouldScrollToBottom)
+    );
+  }
+
+  completeBottomScroll(token: BottomScrollToken): void {
+    if (token.operationId === this.#bottomScrollOperation) {
+      this.initialScrollDone = true;
+    }
+  }
+
+  cancelBottomScroll(): void {
+    this.#bottomScrollOperation += 1;
+  }
+
+  private unlockScrollUp(): void {
+    this.#scrollUpLockedUntil = 0;
+  }
+}


### PR DESCRIPTION
## Why

`EventList` coordinated room changes, new-message indicators, jumped mode,
composer requests, user scrolling, and Virtua corrections through a collection
of loose reactive flags and effects. Their ordering and async cancellation rules
were difficult to understand and risky to change.

This refactor makes those viewport transitions explicit and independently
testable while preserving the current timeline behaviour.

## What changed

- Added a reactive `TimelineViewportController` that owns viewport intent and
  exposes named transitions for room entry, jumps, new messages, composer
  requests, user scrolling, and tab resume.
- Added operation tokens that fence async bottom-scroll convergence by operation,
  room, user intent, and jumped mode.
- Kept DOM measurements, Virtua interaction, timers, pagination, and animation
  frames at the `EventList` component boundary.
- Replaced the component's mirrored flags, counters, and effect ordering with one
  ordered input transition and controller calls at event boundaries.
- Added focused transition tests covering room reset, new-message state,
  virtualizer corrections, scroll-up locking, bottom-scroll fencing, jumps, and
  tab resume.

The `EventList` props and its composer/room/thread contracts are unchanged. This
does not change public APIs, persistence, capabilities, rollout, security, or
operational behaviour.

## Test plan

- `mise lint-frontend` — passed; Svelte diagnostics reported 0 errors and 0 warnings.
- `mise test-frontend` — passed; 293 files and 2,502 tests.
- `mise x -- node node_modules/@playwright/test/cli.js test e2e/auto-scroll.test.ts e2e/jump-to-message.test.ts e2e/pagination.test.ts --retries=0` (from `apps/frontend`) — passed; 25 tests.
- `pnpm exec playwright test e2e/pagination.test.ts --grep 'newest message is visible' --retries=0` (from `apps/frontend`) — passed; 1 test.
- `mise license-check` — passed; REUSE compliant.

Closes #1743.
