### PR TITLE
refactor(frontend): split admin member details

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/+page.svelte
@@ -1,630 +1,88 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
+  import { createAdminUserManagementAPI } from '$lib/api-client/adminUsers';
+  import { UserPermissionsMatrix } from '$lib/components/rbac';
+  import * as m from '$lib/i18n/messages';
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { useConnection } from '$lib/state/server/connection.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import {
-    createAdminUserManagementAPI,
-    type AdminMember,
-    type AdminRoleDetails
-  } from '$lib/api-client/adminUsers';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
-  import { CopyId, Panel } from '$lib/components/admin';
-  import { UserPermissionsMatrix } from '$lib/components/rbac';
-  import { Hint, PaneContent, Pill } from '$lib/ui';
+  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { Hint, PaneContent } from '$lib/ui';
+  import { FormError } from '$lib/ui/form';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import PageTitle from '$lib/ui/PageTitle.svelte';
-  import { Button, Checkbox, Form, FormError, TextInput, z, validate } from '$lib/ui/form';
-  import { toast } from '$lib/ui/toast';
-  import { getAvatarInitials } from '$lib/utils/initials';
-  import { formatDate, formatDateTime } from '$lib/utils/formatTime';
-  import { getLocale } from '$lib/i18n/runtime';
-  import { getLiveLogin } from '$lib/state/userProfiles.svelte';
-  import { getUserSettings } from '$lib/state/userSettings.svelte';
-  import * as m from '$lib/i18n/messages';
-  import {
-    validateAndNormalizeDisplayName,
-    validateAndNormalizeLogin,
-    getLoginChangeCooldownRemaining,
-    formatCooldownRemaining
-  } from '$lib/validation';
+  import { MemberDetailStore } from './MemberDetailStore.svelte';
+  import MemberIdentitySettings from './MemberIdentitySettings.svelte';
+  import MemberOverviewPanel from './MemberOverviewPanel.svelte';
+  import MemberRoleAssignments from './MemberRoleAssignments.svelte';
 
-  // Everyone role is implicit for all server members and shouldn't be assignable
-  const IMPLICIT_ROLES = ['everyone'];
-
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
   const connection = useConnection();
-  const userSettings = getUserSettings();
-  const activeLocale = $derived(getLocale());
+  const serverPermissions = getServerPermissions();
+  const activeServerId = $derived(getActiveServer());
   const userId = $derived(page.params.userId!);
-
-  const serverPerms = getServerPermissions();
-  const canAdminManageAccounts = $derived(serverPerms.current.canAdminManageAccounts);
-
-  let member = $state<AdminMember | null>(null);
-  let allRoles = $state<AdminRoleDetails[]>([]);
-  let memberServerRoles = $state<string[]>([]); // Member's roles (separate from member object)
-  let canAssignRoles = $state(false);
-  let canManageRoles = $state(false);
-  let canManageUserPermissions = $state(false);
-  let assignableRoleNames = $state<string[] | null>(null);
-  let revocableRoleNames = $state<string[] | null>(null);
-  let loading = $state(true);
-  let updating = $state<string | null>(null);
-  let error = $state<string | null>(null);
-
-  // Identity edit state (gated on canAdminManageAccounts)
-  let editLogin = $state('');
-  let editDisplayName = $state('');
-  let savingIdentity = $state(false);
-  let identityError = $state<string | null>(null);
-  let lastLoginChange = $state<Date | null>(null);
-  let clearingCooldown = $state(false);
-  let adminPassword = $state('');
-  let adminConfirmPassword = $state('');
-  let passwordError = $state<string | null>(null);
-  let settingPassword = $state(false);
-
-  async function loadData() {
-    error = null;
-
-    try {
-      const resp = await adminUsersAPI().getMember(userId);
-
-      member = resp.member;
-      allRoles = resp.roles;
-      memberServerRoles = resp.member?.roles ?? [];
-      canAssignRoles = resp.viewerCanAssignRoles;
-      canManageRoles = resp.viewerCanManageRoles;
-      canManageUserPermissions = resp.viewerCanManageUserPermissions;
-      assignableRoleNames = resp.assignableRoleNames;
-      revocableRoleNames = resp.revocableRoleNames;
-      editLogin = resp.member?.login ?? '';
-      editDisplayName = resp.member?.displayName ?? '';
-      lastLoginChange = resp.member?.lastLoginChange ? new Date(resp.member.lastLoginChange) : null;
-    } catch (err) {
-      error = err instanceof Error ? err.message : m['admin.members.load_failed']();
-    } finally {
-      loading = false;
-    }
-  }
-
-  // Identity edit derivations
-  const loginModified = $derived(!!member && editLogin !== member.login);
-  const displayNameModified = $derived(!!member && editDisplayName !== member.displayName);
-  const identityModified = $derived(loginModified || displayNameModified);
-  const cooldownRemaining = $derived(getLoginChangeCooldownRemaining(lastLoginChange));
-  const cooldownActive = $derived(cooldownRemaining > 0);
-  const passwordSchema = z.string().min(8, m['common.validation.password_min']());
-  const adminPasswordValidationError = $derived(
-    adminPassword ? validate(passwordSchema, adminPassword) : undefined
+  const currentUser = $derived(serverRegistry.getStore(activeServerId).currentUser);
+  const memberDetail = new MemberDetailStore(() =>
+    connection().getAPI(createAdminUserManagementAPI)
   );
-  const adminConfirmPasswordError = $derived(
-    adminConfirmPassword && adminPassword !== adminConfirmPassword
-      ? m['common.validation.passwords_match']()
-      : undefined
-  );
-  const canSetMemberPassword = $derived(
-    !!member &&
-      adminPassword !== '' &&
-      adminConfirmPassword !== '' &&
-      !adminPasswordValidationError &&
-      !adminConfirmPasswordError &&
-      !settingPassword
-  );
-
-  function adminUsersAPI() {
-    return connection().getAPI(createAdminUserManagementAPI);
-  }
-
-  async function saveIdentity(e?: Event) {
-    e?.preventDefault();
-    if (!member || !identityModified || savingIdentity) return;
-
-    identityError = null;
-
-    const input: { userId: string; login?: string; displayName?: string } = { userId: member.id };
-
-    if (displayNameModified) {
-      const v = validateAndNormalizeDisplayName(editDisplayName);
-      if (!v.valid || v.normalized === undefined) {
-        identityError = v.error ?? 'Invalid display name';
-        return;
-      }
-      input.displayName = v.normalized;
-    }
-
-    if (loginModified) {
-      const v = validateAndNormalizeLogin(editLogin);
-      if (!v.valid || v.normalized === undefined) {
-        identityError = v.error ?? 'Invalid username';
-        return;
-      }
-      input.login = v.normalized;
-    }
-
-    savingIdentity = true;
-    let updated: { login: string; displayName: string } | null = null;
-    try {
-      updated = await adminUsersAPI().updateUser(input);
-    } catch (err) {
-      identityError = err instanceof Error ? err.message : 'Failed to update user';
-    }
-    savingIdentity = false;
-
-    if (!updated) {
-      return;
-    }
-
-    if (member) {
-      member = { ...member, login: updated.login, displayName: updated.displayName };
-      editLogin = updated.login;
-      editDisplayName = updated.displayName;
-      toast.success('User updated');
-      // Refetch so the rest of the page (live-login lookups, role assignments)
-      // sees the new identity without a manual reload.
-      await loadData();
-    }
-  }
-
-  function resetIdentity() {
-    if (!member) return;
-    editLogin = member.login;
-    editDisplayName = member.displayName;
-    identityError = null;
-  }
-
-  async function clearCooldown() {
-    if (!member || clearingCooldown) return;
-    clearingCooldown = true;
-    identityError = null;
-    let cleared = false;
-    try {
-      cleared = await adminUsersAPI().clearUsernameCooldown(member.id);
-    } catch (err) {
-      identityError = err instanceof Error ? err.message : 'Failed to clear username cooldown';
-    }
-    clearingCooldown = false;
-
-    if (!cleared) {
-      return;
-    }
-    lastLoginChange = null;
-    toast.success('Username change cooldown cleared');
-  }
-
-  async function setMemberPassword(e?: Event) {
-    e?.preventDefault();
-    if (!member || !canSetMemberPassword) {
-      passwordError =
-        adminPasswordValidationError ||
-        adminConfirmPasswordError ||
-        m['common.validation.fix_errors']();
-      return;
-    }
-
-    settingPassword = true;
-    passwordError = null;
-    let updatedMember: AdminMember | null = null;
-    try {
-      updatedMember = await adminUsersAPI().updateUserPassword(member.id, adminPassword);
-    } catch (err) {
-      passwordError = err instanceof Error ? err.message : m['admin.members.set_password_failed']();
-    }
-    settingPassword = false;
-
-    if (!updatedMember) {
-      return;
-    }
-    member = updatedMember;
-    adminPassword = '';
-    adminConfirmPassword = '';
-    toast.success(m['admin.members.password_set']());
-  }
-
-  // Check if user has a specific role (explicit assignment)
-  function hasRole(roleName: string): boolean {
-    return memberServerRoles.includes(roleName);
-  }
-
-  // Check if a role is implicit (always assigned to all members)
-  function isImplicitRole(roleName: string): boolean {
-    return IMPLICIT_ROLES.includes(roleName);
-  }
-
-  function getRoleDisplayName(roleName: string): string {
-    const role = allRoles.find((r) => r.name === roleName);
-    return role?.displayName || roleName;
-  }
-
-  function getRolePosition(roleName: string): number {
-    const role = allRoles.find((r) => r.name === roleName);
-    return role?.position ?? Number.MAX_SAFE_INTEGER;
-  }
-
-  // Check if this is the current user
   const isSelf = $derived(currentUser.user?.id === userId);
-  const canViewMemberEmails = $derived(isSelf || serverPerms.current.canAdminViewUsers);
-
-  // Sorted roles (excluding everyone, sorted by position)
-  const sortedServerRoles = $derived(
-    memberServerRoles
-      .filter((r) => r !== 'everyone')
-      .sort((a, b) => getRolePosition(a) - getRolePosition(b))
+  const canViewMemberEmails = $derived(isSelf || serverPermissions.current.canAdminViewUsers);
+  const canAdminManageAccounts = $derived(serverPermissions.current.canAdminManageAccounts);
+  const backHref = $derived(
+    resolve('/chat/[serverId]/manage/server/members', {
+      serverId: serverIdToSegment(activeServerId)
+    })
   );
-  const serverRoleCount = $derived(sortedServerRoles.length);
-  const cooldownSummary = $derived.by(() => {
-    if (cooldownActive) {
-      return m['admin.member_detail.self_rename_cooldown']({
-        remaining: formatCooldownRemaining(cooldownRemaining)
-      });
-    }
-    if (lastLoginChange) {
-      return m['admin.member_detail.last_self_rename']({
-        time: formatDateTime(lastLoginChange, userSettings, activeLocale)
-      });
-    }
-    return m['admin.member_detail.no_self_rename']();
-  });
 
-  function formatOptionalDate(date: string | null | undefined): string {
-    return date ? formatDate(date, userSettings, activeLocale) : m['admin.common.unknown']();
-  }
-
-  function emailSummary(user: AdminMember): string {
-    if (!canViewMemberEmails) return m['admin.member_detail.email_unavailable']();
-    if (user.verifiedEmails.length > 0) return user.verifiedEmails.join(', ');
-    if (user.hasVerifiedEmail) return m['admin.member_detail.verified_email_on_file']();
-    return m['admin.member_detail.no_verified_email']();
-  }
-
-  async function toggleRole(roleName: string, currentlyHas: boolean) {
-    if (!member) return;
-
-    updating = roleName;
-    error = null;
-
-    try {
-      const result = currentlyHas
-        ? await adminUsersAPI().revokeRole(member.id, roleName)
-        : await adminUsersAPI().assignRole(member.id, roleName);
-      if (result.changed) {
-        const displayName = getRoleDisplayName(roleName);
-        if (currentlyHas) {
-          toast.success(m['admin.members.removed_role']({ role: displayName }));
-        } else {
-          toast.success(m['admin.members.assigned_role']({ role: displayName }));
-        }
-        if (result.member) {
-          member = result.member;
-          memberServerRoles = result.member.roles;
-        } else {
-          await loadData();
-        }
-      }
-    } catch (err) {
-      error = err instanceof Error ? err.message : m['admin.members.role_update_failed']();
-    }
-
-    updating = null;
-  }
-
-  // Load data when params change
   $effect(() => {
-    if (userId) {
-      loadData();
-    }
+    void memberDetail.setMember(activeServerId, userId);
   });
 </script>
 
 <PageTitle
   title={m['admin.common.server_admin_page_title']({
-    title: member?.displayName ?? m['admin.members.member_fallback']()
+    title: memberDetail.member?.displayName ?? m['admin.members.member_fallback']()
   })}
 />
 
 <div class="pane-page">
   <PaneHeader
     title={m['admin.members.member_details']()}
-    subtitle={member?.displayName ?? m['common.loading']()}
-    backHref={resolve('/chat/[serverId]/manage/server/members', {
-      serverId: serverIdToSegment(getActiveServer())
-    })}
+    subtitle={memberDetail.member?.displayName ?? m['common.loading']()}
+    {backHref}
     backLabel={m['admin.members.back_to_members']()}
     showMobileNav
   />
 
   <PaneContent>
     <div class="flex flex-col gap-6">
-    {#if loading}
-      <div class="text-muted">{m['admin.members.loading_member']()}</div>
-    {:else if !member}
-      <Hint tone="danger">{m['admin.members.not_found']()}</Hint>
-    {:else}
-      {#if error}
-        <FormError {error} />
+      {#if memberDetail.loading}
+        <div class="text-muted">{m['admin.members.loading_member']()}</div>
+      {:else if !memberDetail.member}
+        <Hint tone="danger">{m['admin.members.not_found']()}</Hint>
+      {:else}
+        {#if memberDetail.error}
+          <FormError error={memberDetail.error} />
+        {/if}
+
+        <MemberOverviewPanel
+          member={memberDetail.member}
+          roles={memberDetail.roles}
+          {canViewMemberEmails}
+        />
+
+        {#if canAdminManageAccounts}
+          <MemberIdentitySettings store={memberDetail} {isSelf} />
+        {/if}
+
+        <MemberRoleAssignments store={memberDetail} {isSelf} serverId={activeServerId} />
+
+        {#if memberDetail.canManageUserPermissions}
+          <Hint>{m['admin.permissions.resolution_hint']()}</Hint>
+          <UserPermissionsMatrix {userId} />
+        {/if}
       {/if}
-
-      <!-- User Details -->
-      <Panel title={m['admin.members.user_details']()} icon="iconify uil--user">
-        <div class="flex flex-col gap-6">
-          <div class="flex flex-col gap-4 sm:flex-row sm:items-start">
-            {#if member.avatarUrl}
-              <img
-                src={member.avatarUrl}
-                alt={member.displayName}
-                class="h-20 w-20 rounded-full border border-border object-cover"
-              />
-            {:else}
-              <div
-                class="flex h-20 w-20 shrink-0 items-center justify-center rounded-full bg-surface-strong text-3xl text-muted"
-              >
-                {getAvatarInitials(member.displayName, member.login)}
-              </div>
-            {/if}
-
-            <div class="min-w-0 flex-1">
-              <div class="flex flex-col gap-1">
-                <h3 class="truncate text-2xl font-semibold">{member.displayName}</h3>
-                <div class="truncate text-muted">@{getLiveLogin(member.id, member.login)}</div>
-              </div>
-
-              <div class="mt-4 flex flex-wrap gap-2">
-                {#if member.deleted}
-                  <Pill tone="danger">{m['admin.members.deleted_account']()}</Pill>
-                {:else}
-                  <Pill tone="success">{m['admin.members.member']()}</Pill>
-                {/if}
-                {#if canViewMemberEmails}
-                  <Pill tone={member.hasVerifiedEmail ? 'success' : 'muted'}>
-                    {member.hasVerifiedEmail
-                      ? m['admin.members.email_verified']()
-                      : m['admin.members.email_not_verified']()}
-                  </Pill>
-                {:else}
-                  <Pill tone="muted">{m['admin.members.email_hidden']()}</Pill>
-                {/if}
-                <Pill tone={serverRoleCount > 0 ? 'neutral' : 'muted'}>
-                  {serverRoleCount === 1
-                    ? m['admin.members.server_role_one']()
-                    : m['admin.members.server_role_many']({ count: serverRoleCount })}
-                </Pill>
-                <Pill tone={member.viewerCanDeleteAccount ? 'danger' : 'muted'}>
-                  {member.viewerCanDeleteAccount
-                    ? m['admin.members.deletion_allowed']()
-                    : m['admin.members.deletion_protected']()}
-                </Pill>
-                <Pill tone={cooldownActive ? 'action' : 'muted'}>
-                  {cooldownActive
-                    ? m['admin.members.rename_cooldown']()
-                    : m['admin.members.rename_available']()}
-                </Pill>
-              </div>
-            </div>
-          </div>
-
-          <div class="grid gap-4 md:grid-cols-2">
-            <div class="min-w-0">
-              <div class="text-sm text-muted">{m['admin.members.user_id']()}</div>
-              <div class="mt-1 min-w-0">
-                <CopyId value={member.id} />
-              </div>
-            </div>
-            <div>
-              <div class="text-sm text-muted">{m['admin.common.joined']()}</div>
-              <div class="mt-1">{formatOptionalDate(member.createdAt)}</div>
-            </div>
-            <div class="min-w-0">
-              <div class="text-sm text-muted">{m['admin.members.verified_email']()}</div>
-              <div class="mt-1 truncate" title={emailSummary(member)}>
-                {emailSummary(member)}
-              </div>
-            </div>
-            <div>
-              <div class="text-sm text-muted">{m['admin.members.username_changes']()}</div>
-              <div class="mt-1">{cooldownSummary}</div>
-            </div>
-            <div class="min-w-0 md:col-span-2">
-              <div class="text-sm text-muted">{m['admin.members.server_roles']()}</div>
-              <div class="mt-1 flex flex-wrap gap-1">
-                {#each sortedServerRoles as roleName (roleName)}
-                  <Pill tone="neutral">{getRoleDisplayName(roleName)}</Pill>
-                {/each}
-                <Pill>{m['admin.members.member']()}</Pill>
-              </div>
-            </div>
-          </div>
-        </div>
-      </Panel>
-
-      {#if canAdminManageAccounts}
-        <!-- Identity (admin) — bypasses the 30-day rename cooldown -->
-        <Panel title={m['admin.members.identity']()} icon="iconify uil--edit">
-          <Form onsubmit={saveIdentity} error={identityError}>
-            <TextInput
-              id="member-login"
-              testid="admin-identity-login"
-              label={m['common.username']()}
-              bind:value={editLogin}
-              disabled={savingIdentity}
-              description={m['admin.members.admin_rename_description']()}
-            />
-            <TextInput
-              id="member-display-name"
-              testid="admin-identity-display-name"
-              label={m['settings.profile.display_name.label']()}
-              bind:value={editDisplayName}
-              disabled={savingIdentity}
-            />
-            {#snippet footer()}
-              <Button
-                type="submit"
-                disabled={!identityModified || savingIdentity}
-                loading={savingIdentity}
-                loadingText={m['rbac.role_form.saving']()}
-              >
-                {m['rbac.role_form.save']()}
-              </Button>
-              <Button
-                type="button"
-                variant="ghost"
-                onclick={resetIdentity}
-                disabled={!identityModified || savingIdentity}
-              >
-                {m['admin.members.reset']()}
-              </Button>
-            {/snippet}
-            <div class="flex items-center gap-3 surface-box p-3">
-              <div class="flex-1 text-sm text-muted">
-                {#if cooldownActive}
-                  {m['admin.members.cooldown_active']({
-                    remaining: formatCooldownRemaining(cooldownRemaining)
-                  })}
-                {:else if lastLoginChange}
-                  {m['admin.members.last_self_rename']({
-                    time: formatDateTime(lastLoginChange, userSettings, activeLocale)
-                  })}
-                {:else}
-                  {m['admin.members.never_renamed']()}
-                {/if}
-              </div>
-              <Button
-                type="button"
-                variant="ghost"
-                onclick={clearCooldown}
-                disabled={!cooldownActive}
-                loading={clearingCooldown}
-                loadingText={m['admin.members.clearing']()}
-              >
-                {m['admin.members.reset_cooldown']()}
-              </Button>
-            </div>
-          </Form>
-          {#if !isSelf}
-            <form
-              class="mt-6 flex flex-col gap-4 border-t border-border pt-6"
-              onsubmit={setMemberPassword}
-            >
-              <div>
-                <h4 class="text-sm font-semibold">{m['admin.members.set_password']()}</h4>
-                <p class="mt-1 text-sm text-muted">
-                  {m['admin.members.set_password_description']()}
-                </p>
-              </div>
-              <TextInput
-                id="admin-member-password"
-                label={m['common.new_password']()}
-                type="password"
-                bind:value={adminPassword}
-                placeholder={m['common.password_min_placeholder']()}
-                disabled={settingPassword}
-                autocomplete="new-password"
-                error={adminPasswordValidationError}
-              />
-              <TextInput
-                id="admin-member-password-confirm"
-                label={m['common.confirm_password']()}
-                type="password"
-                bind:value={adminConfirmPassword}
-                placeholder={m['common.password_confirm_placeholder']()}
-                disabled={settingPassword}
-                autocomplete="new-password"
-                error={adminConfirmPasswordError}
-              />
-              {#if passwordError}
-                <FormError error={passwordError} />
-              {/if}
-              <div>
-                <Button
-                  type="submit"
-                  loading={settingPassword}
-                  loadingText={m['admin.members.setting_password']()}
-                  disabled={!canSetMemberPassword}
-                >
-                  <span class="iconify mdi--key-change"></span>
-                  {m['admin.members.set_password']()}
-                </Button>
-              </div>
-            </form>
-          {/if}
-        </Panel>
-      {/if}
-
-      <!-- Role Assignments -->
-      <Panel title={m['admin.members.role_assignments']()} icon="iconify uil--shield-check">
-        <p class="mb-4 text-sm text-muted">
-          {#if canAssignRoles}
-            {m['admin.members.assign_roles_description']()}
-          {:else}
-            {m['admin.members.view_roles_description']()}
-          {/if}
-        </p>
-
-        <div class="flex flex-col gap-2">
-          {#each allRoles as role (role.name)}
-            {@const isImplicit = isImplicitRole(role.name)}
-            {@const has = isImplicit || hasRole(role.name)}
-            {@const isUpdating = updating === role.name}
-            {@const isSelfProtectedRole =
-              isSelf && (role.name === 'admin' || role.name === 'owner') && has}
-            {@const isWithinAssignmentAuthority = has
-              ? revocableRoleNames === null || revocableRoleNames.includes(role.name)
-              : assignableRoleNames === null || assignableRoleNames.includes(role.name)}
-            {@const isDisabled =
-              !canAssignRoles ||
-              isImplicit ||
-              isUpdating ||
-              isSelfProtectedRole ||
-              !isWithinAssignmentAuthority}
-            {@const tooltip = isImplicit
-              ? m['admin.members.implicit_role_tooltip']()
-              : isSelfProtectedRole
-                ? m['admin.members.cannot_revoke_own_role']({ role: role.displayName })
-                : !isWithinAssignmentAuthority
-                  ? m['ui.access_denied.message']()
-                  : ''}
-
-            <div class="flex items-center gap-3">
-              <div class="min-w-0 flex-1" title={tooltip}>
-                <Checkbox
-                  id={`role-assignment-${role.name}`}
-                  checked={has}
-                  disabled={isDisabled}
-                  loading={isUpdating}
-                  onchange={() => toggleRole(role.name, has)}
-                >
-                  <span class="block">{role.displayName}</span>
-                  {#if isImplicit}
-                    <span class="block text-xs font-normal text-muted">
-                      {m['admin.members.implicit_all_members']()}
-                    </span>
-                  {/if}
-                </Checkbox>
-              </div>
-              {#if canManageRoles}
-                <a
-                  href={resolve('/chat/[serverId]/manage/server/permissions/[name]', {
-                    serverId: serverIdToSegment(getActiveServer()),
-                    name: role.name
-                  })}
-                  class="shrink-0 text-sm link"
-                >
-                  {m['admin.members.edit']()}
-                </a>
-              {/if}
-            </div>
-          {/each}
-        </div>
-      </Panel>
-
-      {#if canManageUserPermissions}
-        <!-- Per-user permission overrides. -->
-        <Hint>{m['admin.permissions.resolution_hint']()}</Hint>
-        <UserPermissionsMatrix {userId} />
-      {/if}
-    {/if}
     </div>
   </PaneContent>
 </div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberDetailStore.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberDetailStore.svelte.spec.ts
@@ -1,0 +1,196 @@
+import type {
+  AdminMember,
+  AdminMemberDetails,
+  AdminUserManagementAPI
+} from '$lib/api-client/adminUsers';
+import { describe, expect, it, vi } from 'vitest';
+import { MemberDetailStore } from './MemberDetailStore.svelte';
+
+function member(id: string, roles = ['everyone']): AdminMember {
+  return {
+    id,
+    login: id,
+    displayName: id.toUpperCase(),
+    avatarUrl: null,
+    roles,
+    createdAt: '2026-01-01T12:00:00Z',
+    deleted: false,
+    hasVerifiedEmail: false,
+    verifiedEmails: [],
+    viewerCanDeleteAccount: true,
+    lastLoginChange: null
+  };
+}
+
+function details(value: AdminMember): AdminMemberDetails {
+  return {
+    member: value,
+    roles: [
+      {
+        name: 'everyone',
+        displayName: 'Everyone',
+        position: 0,
+        permissions: [],
+        permissionDenials: []
+      },
+      {
+        name: 'admin',
+        displayName: 'Admin',
+        position: 1,
+        permissions: [],
+        permissionDenials: []
+      }
+    ],
+    availablePermissions: [],
+    viewerCanAssignRoles: true,
+    viewerCanManageRoles: true,
+    viewerCanManageUserPermissions: true,
+    assignableRoleNames: null,
+    revocableRoleNames: null
+  };
+}
+
+function api(overrides: Partial<AdminUserManagementAPI> = {}): AdminUserManagementAPI {
+  return {
+    listMembers: vi.fn(),
+    getMember: vi.fn().mockResolvedValue(details(member('default'))),
+    assignRole: vi.fn(),
+    revokeRole: vi.fn(),
+    updateUser: vi.fn(),
+    updateUserPassword: vi.fn(),
+    clearUsernameCooldown: vi.fn(),
+    deleteUser: vi.fn(),
+    ...overrides
+  } as AdminUserManagementAPI;
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+describe('MemberDetailStore', () => {
+  it('ignores an older member response after the route changes', async () => {
+    const aliceDetails = deferred<AdminMemberDetails>();
+    const getMember = vi
+      .fn()
+      .mockReturnValueOnce(aliceDetails.promise)
+      .mockResolvedValueOnce(details(member('bob')));
+    const store = new MemberDetailStore(() => api({ getMember }));
+
+    const staleLoad = store.setMember('server-1', 'alice');
+    const currentLoad = store.setMember('server-1', 'bob');
+    await currentLoad;
+
+    aliceDetails.resolve(details(member('alice')));
+    await staleLoad;
+
+    expect(getMember).toHaveBeenNthCalledWith(1, 'alice');
+    expect(getMember).toHaveBeenNthCalledWith(2, 'bob');
+    expect(store.member).toEqual(member('bob'));
+    expect(store.loading).toBe(false);
+  });
+
+  it('reloads and fences member details when the server changes with the same user ID', async () => {
+    const firstServerDetails = deferred<AdminMemberDetails>();
+    const getMember = vi
+      .fn()
+      .mockReturnValueOnce(firstServerDetails.promise)
+      .mockResolvedValueOnce(details({ ...member('shared-user'), displayName: 'Server Two User' }));
+    const store = new MemberDetailStore(() => api({ getMember }));
+
+    const staleLoad = store.setMember('server-1', 'shared-user');
+    await store.setMember('server-2', 'shared-user');
+    firstServerDetails.resolve(
+      details({ ...member('shared-user'), displayName: 'Server One User' })
+    );
+    await staleLoad;
+
+    expect(getMember).toHaveBeenCalledTimes(2);
+    expect(store.member?.displayName).toBe('Server Two User');
+  });
+
+  it('does not apply a completed role mutation to the next member', async () => {
+    const assignment = deferred<{
+      changed: boolean;
+      member: AdminMember | null;
+    }>();
+    const getMember = vi
+      .fn()
+      .mockResolvedValueOnce(details(member('alice')))
+      .mockResolvedValueOnce(details(member('bob')));
+    const assignRole = vi.fn().mockReturnValue(assignment.promise);
+    const store = new MemberDetailStore(() => api({ getMember, assignRole }));
+
+    await store.setMember('server-1', 'alice');
+    const staleAssignment = store.toggleRole('admin', false);
+    await store.setMember('server-1', 'bob');
+    assignment.resolve({
+      changed: true,
+      member: member('alice', ['everyone', 'admin'])
+    });
+    await staleAssignment;
+
+    expect(assignRole).toHaveBeenCalledWith('alice', 'admin');
+    expect(store.member).toEqual(member('bob'));
+    expect(store.updatingRole).toBe(null);
+  });
+
+  it('keeps role-command success authoritative when the canonical reread fails', async () => {
+    const getMember = vi
+      .fn()
+      .mockResolvedValueOnce(details(member('alice')))
+      .mockRejectedValueOnce(new Error('projection temporarily unavailable'));
+    const assignRole = vi.fn().mockResolvedValue({ changed: true, member: null });
+    const store = new MemberDetailStore(() => api({ getMember, assignRole }));
+
+    await store.setMember('server-1', 'alice');
+
+    expect(await store.toggleRole('admin', false)).toBe(true);
+    expect(store.error).toBe('projection temporarily unavailable');
+    expect(store.updatingRole).toBe(null);
+  });
+
+  it('applies successful identity and password updates to the current member', async () => {
+    const updateUser = vi.fn().mockResolvedValue({
+      id: 'alice',
+      login: 'alice-renamed',
+      displayName: 'Alice Renamed',
+      avatarUrl: null
+    });
+    const updatedMember = {
+      ...member('alice'),
+      login: 'alice-renamed',
+      displayName: 'Alice Renamed'
+    };
+    const updateUserPassword = vi.fn().mockResolvedValue(updatedMember);
+    const store = new MemberDetailStore(() =>
+      api({
+        getMember: vi.fn().mockResolvedValue(details(member('alice'))),
+        updateUser,
+        updateUserPassword
+      })
+    );
+
+    await store.setMember('server-1', 'alice');
+    await store.updateIdentity({
+      login: 'alice-renamed',
+      displayName: 'Alice Renamed'
+    });
+    await store.updatePassword('new-password');
+
+    expect(updateUser).toHaveBeenCalledWith({
+      userId: 'alice',
+      login: 'alice-renamed',
+      displayName: 'Alice Renamed'
+    });
+    expect(updateUserPassword).toHaveBeenCalledWith('alice', 'new-password');
+    expect(store.member).toEqual(updatedMember);
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberDetailStore.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberDetailStore.svelte.ts
@@ -1,0 +1,201 @@
+import type {
+  AdminManagedUser,
+  AdminMember,
+  AdminMemberDetails,
+  AdminRoleDetails,
+  AdminUserManagementAPI
+} from '$lib/api-client/adminUsers';
+import * as m from '$lib/i18n/messages';
+
+type APIProvider = () => AdminUserManagementAPI;
+type MemberTarget = {
+  serverId: string;
+  userId: string;
+  generation: number;
+};
+
+/**
+ * Owns the member-detail page's read and mutation lifecycle.
+ *
+ * SvelteKit preserves the page while only the member route parameter changes,
+ * so every async operation is fenced to the member and generation that started
+ * it. Older responses must never restore the previous member's details.
+ */
+export class MemberDetailStore {
+  member = $state.raw<AdminMember | null>(null);
+  roles = $state.raw<AdminRoleDetails[]>([]);
+  canAssignRoles = $state(false);
+  canManageRoles = $state(false);
+  canManageUserPermissions = $state(false);
+  assignableRoleNames = $state.raw<string[] | null>(null);
+  revocableRoleNames = $state.raw<string[] | null>(null);
+  loading = $state(true);
+  updatingRole = $state<string | null>(null);
+  error = $state<string | null>(null);
+
+  readonly #getAPI: APIProvider;
+  #serverId = '';
+  #userId = '';
+  #generation = 0;
+
+  constructor(getAPI: APIProvider) {
+    this.#getAPI = getAPI;
+  }
+
+  setMember(serverId: string, userId: string): Promise<void> {
+    if (serverId === this.#serverId && userId === this.#userId) return Promise.resolve();
+
+    this.#serverId = serverId;
+    this.#userId = userId;
+    const generation = ++this.#generation;
+    this.#clear();
+
+    if (!serverId || !userId) return Promise.resolve();
+
+    this.loading = true;
+    return this.#load({ serverId, userId, generation });
+  }
+
+  async updateIdentity(input: {
+    login?: string;
+    displayName?: string;
+  }): Promise<AdminManagedUser | null> {
+    const target = this.#target();
+    if (!target || !this.member) return null;
+
+    const updated = await this.#getAPI().updateUser({
+      userId: target.userId,
+      ...input
+    });
+    if (!this.#isCurrent(target) || !this.member) return null;
+
+    this.member = {
+      ...this.member,
+      login: updated.login,
+      displayName: updated.displayName
+    };
+    return updated;
+  }
+
+  async clearUsernameCooldown(): Promise<boolean> {
+    const target = this.#target();
+    if (!target || !this.member) return false;
+
+    const cleared = await this.#getAPI().clearUsernameCooldown(target.userId);
+    if (!cleared || !this.#isCurrent(target) || !this.member) return false;
+
+    this.member = { ...this.member, lastLoginChange: null };
+    return true;
+  }
+
+  async updatePassword(password: string): Promise<AdminMember | null> {
+    const target = this.#target();
+    if (!target || !this.member) return null;
+
+    const updated = await this.#getAPI().updateUserPassword(target.userId, password);
+    if (!this.#isCurrent(target)) return null;
+
+    this.member = updated;
+    return updated;
+  }
+
+  async toggleRole(roleName: string, currentlyHasRole: boolean): Promise<boolean> {
+    const target = this.#target();
+    if (!target || !this.member || this.updatingRole) return false;
+
+    this.updatingRole = roleName;
+    this.error = null;
+
+    try {
+      let result;
+      try {
+        result = currentlyHasRole
+          ? await this.#getAPI().revokeRole(target.userId, roleName)
+          : await this.#getAPI().assignRole(target.userId, roleName);
+      } catch (error) {
+        if (this.#isCurrent(target)) {
+          this.error =
+            error instanceof Error ? error.message : m['admin.members.role_update_failed']();
+        }
+        return false;
+      }
+
+      if (!this.#isCurrent(target) || !result.changed) return false;
+
+      if (result.member) {
+        this.member = result.member;
+      } else {
+        try {
+          await this.#refresh(target);
+        } catch (error) {
+          if (this.#isCurrent(target)) {
+            this.error = error instanceof Error ? error.message : m['admin.members.load_failed']();
+          }
+        }
+      }
+
+      return this.#isCurrent(target);
+    } finally {
+      if (this.#isCurrent(target)) this.updatingRole = null;
+    }
+  }
+
+  #clear(): void {
+    this.member = null;
+    this.roles = [];
+    this.canAssignRoles = false;
+    this.canManageRoles = false;
+    this.canManageUserPermissions = false;
+    this.assignableRoleNames = null;
+    this.revocableRoleNames = null;
+    this.loading = false;
+    this.updatingRole = null;
+    this.error = null;
+  }
+
+  async #load(target: MemberTarget): Promise<void> {
+    try {
+      const details = await this.#getAPI().getMember(target.userId);
+      if (!this.#isCurrent(target)) return;
+      this.#apply(details);
+    } catch (error) {
+      if (!this.#isCurrent(target)) return;
+      this.error = error instanceof Error ? error.message : m['admin.members.load_failed']();
+    } finally {
+      if (this.#isCurrent(target)) this.loading = false;
+    }
+  }
+
+  async #refresh(target: MemberTarget): Promise<void> {
+    const details = await this.#getAPI().getMember(target.userId);
+    if (this.#isCurrent(target)) this.#apply(details);
+  }
+
+  #apply(details: AdminMemberDetails): void {
+    this.member = details.member;
+    this.roles = details.roles;
+    this.canAssignRoles = details.viewerCanAssignRoles;
+    this.canManageRoles = details.viewerCanManageRoles;
+    this.canManageUserPermissions = details.viewerCanManageUserPermissions;
+    this.assignableRoleNames = details.assignableRoleNames;
+    this.revocableRoleNames = details.revocableRoleNames;
+  }
+
+  #target(): MemberTarget | null {
+    return this.#serverId && this.#userId
+      ? {
+          serverId: this.#serverId,
+          userId: this.#userId,
+          generation: this.#generation
+        }
+      : null;
+  }
+
+  #isCurrent(target: MemberTarget): boolean {
+    return (
+      target.serverId === this.#serverId &&
+      target.userId === this.#userId &&
+      target.generation === this.#generation
+    );
+  }
+}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberIdentitySettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberIdentitySettings.svelte
@@ -1,0 +1,267 @@
+<script lang="ts">
+  import { Panel } from '$lib/components/admin';
+  import * as m from '$lib/i18n/messages';
+  import { getLocale } from '$lib/i18n/runtime';
+  import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { Button, Form, FormError, TextInput, validate, z } from '$lib/ui/form';
+  import { toast } from '$lib/ui/toast';
+  import { formatDateTime } from '$lib/utils/formatTime';
+  import { untrack } from 'svelte';
+  import {
+    formatCooldownRemaining,
+    getLoginChangeCooldownRemaining,
+    validateAndNormalizeDisplayName,
+    validateAndNormalizeLogin
+  } from '$lib/validation';
+  import type { MemberDetailStore } from './MemberDetailStore.svelte';
+
+  type Props = {
+    store: MemberDetailStore;
+    isSelf: boolean;
+  };
+
+  let { store, isSelf }: Props = $props();
+
+  const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
+  const member = $derived(store.member);
+  // These are edit buffers, not mirrors. The parent unmounts this component
+  // while switching members, so capture the current values once per member.
+  let editLogin = $state(untrack(() => store.member?.login ?? ''));
+  let editDisplayName = $state(untrack(() => store.member?.displayName ?? ''));
+  let identityError = $state<string | null>(null);
+  let savingIdentity = $state(false);
+  let clearingCooldown = $state(false);
+  let adminPassword = $state('');
+  let adminConfirmPassword = $state('');
+  let passwordError = $state<string | null>(null);
+  let settingPassword = $state(false);
+
+  const loginModified = $derived(!!member && editLogin !== member.login);
+  const displayNameModified = $derived(!!member && editDisplayName !== member.displayName);
+  const identityModified = $derived(loginModified || displayNameModified);
+  const lastLoginChange = $derived(
+    member?.lastLoginChange ? new Date(member.lastLoginChange) : null
+  );
+  const cooldownRemaining = $derived(getLoginChangeCooldownRemaining(lastLoginChange));
+  const cooldownActive = $derived(cooldownRemaining > 0);
+  const passwordSchema = z.string().min(8, m['common.validation.password_min']());
+  const adminPasswordValidationError = $derived(
+    adminPassword ? validate(passwordSchema, adminPassword) : undefined
+  );
+  const adminConfirmPasswordError = $derived(
+    adminConfirmPassword && adminPassword !== adminConfirmPassword
+      ? m['common.validation.passwords_match']()
+      : undefined
+  );
+  const canSetMemberPassword = $derived(
+    !!member &&
+      adminPassword !== '' &&
+      adminConfirmPassword !== '' &&
+      !adminPasswordValidationError &&
+      !adminConfirmPasswordError &&
+      !settingPassword
+  );
+
+  async function saveIdentity(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (!member || !identityModified || savingIdentity) return;
+
+    identityError = null;
+    const input: { login?: string; displayName?: string } = {};
+
+    if (displayNameModified) {
+      const result = validateAndNormalizeDisplayName(editDisplayName);
+      if (!result.valid || result.normalized === undefined) {
+        identityError = result.error ?? 'Invalid display name';
+        return;
+      }
+      input.displayName = result.normalized;
+    }
+
+    if (loginModified) {
+      const result = validateAndNormalizeLogin(editLogin);
+      if (!result.valid || result.normalized === undefined) {
+        identityError = result.error ?? 'Invalid username';
+        return;
+      }
+      input.login = result.normalized;
+    }
+
+    savingIdentity = true;
+    try {
+      const updated = await store.updateIdentity(input);
+      if (updated) {
+        editLogin = updated.login;
+        editDisplayName = updated.displayName;
+        toast.success('User updated');
+      }
+    } catch (error) {
+      identityError = error instanceof Error ? error.message : 'Failed to update user';
+    } finally {
+      savingIdentity = false;
+    }
+  }
+
+  function resetIdentity(): void {
+    if (!member) return;
+    editLogin = member.login;
+    editDisplayName = member.displayName;
+    identityError = null;
+  }
+
+  async function clearCooldown(): Promise<void> {
+    if (!member || clearingCooldown) return;
+
+    clearingCooldown = true;
+    identityError = null;
+    try {
+      if (await store.clearUsernameCooldown()) {
+        toast.success('Username change cooldown cleared');
+      }
+    } catch (error) {
+      identityError = error instanceof Error ? error.message : 'Failed to clear username cooldown';
+    } finally {
+      clearingCooldown = false;
+    }
+  }
+
+  async function setMemberPassword(event: SubmitEvent): Promise<void> {
+    event.preventDefault();
+    if (!member || !canSetMemberPassword) {
+      passwordError =
+        adminPasswordValidationError ||
+        adminConfirmPasswordError ||
+        m['common.validation.fix_errors']();
+      return;
+    }
+
+    settingPassword = true;
+    passwordError = null;
+    try {
+      if (await store.updatePassword(adminPassword)) {
+        adminPassword = '';
+        adminConfirmPassword = '';
+        toast.success(m['admin.members.password_set']());
+      }
+    } catch (error) {
+      passwordError =
+        error instanceof Error ? error.message : m['admin.members.set_password_failed']();
+    } finally {
+      settingPassword = false;
+    }
+  }
+</script>
+
+{#if member}
+  <Panel title={m['admin.members.identity']()} icon="iconify uil--edit">
+    <Form onsubmit={saveIdentity} error={identityError}>
+      <TextInput
+        id="member-login"
+        testid="admin-identity-login"
+        label={m['common.username']()}
+        bind:value={editLogin}
+        disabled={savingIdentity}
+        description={m['admin.members.admin_rename_description']()}
+      />
+      <TextInput
+        id="member-display-name"
+        testid="admin-identity-display-name"
+        label={m['settings.profile.display_name.label']()}
+        bind:value={editDisplayName}
+        disabled={savingIdentity}
+      />
+      {#snippet footer()}
+        <Button
+          type="submit"
+          disabled={!identityModified || savingIdentity}
+          loading={savingIdentity}
+          loadingText={m['rbac.role_form.saving']()}
+        >
+          {m['rbac.role_form.save']()}
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onclick={resetIdentity}
+          disabled={!identityModified || savingIdentity}
+        >
+          {m['admin.members.reset']()}
+        </Button>
+      {/snippet}
+      <div class="flex items-center gap-3 surface-box p-3">
+        <div class="flex-1 text-sm text-muted">
+          {#if cooldownActive}
+            {m['admin.members.cooldown_active']({
+              remaining: formatCooldownRemaining(cooldownRemaining)
+            })}
+          {:else if lastLoginChange}
+            {m['admin.members.last_self_rename']({
+              time: formatDateTime(lastLoginChange, userSettings, activeLocale)
+            })}
+          {:else}
+            {m['admin.members.never_renamed']()}
+          {/if}
+        </div>
+        <Button
+          type="button"
+          variant="ghost"
+          onclick={clearCooldown}
+          disabled={!cooldownActive}
+          loading={clearingCooldown}
+          loadingText={m['admin.members.clearing']()}
+        >
+          {m['admin.members.reset_cooldown']()}
+        </Button>
+      </div>
+    </Form>
+
+    {#if !isSelf}
+      <form
+        class="mt-6 flex flex-col gap-4 border-t border-border pt-6"
+        onsubmit={setMemberPassword}
+      >
+        <div>
+          <h4 class="text-sm font-semibold">{m['admin.members.set_password']()}</h4>
+          <p class="mt-1 text-sm text-muted">
+            {m['admin.members.set_password_description']()}
+          </p>
+        </div>
+        <TextInput
+          id="admin-member-password"
+          label={m['common.new_password']()}
+          type="password"
+          bind:value={adminPassword}
+          placeholder={m['common.password_min_placeholder']()}
+          disabled={settingPassword}
+          autocomplete="new-password"
+          error={adminPasswordValidationError}
+        />
+        <TextInput
+          id="admin-member-password-confirm"
+          label={m['common.confirm_password']()}
+          type="password"
+          bind:value={adminConfirmPassword}
+          placeholder={m['common.password_confirm_placeholder']()}
+          disabled={settingPassword}
+          autocomplete="new-password"
+          error={adminConfirmPasswordError}
+        />
+        {#if passwordError}
+          <FormError error={passwordError} />
+        {/if}
+        <div>
+          <Button
+            type="submit"
+            loading={settingPassword}
+            loadingText={m['admin.members.setting_password']()}
+            disabled={!canSetMemberPassword}
+          >
+            <span class="iconify mdi--key-change"></span>
+            {m['admin.members.set_password']()}
+          </Button>
+        </div>
+      </form>
+    {/if}
+  </Panel>
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberOverviewPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberOverviewPanel.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+  import type { AdminMember, AdminRoleDetails } from '$lib/api-client/adminUsers';
+  import { CopyId, Panel } from '$lib/components/admin';
+  import * as m from '$lib/i18n/messages';
+  import { getLocale } from '$lib/i18n/runtime';
+  import { getLiveLogin } from '$lib/state/userProfiles.svelte';
+  import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { Pill } from '$lib/ui';
+  import { formatDate, formatDateTime } from '$lib/utils/formatTime';
+  import { getAvatarInitials } from '$lib/utils/initials';
+  import { formatCooldownRemaining, getLoginChangeCooldownRemaining } from '$lib/validation';
+
+  type Props = {
+    member: AdminMember;
+    roles: AdminRoleDetails[];
+    canViewMemberEmails: boolean;
+  };
+
+  let { member, roles, canViewMemberEmails }: Props = $props();
+
+  const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
+  const lastLoginChange = $derived(
+    member.lastLoginChange ? new Date(member.lastLoginChange) : null
+  );
+  const cooldownRemaining = $derived(getLoginChangeCooldownRemaining(lastLoginChange));
+  const cooldownActive = $derived(cooldownRemaining > 0);
+  const sortedServerRoles = $derived(
+    member.roles
+      .filter((roleName) => roleName !== 'everyone')
+      .sort((a, b) => rolePosition(a) - rolePosition(b))
+  );
+  const serverRoleCount = $derived(sortedServerRoles.length);
+  const cooldownSummary = $derived.by(() => {
+    if (cooldownActive) {
+      return m['admin.member_detail.self_rename_cooldown']({
+        remaining: formatCooldownRemaining(cooldownRemaining)
+      });
+    }
+    if (lastLoginChange) {
+      return m['admin.member_detail.last_self_rename']({
+        time: formatDateTime(lastLoginChange, userSettings, activeLocale)
+      });
+    }
+    return m['admin.member_detail.no_self_rename']();
+  });
+
+  function roleDisplayName(roleName: string): string {
+    return roles.find((role) => role.name === roleName)?.displayName ?? roleName;
+  }
+
+  function rolePosition(roleName: string): number {
+    return roles.find((role) => role.name === roleName)?.position ?? Number.MAX_SAFE_INTEGER;
+  }
+
+  function formatOptionalDate(date: string | null | undefined): string {
+    return date ? formatDate(date, userSettings, activeLocale) : m['admin.common.unknown']();
+  }
+
+  function emailSummary(): string {
+    if (!canViewMemberEmails) return m['admin.member_detail.email_unavailable']();
+    if (member.verifiedEmails.length > 0) return member.verifiedEmails.join(', ');
+    if (member.hasVerifiedEmail) return m['admin.member_detail.verified_email_on_file']();
+    return m['admin.member_detail.no_verified_email']();
+  }
+</script>
+
+<Panel title={m['admin.members.user_details']()} icon="iconify uil--user">
+  <div class="flex flex-col gap-6">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-start">
+      {#if member.avatarUrl}
+        <img
+          src={member.avatarUrl}
+          alt={member.displayName}
+          class="h-20 w-20 rounded-full border border-border object-cover"
+        />
+      {:else}
+        <div
+          class="flex h-20 w-20 shrink-0 items-center justify-center rounded-full bg-surface-strong text-3xl text-muted"
+        >
+          {getAvatarInitials(member.displayName, member.login)}
+        </div>
+      {/if}
+
+      <div class="min-w-0 flex-1">
+        <div class="flex flex-col gap-1">
+          <h3 class="truncate text-2xl font-semibold">{member.displayName}</h3>
+          <div class="truncate text-muted">@{getLiveLogin(member.id, member.login)}</div>
+        </div>
+
+        <div class="mt-4 flex flex-wrap gap-2">
+          {#if member.deleted}
+            <Pill tone="danger">{m['admin.members.deleted_account']()}</Pill>
+          {:else}
+            <Pill tone="success">{m['admin.members.member']()}</Pill>
+          {/if}
+          {#if canViewMemberEmails}
+            <Pill tone={member.hasVerifiedEmail ? 'success' : 'muted'}>
+              {member.hasVerifiedEmail
+                ? m['admin.members.email_verified']()
+                : m['admin.members.email_not_verified']()}
+            </Pill>
+          {:else}
+            <Pill tone="muted">{m['admin.members.email_hidden']()}</Pill>
+          {/if}
+          <Pill tone={serverRoleCount > 0 ? 'neutral' : 'muted'}>
+            {serverRoleCount === 1
+              ? m['admin.members.server_role_one']()
+              : m['admin.members.server_role_many']({ count: serverRoleCount })}
+          </Pill>
+          <Pill tone={member.viewerCanDeleteAccount ? 'danger' : 'muted'}>
+            {member.viewerCanDeleteAccount
+              ? m['admin.members.deletion_allowed']()
+              : m['admin.members.deletion_protected']()}
+          </Pill>
+          <Pill tone={cooldownActive ? 'action' : 'muted'}>
+            {cooldownActive
+              ? m['admin.members.rename_cooldown']()
+              : m['admin.members.rename_available']()}
+          </Pill>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid gap-4 md:grid-cols-2">
+      <div class="min-w-0">
+        <div class="text-sm text-muted">{m['admin.members.user_id']()}</div>
+        <div class="mt-1 min-w-0">
+          <CopyId value={member.id} />
+        </div>
+      </div>
+      <div>
+        <div class="text-sm text-muted">{m['admin.common.joined']()}</div>
+        <div class="mt-1">{formatOptionalDate(member.createdAt)}</div>
+      </div>
+      <div class="min-w-0">
+        <div class="text-sm text-muted">{m['admin.members.verified_email']()}</div>
+        <div class="mt-1 truncate" title={emailSummary()}>
+          {emailSummary()}
+        </div>
+      </div>
+      <div>
+        <div class="text-sm text-muted">{m['admin.members.username_changes']()}</div>
+        <div class="mt-1">{cooldownSummary}</div>
+      </div>
+      <div class="min-w-0 md:col-span-2">
+        <div class="text-sm text-muted">{m['admin.members.server_roles']()}</div>
+        <div class="mt-1 flex flex-wrap gap-1">
+          {#each sortedServerRoles as roleName (roleName)}
+            <Pill tone="neutral">{roleDisplayName(roleName)}</Pill>
+          {/each}
+          <Pill>{m['admin.members.member']()}</Pill>
+        </div>
+      </div>
+    </div>
+  </div>
+</Panel>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberRoleAssignments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/MemberRoleAssignments.svelte
@@ -1,0 +1,102 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { Panel } from '$lib/components/admin';
+  import * as m from '$lib/i18n/messages';
+  import { serverIdToSegment } from '$lib/navigation';
+  import { Checkbox } from '$lib/ui/form';
+  import { toast } from '$lib/ui/toast';
+  import type { MemberDetailStore } from './MemberDetailStore.svelte';
+
+  type Props = {
+    store: MemberDetailStore;
+    isSelf: boolean;
+    serverId: string;
+  };
+
+  let { store, isSelf, serverId }: Props = $props();
+
+  const memberRoles = $derived(store.member?.roles ?? []);
+
+  function hasRole(roleName: string): boolean {
+    return memberRoles.includes(roleName);
+  }
+
+  function isImplicitRole(roleName: string): boolean {
+    return roleName === 'everyone';
+  }
+
+  async function toggleRole(roleName: string, currentlyHasRole: boolean): Promise<void> {
+    if (!(await store.toggleRole(roleName, currentlyHasRole))) return;
+
+    const displayName = store.roles.find((role) => role.name === roleName)?.displayName ?? roleName;
+    toast.success(
+      currentlyHasRole
+        ? m['admin.members.removed_role']({ role: displayName })
+        : m['admin.members.assigned_role']({ role: displayName })
+    );
+  }
+</script>
+
+<Panel title={m['admin.members.role_assignments']()} icon="iconify uil--shield-check">
+  <p class="mb-4 text-sm text-muted">
+    {store.canAssignRoles
+      ? m['admin.members.assign_roles_description']()
+      : m['admin.members.view_roles_description']()}
+  </p>
+
+  <div class="flex flex-col gap-2">
+    {#each store.roles as role (role.name)}
+      {@const isImplicit = isImplicitRole(role.name)}
+      {@const has = isImplicit || hasRole(role.name)}
+      {@const isUpdating = store.updatingRole === role.name}
+      {@const isSelfProtectedRole =
+        isSelf && (role.name === 'admin' || role.name === 'owner') && has}
+      {@const isWithinAssignmentAuthority = has
+        ? store.revocableRoleNames === null || store.revocableRoleNames.includes(role.name)
+        : store.assignableRoleNames === null || store.assignableRoleNames.includes(role.name)}
+      {@const isDisabled =
+        !store.canAssignRoles ||
+        isImplicit ||
+        isUpdating ||
+        isSelfProtectedRole ||
+        !isWithinAssignmentAuthority}
+      {@const tooltip = isImplicit
+        ? m['admin.members.implicit_role_tooltip']()
+        : isSelfProtectedRole
+          ? m['admin.members.cannot_revoke_own_role']({ role: role.displayName })
+          : !isWithinAssignmentAuthority
+            ? m['ui.access_denied.message']()
+            : ''}
+
+      <div class="flex items-center gap-3">
+        <div class="min-w-0 flex-1" title={tooltip}>
+          <Checkbox
+            id={`role-assignment-${role.name}`}
+            checked={has}
+            disabled={isDisabled}
+            loading={isUpdating}
+            onchange={() => toggleRole(role.name, has)}
+          >
+            <span class="block">{role.displayName}</span>
+            {#if isImplicit}
+              <span class="block text-xs font-normal text-muted">
+                {m['admin.members.implicit_all_members']()}
+              </span>
+            {/if}
+          </Checkbox>
+        </div>
+        {#if store.canManageRoles}
+          <a
+            href={resolve('/chat/[serverId]/manage/server/permissions/[name]', {
+              serverId: serverIdToSegment(serverId),
+              name: role.name
+            })}
+            class="shrink-0 text-sm link"
+          >
+            {m['admin.members.edit']()}
+          </a>
+        {/if}
+      </div>
+    {/each}
+  </div>
+</Panel>


### PR DESCRIPTION
## Why

The Server Admin member-detail route mixed member loading, identity and password forms, role mutations, and overview rendering in one 630-line component. SvelteKit also preserves this page when route parameters change, but its async reads and mutations were not fenced against a later member or server.

## What changed

- reduce the route to page-level composition and permission wiring
- move member reads and mutations into a route-local reactive store
- fence every async result by server, member, and load generation
- split overview, identity/password, and role-assignment UI into focused components
- keep successful role commands authoritative when a fallback refresh fails
- preserve identity edit buffers across unrelated updates
- add focused coverage for stale member reads, stale role mutations, cross-server navigation, refresh failure, and identity/password updates

No backend, public API, protocol, persistence, or user-visible copy changes are included.

## Test plan

- `mise lint-frontend` — passed; Svelte check reported 0 errors and 0 warnings
- `mise test-frontend` — 295 files and 2,519 tests passed
- focused `MemberDetailStore.svelte.spec.ts` run — 5 tests passed
- `playwright test e2e/server-admin-members.test.ts --retries=0` — 7 tests passed
- identity-editing Playwright flow — 1 test passed
- `mise license-check` — passed
- `mise knip` — exited successfully with the repository's existing findings only
- post-rebase frontend check and focused store tests — passed

The in-app browser surface was unavailable for a separate manual pass. The targeted Playwright runs built the production frontend and exercised the changed page in Chromium.
