### PR TITLE
refactor(frontend): split message event responsibilities

### DIFF
--- a/apps/frontend/e2e/thread-reply-echo.test.ts
+++ b/apps/frontend/e2e/thread-reply-echo.test.ts
@@ -38,6 +38,7 @@ async function selectTextInside(locator: Locator, selectedText: string): Promise
         const selection = window.getSelection();
         selection?.removeAllRanges();
         selection?.addRange(range);
+        node.parentElement?.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
         return;
       }
 

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -38,6 +38,7 @@ async function selectTextInside(locator: Locator, selectedText: string): Promise
         const selection = window.getSelection();
         selection?.removeAllRanges();
         selection?.addRange(range);
+        node.parentElement?.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
         return;
       }
 

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -366,6 +366,31 @@ test.describe('Message Threading', () => {
     );
   });
 
+  test('dismissing message actions clears the selected reply quote', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const selectedText = `discarded room quote ${Date.now()}`;
+    const rootMsg = await roomPage.sendMessage(`Before ${selectedText} after`);
+
+    await selectTextInside(rootMsg.locator, selectedText);
+    await rootMsg.revealHoverToolbar();
+    await rootMsg.hoverToolbar.getByLabel('More actions').click();
+    await expect(rootMsg.contextMenu).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await page.keyboard.press('Escape');
+    await expect(rootMsg.contextMenu).not.toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+
+    await rootMsg.replyInRoom();
+
+    await expect(page.getByText('Replying to')).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+    await expect(roomPage.messageInput.locator('blockquote')).toHaveCount(0);
+  });
+
   test('reply in thread quotes selected message text in the thread composer', async ({
     page,
     chatPage,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionSheet.svelte.spec.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import MessageActionSheet from './MessageActionSheet.svelte';
+import MessageEventActionOverlays from './MessageEventActionOverlays.svelte';
+import { MessageEventInteractionState } from './messageEventInteractions.svelte';
 
 const mocks = vi.hoisted(() => ({
   actions: {
@@ -18,6 +20,7 @@ vi.mock('$lib/hooks', () => ({
 }));
 
 vi.mock('$lib/state/recentEmojis.svelte', () => ({
+  MAX_RECENT_EMOJIS: 16,
   getRecentEmojis: () => ({
     quickReactions: ['👍', '❤️']
   })
@@ -207,5 +210,35 @@ describe('MessageActionSheet', () => {
 
     expect(deleteButton).toBeDefined();
     expect(deleteButton).toHaveClass('text-danger');
+  });
+
+  it('notifies the message owner when the mobile sheet is dismissed natively', async () => {
+    const interactions = new MessageEventInteractionState();
+    interactions.showActionSheet = true;
+    const onClose = vi.fn();
+    const { container } = render(MessageEventActionOverlays, {
+      props: {
+        interactions,
+        serverId: 'server-1',
+        roomId: 'room-1',
+        messageEventId: 'message-event-1',
+        eventId: 'event-1',
+        deleteEventId: 'event-1',
+        messageBody: 'Hello',
+        onEmojiSelect: vi.fn(),
+        onClose
+      }
+    });
+    const dialog = q(container, 'dialog') as HTMLDialogElement;
+
+    await vi.waitFor(() => {
+      expect(dialog.open).toBe(true);
+    });
+    dialog.close();
+
+    await vi.waitFor(() => {
+      expect(interactions.showActionSheet).toBe(false);
+      expect(onClose).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -178,6 +178,9 @@
     if (prefersTouch && !canUseHoverActions) {
       interactions.cancelLongPress();
     }
+    if (!interactions.hasOpenActionSurface) {
+      selectedReplyQuoteSnapshot = null;
+    }
   }
 
   // Open context menu from the toolbar's "more actions" button,
@@ -660,6 +663,7 @@
       onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
       onReply={canUseThreadAction ? handleOpenThread : undefined}
       onEmojiSelect={handleEmojiSelect}
+      onClose={() => (selectedReplyQuoteSnapshot = null)}
     />
   {/if}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -411,6 +411,13 @@
     return quote;
   }
 
+  function discardSelectedReplyQuote(): void {
+    selectedReplyQuoteSnapshot = null;
+    if (getSelectedReplyQuote()) {
+      window.getSelection()?.removeAllRanges();
+    }
+  }
+
   function handleReplyInRoom() {
     const quote = takeSelectedReplyQuote();
     const excerpt = (msg?.body ?? '').slice(0, 80);
@@ -663,7 +670,7 @@
       onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
       onReply={canUseThreadAction ? handleOpenThread : undefined}
       onEmojiSelect={handleEmojiSelect}
-      onClose={() => (selectedReplyQuoteSnapshot = null)}
+      onClose={discardSelectedReplyQuote}
     />
   {/if}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -1,14 +1,8 @@
 <script lang="ts">
   import { untrack } from 'svelte';
-  import { startDMWith } from '$lib/dm/startDM';
   import { resolve } from '$app/paths';
   import MessageView from '$lib/components/messages/MessageView.svelte';
-  import UserAvatar from '$lib/components/UserAvatar.svelte';
   import LinkPreviewCard from '$lib/components/LinkPreviewCard.svelte';
-  import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
-  import BanRoomMemberModal from '$lib/components/moderation/BanRoomMemberModal.svelte';
-  import BottomSheet from '$lib/ui/BottomSheet.svelte';
-  import ContextMenu from '$lib/ui/ContextMenu.svelte';
   import type { TimelineEventView } from '$lib/render/timelineEvents';
   import {
     getRoomPermissions,
@@ -16,8 +10,7 @@
     getMentionRoles,
     getComposerContext,
     type MessagesStore,
-    type QuoteInsertionContent,
-    type RoomMember
+    type QuoteInsertionContent
   } from '$lib/state/room';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
@@ -29,10 +22,7 @@
   const serverInfo = stores.serverInfo;
   const activeCallRooms = stores.activeCallRooms;
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
-  import MessageActionSheet from './MessageActionSheet.svelte';
-  import MessageContextMenu from '$lib/components/menus/MessageContextMenu.svelte';
   import MessageHoverBar from './MessageHoverBar.svelte';
-  import EmojiPicker from '$lib/components/EmojiPicker.svelte';
   import MessageAttachments from './MessageAttachments.svelte';
   import MessageMetaBar from './MessageMetaBar.svelte';
   import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
@@ -42,27 +32,28 @@
   import { useMessageActions } from '$lib/hooks';
   import { emojiToName } from '$lib/emoji';
   import { toast } from '$lib/ui/toast';
-  import {
-    copyMessageLinkToClipboard,
-    parseMessageLink,
-    type MessageLink
-  } from '$lib/messageLinks';
+  import { copyMessageLinkToClipboard } from '$lib/messageLinks';
   import { serverIdToSegment } from '$lib/navigation';
-  import { extractURLs } from '$lib/linkPreview';
   import MessagePreviewCard from '$lib/components/MessagePreviewCard.svelte';
-  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
   import { shouldHighlightCurrentUserMention } from './messageMentionHighlight';
   import { roomReplyTargetEventId } from './messageReplyTarget';
   import { selectedQuoteTextForMessageBody } from './selectedReplyQuote';
   import type { OpenThreadHandler } from './threadOpenOptions';
   import { createThreadAPI } from '$lib/api-client/threads';
-  import { createRoomCommandAPI } from '$lib/api-client/rooms';
   import { isMessagePostedEvent } from '$lib/render/timelineEvents';
   import * as m from '$lib/i18n/messages';
-
-  // Long-press thresholds in milliseconds
-  const HIGHLIGHT_DELAY_MS = 150; // Delay before showing visual feedback (avoids flicker on scroll)
-  const LONG_PRESS_MS = 500; // Total time before action sheet appears
+  import MessageReplyAttribution from './MessageReplyAttribution.svelte';
+  import MessageEventActionOverlays from './MessageEventActionOverlays.svelte';
+  import { MessageEventInteractionState } from './messageEventInteractions.svelte';
+  import MessageUserOverlays from './MessageUserOverlays.svelte';
+  import { MessageUserInteractionState } from './messageUserInteractions.svelte';
+  import {
+    buildMessageReplyPreview,
+    canEditMessage,
+    embeddedMessageLinks,
+    isDeletedMessage,
+    resolveMessageEventReferences
+  } from './messageEventModel';
 
   let {
     event,
@@ -117,58 +108,25 @@
   // messages requires message.manage.
   const isAuthor = $derived(currentUser.user?.id === event?.actorId);
   const canEdit = $derived(
-    (isAuthor &&
-      event &&
-      Date.now() - new Date(event.createdAt).getTime() <
-        serverInfo.messageEditWindowSeconds * 1000) ||
-      roomPermissions.canManageOthersMessage
+    canEditMessage({
+      isAuthor,
+      createdAt: event.createdAt,
+      now: Date.now(),
+      editWindowSeconds: serverInfo.messageEditWindowSeconds,
+      canManageOthersMessage: roomPermissions.canManageOthersMessage
+    })
   );
   const canDelete = $derived(isAuthor || roomPermissions.canManageOthersMessage);
 
-  // Mobile action sheet state
-  let showActionSheet = $state(false);
-  let longPressActive = $state(false);
-  let highlightTimer: ReturnType<typeof setTimeout> | null = null;
-  let longPressTimer: ReturnType<typeof setTimeout> | null = null;
-
-  // Desktop context menu state
-  let contextMenuPos = $state<{
-    x: number;
-    y: number;
-    alignRight?: boolean;
-    centerX?: boolean;
-  } | null>(null);
+  const interactions = new MessageEventInteractionState();
+  $effect(() => () => interactions.dispose());
+  const userInteractions = new MessageUserInteractionState(() => members);
   let messageBodySelectionRoot = $state<HTMLElement>();
   let selectedReplyQuoteSnapshot = $state<QuoteInsertionContent | null>(null);
 
-  // Emoji picker state (position doubles as visibility flag in floating mode)
-  let emojiPickerPos = $state<{ x: number; y: number } | null>(null);
-  let emojiPickerPresentation = $state<'auto' | 'sheet'>('auto');
   const emojiActions = useMessageActions();
 
-  function openEmojiPicker(presentation: 'auto' | 'sheet' = 'auto') {
-    emojiPickerPresentation = presentation;
-    // Capture context menu position before it closes. Sheet presentation ignores
-    // this fallback, but ContextMenu still requires a visibility anchor.
-    emojiPickerPos = contextMenuPos ?? { x: 0, y: 0 };
-  }
-
-  function openEmojiPickerFromEvent(e: MouseEvent) {
-    emojiPickerPresentation = 'auto';
-    emojiPickerPos = { x: e.clientX, y: e.clientY };
-  }
-
-  function openEmojiPickerFromToolbar(e: MouseEvent) {
-    emojiPickerPresentation = 'auto';
-    const button = e.currentTarget as HTMLElement;
-    const rect = button.getBoundingClientRect();
-    emojiPickerPos = { x: rect.left, y: rect.bottom + 4 };
-  }
-
   async function handleEmojiSelect(emoji: string) {
-    emojiPickerPresentation = 'auto';
-    emojiPickerPos = null;
-
     if (!msg) return;
 
     const params = {
@@ -184,48 +142,18 @@
     await emojiActions.toggleReaction(params, emoji, alreadyReacted);
   }
 
-  function closeEmojiPicker() {
-    emojiPickerPresentation = 'auto';
-    emojiPickerPos = null;
-  }
-
-  function startLongPress() {
-    // Stage 1: Show highlight after short delay (avoids flicker during scroll)
-    highlightTimer = setTimeout(() => {
-      longPressActive = true;
-    }, HIGHLIGHT_DELAY_MS);
-
-    // Stage 2: Show action sheet after full long-press duration
-    longPressTimer = setTimeout(() => {
-      showActionSheet = true;
-      longPressActive = false;
-    }, LONG_PRESS_MS);
-  }
-
-  function cancelLongPress() {
-    longPressActive = false;
-    if (highlightTimer) {
-      clearTimeout(highlightTimer);
-      highlightTimer = null;
-    }
-    if (longPressTimer) {
-      clearTimeout(longPressTimer);
-      longPressTimer = null;
-    }
-  }
-
   // Touch handlers for mobile
   function handleTouchStart() {
-    startLongPress();
+    interactions.startLongPress();
   }
 
   function handleTouchEnd() {
-    cancelLongPress();
+    interactions.cancelLongPress();
   }
 
   function handleTouchMove() {
     // Cancel long-press if user moves finger (scrolling)
-    cancelLongPress();
+    interactions.cancelLongPress();
   }
 
   // Mouse fallback for pure touch-primary devices. Hybrid devices with a hover-capable
@@ -234,46 +162,43 @@
     if (!prefersTouch || canUseHoverActions) return;
     // Only handle left mouse button
     if (e.button !== 0) return;
-    startLongPress();
+    interactions.startLongPress();
   }
 
-  function handleMouseUp() {
-    cancelLongPress();
+  function handleMouseUp(event: MouseEvent) {
+    if (prefersTouch && !canUseHoverActions) {
+      interactions.cancelLongPress();
+    }
+    if (!(event.target instanceof Element && event.target.closest('[role="toolbar"]'))) {
+      selectedReplyQuoteSnapshot = getSelectedReplyQuote();
+    }
   }
 
   function handleMouseLeave() {
-    cancelLongPress();
+    if (prefersTouch && !canUseHoverActions) {
+      interactions.cancelLongPress();
+    }
   }
 
   // Open context menu from the toolbar's "more actions" button,
   // positioned to cover the toolbar exactly.
   function openMenuFromToolbar(e: MouseEvent) {
-    selectedReplyQuoteSnapshot = getSelectedReplyQuote();
-    const button = e.currentTarget as HTMLElement;
-    const toolbar = button.closest('[role="toolbar"]') as HTMLElement;
-    const rect = toolbar?.getBoundingClientRect() ?? button.getBoundingClientRect();
-    contextMenuPos = { x: rect.right, y: rect.top, alignRight: true };
+    selectedReplyQuoteSnapshot ??= getSelectedReplyQuote();
+    interactions.openContextMenuFromToolbar(e);
   }
 
   // MessagePostedEvent-specific data (threading, inReplyTo, etc.)
   // Guard with event?. for Svelte 5 reactivity glitch during virtualizer data transitions
   const messageEvent = $derived(isMessagePostedEvent(event?.event) ? event.event : null);
 
-  // Check if this is an echo (MessagePostedEvent with echoOfEventId set)
-  const isEcho = $derived(messageEvent?.echoOfEventId != null);
-
-  const editEventId = $derived(isEcho ? messageEvent!.echoOfEventId! : event.id);
-  const editThreadRootEventId = $derived(
-    isEcho
-      ? (messageEvent?.echoFromThreadRootEventId ?? null)
-      : (messageEvent?.threadRootEventId ?? null)
+  const eventReferences = $derived(
+    messageEvent ? resolveMessageEventReferences(event.id, messageEvent) : null
   );
-  const editChannelEchoEventId = $derived(
-    isEcho ? event.id : (messageEvent?.channelEchoEventId ?? null)
-  );
-  const threadRootEventId = $derived(
-    isEcho ? (messageEvent?.echoFromThreadRootEventId ?? null) : event.id
-  );
+  const isEcho = $derived(eventReferences?.isEcho ?? false);
+  const editEventId = $derived(eventReferences?.editEventId ?? event.id);
+  const editThreadRootEventId = $derived(eventReferences?.editThreadRootEventId ?? null);
+  const editChannelEchoEventId = $derived(eventReferences?.editChannelEchoEventId ?? null);
+  const threadRootEventId = $derived(eventReferences?.threadRootEventId ?? null);
   const canReconcileChannelEcho = $derived(
     isAuthor &&
       !!editThreadRootEventId &&
@@ -289,12 +214,7 @@
   );
 
   // Message links referenced in this message's body — rendered inline as previews.
-  const embeddedMessageLinks = $derived.by<MessageLink[]>(() => {
-    if (!msg?.body) return [];
-    return extractURLs(msg.body, 5)
-      .map(parseMessageLink)
-      .filter((link): link is MessageLink => link !== null);
-  });
+  const messageLinks = $derived(embeddedMessageLinks(msg?.body));
 
   async function copyMessageLink(e: MouseEvent) {
     if (!event) return;
@@ -377,14 +297,14 @@
   // Check if message has attachments
   const hasAttachments = $derived((msg?.attachments?.length ?? 0) > 0);
   const hasVisualEmbed = $derived(
-    hasAttachments || !!messageEvent?.linkPreview || embeddedMessageLinks.length > 0
+    hasAttachments || !!messageEvent?.linkPreview || messageLinks.length > 0
   );
 
   // Message is "deleted" if it has no body AND no attachments.
   // Deleted messages always render as a tombstone — hiding them entirely opened up
   // moderation-evading and inconsistency vectors (e.g. event numbering gaps, lost
   // reply-attribution context, deleted-then-reacted-to messages disappearing).
-  const isDeleted = $derived(!msg?.body && !hasAttachments);
+  const isDeleted = $derived(msg ? isDeletedMessage(msg) : true);
 
   const replyTarget = $derived.by(() => {
     const replyToId = messageEvent?.inReplyTo;
@@ -405,20 +325,12 @@
     const replyToId = messageEvent?.inReplyTo;
     if (!replyToId) return null;
 
-    if (!replyTarget) {
-      return { name: 'a message', body: null as string | null, actor: null, deleted: false };
-    }
-
-    const repliedActor = replyTarget.actor ?? null;
-    const activeRepliedActor = repliedActor && !repliedActor.deleted ? repliedActor : null;
-    const name = activeRepliedActor
-      ? getLiveDisplayName(
-          activeRepliedActor.id,
-          activeRepliedActor.displayName || activeRepliedActor.login
-        )
-      : m['common.deleted_user']();
-    const body = isMessagePostedEvent(replyTarget.event) ? (replyTarget.event.body ?? null) : null;
-    return { name, body, actor: activeRepliedActor, deleted: !activeRepliedActor };
+    return buildMessageReplyPreview({
+      target: replyTarget,
+      missingName: 'a message',
+      deletedName: m['common.deleted_user'](),
+      getDisplayName: (member) => getLiveDisplayName(member.id, member.displayName || member.login)
+    });
   });
 
   // Check if this thread has pending reply notifications
@@ -442,112 +354,19 @@
     })
   );
 
-  // User profile popover state
   const serverPerms = getServerPermissions();
   const canStartDMs = $derived(serverPerms.current.canStartDMs);
-  let popoverUser = $state<RoomMember | null>(null);
-  let popoverAnchorRect = $state<DOMRect | null>(null);
-  let banningMemberId = $state<string | null>(null);
-  let banDialogUser = $state<RoomMember | null>(null);
-  let banError = $state<string | null>(null);
-
-  const canBanPopoverUser = $derived.by(() => {
-    if (
-      !popoverUser ||
-      popoverUser.deleted ||
-      !roomPermissions.canBanRoomMembers ||
-      popoverUser.id === currentUser.user?.id
-    ) {
-      return false;
-    }
-    const targetUserId = popoverUser.id;
-    return members.some((member) => member.id === targetUserId);
-  });
-
-  function openBanDialog(member: RoomMember) {
-    if (member.deleted) return;
-
-    banDialogUser = member;
-    banError = null;
-    closePopover();
-  }
-
-  async function banFromRoom(member: RoomMember, reason: string, expiresAt: string | null) {
-    if (banningMemberId) return;
-
-    banningMemberId = member.id;
-    banError = null;
-    const displayName = member.displayName || member.login;
-    try {
-      const api = connection().getAPI(createRoomCommandAPI);
-      await api.banMember({ roomId, userId: member.id, reason, expiresAt });
-    } catch (error) {
-      banningMemberId = null;
-      banError = m['room.sidebar.ban_failed']();
-      toast.error(banError);
-      console.error('Failed to ban member from room:', error);
-      return;
-    }
-    banningMemberId = null;
-
-    toast.success(m['room.sidebar.ban_success']({ name: displayName }));
-    banDialogUser = null;
-  }
 
   function showPopoverForActor(e: MouseEvent) {
-    if (!actor) return;
-    // Capture the bounding rect of the clicked button for popover positioning
-    const button = (e.target as HTMLElement).closest('button');
-    popoverAnchorRect = button?.getBoundingClientRect() ?? null;
-
-    // Look up the full member from the members list (includes live presence)
-    const member = members.find((m) => m.id === actor.id);
-    if (member) {
-      popoverUser = member;
-    } else {
-      // Actor not in current members list (e.g., left the room) — use actor data directly
-      popoverUser = {
-        id: actor.id,
-        login: actor.login,
-        displayName: actor.displayName,
-        avatarUrl: actor.avatarUrl,
-        presenceStatus: actor.presenceStatus
-      };
-    }
+    userInteractions.showUserFromEvent(actor, e);
   }
 
   function showPopoverForMember(userId: string, anchorRect: DOMRect) {
-    const member = members.find((m) => m.id === userId);
-    if (member) {
-      popoverUser = member;
-      popoverAnchorRect = anchorRect;
-    }
+    userInteractions.showMember(userId, anchorRect);
   }
 
   function showPopoverForReplyAuthor(e: MouseEvent) {
-    const replyActor = replyPreview?.actor;
-    if (!replyActor) return;
-
-    const button = (e.target as HTMLElement).closest('button');
-    popoverAnchorRect = button?.getBoundingClientRect() ?? null;
-
-    const member = members.find((m) => m.id === replyActor.id);
-    if (member) {
-      popoverUser = member;
-    } else {
-      popoverUser = {
-        id: replyActor.id,
-        login: replyActor.login,
-        displayName: replyActor.displayName,
-        avatarUrl: replyActor.avatarUrl,
-        presenceStatus: replyActor.presenceStatus
-      };
-    }
-  }
-
-  function closePopover() {
-    popoverUser = null;
-    popoverAnchorRect = null;
+    userInteractions.showUserFromEvent(replyPreview?.actor ?? null, e);
   }
 
   function scrollToReplyTarget() {
@@ -656,7 +475,7 @@
       compact ? (hasVisualEmbed ? 'mt-1.5' : '') : 'mt-4',
       isCurrentUserMentioned ? 'bg-warning/10' : ''
     ]}
-    rowClass={longPressActive || showActionSheet || contextMenuPos ? 'bg-surface' : ''}
+    rowClass={interactions.longPressActive || interactions.hasOpenActionSurface ? 'bg-surface' : ''}
     {members}
     roleHandles={mentionRoleHandles}
     timestampSettings={userSettings}
@@ -696,66 +515,15 @@
 
     {#snippet prelude()}
       {#if replyPreview}
-        {@const replyJumpText =
-          replyPreview.body ??
-          (replyPreview.actor || replyPreview.deleted
-            ? m['room.message.meta.reply_preview_fallback']()
-            : replyPreview.name)}
-        {@const replyJumpLabel = `${m['room.message.meta.in_reply_to']()} ${replyJumpText}`}
-        <!-- svelte-ignore a11y_no_static_element_interactions -->
-        <!-- svelte-ignore a11y_click_events_have_key_events -->
-        <div
-          data-testid="reply-attribution"
-          aria-label={m['room.message.meta.in_reply_to']()}
-          title={m['room.message.meta.in_reply_to']()}
-          class={[
-            'group/reply relative flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted',
-            compact ? '' : '-ml-[39px] pl-[39px]'
-          ]}
-          onclick={scrollToReplyTarget}
-          onmousedown={(e) => e.stopPropagation()}
-        >
-          {#if compact}
-            <span
-              aria-hidden="true"
-              class="h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-strong/30 transition-colors group-hover/reply:border-surface-strong/55"
-            ></span>
-          {:else}
-            <span
-              aria-hidden="true"
-              class="absolute top-[11px] left-0 h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-strong/30 transition-colors group-hover/reply:border-surface-strong/55"
-            ></span>
-          {/if}
-          {#if replyPreview.actor}
-            {@const replyCallPresence = activeCallRooms.getParticipantCallPresence(
-              roomId,
-              replyPreview.actor.id
-            )}
-            <button
-              type="button"
-              data-testid="reply-attribution-author"
-              class="inline-flex max-w-[45%] min-w-0 shrink-0 cursor-pointer items-center gap-1 hover:underline"
-              onclick={(e) => {
-                e.stopPropagation();
-                showPopoverForReplyAuthor(e);
-              }}
-            >
-              <UserAvatar user={replyPreview.actor} size="xs" />
-              <strong class="truncate font-medium">{replyPreview.name}</strong>
-              {@render callPresenceIcon(replyCallPresence)}
-            </button>
-          {:else if replyPreview.deleted}
-            <strong class="max-w-[45%] shrink-0 truncate font-medium"><DeletedUserLabel /></strong>
-          {/if}
-          <button
-            type="button"
-            class="min-w-0 flex-1 cursor-pointer truncate text-left opacity-75 hover:text-text"
-            aria-label={replyJumpLabel}
-            title={replyJumpLabel}
-          >
-            {replyJumpText}
-          </button>
-        </div>
+        <MessageReplyAttribution
+          preview={replyPreview}
+          {compact}
+          callPresence={replyPreview.actor
+            ? activeCallRooms.getParticipantCallPresence(roomId, replyPreview.actor.id)
+            : null}
+          onJump={scrollToReplyTarget}
+          onAuthorClick={showPopoverForReplyAuthor}
+        />
       {/if}
     {/snippet}
 
@@ -800,7 +568,7 @@
         </div>
       {/if}
 
-      {#each embeddedMessageLinks as link, i (link.messageId + ':' + i)}
+      {#each messageLinks as link, i (link.messageId + ':' + i)}
         <div class="mt-2">
           <MessagePreviewCard {link} />
         </div>
@@ -822,7 +590,9 @@
           {isThreadFollowPending}
           onToggleThreadFollow={hasReplies ? toggleThreadFollow : undefined}
           onOpenThread={onOpenThread ? handleOpenThread : undefined}
-          onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPickerFromEvent : undefined}
+          onOpenEmojiPicker={roomPermissions.canReact
+            ? (event) => interactions.openEmojiPickerFromEvent(event)
+            : undefined}
           isEchoEvent={isEcho}
         />
       {/if}
@@ -844,119 +614,52 @@
           reactions={msg?.reactions ?? []}
           canReact={roomPermissions.canReact}
           {canEdit}
-          forceVisible={!!emojiPickerPos || !!contextMenuPos}
+          forceVisible={interactions.forceHoverActionsVisible}
           replyInRoomLabel={replyInRoomActionLabel}
           replyThreadLabel={replyThreadActionLabel}
           onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
           onReply={canUseThreadAction ? handleOpenThread : undefined}
-          onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPickerFromToolbar : undefined}
+          onOpenEmojiPicker={roomPermissions.canReact
+            ? (event) => interactions.openEmojiPickerFromToolbar(event)
+            : undefined}
           onOpenMenu={openMenuFromToolbar}
         />
       {/if}
     {/snippet}
   </MessageView>
 
-  <!-- User profile popover (outside article div to avoid content-visibility containment) -->
-  {#if popoverUser && popoverAnchorRect}
-    <UserContextMenu
-      user={popoverUser}
-      anchorRect={popoverAnchorRect}
-      canSendMessage={canStartDMs && !popoverUser.deleted}
-      canBanFromRoom={canBanPopoverUser}
-      banningFromRoom={banningMemberId === popoverUser.id}
-      onSendMessage={() => startDMWith(getActiveServer(), popoverUser!.id)}
-      onBanFromRoom={() => openBanDialog(popoverUser!)}
-      onClose={closePopover}
+  <MessageUserOverlays
+    interactions={userInteractions}
+    serverId={getActiveServer()}
+    {roomId}
+    currentUserId={currentUser.user?.id}
+    {canStartDMs}
+    canBanRoomMembers={roomPermissions.canBanRoomMembers}
+  />
+
+  {#if !isDeleted}
+    <MessageEventActionOverlays
+      {interactions}
+      serverId={getActiveServer()}
+      {roomId}
+      messageEventId={event.id}
+      eventId={editEventId}
+      deleteEventId={event.id}
+      messageBody={msg.body ?? ''}
+      {permalinkThreadRootEventId}
+      threadRootEventId={editThreadRootEventId}
+      channelEchoEventId={editChannelEchoEventId}
+      canAddChannelEcho={canReconcileChannelEcho}
+      {messageStore}
+      reactions={msg.reactions}
+      canReact={roomPermissions.canReact}
+      {canEdit}
+      {canDelete}
+      replyInRoomLabel={replyInRoomActionLabel}
+      replyThreadLabel={replyThreadActionLabel}
+      onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
+      onReply={canUseThreadAction ? handleOpenThread : undefined}
+      onEmojiSelect={handleEmojiSelect}
     />
-  {/if}
-
-  {#if banDialogUser}
-    <BanRoomMemberModal
-      user={banDialogUser}
-      submitting={banningMemberId === banDialogUser.id}
-      error={banError}
-      onconfirm={(reason, expiresAt) => banFromRoom(banDialogUser!, reason, expiresAt)}
-      onclose={() => (banDialogUser = null)}
-    />
-  {/if}
-
-  <!-- Desktop context menu (via toolbar "more actions" button) -->
-  {#if contextMenuPos && !isDeleted}
-    <ContextMenu
-      position={contextMenuPos}
-      class="min-w-72"
-      onclose={() => {
-        contextMenuPos = null;
-      }}
-    >
-      <MessageContextMenu
-        serverId={getActiveServer()}
-        {roomId}
-        messageEventId={event.id}
-        eventId={editEventId}
-        deleteEventId={event.id}
-        messageBody={msg.body ?? ''}
-        {permalinkThreadRootEventId}
-        threadRootEventId={editThreadRootEventId}
-        channelEchoEventId={editChannelEchoEventId}
-        canAddChannelEcho={canReconcileChannelEcho}
-        {messageStore}
-        reactions={msg?.reactions ?? []}
-        canReact={roomPermissions.canReact}
-        {canEdit}
-        {canDelete}
-        replyInRoomLabel={replyInRoomActionLabel}
-        replyThreadLabel={replyThreadActionLabel}
-        onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
-        onReply={canUseThreadAction ? handleOpenThread : undefined}
-        onOpenEmojiPicker={roomPermissions.canReact ? openEmojiPicker : undefined}
-        onClose={() => (contextMenuPos = null)}
-      />
-    </ContextMenu>
-  {/if}
-
-  <!-- Emoji picker (ContextMenu handles floating vs sheet presentation) -->
-  {#if emojiPickerPos && !isDeleted}
-    <ContextMenu
-      position={emojiPickerPos}
-      presentation={emojiPickerPresentation}
-      scrollDismissal="user"
-      onclose={closeEmojiPicker}
-    >
-      <EmojiPicker
-        serverId={getActiveServer()}
-        onSelect={handleEmojiSelect}
-        onClose={closeEmojiPicker}
-      />
-    </ContextMenu>
-  {/if}
-
-  <!-- Mobile action sheet (long-press menu, mounted on demand) -->
-  {#if showActionSheet && !isDeleted}
-    <BottomSheet bind:visible={showActionSheet}>
-      <MessageActionSheet
-        serverId={getActiveServer()}
-        {roomId}
-        messageEventId={event.id}
-        eventId={editEventId}
-        deleteEventId={event.id}
-        messageBody={msg.body ?? ''}
-        {permalinkThreadRootEventId}
-        threadRootEventId={editThreadRootEventId}
-        channelEchoEventId={editChannelEchoEventId}
-        canAddChannelEcho={canReconcileChannelEcho}
-        {messageStore}
-        reactions={msg?.reactions ?? []}
-        canReact={roomPermissions.canReact}
-        {canEdit}
-        {canDelete}
-        replyInRoomLabel={replyInRoomActionLabel}
-        replyThreadLabel={replyThreadActionLabel}
-        onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
-        onReply={canUseThreadAction ? handleOpenThread : undefined}
-        onOpenEmojiPicker={roomPermissions.canReact ? () => openEmojiPicker('sheet') : undefined}
-        onClose={() => (showActionSheet = false)}
-      />
-    </BottomSheet>
   {/if}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+  import BottomSheet from '$lib/ui/BottomSheet.svelte';
+  import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import EmojiPicker from '$lib/components/EmojiPicker.svelte';
+  import MessageContextMenu from '$lib/components/menus/MessageContextMenu.svelte';
+  import type { ReactionSummaryView } from '$lib/render/reactions';
+  import type { MessagesStore } from '$lib/state/room';
+  import MessageActionSheet from './MessageActionSheet.svelte';
+  import type { MessageEventInteractionState } from './messageEventInteractions.svelte';
+
+  let {
+    interactions,
+    serverId,
+    roomId,
+    messageEventId,
+    eventId,
+    deleteEventId,
+    messageBody,
+    permalinkThreadRootEventId = null,
+    threadRootEventId = null,
+    channelEchoEventId = null,
+    canAddChannelEcho = false,
+    messageStore = null,
+    reactions = [],
+    canReact = false,
+    canEdit = false,
+    canDelete = false,
+    replyInRoomLabel,
+    replyThreadLabel,
+    onReplyInRoom,
+    onReply,
+    onEmojiSelect
+  }: {
+    interactions: MessageEventInteractionState;
+    serverId: string;
+    roomId: string;
+    messageEventId: string;
+    eventId: string;
+    deleteEventId: string;
+    messageBody: string;
+    permalinkThreadRootEventId?: string | null;
+    threadRootEventId?: string | null;
+    channelEchoEventId?: string | null;
+    canAddChannelEcho?: boolean;
+    messageStore?: MessagesStore | null;
+    reactions?: ReactionSummaryView[];
+    canReact?: boolean;
+    canEdit?: boolean;
+    canDelete?: boolean;
+    replyInRoomLabel?: string;
+    replyThreadLabel?: string;
+    onReplyInRoom?: () => void;
+    onReply?: () => void;
+    onEmojiSelect: (emoji: string) => void | Promise<void>;
+  } = $props();
+
+  function openSheetEmojiPicker(): void {
+    interactions.openEmojiPicker('sheet');
+  }
+
+  async function handleEmojiSelect(emoji: string): Promise<void> {
+    interactions.closeEmojiPicker();
+    await onEmojiSelect(emoji);
+  }
+</script>
+
+{#if interactions.contextMenuPosition}
+  <ContextMenu
+    position={interactions.contextMenuPosition}
+    class="min-w-72"
+    onclose={() => interactions.closeContextMenu()}
+  >
+    <MessageContextMenu
+      {serverId}
+      {roomId}
+      {messageEventId}
+      {eventId}
+      {deleteEventId}
+      {messageBody}
+      {permalinkThreadRootEventId}
+      {threadRootEventId}
+      {channelEchoEventId}
+      {canAddChannelEcho}
+      {messageStore}
+      {reactions}
+      {canReact}
+      {canEdit}
+      {canDelete}
+      {replyInRoomLabel}
+      {replyThreadLabel}
+      {onReplyInRoom}
+      {onReply}
+      onOpenEmojiPicker={canReact ? () => interactions.openEmojiPicker() : undefined}
+      onClose={() => interactions.closeContextMenu()}
+    />
+  </ContextMenu>
+{/if}
+
+{#if interactions.emojiPickerPosition}
+  <ContextMenu
+    position={interactions.emojiPickerPosition}
+    presentation={interactions.emojiPickerPresentation}
+    scrollDismissal="user"
+    onclose={() => interactions.closeEmojiPicker()}
+  >
+    <EmojiPicker
+      {serverId}
+      onSelect={handleEmojiSelect}
+      onClose={() => interactions.closeEmojiPicker()}
+    />
+  </ContextMenu>
+{/if}
+
+{#if interactions.showActionSheet}
+  <BottomSheet bind:visible={interactions.showActionSheet}>
+    <MessageActionSheet
+      {serverId}
+      {roomId}
+      {messageEventId}
+      {eventId}
+      {deleteEventId}
+      {messageBody}
+      {permalinkThreadRootEventId}
+      {threadRootEventId}
+      {channelEchoEventId}
+      {canAddChannelEcho}
+      {messageStore}
+      {reactions}
+      {canReact}
+      {canEdit}
+      {canDelete}
+      {replyInRoomLabel}
+      {replyThreadLabel}
+      {onReplyInRoom}
+      {onReply}
+      onOpenEmojiPicker={canReact ? openSheetEmojiPicker : undefined}
+      onClose={() => interactions.closeActionSheet()}
+    />
+  </BottomSheet>
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
@@ -29,7 +29,8 @@
     replyThreadLabel,
     onReplyInRoom,
     onReply,
-    onEmojiSelect
+    onEmojiSelect,
+    onClose
   }: {
     interactions: MessageEventInteractionState;
     serverId: string;
@@ -52,14 +53,30 @@
     onReplyInRoom?: () => void;
     onReply?: () => void;
     onEmojiSelect: (emoji: string) => void | Promise<void>;
+    onClose?: () => void;
   } = $props();
+
+  function closeContextMenu(): void {
+    interactions.closeContextMenu();
+    onClose?.();
+  }
+
+  function closeEmojiPicker(): void {
+    interactions.closeEmojiPicker();
+    onClose?.();
+  }
+
+  function closeActionSheet(): void {
+    interactions.closeActionSheet();
+    onClose?.();
+  }
 
   function openSheetEmojiPicker(): void {
     interactions.openEmojiPicker('sheet');
   }
 
   async function handleEmojiSelect(emoji: string): Promise<void> {
-    interactions.closeEmojiPicker();
+    closeEmojiPicker();
     await onEmojiSelect(emoji);
   }
 </script>
@@ -68,7 +85,7 @@
   <ContextMenu
     position={interactions.contextMenuPosition}
     class="min-w-72"
-    onclose={() => interactions.closeContextMenu()}
+    onclose={closeContextMenu}
   >
     <MessageContextMenu
       {serverId}
@@ -91,7 +108,7 @@
       {onReplyInRoom}
       {onReply}
       onOpenEmojiPicker={canReact ? () => interactions.openEmojiPicker() : undefined}
-      onClose={() => interactions.closeContextMenu()}
+      onClose={closeContextMenu}
     />
   </ContextMenu>
 {/if}
@@ -101,13 +118,9 @@
     position={interactions.emojiPickerPosition}
     presentation={interactions.emojiPickerPresentation}
     scrollDismissal="user"
-    onclose={() => interactions.closeEmojiPicker()}
+    onclose={closeEmojiPicker}
   >
-    <EmojiPicker
-      {serverId}
-      onSelect={handleEmojiSelect}
-      onClose={() => interactions.closeEmojiPicker()}
-    />
+    <EmojiPicker {serverId} onSelect={handleEmojiSelect} onClose={closeEmojiPicker} />
   </ContextMenu>
 {/if}
 
@@ -134,7 +147,7 @@
       {onReplyInRoom}
       {onReply}
       onOpenEmojiPicker={canReact ? openSheetEmojiPicker : undefined}
-      onClose={() => interactions.closeActionSheet()}
+      onClose={closeActionSheet}
     />
   </BottomSheet>
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
@@ -125,7 +125,7 @@
 {/if}
 
 {#if interactions.showActionSheet}
-  <BottomSheet bind:visible={interactions.showActionSheet}>
+  <BottomSheet bind:visible={interactions.showActionSheet} onclose={closeActionSheet}>
     <MessageActionSheet
       {serverId}
       {roomId}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageReplyAttribution.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageReplyAttribution.svelte
@@ -1,0 +1,92 @@
+<script lang="ts">
+  import UserAvatar from '$lib/components/UserAvatar.svelte';
+  import DeletedUserLabel from '$lib/components/DeletedUserLabel.svelte';
+  import type { CallPresenceKind } from '$lib/state/server/activeCallRooms.svelte';
+  import * as m from '$lib/i18n/messages';
+  import type { MessageReplyPreview } from './messageEventModel';
+
+  let {
+    preview,
+    compact = false,
+    callPresence = null,
+    onJump,
+    onAuthorClick
+  }: {
+    preview: MessageReplyPreview;
+    compact?: boolean;
+    callPresence?: CallPresenceKind | null;
+    onJump: () => void;
+    onAuthorClick?: (event: MouseEvent) => void;
+  } = $props();
+
+  const jumpText = $derived(
+    preview.body ??
+      (preview.actor || preview.deleted
+        ? m['room.message.meta.reply_preview_fallback']()
+        : preview.name)
+  );
+  const jumpLabel = $derived(`${m['room.message.meta.in_reply_to']()} ${jumpText}`);
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<!-- svelte-ignore a11y_click_events_have_key_events -->
+<div
+  data-testid="reply-attribution"
+  aria-label={m['room.message.meta.in_reply_to']()}
+  title={m['room.message.meta.in_reply_to']()}
+  class={[
+    'group/reply relative flex min-w-0 cursor-pointer items-center gap-1.5 py-0.5 text-xs leading-none text-muted',
+    compact ? '' : '-ml-[39px] pl-[39px]'
+  ]}
+  onclick={onJump}
+  onmousedown={(event) => event.stopPropagation()}
+>
+  {#if compact}
+    <span
+      aria-hidden="true"
+      class="h-3 w-5 shrink-0 rounded-tl-md border-t-2 border-l-2 border-surface-strong/30 transition-colors group-hover/reply:border-surface-strong/55"
+    ></span>
+  {:else}
+    <span
+      aria-hidden="true"
+      class="absolute top-[11px] left-0 h-7 w-[39px] rounded-tl-md border-t-2 border-l-2 border-surface-strong/30 transition-colors group-hover/reply:border-surface-strong/55"
+    ></span>
+  {/if}
+
+  {#if preview.actor}
+    <button
+      type="button"
+      data-testid="reply-attribution-author"
+      class="inline-flex max-w-[45%] min-w-0 shrink-0 cursor-pointer items-center gap-1 hover:underline"
+      onclick={(event) => {
+        event.stopPropagation();
+        onAuthorClick?.(event);
+      }}
+    >
+      <UserAvatar user={preview.actor} size="xs" />
+      <strong class="truncate font-medium">{preview.name}</strong>
+      {#if callPresence}
+        <span
+          class={[
+            'iconify shrink-0 text-xs leading-none text-action',
+            callPresence === 'video' ? 'uil--video' : 'uil--phone'
+          ]}
+          title={callPresence === 'video' ? 'In a video call' : 'In a voice call'}
+          aria-label={callPresence === 'video' ? 'In a video call' : 'In a voice call'}
+          data-testid={`user-call-presence-${callPresence}`}
+        ></span>
+      {/if}
+    </button>
+  {:else if preview.deleted}
+    <strong class="max-w-[45%] shrink-0 truncate font-medium"><DeletedUserLabel /></strong>
+  {/if}
+
+  <button
+    type="button"
+    class="min-w-0 flex-1 cursor-pointer truncate text-left opacity-75 hover:text-text"
+    aria-label={jumpLabel}
+    title={jumpLabel}
+  >
+    {jumpText}
+  </button>
+</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageReplyAttribution.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageReplyAttribution.svelte.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q } from '$lib/test-utils';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import MessageReplyAttribution from './MessageReplyAttribution.svelte';
+
+vi.mock('$lib/state/presenceCache.svelte', () => ({
+  getPresenceCache: () => ({
+    get: (_scope: { serverId: string; userId: string }, fallback: unknown) => fallback
+  })
+}));
+
+vi.mock('$lib/state/userProfiles.svelte', () => ({
+  getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback,
+  getLiveCustomStatus: (_userId: string, fallback: unknown) => fallback
+}));
+
+const actor = {
+  id: 'user-1',
+  login: 'ada',
+  displayName: 'Ada',
+  avatarUrl: '',
+  deleted: false,
+  presenceStatus: PresenceStatus.ONLINE
+};
+
+describe('MessageReplyAttribution', () => {
+  it('renders the active author, body, and call presence', async () => {
+    const { container } = render(MessageReplyAttribution, {
+      props: {
+        preview: { name: 'Ada', body: 'Original message', actor, deleted: false },
+        callPresence: 'video',
+        onJump: vi.fn()
+      }
+    });
+
+    await expect
+      .element(q(container, '[data-testid="reply-attribution-author"]'))
+      .toHaveTextContent('Ada');
+    await expect
+      .element(q(container, '[aria-label="in reply to Original message"]'))
+      .toBeInTheDocument();
+    await expect
+      .element(q(container, '[data-testid="user-call-presence-video"]'))
+      .toBeInTheDocument();
+  });
+
+  it('keeps author clicks separate from reply-target navigation', () => {
+    const onJump = vi.fn();
+    const onAuthorClick = vi.fn();
+    const { container } = render(MessageReplyAttribution, {
+      props: {
+        preview: { name: 'Ada', body: 'Original message', actor, deleted: false },
+        onJump,
+        onAuthorClick
+      }
+    });
+
+    q(container, '[data-testid="reply-attribution-author"]')!.click();
+
+    expect(onAuthorClick).toHaveBeenCalledOnce();
+    expect(onJump).not.toHaveBeenCalled();
+  });
+
+  it('uses the fallback body and deleted-user label when content is unavailable', async () => {
+    const { container } = render(MessageReplyAttribution, {
+      props: {
+        preview: { name: 'Deleted user', body: null, actor: null, deleted: true },
+        onJump: vi.fn()
+      }
+    });
+
+    await expect.element(q(container, '[aria-label="in reply to Message"]')).toBeInTheDocument();
+    expect(container.textContent).toContain('[deleted user]');
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
@@ -1,0 +1,100 @@
+<script lang="ts">
+  import { startDMWith } from '$lib/dm/startDM';
+  import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
+  import BanRoomMemberModal from '$lib/components/moderation/BanRoomMemberModal.svelte';
+  import { createRoomCommandAPI } from '$lib/api-client/rooms';
+  import { useConnection } from '$lib/state/server/connection.svelte';
+  import type { RoomMember } from '$lib/state/room';
+  import { toast } from '$lib/ui/toast';
+  import * as m from '$lib/i18n/messages';
+  import type { MessageUserInteractionState } from './messageUserInteractions.svelte';
+
+  let {
+    interactions,
+    serverId,
+    roomId,
+    currentUserId,
+    canStartDMs,
+    canBanRoomMembers
+  }: {
+    interactions: MessageUserInteractionState;
+    serverId: string;
+    roomId: string;
+    currentUserId?: string;
+    canStartDMs: boolean;
+    canBanRoomMembers: boolean;
+  } = $props();
+
+  const connection = useConnection();
+  let banningMemberId = $state<string | null>(null);
+  let banDialogUser = $state<RoomMember | null>(null);
+  let banError = $state<string | null>(null);
+
+  const canBanPopoverUser = $derived.by(() => {
+    const user = interactions.user;
+    return (
+      !!user &&
+      !user.deleted &&
+      canBanRoomMembers &&
+      user.id !== currentUserId &&
+      interactions.hasCurrentMember(user.id)
+    );
+  });
+
+  function openBanDialog(member: RoomMember): void {
+    if (member.deleted) return;
+
+    banDialogUser = member;
+    banError = null;
+    interactions.close();
+  }
+
+  async function banFromRoom(
+    member: RoomMember,
+    reason: string,
+    expiresAt: string | null
+  ): Promise<void> {
+    if (banningMemberId) return;
+
+    banningMemberId = member.id;
+    banError = null;
+    const displayName = member.displayName || member.login;
+    try {
+      const api = connection().getAPI(createRoomCommandAPI);
+      await api.banMember({ roomId, userId: member.id, reason, expiresAt });
+    } catch (error) {
+      banningMemberId = null;
+      banError = m['room.sidebar.ban_failed']();
+      toast.error(banError);
+      console.error('Failed to ban member from room:', error);
+      return;
+    }
+    banningMemberId = null;
+
+    toast.success(m['room.sidebar.ban_success']({ name: displayName }));
+    banDialogUser = null;
+  }
+</script>
+
+{#if interactions.user && interactions.anchorRect}
+  <UserContextMenu
+    user={interactions.user}
+    anchorRect={interactions.anchorRect}
+    canSendMessage={canStartDMs && !interactions.user.deleted}
+    canBanFromRoom={canBanPopoverUser}
+    banningFromRoom={banningMemberId === interactions.user.id}
+    onSendMessage={() => startDMWith(serverId, interactions.user!.id)}
+    onBanFromRoom={() => openBanDialog(interactions.user!)}
+    onClose={() => interactions.close()}
+  />
+{/if}
+
+{#if banDialogUser}
+  <BanRoomMemberModal
+    user={banDialogUser}
+    submitting={banningMemberId === banDialogUser.id}
+    error={banError}
+    onconfirm={(reason, expiresAt) => banFromRoom(banDialogUser!, reason, expiresAt)}
+    onclose={() => (banDialogUser = null)}
+  />
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventInteractions.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventInteractions.svelte.spec.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MessageEventInteractionState } from './messageEventInteractions.svelte';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('MessageEventInteractionState', () => {
+  it('stages long-press highlighting before opening the action sheet', () => {
+    vi.useFakeTimers();
+    const state = new MessageEventInteractionState();
+
+    state.startLongPress();
+    vi.advanceTimersByTime(149);
+    expect(state.longPressActive).toBe(false);
+    expect(state.showActionSheet).toBe(false);
+
+    vi.advanceTimersByTime(1);
+    expect(state.longPressActive).toBe(true);
+
+    vi.advanceTimersByTime(350);
+    expect(state.longPressActive).toBe(false);
+    expect(state.showActionSheet).toBe(true);
+  });
+
+  it('cancels both long-press stages when pointer movement begins', () => {
+    vi.useFakeTimers();
+    const state = new MessageEventInteractionState();
+
+    state.startLongPress();
+    vi.advanceTimersByTime(200);
+    state.cancelLongPress();
+    vi.runAllTimers();
+
+    expect(state.longPressActive).toBe(false);
+    expect(state.showActionSheet).toBe(false);
+  });
+
+  it('tracks floating and sheet emoji-picker presentations independently', () => {
+    const state = new MessageEventInteractionState();
+
+    state.contextMenuPosition = { x: 20, y: 30 };
+    state.openEmojiPicker();
+    expect(state.emojiPickerPosition).toEqual({ x: 20, y: 30 });
+    expect(state.emojiPickerPresentation).toBe('auto');
+
+    state.openEmojiPicker('sheet');
+    expect(state.emojiPickerPresentation).toBe('sheet');
+
+    state.closeEmojiPicker();
+    expect(state.emojiPickerPosition).toBeNull();
+    expect(state.emojiPickerPresentation).toBe('auto');
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventInteractions.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventInteractions.svelte.ts
@@ -1,0 +1,93 @@
+const HIGHLIGHT_DELAY_MS = 150;
+const LONG_PRESS_MS = 500;
+
+export type MessageContextMenuPosition = {
+  x: number;
+  y: number;
+  alignRight?: boolean;
+  centerX?: boolean;
+};
+
+export class MessageEventInteractionState {
+  showActionSheet = $state(false);
+  longPressActive = $state(false);
+  contextMenuPosition = $state<MessageContextMenuPosition | null>(null);
+  emojiPickerPosition = $state<{ x: number; y: number } | null>(null);
+  emojiPickerPresentation = $state<'auto' | 'sheet'>('auto');
+
+  #highlightTimer: ReturnType<typeof setTimeout> | null = null;
+  #longPressTimer: ReturnType<typeof setTimeout> | null = null;
+
+  get hasOpenActionSurface(): boolean {
+    return this.showActionSheet || this.contextMenuPosition !== null;
+  }
+
+  get forceHoverActionsVisible(): boolean {
+    return this.emojiPickerPosition !== null || this.contextMenuPosition !== null;
+  }
+
+  openContextMenuFromToolbar(event: MouseEvent): void {
+    const button = event.currentTarget as HTMLElement;
+    const toolbar = button.closest('[role="toolbar"]') as HTMLElement | null;
+    const rect = toolbar?.getBoundingClientRect() ?? button.getBoundingClientRect();
+    this.contextMenuPosition = { x: rect.right, y: rect.top, alignRight: true };
+  }
+
+  closeContextMenu(): void {
+    this.contextMenuPosition = null;
+  }
+
+  openEmojiPicker(presentation: 'auto' | 'sheet' = 'auto'): void {
+    this.emojiPickerPresentation = presentation;
+    this.emojiPickerPosition = this.contextMenuPosition ?? { x: 0, y: 0 };
+  }
+
+  openEmojiPickerFromEvent(event: MouseEvent): void {
+    this.emojiPickerPresentation = 'auto';
+    this.emojiPickerPosition = { x: event.clientX, y: event.clientY };
+  }
+
+  openEmojiPickerFromToolbar(event: MouseEvent): void {
+    this.emojiPickerPresentation = 'auto';
+    const rect = (event.currentTarget as HTMLElement).getBoundingClientRect();
+    this.emojiPickerPosition = { x: rect.left, y: rect.bottom + 4 };
+  }
+
+  closeEmojiPicker(): void {
+    this.emojiPickerPresentation = 'auto';
+    this.emojiPickerPosition = null;
+  }
+
+  startLongPress(): void {
+    this.cancelLongPress();
+    this.#highlightTimer = setTimeout(() => {
+      this.longPressActive = true;
+    }, HIGHLIGHT_DELAY_MS);
+    this.#longPressTimer = setTimeout(() => {
+      this.showActionSheet = true;
+      this.longPressActive = false;
+    }, LONG_PRESS_MS);
+  }
+
+  cancelLongPress(): void {
+    if (this.longPressActive) {
+      this.longPressActive = false;
+    }
+    if (this.#highlightTimer) {
+      clearTimeout(this.#highlightTimer);
+      this.#highlightTimer = null;
+    }
+    if (this.#longPressTimer) {
+      clearTimeout(this.#longPressTimer);
+      this.#longPressTimer = null;
+    }
+  }
+
+  closeActionSheet(): void {
+    this.showActionSheet = false;
+  }
+
+  dispose(): void {
+    this.cancelLongPress();
+  }
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventModel.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventModel.spec.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { TimelineEventKind, type MessagePostedPayload } from '$lib/render/timelineEvents';
+import {
+  buildMessageReplyPreview,
+  canEditMessage,
+  embeddedMessageLinks,
+  isDeletedMessage,
+  resolveMessageEventReferences
+} from './messageEventModel';
+
+function message(overrides: Partial<MessagePostedPayload> = {}): MessagePostedPayload {
+  return {
+    kind: TimelineEventKind.MessagePosted,
+    roomId: 'room-1',
+    body: 'Hello',
+    attachments: [],
+    reactions: [],
+    replyCount: 0,
+    threadParticipants: [],
+    ...overrides
+  };
+}
+
+describe('resolveMessageEventReferences', () => {
+  it('uses the visible event for normal room messages', () => {
+    expect(
+      resolveMessageEventReferences(
+        'event-1',
+        message({ threadRootEventId: 'thread-1', channelEchoEventId: 'echo-1' })
+      )
+    ).toEqual({
+      isEcho: false,
+      editEventId: 'event-1',
+      editThreadRootEventId: 'thread-1',
+      editChannelEchoEventId: 'echo-1',
+      threadRootEventId: 'event-1'
+    });
+  });
+
+  it('maps channel echoes back to their source thread message', () => {
+    expect(
+      resolveMessageEventReferences(
+        'echo-1',
+        message({
+          echoOfEventId: 'thread-message-1',
+          echoFromThreadRootEventId: 'thread-1'
+        })
+      )
+    ).toEqual({
+      isEcho: true,
+      editEventId: 'thread-message-1',
+      editThreadRootEventId: 'thread-1',
+      editChannelEchoEventId: 'echo-1',
+      threadRootEventId: 'thread-1'
+    });
+  });
+});
+
+describe('canEditMessage', () => {
+  it('allows authors inside the edit window and moderators outside it', () => {
+    const createdAt = '2026-07-29T12:00:00.000Z';
+    const now = new Date('2026-07-29T12:05:00.000Z').getTime();
+
+    expect(
+      canEditMessage({
+        isAuthor: true,
+        createdAt,
+        now,
+        editWindowSeconds: 600,
+        canManageOthersMessage: false
+      })
+    ).toBe(true);
+    expect(
+      canEditMessage({
+        isAuthor: true,
+        createdAt,
+        now,
+        editWindowSeconds: 60,
+        canManageOthersMessage: false
+      })
+    ).toBe(false);
+    expect(
+      canEditMessage({
+        isAuthor: false,
+        createdAt,
+        now,
+        editWindowSeconds: 60,
+        canManageOthersMessage: true
+      })
+    ).toBe(true);
+  });
+});
+
+describe('embeddedMessageLinks', () => {
+  it('keeps only the first five Chatto message links', () => {
+    const body = Array.from(
+      { length: 7 },
+      (_, index) => `https://chat.example.test/chat/server/room/m/message-${index}`
+    ).join(' ');
+
+    expect(embeddedMessageLinks(body).map((link) => link.messageId)).toEqual([
+      'message-0',
+      'message-1',
+      'message-2',
+      'message-3',
+      'message-4'
+    ]);
+  });
+});
+
+describe('isDeletedMessage', () => {
+  it('keeps attachment-only messages visible and tombstones empty messages', () => {
+    expect(isDeletedMessage(message({ body: null }))).toBe(true);
+    expect(
+      isDeletedMessage(
+        message({
+          body: null,
+          attachments: [{ id: 'attachment-1' } as MessagePostedPayload['attachments'][number]]
+        })
+      )
+    ).toBe(false);
+  });
+});
+
+describe('buildMessageReplyPreview', () => {
+  it('distinguishes missing, active, and deleted reply targets', () => {
+    expect(
+      buildMessageReplyPreview({
+        target: undefined,
+        missingName: 'a message',
+        deletedName: 'Deleted user',
+        getDisplayName: (actor) => actor.displayName
+      })
+    ).toEqual({ name: 'a message', body: null, actor: null, deleted: false });
+
+    const activeActor = {
+      id: 'user-1',
+      login: 'ada',
+      displayName: 'Ada',
+      avatarUrl: '',
+      deleted: false,
+      presenceStatus: PresenceStatus.ONLINE
+    };
+    expect(
+      buildMessageReplyPreview({
+        target: {
+          id: 'reply-1',
+          createdAt: '2026-07-29T12:00:00.000Z',
+          actor: activeActor,
+          event: message({ body: 'Original' })
+        },
+        missingName: 'a message',
+        deletedName: 'Deleted user',
+        getDisplayName: (actor) => actor.displayName
+      })
+    ).toEqual({ name: 'Ada', body: 'Original', actor: activeActor, deleted: false });
+
+    expect(
+      buildMessageReplyPreview({
+        target: {
+          id: 'reply-2',
+          createdAt: '2026-07-29T12:00:00.000Z',
+          actor: { ...activeActor, deleted: true },
+          event: message({ body: null })
+        },
+        missingName: 'a message',
+        deletedName: 'Deleted user',
+        getDisplayName: (actor) => actor.displayName
+      })
+    ).toEqual({ name: 'Deleted user', body: null, actor: null, deleted: true });
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventModel.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageEventModel.ts
@@ -1,0 +1,98 @@
+import type { MessageLink } from '$lib/messageLinks';
+import { parseMessageLink } from '$lib/messageLinks';
+import { extractURLs } from '$lib/linkPreview';
+import {
+  isMessagePostedEvent,
+  type MessagePostedPayload,
+  type TimelineEventView
+} from '$lib/render/timelineEvents';
+import type { RoomMember } from '$lib/state/room';
+
+export type MessageEventReferences = {
+  isEcho: boolean;
+  editEventId: string;
+  editThreadRootEventId: string | null;
+  editChannelEchoEventId: string | null;
+  threadRootEventId: string | null;
+};
+
+export type MessageReplyPreview = {
+  name: string;
+  body: string | null;
+  actor: RoomMember | null;
+  deleted: boolean;
+};
+
+export function resolveMessageEventReferences(
+  eventId: string,
+  message: MessagePostedPayload
+): MessageEventReferences {
+  const isEcho = message.echoOfEventId != null;
+
+  return {
+    isEcho,
+    editEventId: isEcho ? message.echoOfEventId! : eventId,
+    editThreadRootEventId: isEcho
+      ? (message.echoFromThreadRootEventId ?? null)
+      : (message.threadRootEventId ?? null),
+    editChannelEchoEventId: isEcho ? eventId : (message.channelEchoEventId ?? null),
+    threadRootEventId: isEcho ? (message.echoFromThreadRootEventId ?? null) : eventId
+  };
+}
+
+export function canEditMessage({
+  isAuthor,
+  createdAt,
+  now,
+  editWindowSeconds,
+  canManageOthersMessage
+}: {
+  isAuthor: boolean;
+  createdAt: string;
+  now: number;
+  editWindowSeconds: number;
+  canManageOthersMessage: boolean;
+}): boolean {
+  return (
+    (isAuthor && now - new Date(createdAt).getTime() < editWindowSeconds * 1000) ||
+    canManageOthersMessage
+  );
+}
+
+export function embeddedMessageLinks(body: string | null | undefined): MessageLink[] {
+  if (!body) return [];
+
+  return extractURLs(body, 5)
+    .map(parseMessageLink)
+    .filter((link): link is MessageLink => link !== null);
+}
+
+export function isDeletedMessage(message: MessagePostedPayload): boolean {
+  return !message.body && message.attachments.length === 0;
+}
+
+export function buildMessageReplyPreview({
+  target,
+  missingName,
+  deletedName,
+  getDisplayName
+}: {
+  target: TimelineEventView | null | undefined;
+  missingName: string;
+  deletedName: string;
+  getDisplayName: (member: RoomMember) => string;
+}): MessageReplyPreview {
+  if (!target) {
+    return { name: missingName, body: null, actor: null, deleted: false };
+  }
+
+  const targetActor = target.actor ?? null;
+  const activeActor = targetActor && !targetActor.deleted ? targetActor : null;
+
+  return {
+    name: activeActor ? getDisplayName(activeActor) : deletedName,
+    body: isMessagePostedEvent(target.event) ? (target.event.body ?? null) : null,
+    actor: activeActor,
+    deleted: !activeActor
+  };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageUserInteractions.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageUserInteractions.svelte.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { MessageUserInteractionState } from './messageUserInteractions.svelte';
+
+const member = {
+  id: 'user-1',
+  login: 'ada',
+  displayName: 'Ada',
+  avatarUrl: '',
+  presenceStatus: PresenceStatus.ONLINE
+};
+
+describe('MessageUserInteractionState', () => {
+  it('prefers the live room member over the event actor snapshot', () => {
+    const liveMember = { ...member, displayName: 'Ada Lovelace' };
+    const state = new MessageUserInteractionState(() => [liveMember]);
+
+    state.showUser({ ...member, deleted: false }, null);
+
+    expect(state.user).toEqual(liveMember);
+  });
+
+  it('retains an actor who is no longer in the room', () => {
+    const state = new MessageUserInteractionState(() => []);
+
+    state.showUser({ ...member, deleted: false }, null);
+
+    expect(state.user).toEqual({ ...member, deleted: false, customStatus: undefined });
+    expect(state.hasCurrentMember(member.id)).toBe(false);
+  });
+
+  it('only opens mention users that are current room members', () => {
+    const state = new MessageUserInteractionState(() => [member]);
+    const rect = new DOMRect(1, 2, 3, 4);
+
+    state.showMember('missing', rect);
+    expect(state.user).toBeNull();
+
+    state.showMember(member.id, rect);
+    expect(state.user).toEqual(member);
+    expect(state.anchorRect).toBe(rect);
+
+    state.close();
+    expect(state.user).toBeNull();
+    expect(state.anchorRect).toBeNull();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageUserInteractions.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageUserInteractions.svelte.ts
@@ -1,0 +1,47 @@
+import type { UserAvatarUserView } from '$lib/render/users';
+import type { RoomMember } from '$lib/state/room';
+
+export class MessageUserInteractionState {
+  user = $state<RoomMember | null>(null);
+  anchorRect = $state<DOMRect | null>(null);
+
+  constructor(private readonly getMembers: () => RoomMember[]) {}
+
+  showUserFromEvent(user: UserAvatarUserView | RoomMember | null, event: MouseEvent): void {
+    if (!user) return;
+    const button = (event.target as HTMLElement).closest('button');
+    this.showUser(user, button?.getBoundingClientRect() ?? null);
+  }
+
+  showMember(userId: string, anchorRect: DOMRect): void {
+    const member = this.getMembers().find((candidate) => candidate.id === userId);
+    if (!member) return;
+
+    this.user = member;
+    this.anchorRect = anchorRect;
+  }
+
+  showUser(user: UserAvatarUserView | RoomMember, anchorRect: DOMRect | null): void {
+    this.user =
+      this.getMembers().find((candidate) => candidate.id === user.id) ??
+      ({
+        id: user.id,
+        login: user.login,
+        displayName: user.displayName,
+        deleted: user.deleted ?? false,
+        avatarUrl: user.avatarUrl,
+        customStatus: user.customStatus,
+        presenceStatus: user.presenceStatus
+      } satisfies RoomMember);
+    this.anchorRect = anchorRect;
+  }
+
+  hasCurrentMember(userId: string): boolean {
+    return this.getMembers().some((member) => member.id === userId);
+  }
+
+  close(): void {
+    this.user = null;
+    this.anchorRect = null;
+  }
+}


### PR DESCRIPTION
## Why

`MessageEvent.svelte` renders nearly every room and thread message, but it also
owned reply attribution, action overlays, user popovers, moderation UI, and
most message-derived decisions. Splitting those responsibilities makes this
core frontend surface easier to understand, test, and change safely.

## What changed

- Extracted pure message reference, editability, deletion, link, and reply
  preview decisions into a directly tested model module.
- Extracted reply attribution, message action overlays, and user/moderation
  overlays into focused Svelte components.
- Moved transient menu, emoji-picker, action-sheet, long-press, and user
  popover state into small Svelte state classes with direct tests.
- Made selected reply-quote ownership explicit across desktop menus and mobile
  sheets, including dismissal paths, without changing visible reply behavior.
- Reduced `MessageEvent.svelte` from 962 lines to 669 while keeping it as the
  message-row composition owner.

## Test plan

- `mise lint-frontend` — passed; Svelte Check reported 0 errors and 0 warnings.
- `mise test-frontend` — 302 files and 2,550 tests passed.
- Focused Playwright message matrix — 106 tests passed across actions,
  reactions, threading, reply echoes, editing, links, and mentions.
- Chrome DevTools — verified message rendering, hover actions, context menu,
  reply creation/attribution, attribution user popover, and reactions with no
  console warnings or errors.
- `mise license-check` — passed.
- `mise knip` — completed with only the repository's existing findings.

This is an internal frontend refactor. It changes no public API, persistence,
permissions, configuration, user-facing copy, migration, or rollout behavior.

Closes #1780.
