### PR TITLE
fix(frontend): keep mobile bottom sheets open on input focus

### DIFF
--- a/apps/frontend/src/lib/ui/BottomSheet.svelte
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte
@@ -20,12 +20,9 @@
   let closing = $state(false);
   let dragging = $state(false);
   let dragOffsetY = $state(0);
-  // Tracks whether the most recent pointerdown landed inside the sheet content.
-  // Snapshotting at pointerdown (rather than reading the click event's target /
-  // coordinates) sidesteps mobile touch-to-click synthesis races where the
-  // virtual keyboard appears between touchstart and click — re-positioning the
-  // dialog and skewing both `e.target` and `e.clientY` by the time click fires.
-  let pointerDownInsideContent = false;
+  // Some Android browsers fire a spurious dialog cancel while transferring
+  // focus to an editable control and opening the virtual keyboard.
+  let editableFocusPending = false;
 
   // Threshold past which a release commits to closing (in px of drag, relative
   // to the sheet's own height).
@@ -45,6 +42,22 @@
 
   function registerContent(node: HTMLElement) {
     contentEl = node;
+  }
+
+  function isEditableInsideContent(target: EventTarget | null): boolean {
+    if (!(target instanceof Element) || !contentEl?.contains(target)) return false;
+    return !!target.closest('input, textarea, [contenteditable]:not([contenteditable="false"])');
+  }
+
+  function handlePressStart(e: PointerEvent | TouchEvent) {
+    const content = contentEl;
+    const insideContent = !!content && content.contains(e.target as Node);
+    editableFocusPending = insideContent && isEditableInsideContent(e.target);
+
+    // Dismiss from the original press instead of its later synthesized click.
+    // Opening a virtual keyboard can move the sheet between those two events
+    // and cause Firefox/Chrome Android to retarget the click as backdrop.
+    if (!insideContent) close();
   }
 
   function handleNativeClose() {
@@ -70,39 +83,14 @@
   onclose={handleNativeClose}
   oncancel={(e) => {
     e.preventDefault();
-    // On Android Chrome, the virtual keyboard appearance fires a spurious
-    // cancel event on the dialog. If the most recent pointerdown landed inside
-    // the sheet content (e.g. the user just tapped an input), this cancel is
-    // the keyboard race — not a real dismiss intent. The focus check below
-    // isn't enough on its own because the cancel arrives before focus has
-    // transferred to the tapped input.
-    if (pointerDownInsideContent) return;
-    // Also keep the focus-based guard for the Escape-key path with an input
-    // already focused inside the sheet (external keyboard, or stale flag).
-    const active = document.activeElement;
-    if (
-      active &&
-      dialogEl?.contains(active) &&
-      (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA')
-    ) {
-      return;
-    }
+    // The cancel can arrive before focus transfers, so retain the pointerdown
+    // intent as well as checking the currently focused element.
+    if (editableFocusPending || isEditableInsideContent(document.activeElement)) return;
     close();
   }}
-  onpointerdown={(e) => {
-    // Snapshot whether the press started inside the content. This drives the
-    // click handler below; reading the click event's own target/coordinates is
-    // unreliable on mobile because the virtual keyboard appearance between
-    // touchstart and click re-positions the sheet.
-    const content = contentEl;
-    pointerDownInsideContent = !!content && content.contains(e.target as Node);
-  }}
-  onclick={() => {
-    // Only close when the original press landed on the backdrop, i.e. outside
-    // the sheet content. Any tap inside the content (input focus, button) keeps
-    // the sheet open regardless of what the synthesized click event reports.
-    if (!pointerDownInsideContent) close();
-  }}
+  onpointerdown={handlePressStart}
+  ontouchstart={handlePressStart}
+  onfocusin={() => (editableFocusPending = false)}
   aria-label={ariaLabel}
   class="bottom-sheet m-0 mt-auto w-full max-w-full bg-transparent p-0 backdrop:bg-black/50"
   class:closing

--- a/apps/frontend/src/lib/ui/BottomSheet.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte.spec.ts
@@ -1,0 +1,112 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+import { testSnippet } from '$lib/test-utils';
+import BottomSheet from './BottomSheet.svelte';
+
+let originalShowModal: typeof HTMLDialogElement.prototype.showModal;
+let originalClose: typeof HTMLDialogElement.prototype.close;
+
+function renderSheet(onclose = vi.fn()) {
+  return render(BottomSheet, {
+    props: {
+      visible: true,
+      onclose,
+      children: testSnippet(
+        '<div><input type="text" aria-label="Search"><button>Choose</button></div>'
+      )
+    }
+  });
+}
+
+function sheetElements(container: HTMLElement) {
+  const dialog = container.querySelector<HTMLDialogElement>('dialog');
+  const input = container.querySelector<HTMLInputElement>('input');
+  if (!dialog || !input) throw new Error('BottomSheet test fixture did not render');
+  return { dialog, input };
+}
+
+beforeAll(() => {
+  originalShowModal = HTMLDialogElement.prototype.showModal;
+  originalClose = HTMLDialogElement.prototype.close;
+
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute('open', '');
+  };
+  HTMLDialogElement.prototype.close = function close() {
+    this.removeAttribute('open');
+    this.dispatchEvent(new Event('close'));
+  };
+});
+
+afterAll(() => {
+  HTMLDialogElement.prototype.showModal = originalShowModal;
+  HTMLDialogElement.prototype.close = originalClose;
+});
+
+describe('BottomSheet', () => {
+  it('does not dismiss from a click inside content without a preceding pointer event', () => {
+    const { container } = renderSheet();
+    const { dialog, input } = sheetElements(container);
+
+    input.click();
+
+    expect(dialog).not.toHaveClass('closing');
+    expect(dialog).toHaveAttribute('open');
+  });
+
+  it('ignores a keyboard cancel that arrives while focus is transferring to an input', () => {
+    const { container } = renderSheet();
+    const { dialog, input } = sheetElements(container);
+
+    input.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }));
+    dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+
+    expect(dialog).not.toHaveClass('closing');
+    expect(dialog).toHaveAttribute('open');
+  });
+
+  it('ignores the keyboard cancel when a touch browser omits pointer events', () => {
+    const { container } = renderSheet();
+    const { dialog, input } = sheetElements(container);
+
+    input.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }));
+    dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+
+    expect(dialog).not.toHaveClass('closing');
+    expect(dialog).toHaveAttribute('open');
+  });
+
+  it('stops guarding cancel after editable focus has completed and moved away', () => {
+    const { container } = renderSheet();
+    const { dialog, input } = sheetElements(container);
+
+    input.dispatchEvent(new TouchEvent('touchstart', { bubbles: true }));
+    input.focus();
+    input.blur();
+    dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+    flushSync();
+
+    expect(dialog).toHaveClass('closing');
+  });
+
+  it('dismisses directly from a backdrop pointerdown', () => {
+    const { container } = renderSheet();
+    const { dialog } = sheetElements(container);
+
+    dialog.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'touch' }));
+    flushSync();
+
+    expect(dialog).toHaveClass('closing');
+  });
+
+  it('dismisses a cancel request when focus is not in an editable control', () => {
+    const { container } = renderSheet();
+    const { dialog } = sheetElements(container);
+
+    dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+    flushSync();
+
+    expect(dialog).toHaveClass('closing');
+  });
+});


### PR DESCRIPTION
## Why

Tapping the emoji search input could dismiss its mobile bottom sheet when virtual-keyboard focus changed the event sequence or retargeted the synthesized click.

## What changed

- Dismiss the backdrop from the original pointer or touch press instead of a later synthesized click.
- Keep native dialog cancellation suppressed only while editable focus is pending or active.
- Add browser-component coverage for pointer, touch-only, focus handoff, backdrop, and legitimate cancel paths.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `vitest --run BottomSheet.svelte.spec.ts ContextMenu.svelte.spec.ts EmojiPicker.svelte.spec.ts`: 27 passed.
- `pnpm --filter chatto-frontend run check`: 0 errors and 0 warnings.
- ESLint, Svelte autofixer, design-system guardrails, and `git diff --check` passed.
- Physical Android Firefox verification remains outstanding.
