### PR TITLE
refactor(core): make room group layout projection private

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -110,12 +110,6 @@ type ChattoCore struct {
 	// RoomMembership is the membership index inside RoomDirectory.
 	RoomMembership *RoomMembershipProjection
 
-	// RoomGroups is the group state index inside RoomGroupLayout.
-	RoomGroups *RoomGroupProjection
-
-	// RoomLayout is the sidebar ordering index inside RoomGroupLayout.
-	RoomLayout *RoomLayoutProjection
-
 	// Threads holds an append-only event log per thread root,
 	// derived from the same evt.room.> firehose. Source of truth
 	// for thread-pane reads post-cutover.
@@ -208,8 +202,8 @@ func (c *ChattoCore) Run(ctx context.Context) error {
 		// Seed the default room group and ensure every existing
 		// channel room belongs to a set (ADR-031). Idempotent —
 		// runs on every boot. Has to happen AFTER projectors are
-		// running and caught up because it reads the RoomGroups
-		// projection and depends on WaitFor actually waiting.
+		// running and caught up because it reads RoomModel's group-layout
+		// state and depends on WaitFor actually waiting.
 		if err := c.ensureChannelRoomsAreInAGroup(gctx); err != nil {
 			return fmt.Errorf("ensure channel rooms in a group: %w", err)
 		}

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -63,8 +63,6 @@ func assembleCore(
 		s3Client:       infra.s3Client,
 		EventPublisher: infra.eventPublisher,
 		RoomMembership: projections.roomDirectory.Membership,
-		RoomGroups:     projections.roomGroupLayout.Groups,
-		RoomLayout:     projections.roomGroupLayout.Layout,
 		Threads:        projections.threads,
 		Reactions:      projections.reactions,
 		Users:          projections.users,

--- a/cli/internal/core/room_group_layout_projection.go
+++ b/cli/internal/core/room_group_layout_projection.go
@@ -6,8 +6,7 @@ import (
 )
 
 // RoomGroupLayoutProjection combines room-group state and explicit sidebar
-// ordering. The read APIs remain split between RoomGroups and RoomLayout, but a
-// single projector now tracks the group aggregate plus the layout aggregate.
+// ordering. RoomModel owns both read surfaces and their shared projector.
 type RoomGroupLayoutProjection struct {
 	events.MemoryProjection
 	Groups *RoomGroupProjection

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -23,13 +23,13 @@ const maxMoveRoomToGroupRetries = 5
 // `evt.layout.default` aggregate. The legacy `room_group.{id}` and
 // `room_layout` KV records are no longer written or read by current code.
 //
-// Reads compose three read-model indexes:
-//   - RoomGroups: per-group metadata + ordered room_ids
-//   - RoomLayout: operator-defined ordering of group IDs
-//   - RoomCatalog: room metadata, used for the final reconciliation
+// RoomModel composes three read-model indexes:
+//   - RoomGroupProjection: per-group metadata + ordered room_ids
+//   - RoomLayoutProjection: operator-defined ordering of group IDs
+//   - RoomCatalogProjection: room metadata, used for final reconciliation
 //
 // `ListRoomGroupsOrdered` walks the layout's ordering, drops stale
-// entries, and appends any orphan groups (present in RoomGroups but
+// entries, and appends any orphan groups (present in group state but
 // missing from the layout) at the end by NanoID order — same
 // self-healing reconciliation the KV-era code did, just sourced from
 // in-memory projections.
@@ -114,12 +114,12 @@ func (c *ChattoCore) updateRoomGroupFields(ctx context.Context, actorID, groupID
 		return nil, fmt.Errorf("%w: provide at least one room group field to update", ErrInvalidArgument)
 	}
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
-		snapshot := c.RoomGroups.Snapshot(groupID)
+		snapshot := c.roomModel.roomGroupSnapshot(groupID)
 		if !snapshot.Exists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return nil, fmt.Errorf("wait for room group layout projection before update: %w", err)
 			}
-			snapshot = c.RoomGroups.Snapshot(groupID)
+			snapshot = c.roomModel.roomGroupSnapshot(groupID)
 			if !snapshot.Exists {
 				return nil, ErrRoomGroupNotFound
 			}
@@ -158,7 +158,7 @@ func (c *ChattoCore) updateRoomGroupFields(ctx context.Context, actorID, groupID
 
 		c.logger.Info("Updated room group", "group_id", groupID, "name", nextName, "actor_id", actorID)
 		c.notifyRoomLayoutChanged(ctx, actorID, "update_group")
-		updated, _ := c.RoomGroups.Get(groupID)
+		updated, _ := c.roomModel.roomGroup(groupID)
 		return updated, nil
 	}
 	return nil, fmt.Errorf("update-room-group OCC retry exhausted after %d attempts: %w", maxMoveRoomToGroupRetries, events.ErrConflict)
@@ -212,11 +212,11 @@ func isValidSidebarLinkURL(rawURL string) bool {
 		(parsed.Scheme == "http" || parsed.Scheme == "https")
 }
 
-// GetRoomGroup reads a single group from the RoomGroups projection.
+// GetRoomGroup reads a single group through RoomModel.
 // Returns ErrRoomGroupNotFound if no RoomGroupCreatedEvent for the
 // ID has been observed.
 func (c *ChattoCore) GetRoomGroup(_ context.Context, groupID string) (*corev1.RoomGroup, error) {
-	g, ok := c.RoomGroups.Get(groupID)
+	g, ok := c.roomModel.roomGroup(groupID)
 	if !ok {
 		return nil, ErrRoomGroupNotFound
 	}
@@ -224,14 +224,14 @@ func (c *ChattoCore) GetRoomGroup(_ context.Context, groupID string) (*corev1.Ro
 }
 
 func (c *ChattoCore) sidebarLinkGroup(ctx context.Context, linkID string) (string, error) {
-	groupID := c.RoomGroups.GroupForSidebarLink(linkID)
+	groupID := c.roomModel.roomGroupForSidebarLink(linkID)
 	if groupID != "" {
 		return groupID, nil
 	}
 	if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 		return "", fmt.Errorf("wait for room group layout projection before sidebar-link lookup: %w", err)
 	}
-	groupID = c.RoomGroups.GroupForSidebarLink(linkID)
+	groupID = c.roomModel.roomGroupForSidebarLink(linkID)
 	if groupID == "" {
 		return "", ErrSidebarLinkNotFound
 	}
@@ -243,7 +243,7 @@ func (c *ChattoCore) GetSidebarLinkGroup(ctx context.Context, linkID string) (st
 }
 
 func (c *ChattoCore) sidebarLinkInGroup(groupID, linkID string) (*corev1.SidebarLink, error) {
-	group, ok := c.RoomGroups.Get(groupID)
+	group, ok := c.roomModel.roomGroup(groupID)
 	if !ok {
 		return nil, ErrRoomGroupNotFound
 	}
@@ -380,12 +380,12 @@ func (c *ChattoCore) DeleteRoomGroup(ctx context.Context, actorID, groupID strin
 
 func (c *ChattoCore) deleteRoomGroup(ctx context.Context, actorID, groupID string, authorize func() error) error {
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
-		snapshot := c.RoomGroups.Snapshot(groupID)
+		snapshot := c.roomModel.roomGroupSnapshot(groupID)
 		if !snapshot.Exists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before delete: %w", err)
 			}
-			snapshot = c.RoomGroups.Snapshot(groupID)
+			snapshot = c.roomModel.roomGroupSnapshot(groupID)
 			if !snapshot.Exists {
 				return ErrRoomGroupNotFound
 			}
@@ -451,12 +451,12 @@ func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, autho
 		if err != nil {
 			return fmt.Errorf("read authorization fence seq: %w", err)
 		}
-		snapshot := c.RoomGroups.MoveSnapshot(roomID, targetGroupID)
+		snapshot := c.roomModel.roomGroupMoveSnapshot(roomID, targetGroupID)
 		if !snapshot.TargetExists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before not-found decision: %w", err)
 			}
-			snapshot = c.RoomGroups.MoveSnapshot(roomID, targetGroupID)
+			snapshot = c.roomModel.roomGroupMoveSnapshot(roomID, targetGroupID)
 			if !snapshot.TargetExists {
 				return ErrRoomGroupNotFound
 			}
@@ -470,7 +470,7 @@ func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, autho
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before no-op decision: %w", err)
 			}
-			snapshot = c.RoomGroups.MoveSnapshot(roomID, targetGroupID)
+			snapshot = c.roomModel.roomGroupMoveSnapshot(roomID, targetGroupID)
 			sourceGroupID = snapshot.SourceGroupID
 			if !snapshot.TargetExists {
 				return ErrRoomGroupNotFound
@@ -569,14 +569,14 @@ func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, autho
 
 // ReorderRoomGroups publishes a RoomGroupsReorderedEvent with the
 // new inter-group ordering. orderedGroupIDs must be a permutation of
-// the current set of groups in the RoomGroups projection — extras,
+// the current group set in RoomModel — extras,
 // duplicates, or missing IDs return ErrRoomGroupOrderMismatch.
 func (c *ChattoCore) ReorderRoomGroups(ctx context.Context, actorID string, orderedGroupIDs []string) error {
 	return c.reorderRoomGroups(ctx, actorID, orderedGroupIDs, nil)
 }
 
 func (c *ChattoCore) reorderRoomGroups(ctx context.Context, actorID string, orderedGroupIDs []string, authorize func() error) error {
-	current := c.RoomGroups.All()
+	current := c.roomModel.roomGroups()
 	currentIDs := make(map[string]struct{}, len(current))
 	for _, g := range current {
 		currentIDs[g.Id] = struct{}{}
@@ -613,7 +613,7 @@ func (c *ChattoCore) reorderRoomGroups(ctx context.Context, actorID string, orde
 // Cross-group moves go through MoveRoomToGroup; this method is for
 // intra-group drag-reorder where the membership set doesn't change.
 func (c *ChattoCore) ReorderRoomsInGroup(ctx context.Context, actorID, groupID string, orderedRoomIDs []string) error {
-	g, ok := c.RoomGroups.Get(groupID)
+	g, ok := c.roomModel.roomGroup(groupID)
 	if !ok {
 		return ErrRoomGroupNotFound
 	}
@@ -668,12 +668,12 @@ func (c *ChattoCore) createSidebarLink(ctx context.Context, actorID, groupID, la
 		Url:   rawURL,
 	}
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
-		snapshot := c.RoomGroups.Snapshot(groupID)
+		snapshot := c.roomModel.roomGroupSnapshot(groupID)
 		if !snapshot.Exists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return nil, fmt.Errorf("wait for room group layout projection before sidebar-link create: %w", err)
 			}
-			snapshot = c.RoomGroups.Snapshot(groupID)
+			snapshot = c.roomModel.roomGroupSnapshot(groupID)
 			if !snapshot.Exists {
 				return nil, ErrRoomGroupNotFound
 			}
@@ -724,12 +724,12 @@ func (c *ChattoCore) updateSidebarLinkInGroup(ctx context.Context, actorID, grou
 		return nil, err
 	}
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
-		snapshot := c.RoomGroups.Snapshot(groupID)
+		snapshot := c.roomModel.roomGroupSnapshot(groupID)
 		if !snapshot.Exists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return nil, fmt.Errorf("wait for room group layout projection before sidebar-link update: %w", err)
 			}
-			snapshot = c.RoomGroups.Snapshot(groupID)
+			snapshot = c.roomModel.roomGroupSnapshot(groupID)
 			if !snapshot.Exists {
 				return nil, ErrRoomGroupNotFound
 			}
@@ -779,12 +779,12 @@ func (c *ChattoCore) DeleteSidebarLinkInGroup(ctx context.Context, actorID, grou
 
 func (c *ChattoCore) deleteSidebarLinkInGroup(ctx context.Context, actorID, groupID, linkID string, authorize func() error) error {
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
-		snapshot := c.RoomGroups.Snapshot(groupID)
+		snapshot := c.roomModel.roomGroupSnapshot(groupID)
 		if !snapshot.Exists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before sidebar-link delete: %w", err)
 			}
-			snapshot = c.RoomGroups.Snapshot(groupID)
+			snapshot = c.roomModel.roomGroupSnapshot(groupID)
 			if !snapshot.Exists {
 				return ErrRoomGroupNotFound
 			}
@@ -836,12 +836,12 @@ func (c *ChattoCore) moveSidebarLinkBetweenGroups(ctx context.Context, actorID, 
 		if err != nil {
 			return fmt.Errorf("read authorization fence seq: %w", err)
 		}
-		snapshot := c.RoomGroups.SidebarLinkMoveSnapshot(linkID, targetGroupID)
+		snapshot := c.roomModel.sidebarLinkMoveSnapshot(linkID, targetGroupID)
 		if !snapshot.TargetExists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before sidebar-link move target decision: %w", err)
 			}
-			snapshot = c.RoomGroups.SidebarLinkMoveSnapshot(linkID, targetGroupID)
+			snapshot = c.roomModel.sidebarLinkMoveSnapshot(linkID, targetGroupID)
 			if !snapshot.TargetExists {
 				return ErrRoomGroupNotFound
 			}
@@ -850,7 +850,7 @@ func (c *ChattoCore) moveSidebarLinkBetweenGroups(ctx context.Context, actorID, 
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before sidebar-link move source decision: %w", err)
 			}
-			snapshot = c.RoomGroups.SidebarLinkMoveSnapshot(linkID, targetGroupID)
+			snapshot = c.roomModel.sidebarLinkMoveSnapshot(linkID, targetGroupID)
 			if snapshot.SourceGroupID == "" || snapshot.Link == nil {
 				return ErrSidebarLinkNotFound
 			}
@@ -925,12 +925,12 @@ func (c *ChattoCore) ReorderSidebarItemsInGroup(ctx context.Context, actorID, gr
 
 func (c *ChattoCore) reorderSidebarItemsInGroup(ctx context.Context, actorID, groupID string, orderedEntries []*corev1.SidebarGroupEntry, authorize func() error) error {
 	for attempt := 0; attempt < maxMoveRoomToGroupRetries; attempt++ {
-		snapshot := c.RoomGroups.Snapshot(groupID)
+		snapshot := c.roomModel.roomGroupSnapshot(groupID)
 		if !snapshot.Exists {
 			if err := c.roomModel.waitForGroupLayoutCurrent(ctx, c.EventPublisher); err != nil {
 				return fmt.Errorf("wait for room group layout projection before sidebar-item reorder: %w", err)
 			}
-			snapshot = c.RoomGroups.Snapshot(groupID)
+			snapshot = c.roomModel.roomGroupSnapshot(groupID)
 			if !snapshot.Exists {
 				return ErrRoomGroupNotFound
 			}
@@ -1019,8 +1019,8 @@ func (c *ChattoCore) ListRoomGroupsOrdered(_ context.Context, kind RoomKind) ([]
 		return nil, nil
 	}
 
-	order := c.RoomLayout.Order()
-	all := c.RoomGroups.All()
+	order := c.roomModel.roomLayoutOrder()
+	all := c.roomModel.roomGroups()
 	docs := make(map[string]*corev1.RoomGroup, len(all))
 	for _, g := range all {
 		docs[g.Id] = g
@@ -1054,10 +1054,10 @@ func (c *ChattoCore) ListRoomGroupsOrdered(_ context.Context, kind RoomKind) ([]
 }
 
 // GetRoomLayoutOrder returns the operator-defined ordering from the
-// RoomLayout projection. May include IDs of groups that have since
+// RoomModel's layout state. May include IDs of groups that have since
 // been deleted; use ListRoomGroupsOrdered for the reconciled view.
 func (c *ChattoCore) GetRoomLayoutOrder(_ context.Context) ([]string, error) {
-	return c.RoomLayout.Order(), nil
+	return c.roomModel.roomLayoutOrder(), nil
 }
 
 // ----------------------------------------------------------------------
@@ -1083,7 +1083,7 @@ func (c *ChattoCore) publishLayoutOrdering(ctx context.Context, actorID string, 
 // appendGroupToLayout appends groupID to the current layout ordering
 // if not already present, then publishes the new ordering.
 func (c *ChattoCore) appendGroupToLayout(ctx context.Context, actorID, groupID string) error {
-	current := c.RoomLayout.Order()
+	current := c.roomModel.roomLayoutOrder()
 	if slices.Contains(current, groupID) {
 		return nil
 	}
@@ -1093,7 +1093,7 @@ func (c *ChattoCore) appendGroupToLayout(ctx context.Context, actorID, groupID s
 // removeGroupFromLayout removes groupID from the current layout
 // ordering and republishes if it was present.
 func (c *ChattoCore) removeGroupFromLayout(ctx context.Context, actorID, groupID string) error {
-	current := c.RoomLayout.Order()
+	current := c.roomModel.roomLayoutOrder()
 	if !slices.Contains(current, groupID) {
 		return nil
 	}

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -327,8 +327,6 @@ func TestMoveRoomToSet_FromSourceRejectsChangedSourceAfterOCCRetry(t *testing.T)
 		nc:             harness.nc,
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
-		RoomGroups:     groupLayout.Groups,
-		RoomLayout:     groupLayout.Layout,
 	}
 	core.roomModel = newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 
@@ -352,7 +350,7 @@ func TestMoveRoomToSet_FromSourceRejectsChangedSourceAfterOCCRetry(t *testing.T)
 			}
 		}
 	}
-	if got := core.RoomGroups.GroupForRoom("R1"); got != "G-source" {
+	if got := core.roomModel.roomGroupForRoom("R1"); got != "G-source" {
 		t.Fatalf("test setup source group = %q, want stale G-source", got)
 	}
 
@@ -371,10 +369,10 @@ func TestMoveRoomToSet_FromSourceRejectsChangedSourceAfterOCCRetry(t *testing.T)
 	if err := <-errCh; !errors.Is(err, ErrRoomMoveSourceChanged) {
 		t.Fatalf("MoveRoomToGroupFromSource after OCC retry err = %v, want ErrRoomMoveSourceChanged", err)
 	}
-	if got := core.RoomGroups.GroupForRoom("R1"); got != "G-other" {
+	if got := core.roomModel.roomGroupForRoom("R1"); got != "G-other" {
 		t.Fatalf("room source after rejected move = %q, want G-other", got)
 	}
-	target, ok := core.RoomGroups.Get("G-target")
+	target, ok := core.roomModel.roomGroup("G-target")
 	if !ok {
 		t.Fatal("target group missing after catch-up")
 	}
@@ -393,8 +391,6 @@ func TestMoveRoomToSet_TargetCreatedBeforeProjectionCatchup(t *testing.T) {
 		nc:             harness.nc,
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
-		RoomGroups:     groupLayout.Groups,
-		RoomLayout:     groupLayout.Layout,
 	}
 	core.roomModel = newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 
@@ -406,7 +402,7 @@ func TestMoveRoomToSet_TargetCreatedBeforeProjectionCatchup(t *testing.T) {
 	if _, err := harness.publisher.AppendEventually(ctx, events.GroupAggregate("G-late").SubjectFor(created), created); err != nil {
 		t.Fatalf("append group-created event: %v", err)
 	}
-	if core.RoomGroups.Exists("G-late") {
+	if _, ok := core.roomModel.roomGroup("G-late"); ok {
 		t.Fatal("test setup expected group projection to start stale")
 	}
 
@@ -426,7 +422,7 @@ func TestMoveRoomToSet_TargetCreatedBeforeProjectionCatchup(t *testing.T) {
 		t.Fatalf("MoveRoomToGroup after projection catch-up: %v", err)
 	}
 
-	group, ok := core.RoomGroups.Get("G-late")
+	group, ok := core.roomModel.roomGroup("G-late")
 	if !ok {
 		t.Fatal("target group missing after catch-up")
 	}
@@ -445,8 +441,6 @@ func TestMoveRoomToSet_IdempotentNoopRefreshesStaleSnapshot(t *testing.T) {
 		nc:             harness.nc,
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
-		RoomGroups:     groupLayout.Groups,
-		RoomLayout:     groupLayout.Layout,
 	}
 	core.roomModel = newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 
@@ -469,7 +463,7 @@ func TestMoveRoomToSet_IdempotentNoopRefreshesStaleSnapshot(t *testing.T) {
 			}
 		}
 	}
-	if got := core.RoomGroups.GroupForRoom("R1"); got != "G-target" {
+	if got := core.roomModel.roomGroupForRoom("R1"); got != "G-target" {
 		t.Fatalf("test setup source group = %q, want stale G-target", got)
 	}
 
@@ -489,14 +483,14 @@ func TestMoveRoomToSet_IdempotentNoopRefreshesStaleSnapshot(t *testing.T) {
 		t.Fatalf("MoveRoomToGroup after stale no-op catch-up: %v", err)
 	}
 
-	target, ok := core.RoomGroups.Get("G-target")
+	target, ok := core.roomModel.roomGroup("G-target")
 	if !ok {
 		t.Fatal("target group missing after catch-up")
 	}
 	if len(target.RoomIds) != 1 || target.RoomIds[0] != "R1" {
 		t.Fatalf("target room IDs = %v, want [R1]", target.RoomIds)
 	}
-	other, ok := core.RoomGroups.Get("G-other")
+	other, ok := core.roomModel.roomGroup("G-other")
 	if !ok {
 		t.Fatal("other group missing after catch-up")
 	}
@@ -800,7 +794,7 @@ func TestMoveSidebarLinkToGroupPreservesConcurrentUpdate(t *testing.T) {
 		t.Fatalf("CreateSidebarLink: %v", err)
 	}
 
-	staleSnapshot := core.RoomGroups.SidebarLinkMoveSnapshot(link.Id, target.Id)
+	staleSnapshot := core.roomModel.sidebarLinkMoveSnapshot(link.Id, target.Id)
 	if staleSnapshot.Link == nil {
 		t.Fatal("expected stale move snapshot to include sidebar link")
 	}

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -151,6 +151,38 @@ func (m *RoomModel) nameClaimSnapshot(name string) RoomNameClaimSnapshot {
 	return m.directory.Catalog.NameClaimSnapshot(name)
 }
 
+func (m *RoomModel) roomGroup(groupID string) (*corev1.RoomGroup, bool) {
+	return m.groupLayout.Groups.Get(groupID)
+}
+
+func (m *RoomModel) roomGroupSnapshot(groupID string) RoomGroupSnapshot {
+	return m.groupLayout.Groups.Snapshot(groupID)
+}
+
+func (m *RoomModel) roomGroups() []*corev1.RoomGroup {
+	return m.groupLayout.Groups.All()
+}
+
+func (m *RoomModel) roomGroupForRoom(roomID string) string {
+	return m.groupLayout.Groups.GroupForRoom(roomID)
+}
+
+func (m *RoomModel) roomGroupForSidebarLink(linkID string) string {
+	return m.groupLayout.Groups.GroupForSidebarLink(linkID)
+}
+
+func (m *RoomModel) roomGroupMoveSnapshot(roomID, targetGroupID string) RoomGroupMoveSnapshot {
+	return m.groupLayout.Groups.MoveSnapshot(roomID, targetGroupID)
+}
+
+func (m *RoomModel) sidebarLinkMoveSnapshot(linkID, targetGroupID string) SidebarLinkMoveSnapshot {
+	return m.groupLayout.Groups.SidebarLinkMoveSnapshot(linkID, targetGroupID)
+}
+
+func (m *RoomModel) roomLayoutOrder() []string {
+	return m.groupLayout.Layout.Order()
+}
+
 func (m *RoomModel) waitForDirectoryCurrent(ctx context.Context, publisher *events.Publisher) error {
 	pos, err := publisher.LastSubjectPosition(ctx, events.RoomSubjectFilter())
 	if err != nil {

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -506,7 +506,7 @@ func (c *ChattoCore) DeleteRoom(ctx context.Context, actorID string, kind RoomKi
 	// (Phase-6 note: pre-phase-6 we had to walk room_group docs to
 	// drop the deleted room from group.room_ids. The cascade
 	// RoomRemovedFromGroupEvent above handles that automatically
-	// via the RoomGroups projection now.)
+	// through RoomModel's group-layout state now.)
 
 	c.logger.Info("Room deleted", "kind", kind, "room_id", room_id)
 
@@ -600,7 +600,7 @@ func (c *ChattoCore) UnarchiveRoom(ctx context.Context, actorID string, kind Roo
 
 // GetRoom retrieves a room by id.
 //
-// Reads come from RoomCatalog composed with RoomGroups for the
+// Reads come from RoomModel's room catalog and group-layout state for the
 // group_id field. Returns ErrNotFound (wrapped) if the room isn't
 // projected OR if its kind doesn't match the requested kind —
 // keeping the "the wrong kind is not found" semantic so callers
@@ -610,7 +610,7 @@ func (c *ChattoCore) GetRoom(ctx context.Context, kind RoomKind, room_id string)
 	if !ok || room.Kind != ProtoKindForRoomKind(kind) {
 		return nil, fmt.Errorf("room not found: %w", jetstream.ErrKeyNotFound)
 	}
-	if gid := c.RoomGroups.GroupForRoom(room_id); gid != "" {
+	if gid := c.roomModel.roomGroupForRoom(room_id); gid != "" {
 		room.GroupId = gid
 	}
 	return room, nil
@@ -628,7 +628,7 @@ func (c *ChattoCore) FindRoomByID(ctx context.Context, room_id string) (*corev1.
 	if !ok {
 		return nil, ErrNotFound
 	}
-	if gid := c.RoomGroups.GroupForRoom(room_id); gid != "" {
+	if gid := c.roomModel.roomGroupForRoom(room_id); gid != "" {
 		room.GroupId = gid
 	}
 	return room, nil
@@ -646,12 +646,12 @@ func (c *ChattoCore) FindRoomKind(ctx context.Context, room_id string) (RoomKind
 }
 
 // ListRooms retrieves all rooms of the given kind from the
-// RoomCatalog projection, composed with RoomGroups for the group_id
-// field.
+// RoomModel's room catalog, composed with its group-layout state for the
+// group_id field.
 func (c *ChattoCore) ListRooms(ctx context.Context, kind RoomKind) ([]*corev1.Room, error) {
 	rooms := c.roomModel.roomsByKind(ProtoKindForRoomKind(kind))
 	for _, r := range rooms {
-		if gid := c.RoomGroups.GroupForRoom(r.Id); gid != "" {
+		if gid := c.roomModel.roomGroupForRoom(r.Id); gid != "" {
 			r.GroupId = gid
 		}
 	}

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -19,15 +19,19 @@ become current before completing boot.
 Writers wait for the relevant projector sequence before returning
 read-your-writes. Projection-aware domain models keep the projector references
 needed for those waits; the `ChattoCore` facade does not mirror every registered
-projector. `CallModel` and `AssetModel` own their projection reads and readiness
-for domain logic and API adapters. Call token access material binds the call ID
-and E2EE key to one revalidated projection generation. Active-call and asset API
-mapping use detached snapshots captured under one projection lock. Room
-timeline message hydration likewise obtains deletion and channel-echo metadata
-as one detached snapshot through `RoomTimelineReadModel`; ConnectAPI does not
-read that projection directly. `RoomModel` is the sole production owner of the
-Room Timeline projection; message, reaction, asset, and realtime paths use its
-focused operations rather than a projection field on `ChattoCore`.
+projector.
+
+`CallModel` and `AssetModel` own their projection reads and readiness for domain
+logic and API adapters. Call token access material binds the call ID and E2EE
+key to one revalidated projection generation. Active-call and asset API mapping
+use detached snapshots captured under one projection lock.
+
+Room timeline message hydration obtains deletion and channel-echo metadata as
+one detached snapshot through `RoomTimelineReadModel`; ConnectAPI does not read
+that projection directly. `RoomModel` is the sole production owner of both the
+Room Timeline and combined Room Group Layout projections. Message, reaction,
+asset, realtime, room-group OCC, and sidebar-ordering paths use focused
+`RoomModel` operations instead of projection fields on `ChattoCore`.
 
 Any non-cancellation error from checkpoint or snapshot restore, consumer setup,
 or event application moves the projector into its failed state before its run


### PR DESCRIPTION
## Why

`RoomModel` already owned the combined Room Group Layout projector, but
`ChattoCore` also exposed both child projections as public fields. That split
ownership let core operations bypass the model boundary and made the runtime
wiring more complicated than the actual architecture.

## What changed

- Added focused `RoomModel` reads for room groups, sidebar links, layout
  ordering, and OCC move/update snapshots.
- Routed room, room-group, and sidebar-layout operations through those model
  methods.
- Removed the duplicate `ChattoCore.RoomGroups` and `ChattoCore.RoomLayout`
  handles and their constructor wiring.
- Updated focused tests and the projection architecture inventory to describe
  the single ownership boundary.

This is an internal structural refactor. It does not change public APIs,
authorization, durable events, NATS subjects, persisted projection state,
snapshot contracts, rollout requirements, or user-visible behaviour.

## Test plan

- `mise test-cli` — passed
- `mise lint` — passed, including zero Svelte warnings/errors and ESLint
- `mise x -- go test ./internal/core` — passed
- `git diff --check` — passed
- Independent adversarial code review — no actionable findings

Closes #1792.
