### PR TITLE
refactor(core): make room timeline projection private

### DIFF
--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -5352,7 +5352,7 @@ func TestMessageServiceReactionOnEchoCanonicalizesToOriginal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostMessage reply with echo: %v", err)
 	}
-	echoID, ok := env.core.RoomTimeline.ChannelEchoEventID(reply.Id)
+	echoID, ok := env.core.ChannelEchoEventID(reply.Id)
 	if !ok {
 		t.Fatal("expected channel echo for reply")
 	}
@@ -6648,10 +6648,14 @@ func TestRoomAndThreadTimelineExposeDeletedAt(t *testing.T) {
 	if err := env.core.DeleteMessage(env.ctx, env.viewer.Id, core.KindChannel, room.Id, reply.Id); err != nil {
 		t.Fatalf("DeleteMessage reply: %v", err)
 	}
-	replyDeletedAt, ok := env.core.RoomTimeline.MessageDeletedAt(reply.Id)
-	if !ok {
+	replyState, err := env.core.RoomTimelineReads().MessageHydrationState(reply.Id)
+	if err != nil {
+		t.Fatalf("MessageHydrationState reply: %v", err)
+	}
+	if !replyState.HasDeletedAt {
 		t.Fatal("reply projection deleted_at is missing")
 	}
+	replyDeletedAt := replyState.DeletedAt
 
 	thread, err := env.threads.GetThreadEvents(ctx, connect.NewRequest(&apiv1.GetThreadEventsRequest{
 		RoomId:            room.Id,
@@ -6669,10 +6673,14 @@ func TestRoomAndThreadTimelineExposeDeletedAt(t *testing.T) {
 	if err := env.core.DeleteMessage(env.ctx, env.viewer.Id, core.KindChannel, room.Id, root.Id); err != nil {
 		t.Fatalf("DeleteMessage root: %v", err)
 	}
-	rootDeletedAt, ok := env.core.RoomTimeline.MessageDeletedAt(root.Id)
-	if !ok {
+	rootState, err := env.core.RoomTimelineReads().MessageHydrationState(root.Id)
+	if err != nil {
+		t.Fatalf("MessageHydrationState root: %v", err)
+	}
+	if !rootState.HasDeletedAt {
 		t.Fatal("root projection deleted_at is missing")
 	}
+	rootDeletedAt := rootState.DeletedAt
 	afterDelete, err := env.rooms.GetRoomEvents(ctx, connect.NewRequest(&apiv1.GetRoomEventsRequest{
 		RoomId: room.Id,
 		Limit:  10,
@@ -6694,7 +6702,7 @@ func TestThreadTimelineExposesChannelEchoIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostMessage reply with echo: %v", err)
 	}
-	echoID, ok := env.core.RoomTimeline.ChannelEchoEventID(reply.Id)
+	echoID, ok := env.core.ChannelEchoEventID(reply.Id)
 	if !ok {
 		t.Fatal("expected channel echo for reply")
 	}
@@ -6728,10 +6736,14 @@ func TestRoomTimelineExposesAccountKeyShredDeletedAt(t *testing.T) {
 	if err := env.core.DeleteUser(env.ctx, env.viewer.Id, author.Id); err != nil {
 		t.Fatalf("DeleteUser author: %v", err)
 	}
-	deletedAt, ok := env.core.RoomTimeline.MessageDeletedAt(posted.Id)
-	if !ok {
+	state, err := env.core.RoomTimelineReads().MessageHydrationState(posted.Id)
+	if err != nil {
+		t.Fatalf("MessageHydrationState account-shredded message: %v", err)
+	}
+	if !state.HasDeletedAt {
 		t.Fatal("projection account-shred deleted_at is missing")
 	}
+	deletedAt := state.DeletedAt
 
 	resp, err := env.rooms.GetRoomEvents(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.GetRoomEventsRequest{
 		RoomId: room.Id,

--- a/cli/internal/connectapi/message_search_test.go
+++ b/cli/internal/connectapi/message_search_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/core"
+	"hmans.de/chatto/internal/events"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 	searchv1 "hmans.de/chatto/internal/pb/chatto/search/v1"
 	searchsvc "hmans.de/chatto/internal/search"
@@ -129,9 +130,7 @@ func TestMessageSearchAuthorizesHydratesAndSealsProviderCursor(t *testing.T) {
 	require.NoError(t, err)
 	message, err := env.core.PostMessage(ctx, core.KindChannel, visible.Id, env.viewer.Id, "current searchable body", nil, "", "", nil, false)
 	require.NoError(t, err)
-	messageBody, retracted, ok := env.core.RoomTimeline.LatestBody(message.Id)
-	require.True(t, ok)
-	require.False(t, retracted)
+	messageBodyEventID := currentMessageBodyEventID(t, env, visible.Id, message.Id)
 	stale, err := env.core.PostMessage(ctx, core.KindChannel, visible.Id, env.viewer.Id, "removed searchable body", nil, "", "", nil, false)
 	require.NoError(t, err)
 	require.NoError(t, env.core.DeleteMessage(ctx, env.viewer.Id, core.KindChannel, visible.Id, stale.Id))
@@ -142,7 +141,7 @@ func TestMessageSearchAuthorizesHydratesAndSealsProviderCursor(t *testing.T) {
 		response := &searchv1.QueryResponse{Hits: []*searchv1.QueryHit{
 			{MessageId: stale.Id, RoomId: visible.Id, BodyEventId: "stale-body"},
 			{MessageId: "hidden-message", RoomId: hidden.Id, BodyEventId: "hidden-body"},
-			{MessageId: message.Id, RoomId: visible.Id, BodyEventId: messageBody.GetBodyEventId()},
+			{MessageId: message.Id, RoomId: visible.Id, BodyEventId: messageBodyEventID},
 		}}
 		if len(request.GetCursor()) == 0 {
 			response.NextCursor = providerCursor
@@ -194,6 +193,23 @@ func TestMessageSearchAuthorizesHydratesAndSealsProviderCursor(t *testing.T) {
 	_, err = service.SearchMessages(withCaller(env.ctx, otherViewer), connect.NewRequest(secondRequest))
 	require.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
 	require.Len(t, provider.capturedQueries(), 2)
+}
+
+func currentMessageBodyEventID(t *testing.T, env *connectAPITestEnv, roomID, messageID string) string {
+	t.Helper()
+	bodyEvents, _, err := env.core.EventPublisher.SubjectEvents(
+		env.ctx,
+		events.RoomAggregate(roomID).Subject(events.EventMessageBody),
+	)
+	require.NoError(t, err)
+	for _, event := range bodyEvents {
+		bodyEvent := event.GetMessageBody()
+		if bodyEvent.GetEventId() == messageID && bodyEvent.GetBody() != nil {
+			return bodyEvent.GetBody().GetBodyEventId()
+		}
+	}
+	t.Fatalf("message body event for %s not found", messageID)
+	return ""
 }
 
 func TestMessageSearchMapsFeatureAndProviderFailures(t *testing.T) {

--- a/cli/internal/core/asset_model.go
+++ b/cli/internal/core/asset_model.go
@@ -707,7 +707,7 @@ func (s *AssetModel) IsPublicLinkPreviewAsset(assetID string) bool {
 }
 
 func (s *AssetModel) MessageTombstoned(eventID string) bool {
-	return s != nil && s.ChattoCore != nil && s.roomModel != nil && s.roomModel.messageTombstoned(eventID)
+	return s != nil && s.ChattoCore != nil && s.roomModel.hasTimeline() && s.roomModel.messageTombstoned(eventID)
 }
 
 func (s *AssetModel) shouldAppendAssetProcessingEvent(assetID string, event *corev1.Event) bool {

--- a/cli/internal/core/asset_model.go
+++ b/cli/internal/core/asset_model.go
@@ -707,7 +707,7 @@ func (s *AssetModel) IsPublicLinkPreviewAsset(assetID string) bool {
 }
 
 func (s *AssetModel) MessageTombstoned(eventID string) bool {
-	return s != nil && s.RoomTimeline != nil && s.RoomTimeline.MessageTombstoned(eventID)
+	return s != nil && s.ChattoCore != nil && s.roomModel != nil && s.roomModel.messageTombstoned(eventID)
 }
 
 func (s *AssetModel) shouldAppendAssetProcessingEvent(assetID string, event *corev1.Event) bool {

--- a/cli/internal/core/asset_projection_test.go
+++ b/cli/internal/core/asset_projection_test.go
@@ -239,7 +239,10 @@ func TestAssetProjectionAssetStateIsConsistentAndDetached(t *testing.T) {
 func TestAssetModelUnmanifestedVideoAttachmentsUsesAssetOwnershipAndTimelineTombstones(t *testing.T) {
 	assets := NewAssetProjection()
 	timeline := NewRoomTimelineProjection()
-	model := NewAssetModel(&ChattoCore{RoomTimeline: timeline}, assets, nil)
+	core := &ChattoCore{
+		roomModel: newRoomModel(nil, nil, nil, nil, timeline, nil, nil, nil, nil, nil),
+	}
+	model := NewAssetModel(core, assets, nil)
 	post := postedEvent(postedOpts{envelopeID: "M1", roomID: "R1", actorID: "U1", at: 1})
 	body := bodyEventWithAssets("E-body", "M1", "R1", "U1", "", []string{"A-video"}, 2)
 	applyAll(t, assets, []*corev1.Event{body, attachmentDeclaredEvent("R1", "A-video", "video/mp4")})

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -116,11 +116,6 @@ type ChattoCore struct {
 	// RoomLayout is the sidebar ordering index inside RoomGroupLayout.
 	RoomLayout *RoomLayoutProjection
 
-	// RoomTimeline holds an append-only event log per room, derived
-	// from the full evt.room.> firehose (#597 phase 2). Source of
-	// truth for room timeline reads post-cutover.
-	RoomTimeline *RoomTimelineProjection
-
 	// Threads holds an append-only event log per thread root,
 	// derived from the same evt.room.> firehose. Source of truth
 	// for thread-pane reads post-cutover.

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -130,8 +130,8 @@ func initializeCoreServices(
 	core.messageSearchReads = &MessageSearchReadModel{core: core}
 	core.notificationPrefs = &NotificationPreferencesModel{core: core}
 	core.roomTimelineReads = &RoomTimelineReadModel{
-		core:     core,
-		timeline: projections.roomTimeline,
+		core:  core,
+		rooms: core.roomModel,
 	}
 	core.readStateModel = &ReadStateModel{
 		core:  core,

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -65,7 +65,6 @@ func assembleCore(
 		RoomMembership: projections.roomDirectory.Membership,
 		RoomGroups:     projections.roomGroupLayout.Groups,
 		RoomLayout:     projections.roomGroupLayout.Layout,
-		RoomTimeline:   projections.roomTimeline,
 		Threads:        projections.threads,
 		Reactions:      projections.reactions,
 		Users:          projections.users,

--- a/cli/internal/core/encryption_test.go
+++ b/cli/internal/core/encryption_test.go
@@ -94,7 +94,7 @@ func TestPostMessage_EncryptsMessageBody(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, event)
 
-	stored, retracted, ok := core.RoomTimeline.LatestBody(event.Id)
+	stored, retracted, ok := core.roomModel.latestBody(event.Id)
 	require.True(t, ok, "expected message to be projected")
 	require.False(t, retracted, "new message should not be retracted")
 	require.NotNil(t, stored, "expected projected body from MessageBodyEvent")
@@ -142,7 +142,7 @@ func TestMessageBodyV2AADRejectsWrongEventContext(t *testing.T) {
 
 	event, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "Bound to one event", nil, "", "", nil, false)
 	require.NoError(t, err)
-	stored, retracted, ok := core.RoomTimeline.LatestBody(event.Id)
+	stored, retracted, ok := core.roomModel.latestBody(event.Id)
 	require.True(t, ok)
 	require.False(t, retracted)
 	require.NotNil(t, stored)
@@ -608,7 +608,7 @@ func TestEditMessage_PreservesEncryptionState(t *testing.T) {
 
 	// Post-#597 cutover: the edited body rides on a MessageEditedEvent
 	// in the EVT stream, surfaced via the projection's LatestBody.
-	stored, retracted, ok := core.RoomTimeline.LatestBody(event.Id)
+	stored, retracted, ok := core.roomModel.latestBody(event.Id)
 	require.True(t, ok, "expected the edited message to still be projected")
 	require.False(t, retracted, "message should not be retracted by an edit")
 	require.NotNil(t, stored, "expected a body after edit")

--- a/cli/internal/core/media_model_test.go
+++ b/cli/internal/core/media_model_test.go
@@ -843,7 +843,7 @@ func TestMediaModelMessageBodyAttachmentLookups(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PostMessage: %v", err)
 	}
-	body, retracted, ok := core.RoomTimeline.LatestBody(event.GetId())
+	body, retracted, ok := core.roomModel.latestBody(event.GetId())
 	if !ok || retracted {
 		t.Fatalf("LatestBody ok=%v retracted=%v, want ok true retracted false", ok, retracted)
 	}

--- a/cli/internal/core/message_search_read_model_test.go
+++ b/cli/internal/core/message_search_read_model_test.go
@@ -73,7 +73,7 @@ func TestMessageSearchReadModelHydratesThreadMessages(t *testing.T) {
 	require.NoError(t, err)
 	reply, err := chattoCore.PostMessage(ctx, KindChannel, room.Id, viewer.Id, "searchable thread reply", nil, root.Id, "", nil, false)
 	require.NoError(t, err)
-	body, retracted, ok := chattoCore.RoomTimeline.LatestBody(reply.Id)
+	body, retracted, ok := chattoCore.roomModel.latestBody(reply.Id)
 	require.True(t, ok)
 	require.False(t, retracted)
 
@@ -107,7 +107,7 @@ func TestMessageSearchReadModelReauthorizesAndHydratesHits(t *testing.T) {
 
 	scope, err := chattoCore.MessageSearchReads().ResolveScope(ctx, MessageSearchScopeInput{ActorID: viewer.Id})
 	require.NoError(t, err)
-	visibleBody, retracted, ok := chattoCore.RoomTimeline.LatestBody(visibleMessage.Id)
+	visibleBody, retracted, ok := chattoCore.roomModel.latestBody(visibleMessage.Id)
 	require.True(t, ok)
 	require.False(t, retracted)
 	require.NotNil(t, visibleBody)
@@ -127,7 +127,7 @@ func TestMessageSearchReadModelReauthorizesAndHydratesHits(t *testing.T) {
 	}})
 	require.NoError(t, err)
 	require.Empty(t, results)
-	currentBody, retracted, ok := chattoCore.RoomTimeline.LatestBody(visibleMessage.Id)
+	currentBody, retracted, ok := chattoCore.roomModel.latestBody(visibleMessage.Id)
 	require.True(t, ok)
 	require.False(t, retracted)
 	results, err = chattoCore.MessageSearchReads().HydrateHits(ctx, viewer.Id, scope, []MessageSearchHit{{

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -184,7 +184,7 @@ func (c *ChattoCore) appendThreadReplyEcho(
 				return "", false, err
 			}
 		}
-		if echoID, ok := c.RoomTimeline.ChannelEchoEventID(originalID); ok {
+		if echoID, ok := c.roomModel.channelEchoEventID(originalID); ok {
 			return echoID, false, nil
 		}
 
@@ -276,7 +276,7 @@ func (c *ChattoCore) hideChannelEchoForReply(ctx context.Context, actorID string
 				return err
 			}
 		}
-		echoID, ok := c.RoomTimeline.ChannelEchoEventID(originalEventID)
+		echoID, ok := c.roomModel.channelEchoEventID(originalEventID)
 		if !ok {
 			return nil
 		}
@@ -960,7 +960,7 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		echoTargetEvent := originalEntry.Event
 		echoTargetPost := origPost
 		if echoOf := origPost.GetEchoOfEventId(); echoOf != "" {
-			origEchoEntry, ok := c.RoomTimeline.Get(echoOf)
+			origEchoEntry, ok := c.roomModel.timelineEntry(echoOf)
 			if !ok || origEchoEntry.Event == nil {
 				return ErrMessageNotFound
 			}
@@ -1036,7 +1036,7 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 }
 
 func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, actorID string, kind RoomKind, roomID, eventID string, enabled bool) error {
-	entry, ok := c.RoomTimeline.Get(eventID)
+	entry, ok := c.roomModel.timelineEntry(eventID)
 	if !ok || entry.Event == nil {
 		return ErrMessageNotFound
 	}
@@ -1050,7 +1050,7 @@ func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, acto
 	originalID := eventID
 	if echoOf := posted.GetEchoOfEventId(); echoOf != "" {
 		originalID = echoOf
-		originalEntry, ok := c.RoomTimeline.Get(originalID)
+		originalEntry, ok := c.roomModel.timelineEntry(originalID)
 		if !ok || originalEntry.Event == nil {
 			return ErrMessageNotFound
 		}
@@ -1069,7 +1069,7 @@ func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, acto
 	if time.Since(originalEvent.GetCreatedAt().AsTime()) > MessageEditWindow {
 		return ErrEditWindowExpired
 	}
-	current, retracted, _ := c.RoomTimeline.LatestBody(originalID)
+	current, retracted, _ := c.roomModel.latestBody(originalID)
 	if retracted || current == nil {
 		return ErrMessageNotFound
 	}

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -184,14 +184,14 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Post reply: %v", err)
 	}
-	if _, ok := core.RoomTimeline.ChannelEchoEventID(reply.Id); ok {
+	if _, ok := core.roomModel.channelEchoEventID(reply.Id); ok {
 		t.Fatal("reply unexpectedly starts with a channel echo")
 	}
 
 	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "reply edited with echo", WithMessageChannelEcho(true)); err != nil {
 		t.Fatalf("EditMessage add echo: %v", err)
 	}
-	echoID, ok := core.RoomTimeline.ChannelEchoEventID(reply.Id)
+	echoID, ok := core.roomModel.channelEchoEventID(reply.Id)
 	if !ok {
 		t.Fatal("expected edit to create a channel echo")
 	}
@@ -206,14 +206,14 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "reply edited again"); err != nil {
 		t.Fatalf("EditMessage preserve echo: %v", err)
 	}
-	if gotEchoID, ok := core.RoomTimeline.ChannelEchoEventID(reply.Id); !ok || gotEchoID != echoID {
+	if gotEchoID, ok := core.roomModel.channelEchoEventID(reply.Id); !ok || gotEchoID != echoID {
 		t.Fatalf("nil echo option should preserve echo; got id=%q ok=%v", gotEchoID, ok)
 	}
 
 	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "reply without echo", WithMessageChannelEcho(false)); err != nil {
 		t.Fatalf("EditMessage remove echo: %v", err)
 	}
-	if _, ok := core.RoomTimeline.ChannelEchoEventID(reply.Id); ok {
+	if _, ok := core.roomModel.channelEchoEventID(reply.Id); ok {
 		t.Fatal("expected echo to be hidden after unchecking")
 	}
 	replyText, err := core.GetMessageBody(ctx, reply.Id)
@@ -341,7 +341,7 @@ func TestChattoCore_PostMessage_BodyStoredInMessageBodyEvent(t *testing.T) {
 		t.Errorf("Message body = %s, want %s", fetchedBody, messageBody)
 	}
 
-	storedBody, retracted, ok := core.RoomTimeline.LatestBody(roomEvent.Id)
+	storedBody, retracted, ok := core.roomModel.latestBody(roomEvent.Id)
 	if !ok || retracted || storedBody == nil {
 		t.Fatal("Expected projected message body from MessageBodyEvent")
 	}
@@ -449,7 +449,7 @@ func TestChattoCore_MessageBodyEventsAreSecureDeletedAfterEditAndDelete(t *testi
 	if err != nil {
 		t.Fatalf("PostMessage: %v", err)
 	}
-	seqs, current, ok := core.RoomTimeline.BodyEventSeqs(posted.Id)
+	seqs, current, ok := core.roomModel.bodyEventSeqs(posted.Id)
 	if !ok || len(seqs) != 1 || current == 0 {
 		t.Fatalf("BodyEventSeqs after post = (%v, %d, %v), want one current body event", seqs, current, ok)
 	}
@@ -464,7 +464,7 @@ func TestChattoCore_MessageBodyEventsAreSecureDeletedAfterEditAndDelete(t *testi
 	if _, err := core.storage.serverEvtStream.GetMsg(ctx, originalSeq); !errors.Is(err, jetstream.ErrMsgNotFound) {
 		t.Fatalf("original body event after edit error = %v, want ErrMsgNotFound", err)
 	}
-	_, editedSeq, ok := core.RoomTimeline.BodyEventSeqs(posted.Id)
+	_, editedSeq, ok := core.roomModel.bodyEventSeqs(posted.Id)
 	if !ok || editedSeq == 0 || editedSeq == originalSeq {
 		t.Fatalf("current body seq after edit = %d (ok=%v), want new seq", editedSeq, ok)
 	}

--- a/cli/internal/core/reactions.go
+++ b/cli/internal/core/reactions.go
@@ -171,36 +171,36 @@ func (c *ChattoCore) CanonicalReactionMessageEventID(roomID, messageEventID stri
 // ChannelEchoEventID returns the visible room-timeline echo for an original
 // thread reply. The boolean is false when the reply is not currently echoed.
 func (c *ChattoCore) ChannelEchoEventID(messageEventID string) (string, bool) {
-	if c == nil || c.RoomTimeline == nil {
+	if c == nil || c.roomModel == nil {
 		return "", false
 	}
-	return c.RoomTimeline.ChannelEchoEventID(messageEventID)
+	return c.roomModel.channelEchoEventID(messageEventID)
 }
 
 // LinkedChannelEchoEventID returns a linked non-hidden echo even after the
 // canonical reply retraction has turned that echo into a tombstone.
 func (c *ChattoCore) LinkedChannelEchoEventID(messageEventID string) (string, bool) {
-	if c == nil || c.RoomTimeline == nil {
+	if c == nil || c.roomModel == nil {
 		return "", false
 	}
-	return c.RoomTimeline.LinkedChannelEchoEventID(messageEventID)
+	return c.roomModel.linkedChannelEchoEventID(messageEventID)
 }
 
 // IsHiddenChannelEcho reports whether an echo row was directly retracted while
 // its canonical thread reply remains visible. Such rows disappear from the
 // room projection instead of rendering as deleted-message tombstones.
 func (c *ChattoCore) IsHiddenChannelEcho(messageEventID string) bool {
-	return c != nil && c.RoomTimeline != nil && c.RoomTimeline.IsHiddenEcho(messageEventID)
+	return c != nil && c.roomModel != nil && c.roomModel.isHiddenEcho(messageEventID)
 }
 
 func (c *ChattoCore) canonicalReactionMessageEventID(roomID, messageEventID string) (string, error) {
 	if strings.TrimSpace(messageEventID) == "" {
 		return messageEventID, nil
 	}
-	if c == nil || c.RoomTimeline == nil {
+	if c == nil || c.roomModel == nil {
 		return messageEventID, nil
 	}
-	entry, ok := c.RoomTimeline.Get(messageEventID)
+	entry, ok := c.roomModel.timelineEntry(messageEventID)
 	if !ok || entry == nil || entry.Event == nil {
 		return messageEventID, nil
 	}
@@ -213,7 +213,7 @@ func (c *ChattoCore) canonicalReactionMessageEventID(roomID, messageEventID stri
 	}
 	originalID := posted.GetEchoOfEventId()
 	if roomID != "" {
-		if originalEntry, ok := c.RoomTimeline.Get(originalID); ok && originalEntry != nil && originalEntry.Event != nil && roomIDOfEvent(originalEntry.Event) != roomID {
+		if originalEntry, ok := c.roomModel.timelineEntry(originalID); ok && originalEntry != nil && originalEntry.Event != nil && roomIDOfEvent(originalEntry.Event) != roomID {
 			return "", ErrMessageNotFound
 		}
 	}

--- a/cli/internal/core/reactions.go
+++ b/cli/internal/core/reactions.go
@@ -171,7 +171,7 @@ func (c *ChattoCore) CanonicalReactionMessageEventID(roomID, messageEventID stri
 // ChannelEchoEventID returns the visible room-timeline echo for an original
 // thread reply. The boolean is false when the reply is not currently echoed.
 func (c *ChattoCore) ChannelEchoEventID(messageEventID string) (string, bool) {
-	if c == nil || c.roomModel == nil {
+	if c == nil || !c.roomModel.hasTimeline() {
 		return "", false
 	}
 	return c.roomModel.channelEchoEventID(messageEventID)
@@ -180,7 +180,7 @@ func (c *ChattoCore) ChannelEchoEventID(messageEventID string) (string, bool) {
 // LinkedChannelEchoEventID returns a linked non-hidden echo even after the
 // canonical reply retraction has turned that echo into a tombstone.
 func (c *ChattoCore) LinkedChannelEchoEventID(messageEventID string) (string, bool) {
-	if c == nil || c.roomModel == nil {
+	if c == nil || !c.roomModel.hasTimeline() {
 		return "", false
 	}
 	return c.roomModel.linkedChannelEchoEventID(messageEventID)
@@ -190,14 +190,14 @@ func (c *ChattoCore) LinkedChannelEchoEventID(messageEventID string) (string, bo
 // its canonical thread reply remains visible. Such rows disappear from the
 // room projection instead of rendering as deleted-message tombstones.
 func (c *ChattoCore) IsHiddenChannelEcho(messageEventID string) bool {
-	return c != nil && c.roomModel != nil && c.roomModel.isHiddenEcho(messageEventID)
+	return c != nil && c.roomModel.hasTimeline() && c.roomModel.isHiddenEcho(messageEventID)
 }
 
 func (c *ChattoCore) canonicalReactionMessageEventID(roomID, messageEventID string) (string, error) {
 	if strings.TrimSpace(messageEventID) == "" {
 		return messageEventID, nil
 	}
-	if c == nil || c.roomModel == nil {
+	if c == nil || !c.roomModel.hasTimeline() {
 		return messageEventID, nil
 	}
 	entry, ok := c.roomModel.timelineEntry(messageEventID)

--- a/cli/internal/core/reactions_test.go
+++ b/cli/internal/core/reactions_test.go
@@ -11,6 +11,29 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
+func TestTimelineFacadesHandleUnavailableRoomTimeline(t *testing.T) {
+	for name, core := range map[string]*ChattoCore{
+		"nil core":          nil,
+		"nil room model":    {},
+		"nil room timeline": {roomModel: &RoomModel{}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if echoID, ok := core.ChannelEchoEventID("M1"); ok || echoID != "" {
+				t.Fatalf("ChannelEchoEventID = %q/%v, want empty/false", echoID, ok)
+			}
+			if echoID, ok := core.LinkedChannelEchoEventID("M1"); ok || echoID != "" {
+				t.Fatalf("LinkedChannelEchoEventID = %q/%v, want empty/false", echoID, ok)
+			}
+			if core.IsHiddenChannelEcho("M1") {
+				t.Fatal("IsHiddenChannelEcho = true, want false")
+			}
+			if got := core.CanonicalReactionMessageEventID("R1", "M1"); got != "M1" {
+				t.Fatalf("CanonicalReactionMessageEventID = %q, want M1", got)
+			}
+		})
+	}
+}
+
 func TestReactionModel_AddReactionWrite(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/room_attachments_test.go
+++ b/cli/internal/core/room_attachments_test.go
@@ -139,7 +139,7 @@ func TestChattoCore_GetRoomAttachmentsDoesNotDecryptNonFileMessages(t *testing.T
 		EncryptedBody:   []byte("not-valid-ciphertext"),
 		EncryptionNonce: []byte("bad-nonce"),
 	}
-	if err := core.RoomTimeline.Apply(&corev1.Event{
+	if err := core.roomModel.timeline.Apply(&corev1.Event{
 		Id:        bodyEventID,
 		ActorId:   user.Id,
 		CreatedAt: createdAt,
@@ -153,7 +153,7 @@ func TestChattoCore_GetRoomAttachmentsDoesNotDecryptNonFileMessages(t *testing.T
 	}, 1_000_000); err != nil {
 		t.Fatalf("Apply corrupt text body: %v", err)
 	}
-	if err := core.RoomTimeline.Apply(&corev1.Event{
+	if err := core.roomModel.timeline.Apply(&corev1.Event{
 		Id:        messageEventID,
 		ActorId:   user.Id,
 		CreatedAt: createdAt,

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -178,6 +178,10 @@ func (m *RoomModel) isRoomBanActive(roomID, userID string, now time.Time) bool {
 	return m.directory.Bans.IsActive(roomID, userID, now)
 }
 
+func (m *RoomModel) hasTimeline() bool {
+	return m != nil && m.timeline != nil
+}
+
 func (m *RoomModel) timelineEntry(eventID string) (*TimelineEntry, bool) {
 	return m.timeline.Get(eventID)
 }
@@ -204,6 +208,10 @@ func (m *RoomModel) channelEchoEventID(eventID string) (string, bool) {
 
 func (m *RoomModel) linkedChannelEchoEventID(eventID string) (string, bool) {
 	return m.timeline.LinkedChannelEchoEventID(eventID)
+}
+
+func (m *RoomModel) messageHydrationState(eventID string) RoomTimelineMessageHydrationState {
+	return m.timeline.MessageHydrationState(eventID)
 }
 
 func (m *RoomModel) linkedEventIDs(eventID string) []string {

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -198,6 +198,14 @@ func (m *RoomModel) isHiddenEcho(eventID string) bool {
 	return m.timeline.IsHiddenEcho(eventID)
 }
 
+func (m *RoomModel) channelEchoEventID(eventID string) (string, bool) {
+	return m.timeline.ChannelEchoEventID(eventID)
+}
+
+func (m *RoomModel) linkedChannelEchoEventID(eventID string) (string, bool) {
+	return m.timeline.LinkedChannelEchoEventID(eventID)
+}
+
 func (m *RoomModel) linkedEventIDs(eventID string) []string {
 	return m.timeline.LinkedEventIDs(eventID)
 }

--- a/cli/internal/core/room_timeline_read_model.go
+++ b/cli/internal/core/room_timeline_read_model.go
@@ -19,8 +19,8 @@ func (c *ChattoCore) RoomTimelineReads() *RoomTimelineReadModel {
 // validation. It returns core event pages; transports remain responsible for
 // cursor encoding and public DTO hydration.
 type RoomTimelineReadModel struct {
-	core     *ChattoCore
-	timeline *RoomTimelineProjection
+	core  *ChattoCore
+	rooms *RoomModel
 }
 
 // MessageHydrationState returns detached projection metadata for rendering one
@@ -28,10 +28,10 @@ type RoomTimelineReadModel struct {
 // message event; this method only interprets already-authorized projected
 // state.
 func (s *RoomTimelineReadModel) MessageHydrationState(eventID string) (RoomTimelineMessageHydrationState, error) {
-	if s == nil || s.timeline == nil {
-		return RoomTimelineMessageHydrationState{}, errors.New("room timeline projection unavailable")
+	if s == nil || !s.rooms.hasTimeline() {
+		return RoomTimelineMessageHydrationState{}, errors.New("room model unavailable")
 	}
-	return s.timeline.MessageHydrationState(eventID), nil
+	return s.rooms.messageHydrationState(eventID), nil
 }
 
 type RoomTimelineEventsInput struct {

--- a/cli/internal/core/room_timeline_read_model_test.go
+++ b/cli/internal/core/room_timeline_read_model_test.go
@@ -5,9 +5,12 @@ import (
 	"testing"
 )
 
-func TestRoomTimelineReadModelMessageHydrationStateRequiresProjection(t *testing.T) {
+func TestRoomTimelineReadModelMessageHydrationStateRequiresRoomModel(t *testing.T) {
 	if _, err := (&RoomTimelineReadModel{}).MessageHydrationState("ENV-M1"); err == nil {
-		t.Fatal("MessageHydrationState without projection error = nil")
+		t.Fatal("MessageHydrationState without room model error = nil")
+	}
+	if _, err := (&RoomTimelineReadModel{rooms: &RoomModel{}}).MessageHydrationState("ENV-M1"); err == nil {
+		t.Fatal("MessageHydrationState without timeline projection error = nil")
 	}
 }
 

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -62,10 +62,10 @@ func TestChattoCore_PostMessage_Threading(t *testing.T) {
 		if created == nil {
 			t.Fatalf("expected ThreadCreatedEvent for root %s", root.Id)
 		}
-		if _, ok := core.RoomTimeline.Get(created.Id); ok {
+		if _, ok := core.roomModel.timelineEntry(created.Id); ok {
 			t.Fatalf("ThreadCreatedEvent %s should not be retained in room timeline lookup", created.Id)
 		}
-		replyEntry, ok := core.RoomTimeline.Get(reply.Id)
+		replyEntry, ok := core.roomModel.timelineEntry(reply.Id)
 		if !ok {
 			t.Fatalf("reply %s was not projected", reply.Id)
 		}
@@ -1453,7 +1453,7 @@ func TestChattoCore_PostMessage_ThreadReplyEcho(t *testing.T) {
 
 		// Echo and reply each have their own envelope id and encryption
 		// context, but decrypt to the same visible content.
-		replyBody, retracted, ok := core.RoomTimeline.LatestBody(replyEvent.Id)
+		replyBody, retracted, ok := core.roomModel.latestBody(replyEvent.Id)
 		if !ok || retracted || replyBody == nil {
 			t.Fatal("reply has no projected body")
 		}
@@ -1468,7 +1468,7 @@ func TestChattoCore_PostMessage_ThreadReplyEcho(t *testing.T) {
 			}
 		}
 		if echoID != "" {
-			echoBody, retracted, ok = core.RoomTimeline.LatestBody(echoID)
+			echoBody, retracted, ok = core.roomModel.latestBody(echoID)
 			if !ok || retracted {
 				echoBody = nil
 			}

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -25,7 +25,9 @@ and E2EE key to one revalidated projection generation. Active-call and asset API
 mapping use detached snapshots captured under one projection lock. Room
 timeline message hydration likewise obtains deletion and channel-echo metadata
 as one detached snapshot through `RoomTimelineReadModel`; ConnectAPI does not
-read that projection directly.
+read that projection directly. `RoomModel` is the sole production owner of the
+Room Timeline projection; message, reaction, asset, and realtime paths use its
+focused operations rather than a projection field on `ChattoCore`.
 
 Any non-cancellation error from checkpoint or snapshot restore, consumer setup,
 or event application moves the projector into its failed state before its run


### PR DESCRIPTION
## Why

`RoomModel` already owned Room Timeline projection readiness and most reads, but
`ChattoCore` still exposed the raw projection. Message, reaction, asset, tests,
and a read model could therefore bypass the intended ownership boundary,
leaving two competing ways to access timeline state.

## What changed

- Removed the public `ChattoCore.RoomTimeline` field and its construction
  wiring.
- Added the remaining focused timeline operations to `RoomModel`.
- Routed message echo reconciliation, reaction canonicalisation, asset
  tombstone checks, realtime-facing facades, and `RoomTimelineReadModel`
  through the room model.
- Preserved safe fallback behavior when partial test/service wiring omits the
  room model or timeline projection.
- Updated tests to use behavioral APIs, intentional facades, or the
  package-private room-model boundary.
- Updated the projection architecture inventory to name `RoomModel` as the sole
  production owner.

This is an internal ownership refactor. It does not change public protobufs,
wire behavior, events, subjects, persistence, projection state, snapshot
contracts, authorization, rollout, or migration requirements.

## Test plan

- `mise x -- go test ./internal/core ./internal/connectapi` from `cli/` — passed
- `mise test-cli` — passed before and after review fixes
- `git diff --check origin/main...HEAD` — passed

Closes #1787.
