### PR TITLE
refactor(frontend): simplify attachment rendering

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -438,6 +438,23 @@
 </script>
 
 {#if attachments.length > 0}
+  {#snippet deleteAttachmentButton(attachment: Attachment, className = '')}
+    {#if canDeleteAttachment}
+      <button
+        type="button"
+        onclick={(event) => openDeleteConfirmation(attachment, event)}
+        class={[
+          'attachment-remove-button md:group-hover/attachment:opacity-100',
+          className
+        ]}
+        aria-label={m['room.attachment.delete_label']()}
+        title={m['room.attachment.delete_label']()}
+      >
+        <span class="iconify text-sm uil--times"></span>
+      </button>
+    {/if}
+  {/snippet}
+
   {#snippet imageAttachmentButton(attachment: Attachment, variant: 'single' | 'gallery')}
     {@const display =
       attachment.width && attachment.height
@@ -495,7 +512,8 @@
   {/snippet}
 
   {#snippet attachmentItem(attachment: Attachment)}
-    {#if attachment.contentType === 'image/gif' && attachment.videoProcessing}
+    {#if attachment.videoProcessing && (attachment.contentType === 'image/gif' || attachment.contentType.startsWith('video/'))}
+      {@const autoLoop = attachment.contentType === 'image/gif'}
       <div class="group/attachment relative min-w-0">
         <VideoPlayer
           status={attachment.videoProcessing.status}
@@ -508,55 +526,18 @@
           height={attachment.videoProcessing.height}
           reasonCode={attachment.videoProcessing.reasonCode}
           filename={attachment.filename}
-          autoLoop
-          onMediaError={() => refreshAfterAssetError(attachment, 'video')}
-        />
-        {#if canDeleteAttachment}
-          <button
-            type="button"
-            onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="attachment-remove-button md:group-hover/attachment:opacity-100"
-            aria-label={m['room.attachment.delete_label']()}
-            title={m['room.attachment.delete_label']()}
-          >
-            <span class="iconify text-sm uil--times"></span>
-          </button>
-        {/if}
-      </div>
-    {:else if attachment.contentType.startsWith('image/')}
-      {@render imageAttachmentButton(attachment, 'single')}
-    {:else if attachment.contentType.startsWith('video/') && attachment.videoProcessing}
-      <div class="group/attachment relative min-w-0">
-        <VideoPlayer
-          status={attachment.videoProcessing.status}
-          variants={attachment.videoProcessing.variants}
-          thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
-          hlsUrl={attachment.videoProcessing.hlsUrl}
-          fallbackUrl={attachment.url}
-          fallbackContentType={attachment.contentType}
-          width={attachment.videoProcessing.width}
-          height={attachment.videoProcessing.height}
-          reasonCode={attachment.videoProcessing.reasonCode}
-          filename={attachment.filename}
-          onPosterError={() => refreshAfterAssetError(attachment, 'video')}
+          {autoLoop}
+          onPosterError={autoLoop ? undefined : () => refreshAfterAssetError(attachment, 'video')}
           onMediaError={() =>
             refreshAfterAssetError(
               attachment,
-              attachment.videoProcessing?.hlsUrl ? 'hls' : 'video'
+              !autoLoop && attachment.videoProcessing?.hlsUrl ? 'hls' : 'video'
             )}
         />
-        {#if canDeleteAttachment}
-          <button
-            type="button"
-            onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="attachment-remove-button z-10 md:group-hover/attachment:opacity-100"
-            aria-label={m['room.attachment.delete_label']()}
-            title={m['room.attachment.delete_label']()}
-          >
-            <span class="iconify text-sm uil--times"></span>
-          </button>
-        {/if}
+        {@render deleteAttachmentButton(attachment, autoLoop ? '' : 'z-10')}
       </div>
+    {:else if attachment.contentType.startsWith('image/')}
+      {@render imageAttachmentButton(attachment, 'single')}
     {:else if attachment.contentType.startsWith('video/') && attachment.url}
       <!--
           A video attachment that hasn't been projected as a processing manifest
@@ -590,17 +571,7 @@
           </audio>
           <span class="text-sm text-muted">{attachment.filename}</span>
         </div>
-        {#if canDeleteAttachment}
-          <button
-            type="button"
-            onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="attachment-remove-button md:group-hover/attachment:opacity-100"
-            aria-label={m['room.attachment.delete_label']()}
-            title={m['room.attachment.delete_label']()}
-          >
-            <span class="iconify text-sm uil--times"></span>
-          </button>
-        {/if}
+        {@render deleteAttachmentButton(attachment)}
       </div>
     {:else}
       <div class="group/attachment relative embed-frame block">
@@ -628,17 +599,7 @@
             <span class="text-sm">{attachment.filename}</span>
           </div>
         </button>
-        {#if canDeleteAttachment}
-          <button
-            type="button"
-            onclick={(e) => openDeleteConfirmation(attachment, e)}
-            class="attachment-remove-button md:group-hover/attachment:opacity-100"
-            aria-label={m['room.attachment.delete_label']()}
-            title={m['room.attachment.delete_label']()}
-          >
-            <span class="iconify text-sm uil--times"></span>
-          </button>
-        {/if}
+        {@render deleteAttachmentButton(attachment)}
       </div>
     {/if}
   {/snippet}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -208,19 +208,41 @@ describe('MessageAttachments', () => {
   });
 
   it('uses a subtle attachment remove control when deletion is allowed', () => {
-    const { container } = renderAttachment(
+    const { container } = renderAttachments([
       imageAttachment({
         filename: 'delete-me.jpg'
       }),
-      { canDeleteAttachment: true }
+      fileAttachment({ filename: 'delete-me.pdf' })
+    ], { canDeleteAttachment: true });
+
+    const deleteControls = container.querySelectorAll<HTMLElement>(
+      '[aria-label="Delete attachment"]'
     );
 
-    const deleteControl = container.querySelector<HTMLElement>('[aria-label="Delete attachment"]');
+    expect(deleteControls).toHaveLength(2);
+    expect(deleteControls[0].tagName).toBe('SPAN');
+    expect(deleteControls[1].tagName).toBe('BUTTON');
+    expect(deleteControls[1].getAttribute('title')).toBe('Delete attachment');
+    expect(deleteControls[1].className).toContain('attachment-remove-button');
+    expect(deleteControls[1].className).not.toContain('embed-control-button');
+  });
 
-    expect(deleteControl).not.toBeNull();
-    expect(deleteControl!.getAttribute('title')).toBe('Delete attachment');
-    expect(deleteControl!.className).toContain('attachment-remove-button');
-    expect(deleteControl!.className).not.toContain('embed-control-button');
+  it('keeps processed GIFs autolooping and processed videos using standard playback', () => {
+    const gif = hlsVideoAttachment({
+      id: 'gif_1',
+      filename: 'animated.gif',
+      contentType: 'image/gif',
+      videoProcessing: {
+        ...hlsVideoAttachment().videoProcessing!,
+        hlsMasterPlaylistUrl: null
+      }
+    });
+    const { container } = renderAttachments([gif, hlsVideoAttachment()]);
+
+    const players = container.querySelectorAll<HTMLElement>(
+      '[data-testid="message-attachments-video-player"]'
+    );
+    expect(Array.from(players, (player) => player.dataset.autoLoop)).toEqual(['true', 'false']);
   });
 
   it('does not render empty media URLs for attachments that are missing asset URLs', () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachmentsVideoPlayerStub.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachmentsVideoPlayerStub.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
   let {
     hlsUrl = null,
+    autoLoop = false,
     onMediaError
   }: {
     hlsUrl?: string | null;
+    autoLoop?: boolean;
     onMediaError?: () => void | Promise<string | null>;
   } = $props();
 </script>
@@ -12,6 +14,7 @@
   type="button"
   data-testid="message-attachments-video-player"
   data-hls-url={hlsUrl ?? ''}
+  data-auto-loop={autoLoop}
   onclick={() => onMediaError?.()}
 >
   Test video player


### PR DESCRIPTION
## Why

`MessageAttachments.svelte` rendered processed GIFs and processed videos through
two nearly identical `VideoPlayer` branches, while standalone attachment delete
buttons were repeated across several media types. This made a central room and
thread renderer longer and easier to change inconsistently.

## What changed

- render processed GIFs and videos through one shared media branch
- preserve GIF auto-looping and the existing video poster/HLS recovery paths
- reuse a local snippet for standalone attachment delete buttons while keeping
  the nested image control separate for valid button markup
- add mounted coverage for GIF/video playback mode and shared delete-control
  semantics

This is a frontend-only, behavior-preserving refactor. It changes no public API,
copy, permissions, persistence, rollout behavior, or documentation. The
production component is 39 lines smaller and the branch is net 14 lines smaller
overall.

## Test plan

- Svelte autofixer: no issues or suggestions
- focused `MessageAttachments.svelte.spec.ts`: 17 tests passed
- `mise lint-frontend`: passed; 0 Svelte errors and 0 warnings
- `mise test-frontend`: 303 files and 2,555 tests passed
- focused Playwright media coverage: static GIF, animated GIF
  conversion/looping, and failed video processing passed
- uploaded-video Playwright coverage: fails waiting for Vidstack
  `media-controls`; the same test fails at the same assertion on an isolated
  `origin/main` worktree, so this is not introduced by this branch
- `mise knip`: completed successfully with existing repository findings
- `mise license-check`: passed
- `git diff --check`: passed
- independent adversarial review: no actionable findings

All required CI checks passed.
