### PR TITLE
refactor(frontend): centralize per-server API services

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ path-specific guidance.
 - Chatto is public, self-hosted, and has real user data.
 - The project is pre-1.0, but people are already self-hosting Chatto. The public API is experimental: compatibility is preferred, not guaranteed, and `v1` identifies the current wire namespace rather than a long-term stability promise. Prefer additive changes. Breaking public API changes are allowed when they materially improve the design, but discuss them with the user first and include an explicit compatibility plan, generated-client/docs updates, and release-note guidance. Changes to authoritative `core` protobuf messages used by persistence must never be breaking; disposable projection snapshot payloads are the exception described under Public API And Compatibility. Follow ADR-045.
 - Assume that mixed versions are in use in the wider ecosystem; but self-hosters have been advised to track `:latest`, or upgrade to newly released versions quickly.
-- The next planned version is `0.5.0`. Use the GitHub `0.5.0` milestone as the canonical roadmap and keep its issues current as work progresses.
+- The next planned version is `0.5.0`. Use the GitHub `0.5.0` milestone as the canonical roadmap and keep its issues current as work progresses. It significantly changes the API's realtime channel, so we are no longer trying to remain API compatible with 0.4.x versions; breaking API changes are OK for this release.
 
 ## Prime Directives
 

--- a/apps/frontend/src/lib/CreateRoom.svelte
+++ b/apps/frontend/src/lib/CreateRoom.svelte
@@ -51,12 +51,7 @@
         return;
       }
 
-      const conn = connection();
-      const api = createRoomCommandAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = connection().getAPI(createRoomCommandAPI);
       const created = await api.createRoom({
         name: normalizeRoomName(values.name),
         description: values.description.trim() || null,

--- a/apps/frontend/src/lib/CreateRoom.svelte.spec.ts
+++ b/apps/frontend/src/lib/CreateRoom.svelte.spec.ts
@@ -15,7 +15,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     serverId: 'origin',
     connectBaseUrl: 'https://chat.example.test/api/connect',
-    bearerToken: 'token'
+    bearerToken: 'token',
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/lib/api-client/presence.ts
+++ b/apps/frontend/src/lib/api-client/presence.ts
@@ -1,13 +1,13 @@
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
+import {
+  authHeaders,
+  createChattoClient,
+  handleAuthError,
+  type ConnectAPIConfig,
+} from "./connect.js";
 import { MyAccountService } from "@chatto/api-types/api/v1/account_connect";
 import { PresenceStatus } from "@chatto/api-types/api/v1/presence_pb";
 
-export type PresenceAPIConfig = {
-  serverId?: string;
-  baseUrl: string;
-  bearerToken: string | null;
-  onAuthenticationRequired?: (serverId: string) => void;
-};
+export type PresenceAPIConfig = ConnectAPIConfig;
 
 export { PresenceStatus as APIPresenceStatus };
 
@@ -31,3 +31,5 @@ export function createPresenceAPI(config: PresenceAPIConfig) {
     },
   };
 }
+
+export type PresenceAPI = ReturnType<typeof createPresenceAPI>;

--- a/apps/frontend/src/lib/api-client/reactions.ts
+++ b/apps/frontend/src/lib/api-client/reactions.ts
@@ -1,13 +1,11 @@
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
+import {
+  authHeaders,
+  createChattoClient,
+  handleAuthError,
+  type ConnectAPIConfig,
+} from "./connect.js";
 import { MessageService } from "@chatto/api-types/api/v1/messages_connect";
 import type { MessageReaction } from "@chatto/api-types/api/v1/message_types_pb";
-
-export type ConnectAPIConfig = {
-  serverId?: string;
-  baseUrl: string;
-  bearerToken: string | null;
-  onAuthenticationRequired?: (serverId: string) => void;
-};
 
 export type ReactionInput = {
   roomId: string;

--- a/apps/frontend/src/lib/api-client/readState.ts
+++ b/apps/frontend/src/lib/api-client/readState.ts
@@ -1,13 +1,11 @@
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
+import {
+  authHeaders,
+  createChattoClient,
+  handleAuthError,
+  type ConnectAPIConfig,
+} from "./connect.js";
 import { RoomService } from "@chatto/api-types/api/v1/rooms_connect";
 import { ThreadService } from "@chatto/api-types/api/v1/threads_connect";
-
-export type ConnectAPIConfig = {
-  serverId?: string;
-  baseUrl: string;
-  bearerToken: string | null;
-  onAuthenticationRequired?: (serverId: string) => void;
-};
 
 export type MarkRoomAsReadResult = {
   lastReadAt: string | null;

--- a/apps/frontend/src/lib/api-client/threads.ts
+++ b/apps/frontend/src/lib/api-client/threads.ts
@@ -1,15 +1,13 @@
-import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
+import {
+  authHeaders,
+  createChattoClient,
+  handleAuthError,
+  type ConnectAPIConfig
+} from './connect.js';
 import { ThreadService } from '@chatto/api-types/api/v1/threads_connect';
 import type { User } from '@chatto/api-types/api/v1/users_pb';
 import type { TimelineEventView } from '$lib/render/timelineEvents';
 import { messageToTimelineEvent } from './roomTimeline.js';
-
-export type ConnectAPIConfig = {
-  serverId?: string;
-  baseUrl: string;
-  bearerToken: string | null;
-  onAuthenticationRequired?: (serverId: string) => void;
-};
 
 export type FollowedThread = {
   roomId: string;

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -91,12 +91,7 @@ to the user settings page for the active server.
   let customStatusDialogVisible = $state(false);
 
   function customStatusAPIConfig() {
-    const conn = connection();
-    return {
-      serverId: activeServerId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    };
+    return { ...connection().apiConfig, serverId: activeServerId };
   }
 
   function openStatusMenu(event: MouseEvent) {

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -94,7 +94,12 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     connectBaseUrl: 'https://chat.example.test',
-    bearerToken: 'token'
+    bearerToken: 'token',
+    apiConfig: {
+      serverId: 'origin',
+      baseUrl: 'https://chat.example.test',
+      bearerToken: 'token'
+    }
   })
 }));
 

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -22,6 +22,7 @@ unknown instance) the component renders nothing.
   import { serverIdToSegment } from '$lib/navigation';
   import * as m from '$lib/i18n/messages';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { createRoomTimelineAPI } from '$lib/api-client/roomTimeline';
   import { createAttachmentAPI } from '$lib/api-client/attachments';
@@ -80,10 +81,6 @@ unknown instance) the component renders nothing.
     fit: ImageFitMode.COVER
   };
 
-  function connectBaseUrl(serverUrl: string): string {
-    return new URL('/api/connect', serverUrl).toString();
-  }
-
   function roomName(serverId: string, roomId: string): string | null {
     return (
       serverRegistry.tryGetStore(serverId)?.navigation.rooms.find((room) => room.id === roomId)?.name ??
@@ -124,15 +121,14 @@ unknown instance) the component renders nothing.
       try {
         const server = serverRegistry.getServer(serverId);
         if (!server) return;
-        const page = await createRoomTimelineAPI({
-          serverId,
-          baseUrl: connectBaseUrl(server.url),
-          bearerToken: server.token
-        }).getRoomEventsAround({
-          roomId,
-          eventId: messageId,
-          limit: 1
-        });
+        const page = await serverConnectionManager
+          .getClient(serverId)
+          .getAPI(createRoomTimelineAPI)
+          .getRoomEventsAround({
+            roomId,
+            eventId: messageId,
+            limit: 1
+          });
 
         if (cancelled) return;
 
@@ -223,14 +219,9 @@ unknown instance) the component renders nothing.
     if (!preview || refreshPromise) return refreshPromise ?? undefined;
 
     const current = preview;
-    const server = serverRegistry.getServer(current.serverId);
-    if (!server) return undefined;
+    if (!serverRegistry.getServer(current.serverId)) return undefined;
     refreshPromise = refreshAttachmentUrlsForAssets(
-      createAttachmentAPI({
-        serverId: current.serverId,
-        baseUrl: connectBaseUrl(server.url),
-        bearerToken: server.token
-      }),
+      serverConnectionManager.getClient(current.serverId).getAPI(createAttachmentAPI),
       current.roomId,
       current.attachments.map((attachment) => attachment.id),
       PREVIEW_THUMBNAIL_REFRESH

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -56,6 +56,14 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
   getActiveServer: () => 'server_1'
 }));
 
+vi.mock('$lib/state/server/serverConnection.svelte', () => ({
+  serverConnectionManager: {
+    getClient: () => ({
+      getAPI: (factory: (config: never) => unknown) => factory({} as never)
+    })
+  }
+}));
+
 function link(): MessageLink {
   return {
     serverSegment: '-',

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -169,10 +169,7 @@
         if (!store?.permissions.canStartDMs) return;
 
         const currentUserId = store.currentUser.user?.id ?? undefined;
-        const api = createMemberDirectoryAPI({
-          baseUrl: serverConnection.connectBaseUrl,
-          bearerToken: serverConnection.bearerToken
-        });
+        const api = serverConnection.getAPI(createMemberDirectoryAPI);
         const result = await api.listUsers(search, 20, 0);
         for (const member of result.members) {
           const user = avatarUser(member);
@@ -355,11 +352,9 @@
     if (!item.targetUserId) throw new Error('Missing DM target');
 
     const conn = serverConnectionManager.getClient(item.serverId);
-    const room = await createRoomCommandAPI({
-      serverId: item.serverId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    }).startDM(item.targetUserId === item.currentUserId ? [] : [item.targetUserId]);
+    const room = await conn
+      .getAPI(createRoomCommandAPI)
+      .startDM(item.targetUserId === item.currentUserId ? [] : [item.targetUserId]);
 
     const roomId = room?.id;
     if (!roomId) throw new Error('Failed to start DM');

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -83,6 +83,7 @@ vi.mock('$lib/state/server/serverConnection.svelte', () => ({
     getClient: () => ({
       connectBaseUrl: 'https://chat.example.test/api/connect',
       bearerToken: 'token-1',
+      getAPI: (factory: (config: never) => unknown) => factory({} as never),
       client: {
         query: mocks.query,
         mutation: mocks.mutation

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -184,14 +184,7 @@
   let editorApi = $state<TipTapEditorApi | null>(null);
   const draftState = new DraftState();
   const attachments = new AttachmentsState(() => serverInfo);
-  const linkPreviews = new LinkPreviewState(() => {
-    const conn = connection();
-    return createLinkPreviewAPI({
-      serverId: conn.serverId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
-  });
+  const linkPreviews = new LinkPreviewState(() => connection().getAPI(createLinkPreviewAPI));
   const autocomplete = new AutocompleteState(
     () => editorApi,
     () => mentionCandidateMembers,
@@ -657,12 +650,7 @@
 
   async function sendPreparedPost(post: PreparedPost): Promise<SendPreparedPostResponse> {
     try {
-      const conn = connection();
-      const result = await createMessageAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).createMessage({
+      const result = await connection().getAPI(createMessageAPI).createMessage({
         roomId: post.roomId,
         body: post.bodyToSend,
         attachmentAssetIds: post.attachmentAssetIds,
@@ -825,12 +813,7 @@
     }
 
     try {
-      const conn = connection();
-      await createMessageAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).updateMessage(input);
+      await connection().getAPI(createMessageAPI).updateMessage(input);
       autocomplete.reset();
       message = '';
       editorApi?.setContent('');

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -108,7 +108,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
     },
     connectBaseUrl: 'http://localhost/api/connect',
     bearerToken: null,
-    serverId: 'test-instance'
+    serverId: 'test-instance',
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte
@@ -135,11 +135,7 @@ focusing a cell highlights its permission row and role column.
   const connection = useConnection();
 
   function permissionAPI() {
-    const conn = connection();
-    return createPermissionAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createPermissionAPI);
   }
 
   let data = $state<TierRoles | null>(null);

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
@@ -74,7 +74,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
     isConnected: true,
     showConnectionLostBanner: false,
     connectBaseUrl: '/api/connect',
-    bearerToken: 'token'
+    bearerToken: 'token',
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/lib/components/rbac/RolePermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/RolePermissionsMatrix.svelte
@@ -32,11 +32,7 @@ rendering to `SubjectPermissionsMatrix` (shared with the user variant).
   const connection = useConnection();
 
   function permissionAPI() {
-    const conn = connection();
-    return createPermissionAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createPermissionAPI);
   }
 
   let data = $state<Matrix | null>(null);

--- a/apps/frontend/src/lib/components/rbac/UserPermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/UserPermissionsMatrix.svelte
@@ -30,11 +30,7 @@ matrix and the mutation dispatch for cell clicks; delegates rendering to
   const connection = useConnection();
 
   function permissionAPI() {
-    const conn = connection();
-    return createPermissionAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createPermissionAPI);
   }
 
   let data = $state<Matrix | null>(null);

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -59,11 +59,12 @@ These preferences are server-side and sync across devices.
     error = '';
 
     try {
-      const config = connectConfig();
+      const conn = connection();
+      const config = preferenceConfig();
       const [serverPref, viewer, channelRooms] = await Promise.all([
         getServerNotificationPreference(config),
         getViewerStateViaConnect(config),
-        createRoomDirectoryAPI(config).listRooms(RoomDirectoryScope.CHANNELS)
+        conn.getAPI(createRoomDirectoryAPI).listRooms(RoomDirectoryScope.CHANNELS)
       ]);
 
       const mappedServerPref = notificationPreferenceFromAPI(serverPref);
@@ -105,7 +106,7 @@ These preferences are server-side and sync across devices.
 
     try {
       const pref = notificationPreferenceFromAPI(
-        await updateServerNotificationPreference(connectConfig(), newLevel)
+        await updateServerNotificationPreference(preferenceConfig(), newLevel)
       );
       serverLevel = pref.level;
       serverEffectiveLevel = pref.effectiveLevel;
@@ -172,17 +173,12 @@ These preferences are server-side and sync across devices.
     roomId: string,
     newLevel: NotificationLevel
   ): Promise<NotificationPreference> {
-    const pref = await updateRoomNotificationPreference(connectConfig(), roomId, newLevel);
+    const pref = await updateRoomNotificationPreference(preferenceConfig(), roomId, newLevel);
     return notificationPreferenceFromAPI(pref);
   }
 
-  function connectConfig() {
-    const conn = connection();
-    return {
-      serverId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    };
+  function preferenceConfig() {
+    return { ...connection().apiConfig, serverId };
   }
 
   function notificationPreferenceFromAPI(pref: {

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte
@@ -58,11 +58,7 @@
 
   async function searchUsers(search: string, currentRequest: number) {
     try {
-      const currentConnection = connection();
-      const api = createMemberDirectoryAPI({
-        baseUrl: currentConnection.connectBaseUrl,
-        bearerToken: currentConnection.bearerToken
-      });
+      const api = connection().getAPI(createMemberDirectoryAPI);
       const result = await api.listUsers(search, 10, 0);
       if (currentRequest !== requestId) return;
       users = result.members;

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
@@ -10,7 +10,8 @@ const mocks = vi.hoisted(() => ({
 vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     connectBaseUrl: 'http://localhost/api/connect',
-    bearerToken: null
+    bearerToken: null,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/lib/dm/startDM.ts
+++ b/apps/frontend/src/lib/dm/startDM.ts
@@ -9,11 +9,7 @@ import { createRoomCommandAPI } from '$lib/api-client/rooms';
  */
 export async function startDMWith(serverId: string, userId: string): Promise<void> {
   const conn = serverConnectionManager.getClient(serverId);
-  const room = await createRoomCommandAPI({
-    serverId,
-    baseUrl: conn.connectBaseUrl,
-    bearerToken: conn.bearerToken
-  }).startDM([userId]);
+  const room = await conn.getAPI(createRoomCommandAPI).startDM([userId]);
 
   if (room) {
     goto(

--- a/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
@@ -50,12 +50,7 @@ export function useReactionActions() {
     });
 
     try {
-      const conn = connection();
-      const result = await createReactionAPI({
-        serverId: conn.serverId ?? params.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).addReaction({
+      const result = await connection().getAPI(createReactionAPI).addReaction({
         roomId: params.roomId,
         messageEventId: params.messageEventId,
         emoji: name
@@ -77,12 +72,7 @@ export function useReactionActions() {
     });
 
     try {
-      const conn = connection();
-      const result = await createReactionAPI({
-        serverId: conn.serverId ?? params.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).removeReaction({
+      const result = await connection().getAPI(createReactionAPI).removeReaction({
         roomId: params.roomId,
         messageEventId: params.messageEventId,
         emoji: name

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
@@ -19,7 +19,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     serverId: 'server-1',
     connectBaseUrl: '/api/connect',
-    bearerToken: 'token'
+    bearerToken: 'token',
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -20,12 +20,9 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
       const optimisticRead = roomUnreadStore.beginOptimisticRead(targetRoomId);
 
       try {
-        const conn = connection();
-        const result = await createReadStateAPI({
-          serverId: conn.serverId ?? getActiveServer(),
-          baseUrl: conn.connectBaseUrl,
-          bearerToken: conn.bearerToken
-        }).markRoomAsRead({ roomId: targetRoomId, upToEventId });
+        const result = await connection()
+          .getAPI(createReadStateAPI)
+          .markRoomAsRead({ roomId: targetRoomId, upToEventId });
         optimisticRead.commit();
         return result;
       } catch (err) {

--- a/apps/frontend/src/lib/hooks/useTypingIndicator.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useTypingIndicator.svelte.ts
@@ -1,7 +1,6 @@
 import { SvelteMap } from 'svelte/reactivity';
 import { onTypingEvent, type TypingEventData } from '$lib/eventBus.svelte';
 import { useConnection } from '$lib/state/server/connection.svelte';
-import { getActiveServer } from '$lib/state/activeServer.svelte';
 import { createRoomCommandAPI } from '$lib/api-client/rooms';
 
 /** How long to display typing indicator after receiving an event (ms) */
@@ -144,12 +143,9 @@ export function createTypingIndicator(getConfig: () => TypingIndicatorConfig) {
       lastSentAt = now;
 
       try {
-        const conn = connection();
-        await createRoomCommandAPI({
-          serverId: conn.serverId ?? getActiveServer(),
-          baseUrl: conn.connectBaseUrl,
-          bearerToken: conn.bearerToken
-        }).updateTypingIndicator(configRoomId, configThreadRootEventId);
+        await connection()
+          .getAPI(createRoomCommandAPI)
+          .updateTypingIndicator(configRoomId, configThreadRootEventId);
       } catch (err) {
         console.debug('Failed to send typing indicator:', err);
       }

--- a/apps/frontend/src/lib/navigation/readActions.spec.ts
+++ b/apps/frontend/src/lib/navigation/readActions.spec.ts
@@ -42,7 +42,8 @@ vi.mock('$lib/state/server/serverConnection.svelte', () => ({
 		getClient: () => ({
 			serverId: 'remote',
 			connectBaseUrl: 'https://remote.example.test/api/connect',
-			bearerToken: 'token'
+			bearerToken: 'token',
+			getAPI: (factory: (config: unknown) => unknown) => factory({})
 		})
 	}
 }));

--- a/apps/frontend/src/lib/navigation/readActions.ts
+++ b/apps/frontend/src/lib/navigation/readActions.ts
@@ -3,22 +3,16 @@ import { createRoomDirectoryAPI, RoomDirectoryScope } from '$lib/api-client/room
 import { serverRegistry } from '$lib/state/server/registry.svelte';
 import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
 
-function apiConfig(serverId: string) {
-	const connection = serverConnectionManager.getClient(serverId);
-	return {
-		serverId: connection.serverId ?? serverId,
-		baseUrl: connection.connectBaseUrl,
-		bearerToken: connection.bearerToken
-	};
-}
-
 /** Mark one room read while keeping the local unread indicator optimistic and race-safe. */
 export async function markNavigationRoomAsRead(serverId: string, roomId: string): Promise<boolean> {
 	const unread = serverRegistry.getStore(serverId).roomUnread;
 	const optimisticRead = unread.beginOptimisticRead(roomId);
 
 	try {
-		await createReadStateAPI(apiConfig(serverId)).markRoomAsRead({ roomId });
+		await serverConnectionManager
+			.getClient(serverId)
+			.getAPI(createReadStateAPI)
+			.markRoomAsRead({ roomId });
 		optimisticRead.commit();
 		return true;
 	} catch (error) {
@@ -34,9 +28,10 @@ export async function markNavigationServerAsRead(serverId: string): Promise<bool
 	const snapshotRevision = unread.captureSnapshotRevision();
 
 	try {
-		const rooms = await createRoomDirectoryAPI(apiConfig(serverId)).listRooms(
-			RoomDirectoryScope.ALL
-		);
+		const rooms = await serverConnectionManager
+			.getClient(serverId)
+			.getAPI(createRoomDirectoryAPI)
+			.listRooms(RoomDirectoryScope.ALL);
 		unread.updateRooms(rooms, snapshotRevision);
 		unread.resolveUnknownUnread();
 

--- a/apps/frontend/src/lib/notifications/pushNotifications.spec.ts
+++ b/apps/frontend/src/lib/notifications/pushNotifications.spec.ts
@@ -33,7 +33,12 @@ vi.mock('$lib/state/server/serverConnection.svelte', () => ({
   serverConnectionManager: {
     originClient: {
       connectBaseUrl: 'https://origin.test/api/connect',
-      bearerToken: 'origin-token'
+      bearerToken: 'origin-token',
+      getAPI: (factory: (config: never) => unknown) =>
+        factory({
+          baseUrl: 'https://origin.test/api/connect',
+          bearerToken: 'origin-token'
+        } as never)
     }
   }
 }));

--- a/apps/frontend/src/lib/notifications/pushNotifications.ts
+++ b/apps/frontend/src/lib/notifications/pushNotifications.ts
@@ -253,11 +253,7 @@ export async function unsubscribe(): Promise<boolean> {
 }
 
 function originPushAPI() {
-  const origin = serverConnectionManager.originClient;
-  return createPushNotificationAPI({
-    baseUrl: origin.connectBaseUrl,
-    bearerToken: origin.bearerToken
-  });
+  return serverConnectionManager.originClient.getAPI(createPushNotificationAPI);
 }
 
 /**

--- a/apps/frontend/src/lib/presenceTracking.spec.ts
+++ b/apps/frontend/src/lib/presenceTracking.spec.ts
@@ -14,16 +14,6 @@ const mocks = vi.hoisted(() => ({
 	updatePresence: vi.fn()
 }));
 
-vi.mock('$lib/api-client/presence', async (importOriginal) => {
-	const actual = await importOriginal<typeof import('$lib/api-client/presence')>();
-	return {
-		...actual,
-		createPresenceAPI: () => ({
-			updatePresence: mocks.updatePresence
-		})
-	};
-});
-
 let documentTarget: EventTarget;
 let windowTarget: EventTarget;
 let visibilityState: DocumentVisibilityState;
@@ -55,7 +45,7 @@ function setVisibility(next: DocumentVisibilityState) {
 function startTracking() {
 	onStatusChange = vi.fn<PresenceStatusHandler>();
 	cleanup = initPresenceTracking(
-		() => [{ serverId: 'origin', baseUrl: 'https://chat.example.test/api/connect', bearerToken: 't' }],
+		() => [{ updatePresence: mocks.updatePresence }],
 		onStatusChange
 	);
 }

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -1,4 +1,4 @@
-import { createPresenceAPI, APIPresenceStatus, type PresenceAPIConfig } from '$lib/api-client/presence';
+import { APIPresenceStatus, type PresenceAPI } from '$lib/api-client/presence';
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
 
@@ -10,7 +10,7 @@ const PRESENCE_MODE_STORAGE_KEY = 'chatto.presence.mode';
 
 type ActivityState = 'active' | 'idle' | 'hidden';
 
-export type PresenceReporterConfig = PresenceAPIConfig;
+export type PresenceReporter = Pick<PresenceAPI, 'updatePresence'>;
 
 let initialized = false;
 let applyModeFromUI: ((mode: PresenceMode) => void) | null = null;
@@ -76,7 +76,7 @@ export function setPresenceMode(mode: PresenceMode) {
 }
 
 export function initPresenceTracking(
-	getReporters: () => PresenceReporterConfig[],
+	getReporters: () => PresenceReporter[],
 	onStatusChange?: (status: PresenceStatus) => void
 ): () => void {
 	if (initialized) return () => {};
@@ -108,8 +108,8 @@ export function initPresenceTracking(
 	}
 
 	function sendPresenceReport(status: PresenceStatus, userSelected: boolean, revision: number) {
-		for (const config of getReporters()) {
-			createPresenceAPI(config)
+		for (const reporter of getReporters()) {
+			reporter
 				.updatePresence(presenceStatusToAPIStatus(status), userSelected)
 				.then((accepted) => applyAcceptedStatus(accepted, revision))
 				.catch(() => {});

--- a/apps/frontend/src/lib/state/room/files.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/files.svelte.spec.ts
@@ -26,7 +26,13 @@ function serverConnection(): ServerConnection {
   return {
     serverId: 'test-server',
     connectBaseUrl: 'https://chat.example.test/api/connect',
-    bearerToken: 'test-token'
+    bearerToken: 'test-token',
+    getAPI: (factory) =>
+      factory({
+        serverId: 'test-server',
+        baseUrl: 'https://chat.example.test/api/connect',
+        bearerToken: 'test-token'
+      })
   } as ServerConnection;
 }
 

--- a/apps/frontend/src/lib/state/room/files.svelte.ts
+++ b/apps/frontend/src/lib/state/room/files.svelte.ts
@@ -119,11 +119,7 @@ export class RoomFilesStore {
 
   constructor(serverConnection: ServerConnection, roomId: string) {
     this.roomId = roomId;
-    this.attachmentAPI = createAttachmentAPI({
-      serverId: serverConnection.serverId,
-      baseUrl: serverConnection.connectBaseUrl,
-      bearerToken: serverConnection.bearerToken
-    });
+    this.attachmentAPI = serverConnection.getAPI(createAttachmentAPI);
   }
 
   /** Hydrate this room's file cache the first time its Files panel opens. */

--- a/apps/frontend/src/lib/state/room/members.svelte.ts
+++ b/apps/frontend/src/lib/state/room/members.svelte.ts
@@ -86,10 +86,7 @@ export class RoomMembersStore {
     } else if ('listRoomMembers' in source) {
       this.api = source;
     } else {
-      this.api = createMemberDirectoryAPI({
-        baseUrl: source.connectBaseUrl,
-        bearerToken: source.bearerToken
-      });
+      this.api = source.getAPI(createMemberDirectoryAPI);
     }
   }
 

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -165,19 +165,7 @@ function isRoomDeletedPayload(event: TimelineEventView['event']): event is RoomD
 }
 
 function roomTimelineFromServerConnection(serverConnection: ServerConnection): RoomTimelineAPI {
-  const candidate = serverConnection as {
-    serverId?: string;
-    connectBaseUrl?: string;
-    bearerToken?: string | null;
-  };
-  if (!candidate.connectBaseUrl) {
-    throw new Error('MessagesStore requires the ConnectRPC timeline API');
-  }
-  return createRoomTimelineAPI({
-    serverId: candidate.serverId,
-    baseUrl: candidate.connectBaseUrl,
-    bearerToken: candidate.bearerToken ?? null
-  });
+  return serverConnection.getAPI(createRoomTimelineAPI);
 }
 
 /**

--- a/apps/frontend/src/lib/state/server/compatibility.ts
+++ b/apps/frontend/src/lib/state/server/compatibility.ts
@@ -7,6 +7,7 @@ export const LEGACY_SERVER_WARNING_BEFORE_VERSION = '0.5.0';
 export const REALTIME_PROJECTION_CAPABILITY = 'chatto.realtime.projection.v1';
 export const MESSAGE_SEARCH_CAPABILITY = 'chatto.api.message-search.v1';
 export const ROOM_MANAGER_MEMBER_READS_CAPABILITY = 'chatto.api.room-manager-member-reads.v1';
+export const ADMIN_API_CAPABILITY = 'chatto.admin.v1';
 
 export const REQUIRED_PROTOCOL_CAPABILITIES = [
   'chatto.api.v1',
@@ -15,11 +16,7 @@ export const REQUIRED_PROTOCOL_CAPABILITIES = [
 export const RECOMMENDED_PROTOCOL_CAPABILITIES = ['chatto.realtime.v1'] as const;
 
 export type ServerCompatibilityStatus =
-  | 'supported'
-  | 'degraded'
-  | 'unsupported'
-  | 'unknown'
-  | 'unreachable';
+  'supported' | 'degraded' | 'unsupported' | 'unknown' | 'unreachable';
 
 export type ServerCompatibilityReason =
   | 'capabilities-confirmed'

--- a/apps/frontend/src/lib/state/server/serverConnection.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/serverConnection.svelte.spec.ts
@@ -107,6 +107,42 @@ describe('ServerConnection', () => {
     client.dispose();
   });
 
+  it('creates each API facade once with this connection configuration', () => {
+    const client = new ServerConnection(
+      makeConfig({
+        serverUrl: 'https://remote.example.com',
+        token: 'my-token',
+        serverId: 'remote-1'
+      })
+    );
+    const factory = vi.fn((config) => ({ config }));
+
+    const first = client.getAPI(factory);
+    const second = client.getAPI(factory);
+
+    expect(first).toBe(second);
+    expect(factory).toHaveBeenCalledOnce();
+    expect(factory).toHaveBeenCalledWith({
+      serverId: 'remote-1',
+      baseUrl: 'https://remote.example.com/api/connect',
+      bearerToken: 'my-token'
+    });
+    client.dispose();
+  });
+
+  it('drops cached API facades when disposed', () => {
+    const client = new ServerConnection(makeConfig());
+    const factory = vi.fn(() => ({}));
+
+    const first = client.getAPI(factory);
+    client.dispose();
+    const second = client.getAPI(factory);
+
+    expect(second).not.toBe(first);
+    expect(factory).toHaveBeenCalledTimes(2);
+    client.dispose();
+  });
+
   it('forces reconnect through the registered realtime handler', () => {
     const client = new ServerConnection(makeConfig());
     const reconnect = vi.fn();

--- a/apps/frontend/src/lib/state/server/serverConnection.svelte.ts
+++ b/apps/frontend/src/lib/state/server/serverConnection.svelte.ts
@@ -1,4 +1,5 @@
 import { isExplicitSignOutRedirectInProgress } from '$lib/auth/signOut';
+import type { ConnectAPIConfig } from '$lib/api-client/connect';
 import { serverRegistry } from './registry.svelte';
 
 export type ConnectionStatus = 'connected' | 'connecting' | 'dormant' | 'disconnected';
@@ -56,6 +57,7 @@ export class ServerConnection {
   #token: string | null;
   #serverId: string | undefined;
   #realtimeReconnect: ((reason: string) => void) | null = null;
+  #apis = new WeakMap<object, unknown>();
 
   get isConnected() {
     return this.status === 'connected';
@@ -85,6 +87,23 @@ export class ServerConnection {
 
   get serverId(): string | undefined {
     return this.#serverId;
+  }
+
+  /** ConnectRPC configuration for helpers that are not API factories. */
+  get apiConfig(): ConnectAPIConfig {
+    return {
+      serverId: this.#serverId,
+      baseUrl: this.#connectBaseUrl,
+      bearerToken: this.#token
+    };
+  }
+
+  /** Return one API facade per factory for this connection's lifetime. */
+  getAPI<T>(factory: (config: ConnectAPIConfig) => T): T {
+    if (this.#apis.has(factory)) return this.#apis.get(factory) as T;
+    const api = factory(this.apiConfig);
+    this.#apis.set(factory, api);
+    return api;
   }
 
   /** Force-terminate and immediately reconnect the WebSocket. */
@@ -236,6 +255,7 @@ export class ServerConnection {
 
   /** Clean up event listeners owned by the connection state object. */
   dispose() {
+    this.#apis = new WeakMap();
     if (this.#visibilityHandler && typeof document !== 'undefined') {
       document.removeEventListener('visibilitychange', this.#visibilityHandler);
       this.#visibilityHandler = null;

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -298,6 +298,10 @@ class FakeServerConnection {
       };
     });
   }
+
+  getAPI<T>(factory: (config: never) => T): T {
+    return factory({} as never);
+  }
 }
 
 const registered: RegisteredServer = {

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -129,13 +129,13 @@ export class ServerStateStore {
       baseUrl: serverConnection.connectBaseUrl,
       bearerToken: serverConnection.bearerToken
     };
-    const notificationAPI = createNotificationAPI(connectAPIConfig);
-    const voiceCallAPI = createVoiceCallAPI(connectAPIConfig);
-    const adminRoomLayoutAPI = createAdminRoomLayoutAPI(connectAPIConfig);
-    const adminEventLogAPI = createAdminEventLogAPI(connectAPIConfig);
-    const messageSearchAPI = createMessageSearchAPI(connectAPIConfig);
-    const memberDirectoryAPI = createMemberDirectoryAPI(connectAPIConfig);
-    const roleAPI = createRoleAPI(connectAPIConfig);
+    const notificationAPI = serverConnection.getAPI(createNotificationAPI);
+    const voiceCallAPI = serverConnection.getAPI(createVoiceCallAPI);
+    const adminRoomLayoutAPI = serverConnection.getAPI(createAdminRoomLayoutAPI);
+    const adminEventLogAPI = serverConnection.getAPI(createAdminEventLogAPI);
+    const messageSearchAPI = serverConnection.getAPI(createMessageSearchAPI);
+    const memberDirectoryAPI = serverConnection.getAPI(createMemberDirectoryAPI);
+    const roleAPI = serverConnection.getAPI(createRoleAPI);
     this.currentUser = new CurrentUserState(
       cookieAuth,
       connectAPIConfig,
@@ -146,11 +146,7 @@ export class ServerStateStore {
     this.notifications = new NotificationStore(notificationAPI);
     this.roomUnread = new RoomUnreadStore(() => this.projection);
     this.notificationLevels = new NotificationLevelStore();
-    const roomCommandAPI = createRoomCommandAPI({
-      serverId: serverConnection.serverId ?? registered.id,
-      baseUrl: serverConnection.connectBaseUrl,
-      bearerToken: serverConnection.bearerToken
-    });
+    const roomCommandAPI = serverConnection.getAPI(createRoomCommandAPI);
     this.pendingHighlights = new PendingHighlightStore();
     this.voiceCall = new VoiceCallState(voiceCallAPI);
     this.activeCallRooms = new ActiveCallRoomsState(this.voiceCall);

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -15,6 +15,7 @@
   import { eventBusManager } from '$lib/state/server/eventBus.svelte';
   import { useProjectionEvent, useSessionTerminated } from '$lib/hooks';
   import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
+  import { createPresenceAPI } from '$lib/api-client/presence';
   import { viewerResponseToState } from '$lib/api-client/viewer';
   import {
     scheduleCustomStatusExpiry,
@@ -174,14 +175,9 @@
     () =>
       serverRegistry.servers
         .filter((server) => serverRegistry.tryGetStore(server.id)?.isAuthenticated)
-        .map((server) => {
-          const client = serverConnectionManager.getClient(server.id);
-          return {
-            serverId: server.id,
-            baseUrl: client.connectBaseUrl,
-            bearerToken: client.bearerToken
-          };
-        }),
+        .map((server) =>
+          serverConnectionManager.getClient(server.id).getAPI(createPresenceAPI)
+        ),
     (status) => {
       updateAuthenticatedCurrentUserPresenceEntries(
         presenceCache,

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte
@@ -45,21 +45,11 @@
   }
 
   function getActiveMessageAPI() {
-    const conn = serverConnectionManager.getClient(activeInstanceId);
-    return createMessageAPI({
-      serverId: conn.serverId ?? activeInstanceId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return serverConnectionManager.getClient(activeInstanceId).getAPI(createMessageAPI);
   }
 
   function getActiveAttachmentAPI() {
-    const conn = serverConnectionManager.getClient(activeInstanceId);
-    return createAttachmentAPI({
-      serverId: conn.serverId ?? activeInstanceId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return serverConnectionManager.getClient(activeInstanceId).getAPI(createAttachmentAPI);
   }
 
   function handleRoomCreated(roomId: string) {
@@ -78,12 +68,9 @@
   async function handleLeaveRoom(roomId: string) {
     leavingRoom = true;
     try {
-      const conn = serverConnectionManager.getClient(activeInstanceId);
-      const api = createRoomCommandAPI({
-        serverId: conn.serverId ?? activeInstanceId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = serverConnectionManager
+        .getClient(activeInstanceId)
+        .getAPI(createRoomCommandAPI);
       await api.leaveRoom(roomId);
     } catch (error) {
       leavingRoom = false;

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -96,6 +96,7 @@ vi.mock('$lib/state/server/serverConnection.svelte', () => ({
       serverId: 'origin',
       connectBaseUrl: 'https://origin.example.test/api/connect',
       bearerToken: null,
+      getAPI: (factory: (config: never) => unknown) => factory({} as never),
       client: {
         mutation: mocks.mutation
       }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -393,12 +393,7 @@
   }
 
   function currentAttachmentAPI() {
-    const conn = connection();
-    return createAttachmentAPI({
-      serverId: conn.serverId,
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createAttachmentAPI);
   }
 
   async function refreshLightboxUrls(): Promise<Map<string, RefreshedAttachmentUrls>> {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -34,7 +34,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     serverId: 'server_1',
     connectBaseUrl: 'https://chat.example.test/api/connect',
-    bearerToken: null
+    bearerToken: null,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -361,12 +361,7 @@
     isFollowingThread = nextFollowing;
 
     try {
-      const conn = connection();
-      const api = createThreadAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = connection().getAPI(createThreadAPI);
       const input = { roomId, threadRootEventId: event.id };
       const result = wasFollowing ? await api.unfollowThread(input) : await api.followThread(input);
       if (threadFollowRequestId !== requestId) return;
@@ -484,12 +479,7 @@
     banError = null;
     const displayName = member.displayName || member.login;
     try {
-      const conn = connection();
-      const api = createRoomCommandAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = connection().getAPI(createRoomCommandAPI);
       await api.banMember({ roomId, userId: member.id, reason, expiresAt });
     } catch (error) {
       banningMemberId = null;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -157,6 +157,7 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
     serverId: 'server-1',
     connectBaseUrl: 'http://localhost/api/connect',
     bearerToken: null,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never),
     client: {
       query: mocks.query,
       mutation: mocks.mutation,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -195,12 +195,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     banError = null;
     const displayName = member.displayName || member.login;
     try {
-      const conn = connection();
-      const api = createRoomCommandAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = connection().getAPI(createRoomCommandAPI);
       await api.banMember({ roomId, userId: member.id, reason, expiresAt });
     } catch (error) {
       banningMemberId = null;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -121,6 +121,7 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
     bearerToken: 'test-token',
     isConnected: true,
     showConnectionLostBanner: false,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never),
     client: {
       query: (...args: unknown[]) => {
         const result = queryMock(...args);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -270,12 +270,7 @@
     isFollowingThread = nextFollowing;
 
     try {
-      const conn = connection();
-      const api = createThreadAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = connection().getAPI(createThreadAPI);
       const input = { roomId, threadRootEventId };
       const result = wasFollowing ? await api.unfollowThread(input) : await api.followThread(input);
       if (threadFollowRequestId !== requestId) return;
@@ -292,12 +287,9 @@
     upToEventId?: string
   ): Promise<MarkThreadAsReadResult | null> {
     try {
-      const conn = connection();
-      return await createReadStateAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).markThreadAsRead({ roomId, threadRootEventId: currentThreadId, upToEventId });
+      return await connection()
+        .getAPI(createReadStateAPI)
+        .markThreadAsRead({ roomId, threadRootEventId: currentThreadId, upToEventId });
     } catch (err) {
       console.error('Failed to mark thread as read:', err);
       return null;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -77,7 +77,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
     serverId: 'server-1',
     connectBaseUrl: 'http://localhost/api/connect',
-    bearerToken: null
+    bearerToken: null,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/m/[messageId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/m/[messageId]/+page.svelte
@@ -8,7 +8,10 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { TimelineEventKind } from '$lib/render/timelineEvents';
-  import { createRoomTimelineAPI, type RoomTimelineAPIConfig } from '$lib/api-client/roomTimeline';
+  import {
+    createRoomTimelineAPI,
+    type RoomTimelineAPI
+  } from '$lib/api-client/roomTimeline';
   import type { PendingHighlightStore } from '$lib/state/server/pendingHighlight.svelte';
 
   /**
@@ -17,7 +20,7 @@
    * on error, falls back to the room URL.
    */
   export async function resolveAndRedirect(
-    config: RoomTimelineAPIConfig,
+    api: Pick<RoomTimelineAPI, 'getMessage'>,
     pendingHighlights: PendingHighlightStore,
     serverSegment: string,
     roomId: string,
@@ -26,7 +29,7 @@
     const roomParams = { serverId: serverSegment, roomId };
 
     try {
-      const target = await createRoomTimelineAPI(config).getMessage({
+      const target = await api.getMessage({
         roomId,
         eventId: messageId
       });
@@ -78,13 +81,8 @@
 
   $effect(() => {
     if (navigation.isInitialLoading) return;
-    const conn = connection();
     resolveAndRedirect(
-      {
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      },
+      connection().getAPI(createRoomTimelineAPI),
       stores.pendingHighlights,
       page.params.serverId!,
       page.params.roomId!,

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/+page.svelte
@@ -3,12 +3,7 @@
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import {
-    createAdminRoomLayoutAPI,
-    type AdminManagedRoomGroup,
-    type AdminRoomGroup
-  } from '$lib/api-client/adminRoomLayout';
-  import { Code, ConnectError } from '@connectrpc/connect';
+  import { createAdminRoomLayoutAPI, type AdminRoomGroup } from '$lib/api-client/adminRoomLayout';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { Panel } from '$lib/components/admin';
@@ -22,6 +17,7 @@
   import { toast } from '$lib/ui/toast';
   import { isCurrentResourceOperation } from '$lib/utils/resourceOperationFence';
   import { classifyManagementLoadError } from '$lib/utils/managementLoadError';
+  import { ADMIN_API_CAPABILITY, hasProtocolCapability } from '$lib/state/server/compatibility';
   import { buildRoomGroupSettingsUpdate } from './roomGroupSettings';
   import * as m from '$lib/i18n/messages';
 
@@ -65,23 +61,16 @@
     canManageGroup = false;
     canManagePermissions = false;
     try {
-      const conn = connection();
-      const api = createAdminRoomLayoutAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
-      let details: AdminManagedRoomGroup | null;
-      try {
-        details = await api.getRoomGroup(targetGroupId);
-      } catch (error) {
-        if (ConnectError.from(error).code !== Code.Unimplemented) throw error;
-        const groups = await api.listRoomGroups();
-        const legacyGroup = groups.find((candidate) => candidate.id === targetGroupId) ?? null;
-        details = legacyGroup
-          ? { group: legacyGroup, canManageGroup: true, canManagePermissions: true }
-          : null;
+      const info = serverRegistry.tryGetStore(activeServerId)?.serverInfo;
+      if (
+        hasProtocolCapability(info?.protocolCapabilities ?? null, ADMIN_API_CAPABILITY) !== true
+      ) {
+        accessDenied = true;
+        return;
       }
+      const details = await connection()
+        .getAPI(createAdminRoomLayoutAPI)
+        .getRoomGroup(targetGroupId);
       if (thisId !== loadId) return;
       if (details) {
         canManageGroup = details.canManageGroup;
@@ -119,12 +108,7 @@
     );
     saving = true;
     try {
-      const conn = connection();
-      const api = createAdminRoomLayoutAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = connection().getAPI(createAdminRoomLayoutAPI);
       const updated = await api.updateRoomGroup(update);
       if (!isCurrentResourceOperation(target, groupId, loadId)) return;
       if (!updated) throw new Error('Room group update returned no group');

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -4,7 +4,6 @@
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { createRoomDirectoryAPI, type DirectoryRoomDetails } from '$lib/api-client/roomDirectory';
   import { createAdminRoomLayoutAPI, type AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
   import {
@@ -14,11 +13,14 @@
     roomNameCharacterCount
   } from '$lib/utils/roomName';
   import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
-  import { Code, ConnectError } from '@connectrpc/connect';
   import { getChromePermissions } from '$lib/state/server/chromePermissions.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
-  import { supportsRoomManagerMemberReads } from '$lib/state/server/compatibility';
+  import {
+    ADMIN_API_CAPABILITY,
+    hasProtocolCapability,
+    supportsRoomManagerMemberReads
+  } from '$lib/state/server/compatibility';
   import { useProjectionEvent } from '$lib/hooks';
   import { Panel } from '$lib/components/admin';
   import { Button, Checkbox, TextArea, TextInput } from '$lib/ui/form';
@@ -59,16 +61,8 @@
   const memberManagement = new RoomMemberManagementStore((serverId) => {
     const conn = serverConnectionManager.getClient(serverId);
     return {
-      directory: createMemberDirectoryAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }),
-      commands: createRoomCommandAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      })
+      directory: conn.getAPI(createMemberDirectoryAPI),
+      commands: conn.getAPI(createRoomCommandAPI)
     };
   });
 
@@ -143,36 +137,17 @@
     accessDenied = false;
     loadFailure = null;
     try {
-      const conn = serverConnectionManager.getClient(targetServerId);
-      const adminAPI = createAdminRoomLayoutAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
-      let nextRoom: AdminManagedRoom | null;
-      try {
-        nextRoom = await adminAPI.getRoom(targetRoomId);
-      } catch (error) {
-        if (ConnectError.from(error).code !== Code.Unimplemented) throw error;
-        const directoryAPI = createRoomDirectoryAPI({
-          serverId: conn.serverId,
-          baseUrl: conn.connectBaseUrl,
-          bearerToken: conn.bearerToken
-        });
-        const legacyRoom: DirectoryRoomDetails | null = await directoryAPI.getRoom(targetRoomId);
-        nextRoom = legacyRoom
-          ? {
-              id: legacyRoom.id,
-              name: legacyRoom.name,
-              description: legacyRoom.description,
-              archived: legacyRoom.archived,
-              isUniversal: legacyRoom.isUniversal,
-              canManageRoom: legacyRoom.canManageRoom,
-              canManagePermissions:
-                legacyRoom.canManageRoom || chromePermissions.current.canManageRoles
-            }
-          : null;
+      const info = serverRegistry.tryGetStore(targetServerId)?.serverInfo;
+      if (
+        hasProtocolCapability(info?.protocolCapabilities ?? null, ADMIN_API_CAPABILITY) !== true
+      ) {
+        accessDenied = true;
+        return;
       }
+      const conn = serverConnectionManager.getClient(targetServerId);
+      const nextRoom: AdminManagedRoom | null = await conn
+        .getAPI(createAdminRoomLayoutAPI)
+        .getRoom(targetRoomId);
       if (!isCurrentLoad(thisId, targetServerId, targetRoomId)) return;
       if (nextRoom) {
         applyRoom(nextRoom);
@@ -245,11 +220,7 @@
     saving = true;
     try {
       const conn = serverConnectionManager.getClient(target.serverId);
-      const api = createRoomCommandAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      });
+      const api = conn.getAPI(createRoomCommandAPI);
       const updated = await api.updateRoom(update);
       if (!isCurrentIdentity(target)) return;
       if (!updated) throw new Error('Room update returned no room');

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -20,7 +20,7 @@ const mocks = vi.hoisted(() => ({
   getRoom: vi.fn(),
   projectionHandlers: [] as Array<(event: RealtimeProjectionEvent) => void>,
   updateRoom: vi.fn(),
-  protocolCapabilities: ['chatto.api.room-manager-member-reads.v1'] as string[]
+  protocolCapabilities: ['chatto.admin.v1', 'chatto.api.room-manager-member-reads.v1'] as string[]
 }));
 
 vi.mock('$app/state', () => ({ page: roomManagementTestPage }));
@@ -40,7 +40,13 @@ vi.mock('$lib/state/server/serverConnection.svelte', () => ({
     getClient: (serverId: string) => ({
       serverId,
       connectBaseUrl: `https://${serverId}.example.test/api/connect`,
-      bearerToken: `${serverId}-token`
+      bearerToken: `${serverId}-token`,
+      getAPI: (factory: (config: never) => unknown) =>
+        factory({
+          serverId,
+          baseUrl: `https://${serverId}.example.test/api/connect`,
+          bearerToken: `${serverId}-token`
+        } as never)
     })
   }
 }));
@@ -152,7 +158,7 @@ describe('room management page identity and realtime authority', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     mocks.projectionHandlers = [];
-    mocks.protocolCapabilities = ['chatto.api.room-manager-member-reads.v1'];
+    mocks.protocolCapabilities = ['chatto.admin.v1', 'chatto.api.room-manager-member-reads.v1'];
     mocks.updateRoom.mockResolvedValue({
       id: 'shared-room',
       name: 'general',
@@ -207,7 +213,7 @@ describe('room management page identity and realtime authority', () => {
   });
 
   it('hides member management when the server does not advertise manager reads', async () => {
-    mocks.protocolCapabilities = ['chatto.api.v1'];
+    mocks.protocolCapabilities = ['chatto.admin.v1'];
     mocks.getRoom.mockResolvedValue(managedRoom('general'));
 
     const { container } = render(RoomManagementPage);
@@ -215,6 +221,16 @@ describe('room management page identity and realtime authority', () => {
 
     expect(container.textContent).not.toContain('Members');
     expect(container.querySelector('#room-member-picker')).toBeNull();
+  });
+
+  it('does not request management details without the admin API capability', async () => {
+    mocks.protocolCapabilities = ['chatto.api.v1'];
+
+    const { container } = render(RoomManagementPage);
+    await settle();
+
+    expect(mocks.getRoom).not.toHaveBeenCalled();
+    expect(container.textContent).toContain('You do not have permission to access this page.');
   });
 
   it('accepts and normalizes Unicode room names', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/+page.svelte
@@ -62,11 +62,7 @@
   }
 
   async function queryMembers(search: string, offset: number) {
-    const conn = connection();
-    return createAdminUserManagementAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    }).listMembers({
+    return connection().getAPI(createAdminUserManagementAPI).listMembers({
       search: search || null,
       limit: PAGE_SIZE,
       offset

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/+page.svelte
@@ -116,11 +116,7 @@
   );
 
   function adminUsersAPI() {
-    const conn = connection();
-    return createAdminUserManagementAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createAdminUserManagementAPI);
   }
 
   async function saveIdentity(e?: Event) {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/members.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/members.page.svelte.spec.ts
@@ -93,7 +93,8 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
     isConnected: true,
     showConnectionLostBanner: false,
     connectBaseUrl: 'http://localhost/api/connect',
-    bearerToken: null
+    bearerToken: null,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/moderation/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/moderation/+page.svelte
@@ -13,7 +13,6 @@
   import { getLocale } from '$lib/i18n/runtime';
   import { toast } from '$lib/ui/toast';
   import { useConnection } from '$lib/state/server/connection.svelte';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
   import * as m from '$lib/i18n/messages';
 
   const userSettings = getUserSettings();
@@ -29,12 +28,7 @@
   let loadRequest = 0;
 
   function roomAPI() {
-    const conn = connection();
-    return createRoomCommandAPI({
-      serverId: conn.serverId ?? getActiveServer(),
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createRoomCommandAPI);
   }
 
   async function loadRoomBans() {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
@@ -144,11 +144,7 @@
   }
 
   function roleAPI() {
-    const conn = connection();
-    return createRoleAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createRoleAPI);
   }
 
   const permissionsHref = $derived(

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/new/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/new/+page.svelte
@@ -70,11 +70,7 @@
   }
 
   function roleAPI() {
-    const conn = connection();
-    return createRoleAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createRoleAPI);
   }
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/security/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/security/+page.svelte
@@ -17,19 +17,11 @@
   let saving = $state(false);
   let error = $state<string | null>(null);
 
-  function apiConfig() {
-    const conn = connection();
-    return {
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    };
-  }
-
   async function loadSecurityConfig() {
     loading = true;
     error = null;
     try {
-      const config = await getServerSecurityConfig(apiConfig());
+      const config = await getServerSecurityConfig(connection().apiConfig);
       blockedUsernames = config.blockedUsernames;
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
@@ -48,7 +40,7 @@
     saving = true;
     error = null;
     try {
-      const config = await updateBlockedUsernames(apiConfig(), blockedUsernames);
+      const config = await updateBlockedUsernames(connection().apiConfig, blockedUsernames);
       blockedUsernames = config.blockedUsernames;
       toast.success(m['admin.security.settings_saved']());
     } catch (err) {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
@@ -71,19 +71,11 @@
     return largest;
   });
 
-  function apiConfig() {
-    const conn = connection();
-    return {
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    };
-  }
-
   async function loadSystemInfo() {
     loading = true;
     error = null;
     try {
-      systemInfo = await getAdminSystemInfo(apiConfig());
+      systemInfo = await getAdminSystemInfo(connection().apiConfig);
     } catch (err) {
       error = err instanceof Error ? err.message : String(err);
       systemInfo = null;

--- a/apps/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -28,11 +28,7 @@
   const connection = useConnection();
 
   function accountAPI() {
-    const conn = connection();
-    return createAccountAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createAccountAPI);
   }
 
   // Form state seeded once from the user's current profile. After init

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -36,11 +36,7 @@
   const canDeleteAccount = $derived(currentUser.user?.viewerCanDeleteAccount ?? false);
 
   function accountAPI() {
-    const conn = connection();
-    return createAccountAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createAccountAPI);
   }
 
   // Modal state
@@ -113,32 +109,15 @@
 
   async function refreshExternalIdentities() {
     const activeServerId = serverId;
-    const client = connection();
     const loadSerial = ++ssoLoadSerial;
-    await loadExternalIdentities(
-      loadSerial,
-      activeServerId,
-      client.serverId,
-      client.connectBaseUrl,
-      client.bearerToken
-    );
+    await loadExternalIdentities(loadSerial, activeServerId);
   }
 
-  async function loadExternalIdentities(
-    loadSerial: number,
-    activeServerId: string,
-    apiServerId: string | undefined,
-    baseUrl: string,
-    bearerToken: string | null
-  ) {
+  async function loadExternalIdentities(loadSerial: number, activeServerId: string) {
     ssoLoading = true;
     ssoError = '';
     try {
-      const api = createExternalIdentityAPI({
-        serverId: apiServerId,
-        baseUrl,
-        bearerToken
-      });
+      const api = connection().getAPI(createExternalIdentityAPI);
       const result = await api.list();
       if (loadSerial !== ssoLoadSerial || activeServerId !== getActiveServer()) {
         return;
@@ -184,11 +163,7 @@
     linkingProviderId = provider.id;
     ssoError = '';
     try {
-      const api = createExternalIdentityAPI({
-        serverId: client.serverId,
-        baseUrl: client.connectBaseUrl,
-        bearerToken: client.bearerToken
-      });
+      const api = client.getAPI(createExternalIdentityAPI);
       const startUrl = await api.startLink({
         providerId: provider.id,
         redirectPath: accountSettingsPath,
@@ -291,11 +266,7 @@
     disconnectingSubjectHash = subjectHash;
     ssoError = '';
     try {
-      const api = createExternalIdentityAPI({
-        serverId: client.serverId,
-        baseUrl: client.connectBaseUrl,
-        bearerToken: client.bearerToken
-      });
+      const api = client.getAPI(createExternalIdentityAPI);
       beginExplicitSignOutRedirect();
       await api.disconnect(subjectHash, currentPassword);
       disconnectTarget = null;

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -97,7 +97,13 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
       subscription: vi.fn()
     },
     connectBaseUrl: 'https://origin.test/api/connect',
-    bearerToken: 'origin-token'
+    bearerToken: 'origin-token',
+    apiConfig: {
+      serverId: 'origin',
+      baseUrl: 'https://origin.test/api/connect',
+      bearerToken: 'origin-token'
+    },
+    getAPI: (factory: (config: never) => unknown) => factory({} as never)
   })
 }));
 

--- a/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -20,11 +20,7 @@
   const activeLocale = $derived(getLocale());
 
   function accountAPI() {
-    const conn = connection();
-    return createAccountAPI({
-      baseUrl: conn.connectBaseUrl,
-      bearerToken: conn.bearerToken
-    });
+    return connection().getAPI(createAccountAPI);
   }
 
   // All available IANA timezone names

--- a/apps/frontend/src/routes/chat/[serverId]/settings/profile.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/profile.page.svelte.spec.ts
@@ -44,6 +44,7 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
     showConnectionLostBanner: false,
     connectBaseUrl: '/api/connect',
     bearerToken: null,
+    getAPI: (factory: (config: never) => unknown) => factory({} as never),
     client: {
       query: mocks.query,
       mutation: mocks.mutation,

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -102,12 +102,7 @@
     error = null;
 
     try {
-      const conn = connection();
-      const result = await createThreadAPI({
-        serverId: conn.serverId,
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).listFollowedThreads({
+      const result = await connection().getAPI(createThreadAPI).listFollowedThreads({
         limit: PAGE_SIZE,
         offset: append ? threads.length : 0
       });


### PR DESCRIPTION
## Why

Authenticated frontend features repeatedly rebuilt equivalent ConnectRPC API
facades from the same server ID, base URL, and bearer token. That scattered
connection ownership through components and routes, and left mixed-version
room-management fallbacks guessing permissions from weaker directory reads.

Closes #1747.

## What changed

- cache each typed API facade for the lifetime of its owning
  `ServerConnection`, clearing the cache when that connection is disposed
- migrate chat, settings, management, navigation, presence, and notification
  consumers to request their API from the owning connection
- remove `UNIMPLEMENTED` room and room-group fallbacks and their inferred
  management permissions
- require the existing package-level `chatto.admin.v1` capability before
  loading administrative room or room-group resource settings
- reuse the canonical `ConnectAPIConfig` shape across smaller API helpers
- keep the public SSO confirmation flow independent because it has no
  registered server connection
- clarify that the 0.5 release does not preserve API compatibility with 0.4.x

The diff removes 183 net lines (304 additions, 487 deletions).

## Compatibility and rollout

- no public protocol or protobuf shape changes
- multi-server clients inspect the target server's existing `chatto.admin.v1`
  capability before opening administrative resource settings
- Chatto 0.5 treats that package capability as the complete 0.5 admin contract;
  no method-level capability or pre-0.5 fallback is retained
- older-client/newer-server behaviour is unchanged; pre-0.5 servers are outside
  the 0.5 client's supported API boundary
- replacing authentication disposes and recreates the connection, so cached
  facades never retain credentials beyond the connection that owns them
- no persistence migration or operational action is required

## Test plan

- `mise lint-frontend` — passed with 0 Svelte errors and 0 warnings
- `mise test-frontend` — passed: 294 files, 2,514 tests
- focused API-cache, capability-gating, presence, room-state, navigation, and
  affected route/component tests — passed
- focused discovery handler test — passed
- `mise codegen-proto` — passed with no generated API delta
- focused production E2E room-navigation/message-editing regression — passed
- `mise license-check` — passed, REUSE compliant
- Svelte autofixer analysis across all 38 changed Svelte files/modules — no
  change-related errors
