### PR TITLE
refactor(frontend): centralize link preview actions

### DIFF
--- a/apps/frontend/src/lib/components/LinkPreviewCard.svelte
+++ b/apps/frontend/src/lib/components/LinkPreviewCard.svelte
@@ -39,7 +39,7 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
     eventId?: string;
   } = $props();
 
-  // Context menu state
+  const isYouTube = $derived(preview.embedType === 'youtube' && Boolean(preview.embedId));
   let contextMenuPos = $state<{ x: number; y: number } | null>(null);
 
   function openDeleteConfirmation() {
@@ -85,12 +85,10 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
 {#if preview.embedType === 'youtube' && preview.embedId}
   <YouTubeEmbed
     videoId={preview.embedId}
-    url={preview.url}
     {onDismiss}
     {showDismiss}
-    {canDelete}
-    {roomId}
-    {eventId}
+    onContextMenu={handleContextMenu}
+    onDelete={canDelete ? openDeleteConfirmation : undefined}
   />
 {:else if preview.socialPost}
   <SocialPostEmbed
@@ -98,9 +96,8 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
     post={preview.socialPost}
     {onDismiss}
     {showDismiss}
-    {canDelete}
-    {roomId}
-    {eventId}
+    onContextMenu={handleContextMenu}
+    onDelete={canDelete ? openDeleteConfirmation : undefined}
   />
 {:else if preview.imageUrl || preview.title || preview.description || preview.siteName}
   <!-- eslint-disable svelte/no-navigation-without-resolve -- preview.url is a third-party URL, not an internal SvelteKit route -->
@@ -163,32 +160,32 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
     {/if}
   </a>
   <!-- eslint-enable svelte/no-navigation-without-resolve -->
+{/if}
 
-  <!-- Context menu (posted message mode only) -->
-  {#if contextMenuPos}
-    <ContextMenu position={contextMenuPos} onclose={() => (contextMenuPos = null)}>
-      <div class="menu-section">
-        <nav class="sidebar-nav">
-          <button class="sidebar-item" onclick={handleOpenLink} role="menuitem">
-            <span class="sidebar-icon iconify uil--external-link-alt"></span>
-            {m['preview.open_link']()}
+<!-- Context menu (posted message mode only) -->
+{#if contextMenuPos}
+  <ContextMenu position={contextMenuPos} onclose={() => (contextMenuPos = null)}>
+    <div class="menu-section">
+      <nav class="sidebar-nav">
+        <button class="sidebar-item" onclick={handleOpenLink} role="menuitem">
+          <span class="sidebar-icon iconify uil--external-link-alt"></span>
+          {isYouTube ? m['preview.youtube_open']() : m['preview.open_link']()}
+        </button>
+        <button class="sidebar-item" onclick={handleCopyUrl} role="menuitem">
+          <span class="sidebar-icon iconify uil--copy"></span>
+          {m['preview.copy_url']()}
+        </button>
+        {#if canDelete}
+          <button
+            class="sidebar-item text-danger hover:text-danger"
+            onclick={handleDeleteFromMenu}
+            role="menuitem"
+          >
+            <span class="sidebar-icon iconify uil--trash-alt"></span>
+            {isYouTube ? m['preview.youtube_delete_embed']() : m['preview.delete']()}
           </button>
-          <button class="sidebar-item" onclick={handleCopyUrl} role="menuitem">
-            <span class="sidebar-icon iconify uil--copy"></span>
-            {m['preview.copy_url']()}
-          </button>
-          {#if canDelete}
-            <button
-              class="sidebar-item text-danger hover:text-danger"
-              onclick={handleDeleteFromMenu}
-              role="menuitem"
-            >
-              <span class="sidebar-icon iconify uil--trash-alt"></span>
-              {m['preview.delete']()}
-            </button>
-          {/if}
-        </nav>
-      </div>
-    </ContextMenu>
-  {/if}
+        {/if}
+      </nav>
+    </div>
+  </ContextMenu>
 {/if}

--- a/apps/frontend/src/lib/components/LinkPreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/LinkPreviewCard.svelte.spec.ts
@@ -1,7 +1,21 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import type { LinkPreviewView } from '$lib/render/linkPreviews';
 import LinkPreviewCard from './LinkPreviewCard.svelte';
+
+const navigation = vi.hoisted(() => ({
+  pushState: vi.fn()
+}));
+
+vi.mock('$app/navigation', () => navigation);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 function preview(o: Partial<LinkPreviewView> = {}): LinkPreviewView {
   return {
@@ -14,6 +28,23 @@ function preview(o: Partial<LinkPreviewView> = {}): LinkPreviewView {
     embedId: null,
     ...o
   };
+}
+
+function openContextMenu(container: HTMLElement, selector: string) {
+  const surface = container.querySelector(selector);
+  if (!surface) throw new Error(`Missing preview surface: ${selector}`);
+  surface.dispatchEvent(
+    new MouseEvent('contextmenu', { bubbles: true, cancelable: true, clientX: 20, clientY: 30 })
+  );
+}
+
+async function menuButton(label: string): Promise<HTMLButtonElement> {
+  await vi.waitFor(() => expect(document.body.textContent).toContain(label));
+  const button = Array.from(document.querySelectorAll('button')).find(
+    (candidate) => candidate.textContent?.trim() === label
+  );
+  if (!button) throw new Error(`Missing menu button: ${label}`);
+  return button;
 }
 
 describe('LinkPreviewCard', () => {
@@ -66,6 +97,115 @@ describe('LinkPreviewCard', () => {
     });
     expect(container.querySelector('[data-testid="link-preview-card"]')).toBeNull();
     expect(container.querySelector('iframe')).not.toBeNull();
+  });
+
+  it('owns context-menu actions for every preview renderer', async () => {
+    const open = vi.spyOn(window, 'open').mockImplementation(() => null);
+    const sharedProps = {
+      canDelete: true,
+      roomId: 'room-1',
+      eventId: 'event-1',
+      showDismiss: false
+    };
+    const { container, rerender } = render(LinkPreviewCard, {
+      props: {
+        preview: preview({ url: 'https://generic.example', title: 'Generic' }),
+        ...sharedProps
+      }
+    });
+
+    openContextMenu(container, '[data-testid="link-preview-card"]');
+    (await menuButton('Open link')).click();
+    expect(open).toHaveBeenCalledWith(
+      'https://generic.example',
+      '_blank',
+      'noopener,noreferrer'
+    );
+
+    await rerender({
+      preview: preview({
+        url: 'https://youtube.example/watch?v=abc123',
+        embedType: 'youtube',
+        embedId: 'abc123'
+      }),
+      ...sharedProps
+    });
+    openContextMenu(container, '[data-testid="youtube-embed"]');
+    expect((await menuButton('Open on YouTube')).textContent).toContain('Open on YouTube');
+    (await menuButton('Delete embed')).click();
+    expect(navigation.pushState).toHaveBeenLastCalledWith('', {
+      modal: {
+        type: 'deleteLinkPreview',
+        roomId: 'room-1',
+        eventId: 'event-1',
+        previewUrl: 'https://youtube.example/watch?v=abc123'
+      }
+    });
+
+    await rerender({
+      preview: preview({
+        url: 'https://social.example/@alice/post',
+        socialPost: { provider: 'mastodon', text: 'Hello', images: [] }
+      }),
+      ...sharedProps
+    });
+    openContextMenu(container, '[data-testid="social-post-embed"]');
+    expect((await menuButton('Open link')).textContent).toContain('Open link');
+    (await menuButton('Delete preview')).click();
+    expect(navigation.pushState).toHaveBeenLastCalledWith('', {
+      modal: {
+        type: 'deleteLinkPreview',
+        roomId: 'room-1',
+        eventId: 'event-1',
+        previewUrl: 'https://social.example/@alice/post'
+      }
+    });
+  });
+
+  it('routes rich-preview delete controls through the shared owner', async () => {
+    const sharedProps = {
+      canDelete: true,
+      roomId: 'room-1',
+      eventId: 'event-1',
+      showDismiss: false
+    };
+    const { container, rerender } = render(LinkPreviewCard, {
+      props: {
+        preview: preview({
+          url: 'https://youtube.example/watch?v=abc123',
+          embedType: 'youtube',
+          embedId: 'abc123'
+        }),
+        ...sharedProps
+      }
+    });
+
+    container.querySelector<HTMLButtonElement>('button[aria-label="Delete video"]')?.click();
+    expect(navigation.pushState).toHaveBeenLastCalledWith('', {
+      modal: {
+        type: 'deleteLinkPreview',
+        roomId: 'room-1',
+        eventId: 'event-1',
+        previewUrl: 'https://youtube.example/watch?v=abc123'
+      }
+    });
+
+    await rerender({
+      preview: preview({
+        url: 'https://social.example/@alice/post',
+        socialPost: { provider: 'mastodon', text: 'Hello', images: [] }
+      }),
+      ...sharedProps
+    });
+    container.querySelector<HTMLButtonElement>('button[aria-label="Delete preview"]')?.click();
+    expect(navigation.pushState).toHaveBeenLastCalledWith('', {
+      modal: {
+        type: 'deleteLinkPreview',
+        roomId: 'room-1',
+        eventId: 'event-1',
+        previewUrl: 'https://social.example/@alice/post'
+      }
+    });
   });
 
   it('renders a native social-post snapshot and conceals a warned quote', async () => {

--- a/apps/frontend/src/lib/components/SocialPostEmbed.svelte
+++ b/apps/frontend/src/lib/components/SocialPostEmbed.svelte
@@ -2,32 +2,27 @@
 @component
 
 Renders a compact, provider-neutral social-post snapshot with Chatto's native
-preview-card styling and the same actions as other link previews.
+preview-card styling. Its parent owns shared link-preview actions.
 -->
 <script lang="ts">
-  import { pushState } from '$app/navigation';
   import * as m from '$lib/i18n/messages';
   import type { SocialPostPreviewView } from '$lib/render/linkPreviews';
-  import ContextMenu from '$lib/ui/ContextMenu.svelte';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
-  import { toast } from '$lib/ui/toast';
 
   let {
     url,
     post,
     onDismiss,
     showDismiss = true,
-    canDelete = false,
-    roomId,
-    eventId
+    onContextMenu,
+    onDelete
   }: {
     url: string;
     post: SocialPostPreviewView;
     onDismiss?: () => void;
     showDismiss?: boolean;
-    canDelete?: boolean;
-    roomId?: string;
-    eventId?: string;
+    onContextMenu?: (event: MouseEvent) => void;
+    onDelete?: () => void;
   } = $props();
 
   const providerName = $derived(post.provider === 'bluesky' ? 'Bluesky' : post.provider);
@@ -56,47 +51,6 @@ preview-card styling and the same actions as other link previews.
   function displayHandle(post: SocialPostPreviewView) {
     return post.author?.handle ? `@${post.author.handle.replace(/^@/, '')}` : '';
   }
-
-  let contextMenuPos = $state<{ x: number; y: number } | null>(null);
-
-  function openDeleteConfirmation() {
-    if (!roomId || !eventId) return;
-    pushState('', {
-      modal: {
-        type: 'deleteLinkPreview',
-        roomId,
-        eventId,
-        previewUrl: url
-      }
-    });
-  }
-
-  function handleContextMenu(e: MouseEvent) {
-    if (!canDelete) return;
-    e.preventDefault();
-    e.stopPropagation();
-    contextMenuPos = { x: e.clientX, y: e.clientY };
-  }
-
-  async function handleCopyUrl() {
-    try {
-      await navigator.clipboard.writeText(url);
-      toast.success('URL copied to clipboard');
-    } catch {
-      toast.error('Failed to copy URL');
-    }
-    contextMenuPos = null;
-  }
-
-  function handleOpenLink() {
-    window.open(url, '_blank', 'noopener,noreferrer');
-    contextMenuPos = null;
-  }
-
-  function handleDeleteFromMenu() {
-    openDeleteConfirmation();
-    contextMenuPos = null;
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
@@ -104,7 +58,7 @@ preview-card styling and the same actions as other link previews.
   class="group/preview relative embed-frame flex w-full max-w-md flex-col gap-3 p-3"
   data-testid="social-post-embed"
   data-provider={post.provider}
-  oncontextmenu={handleContextMenu}
+  oncontextmenu={onContextMenu}
 >
   <!-- eslint-disable svelte/no-navigation-without-resolve -- url is a third-party social-post URL -->
   <a href={url} target="_blank" rel="noopener noreferrer" class="flex min-w-0 items-center gap-2.5">
@@ -321,13 +275,13 @@ preview-card styling and the same actions as other link previews.
     >
       <span class="iconify text-sm uil--times"></span>
     </button>
-  {:else if canDelete}
+  {:else if onDelete}
     <button
       type="button"
       onclick={(event) => {
         event.preventDefault();
         event.stopPropagation();
-        openDeleteConfirmation();
+        onDelete();
       }}
       class="embed-control-button md:group-hover/preview:opacity-100"
       aria-label={m['preview.delete']()}
@@ -336,30 +290,3 @@ preview-card styling and the same actions as other link previews.
     </button>
   {/if}
 </div>
-
-{#if contextMenuPos}
-  <ContextMenu position={contextMenuPos} onclose={() => (contextMenuPos = null)}>
-    <div class="menu-section">
-      <nav class="sidebar-nav">
-        <button class="sidebar-item" onclick={handleOpenLink} role="menuitem">
-          <span class="sidebar-icon iconify uil--external-link-alt"></span>
-          {m['preview.open_link']()}
-        </button>
-        <button class="sidebar-item" onclick={handleCopyUrl} role="menuitem">
-          <span class="sidebar-icon iconify uil--copy"></span>
-          {m['preview.copy_url']()}
-        </button>
-        {#if canDelete}
-          <button
-            class="sidebar-item text-danger hover:text-danger"
-            onclick={handleDeleteFromMenu}
-            role="menuitem"
-          >
-            <span class="sidebar-icon iconify uil--trash-alt"></span>
-            {m['preview.delete']()}
-          </button>
-        {/if}
-      </nav>
-    </div>
-  </ContextMenu>
-{/if}

--- a/apps/frontend/src/lib/components/YouTubeEmbed.svelte
+++ b/apps/frontend/src/lib/components/YouTubeEmbed.svelte
@@ -2,92 +2,38 @@
 @component
 
 Renders an embedded YouTube video player using youtube-nocookie.com for privacy.
-Supports dismiss (composer) and delete (posted message) actions.
-When `canDelete` is true, right-click / long-press opens a context menu with Open on YouTube, Copy URL, and Delete.
+Its parent owns shared link-preview actions and passes the relevant callbacks.
 
 **Props:**
 - `videoId` - The YouTube video ID to embed
-- `url` - The original YouTube URL (for context menu actions)
 - `onDismiss` - Callback when user dismisses the embed (composer mode)
 - `showDismiss` - Whether to show the dismiss button (default: true)
-- `canDelete` - Whether the user can delete this embed (default: false)
-- `roomId` - Room ID (required when canDelete is true, for confirmation dialog)
-- `eventId` - Message body ID (required when canDelete is true, for confirmation dialog)
+- `onContextMenu` - Callback for a permitted posted-message context menu
+- `onDelete` - Callback for deleting the posted embed
 -->
 <script lang="ts">
-  import { pushState } from '$app/navigation';
   import * as m from '$lib/i18n/messages';
-  import ContextMenu from '$lib/ui/ContextMenu.svelte';
-  import { toast } from '$lib/ui/toast';
 
   let {
     videoId,
-    url,
     onDismiss,
     showDismiss = true,
-    canDelete = false,
-    roomId,
-    eventId
+    onContextMenu,
+    onDelete
   }: {
     videoId: string;
-    url?: string;
     onDismiss?: () => void;
     showDismiss?: boolean;
-    canDelete?: boolean;
-    roomId?: string;
-    eventId?: string;
+    onContextMenu?: (event: MouseEvent) => void;
+    onDelete?: () => void;
   } = $props();
-
-  const youtubeUrl = $derived(url ?? `https://www.youtube.com/watch?v=${videoId}`);
-
-  // Context menu state
-  let contextMenuPos = $state<{ x: number; y: number } | null>(null);
-
-  function openDeleteConfirmation() {
-    if (!roomId || !eventId) return;
-    pushState('', {
-      modal: {
-        type: 'deleteLinkPreview',
-        roomId,
-        eventId,
-        previewUrl: youtubeUrl
-      }
-    });
-  }
-
-  function handleContextMenu(e: MouseEvent) {
-    if (!canDelete) return;
-    e.preventDefault();
-    e.stopPropagation();
-    contextMenuPos = { x: e.clientX, y: e.clientY };
-  }
-
-  async function handleCopyUrl() {
-    try {
-      await navigator.clipboard.writeText(youtubeUrl);
-      toast.success('URL copied to clipboard');
-    } catch {
-      toast.error('Failed to copy URL');
-    }
-    contextMenuPos = null;
-  }
-
-  function handleOpenLink() {
-    window.open(youtubeUrl, '_blank', 'noopener,noreferrer');
-    contextMenuPos = null;
-  }
-
-  function handleDeleteFromMenu() {
-    openDeleteConfirmation();
-    contextMenuPos = null;
-  }
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   class="group/preview relative embed-frame w-full max-w-md"
   data-testid="youtube-embed"
-  oncontextmenu={handleContextMenu}
+  oncontextmenu={onContextMenu}
 >
   <iframe
     src="https://www.youtube-nocookie.com/embed/{videoId}"
@@ -105,10 +51,10 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
     >
       <span class="iconify text-sm uil--times"></span>
     </button>
-  {:else if canDelete}
+  {:else if onDelete}
     <button
       type="button"
-      onclick={openDeleteConfirmation}
+      onclick={onDelete}
       class="embed-control-button md:group-hover/preview:opacity-100"
       aria-label={m['preview.youtube_delete']()}
     >
@@ -116,31 +62,3 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
     </button>
   {/if}
 </div>
-
-<!-- Context menu (posted message mode only) -->
-{#if contextMenuPos}
-  <ContextMenu position={contextMenuPos} onclose={() => (contextMenuPos = null)}>
-    <div class="menu-section">
-      <nav class="sidebar-nav">
-        <button class="sidebar-item" onclick={handleOpenLink} role="menuitem">
-          <span class="sidebar-icon iconify uil--external-link-alt"></span>
-          {m['preview.youtube_open']()}
-        </button>
-        <button class="sidebar-item" onclick={handleCopyUrl} role="menuitem">
-          <span class="sidebar-icon iconify uil--copy"></span>
-          {m['preview.copy_url']()}
-        </button>
-        {#if canDelete}
-          <button
-            class="sidebar-item text-danger hover:text-danger"
-            onclick={handleDeleteFromMenu}
-            role="menuitem"
-          >
-            <span class="sidebar-icon iconify uil--trash-alt"></span>
-            {m['preview.youtube_delete_embed']()}
-          </button>
-        {/if}
-      </nav>
-    </div>
-  </ContextMenu>
-{/if}


### PR DESCRIPTION
## Why

Generic link cards, YouTube embeds, and social-post embeds each owned identical
context-menu state, clipboard and external-link actions, and delete-modal
routing. Keeping that lifecycle in three renderers made an everyday message
surface harder to maintain and allowed the variants to drift.

## What changed

- Made `LinkPreviewCard` the single owner of open, copy, delete, menu-position,
  and delete-modal behavior across all link-preview variants.
- Reduced the YouTube and social-post components to presentation plus explicit
  context-menu and delete callbacks.
- Preserved composer dismissal, posted-message deletion, provider-specific
  YouTube labels, generic/social labels, preview URLs, and visible rendering.
- Added mounted coverage for the shared context menu and rich-preview delete
  controls.
- Removed 158 production lines and 18 lines overall.

This is a frontend-only internal refactor. It does not change public APIs,
persisted data, permissions, compatibility, user-facing copy, visual design,
migrations, rollout, security boundaries, or operational behavior.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/components/LinkPreviewCard.svelte.spec.ts` — passed; 10 tests.
- `mise lint-frontend` — passed; zero Svelte errors or warnings, and ESLint passed.
- `mise test-frontend` — passed; 304 files and 2,572 tests.
- `mise x -- pnpm exec playwright test e2e/link-previews.test.ts --retries=0` — passed; production build and all 7 tests.
- Svelte autofixer — no issues or suggestions in the three changed components.
- `mise knip` — exited successfully with only the repository's existing unrelated inventory.
- `mise license-check` — passed with full REUSE compliance.
- `git diff --check` — passed.
