### PR TITLE
refactor(frontend): split room orchestration

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -292,6 +292,16 @@
       hasActiveRoomCall &&
       appUi.isRoomCallWideFor(getActiveServer(), roomId)
   );
+  const sharedRoomSidebarProps = $derived({
+    roomId,
+    hasActiveCall: hasActiveRoomCall,
+    loading: room.isRoomLoading,
+    filesStore: roomFilesStore,
+    livekitUrl: serverInfo.livekitUrl ?? undefined,
+    canBanRoomMembers: canBanMembersFromRoomSidebar(room.isDM, room.roomData?.canBanRoomMembers),
+    currentUserId: currentUser.user?.id ?? null,
+    membersStore: roomMembersStore
+  });
 
   const syncRoomMembers: Attachment = () => {
     const selectedRoomId = roomId;
@@ -575,21 +585,13 @@
       {#if mobileRoomSidebarPanel}
         <RoomSidebarPane
           presentation="mobile"
-          {roomId}
-          activePanel={mobileRoomSidebarPanel}
-          hasActiveCall={hasActiveRoomCall}
-          loading={room.isRoomLoading}
-          filesStore={roomFilesStore}
-          livekitUrl={serverInfo.livekitUrl ?? undefined}
-          canBanRoomMembers={canBanMembersFromRoomSidebar(
-            room.isDM,
-            room.roomData?.canBanRoomMembers
-          )}
-          currentUserId={currentUser.user?.id ?? null}
-          membersStore={roomMembersStore}
-          onOpenFile={(messageEventId, threadRootEventId) =>
-            openFileMessage(messageEventId, threadRootEventId, true)}
-          onClose={() => appUi.closeMobileRoomSidebarPanel()}
+          sidebarProps={{
+            ...sharedRoomSidebarProps,
+            activePanel: mobileRoomSidebarPanel,
+            onOpenFile: (messageEventId, threadRootEventId) =>
+              openFileMessage(messageEventId, threadRootEventId, true),
+            onClose: () => appUi.closeMobileRoomSidebarPanel()
+          }}
         />
       {/if}
     </div>
@@ -597,23 +599,14 @@
     {#if activeRoomSidebarPanel}
       <RoomSidebarPane
         presentation="desktop"
-        {roomId}
-        activePanel={activeRoomSidebarPanel}
-        maximized={isDesktopCallMaximized}
-        hasActiveCall={hasActiveRoomCall}
-        loading={room.isRoomLoading}
-        filesStore={roomFilesStore}
-        livekitUrl={serverInfo.livekitUrl ?? undefined}
-        canBanRoomMembers={canBanMembersFromRoomSidebar(
-          room.isDM,
-          room.roomData?.canBanRoomMembers
-        )}
-        currentUserId={currentUser.user?.id ?? null}
-        membersStore={roomMembersStore}
-        onOpenFile={(messageEventId, threadRootEventId) =>
-          openFileMessage(messageEventId, threadRootEventId)}
-        onToggleMaximized={toggleDesktopCallWide}
-        onClose={closeDesktopRoomSidebarPanel}
+        sidebarProps={{
+          ...sharedRoomSidebarProps,
+          activePanel: activeRoomSidebarPanel,
+          maximized: isDesktopCallMaximized,
+          onOpenFile: openFileMessage,
+          onToggleMaximized: toggleDesktopCallWide,
+          onClose: closeDesktopRoomSidebarPanel
+        }}
       />
     {/if}
   </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -25,8 +25,7 @@
     RoomMembersStore,
     setRoomMembersStore,
     createRoomPermissions,
-    DEFAULT_ROOM_PERMISSIONS,
-    type QuoteInsertionContent
+    DEFAULT_ROOM_PERMISSIONS
   } from '$lib/state/room';
   import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import { getAppUiState } from '$lib/state/appUi.svelte';
@@ -47,9 +46,8 @@
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { tick } from 'svelte';
-  import { fly } from 'svelte/transition';
   import RoomEventsPane from './RoomEventsPane.svelte';
-  import RoomSidebar from './RoomSidebar.svelte';
+  import RoomSidebarPane from './RoomSidebarPane.svelte';
   import RoomSidebarToggle from './RoomSidebarToggle.svelte';
   import {
     canBanMembersFromRoomSidebar,
@@ -57,8 +55,10 @@
     roomSidebarPanelsForRoom,
     visibleRoomSidebarPanel
   } from './roomSidebarBehavior';
+  import { RoomNavigationState } from './roomNavigationState.svelte';
+  import { buildRoomPresentation } from './roomPresentation';
   import ThreadPane from './ThreadPane.svelte';
-  import type { PendingThreadReplyRequest, ThreadOpenOptions } from './threadOpenOptions';
+  import type { ThreadOpenOptions } from './threadOpenOptions';
 
   let {
     roomId,
@@ -75,24 +75,10 @@
   const appUi = getAppUiState();
   const desktopRoomLayout = new MediaQuery('(min-width: 1024px)', false);
 
-  // Thread navigation functions (URL-driven state)
-  let pendingThreadHighlight = $state<string | null>(null);
-  let pendingMainHighlightId = $state<string | null>(null);
-  let mainHighlightRequestId = 0;
-  let pendingThreadQuote = $state<{ id: number; text: QuoteInsertionContent } | null>(null);
-  let pendingThreadQuoteId = 0;
-  let pendingThreadReply = $state<PendingThreadReplyRequest | null>(null);
-  let pendingThreadReplyId = 0;
-  let appliedThreadMessageRoute: string | null = null;
+  const navigation = new RoomNavigationState();
 
   function openThread(threadRootEventId: string, options: ThreadOpenOptions = {}) {
-    pendingThreadHighlight = options.highlightEventId ?? null;
-    pendingThreadQuote = options.quoteText
-      ? { id: ++pendingThreadQuoteId, text: options.quoteText }
-      : null;
-    pendingThreadReply = options.reply
-      ? { id: ++pendingThreadReplyId, threadRootEventId, ...options.reply }
-      : null;
+    navigation.prepareThreadOpen(threadRootEventId, options);
     goto(
       resolve('/chat/[serverId]/[roomId]/[threadId]', {
         serverId: serverSegment,
@@ -176,41 +162,16 @@
     }
   });
 
-  // Get display title for room header
-  let title = $derived.by(() => {
-    if (!room.roomData) return '';
-
-    if (!room.isDM) {
-      return `# ${room.roomData.room.name}`;
-    }
-
-    if (!room.dmData || room.dmData.participants.length === 0) {
-      return m['room.title.direct_message']();
-    }
-
-    const others = room.dmData.participants.filter((p) => p.id !== room.dmData!.currentUserId);
-    if (others.length === 0) {
-      const self = room.dmData.participants.find((p) => p.id === room.dmData!.currentUserId);
-      return self?.displayName || self?.login || m['common.you']();
-    }
-    return others.map((p) => getLiveDisplayName(p.id, p.displayName || p.login)).join(', ');
-  });
-
-  let roomDescription = $derived.by(() => {
-    if (!room.roomData || room.isDM) return undefined;
-
-    const description = room.roomData.room.description?.trim();
-    return description || undefined;
-  });
-
-  // Page title includes space name for regular rooms
-  let pageTitle = $derived.by(() => {
-    if (!room.roomData) return '';
-    if (!room.isDM && room.roomData.spaceName) {
-      return `#${room.roomData.room.name} - ${room.roomData.spaceName}`;
-    }
-    return title;
-  });
+  const presentation = $derived(
+    buildRoomPresentation({
+      roomData: room.roomData,
+      isDM: room.isDM,
+      dmData: room.dmData,
+      directMessageLabel: m['room.title.direct_message'](),
+      currentUserLabel: m['common.you'](),
+      getDisplayName: getLiveDisplayName
+    })
+  );
 
   // Remember this room as the last visited (for the chat-root → last-room
   // auto-redirect). Room.svelte is reused across roomId changes, so wait for
@@ -233,14 +194,15 @@
     // until the new room's data has actually loaded.
     if (room.roomData.room.id !== roomId) return;
 
-    if (threadId && routeMessageId) {
-      const threadMessageRoute = `${roomId}:${threadId}:${routeMessageId}`;
-      if (appliedThreadMessageRoute === threadMessageRoute) return;
-      appliedThreadMessageRoute = threadMessageRoute;
-      applyHighlight(routeMessageId);
+    const threadMessageTarget = navigation.consumeThreadMessageRoute(
+      roomId,
+      threadId,
+      routeMessageId
+    );
+    if (threadMessageTarget !== undefined) {
+      if (threadMessageTarget) applyHighlight(threadMessageTarget);
       return;
     }
-    appliedThreadMessageRoute = null;
 
     const pending = stores.pendingHighlights.consume(roomId, threadId ?? null);
     if (pending) {
@@ -267,19 +229,15 @@
   });
 
   function applyHighlight(eventId: string): void {
-    if (threadId) {
-      pendingThreadHighlight = eventId;
-    } else {
-      const requestId = ++mainHighlightRequestId;
-      pendingMainHighlightId = eventId;
-      tick().then(async () => {
-        const jumped = await jumpState.jumpToMessage(eventId);
-        if (!jumped && mainHighlightRequestId === requestId && pendingMainHighlightId === eventId) {
-          pendingMainHighlightId = null;
-          toast.error(m['room.jump_failed']());
-        }
-      });
-    }
+    const requestId = navigation.beginHighlight(eventId, !!threadId);
+    if (requestId === null) return;
+
+    tick().then(async () => {
+      const jumped = await jumpState.jumpToMessage(eventId);
+      if (!jumped && navigation.failMainHighlight(requestId, eventId)) {
+        toast.error(m['room.jump_failed']());
+      }
+    });
   }
 
   // Durable message rows arrive only through projection operations. Keep
@@ -491,8 +449,8 @@
   the new (empty) data.
 -->
 {#if room.roomData !== null}
-  {#if pageTitle}
-    <PageTitle title={pageTitle} />
+  {#if presentation.pageTitle}
+    <PageTitle title={presentation.pageTitle} />
   {/if}
 
   <div
@@ -520,7 +478,11 @@
       >
         <DropZoneOverlay visible={isDraggingFiles} />
 
-        <PaneHeader {title} subtitle={roomDescription} loading={!room.roomData}>
+        <PaneHeader
+          title={presentation.title}
+          subtitle={presentation.description}
+          loading={!room.roomData}
+        >
           {#snippet actions()}
             <RoomSidebarToggle
               mode="mobile"
@@ -564,10 +526,8 @@
           onUnreadMarkerResolved={(eventId) => unread.setUnreadMarkerEventId(eventId)}
           onUnreadMarkerCleared={() => unread.clearUnreadMarker()}
           onOpenThread={openThread}
-          pendingHighlightId={pendingMainHighlightId}
-          onHighlightComplete={() => {
-            pendingMainHighlightId = null;
-          }}
+          pendingHighlightId={navigation.pendingMainHighlightId}
+          onHighlightComplete={() => navigation.clearMainHighlight()}
           typingUserIds={typingIndicator.userIds}
           typingMembers={getRoomMembers()}
         />
@@ -603,64 +563,20 @@
           canPostInThread={room.roomData.canPostInThread}
           canAttach={room.roomData.canAttach}
           canEchoMessage={room.roomData.canEchoMessage && room.roomData.canPostMessage}
-          highlightEventId={pendingThreadHighlight}
-          pendingQuote={pendingThreadQuote}
-          pendingReply={pendingThreadReply}
-          onHighlightComplete={() => {
-            pendingThreadHighlight = null;
-          }}
-          onQuoteConsumed={() => {
-            pendingThreadQuote = null;
-          }}
-          onReplyConsumed={() => {
-            pendingThreadReply = null;
-          }}
+          highlightEventId={navigation.pendingThreadHighlight}
+          pendingQuote={navigation.pendingThreadQuote}
+          pendingReply={navigation.pendingThreadReply}
+          onHighlightComplete={() => navigation.clearThreadHighlight()}
+          onQuoteConsumed={() => navigation.clearThreadQuote()}
+          onReplyConsumed={() => navigation.clearThreadReply()}
         />
       {/if}
 
       {#if mobileRoomSidebarPanel}
-        <button
-          type="button"
-          class="absolute inset-0 z-10 bg-transparent lg:hidden"
-          aria-label={m['room.close_extras']()}
-          onclick={() => appUi.closeMobileRoomSidebarPanel()}
-        ></button>
-        <div
-          class="absolute inset-y-0 right-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] lg:hidden"
-          data-testid="room-sidebar-mobile-pane"
-          transition:fly={{ x: 300, duration: 200 }}
-        >
-          <RoomSidebar
-            {roomId}
-            activePanel={mobileRoomSidebarPanel}
-            presentation="overlay"
-            hasActiveCall={hasActiveRoomCall}
-            loading={room.isRoomLoading}
-            filesStore={roomFilesStore}
-            livekitUrl={serverInfo.livekitUrl ?? undefined}
-            canBanRoomMembers={canBanMembersFromRoomSidebar(
-              room.isDM,
-              room.roomData?.canBanRoomMembers
-            )}
-            currentUserId={currentUser.user?.id ?? null}
-            membersStore={roomMembersStore}
-            onOpenFile={(messageEventId, threadRootEventId) =>
-              openFileMessage(messageEventId, threadRootEventId, true)}
-            onClose={() => appUi.closeMobileRoomSidebarPanel()}
-          />
-        </div>
-      {/if}
-    </div>
-
-    {#if activeRoomSidebarPanel}
-      <div
-        class={['hidden min-h-0 min-w-0 lg:flex', isDesktopCallMaximized ? 'flex-1' : 'shrink-0']}
-        data-testid="room-sidebar-desktop-pane"
-      >
-        <RoomSidebar
+        <RoomSidebarPane
+          presentation="mobile"
           {roomId}
-          activePanel={activeRoomSidebarPanel}
-          maximized={isDesktopCallMaximized}
+          activePanel={mobileRoomSidebarPanel}
           hasActiveCall={hasActiveRoomCall}
           loading={room.isRoomLoading}
           filesStore={roomFilesStore}
@@ -672,11 +588,33 @@
           currentUserId={currentUser.user?.id ?? null}
           membersStore={roomMembersStore}
           onOpenFile={(messageEventId, threadRootEventId) =>
-            openFileMessage(messageEventId, threadRootEventId)}
-          onToggleMaximized={toggleDesktopCallWide}
-          onClose={closeDesktopRoomSidebarPanel}
+            openFileMessage(messageEventId, threadRootEventId, true)}
+          onClose={() => appUi.closeMobileRoomSidebarPanel()}
         />
-      </div>
+      {/if}
+    </div>
+
+    {#if activeRoomSidebarPanel}
+      <RoomSidebarPane
+        presentation="desktop"
+        {roomId}
+        activePanel={activeRoomSidebarPanel}
+        maximized={isDesktopCallMaximized}
+        hasActiveCall={hasActiveRoomCall}
+        loading={room.isRoomLoading}
+        filesStore={roomFilesStore}
+        livekitUrl={serverInfo.livekitUrl ?? undefined}
+        canBanRoomMembers={canBanMembersFromRoomSidebar(
+          room.isDM,
+          room.roomData?.canBanRoomMembers
+        )}
+        currentUserId={currentUser.user?.id ?? null}
+        membersStore={roomMembersStore}
+        onOpenFile={(messageEventId, threadRootEventId) =>
+          openFileMessage(messageEventId, threadRootEventId)}
+        onToggleMaximized={toggleDesktopCallWide}
+        onClose={closeDesktopRoomSidebarPanel}
+      />
     {/if}
   </div>
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -582,18 +582,18 @@
         />
       {/if}
 
-      {#if mobileRoomSidebarPanel}
-        <RoomSidebarPane
-          presentation="mobile"
-          sidebarProps={{
-            ...sharedRoomSidebarProps,
-            activePanel: mobileRoomSidebarPanel,
-            onOpenFile: (messageEventId, threadRootEventId) =>
-              openFileMessage(messageEventId, threadRootEventId, true),
-            onClose: () => appUi.closeMobileRoomSidebarPanel()
-          }}
-        />
-      {/if}
+      <RoomSidebarPane
+        presentation="mobile"
+        sidebarProps={mobileRoomSidebarPanel
+          ? {
+              ...sharedRoomSidebarProps,
+              activePanel: mobileRoomSidebarPanel,
+              onOpenFile: (messageEventId, threadRootEventId) =>
+                openFileMessage(messageEventId, threadRootEventId, true),
+              onClose: () => appUi.closeMobileRoomSidebarPanel()
+            }
+          : null}
+      />
     </div>
 
     {#if activeRoomSidebarPanel}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -529,6 +529,22 @@ describe('Room local message echo', () => {
     expect(consumePendingRoomSidebarPanel('server-1', 'room-1')).toBeNull();
   });
 
+  it('keeps the mobile sidebar mounted during its close transition', async () => {
+    mocks.livekitUrl = 'wss://livekit.example.test';
+    stubMatchMedia(false);
+    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+    const pane = q(container, '[data-testid="room-sidebar-mobile-pane"]');
+    await expect.element(pane).toBeInTheDocument();
+
+    appUi.closeMobileRoomSidebarPanel();
+    await tick();
+
+    expect(pane.isConnected).toBe(true);
+    await expect.element(pane).not.toBeInTheDocument();
+  });
+
   it('starts with the desktop room sidebar closed', async () => {
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -535,7 +535,7 @@ describe('Room local message echo', () => {
     setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
 
     const { container } = render(Room, { props: { roomId: 'room-1' } });
-    const pane = q(container, '[data-testid="room-sidebar-mobile-pane"]');
+    const pane = q(container, '[data-testid="room-sidebar-mobile-pane"]') as HTMLElement;
     await expect.element(pane).toBeInTheDocument();
 
     appUi.closeMobileRoomSidebarPanel();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
@@ -1,60 +1,22 @@
 <script lang="ts">
+  import type { ComponentProps } from 'svelte';
   import { fly } from 'svelte/transition';
   import * as m from '$lib/i18n/messages';
-  import type { RoomFilesStore, RoomMembersStore } from '$lib/state/room';
-  import type { RoomSidebarPanel } from '$lib/storage/roomSidebarPanel';
   import RoomSidebar from './RoomSidebar.svelte';
 
   let {
     presentation,
-    roomId,
-    activePanel,
-    maximized = false,
-    hasActiveCall = false,
-    loading = false,
-    filesStore,
-    livekitUrl,
-    canBanRoomMembers = false,
-    currentUserId = null,
-    membersStore,
-    onOpenFile,
-    onToggleMaximized,
-    onClose
+    sidebarProps
   }: {
     presentation: 'mobile' | 'desktop';
-    roomId: string;
-    activePanel: RoomSidebarPanel;
-    maximized?: boolean;
-    hasActiveCall?: boolean;
-    loading?: boolean;
-    filesStore: RoomFilesStore;
-    livekitUrl?: string;
-    canBanRoomMembers?: boolean;
-    currentUserId?: string | null;
-    membersStore: RoomMembersStore;
-    onOpenFile: (messageEventId: string, threadRootEventId: string | null) => void;
-    onToggleMaximized?: () => void;
-    onClose: () => void;
+    sidebarProps: ComponentProps<typeof RoomSidebar> & { onClose: () => void };
   } = $props();
+
+  const maximized = $derived(sidebarProps.maximized ?? false);
 </script>
 
 {#snippet sidebar()}
-  <RoomSidebar
-    {roomId}
-    {activePanel}
-    presentation={presentation === 'mobile' ? 'overlay' : 'desktop'}
-    {maximized}
-    {hasActiveCall}
-    {loading}
-    {filesStore}
-    {livekitUrl}
-    {canBanRoomMembers}
-    {currentUserId}
-    {membersStore}
-    {onOpenFile}
-    {onToggleMaximized}
-    {onClose}
-  />
+  <RoomSidebar {...sidebarProps} presentation={presentation === 'mobile' ? 'overlay' : 'desktop'} />
 {/snippet}
 
 {#if presentation === 'mobile'}
@@ -62,12 +24,12 @@
     type="button"
     class="absolute inset-0 z-10 bg-transparent lg:hidden"
     aria-label={m['room.close_extras']()}
-    onclick={onClose}
+    onclick={sidebarProps.onClose}
   ></button>
   <div
     class="absolute inset-y-0 right-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] lg:hidden"
     data-testid="room-sidebar-mobile-pane"
-    transition:fly={{ x: 300, duration: 200 }}
+    transition:fly|global={{ x: 300, duration: 200 }}
   >
     {@render sidebar()}
   </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
@@ -9,35 +9,37 @@
     sidebarProps
   }: {
     presentation: 'mobile' | 'desktop';
-    sidebarProps: ComponentProps<typeof RoomSidebar> & { onClose: () => void };
+    sidebarProps: (ComponentProps<typeof RoomSidebar> & { onClose: () => void }) | null;
   } = $props();
 
-  const maximized = $derived(sidebarProps.maximized ?? false);
+  const maximized = $derived(sidebarProps?.maximized ?? false);
 </script>
 
-{#snippet sidebar()}
-  <RoomSidebar {...sidebarProps} presentation={presentation === 'mobile' ? 'overlay' : 'desktop'} />
+{#snippet sidebar(props: NonNullable<typeof sidebarProps>)}
+  <RoomSidebar {...props} presentation={presentation === 'mobile' ? 'overlay' : 'desktop'} />
 {/snippet}
 
 {#if presentation === 'mobile'}
-  <button
-    type="button"
-    class="absolute inset-0 z-10 bg-transparent lg:hidden"
-    aria-label={m['room.close_extras']()}
-    onclick={sidebarProps.onClose}
-  ></button>
-  <div
-    class="absolute inset-y-0 right-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] lg:hidden"
-    data-testid="room-sidebar-mobile-pane"
-    transition:fly|global={{ x: 300, duration: 200 }}
-  >
-    {@render sidebar()}
-  </div>
-{:else}
+  {#if sidebarProps}
+    <button
+      type="button"
+      class="absolute inset-0 z-10 bg-transparent lg:hidden"
+      aria-label={m['room.close_extras']()}
+      onclick={sidebarProps.onClose}
+    ></button>
+    <div
+      class="absolute inset-y-0 right-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] lg:hidden"
+      data-testid="room-sidebar-mobile-pane"
+      transition:fly={{ x: 300, duration: 200 }}
+    >
+      {@render sidebar(sidebarProps)}
+    </div>
+  {/if}
+{:else if sidebarProps}
   <div
     class={['hidden min-h-0 min-w-0 lg:flex', maximized ? 'flex-1' : 'shrink-0']}
     data-testid="room-sidebar-desktop-pane"
   >
-    {@render sidebar()}
+    {@render sidebar(sidebarProps)}
   </div>
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+  import { fly } from 'svelte/transition';
+  import * as m from '$lib/i18n/messages';
+  import type { RoomFilesStore, RoomMembersStore } from '$lib/state/room';
+  import type { RoomSidebarPanel } from '$lib/storage/roomSidebarPanel';
+  import RoomSidebar from './RoomSidebar.svelte';
+
+  let {
+    presentation,
+    roomId,
+    activePanel,
+    maximized = false,
+    hasActiveCall = false,
+    loading = false,
+    filesStore,
+    livekitUrl,
+    canBanRoomMembers = false,
+    currentUserId = null,
+    membersStore,
+    onOpenFile,
+    onToggleMaximized,
+    onClose
+  }: {
+    presentation: 'mobile' | 'desktop';
+    roomId: string;
+    activePanel: RoomSidebarPanel;
+    maximized?: boolean;
+    hasActiveCall?: boolean;
+    loading?: boolean;
+    filesStore: RoomFilesStore;
+    livekitUrl?: string;
+    canBanRoomMembers?: boolean;
+    currentUserId?: string | null;
+    membersStore: RoomMembersStore;
+    onOpenFile: (messageEventId: string, threadRootEventId: string | null) => void;
+    onToggleMaximized?: () => void;
+    onClose: () => void;
+  } = $props();
+</script>
+
+{#snippet sidebar()}
+  <RoomSidebar
+    {roomId}
+    {activePanel}
+    presentation={presentation === 'mobile' ? 'overlay' : 'desktop'}
+    {maximized}
+    {hasActiveCall}
+    {loading}
+    {filesStore}
+    {livekitUrl}
+    {canBanRoomMembers}
+    {currentUserId}
+    {membersStore}
+    {onOpenFile}
+    {onToggleMaximized}
+    {onClose}
+  />
+{/snippet}
+
+{#if presentation === 'mobile'}
+  <button
+    type="button"
+    class="absolute inset-0 z-10 bg-transparent lg:hidden"
+    aria-label={m['room.close_extras']()}
+    onclick={onClose}
+  ></button>
+  <div
+    class="absolute inset-y-0 right-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] lg:hidden"
+    data-testid="room-sidebar-mobile-pane"
+    transition:fly={{ x: 300, duration: 200 }}
+  >
+    {@render sidebar()}
+  </div>
+{:else}
+  <div
+    class={['hidden min-h-0 min-w-0 lg:flex', maximized ? 'flex-1' : 'shrink-0']}
+    data-testid="room-sidebar-desktop-pane"
+  >
+    {@render sidebar()}
+  </div>
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomNavigationState.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomNavigationState.svelte.spec.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+import { RoomNavigationState } from './roomNavigationState.svelte';
+
+describe('RoomNavigationState', () => {
+  it('prepares one-shot thread highlight, quote, and reply hand-offs', () => {
+    const state = new RoomNavigationState();
+
+    state.prepareThreadOpen('thread-1', {
+      highlightEventId: 'highlight-1',
+      quoteText: 'selected quote',
+      reply: {
+        eventId: 'reply-1',
+        actorDisplayName: 'Alice',
+        excerpt: 'Reply excerpt'
+      }
+    });
+
+    expect(state.pendingThreadHighlight).toBe('highlight-1');
+    expect(state.pendingThreadQuote).toEqual({
+      id: 1,
+      text: 'selected quote'
+    });
+    expect(state.pendingThreadReply).toEqual({
+      id: 1,
+      threadRootEventId: 'thread-1',
+      eventId: 'reply-1',
+      actorDisplayName: 'Alice',
+      excerpt: 'Reply excerpt'
+    });
+
+    state.clearThreadHighlight();
+    state.clearThreadQuote();
+    state.clearThreadReply();
+    expect(state.pendingThreadHighlight).toBeNull();
+    expect(state.pendingThreadQuote).toBeNull();
+    expect(state.pendingThreadReply).toBeNull();
+  });
+
+  it('clears stale hand-offs when a later thread open omits them', () => {
+    const state = new RoomNavigationState();
+    state.prepareThreadOpen('thread-1', {
+      highlightEventId: 'highlight-1',
+      quoteText: 'selected quote',
+      reply: {
+        eventId: 'reply-1',
+        actorDisplayName: 'Alice',
+        excerpt: 'Reply excerpt'
+      }
+    });
+
+    state.prepareThreadOpen('thread-2');
+
+    expect(state.pendingThreadHighlight).toBeNull();
+    expect(state.pendingThreadQuote).toBeNull();
+    expect(state.pendingThreadReply).toBeNull();
+  });
+
+  it('consumes each nested thread message route once', () => {
+    const state = new RoomNavigationState();
+
+    expect(state.consumeThreadMessageRoute('room-1', 'thread-1', 'message-1')).toBe('message-1');
+    expect(state.consumeThreadMessageRoute('room-1', 'thread-1', 'message-1')).toBeNull();
+    expect(state.consumeThreadMessageRoute('room-1', 'thread-1', 'message-2')).toBe('message-2');
+    expect(state.consumeThreadMessageRoute('room-2', 'thread-1', 'message-2')).toBe('message-2');
+  });
+
+  it('allows the same nested route after leaving it', () => {
+    const state = new RoomNavigationState();
+
+    expect(state.consumeThreadMessageRoute('room-1', 'thread-1', 'message-1')).toBe('message-1');
+    expect(state.consumeThreadMessageRoute('room-1', undefined, undefined)).toBeUndefined();
+    expect(state.consumeThreadMessageRoute('room-1', 'thread-1', 'message-1')).toBe('message-1');
+  });
+
+  it('fences stale failed main-room highlight requests', () => {
+    const state = new RoomNavigationState();
+    const firstRequest = state.beginHighlight('message-1', false);
+    const secondRequest = state.beginHighlight('message-2', false);
+
+    expect(firstRequest).toBeTypeOf('number');
+    expect(secondRequest).toBeTypeOf('number');
+    expect(state.failMainHighlight(firstRequest!, 'message-1')).toBe(false);
+    expect(state.pendingMainHighlightId).toBe('message-2');
+    expect(state.failMainHighlight(secondRequest!, 'message-2')).toBe(true);
+    expect(state.pendingMainHighlightId).toBeNull();
+  });
+
+  it('routes thread highlights without creating a main-room request', () => {
+    const state = new RoomNavigationState();
+
+    expect(state.beginHighlight('message-1', true)).toBeNull();
+    expect(state.pendingThreadHighlight).toBe('message-1');
+    expect(state.pendingMainHighlightId).toBeNull();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomNavigationState.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomNavigationState.svelte.ts
@@ -1,0 +1,75 @@
+import type { QuoteInsertionContent } from '$lib/state/room';
+import type { PendingThreadReplyRequest, ThreadOpenOptions } from './threadOpenOptions';
+
+export class RoomNavigationState {
+  pendingThreadHighlight = $state<string | null>(null);
+  pendingMainHighlightId = $state<string | null>(null);
+  pendingThreadQuote = $state<{ id: number; text: QuoteInsertionContent } | null>(null);
+  pendingThreadReply = $state<PendingThreadReplyRequest | null>(null);
+
+  #mainHighlightRequestId = 0;
+  #pendingThreadQuoteId = 0;
+  #pendingThreadReplyId = 0;
+  #appliedThreadMessageRoute: string | null = null;
+
+  prepareThreadOpen(threadRootEventId: string, options: ThreadOpenOptions = {}): void {
+    this.pendingThreadHighlight = options.highlightEventId ?? null;
+    this.pendingThreadQuote = options.quoteText
+      ? { id: ++this.#pendingThreadQuoteId, text: options.quoteText }
+      : null;
+    this.pendingThreadReply = options.reply
+      ? { id: ++this.#pendingThreadReplyId, threadRootEventId, ...options.reply }
+      : null;
+  }
+
+  consumeThreadMessageRoute(
+    roomId: string,
+    threadRootEventId: string | undefined,
+    messageEventId: string | undefined
+  ): string | null | undefined {
+    if (!threadRootEventId || !messageEventId) {
+      this.#appliedThreadMessageRoute = null;
+      return undefined;
+    }
+
+    const route = `${roomId}:${threadRootEventId}:${messageEventId}`;
+    if (this.#appliedThreadMessageRoute === route) return null;
+    this.#appliedThreadMessageRoute = route;
+    return messageEventId;
+  }
+
+  beginHighlight(eventId: string, inThread: boolean): number | null {
+    if (inThread) {
+      this.pendingThreadHighlight = eventId;
+      return null;
+    }
+
+    this.pendingMainHighlightId = eventId;
+    return ++this.#mainHighlightRequestId;
+  }
+
+  failMainHighlight(requestId: number, eventId: string): boolean {
+    if (this.#mainHighlightRequestId !== requestId || this.pendingMainHighlightId !== eventId) {
+      return false;
+    }
+
+    this.pendingMainHighlightId = null;
+    return true;
+  }
+
+  clearMainHighlight(): void {
+    this.pendingMainHighlightId = null;
+  }
+
+  clearThreadHighlight(): void {
+    this.pendingThreadHighlight = null;
+  }
+
+  clearThreadQuote(): void {
+    this.pendingThreadQuote = null;
+  }
+
+  clearThreadReply(): void {
+    this.pendingThreadReply = null;
+  }
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.spec.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RoomKind } from '$lib/api-client/roomDirectory';
+import type { DMData, RoomData } from '$lib/hooks/useRoomData.svelte';
+import { buildRoomPresentation } from './roomPresentation';
+
+function roomData(overrides: Partial<RoomData> = {}): RoomData {
+  return {
+    room: {
+      id: 'room-1',
+      name: 'general',
+      type: RoomKind.CHANNEL,
+      description: ' Room description ',
+      isUniversal: false
+    },
+    spaceName: 'Test Space',
+    canPostMessage: true,
+    canPostInThread: true,
+    canAttach: true,
+    canReact: true,
+    canManageOthersMessage: false,
+    canEchoMessage: true,
+    canManageRoom: false,
+    canBanRoomMembers: false,
+    ...overrides
+  };
+}
+
+function build(room: RoomData | null | undefined, isDM = false, dmData: DMData | null = null) {
+  return buildRoomPresentation({
+    roomData: room,
+    isDM,
+    dmData,
+    directMessageLabel: 'Direct message',
+    currentUserLabel: 'You',
+    getDisplayName: (_userId, fallback) => `Live ${fallback}`
+  });
+}
+
+describe('buildRoomPresentation', () => {
+  it('builds channel header, description, and page title', () => {
+    expect(build(roomData())).toEqual({
+      title: '# general',
+      description: 'Room description',
+      pageTitle: '#general - Test Space'
+    });
+  });
+
+  it('omits blank channel descriptions and uses the header title without a space name', () => {
+    const room = roomData({
+      room: {
+        id: 'room-1',
+        name: 'general',
+        type: RoomKind.CHANNEL,
+        description: ' ',
+        isUniversal: false
+      },
+      spaceName: null
+    });
+
+    expect(build(room)).toEqual({
+      title: '# general',
+      description: undefined,
+      pageTitle: '# general'
+    });
+  });
+
+  it('builds a direct-message title from the other participants', () => {
+    const getDisplayName = vi.fn((_userId: string, fallback: string) => `Live ${fallback}`);
+    const presentation = buildRoomPresentation({
+      roomData: roomData(),
+      isDM: true,
+      dmData: {
+        currentUserId: 'self',
+        participants: [
+          {
+            id: 'self',
+            login: 'me',
+            displayName: 'Me',
+            presenceStatus: 0
+          },
+          {
+            id: 'other',
+            login: 'friend',
+            displayName: 'Friend',
+            presenceStatus: 0
+          }
+        ]
+      },
+      directMessageLabel: 'Direct message',
+      currentUserLabel: 'You',
+      getDisplayName
+    });
+
+    expect(presentation).toEqual({
+      title: 'Live Friend',
+      description: undefined,
+      pageTitle: 'Live Friend'
+    });
+    expect(getDisplayName).toHaveBeenCalledWith('other', 'Friend');
+  });
+
+  it('uses the current participant for a self direct message', () => {
+    expect(
+      build(roomData(), true, {
+        currentUserId: 'self',
+        participants: [
+          {
+            id: 'self',
+            login: 'me',
+            displayName: 'Me',
+            presenceStatus: 0
+          }
+        ]
+      })
+    ).toEqual({
+      title: 'Me',
+      description: undefined,
+      pageTitle: 'Me'
+    });
+  });
+
+  it('uses the direct-message label while participant data is empty', () => {
+    expect(build(roomData(), true, { currentUserId: 'self', participants: [] })).toEqual({
+      title: 'Direct message',
+      description: undefined,
+      pageTitle: 'Direct message'
+    });
+  });
+
+  it('returns an empty loading presentation without room data', () => {
+    expect(build(undefined)).toEqual({
+      title: '',
+      description: undefined,
+      pageTitle: ''
+    });
+    expect(build(null)).toEqual({
+      title: '',
+      description: undefined,
+      pageTitle: ''
+    });
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.ts
@@ -1,0 +1,51 @@
+import type { DMData, RoomData } from '$lib/hooks/useRoomData.svelte';
+
+export type RoomPresentation = {
+  title: string;
+  description: string | undefined;
+  pageTitle: string;
+};
+
+export function buildRoomPresentation({
+  roomData,
+  isDM,
+  dmData,
+  directMessageLabel,
+  currentUserLabel,
+  getDisplayName
+}: {
+  roomData: RoomData | null | undefined;
+  isDM: boolean;
+  dmData: DMData | null;
+  directMessageLabel: string;
+  currentUserLabel: string;
+  getDisplayName: (userId: string, fallback: string) => string;
+}): RoomPresentation {
+  if (!roomData) {
+    return { title: '', description: undefined, pageTitle: '' };
+  }
+
+  if (!isDM) {
+    const title = `# ${roomData.room.name}`;
+    const description = roomData.room.description?.trim() || undefined;
+    const pageTitle = roomData.spaceName ? `#${roomData.room.name} - ${roomData.spaceName}` : title;
+    return { title, description, pageTitle };
+  }
+
+  const participants = dmData?.participants ?? [];
+  const currentUserId = dmData?.currentUserId ?? null;
+  const others = participants.filter((participant) => participant.id !== currentUserId);
+  let title = directMessageLabel;
+  if (others.length > 0) {
+    title = others
+      .map((participant) =>
+        getDisplayName(participant.id, participant.displayName || participant.login)
+      )
+      .join(', ');
+  } else if (participants.length > 0) {
+    const self = participants.find((participant) => participant.id === currentUserId);
+    title = self?.displayName || self?.login || currentUserLabel;
+  }
+
+  return { title, description: undefined, pageTitle: title };
+}


### PR DESCRIPTION
## Why

`Room.svelte` had accumulated unrelated responsibilities for navigation
hand-offs, room-title presentation, and both responsive sidebar shells. This
made everyday room behavior harder to reason about and change safely.

## What changed

- move pending room/thread highlight, quote, and reply hand-offs into a focused
  reactive state class
- move channel/direct-message header and document-title construction into a
  pure presentation helper
- share the mobile and desktop room-sidebar composition through
  `RoomSidebarPane`
- add direct tests for extracted navigation and presentation semantics

This is a frontend-only, behavior-preserving refactor. It does not change
public APIs, persistence, permissions, user-facing copy, compatibility,
migrations, rollout, security boundaries, or operations.

## Test plan

- `mise lint-frontend` — passed; Svelte Check reported 0 errors and 0 warnings
- `mise test-frontend` — passed; 2,563 tests across 304 files
- focused room/navigation/presentation Vitest — passed; 36 tests
- focused Playwright room, thread, sidebar, file, drag-and-drop, direct-message,
  and message-link coverage — passed; 80 tests
- `mise knip` — completed without new branch findings
- `mise license-check` — passed
- Svelte autofixer — no issues in changed Svelte files
- Chrome DevTools — verified desktop and mobile room extras, the mobile
  200 ms close animation, header/title presentation, and a clean warning/error
  console

Closes #1784.
