### PR TITLE
refactor(core): encapsulate timeline hydration state

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -6686,6 +6686,33 @@ func TestRoomAndThreadTimelineExposeDeletedAt(t *testing.T) {
 	}
 }
 
+func TestThreadTimelineExposesChannelEchoIdentity(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("timeline-channel-echo")
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	reply, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, env.viewer.Id, "reply", nil, root.Id, root.Id, nil, true)
+	if err != nil {
+		t.Fatalf("PostMessage reply with echo: %v", err)
+	}
+	echoID, ok := env.core.RoomTimeline.ChannelEchoEventID(reply.Id)
+	if !ok {
+		t.Fatal("expected channel echo for reply")
+	}
+
+	resp, err := env.threads.GetThreadEvents(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.GetThreadEventsRequest{
+		RoomId:            room.Id,
+		ThreadRootEventId: root.Id,
+		Limit:             10,
+	}))
+	if err != nil {
+		t.Fatalf("GetThreadEvents: %v", err)
+	}
+	message := timelinePageEvent(resp.Msg.GetPage(), reply.Id).GetMessagePosted().GetMessage()
+	if got := message.GetChannelEchoEventId(); got != echoID {
+		t.Fatalf("channel_echo_event_id = %q, want %q", got, echoID)
+	}
+}
+
 func TestRoomTimelineExposesAccountKeyShredDeletedAt(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("timeline-account-key-shred")

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -203,6 +203,11 @@ func (h *timelineHydrator) event(ctx context.Context, event *core.RoomEvent) (*a
 }
 
 func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEvent, payload *corev1.MessagePostedEvent) (*apiv1.Message, error) {
+	hydrationState, err := h.api.core.RoomTimelineReads().MessageHydrationState(event.Id)
+	if err != nil {
+		return nil, err
+	}
+
 	message := &apiv1.Message{
 		Id:                        event.Id,
 		RoomId:                    payload.GetRoomId(),
@@ -214,13 +219,10 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 		EchoFromThreadRootEventId: payload.GetEchoFromThreadRootEventId(),
 		Reactions:                 h.reactions(event.Id),
 	}
-	if deletedAt, ok := h.api.core.RoomTimeline.MessageDeletedAt(event.Id); ok {
-		message.DeletedAt = timestamppb.New(deletedAt)
+	if hydrationState.HasDeletedAt {
+		message.DeletedAt = timestamppb.New(hydrationState.DeletedAt)
 	}
-
-	if echoID, ok := h.api.core.RoomTimeline.ChannelEchoEventID(event.Id); ok {
-		message.ChannelEchoEventId = echoID
-	}
+	message.ChannelEchoEventId = hydrationState.ChannelEchoEventID
 
 	body, err := h.api.core.GetFullMessageBody(ctx, event.Id)
 	if err != nil {

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -130,7 +130,10 @@ func initializeCoreServices(
 	core.messageModel = &MessageModel{core: core}
 	core.messageSearchReads = &MessageSearchReadModel{core: core}
 	core.notificationPrefs = &NotificationPreferencesModel{core: core}
-	core.roomTimelineReads = &RoomTimelineReadModel{core: core}
+	core.roomTimelineReads = &RoomTimelineReadModel{
+		core:     core,
+		timeline: projections.roomTimeline,
+	}
 	core.readStateModel = &ReadStateModel{
 		core:  core,
 		index: NewReadStateIndex(infra.storage.runtimeStateKV, logger.WithPrefix("core.ReadStateIndex")),

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -61,6 +61,14 @@ type TimelineEntry struct {
 	Event     *corev1.Event
 }
 
+// RoomTimelineMessageHydrationState is the detached projection state needed to
+// render one message in a public timeline response.
+type RoomTimelineMessageHydrationState struct {
+	DeletedAt          time.Time
+	HasDeletedAt       bool
+	ChannelEchoEventID string
+}
+
 type projectedRoomAttachmentMessage struct {
 	Entry *TimelineEntry
 	Body  *corev1.MessageBody
@@ -683,6 +691,10 @@ func (p *RoomTimelineProjection) IsHiddenEcho(eventID string) bool {
 func (p *RoomTimelineProjection) ChannelEchoEventID(originalEventID string) (string, bool) {
 	p.RLock()
 	defer p.RUnlock()
+	return p.channelEchoEventIDLocked(originalEventID)
+}
+
+func (p *RoomTimelineProjection) channelEchoEventIDLocked(originalEventID string) (string, bool) {
 	if originalEventID == "" {
 		return "", false
 	}
@@ -705,6 +717,22 @@ func (p *RoomTimelineProjection) ChannelEchoEventID(originalEventID string) (str
 		return echoID, true
 	}
 	return "", false
+}
+
+// MessageHydrationState returns the timeline metadata needed to render one
+// message. The detached result is captured under one projection read lock so
+// transports cannot assemble a response from different projection moments.
+func (p *RoomTimelineProjection) MessageHydrationState(eventID string) RoomTimelineMessageHydrationState {
+	p.RLock()
+	defer p.RUnlock()
+
+	deletedAt, hasDeletedAt := p.messageTombstonedAtLocked(eventID)
+	channelEchoEventID, _ := p.channelEchoEventIDLocked(eventID)
+	return RoomTimelineMessageHydrationState{
+		DeletedAt:          deletedAt,
+		HasDeletedAt:       hasDeletedAt,
+		ChannelEchoEventID: channelEchoEventID,
+	}
 }
 
 // LinkedChannelEchoEventID returns the first non-hidden echo linked to an

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -721,7 +721,7 @@ func (p *RoomTimelineProjection) channelEchoEventIDLocked(originalEventID string
 
 // MessageHydrationState returns the timeline metadata needed to render one
 // message. The detached result is captured under one projection read lock so
-// transports cannot assemble a response from different projection moments.
+// deletion and channel-echo metadata come from the same projection moment.
 func (p *RoomTimelineProjection) MessageHydrationState(eventID string) RoomTimelineMessageHydrationState {
 	p.RLock()
 	defer p.RUnlock()

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -609,6 +609,24 @@ func TestRoomTimeline_MessageDeletedAtTracksRetractionsAndEchoes(t *testing.T) {
 	if got, ok := p.MessageDeletedAt("ENV-ECHO"); !ok || !got.Equal(fixedTime(4)) {
 		t.Fatalf("echo inherited tombstoned at = %v/%v, want %v", got, ok, fixedTime(4))
 	}
+
+	state := p.MessageHydrationState("ENV-REPLY")
+	if !state.HasDeletedAt || !state.DeletedAt.Equal(fixedTime(4)) {
+		t.Fatalf("hydration deleted_at = %v/%v, want %v/true", state.DeletedAt, state.HasDeletedAt, fixedTime(4))
+	}
+	if state.ChannelEchoEventID != "ENV-ECHO" {
+		t.Fatalf("hydration channel echo = %q, want ENV-ECHO", state.ChannelEchoEventID)
+	}
+
+	applyAll(t, p, []*corev1.Event{
+		retractedEvent("RETRACT-ECHO", "ENV-ECHO", "R1", "U2", "", 5),
+	})
+	if got := p.MessageHydrationState("ENV-REPLY").ChannelEchoEventID; got != "" {
+		t.Fatalf("hydration channel echo after echo retraction = %q, want empty", got)
+	}
+	if state.ChannelEchoEventID != "ENV-ECHO" {
+		t.Fatalf("detached hydration state changed to %q, want ENV-ECHO", state.ChannelEchoEventID)
+	}
 }
 
 func TestRoomTimeline_MessageDeletedAtUsesUserKeyShredTime(t *testing.T) {

--- a/cli/internal/core/room_timeline_read_model.go
+++ b/cli/internal/core/room_timeline_read_model.go
@@ -19,7 +19,19 @@ func (c *ChattoCore) RoomTimelineReads() *RoomTimelineReadModel {
 // validation. It returns core event pages; transports remain responsible for
 // cursor encoding and public DTO hydration.
 type RoomTimelineReadModel struct {
-	core *ChattoCore
+	core     *ChattoCore
+	timeline *RoomTimelineProjection
+}
+
+// MessageHydrationState returns detached projection metadata for rendering one
+// message. Timeline authorization belongs to the operation that supplied the
+// message event; this method only interprets already-authorized projected
+// state.
+func (s *RoomTimelineReadModel) MessageHydrationState(eventID string) (RoomTimelineMessageHydrationState, error) {
+	if s == nil || s.timeline == nil {
+		return RoomTimelineMessageHydrationState{}, errors.New("room timeline projection unavailable")
+	}
+	return s.timeline.MessageHydrationState(eventID), nil
 }
 
 type RoomTimelineEventsInput struct {

--- a/cli/internal/core/room_timeline_read_model_test.go
+++ b/cli/internal/core/room_timeline_read_model_test.go
@@ -5,6 +5,12 @@ import (
 	"testing"
 )
 
+func TestRoomTimelineReadModelMessageHydrationStateRequiresProjection(t *testing.T) {
+	if _, err := (&RoomTimelineReadModel{}).MessageHydrationState("ENV-M1"); err == nil {
+		t.Fatal("MessageHydrationState without projection error = nil")
+	}
+}
+
 func TestRoomTimelineReadModelRequiresMembership(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -22,7 +22,10 @@ needed for those waits; the `ChattoCore` facade does not mirror every registered
 projector. `CallModel` and `AssetModel` own their projection reads and readiness
 for domain logic and API adapters. Call token access material binds the call ID
 and E2EE key to one revalidated projection generation. Active-call and asset API
-mapping use detached snapshots captured under one projection lock.
+mapping use detached snapshots captured under one projection lock. Room
+timeline message hydration likewise obtains deletion and channel-echo metadata
+as one detached snapshot through `RoomTimelineReadModel`; ConnectAPI does not
+read that projection directly.
 
 Any non-cancellation error from checkpoint or snapshot restore, consumer setup,
 or event application moves the projector into its failed state before its run


### PR DESCRIPTION
## Why

ConnectAPI assembled room timeline messages by reading deletion and channel-echo
metadata directly from `RoomTimelineProjection`. Besides leaking projection
ownership into the transport, the two values could come from different
projection moments.

## What changed

- Added a detached room timeline message hydration state that captures deletion
  time and visible channel-echo identity under one projection read lock.
- Made `RoomTimelineReadModel` own access to that projected hydration state and
  fail explicitly when its projection dependency is unavailable.
- Routed ConnectAPI timeline hydration through the read model instead of
  reaching into `ChattoCore.RoomTimeline`.
- Added projection, read-model, and ConnectAPI regression coverage, including
  deletion inheritance, detached-state behavior, unavailable dependencies, and
  public channel-echo identity.
- Updated the projection architecture inventory with the detached read path.

This is an internal ownership refactor. It does not change public protobufs,
wire behavior, persisted events, projection state, snapshot contracts,
authorization, rollout, or migration requirements.

## Test plan

- `mise x -- go test ./internal/core ./internal/connectapi` from `cli/` — passed
- `mise test-cli` — passed
- `git diff --check origin/main...HEAD` — passed

Closes #1783.
