### PR TITLE
fix(docker): use real service health checks

### DIFF
--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -204,14 +204,21 @@ docker compose config
 # Confirm all containers are running or healthy
 docker compose ps
 
+# Check the same internal readiness endpoints used by Compose
+docker compose exec nats wget -qO- 'http://127.0.0.1:8222/healthz?js-enabled-only=true'
+docker compose exec livekit wget -qO- http://127.0.0.1:7880/
+docker compose exec chatto wget -qO- http://127.0.0.1:4000/readyz
+
 # Check both HTTPS endpoints
 curl --fail --silent --show-error --output /dev/null https://chat.example.com
 curl --fail --silent --show-error --output /dev/null https://livekit.chat.example.com
 ```
 
-The HTTPS checks verify routing and LiveKit signaling, but not WebRTC media.
-Join a call from two different networks or devices to exercise TCP 7881 and the
-UDP media ports 3478 and 7882.
+The NATS check also verifies that JetStream is enabled. Chatto's readiness check
+waits for its NATS connection and core projections, while LiveKit's root
+endpoint reports whether the node is ready. The HTTPS checks verify routing and
+LiveKit signaling, but not WebRTC media. Join a call from two different networks
+or devices to exercise TCP 7881 and the UDP media ports 3478 and 7882.
 
 ## Inspecting NATS
 

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -1,11 +1,12 @@
 services:
   nats:
-    image: nats:latest
-    command: ["--jetstream", "--store_dir=/data", "--auth=${NATS_TOKEN}"]
+    # The Alpine variant includes wget for the HTTP health check.
+    image: nats:alpine
+    command: ["--jetstream", "--store_dir=/data", "--auth=${NATS_TOKEN}", "--http_port=8222"]
     volumes:
       - nats_data:/data
     healthcheck:
-      test: ["CMD", "nats-server", "--help"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8222/healthz?js-enabled-only=true"]
       interval: 5s
       timeout: 3s
       retries: 3
@@ -24,7 +25,7 @@ services:
     volumes:
       - ${LIVEKIT_CONFIG_FILE:-./livekit.yaml}:/etc/livekit.yaml:ro
     healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://localhost:7880"]
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7880/"]
       interval: 5s
       timeout: 3s
       retries: 3
@@ -42,6 +43,12 @@ services:
         condition: service_healthy
     expose:
       - "4000"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:4000/readyz"]
+      interval: 5s
+      timeout: 3s
+      retries: 12
+      start_period: 10s
 
   caddy:
     image: caddy:latest
@@ -55,8 +62,10 @@ services:
       - caddy_data:/data
       - caddy_config:/config
     depends_on:
-      - chatto
-      - livekit
+      chatto:
+        condition: service_healthy
+      livekit:
+        condition: service_healthy
 
 volumes:
   nats_data:


### PR DESCRIPTION
## Why

The Docker Compose example marked NATS healthy by launching
`nats-server --help`, which did not inspect the running server or confirm that
JetStream was available. Chatto also had no Compose health check, so Caddy
could start before Chatto was ready to serve traffic.

## What changed

- use the official NATS `/healthz?js-enabled-only=true` endpoint so readiness
  requires a running server with JetStream enabled
- use the official `nats:alpine` variant, which includes `wget` for the
  in-container HTTP probe; the monitoring listener remains private to the
  Compose network
- keep LiveKit's server-provided `/` readiness endpoint, using an explicit
  loopback address
- add a Chatto `/readyz` health check covering NATS connectivity and core
  projection readiness
- make Caddy wait for healthy Chatto and LiveKit services
- document commands for checking all three internal readiness endpoints

There are no public API, persisted-data, migration, or compatibility changes.
The operational change is that NATS now enables its unauthenticated monitoring
listener on port 8222 inside the Compose network; it is not published to the
host.

## Test plan

- `docker compose config --quiet`
- `git diff --check`
- `mise build-frontend`
- built the current Chatto release image from this checkout
- started a clean temporary four-service stack with
  `docker compose up -d --wait --wait-timeout 180`
- confirmed NATS returned `{"status":"ok"}`
- confirmed LiveKit returned `OK`
- confirmed Chatto returned `{"status":"ready"}`
- confirmed the Chatto root, Chatto readiness, and LiveKit routes through
  Caddy returned HTTP 200
- removed the temporary containers, network, and volumes

A fresh pull of `ghcr.io/chattocorp/chatto:latest` was denied in the local
environment, so the end-to-end run used a locally built current-source Chatto
release image. NATS and LiveKit used their official pulled images.
