### PR TITLE
fix(threads): reject echoes as thread roots

### DIFF
--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -199,7 +199,7 @@ func (s *MessageModel) validatePostBeforeUpload(ctx context.Context, input Messa
 	if rootMsg == nil {
 		return invalidArgument("thread root is not a message event")
 	}
-	if rootMsg.InThread != "" {
+	if rootMsg.InThread != "" || rootMsg.EchoOfEventId != "" {
 		return invalidArgument("thread root must be a root message, not a thread reply")
 	}
 	return nil

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -493,7 +493,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 			return nil, invalidArgument("thread root is not a message event")
 		}
 		// Verify it's actually a root message (not itself a thread reply)
-		if rootMsg.InThread != "" {
+		if rootMsg.InThread != "" || rootMsg.EchoOfEventId != "" {
 			return nil, invalidArgument("thread root must be a root message, not a thread reply")
 		}
 	}

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -58,6 +58,62 @@ func TestChattoCore_PostMessage(t *testing.T) {
 	}
 }
 
+func TestPostMessageRejectsEchoAsThreadRoot(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "echo-root-user", "Echo Root User", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, user.Id, KindChannel, "", "echo-root-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "root", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("Post root: %v", err)
+	}
+	reply, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "reply", nil, root.Id, "", nil, true)
+	if err != nil {
+		t.Fatalf("Post reply: %v", err)
+	}
+
+	roomEvents, err := core.GetRoomEvents(ctx, KindChannel, room.Id, 50, nil)
+	if err != nil {
+		t.Fatalf("GetRoomEvents: %v", err)
+	}
+	var echoID string
+	for _, event := range roomEvents.Events {
+		if message := event.GetMessagePosted(); message != nil && message.GetEchoOfEventId() == reply.Id {
+			echoID = event.Id
+			break
+		}
+	}
+	if echoID == "" {
+		t.Fatal("expected echoed reply in room timeline")
+	}
+
+	if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "invalid core reply", nil, echoID, echoID, nil, false); !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("core PostMessage error = %v, want ErrInvalidArgument", err)
+	}
+
+	_, err = core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		Body:              "invalid model reply",
+		ThreadRootEventID: echoID,
+		InReplyTo:         echoID,
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("MessageModel PostMessage error = %v, want ErrInvalidArgument", err)
+	}
+}
+
 func TestChattoCore_PostMessageRejectsAssetFromDifferentRoom(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)


### PR DESCRIPTION
## Summary

- Backport the echo-as-thread-root validation fix from #1757 to `release-0.4`.
- Reject channel echo events in both message-model preflight and the lower-level core posting path.
- Add release-compatible regression coverage for both posting APIs.
- Prevent new malformed `ThreadCreated` events and associated follow/read state on the currently deployed release line.

## Root cause

Channel echoes have no `in_thread` value, so the existing validation mistook them for room-root messages. A caller that explicitly supplied an echo event ID as `thread_root_event_id` could therefore create a malformed thread.

This change prevents new malformed threads. It does not modify or repair existing persisted data.

## Testing

- `mise exec -- go test ./internal/core -run '^(TestChattoCore_PostMessage|TestPostMessageRejectsEchoAsThreadRoot)$' -count=1`
