### PR TITLE
fix(frontend): backport on-demand PWA caching

### DIFF
--- a/apps/frontend/e2e/service-worker.test.ts
+++ b/apps/frontend/e2e/service-worker.test.ts
@@ -3,7 +3,6 @@ import { expect, test } from './setup';
 
 type CacheSnapshot = {
   cacheNames: string[];
-  rootShellCached: boolean;
   fallbackShellCached: boolean;
   lazyStaticAssetCached: boolean;
   apiDiscoveryCached: boolean;
@@ -25,10 +24,7 @@ type BadgeStateSnapshot = {
 const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v2';
 const BADGE_STATE_REQUEST = '/__chatto/foreground-badge-intent';
 
-test('service worker caches only the app shell and serves it offline', async ({
-  page,
-  context
-}) => {
+test('service worker caches frontend assets only after they are requested', async ({ page }) => {
   await page.goto('/');
   await expect(page.getByRole('heading', { name: 'Sign In' })).toBeVisible();
 
@@ -37,35 +33,18 @@ test('service worker caches only the app shell and serves it offline', async ({
   expect(registration.scope).toBe(`${new URL(page.url()).origin}/`);
   expect(registration.scriptURL).toBe(`${new URL(page.url()).origin}/service-worker.js`);
 
-  await requestNetworkOnlyPaths(page);
-
-  const onlineCacheSnapshot = await cacheSnapshot(page);
-  expect(onlineCacheSnapshot.cacheNames.some((name) => name.startsWith('chatto-shell-'))).toBe(
-    true
-  );
-  expect(onlineCacheSnapshot.rootShellCached).toBe(true);
-  expect(onlineCacheSnapshot.fallbackShellCached).toBe(true);
-  expect(onlineCacheSnapshot.lazyStaticAssetCached).toBe(false);
-  expect(onlineCacheSnapshot.apiDiscoveryCached).toBe(false);
-  expect(onlineCacheSnapshot.apiConnectCached).toBe(false);
-  expect(onlineCacheSnapshot.uploadedAssetCached).toBe(false);
+  const installCacheSnapshot = await cacheSnapshot(page);
+  expect(installCacheSnapshot.fallbackShellCached).toBe(false);
+  expect(installCacheSnapshot.lazyStaticAssetCached).toBe(false);
 
   await requestLazyStaticAsset(page);
+  await requestNetworkOnlyPaths(page);
   const lazyCacheSnapshot = await cacheSnapshot(page);
+  expect(lazyCacheSnapshot.cacheNames.some((name) => name.startsWith('chatto-shell-'))).toBe(true);
   expect(lazyCacheSnapshot.lazyStaticAssetCached).toBe(true);
-
-  await context.setOffline(true);
-  try {
-    await page.reload({ waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: 'Welcome to Chatto' })).toBeVisible();
-
-    const offlineCacheSnapshot = await cacheSnapshot(page);
-    expect(offlineCacheSnapshot.apiDiscoveryCached).toBe(false);
-    expect(offlineCacheSnapshot.apiConnectCached).toBe(false);
-    expect(offlineCacheSnapshot.uploadedAssetCached).toBe(false);
-  } finally {
-    await context.setOffline(false);
-  }
+  expect(lazyCacheSnapshot.apiDiscoveryCached).toBe(false);
+  expect(lazyCacheSnapshot.apiConnectCached).toBe(false);
+  expect(lazyCacheSnapshot.uploadedAssetCached).toBe(false);
 });
 
 test('browser-tab badge-state messages do not crash service worker badging', async ({ page }) => {
@@ -322,7 +301,6 @@ async function cacheSnapshot(page: Page) {
   return page.evaluate<CacheSnapshot>(async () => {
     return {
       cacheNames: await caches.keys(),
-      rootShellCached: Boolean(await caches.match('/')),
       fallbackShellCached: Boolean(await caches.match('/200.html')),
       lazyStaticAssetCached: Boolean(await caches.match('/robots.txt')),
       apiDiscoveryCached: Boolean(

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -117,9 +117,84 @@ async function importServiceWorker(cacheStorage = createMemoryCacheStorage()) {
     registration,
     setAppBadge,
     clearAppBadge,
-    cacheStorage
+    cacheStorage,
+    async dispatchFetch(request: Pick<Request, 'method' | 'mode' | 'destination' | 'url'>) {
+      const responses: Promise<Response>[] = [];
+      const { event, pending } = createWaitUntilEvent({
+        request,
+        respondWith: (response: Response | Promise<Response>) => {
+          responses.push(Promise.resolve(response));
+        }
+      });
+      for (const handler of handlers.get('fetch') ?? []) {
+        handler(event);
+      }
+      if (responses.length !== 1) {
+        throw new Error(`expected one service worker response, got ${responses.length}`);
+      }
+      const response = await responses[0];
+      await Promise.all(pending);
+      return response;
+    }
   };
 }
+
+describe('service worker frontend caching', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('does not fetch build assets while installing', async () => {
+    const worker = await importServiceWorker();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await worker.dispatch('install');
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('caches known frontend assets only after they are requested', async () => {
+    const worker = await importServiceWorker();
+    const fetchMock = vi.fn(async () => new Response('app'));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = {
+      method: 'GET',
+      mode: 'same-origin',
+      destination: 'script',
+      url: 'https://chatto.example/app.js'
+    } as const;
+
+    expect(await (await worker.dispatchFetch(request)).text()).toBe('app');
+    expect(await (await worker.dispatchFetch(request)).text()).toBe('app');
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('reuses a successfully requested navigation as a best-effort shell fallback', async () => {
+    const worker = await importServiceWorker();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('<main>Chatto</main>'))
+      .mockRejectedValueOnce(new TypeError('offline'));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = {
+      method: 'GET',
+      mode: 'navigate',
+      destination: 'document',
+      url: 'https://chatto.example/chat/server/room'
+    } as const;
+
+    expect(await (await worker.dispatchFetch(request)).text()).toBe('<main>Chatto</main>');
+    expect(await (await worker.dispatchFetch(request)).text()).toBe('<main>Chatto</main>');
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe('service worker badge orchestration', () => {
   beforeEach(() => {

--- a/apps/frontend/src/service-worker.spec.ts
+++ b/apps/frontend/src/service-worker.spec.ts
@@ -44,7 +44,7 @@ function createWaitUntilEvent(extra: Record<string, unknown> = {}) {
   };
 }
 
-function createMemoryCacheStorage() {
+function createMemoryCacheStorage(beforePut?: () => Promise<void>) {
   const cachesByName = new Map<string, Map<string, Response>>();
   return {
     open: vi.fn(async (name: string) => {
@@ -57,6 +57,7 @@ function createMemoryCacheStorage() {
       return {
         match: vi.fn(async (request: RequestInfo | URL) => cache.get(request.toString())?.clone()),
         put: vi.fn(async (request: RequestInfo | URL, response: Response) => {
+          await beforePut?.();
           cache.set(request.toString(), response.clone());
         }),
         delete: vi.fn(async (request: RequestInfo | URL) => cache.delete(request.toString()))
@@ -82,12 +83,13 @@ async function importServiceWorker(cacheStorage = createMemoryCacheStorage()) {
   };
   const setAppBadge = vi.fn(async () => {});
   const clearAppBadge = vi.fn(async () => {});
+  const skipWaiting = vi.fn(async () => {});
 
   vi.stubGlobal('self', {
     location: { origin: 'https://chatto.example' },
     registration,
     clients,
-    skipWaiting: vi.fn(),
+    skipWaiting,
     addEventListener: vi.fn((type: string, handler: ServiceWorkerHandler) => {
       const list = handlers.get(type) ?? [];
       list.push(handler);
@@ -107,6 +109,26 @@ async function importServiceWorker(cacheStorage = createMemoryCacheStorage()) {
     await Promise.all(pending);
   };
 
+  const startFetch = (request: Pick<Request, 'method' | 'mode' | 'destination' | 'url'>) => {
+    const responses: Promise<Response>[] = [];
+    const { event, pending } = createWaitUntilEvent({
+      request,
+      respondWith: (response: Response | Promise<Response>) => {
+        responses.push(Promise.resolve(response));
+      }
+    });
+    for (const handler of handlers.get('fetch') ?? []) {
+      handler(event);
+    }
+    if (responses.length !== 1) {
+      throw new Error(`expected one service worker response, got ${responses.length}`);
+    }
+    return {
+      response: responses[0],
+      lifetime: Promise.all(pending).then(() => {})
+    };
+  };
+
   return {
     clients,
     dispatch,
@@ -117,23 +139,13 @@ async function importServiceWorker(cacheStorage = createMemoryCacheStorage()) {
     registration,
     setAppBadge,
     clearAppBadge,
+    skipWaiting,
     cacheStorage,
+    startFetch,
     async dispatchFetch(request: Pick<Request, 'method' | 'mode' | 'destination' | 'url'>) {
-      const responses: Promise<Response>[] = [];
-      const { event, pending } = createWaitUntilEvent({
-        request,
-        respondWith: (response: Response | Promise<Response>) => {
-          responses.push(Promise.resolve(response));
-        }
-      });
-      for (const handler of handlers.get('fetch') ?? []) {
-        handler(event);
-      }
-      if (responses.length !== 1) {
-        throw new Error(`expected one service worker response, got ${responses.length}`);
-      }
-      const response = await responses[0];
-      await Promise.all(pending);
+      const fetch = startFetch(request);
+      const response = await fetch.response;
+      await fetch.lifetime;
       return response;
     }
   };
@@ -151,11 +163,21 @@ describe('service worker frontend caching', () => {
   it('does not fetch build assets while installing', async () => {
     const worker = await importServiceWorker();
     const fetchMock = vi.fn();
+    const waiting = deferred<void>();
+    worker.skipWaiting.mockReturnValueOnce(waiting.promise);
     vi.stubGlobal('fetch', fetchMock);
 
-    await worker.dispatch('install');
+    const install = worker.getPendingDispatch('install');
+    for (const handler of worker.handlers.get('install') ?? []) {
+      handler(install.event);
+    }
 
     expect(fetchMock).not.toHaveBeenCalled();
+    expect(worker.skipWaiting).toHaveBeenCalledOnce();
+    expect(install.pending).toEqual([waiting.promise]);
+
+    waiting.resolve();
+    await Promise.all(install.pending);
   });
 
   it('caches known frontend assets only after they are requested', async () => {
@@ -172,6 +194,62 @@ describe('service worker frontend caching', () => {
     expect(await (await worker.dispatchFetch(request)).text()).toBe('app');
     expect(await (await worker.dispatchFetch(request)).text()).toBe('app');
 
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it('returns a fetched asset without waiting for a best-effort cache write', async () => {
+    const cacheWrite = deferred<void>();
+    const worker = await importServiceWorker(createMemoryCacheStorage(() => cacheWrite.promise));
+    const fetchMock = vi.fn(async () => new Response('app'));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = {
+      method: 'GET',
+      mode: 'same-origin',
+      destination: 'script',
+      url: 'https://chatto.example/app.js'
+    } as const;
+
+    const fetch = worker.startFetch(request);
+    expect(await (await fetch.response).text()).toBe('app');
+
+    cacheWrite.resolve();
+    await fetch.lifetime;
+  });
+
+  it('keeps a fetched asset usable when the best-effort cache write fails', async () => {
+    const worker = await importServiceWorker(
+      createMemoryCacheStorage(async () => {
+        throw new Error('cache quota exceeded');
+      })
+    );
+    const fetchMock = vi.fn(async () => new Response('app'));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = {
+      method: 'GET',
+      mode: 'same-origin',
+      destination: 'script',
+      url: 'https://chatto.example/app.js'
+    } as const;
+
+    const fetch = worker.startFetch(request);
+    expect(await (await fetch.response).text()).toBe('app');
+    await expect(fetch.lifetime).resolves.toBeUndefined();
+  });
+
+  it('does not retry a failed frontend asset request', async () => {
+    const worker = await importServiceWorker();
+    const fetchMock = vi.fn().mockRejectedValueOnce(new TypeError('offline'));
+    vi.stubGlobal('fetch', fetchMock);
+    const request = {
+      method: 'GET',
+      mode: 'same-origin',
+      destination: 'script',
+      url: 'https://chatto.example/app.js'
+    } as const;
+
+    const fetch = worker.startFetch(request);
+    await expect(fetch.response).rejects.toThrow('offline');
+    await expect(fetch.lifetime).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledOnce();
   });
 

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -4,9 +4,9 @@
 /**
  * Service Worker for Chatto's PWA shell and push notifications.
  *
- * Keeps the app shell available during offline launches while leaving live
- * Chatto data on the network. It also handles Web Push notifications and
- * notification-click navigation.
+ * Caches requested frontend assets while leaving live Chatto data on the
+ * network. It also handles Web Push notifications and notification-click
+ * navigation.
  */
 
 import { build, files, version } from '$service-worker';
@@ -28,7 +28,6 @@ const CACHE_PREFIX = 'chatto-shell';
 const CACHE_NAME = `${CACHE_PREFIX}-${version}`;
 const BADGE_STATE_CACHE_NAME = 'chatto-badge-state-v2';
 const SHELL_ASSETS = new Set([...build, ...files, OFFLINE_SHELL_PATH]);
-const PRECACHE_ASSETS = Array.from(new Set([...build, OFFLINE_SHELL_PATH, '/']));
 
 type ServiceWorkerAppBadgeNavigator = WorkerNavigator & {
   setAppBadge?: (contents?: number) => Promise<void>;
@@ -42,16 +41,11 @@ const badgeCoordinator = new ServiceWorkerBadgeCoordinator(
 );
 
 /**
- * Immediately activate new service worker versions.
- * Without this, users must close all tabs before updates take effect.
+ * Immediately activate new service worker versions without downloading the
+ * complete build manifest. Static assets enter the cache only when requested.
  */
-self.addEventListener('install', (event) => {
+self.addEventListener('install', () => {
   self.skipWaiting();
-  event.waitUntil(
-    caches
-      .open(CACHE_NAME)
-      .then((cache) => Promise.all(PRECACHE_ASSETS.map((path) => cacheShellAsset(cache, path))))
-  );
 });
 
 self.addEventListener('activate', (event) => {
@@ -110,10 +104,16 @@ self.addEventListener('fetch', (event) => {
   }
 
   if (policy.navigationRequest) {
+    const networkResponse = fetch(event.request);
+    event.waitUntil(
+      networkResponse
+        .then((response) => (response.ok ? cacheNavigationShell(response.clone()) : undefined))
+        .catch(() => {})
+    );
     event.respondWith(
       (async () => {
         try {
-          return await fetch(event.request);
+          return await networkResponse;
         } catch (err) {
           const cache = await caches.open(CACHE_NAME);
           const shell = await getCachedOfflineShell(cache);
@@ -125,15 +125,9 @@ self.addEventListener('fetch', (event) => {
   }
 });
 
-async function cacheShellAsset(cache: Cache, path: string): Promise<void> {
-  try {
-    const response = await fetch(path, { cache: 'reload' });
-    if (!response.ok) return;
-    await cache.put(path, response);
-  } catch {
-    // A missing static fallback in local preview must not invalidate the whole
-    // service worker. Production nginx serves the same shell through /200.html.
-  }
+async function cacheNavigationShell(response: Response): Promise<void> {
+  const cache = await caches.open(CACHE_NAME);
+  await cache.put(OFFLINE_SHELL_PATH, response);
 }
 
 async function getCachedOfflineShell(cache: Cache): Promise<Response | undefined> {

--- a/apps/frontend/src/service-worker.ts
+++ b/apps/frontend/src/service-worker.ts
@@ -44,8 +44,8 @@ const badgeCoordinator = new ServiceWorkerBadgeCoordinator(
  * Immediately activate new service worker versions without downloading the
  * complete build manifest. Static assets enter the cache only when requested.
  */
-self.addEventListener('install', () => {
-  self.skipWaiting();
+self.addEventListener('install', (event) => {
+  event.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener('activate', (event) => {
@@ -86,20 +86,16 @@ self.addEventListener('fetch', (event) => {
   if (policy.networkOnly) return;
 
   if (policy.cacheableShellAsset) {
-    event.respondWith(
-      (async () => {
-        const cache = await caches.open(CACHE_NAME);
-        const url = new URL(event.request.url);
-        const cached = await cache.match(url.pathname);
-        if (cached) return cached;
-
-        const response = await fetch(event.request);
-        if (response.ok) {
-          await cache.put(url.pathname, response.clone());
-        }
-        return response;
-      })()
+    const path = new URL(event.request.url).pathname;
+    const assetResult = loadShellAsset(event.request, path);
+    event.waitUntil(
+      assetResult
+        .then(({ cache, response }) =>
+          cache && response.ok ? cache.put(path, response.clone()) : undefined
+        )
+        .catch(() => {})
     );
+    event.respondWith(assetResult.then(({ response }) => response));
     return;
   }
 
@@ -124,6 +120,21 @@ self.addEventListener('fetch', (event) => {
     );
   }
 });
+
+async function loadShellAsset(
+  request: Request,
+  path: string
+): Promise<{ cache?: Cache; response: Response }> {
+  let cache: Cache;
+  try {
+    cache = await caches.open(CACHE_NAME);
+    const cached = await cache.match(path);
+    if (cached) return { response: cached };
+  } catch {
+    return { response: await fetch(request) };
+  }
+  return { cache, response: await fetch(request) };
+}
 
 async function cacheNavigationShell(response: Response): Promise<void> {
   const cache = await caches.open(CACHE_NAME);

--- a/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
+++ b/docs/fdr/FDR-027-pwa-shell-and-service-worker.md
@@ -1,24 +1,24 @@
 # FDR-027: PWA Shell & Service Worker
 
 **Status:** Active
-**Last reviewed:** 2026-07-14
+**Last reviewed:** 2026-07-29
 
 ## Overview
 
-Chatto ships a service worker so the installed web app can launch reliably and handle push notifications. The worker caches the SPA fallback shell and SvelteKit build assets during install, then caches static PWA assets when the browser actually requests them. The web manifest stays network-only because the server may generate it from current public server branding. The worker deliberately does not cache chat data, API responses, live-event traffic, or protected uploaded asset bodies.
+Chatto ships a service worker so the installed web app can handle push notifications and reuse frontend assets across launches. The worker caches SvelteKit build and static PWA assets only after the browser requests them. The web manifest stays network-only because the server may generate it from current public server branding. The worker deliberately does not cache chat data, API responses, live-event traffic, or protected uploaded asset bodies.
 
-Offline support means the app can open and show its normal disconnected state instead of the browser's generic offline page. It does not mean offline message history, offline search, or an outbox for composing messages while disconnected.
+Offline launches are not guaranteed. A previously visited app shell may remain available opportunistically, but the PWA expects a network connection for normal use.
 
 Reconnect catch-up is owned by the foreground web app, not the service worker. When a controlled PWA tab wakes or reconnects, server-scoped stores refetch projected ConnectRPC state and the room UI refetches the currently viewed room/thread window. The worker must not cache or replay messages, API responses, or live-event traffic.
 
 ## Behavior
 
 - The service worker is registered by SvelteKit in production builds.
-- On install, the worker caches the SPA fallback shell and SvelteKit build assets required to boot it.
+- Installing or updating the worker does not download frontend assets.
 - On activate, old Chatto shell caches are deleted and the new worker claims open clients.
-- Known shell assets are served cache-first from the versioned cache; static PWA assets other than the web manifest are cached lazily on first request.
+- Known build and static PWA assets are cached when requested and served cache-first afterward.
 - The served web manifest uses the server name as the installed app name. Its icons, along with favicon and Apple touch icon metadata, use the uploaded server logo when one exists and fall back to bundled Chatto icons otherwise.
-- Same-origin navigations are network-first, falling back to the cached SPA shell only when the network fails.
+- Same-origin navigations are network-first. Successful navigations update the cached SPA shell without another request; that shell is used as a best-effort fallback when the network fails.
 - API, auth, OAuth, webhook, uploaded-asset, dynamic branding metadata, non-GET, and cross-origin requests are network-only.
 - Protected uploaded asset loads use direct signed asset URLs owned by the foreground app. The worker does not receive registered-server API bearer tokens, does not proxy asset requests, and does not cache protected asset bodies.
 - Push notifications continue to display native OS notifications and route notification clicks into the SPA.
@@ -28,15 +28,15 @@ Reconnect catch-up is owned by the foreground web app, not the service worker. W
 
 ### 1. Shell-only caching
 
-**Decision:** Cache only the app shell and static PWA assets that do not depend on current server state. Build assets required to boot the shell are cached during install, while static PWA assets are cached lazily after install. The web manifest remains network-only.
-**Why:** Chatto is a real-time chat app. Serving stale messages, permissions, assets, or notification state as if they were live would be worse than showing the disconnected state.
-**Tradeoff:** Offline launches do not show recent rooms or messages unless the live app already has that state in memory, and full static asset coverage accumulates as the app requests assets. The install manifest may be unavailable while offline, but installed apps already have their manifest metadata. This keeps the data model honest while avoiding install-time requests for icons and unrelated static files.
+**Decision:** Cache static frontend assets only after the browser requests them. Successful navigations may seed a shell fallback, but installing the worker does not precache the build. The web manifest remains network-only.
+**Why:** Chatto is a real-time chat app that requires the network for useful state. Downloading every route, lazy chunk, font, and stylesheet during service-worker installation makes startup contend with assets the user may never need.
+**Tradeoff:** Offline launches are best-effort and may fail if the necessary shell assets have not already been requested. In exchange, first load and worker updates avoid a large background request burst.
 
 ### 2. Versioned cache names
 
 **Decision:** Shell caches include the SvelteKit app version in their name.
 **Why:** A deploy can replace hashed JavaScript and CSS chunks. Versioned cache names let the new worker populate a fresh shell cache and delete older shell caches during activation.
-**Tradeoff:** A user briefly stores two shell versions during update. The cached asset set is small, so this is acceptable.
+**Tradeoff:** A user may briefly store assets from two shell versions during update. Old versioned caches are removed when the new worker activates.
 
 ### 3. SvelteKit owns registration
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -36,5 +36,5 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-06-15 |
 | [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-05-19 |
 | [FDR-026](FDR-026-last-room-memory.md) | Last-Room Memory | Active | 2026-05-19 |
-| [FDR-027](FDR-027-pwa-shell-and-service-worker.md) | PWA Shell & Service Worker | Active | 2026-07-14 |
+| [FDR-027](FDR-027-pwa-shell-and-service-worker.md) | PWA Shell & Service Worker | Active | 2026-07-29 |
 | [FDR-028](FDR-028-operator-api-and-cli.md) | Operator API & CLI | Active | 2026-06-29 |


### PR DESCRIPTION
## Why

The PWA cache policy from #1786 has been validated on `main` and is ready for
the 0.4 release line. Service-worker installation currently downloads the
complete SvelteKit build manifest, creating a large request burst for route
chunks, stylesheets, and fonts the user may never need.

## What changed

- stop downloading frontend assets during service-worker installation
- cache known frontend shell assets only after the browser requests them
- keep cache writes best-effort and off the asset response path
- keep navigations online-first while letting successful responses seed an
  opportunistic shell fallback without another request
- preserve network-only handling for API, authentication, OAuth, webhook,
  uploaded-asset, non-GET, and cross-origin traffic
- update FDR-027 and replace guaranteed-offline coverage with the lazy-cache
  contract

This is a backport of #1786. Offline operation is no longer guaranteed. Existing
versioned shell caches are retired normally when the new worker activates, and
required frontend assets are cached again as they are requested.

There are no public API, persistence, migration, authorization, or deployment
configuration changes.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest run src/service-worker.spec.ts src/lib/pwa/notificationBadge.worker.spec.ts`
  — 40 passed
- `mise x -- pnpm --dir apps/frontend check`
  — 0 errors and 0 warnings
- `mise x -- pnpm --dir apps/frontend exec eslint src/service-worker.ts src/service-worker.spec.ts e2e/service-worker.test.ts`
  — passed
- `mise x -- pnpm --dir apps/frontend build`
  — passed
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/service-worker.test.ts --retries=0`
  — 2 passed
- Full repository CI — passed.

Closes #1779.
