### PR TITLE
refactor(core): make thread and reaction projections private

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -110,15 +110,6 @@ type ChattoCore struct {
 	// RoomMembership is the membership index inside RoomDirectory.
 	RoomMembership *RoomMembershipProjection
 
-	// Threads holds an append-only event log per thread root,
-	// derived from the same evt.room.> firehose. Source of truth
-	// for thread-pane reads post-cutover.
-	Threads *ThreadProjection
-
-	// Reactions holds current per-message reaction state derived
-	// from durable room-aggregate reaction events.
-	Reactions *ReactionProjection
-
 	// Users holds current user/account/profile/auth lookup state derived
 	// from durable user-aggregate events.
 	Users *UserProjection

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -63,8 +63,6 @@ func assembleCore(
 		s3Client:       infra.s3Client,
 		EventPublisher: infra.eventPublisher,
 		RoomMembership: projections.roomDirectory.Membership,
-		Threads:        projections.threads,
-		Reactions:      projections.reactions,
 		Users:          projections.users,
 		ContentKeys:    projections.contentKeys,
 		RBAC:           projections.rbac,

--- a/cli/internal/core/projection_snapshot_integration_test.go
+++ b/cli/internal/core/projection_snapshot_integration_test.go
@@ -112,7 +112,7 @@ func TestProjectionSnapshotsPersistAndRestoreCohort(t *testing.T) {
 			t.Errorf("%s projector replayed %d messages after current snapshot restore", registration.key, status.StartupMessages)
 		}
 	}
-	if got := threadEventIDs(second.Threads.ThreadEvents("ROOT")); !slices.Equal(got, []string{"REPLY-1"}) {
+	if got := timelineEventIDs(second.roomModel.threadEvents("ROOT")); !slices.Equal(got, []string{"REPLY-1"}) {
 		t.Fatalf("restored Thread events = %v", got)
 	}
 	select {

--- a/cli/internal/core/reactions_test.go
+++ b/cli/internal/core/reactions_test.go
@@ -158,7 +158,6 @@ func TestReactionModel_AddReactionRefreshesStaleNoopSnapshot(t *testing.T) {
 	core := &ChattoCore{
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
-		Reactions:      reactions,
 	}
 	core.roomModel = newRoomModel(nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
 	service := &ReactionModel{core: core}

--- a/cli/internal/core/threads_test.go
+++ b/cli/internal/core/threads_test.go
@@ -72,7 +72,7 @@ func TestChattoCore_PostMessage_Threading(t *testing.T) {
 		if replyEntry.Event.GetMessagePosted().GetInThread() != root.Id {
 			t.Fatalf("reply in_thread = %q, want %q", replyEntry.Event.GetMessagePosted().GetInThread(), root.Id)
 		}
-		if !core.Threads.ThreadExists(root.Id) {
+		if !core.roomModel.threadExists(root.Id) {
 			t.Fatalf("thread projection does not know root %s exists", root.Id)
 		}
 
@@ -1289,7 +1289,7 @@ func TestChattoCore_LegacyThreadFollowValueIsIgnored(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewChattoCore second: %v", err)
 	}
-	if got := second.Threads.FollowState("U1", "R1", "ROOT"); got != ThreadFollowStateNone {
+	if got := second.roomModel.threadFollowState("U1", "R1", "ROOT"); got != ThreadFollowStateNone {
 		t.Fatalf("retired thread follow marker was imported: %q", got)
 	}
 }

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -28,10 +28,11 @@ use detached snapshots captured under one projection lock.
 
 Room timeline message hydration obtains deletion and channel-echo metadata as
 one detached snapshot through `RoomTimelineReadModel`; ConnectAPI does not read
-that projection directly. `RoomModel` is the sole production owner of both the
-Room Timeline and combined Room Group Layout projections. Message, reaction,
-asset, realtime, room-group OCC, and sidebar-ordering paths use focused
-`RoomModel` operations instead of projection fields on `ChattoCore`.
+that projection directly. `RoomModel` is the sole production owner of the Room
+Group Layout, Room Timeline, Threads, and Reactions projections. Message,
+thread, reaction, asset, realtime, room-group OCC, and sidebar-ordering paths
+use focused `RoomModel` operations instead of projection fields on
+`ChattoCore`.
 
 Any non-cancellation error from checkpoint or snapshot restore, consumer setup,
 or event application moves the projector into its failed state before its run


### PR DESCRIPTION
## Why

`RoomModel` already owned the Threads and Reactions projections, including
their focused read operations and readiness barriers. `ChattoCore` still
mirrored both projections as public fields even though production code no
longer used those handles, leaving two unnecessary ways to reach the same
state.

## What changed

- Removed `ChattoCore.Threads` and `ChattoCore.Reactions` plus their duplicate
  constructor wiring.
- Updated thread, reaction, and snapshot integration tests to inspect state
  through focused `RoomModel` operations.
- Updated the projection architecture inventory to record `RoomModel` as the
  sole production owner of the Threads and Reactions projections.

This is an internal structural refactor. It does not change public APIs,
authorization, durable events, NATS subjects, persisted projection state,
snapshot contracts, OCC scopes, readiness waits, rollout requirements, or
user-visible behaviour.

## Test plan

- `mise x -- go test ./internal/core -timeout 180s` — passed
- `mise test-cli` — passed
- `mise lint` — passed, including zero Svelte warnings/errors and ESLint
- `git diff --check` — passed
- Independent adversarial code review — no actionable findings

Closes #1795.
