### PR TITLE
refactor(core): centralise projection snapshot policy

### DIFF
--- a/cli/internal/core/projection_registry.go
+++ b/cli/internal/core/projection_registry.go
@@ -12,6 +12,7 @@ type projectionRegistration struct {
 	name            string
 	projector       *events.Projector
 	subjects        []string
+	snapshotPolicy  projectionSnapshotPolicy
 	snapshotEnabled bool
 	estimate        func() (entries int64, estimatedBytes int64, metrics []ProjectionAdminMetric)
 }

--- a/cli/internal/core/projection_registry_test.go
+++ b/cli/internal/core/projection_registry_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/projectionsnapshot"
 )
 
 var registryKeyPattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
@@ -108,5 +109,41 @@ func TestProjectionRegistryDefinesIndependentConsumers(t *testing.T) {
 		if replaySubjects := registration.projector.ReplaySubjects(); len(replaySubjects) == 0 {
 			t.Fatalf("%s projection has no physical replay filter", registration.name)
 		}
+	}
+}
+
+func TestProjectionRegistryDefinesSnapshotEligibility(t *testing.T) {
+	core, _ := setupTestCore(t)
+
+	wantEligible := map[string]struct{}{
+		projectionsnapshot.ProjectionThreadsKey:         {},
+		projectionsnapshot.ProjectionRoomDirectoryKey:   {},
+		projectionsnapshot.ProjectionServerConfigKey:    {},
+		projectionsnapshot.ProjectionRoomGroupLayoutKey: {},
+		projectionsnapshot.ProjectionRoomTimelineKey:    {},
+		projectionsnapshot.ProjectionCallStateKey:       {},
+		projectionsnapshot.ProjectionAssetsKey:          {},
+		projectionsnapshot.ProjectionReactionsKey:       {},
+		projectionsnapshot.ProjectionContentKeysKey:     {},
+		projectionsnapshot.ProjectionRBACKey:            {},
+		projectionsnapshot.ProjectionMentionablesKey:    {},
+		projectionsnapshot.ProjectionUsersKey:           {},
+	}
+
+	for _, registration := range core.projections {
+		_, want := wantEligible[registration.key]
+		got := registration.snapshotPolicy == sharedSnapshots
+		if got != want {
+			t.Errorf(
+				"projection %q snapshot eligibility = %t, want %t",
+				registration.key,
+				got,
+				want,
+			)
+		}
+		delete(wantEligible, registration.key)
+	}
+	if len(wantEligible) != 0 {
+		t.Fatalf("snapshot-eligible projections are not registered: %v", wantEligible)
 	}
 }

--- a/cli/internal/core/projection_wiring.go
+++ b/cli/internal/core/projection_wiring.go
@@ -45,6 +45,13 @@ type coreProjections struct {
 	mentionablesProjector    *events.Projector
 }
 
+type projectionSnapshotPolicy bool
+
+const (
+	coldReplayOnly  projectionSnapshotPolicy = false
+	sharedSnapshots projectionSnapshotPolicy = true
+)
+
 // projectionRegistrar keeps projector construction and diagnostic
 // registration atomic so those inventories cannot drift apart.
 type projectionRegistrar struct {
@@ -58,6 +65,7 @@ func (r *projectionRegistrar) register(
 	key string,
 	name string,
 	estimate func() (int64, int64, []ProjectionAdminMetric),
+	snapshotPolicy projectionSnapshotPolicy,
 ) *events.Projector {
 	loggerName := strings.ReplaceAll(name, " ", "") + "Projector"
 	projector := events.NewProjector(
@@ -67,11 +75,12 @@ func (r *projectionRegistrar) register(
 		r.logger.WithPrefix("core."+loggerName),
 	)
 	r.registrations = append(r.registrations, projectionRegistration{
-		key:       key,
-		name:      name,
-		projector: projector,
-		subjects:  slices.Clone(projection.Subjects()),
-		estimate:  estimate,
+		key:            key,
+		name:           name,
+		projector:      projector,
+		subjects:       slices.Clone(projection.Subjects()),
+		snapshotPolicy: snapshotPolicy,
+		estimate:       estimate,
 	})
 	return projector
 }
@@ -86,73 +95,82 @@ func initializeCoreProjections(
 	projections.roomDirectory = NewRoomDirectoryProjection()
 	projections.roomDirectoryProjector = registrar.register(
 		projections.roomDirectory,
-		"room_directory",
+		projectionsnapshot.ProjectionRoomDirectoryKey,
 		"Room Directory",
 		projections.roomDirectory.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.serverConfig = NewConfigProjection()
 	projections.serverConfigProjector = registrar.register(
 		projections.serverConfig,
-		"server_config",
+		projectionsnapshot.ProjectionServerConfigKey,
 		"Server Config",
 		projections.serverConfig.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.roomGroupLayout = NewRoomGroupLayoutProjection()
 	projections.roomGroupLayoutProjector = registrar.register(
 		projections.roomGroupLayout,
-		"room_group_layout",
+		projectionsnapshot.ProjectionRoomGroupLayoutKey,
 		"Room Group Layout",
 		projections.roomGroupLayout.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.roomTimeline = NewRoomTimelineProjection()
 	projections.roomTimelineProjector = registrar.register(
 		projections.roomTimeline,
-		"room_timeline",
+		projectionsnapshot.ProjectionRoomTimelineKey,
 		"Room Timeline",
 		projections.roomTimeline.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.callState = NewCallStateProjection()
 	projections.callStateProjector = registrar.register(
 		projections.callState,
-		"call_state",
+		projectionsnapshot.ProjectionCallStateKey,
 		"Call State",
 		projections.callState.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.assets = NewAssetProjection()
 	projections.assetsProjector = registrar.register(
 		projections.assets,
-		"assets",
+		projectionsnapshot.ProjectionAssetsKey,
 		"Assets",
 		projections.assets.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.threads = NewThreadProjection()
 	projections.threadsProjector = registrar.register(
 		projections.threads,
-		"threads",
+		projectionsnapshot.ProjectionThreadsKey,
 		"Threads",
 		projections.threads.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.reactions = NewReactionProjection()
 	projections.reactionsProjector = registrar.register(
 		projections.reactions,
-		"reactions",
+		projectionsnapshot.ProjectionReactionsKey,
 		"Reactions",
 		projections.reactions.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.users = newUserProjectionWithDEKResolver(infra.dekResolver)
 	projections.usersProjector = registrar.register(
 		projections.users,
-		"users",
+		projectionsnapshot.ProjectionUsersKey,
 		"Users",
 		projections.users.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 	userAuth := projections.users.AuthProjection()
 	projections.userAuthProjector = registrar.register(
@@ -160,30 +178,34 @@ func initializeCoreProjections(
 		"user_auth",
 		"User Auth",
 		userAuth.adminProjectionEstimate,
+		coldReplayOnly,
 	)
 
 	projections.contentKeys = NewContentKeyProjection()
 	projections.contentKeysProjector = registrar.register(
 		projections.contentKeys,
-		"content_keys",
+		projectionsnapshot.ProjectionContentKeysKey,
 		"Content Keys",
 		projections.contentKeys.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.rbac = NewRBACProjection()
 	projections.rbacProjector = registrar.register(
 		projections.rbac,
-		"rbac",
+		projectionsnapshot.ProjectionRBACKey,
 		"RBAC",
 		projections.rbac.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.mentionables = newMentionablesProjectionWithDEKResolver(infra.dekResolver)
 	projections.mentionablesProjector = registrar.register(
 		projections.mentionables,
-		"mentionables",
+		projectionsnapshot.ProjectionMentionablesKey,
 		"Mentionables",
 		projections.mentionables.adminProjectionEstimate,
+		sharedSnapshots,
 	)
 
 	projections.registrations = registrar.registrations
@@ -202,45 +224,26 @@ func configureProjectionSnapshots(
 	}
 
 	streamName := infra.storage.serverEvtStream.CachedInfo().Config.Name
-	specs := []struct {
-		key       string
-		projector *events.Projector
-	}{
-		{projectionsnapshot.ProjectionThreadsKey, projections.threadsProjector},
-		{projectionsnapshot.ProjectionRoomDirectoryKey, projections.roomDirectoryProjector},
-		{projectionsnapshot.ProjectionServerConfigKey, projections.serverConfigProjector},
-		{projectionsnapshot.ProjectionRoomGroupLayoutKey, projections.roomGroupLayoutProjector},
-		{projectionsnapshot.ProjectionRoomTimelineKey, projections.roomTimelineProjector},
-		{projectionsnapshot.ProjectionCallStateKey, projections.callStateProjector},
-		{projectionsnapshot.ProjectionAssetsKey, projections.assetsProjector},
-		{projectionsnapshot.ProjectionReactionsKey, projections.reactionsProjector},
-		{projectionsnapshot.ProjectionContentKeysKey, projections.contentKeysProjector},
-		{projectionsnapshot.ProjectionRBACKey, projections.rbacProjector},
-		{projectionsnapshot.ProjectionMentionablesKey, projections.mentionablesProjector},
-		{projectionsnapshot.ProjectionUsersKey, projections.usersProjector},
-	}
-
-	for _, spec := range specs {
-		if err := spec.projector.ConfigureSnapshots(
-			spec.key,
+	for i := range projections.registrations {
+		registration := &projections.registrations[i]
+		if registration.snapshotPolicy == coldReplayOnly {
+			continue
+		}
+		if err := registration.projector.ConfigureSnapshots(
+			registration.key,
 			projectionSnapshotSource{repository: infra.snapshotRepository},
 			infra.snapshotStreamIdentity,
 		); err != nil {
-			return fmt.Errorf("configure %s projection snapshots: %w", spec.key, err)
+			return fmt.Errorf("configure %s projection snapshots: %w", registration.key, err)
 		}
 		projections.snapshotJobs = append(projections.snapshotJobs, projectionSnapshotJob{
-			projector:      spec.projector,
+			projector:      registration.projector,
 			repository:     infra.snapshotRepository,
-			projectionKey:  spec.key,
+			projectionKey:  registration.key,
 			streamName:     streamName,
 			streamIdentity: infra.snapshotStreamIdentity,
 		})
-		for i := range projections.registrations {
-			if projections.registrations[i].key == spec.key {
-				projections.registrations[i].snapshotEnabled = true
-				break
-			}
-		}
+		registration.snapshotEnabled = true
 	}
 	return nil
 }

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -7,7 +7,9 @@ optional providers may own disposable locally checkpointed indexes.
 `initializeCoreProjections` registers each top-level core projector once with a
 stable machine-readable key, such as `content_keys`, and a human display name,
 such as `Content Keys`. `NewChattoCore` installs that single registry into the
-core runtime.
+core runtime. Each registration also declares whether that same stable key is
+eligible for shared snapshots. Snapshot configuration iterates the registry
+directly rather than maintaining a parallel projector list.
 
 `ChattoCore.Run` starts one process-local ordered EVT consumer per registered
 projection. Each projector owns its physical filters, replay progress, failure


### PR DESCRIPTION
## Why

Core projection setup maintained snapshot eligibility in a second projector inventory, making it possible for registration, diagnostics, and snapshot configuration to drift apart.

## What changed

- Declare shared-snapshot eligibility on each projection registration and use the canonical snapshot key as its registry key.
- Configure snapshot restore and save jobs directly from the authoritative projection registry while keeping `user_auth` cold-replay-only.
- Add a registry eligibility regression test and document the ownership pattern in the architecture inventory.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise x -- go test ./internal/core -count=1` — passed.
- `mise x -- go test ./... -run '^$' -count=1` — passed.
- Focused projection registry, subject policy, and snapshot tests — passed.
- `git diff --check` and architecture link validation — passed.
