### PR TITLE
refactor(frontend): centralize expiring asset URL refresh

### DIFF
--- a/apps/frontend/src/lib/attachments/useExpiringAssetUrlRefresh.svelte.ts
+++ b/apps/frontend/src/lib/attachments/useExpiringAssetUrlRefresh.svelte.ts
@@ -36,10 +36,11 @@ export function useExpiringAssetUrlRefresh({
 
 	$effect(() => {
 		const refreshAt = getRefreshAt();
+		const hasStale = hasStaleUrl();
 		if (refreshAt === null) return;
 
 		const delay = refreshAt - Date.now();
-		if (delay <= 0) {
+		if (delay <= 0 && hasStale) {
 			untrack(() => void runRefresh());
 			return;
 		}

--- a/apps/frontend/src/lib/attachments/useExpiringAssetUrlRefresh.svelte.ts
+++ b/apps/frontend/src/lib/attachments/useExpiringAssetUrlRefresh.svelte.ts
@@ -1,0 +1,64 @@
+import { onMount, untrack } from 'svelte';
+
+type ExpiringAssetUrlRefreshOptions = {
+	getRefreshAt: () => number | null;
+	hasStaleUrl: () => boolean;
+	refresh: () => void | Promise<unknown>;
+	errorMessage: string;
+	refreshOnFocus?: boolean;
+};
+
+/**
+ * Refresh expiring asset URLs at their next deadline and after a suspended tab
+ * becomes active again.
+ *
+ * Getters keep the caller's reactive URL state owned by the component or store
+ * while this hook owns only browser lifecycle orchestration.
+ */
+export function useExpiringAssetUrlRefresh({
+	getRefreshAt,
+	hasStaleUrl,
+	refresh,
+	errorMessage,
+	refreshOnFocus = true
+}: ExpiringAssetUrlRefreshOptions): void {
+	async function runRefresh(): Promise<void> {
+		try {
+			await refresh();
+		} catch (error: unknown) {
+			console.warn(errorMessage, error);
+		}
+	}
+
+	function refreshIfStale(): void {
+		if (hasStaleUrl()) void runRefresh();
+	}
+
+	$effect(() => {
+		const refreshAt = getRefreshAt();
+		if (refreshAt === null) return;
+
+		const delay = refreshAt - Date.now();
+		if (delay <= 0) {
+			untrack(() => void runRefresh());
+			return;
+		}
+
+		const timeout = window.setTimeout(() => void runRefresh(), delay);
+		return () => window.clearTimeout(timeout);
+	});
+
+	onMount(() => {
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === 'visible') refreshIfStale();
+		};
+
+		if (refreshOnFocus) window.addEventListener('focus', refreshIfStale);
+		document.addEventListener('visibilitychange', handleVisibilityChange);
+
+		return () => {
+			if (refreshOnFocus) window.removeEventListener('focus', refreshIfStale);
+			document.removeEventListener('visibilitychange', handleVisibilityChange);
+		};
+	});
+}

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -36,6 +36,7 @@ unknown instance) the component renders nothing.
     type ExpiringAssetUrl
   } from '$lib/attachments/attachmentUrls';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
+  import { useExpiringAssetUrlRefresh } from '$lib/attachments/useExpiringAssetUrlRefresh.svelte';
   import { ScrollFader } from '$lib/ui';
   import MessageContent from './MessageContent.svelte';
   import UserAvatar from './UserAvatar.svelte';
@@ -285,18 +286,6 @@ unknown instance) the component renders nothing.
     });
   }
 
-  function refreshStalePreviewUrls() {
-    if (hasStaleThumbnailUrl()) {
-      refreshPreviewAttachmentUrls();
-    }
-  }
-
-  function handleVisibilityChange() {
-    if (document.visibilityState === 'visible') {
-      refreshStalePreviewUrls();
-    }
-  }
-
   function openPreview(event: MouseEvent) {
     if (!preview) return;
     if (event.defaultPrevented) return;
@@ -340,31 +329,11 @@ unknown instance) the component renders nothing.
     );
   }
 
-  $effect(() => {
-    if (nextThumbnailRefreshAt === null) return;
-
-    const timeout = window.setTimeout(
-      () => {
-        refreshPreviewAttachmentUrls();
-      },
-      Math.max(0, nextThumbnailRefreshAt - Date.now())
-    );
-
-    return () => window.clearTimeout(timeout);
-  });
-
-  $effect(() => {
-    refreshStalePreviewUrls();
-  });
-
-  $effect(() => {
-    window.addEventListener('focus', refreshStalePreviewUrls);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener('focus', refreshStalePreviewUrls);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
+  useExpiringAssetUrlRefresh({
+    getRefreshAt: () => nextThumbnailRefreshAt,
+    hasStaleUrl: hasStaleThumbnailUrl,
+    refresh: refreshPreviewAttachmentUrls,
+    errorMessage: 'Failed to refresh message preview attachment URLs'
   });
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -23,6 +23,7 @@
   } from '$lib/attachments/attachmentUrls';
   import { createAttachmentAPI } from '$lib/api-client/attachments';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
+  import { useExpiringAssetUrlRefresh } from '$lib/attachments/useExpiringAssetUrlRefresh.svelte';
 
   let {
     attachments: rawAttachments,
@@ -282,38 +283,10 @@
     );
   });
 
-  $effect(() => {
-    if (nextAssetUrlRefreshAt === null) return;
-
-    const timeout = window.setTimeout(
-      () => {
-        refreshAndApplyUrls().catch((error: unknown) => {
-          console.warn('Failed to refresh attachment URLs before expiry', error);
-        });
-      },
-      Math.max(0, nextAssetUrlRefreshAt - Date.now())
-    );
-
-    return () => window.clearTimeout(timeout);
-  });
-
   function hasRefreshableStaleUrl() {
     return attachments.some((attachment) =>
       attachmentAssetUrls(attachment).some((assetUrl) => assetUrlNeedsRefresh(assetUrl))
     );
-  }
-
-  function refreshStaleUrls() {
-    if (!hasRefreshableStaleUrl()) return;
-    refreshAndApplyUrls().catch((error: unknown) => {
-      console.warn('Failed to refresh stale attachment URLs', error);
-    });
-  }
-
-  function handleVisibilityChange() {
-    if (document.visibilityState === 'visible') {
-      refreshStaleUrls();
-    }
   }
 
   async function refreshAndApplyUrls(): Promise<Map<string, RefreshedAttachmentUrls>> {
@@ -366,22 +339,11 @@
     }
   }
 
-  $effect(() => {
-    if (hasRefreshableStaleUrl()) {
-      refreshAndApplyUrls().catch((error: unknown) => {
-        console.warn('Failed to refresh stale attachment URLs', error);
-      });
-    }
-  });
-
-  $effect(() => {
-    window.addEventListener('focus', refreshStaleUrls);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener('focus', refreshStaleUrls);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
+  useExpiringAssetUrlRefresh({
+    getRefreshAt: () => nextAssetUrlRefreshAt,
+    hasStaleUrl: hasRefreshableStaleUrl,
+    refresh: refreshAndApplyUrls,
+    errorMessage: 'Failed to refresh attachment URLs'
   });
 
   async function refreshUrlsForMessage(): Promise<Map<string, RefreshedAttachmentUrls>> {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -238,6 +238,25 @@ describe('MessageAttachments', () => {
     expect(container.querySelector('img[alt="pending.jpg"]')).toBeNull();
   });
 
+  it('refreshes stale attachment URLs when mounted', async () => {
+    renderAttachment(
+      imageAttachment({
+        assetUrl: {
+          url: transparentGif,
+          expiresAt: '2026-01-01T00:00:00Z'
+        }
+      })
+    );
+
+    await vi.waitFor(() => {
+      expect(attachmentMocks.refreshAssetUrls).toHaveBeenCalledWith('room_1', ['att_1'], {
+        width: 960,
+        height: 400,
+        fit: ImageFitMode.CONTAIN
+      });
+    });
+  });
+
   it('retries HLS URL recovery after an earlier refresh request fails', async () => {
     attachmentMocks.refreshAssetUrls
       .mockRejectedValueOnce(new Error('network failed'))

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
@@ -4,9 +4,9 @@
 Room-scoped file list for the room sidebar.
 -->
 <script lang="ts">
-  import type { Attachment } from 'svelte/attachments';
   import type { RoomFileItem, RoomFilesStore } from '$lib/state/room';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
+  import { useExpiringAssetUrlRefresh } from '$lib/attachments/useExpiringAssetUrlRefresh.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { fileDateGroup, formatDateTime } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
@@ -110,43 +110,18 @@ Room-scoped file list for the room sidebar.
     return formatDateTime(value, userSettings, activeLocale);
   }
 
-  const refreshExpiringUrls: Attachment = () => {
-    const refreshAt = store.nextAssetUrlRefreshAt;
-    if (refreshAt === null) return;
-
-    if (refreshAt <= Date.now()) {
-      store.refreshStaleUrls().catch((error: unknown) => {
-        console.warn('Failed to refresh stale room file URLs', error);
-      });
-      return;
-    }
-
-    const timeout = window.setTimeout(
-      () => {
-        store.refreshStaleUrls().catch((error: unknown) => {
-          console.warn('Failed to refresh room file URLs before expiry', error);
-        });
-      },
-      Math.max(0, refreshAt - Date.now())
-    );
-
-    return () => window.clearTimeout(timeout);
-  };
-
-  function handleVisibilityChange(): void {
-    if (document.visibilityState !== 'visible') return;
-    store.refreshStaleUrls().catch((error: unknown) => {
-      console.warn('Failed to refresh stale room file URLs', error);
-    });
-  }
+  useExpiringAssetUrlRefresh({
+    getRefreshAt: () => store.nextAssetUrlRefreshAt,
+    hasStaleUrl: () => store.hasRefreshableStaleUrl(),
+    refresh: () => store.refreshStaleUrls(),
+    errorMessage: 'Failed to refresh room file URLs',
+    refreshOnFocus: false
+  });
 </script>
-
-<svelte:document onvisibilitychange={handleVisibilityChange} />
 
 <nav
   class="flex min-h-0 flex-1 flex-col overflow-y-auto p-2"
   aria-label={m['room.sidebar.files']()}
-  {@attach refreshExpiringUrls}
 >
   {#if loading}
     <ul role="list" class="space-y-1">


### PR DESCRIPTION
## Why

Message attachments, linked-message previews, and the room-files panel each
owned nearly identical expiry timers and tab-resume listeners for signed asset
URLs. Keeping that browser lifecycle in three places made the frontend larger
and allowed subtle behaviour differences to accumulate.

## What changed

- Added one shared Svelte lifecycle helper for expiry deadlines,
  visibility-resume refreshes, focus refreshes, cleanup, and error reporting.
- Kept each consumer's URL mapping, request coalescing, retry rules, and stale
  response fencing in its existing owner.
- Preserved the room-files panel's existing visibility-only resume behaviour.
- Added mounted-component coverage for refreshing an already-stale attachment.
- Reduced production code by 29 lines (85 insertions, 114 deletions); the full
  diff is 104 insertions and 114 deletions including the regression test.

This is a frontend-only, behaviour-preserving refactor. It does not change UI,
copy, APIs, persistence, permissions, compatibility, rollout, or migration
behaviour.

## Test plan

- `mise lint-frontend`
- `mise test-frontend` — 2,570 tests passed across 304 files
- Focused mounted component suites — 60 tests passed across 3 files
- Focused Playwright coverage for authorised asset URLs, message links, and
  room files — 8 tests passed
- Browser verification of message media, a linked-message preview, and the
  room-files panel; relevant requests returned 200 and the console remained
  clean
- `mise knip` — completed with pre-existing repository findings only
- `mise license-check`
