### PR TITLE
refactor(frontend): centralize search debounce lifecycle

### DIFF
--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -12,6 +12,7 @@
   import { getGradientForName } from '$lib/utils/gradients';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
 
   import { isNavigationVisibleRoom } from '$lib/state/server/rooms.svelte';
   import * as m from '$lib/i18n/messages';
@@ -48,7 +49,7 @@
   let userItems = $state.raw<ResultItem[]>([]);
   let dialogEl: HTMLDialogElement | undefined;
   let inputEl: HTMLInputElement | undefined;
-  let userSearchTimer: ReturnType<typeof setTimeout> | undefined;
+  const userSearchDebounce = useDebounce();
   let userSearchRequestId = 0;
 
   // --- Data loading ---
@@ -131,7 +132,7 @@
   }
 
   function scheduleUserSearch(raw: string) {
-    if (userSearchTimer) clearTimeout(userSearchTimer);
+    userSearchDebounce.cancel();
 
     const search = raw.trim();
     const requestId = ++userSearchRequestId;
@@ -143,7 +144,7 @@
     }
 
     userSearchLoading = true;
-    userSearchTimer = setTimeout(() => {
+    userSearchDebounce.run(() => {
       void loadUserResults(search, requestId);
     }, 200);
   }
@@ -302,7 +303,7 @@
         scheduleUserSearch('');
         if (!node.open) node.showModal();
       } else {
-        if (userSearchTimer) clearTimeout(userSearchTimer);
+        userSearchDebounce.cancel();
         userItems = [];
         userSearchLoading = false;
         userSearchRequestId++;

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, tick, untrack } from 'svelte';
+  import { tick, untrack } from 'svelte';
   import type { TimelineEventView } from '$lib/render/timelineEvents';
   import { createMessageAPI, type UpdateMessageInput } from '$lib/api-client/messages';
   import { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
@@ -17,6 +17,7 @@
   } from '$lib/state/room';
   import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
   import { prefersTouchActions } from '$lib/utils/inputCapabilities';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
   import { hasVisibleContent } from '$lib/validation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
@@ -98,15 +99,11 @@
   const members = $derived(getRoomMembers());
   const membersStore = getRoomMembersStore();
   let mentionSearchMembers = $state.raw<RoomMember[]>([]);
-  let mentionSearchTimer: ReturnType<typeof setTimeout> | null = null;
+  const mentionSearchDebounce = useDebounce();
   let mentionSearchRequestId = 0;
   const mentionCandidateMembers = $derived(
     mentionSearchMembers.length > 0 ? mentionSearchMembers : members
   );
-
-  onDestroy(() => {
-    if (mentionSearchTimer) clearTimeout(mentionSearchTimer);
-  });
 
   const composerContext = getComposerContext();
   const editState = composerContext.editState;
@@ -151,17 +148,14 @@
     const query = autocomplete.mention?.query ?? null;
     const requestId = ++mentionSearchRequestId;
 
-    if (mentionSearchTimer) {
-      clearTimeout(mentionSearchTimer);
-      mentionSearchTimer = null;
-    }
+    mentionSearchDebounce.cancel();
 
     if (!query) {
       mentionSearchMembers = [];
       return;
     }
 
-    mentionSearchTimer = setTimeout(() => {
+    mentionSearchDebounce.run(() => {
       void membersStore.searchMembers(query).then((results) => {
         if (requestId !== mentionSearchRequestId) return;
         mentionSearchMembers = results;

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import { createMemberDirectoryAPI, type DirectoryMember } from '$lib/api-client/memberDirectory';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { Combobox } from '$lib/ui/form';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
@@ -28,11 +28,7 @@
   let users = $state.raw<User[]>([]);
   let loading = $state(false);
   let requestId = 0;
-  let searchTimer: ReturnType<typeof setTimeout> | null = null;
-
-  onDestroy(() => {
-    if (searchTimer) clearTimeout(searchTimer);
-  });
+  const searchDebounce = useDebounce();
 
   function userLabel(user: User): string {
     const handle = user.login ? `@${user.login}` : user.id;
@@ -40,7 +36,7 @@
   }
 
   function scheduleSearch(query: string) {
-    if (searchTimer) clearTimeout(searchTimer);
+    searchDebounce.cancel();
     const search = query.trim();
     const currentRequest = ++requestId;
 
@@ -51,7 +47,7 @@
     }
 
     loading = true;
-    searchTimer = setTimeout(() => {
+    searchDebounce.run(() => {
       void searchUsers(search, currentRequest);
     }, 200);
   }

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
@@ -55,7 +55,7 @@ describe('UserCombobox', () => {
   });
 
   it('searches server members as the actor text changes', async () => {
-    const { container } = render(UserCombobox, {
+    const { container, unmount } = render(UserCombobox, {
       props: {
         id: 'actor',
         label: 'Actor'
@@ -69,5 +69,11 @@ describe('UserCombobox', () => {
     await settle();
 
     expect(mocks.listUsers).toHaveBeenCalledWith('alice', 10, 0);
+
+    input.value = 'bob';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    unmount();
+    await vi.advanceTimersByTimeAsync(220);
+    expect(mocks.listUsers).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/frontend/src/lib/hooks/useDebounce.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useDebounce.svelte.ts
@@ -1,0 +1,24 @@
+import { onDestroy } from 'svelte';
+
+/**
+ * Own a replaceable timeout for callbacks scheduled by a component.
+ */
+export function useDebounce() {
+	let timeout: ReturnType<typeof setTimeout> | undefined;
+
+	function cancel(): void {
+		clearTimeout(timeout);
+		timeout = undefined;
+	}
+
+	function run(callback: () => void, delay: number): void {
+		cancel();
+		timeout = setTimeout(() => {
+			timeout = undefined;
+			callback();
+		}, delay);
+	}
+
+	onDestroy(cancel);
+	return { cancel, run };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -12,7 +12,6 @@ calls, and similar room-specific panels can plug into the same shell. See the
 </script>
 
 <script lang="ts">
-  import { onDestroy } from 'svelte';
   import * as m from '$lib/i18n/messages';
   import { startDMWith } from '$lib/dm/startDM';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
@@ -41,6 +40,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
   import BanRoomMemberModal from '$lib/components/moderation/BanRoomMemberModal.svelte';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
   import VoiceCallPanel from '$lib/components/voice/VoiceCallPanel.svelte';
   import RoomFilesPanel from './RoomFilesPanel.svelte';
 
@@ -108,12 +108,8 @@ calls, and similar room-specific panels can plug into the same shell. See the
   let banningMemberId = $state<string | null>(null);
   let banDialogMember = $state<RoomMember | null>(null);
   let banError = $state<string | null>(null);
-  let memberSearchTimer: ReturnType<typeof setTimeout> | null = null;
+  const memberSearchDebounce = useDebounce();
   let memberSearchInput = $state<HTMLInputElement | null>(null);
-
-  onDestroy(() => {
-    if (memberSearchTimer) clearTimeout(memberSearchTimer);
-  });
 
   function togglePopover(memberId: string, e: MouseEvent) {
     if (popoverMemberId === memberId) {
@@ -213,18 +209,13 @@ calls, and similar room-specific panels can plug into the same shell. See the
   function scheduleMemberSearch(event: Event) {
     const value = event.currentTarget instanceof HTMLInputElement ? event.currentTarget.value : '';
     membersStore.searchInput = value;
-    if (memberSearchTimer) clearTimeout(memberSearchTimer);
-    memberSearchTimer = setTimeout(() => {
-      memberSearchTimer = null;
+    memberSearchDebounce.run(() => {
       void membersStore.setSearch(value);
     }, 250);
   }
 
   function clearMemberSearch() {
-    if (memberSearchTimer) {
-      clearTimeout(memberSearchTimer);
-      memberSearchTimer = null;
-    }
+    memberSearchDebounce.cancel();
     void membersStore.setSearch('');
     memberSearchInput?.focus();
   }

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { onDestroy, untrack } from 'svelte';
+  import { untrack } from 'svelte';
   import type { DirectoryMember } from '$lib/api-client/memberDirectory';
   import { DataTable, Panel } from '$lib/components/admin';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
@@ -9,6 +9,7 @@
   import { useProjectionEvent } from '$lib/hooks';
   import { toast } from '$lib/ui/toast';
   import { getAvatarInitials } from '$lib/utils/initials';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
   import * as m from '$lib/i18n/messages';
   import { RoomMemberManagementStore } from './RoomMemberManagementStore.svelte';
 
@@ -36,7 +37,7 @@
   let selectedUserId = $state('');
   let selectedUserText = $state('');
   let removeCandidate = $state<DirectoryMember | null>(null);
-  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  const searchDebounce = useDebounce();
 
   const canEditMembership = $derived(canManageMembers && !isUniversal && !archived);
   const columns = $derived(canEditMembership ? 3 : 2);
@@ -71,23 +72,17 @@
     }
   });
 
-  onDestroy(() => {
-    if (searchTimer) clearTimeout(searchTimer);
-  });
-
   function memberLabel(member: DirectoryMember): string {
     return `${member.displayName} @${member.login}`;
   }
 
   function scheduleDirectorySearch(text: string): void {
     selectedUser = null;
-    if (searchTimer) clearTimeout(searchTimer);
-    searchTimer = setTimeout(() => void store.searchDirectory(text), 200);
+    searchDebounce.run(() => void store.searchDirectory(text), 200);
   }
 
   function clearLocalState(): void {
-    if (searchTimer) clearTimeout(searchTimer);
-    searchTimer = null;
+    searchDebounce.cancel();
     selectedUser = null;
     selectedUserId = '';
     selectedUserText = '';

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/+page.svelte
@@ -18,6 +18,7 @@
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { formatDate as formatDateUtil } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
   import * as m from '$lib/i18n/messages';
 
   const userSettings = getUserSettings();
@@ -35,26 +36,17 @@
   let loadingMore = $state(false);
   let error = $state<string | null>(null);
   let requestId = 0;
-  let searchTimer: ReturnType<typeof setTimeout> | null = null;
+  const searchDebounce = useDebounce();
   let scrollContainer = $state<HTMLDivElement>();
 
   onMount(() => {
     void loadFirstPage('');
-    return () => clearSearchTimer();
   });
-
-  function clearSearchTimer() {
-    if (searchTimer) {
-      clearTimeout(searchTimer);
-      searchTimer = null;
-    }
-  }
 
   function scheduleSearch(event: Event) {
     const value = event.currentTarget instanceof HTMLInputElement ? event.currentTarget.value : '';
     searchInput = value;
-    clearSearchTimer();
-    searchTimer = setTimeout(() => {
+    searchDebounce.run(() => {
       const nextSearch = value.trim();
       if (nextSearch === activeSearch) return;
       void loadFirstPage(nextSearch);


### PR DESCRIPTION
## Why

Six frontend search surfaces independently owned the same replaceable timeout
and component teardown lifecycle. That repeated plumbing obscured the
consumer-specific query and request logic and made cancellation behaviour
easier to drift.

## What changed

- Added a small Svelte lifecycle helper that replaces pending callbacks,
  supports explicit cancellation, and cancels automatically on component
  teardown.
- Applied it to composer mention search, Quick Switcher member search,
  room-sidebar member filtering, the shared user combobox, room-member
  management, and server-member search.
- Kept every search delay, query rule, loading state, async request fence,
  result mapping, and error path in its existing owner.
- Extended mounted-component coverage to verify that unmounting cancels a
  pending search.
- Reduced production code by 7 lines (50 insertions, 57 deletions); the full
  diff is also net-negative at 57 insertions and 58 deletions.

This is a frontend-only, behaviour-preserving refactor. It changes no UI, copy,
API, persistence, permissions, compatibility, rollout, or migration behaviour.

## Test plan

- `mise lint-frontend`
- `mise test-frontend` — 2,570 tests passed across 304 files
- Focused mounted component suites — 181 tests passed across 6 files
- Focused Playwright coverage for Quick Switcher and mention autocomplete — 7
  tests passed
- Production frontend build — passed as part of Playwright setup
- Svelte autofixer — no issues in all changed Svelte files/modules
- `mise knip` — completed with pre-existing repository findings only
- `mise license-check`
