### PR TITLE
refactor(docker): simplify Compose service startup

### DIFF
--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -261,7 +261,7 @@ CHATTO_VIDEO_ENABLED=true
 
 If you don't need voice and video calls, simplify the stack by:
 
-1. Removing the `livekit` service and its `depends_on` references from `compose.yml`
+1. Removing the `livekit` service from `compose.yml`
 2. Deleting the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`)
 3. Removing the `livekit.*` block from the `Caddyfile`
 4. Removing the `CHATTO_LIVEKIT_*` variables from `.env`
@@ -316,8 +316,6 @@ See [Voice & Video Calls](/guides/infrastructure/voice-calls/#turn-for-restricti
 **The first account is not an owner** — Make sure `CHATTO_OWNERS_EMAILS` contains the verified email address for that account. For an already-verified account, restart Chatto after updating the variable; Chatto applies matching owner roles on boot.
 
 **Caddy not getting certificates** — Verify DNS records point to your server and ports 80/443 are open. Check `docker compose logs caddy` for ACME errors.
-
-**Container startup order** — `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts. If health checks fail, check the individual service logs.
 
 **Calls don't connect** — Verify the LiveKit API key/secret in `.env` matches the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Ensure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.*` subdomain (browsers connect to it directly). Check that TCP 7881 and UDP 3478 and 7882 are open in your firewall. For a LAN-only host without an external IP address, set `rtc.use_external_ip: false` in `livekit.generated.yaml` before starting or restarting LiveKit.
 

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -201,24 +201,17 @@ accepted them.
 # Validate and render the Compose configuration
 docker compose config
 
-# Confirm all containers are running or healthy
+# Confirm all containers are running
 docker compose ps
-
-# Check the same internal readiness endpoints used by Compose
-docker compose exec nats wget -qO- 'http://127.0.0.1:8222/healthz?js-enabled-only=true'
-docker compose exec livekit wget -qO- http://127.0.0.1:7880/
-docker compose exec chatto wget -qO- http://127.0.0.1:4000/readyz
 
 # Check both HTTPS endpoints
 curl --fail --silent --show-error --output /dev/null https://chat.example.com
 curl --fail --silent --show-error --output /dev/null https://livekit.chat.example.com
 ```
 
-The NATS check also verifies that JetStream is enabled. Chatto's readiness check
-waits for its NATS connection and core projections, while LiveKit's root
-endpoint reports whether the node is ready. The HTTPS checks verify routing and
-LiveKit signaling, but not WebRTC media. Join a call from two different networks
-or devices to exercise TCP 7881 and the UDP media ports 3478 and 7882.
+The HTTPS checks verify routing and LiveKit signaling, but not WebRTC media.
+Join a call from two different networks or devices to exercise TCP 7881 and the
+UDP media ports 3478 and 7882.
 
 ## Inspecting NATS
 
@@ -263,7 +256,7 @@ Data is persisted in Docker volumes:
 
 ## Disabling Voice and Video Calls
 
-If you don't need calls, remove the `livekit` service from `compose.yml`, delete the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`), remove the `livekit.*` block from the `Caddyfile`, remove LiveKit from `chatto.depends_on` and `caddy.depends_on`, and remove the LiveKit environment variables from `.env`. You can then close TCP 7881 and UDP 3478 and 7882 and remove the `livekit.*` DNS record.
+If you don't need calls, remove the `livekit` service from `compose.yml`, delete the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`), remove the `livekit.*` block from the `Caddyfile`, and remove the LiveKit environment variables from `.env`. You can then close TCP 7881 and UDP 3478 and 7882 and remove the `livekit.*` DNS record.
 
 ## Troubleshooting
 
@@ -274,8 +267,6 @@ If you don't need calls, remove the `livekit` service from `compose.yml`, delete
 **The first account is not an owner**: Ensure `CHATTO_OWNERS_EMAILS` contains that account's verified email address. Chatto assigns matching owner roles when the email is verified and on server boot.
 
 **Caddy not getting certificates**: Ensure your domain's DNS points to your server and ports 80/443 are open.
-
-**Container startup order issues**: The `depends_on` with `condition: service_healthy` ensures NATS and LiveKit are ready before Chatto starts.
 
 **Calls not working**: Ensure the LiveKit API key/secret in `.env` matches the `keys:` section in the selected LiveKit config (`livekit.generated.yaml` or `livekit.yaml`). Also verify the webhook URL points to your Chatto instance. Make sure `CHATTO_LIVEKIT_URL` uses the public `wss://livekit.` subdomain (not the internal Docker hostname), since browsers connect to it directly.
 

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -1,15 +1,9 @@
 services:
   nats:
-    # The Alpine variant includes wget for the HTTP health check.
-    image: nats:alpine
-    command: ["--jetstream", "--store_dir=/data", "--auth=${NATS_TOKEN}", "--http_port=8222"]
+    image: nats:latest
+    command: ["--jetstream", "--store_dir=/data", "--auth=${NATS_TOKEN}"]
     volumes:
       - nats_data:/data
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:8222/healthz?js-enabled-only=true"]
-      interval: 5s
-      timeout: 3s
-      retries: 3
 
   livekit:
     image: livekit/livekit-server:latest
@@ -24,11 +18,6 @@ services:
       - "7880"  # WebSocket signaling (proxied through Caddy)
     volumes:
       - ${LIVEKIT_CONFIG_FILE:-./livekit.yaml}:/etc/livekit.yaml:ro
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:7880/"]
-      interval: 5s
-      timeout: 3s
-      retries: 3
 
   chatto:
     image: ghcr.io/chattocorp/chatto:latest
@@ -37,18 +26,9 @@ services:
       PUID: "${PUID:-1000}"
       PGID: "${PGID:-1000}"
     depends_on:
-      nats:
-        condition: service_healthy
-      livekit:
-        condition: service_healthy
+      - nats
     expose:
       - "4000"
-    healthcheck:
-      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:4000/readyz"]
-      interval: 5s
-      timeout: 3s
-      retries: 12
-      start_period: 10s
 
   caddy:
     image: caddy:latest
@@ -61,11 +41,6 @@ services:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
       - caddy_data:/data
       - caddy_config:/config
-    depends_on:
-      chatto:
-        condition: service_healthy
-      livekit:
-        condition: service_healthy
 
 volumes:
   nats_data:


### PR DESCRIPTION
## Why

The Docker Compose example accumulated health checks used primarily for startup ordering, adding probe-specific image and service coupling without providing ongoing recovery.

## What changed

- Remove the NATS, LiveKit, and Chatto health checks and unnecessary startup dependencies.
- Keep Chatto's short-form dependency on NATS, switch NATS back to `nats:latest`, and remove its probe-only monitoring port.
- Update the example README and public deployment guide to match the simplified stack.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: No change.

## Test plan

- `docker compose config --quiet --no-env-resolution --no-interpolate`
- Full isolated Compose smoke test: NATS, LiveKit, Chatto, and Caddy all started; Chatto returned `{"status":"ready"}` and LiveKit returned `OK` through Caddy.
- `mise x -- pnpm --filter docs-website build`
- `git diff --check`
