### PR TITLE
fix: reduce authenticated startup latency

### DIFF
--- a/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
@@ -233,4 +233,49 @@ describe('getCurrentUserViaConnect', () => {
       })
     ).rejects.toThrow('room notification preference response did not include preference metadata');
   });
+
+  it('coalesces simultaneous viewer requests for the same connection', async () => {
+    let resolveViewer!: (value: {
+      user: {
+        profile: {
+          id: string;
+          login: string;
+          displayName: string;
+          presenceStatus: APIPresenceStatus;
+        };
+        hasVerifiedEmail: boolean;
+      };
+      roomNotificationPreferences: never[];
+    }) => void;
+    mocks.getViewer.mockReturnValue(
+      new Promise((resolve) => {
+        resolveViewer = resolve;
+      })
+    );
+
+    const config = {
+      serverId: 'remote',
+      baseUrl: 'https://chat.example.test/api/connect',
+      bearerToken: 'token'
+    };
+    const first = getViewerStateViaConnect(config);
+    const second = getViewerStateViaConnect({ ...config });
+
+    expect(mocks.getViewer).toHaveBeenCalledTimes(1);
+
+    resolveViewer({
+      user: {
+        profile: {
+          id: 'U4',
+          login: 'dora',
+          displayName: 'Dora',
+          presenceStatus: APIPresenceStatus.ONLINE
+        },
+        hasVerifiedEmail: true
+      },
+      roomNotificationPreferences: []
+    });
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2);
+  });
 });

--- a/apps/frontend/src/lib/api-client/serverState.ts
+++ b/apps/frontend/src/lib/api-client/serverState.ts
@@ -2,8 +2,8 @@ import { authHeaders, createChattoClient } from './connect.js';
 import { AdminServerService } from '@chatto/api-types/admin/v1/server_connect';
 import { ServerService } from '@chatto/api-types/api/v1/server_state_connect';
 import { ServerDiscoveryService } from '@chatto/api-types/chatto/discovery/v1/server_connect';
-import { ViewerService } from '@chatto/api-types/api/v1/viewer_connect';
 import { mapServerProfile, type ServerProfile } from './serverProfile.js';
+import { getViewerResponseViaConnect } from './viewer.js';
 
 export type ServerStateAPIConfig = {
   baseUrl: string;
@@ -82,10 +82,9 @@ function mapViewerCapabilities(
 function serverClients(config: ServerStateAPIConfig) {
   const discovery = createChattoClient(ServerDiscoveryService, config);
   const server = createChattoClient(ServerService, config);
-  const viewer = createChattoClient(ViewerService, config);
   const adminServer = createChattoClient(AdminServerService, config);
   const headers = authHeaders(config);
-  return { discovery, server, viewer, adminServer, headers };
+  return { discovery, server, adminServer, headers };
 }
 
 function mapEditableServerConfig(
@@ -121,12 +120,12 @@ function blockedUsernameEntries(text: string): string[] {
 export async function getAuthenticatedServerState(
   config: ServerStateAPIConfig
 ): Promise<AuthenticatedServerState> {
-  const { discovery, server, viewer, headers } = serverClients(config);
+  const { discovery, server, headers } = serverClients(config);
   const [discoveryResponse, motdResponse, runtimeResponse, viewerResponse] = await Promise.all([
     discovery.getServer({}),
     server.getMotd({}, { headers }),
     server.getRuntimeConfig({}, { headers }),
-    viewer.getViewer({}, { headers })
+    getViewerResponseViaConnect(config)
   ]);
   const profile = mapServerProfile(discoveryResponse.profile);
   const runtime = runtimeResponse.runtime;

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -2,7 +2,10 @@ import { authHeaders, createChattoClient } from './connect.js';
 import { ViewerService } from '@chatto/api-types/api/v1/viewer_connect';
 import { PresenceStatus as APIPresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { NotificationLevel as APINotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
-import { TimeFormat as APITimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
+import {
+  TimeFormat as APITimeFormat,
+  type GetViewerResponse
+} from '@chatto/api-types/api/v1/viewer_pb';
 import { NotificationLevel, PresenceStatus, TimeFormat } from './renderTypes.js';
 
 export type ViewerAPIConfig = {
@@ -78,14 +81,59 @@ const capabilityKeys = {
   manageUserPermissions: 'user.manage-permissions'
 } as const;
 
-export async function getViewerStateViaConnect(config: ViewerAPIConfig): Promise<ViewerState> {
+const pendingViewerResponses = new Map<string, Promise<GetViewerResponse>>();
+const authenticationCallbackIds = new WeakMap<
+  NonNullable<ViewerAPIConfig['onAuthenticationRequired']>,
+  number
+>();
+let nextAuthenticationCallbackId = 1;
+
+function authenticationCallbackId(callback: ViewerAPIConfig['onAuthenticationRequired']): number {
+  if (!callback) return 0;
+  const existing = authenticationCallbackIds.get(callback);
+  if (existing) return existing;
+  const id = nextAuthenticationCallbackId++;
+  authenticationCallbackIds.set(callback, id);
+  return id;
+}
+
+function viewerRequestKey(config: ViewerAPIConfig): string {
+  return [
+    config.serverId ?? '',
+    config.baseUrl,
+    config.bearerToken ?? '',
+    authenticationCallbackId(config.onAuthenticationRequired)
+  ].join('\u0000');
+}
+
+/**
+ * Loads the shared viewer response, coalescing simultaneous startup consumers
+ * for the same authenticated server into one RPC.
+ */
+export function getViewerResponseViaConnect(config: ViewerAPIConfig): Promise<GetViewerResponse> {
+  const key = viewerRequestKey(config);
+  const pending = pendingViewerResponses.get(key);
+  if (pending) return pending;
+
   const client = createChattoClient(ViewerService, config);
-  const response = await client.getViewer(
+  const request = client.getViewer(
     {},
     {
       headers: authHeaders(config)
     }
   );
+  pendingViewerResponses.set(key, request);
+  const clearPending = () => {
+    if (pendingViewerResponses.get(key) === request) {
+      pendingViewerResponses.delete(key);
+    }
+  };
+  request.then(clearPending, clearPending);
+  return request;
+}
+
+export async function getViewerStateViaConnect(config: ViewerAPIConfig): Promise<ViewerState> {
+  const response = await getViewerResponseViaConnect(config);
   if (!response.user) {
     throw new Error('viewer response did not include a user');
   }

--- a/cli/internal/core/notifications.go
+++ b/cli/internal/core/notifications.go
@@ -107,29 +107,9 @@ func (c *ChattoCore) suppressesNotificationAlertsForPresence(ctx context.Context
 // GetNotifications returns all notifications for a user, ordered by creation time (newest first).
 // Authorization: Caller must verify userID matches authenticated user.
 func (c *ChattoCore) GetNotifications(ctx context.Context, userID string) ([]*corev1.Notification, error) {
-	prefix := notificationKeyFilter(userID)
-	lister, err := c.storage.runtimeStateKV.ListKeysFiltered(ctx, prefix)
+	notifications, err := c.notificationSnapshot(ctx, userID)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrNoKeysFound) {
-			return []*corev1.Notification{}, nil
-		}
-		return nil, fmt.Errorf("failed to list notification keys: %w", err)
-	}
-
-	var notifications []*corev1.Notification
-	for key := range lister.Keys() {
-		entry, err := c.storage.runtimeStateKV.Get(ctx, key)
-		if err != nil {
-			c.logger.Warn("Failed to get notification", "key", key, "error", err)
-			continue
-		}
-
-		var notif corev1.Notification
-		if err := proto.Unmarshal(entry.Value(), &notif); err != nil {
-			c.logger.Warn("Failed to unmarshal notification", "key", key, "error", err)
-			continue
-		}
-		notifications = append(notifications, &notif)
+		return nil, err
 	}
 
 	// Sort by created_at descending (newest first)
@@ -138,6 +118,54 @@ func (c *ChattoCore) GetNotifications(ctx context.Context, userID string) ([]*co
 	})
 
 	return notifications, nil
+}
+
+// notificationSnapshot reads the current notification values through one
+// filtered KV watcher. Listing keys and then calling Get for every key turns a
+// single viewer request into an unbounded sequence of broker round trips for
+// users with many pending notifications.
+func (c *ChattoCore) notificationSnapshot(ctx context.Context, userID string) ([]*corev1.Notification, error) {
+	watcher, err := c.storage.runtimeStateKV.WatchFiltered(ctx, []string{notificationKeyFilter(userID)})
+	if err != nil {
+		if errors.Is(err, jetstream.ErrNoKeysFound) {
+			return []*corev1.Notification{}, nil
+		}
+		return nil, fmt.Errorf("failed to watch notifications: %w", err)
+	}
+	defer watcher.Stop()
+
+	notificationsByKey := make(map[string]*corev1.Notification)
+	updates := watcher.Updates()
+	for {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case entry, ok := <-updates:
+			if !ok {
+				return nil, errors.New("notification snapshot watcher closed before initial sync")
+			}
+			if entry == nil {
+				notifications := make([]*corev1.Notification, 0, len(notificationsByKey))
+				for _, notification := range notificationsByKey {
+					notifications = append(notifications, notification)
+				}
+				return notifications, nil
+			}
+
+			switch entry.Operation() {
+			case jetstream.KeyValueDelete, jetstream.KeyValuePurge:
+				delete(notificationsByKey, entry.Key())
+				continue
+			}
+
+			var notification corev1.Notification
+			if err := proto.Unmarshal(entry.Value(), &notification); err != nil {
+				c.logger.Warn("Failed to unmarshal notification", "key", entry.Key(), "error", err)
+				continue
+			}
+			notificationsByKey[entry.Key()] = &notification
+		}
+	}
 }
 
 // GetNotification retrieves a single notification.
@@ -319,7 +347,7 @@ func (c *ChattoCore) GetNotificationCount(ctx context.Context, userID string) (i
 // belongs to a thread the user currently follows in one of the requested
 // spaces.
 func (c *ChattoCore) HasPendingFollowedThreadNotifications(ctx context.Context, userID string, spaceIDs []string) (bool, error) {
-	notifications, err := c.GetNotifications(ctx, userID)
+	notifications, err := c.notificationSnapshot(ctx, userID)
 	if err != nil {
 		return false, err
 	}

--- a/cli/internal/core/notifications_test.go
+++ b/cli/internal/core/notifications_test.go
@@ -3,14 +3,26 @@ package core
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/core/subjects"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+type countingGetKeyValue struct {
+	jetstream.KeyValue
+	getCalls atomic.Int64
+}
+
+func (kv *countingGetKeyValue) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	kv.getCalls.Add(1)
+	return kv.KeyValue.Get(ctx, key)
+}
 
 func TestCreateNotification(t *testing.T) {
 	core, nc := setupTestCore(t)
@@ -350,6 +362,26 @@ func TestGetNotifications(t *testing.T) {
 			if notifs[i-1].CreatedAt.AsTime().Before(notifs[i].CreatedAt.AsTime()) {
 				t.Error("Notifications not in descending chronological order")
 			}
+		}
+	})
+
+	t.Run("loads the snapshot without one Get call per notification", func(t *testing.T) {
+		underlying := core.storage.runtimeStateKV
+		counting := &countingGetKeyValue{KeyValue: underlying}
+		core.storage.runtimeStateKV = counting
+		t.Cleanup(func() {
+			core.storage.runtimeStateKV = underlying
+		})
+
+		notifs, err := core.GetNotifications(ctx, userID)
+		if err != nil {
+			t.Fatalf("GetNotifications error: %v", err)
+		}
+		if len(notifs) != 3 {
+			t.Fatalf("Expected 3 notifications, got %d", len(notifs))
+		}
+		if got := counting.getCalls.Load(); got != 0 {
+			t.Fatalf("GetNotifications made %d per-key Get calls, want 0", got)
 		}
 	})
 }


### PR DESCRIPTION
Authenticated startup became slow in v0.4.16 because the viewer request loaded notification keys and then fetched every value with a separate NATS KV round trip.

This replaces that N+1 path with a single filtered KV snapshot and reuses it for followed-thread notification checks.

The frontend now coalesces simultaneous `GetViewer` calls for the same authenticated server so startup consumers share one in-flight request.

Validated with `mise test-cli`, the production frontend build, and the complete frontend suite (193 files and 1,997 tests).
