### PR TITLE
refactor(core): make room membership projection private

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -107,9 +107,6 @@ type ChattoCore struct {
 	// higher-level helpers as aggregates migrate.
 	EventPublisher *events.Publisher
 
-	// RoomMembership is the membership index inside RoomDirectory.
-	RoomMembership *RoomMembershipProjection
-
 	// Users holds current user/account/profile/auth lookup state derived
 	// from durable user-aggregate events.
 	Users *UserProjection

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -62,7 +62,6 @@ func assembleCore(
 		mentionables:   newMentionablesModel(projections.mentionables, projections.mentionablesProjector),
 		s3Client:       infra.s3Client,
 		EventPublisher: infra.eventPublisher,
-		RoomMembership: projections.roomDirectory.Membership,
 		Users:          projections.users,
 		ContentKeys:    projections.contentKeys,
 		RBAC:           projections.rbac,

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -15,11 +15,11 @@ import (
 const maxJoinRoomRetries = 5
 
 // GetRoomMembership retrieves a room membership for a user in a specific room.
-// Reads from the RoomMembership projection (ADR-035 phase 5 cutover).
+// Reads explicit membership through RoomModel (ADR-035 phase 5 cutover).
 // kind is ignored — roomID is globally unique, so the (roomID, userID)
 // pair fully identifies a membership.
 func (c *ChattoCore) GetRoomMembership(ctx context.Context, kind RoomKind, user_id, room_id string) (*corev1.RoomMembership, error) {
-	if !c.RoomMembership.IsMember(room_id, user_id) {
+	if !c.roomModel.hasExplicitRoomMembership(room_id, user_id) {
 		return nil, fmt.Errorf("room membership not found for user %s in room %s: %w", user_id, room_id, jetstream.ErrKeyNotFound)
 	}
 	return &corev1.RoomMembership{
@@ -29,13 +29,13 @@ func (c *ChattoCore) GetRoomMembership(ctx context.Context, kind RoomKind, user_
 }
 
 // RoomMembershipExists checks if a user is a member of a room.
-// Reads from the RoomMembership projection (ADR-035 phase 5 cutover).
+// Reads explicit membership through RoomModel (ADR-035 phase 5 cutover).
 //
 // Channel rooms marked universal grant effective membership to every server
 // member who is currently eligible to join the room. Explicit memberships
 // remain the durable state; universal membership is derived at read time.
 func (c *ChattoCore) RoomMembershipExists(ctx context.Context, kind RoomKind, user_id, room_id string) (bool, error) {
-	if c.RoomMembership.IsMember(room_id, user_id) {
+	if c.roomModel.hasExplicitRoomMembership(room_id, user_id) {
 		return true, nil
 	}
 	if kind != KindChannel {
@@ -91,7 +91,7 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 	joinSubject := events.RoomAggregate(room_id).SubjectFor(event)
 	var seq uint64
 	for attempt := 0; attempt < maxJoinRoomRetries; attempt++ {
-		if c.RoomMembership.IsMember(room_id, user_id) {
+		if c.roomModel.hasExplicitRoomMembership(room_id, user_id) {
 			return membership, nil
 		}
 
@@ -103,7 +103,7 @@ func (c *ChattoCore) JoinRoom(ctx context.Context, actorID string, kind RoomKind
 			if err := c.roomModel.waitForDirectory(ctx, events.SubjectPosition(joinSubject, expectedSeq)); err != nil {
 				return nil, fmt.Errorf("wait for room directory projection before join: %w", err)
 			}
-			if c.RoomMembership.IsMember(room_id, user_id) {
+			if c.roomModel.hasExplicitRoomMembership(room_id, user_id) {
 				return membership, nil
 			}
 		}
@@ -178,7 +178,7 @@ func (c *ChattoCore) AddMember(ctx context.Context, actorID string, kind RoomKin
 				return nil, fmt.Errorf("wait for room directory projection before member add: %w", err)
 			}
 		}
-		if c.RoomMembership.IsMember(roomID, targetUserID) {
+		if c.roomModel.hasExplicitRoomMembership(roomID, targetUserID) {
 			return membership, nil
 		}
 		if kind == KindChannel && c.roomModel.isRoomBanActive(roomID, targetUserID, time.Now()) {
@@ -236,7 +236,7 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 
 	room, err := c.GetRoom(ctx, kind, room_id)
 	if err != nil {
-		if errors.Is(err, jetstream.ErrKeyNotFound) && !c.RoomMembership.IsMember(room_id, user_id) {
+		if errors.Is(err, jetstream.ErrKeyNotFound) && !c.roomModel.hasExplicitRoomMembership(room_id, user_id) {
 			return nil
 		}
 		return err
@@ -255,7 +255,7 @@ func (c *ChattoCore) LeaveRoom(ctx context.Context, actorID string, kind RoomKin
 		if err := c.waitForRoomLeaveTail(ctx, filter, expectedSeq); err != nil {
 			return fmt.Errorf("wait for room projections before leave: %w", err)
 		}
-		if !c.RoomMembership.IsMember(room_id, user_id) {
+		if !c.roomModel.hasExplicitRoomMembership(room_id, user_id) {
 			return nil
 		}
 
@@ -309,7 +309,7 @@ func (c *ChattoCore) RemoveMember(ctx context.Context, actorID string, kind Room
 				return false, fmt.Errorf("wait for room directory projection before member remove: %w", err)
 			}
 		}
-		if !c.RoomMembership.IsMember(roomID, targetUserID) {
+		if !c.roomModel.hasExplicitRoomMembership(roomID, targetUserID) {
 			return false, nil
 		}
 
@@ -522,7 +522,7 @@ func (c *ChattoCore) GetUserRoomMemberships(ctx context.Context, kind RoomKind, 
 }
 
 // GetAllUserRoomMemberships retrieves all of a user's room memberships
-// across every kind. Reads from the RoomMembership projection
+// across every kind. Reads membership through RoomModel
 // (ADR-035 phase 5 cutover).
 func (c *ChattoCore) GetAllUserRoomMemberships(ctx context.Context, user_id string) ([]*corev1.RoomMembership, error) {
 	channelRooms, err := c.ListMemberRooms(ctx, KindChannel, user_id, MemberRoomListOptions{})
@@ -552,7 +552,7 @@ func (c *ChattoCore) GetAllUserRoomMemberships(ctx context.Context, user_id stri
 // from the projection rather than scanning the KV bucket. The kind
 // filter is applied via GetRoom to skip rooms of other kinds.
 func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_id string, kind RoomKind) error {
-	allRoomIDs := c.RoomMembership.Rooms(user_id)
+	allRoomIDs := c.roomModel.explicitRoomIDsForUser(user_id)
 	if len(allRoomIDs) == 0 {
 		return nil
 	}
@@ -641,7 +641,7 @@ func (c *ChattoCore) deleteUserRoomMembershipsInSpace(ctx context.Context, user_
 // room API; the (roomID, userID) pair is globally unique so kind is
 // irrelevant to the lookup.
 func (c *ChattoCore) GetRoomMembersList(ctx context.Context, kind RoomKind, room_id string) ([]*corev1.RoomMembership, error) {
-	userIDs := c.RoomMembership.Members(room_id)
+	userIDs := c.roomModel.explicitRoomMemberIDs(room_id)
 	seen := make(map[string]struct{}, len(userIDs))
 	out := make([]*corev1.RoomMembership, 0, len(userIDs))
 	add := func(uid string) {

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -151,6 +151,18 @@ func (m *RoomModel) nameClaimSnapshot(name string) RoomNameClaimSnapshot {
 	return m.directory.Catalog.NameClaimSnapshot(name)
 }
 
+func (m *RoomModel) hasExplicitRoomMembership(roomID, userID string) bool {
+	return m.directory.Membership.IsMember(roomID, userID)
+}
+
+func (m *RoomModel) explicitRoomIDsForUser(userID string) []string {
+	return m.directory.Membership.Rooms(userID)
+}
+
+func (m *RoomModel) explicitRoomMemberIDs(roomID string) []string {
+	return m.directory.Membership.Members(roomID)
+}
+
 func (m *RoomModel) roomGroup(groupID string) (*corev1.RoomGroup, bool) {
 	return m.groupLayout.Groups.Get(groupID)
 }

--- a/cli/internal/core/rooms.go
+++ b/cli/internal/core/rooms.go
@@ -671,7 +671,7 @@ type MemberRoomListOptions struct {
 // in. It is the shared room-list primitive for member-scoped room surfaces;
 // callers layer product policy on top with MemberRoomListOptions.
 func (c *ChattoCore) ListMemberRooms(ctx context.Context, kind RoomKind, userID string, opts MemberRoomListOptions) ([]*corev1.Room, error) {
-	roomIDs := c.RoomMembership.Rooms(userID)
+	roomIDs := c.roomModel.explicitRoomIDsForUser(userID)
 	seen := make(map[string]struct{}, len(roomIDs))
 
 	type listedRoom struct {

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -29,10 +29,11 @@ use detached snapshots captured under one projection lock.
 Room timeline message hydration obtains deletion and channel-echo metadata as
 one detached snapshot through `RoomTimelineReadModel`; ConnectAPI does not read
 that projection directly. `RoomModel` is the sole production owner of the Room
-Group Layout, Room Timeline, Threads, and Reactions projections. Message,
-thread, reaction, asset, realtime, room-group OCC, and sidebar-ordering paths
-use focused `RoomModel` operations instead of projection fields on
-`ChattoCore`.
+Directory, Room Group Layout, Room Timeline, Threads, and Reactions
+projections. Membership, message, thread, reaction, asset, realtime, room-group
+OCC, and sidebar-ordering paths use focused `RoomModel` operations instead of
+projection fields on `ChattoCore`. Raw membership reads are named as explicit
+membership so they remain distinct from policy-derived Universal-room access.
 
 Any non-cancellation error from checkpoint or snapshot restore, consumer setup,
 or event application moves the projector into its failed state before its run


### PR DESCRIPTION
## Why

`RoomModel` already owned the composite Room Directory projection and its
readiness barrier, but `ChattoCore` still exposed the nested membership
projection as a public field. That allowed callers to bypass the model boundary
and made it easy to confuse explicit durable membership with effective
Universal-room access.

## What changed

- Added focused `RoomModel` operations for explicit membership existence, a
  user's explicit room IDs, and a room's explicit member IDs.
- Routed membership mutation checks, cleanup, member lists, and member-room
  lists through those operations.
- Removed `ChattoCore.RoomMembership` and its duplicate constructor wiring.
- Updated ownership comments and the projection architecture inventory.

Policy-aware callers still use `RoomMembershipExists`, which derives effective
Universal-room membership separately from explicit stored membership.

This is an internal structural refactor. It does not change public APIs,
authorization, Universal-room policy, durable events, NATS subjects, persisted
projection state, snapshot contracts, OCC scopes, readiness waits, rollout
requirements, or user-visible behaviour.

## Test plan

- `mise x -- go test ./internal/core -timeout 180s` — passed
- `mise test-cli` — passed
- `mise lint` — passed, including zero Svelte warnings/errors and ESLint
- `git diff --check` — passed
- Two independent adversarial privacy reviews — no actionable findings

Closes #1798.
