### PR TITLE
refactor(events): introduce typed projection handles

### DIFF
--- a/cli/internal/core/asset_cleanup_test.go
+++ b/cli/internal/core/asset_cleanup_test.go
@@ -16,8 +16,9 @@ import (
 	"hmans.de/chatto/internal/testutil"
 )
 
-func restartAssetModel(core *ChattoCore) *AssetModel {
-	return NewAssetModel(core, core.assetModel.projection, core.assetModel.projector)
+func restartAssetModel(t *testing.T, core *ChattoCore) *AssetModel {
+	t.Helper()
+	return NewAssetModel(core, core.assetModel.assets)
 }
 
 func TestAssetCleanupReplaysDeletionAndIsIdempotent(t *testing.T) {
@@ -39,7 +40,7 @@ func TestAssetCleanupReplaysDeletionAndIsIdempotent(t *testing.T) {
 		t.Fatalf("RecordAssetDeleted: %v", err)
 	}
 
-	restarted := restartAssetModel(core)
+	restarted := restartAssetModel(t, core)
 	if err := restarted.consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("consumeAssetCleanup after restart: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestAssetCleanupReplaysDeletionAndIsIdempotent(t *testing.T) {
 		t.Fatalf("cached resize after replayed cleanup = %q, %v; want nil, nil", got, err)
 	}
 
-	secondRestart := restartAssetModel(core)
+	secondRestart := restartAssetModel(t, core)
 	if err := secondRestart.consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("idempotent cleanup after second restart: %v", err)
 	}
@@ -118,10 +119,10 @@ func TestAssetCleanupReconcilesHLSChildrenMissedByOlderReplica(t *testing.T) {
 
 	// A new-version durable cleanup consumer replays the source tombstone,
 	// recovers HLS child IDs from the source aggregate, and deletes the children.
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err != nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("consumeAssetCleanup reconciliation: %v", err)
 	}
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err != nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("consumeAssetCleanup child deletion: %v", err)
 	}
 	for _, derivative := range []*corev1.Attachment{segment} {
@@ -139,7 +140,7 @@ func TestAssetCleanupSkipsDeletionWithoutCanonicalCreationFact(t *testing.T) {
 	ctx := testContext(t)
 	appendAssetDeletionTestEvent(t, ctx, core, &corev1.AssetDeletedEvent{AssetId: "A-historical"})
 
-	restarted := restartAssetModel(core)
+	restarted := restartAssetModel(t, core)
 	if err := restarted.consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("consume historical deletion: %v", err)
 	}
@@ -167,7 +168,7 @@ func TestAssetCleanupFailureDoesNotBlockLaterDeletion(t *testing.T) {
 		t.Fatalf("RecordAssetDeleted: %v", err)
 	}
 
-	restarted := restartAssetModel(core)
+	restarted := restartAssetModel(t, core)
 	if err := restarted.consumeAssetCleanup(ctx); err == nil {
 		t.Fatal("consumeAssetCleanup returned nil despite unavailable S3 deletion")
 	}
@@ -203,7 +204,7 @@ func TestAssetCleanupDoesNotDeleteUnrelatedAssetOrCache(t *testing.T) {
 		t.Fatalf("RecordAssetDeleted: %v", err)
 	}
 
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err != nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("consumeAssetCleanup: %v", err)
 	}
 	if _, _, err := core.mediaModel.GetAttachmentReader(ctx, deletedAsset); err == nil {
@@ -236,7 +237,7 @@ func TestAssetCleanupRejectsMismatchedCreationPayload(t *testing.T) {
 	})
 	appendAssetDeletionTestEvent(t, ctx, core, &corev1.AssetDeletedEvent{AssetId: "A-deleted"})
 
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err == nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err == nil {
 		t.Fatal("consumeAssetCleanup returned nil for mismatched creation payload")
 	}
 	if got, err := store.GetBytes(ctx, "A-victim"); err != nil || string(got) != "victim" {
@@ -260,7 +261,7 @@ func TestAssetCleanupRejectsMismatchedDeletionSubject(t *testing.T) {
 	})
 	appendAssetDeletionTestEventOnAggregate(t, ctx, core, "A-other", &corev1.AssetDeletedEvent{AssetId: "A-victim"})
 
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err == nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err == nil {
 		t.Fatal("consumeAssetCleanup returned nil for mismatched deletion subject")
 	}
 	if got, err := store.GetBytes(ctx, "A-victim"); err != nil || string(got) != "victim" {
@@ -288,7 +289,7 @@ func TestAssetCleanupRejectsNATSPointerToAnotherAsset(t *testing.T) {
 	})
 	appendAssetDeletionTestEvent(t, ctx, core, &corev1.AssetDeletedEvent{AssetId: "A-attacker"})
 
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err == nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err == nil {
 		t.Fatal("consumeAssetCleanup returned nil for cross-asset NATS pointer")
 	}
 	if got, err := store.GetBytes(ctx, "A-victim"); err != nil || string(got) != "victim" {
@@ -315,7 +316,7 @@ func TestAssetCleanupRejectsS3PointerToAnotherAsset(t *testing.T) {
 	})
 	appendAssetDeletionTestEvent(t, ctx, core, &corev1.AssetDeletedEvent{AssetId: "A-attacker"})
 
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err == nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err == nil {
 		t.Fatal("consumeAssetCleanup returned nil for cross-asset S3 pointer")
 	}
 	if _, err := s3Client.StatObject(ctx, victimKey); err != nil {
@@ -342,7 +343,7 @@ func TestAssetCleanupDeletesS3ObjectFromDurableFacts(t *testing.T) {
 		t.Fatalf("RecordAssetDeleted: %v", err)
 	}
 
-	if err := restartAssetModel(core).consumeAssetCleanup(ctx); err != nil {
+	if err := restartAssetModel(t, core).consumeAssetCleanup(ctx); err != nil {
 		t.Fatalf("consumeAssetCleanup: %v", err)
 	}
 	if _, err := s3Client.StatObject(ctx, s3Key); !IsNoSuchKeyError(err) {

--- a/cli/internal/core/asset_model.go
+++ b/cli/internal/core/asset_model.go
@@ -42,8 +42,7 @@ type derivativeContext struct {
 // tombstones, derivative cleanup ordering, and projection read-your-writes.
 type AssetModel struct {
 	*ChattoCore
-	projection            *AssetProjection
-	projector             *events.Projector
+	assets                events.ProjectionHandle[*AssetProjection]
 	cleanupLease          *lease.Lease
 	cleanupConsumer       *events.IncrementalEffectConsumer
 	cleanupPollEvery      time.Duration
@@ -52,11 +51,10 @@ type AssetModel struct {
 	cleanupPass           assetCleanupPassStatus
 }
 
-func NewAssetModel(core *ChattoCore, projection *AssetProjection, projector *events.Projector) *AssetModel {
+func NewAssetModel(core *ChattoCore, assets events.ProjectionHandle[*AssetProjection]) *AssetModel {
 	model := &AssetModel{
 		ChattoCore:       core,
-		projection:       projection,
-		projector:        projector,
+		assets:           assets,
 		cleanupPollEvery: assetCleanupPollEvery,
 	}
 	if core != nil && core.EventPublisher != nil {
@@ -622,88 +620,88 @@ func (s *AssetModel) waitForAssets(ctx context.Context, pos events.StreamPositio
 	if s.waitForAssetsOverride != nil {
 		return s.waitForAssetsOverride(ctx, pos)
 	}
-	if s.projector == nil {
+	if s.assets.Projector() == nil {
 		return fmt.Errorf("asset projector is not initialized")
 	}
-	return waitForPositionAll(ctx, pos, waitForProjection("assets", s.projector))
+	return waitForPositionAll(ctx, pos, waitForProjection("assets", s.assets.Projector()))
 }
 
 func (s *AssetModel) waitForAssetsCurrent(ctx context.Context) error {
-	if s == nil || s.projector == nil {
+	if s == nil || s.assets.Projector() == nil {
 		return fmt.Errorf("asset projector is not initialized")
 	}
-	return waitForCurrentAll(ctx, waitForProjection("assets", s.projector))
+	return waitForCurrentAll(ctx, waitForProjection("assets", s.assets.Projector()))
 }
 
 func (s *AssetModel) AssetCreation(assetID string) (*corev1.AssetCreatedEvent, bool) {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return nil, false
 	}
-	return s.projection.AssetCreation(assetID)
+	return s.assets.Projection().AssetCreation(assetID)
 }
 
 func (s *AssetModel) AssetRoomID(assetID string) (string, bool) {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return "", false
 	}
-	return s.projection.AssetRoomID(assetID)
+	return s.assets.Projection().AssetRoomID(assetID)
 }
 
 func (s *AssetModel) VideoAttachmentManifest(assetID string) (*VideoAttachmentManifest, bool) {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return nil, false
 	}
-	return s.projection.VideoAttachmentManifest(assetID)
+	return s.assets.Projection().VideoAttachmentManifest(assetID)
 }
 
 func (s *AssetModel) AssetDeleted(assetID string) bool {
-	return s != nil && s.projection != nil && s.projection.AssetDeleted(assetID)
+	return s != nil && s.assets.Projection() != nil && s.assets.Projection().AssetDeleted(assetID)
 }
 
 func (s *AssetModel) PendingExpiredAssets(now time.Time) []*corev1.AssetCreatedEvent {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return nil
 	}
-	return s.projection.PendingExpiredAssets(now)
+	return s.assets.Projection().PendingExpiredAssets(now)
 }
 
 func (s *AssetModel) AssetSubtreeIDs(assetID string) []string {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return nil
 	}
-	return s.projection.AssetSubtreeIDs(assetID)
+	return s.assets.Projection().AssetSubtreeIDs(assetID)
 }
 
 func (s *AssetModel) MessageAssetsByAuthor(userID string) []MessageAssetRef {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return nil
 	}
-	return s.projection.MessageAssetsByAuthor(userID)
+	return s.assets.Projection().MessageAssetsByAuthor(userID)
 }
 
 func (s *AssetModel) MessageAssetOwners() []MessageAssetRef {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return nil
 	}
-	return s.projection.MessageAssetOwners()
+	return s.assets.Projection().MessageAssetOwners()
 }
 
 func (s *AssetModel) AssetState(assetID string) AssetState {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return AssetState{}
 	}
-	return s.projection.AssetState(assetID)
+	return s.assets.Projection().AssetState(assetID)
 }
 
 func (s *AssetModel) AssetMessageOwner(assetID string) (roomID, messageEventID string, ok bool) {
-	if s == nil || s.projection == nil {
+	if s == nil || s.assets.Projection() == nil {
 		return "", "", false
 	}
-	return s.projection.AssetMessageOwner(assetID)
+	return s.assets.Projection().AssetMessageOwner(assetID)
 }
 
 func (s *AssetModel) IsPublicLinkPreviewAsset(assetID string) bool {
-	return s != nil && s.projection != nil && s.projection.IsPublicLinkPreviewAsset(assetID)
+	return s != nil && s.assets.Projection() != nil && s.assets.Projection().IsPublicLinkPreviewAsset(assetID)
 }
 
 func (s *AssetModel) MessageTombstoned(eventID string) bool {

--- a/cli/internal/core/asset_model_test.go
+++ b/cli/internal/core/asset_model_test.go
@@ -11,18 +11,18 @@ func TestNewAssetModelWiresCore(t *testing.T) {
 	core := &ChattoCore{}
 	projection := NewAssetProjection()
 
-	service := NewAssetModel(core, projection, nil)
+	service := newTestAssetModel(t, core, projection, nil)
 
 	if service.ChattoCore != core {
 		t.Fatal("core facade was not wired")
 	}
-	if service.projection != projection || service.projector != nil {
+	if service.assets.Projection() != projection || service.assets.Projector() == nil {
 		t.Fatal("asset projection dependencies were not wired")
 	}
 }
 
 func TestAssetModelMissingProjectionFailsClosed(t *testing.T) {
-	model := NewAssetModel(&ChattoCore{}, nil, nil)
+	model := newTestAssetModel(t, &ChattoCore{}, nil, nil)
 
 	if got := model.AssetState(NewAssetID()); got != (AssetState{}) {
 		t.Fatalf("AssetState = %#v, want zero state", got)
@@ -48,7 +48,7 @@ func TestChattoCoreAssetBoundaryFailsClosedBeforeInitialization(t *testing.T) {
 		t.Fatal("AssetEventTimelineTarget resolved without an initialized model")
 	}
 
-	core.assetModel = NewAssetModel(core, nil, nil)
+	core.assetModel = newTestAssetModel(t, core, nil, nil)
 	if _, ok := core.ResolvePublicServerAsset(context.Background(), NewAssetID()); ok {
 		t.Fatal("ResolvePublicServerAsset accepted an asset without an initialized projection")
 	}

--- a/cli/internal/core/asset_projection_test.go
+++ b/cli/internal/core/asset_projection_test.go
@@ -240,9 +240,9 @@ func TestAssetModelUnmanifestedVideoAttachmentsUsesAssetOwnershipAndTimelineTomb
 	assets := NewAssetProjection()
 	timeline := NewRoomTimelineProjection()
 	core := &ChattoCore{
-		roomModel: newRoomModel(nil, nil, nil, nil, timeline, nil, nil, nil, nil, nil),
+		roomModel: newTestRoomModel(t, nil, nil, nil, nil, timeline, nil, nil, nil, nil, nil),
 	}
-	model := NewAssetModel(core, assets, nil)
+	model := newTestAssetModel(t, core, assets, nil)
 	post := postedEvent(postedOpts{envelopeID: "M1", roomID: "R1", actorID: "U1", at: 1})
 	body := bodyEventWithAssets("E-body", "M1", "R1", "U1", "", []string{"A-video"}, 2)
 	applyAll(t, assets, []*corev1.Event{body, attachmentDeclaredEvent("R1", "A-video", "video/mp4")})

--- a/cli/internal/core/attachments_test.go
+++ b/cli/internal/core/attachments_test.go
@@ -1186,7 +1186,7 @@ func TestChattoCore_DeleteMessageOwnedAssetsForUser_CleansUpDerivativeCaches(t *
 	if err != nil {
 		t.Fatalf("Failed to append inherited-room derivative: %v", err)
 	}
-	if err := core.assetModel.projector.WaitFor(ctx, events.SubjectPosition(inheritedSubject, inheritedSeq)); err != nil {
+	if err := core.assetModel.assets.Projector().WaitFor(ctx, events.SubjectPosition(inheritedSubject, inheritedSeq)); err != nil {
 		t.Fatalf("Failed to wait for inherited-room derivative: %v", err)
 	}
 

--- a/cli/internal/core/call_model.go
+++ b/cli/internal/core/call_model.go
@@ -53,8 +53,7 @@ type liveKitParticipantRemover interface {
 
 type CallModel struct {
 	publisher      *events.Publisher
-	projection     *CallStateProjection
-	projector      *events.Projector
+	callState      events.ProjectionHandle[*CallStateProjection]
 	callKeys       kms.CallKeyStore
 	livekit        liveKitParticipantLister
 	reconcileLease *lease.Lease
@@ -108,8 +107,7 @@ func (e *liveKitListFailureError) Unwrap() error {
 
 func NewCallModel(
 	publisher *events.Publisher,
-	projection *CallStateProjection,
-	projector *events.Projector,
+	callState events.ProjectionHandle[*CallStateProjection],
 	callKeys kms.CallKeyStore,
 	livekit liveKitParticipantLister,
 	reconcileLease *lease.Lease,
@@ -118,8 +116,7 @@ func NewCallModel(
 ) *CallModel {
 	model := &CallModel{
 		publisher:      publisher,
-		projection:     projection,
-		projector:      projector,
+		callState:      callState,
 		callKeys:       callKeys,
 		livekit:        livekit,
 		reconcileLease: reconcileLease,
@@ -135,26 +132,26 @@ func NewCallModel(
 }
 
 func (s *CallModel) waitFor(ctx context.Context, pos events.StreamPosition) error {
-	if s == nil || s.projector == nil {
+	if s == nil || s.callState.Projector() == nil {
 		return fmt.Errorf("call state projector is not initialized")
 	}
-	return s.projector.WaitFor(ctx, pos)
+	return s.callState.Projector().WaitFor(ctx, pos)
 }
 
 func (s *CallModel) roomSnapshot(roomID string) CallRoomSnapshot {
-	return s.projection.RoomSnapshot(roomID)
+	return s.callState.Projection().RoomSnapshot(roomID)
 }
 
 func (s *CallModel) activeCall(roomID string) (CallSession, bool) {
-	return s.projection.ActiveCall(roomID)
+	return s.callState.Projection().ActiveCall(roomID)
 }
 
 func (s *CallModel) participants(roomID string) []CallParticipant {
-	return s.projection.Participants(roomID)
+	return s.callState.Projection().Participants(roomID)
 }
 
 func (s *CallModel) activeRoomIDs() []string {
-	return s.projection.ActiveRoomIDs()
+	return s.callState.Projection().ActiveRoomIDs()
 }
 
 func (c *ChattoCore) EnableLiveKitCallReconciliation(cfg config.LiveKitConfig) error {
@@ -309,7 +306,7 @@ func (s *CallModel) GetAccessMaterial(ctx context.Context, roomID string) (CallA
 	if s.callKeys == nil {
 		return CallAccessMaterial{}, fmt.Errorf("call key store is not initialized")
 	}
-	call, ok := s.projection.ActiveCall(roomID)
+	call, ok := s.callState.Projection().ActiveCall(roomID)
 	if !ok || call.CallID == "" || call.E2EEKeyRef == "" {
 		return CallAccessMaterial{}, fmt.Errorf("no active voice call for room %s: %w", roomID, ErrNotFound)
 	}
@@ -317,7 +314,7 @@ func (s *CallModel) GetAccessMaterial(ctx context.Context, roomID string) (CallA
 	if err != nil {
 		return CallAccessMaterial{}, fmt.Errorf("read call E2EE key: %w", err)
 	}
-	current, ok := s.projection.ActiveCall(roomID)
+	current, ok := s.callState.Projection().ActiveCall(roomID)
 	if !ok || current.CallID != call.CallID || current.E2EEKeyRef != call.E2EEKeyRef {
 		return CallAccessMaterial{}, fmt.Errorf("active voice call changed while resolving access for room %s: %w", roomID, ErrNotFound)
 	}
@@ -395,7 +392,7 @@ func (s *CallModel) appendParticipantTransition(ctx context.Context, roomID, use
 	aggregate := events.RoomAggregate(roomID)
 	filter := aggregate.AllEventsFilter()
 	for attempt := 0; attempt < callReconcileMaxRetries; attempt++ {
-		snapshot := s.projection.RoomSnapshot(roomID)
+		snapshot := s.callState.Projection().RoomSnapshot(roomID)
 		if expectedCallID != "" && snapshot.Call.CallID != expectedCallID {
 			return nil
 		}
@@ -415,7 +412,7 @@ func (s *CallModel) appendParticipantTransition(ctx context.Context, roomID, use
 					return fmt.Errorf("shred ended call key: %w", err)
 				}
 			}
-			if err := s.projector.WaitFor(ctx, events.SubjectPosition(filter, seq)); err != nil {
+			if err := s.callState.Projector().WaitFor(ctx, events.SubjectPosition(filter, seq)); err != nil {
 				return err
 			}
 			return nil
@@ -513,7 +510,7 @@ func (s *CallModel) waitForLatestRoomTransition(ctx context.Context, filter stri
 	if err != nil {
 		return err
 	}
-	return s.projector.WaitFor(ctx, tail)
+	return s.callState.Projector().WaitFor(ctx, tail)
 }
 
 func callParticipantTransitionAlreadyApplied(active []CallParticipant, userID string, joined bool) bool {
@@ -548,7 +545,7 @@ func (s *CallModel) reconcileRoomParticipants(ctx context.Context, roomID string
 		}
 	}
 
-	active := s.projection.Participants(roomID)
+	active := s.callState.Projection().Participants(roomID)
 	activeByUser := make(map[string]struct{}, len(active))
 	for _, participant := range active {
 		activeByUser[participant.UserID] = struct{}{}
@@ -625,7 +622,7 @@ func newCallParticipantEvent(roomID, userID, callID string, joined bool, source 
 }
 
 func (s *CallModel) reconciliationMismatchResolved(roomID, userID string, joined bool) bool {
-	active := s.projection.Participants(roomID)
+	active := s.callState.Projection().Participants(roomID)
 	for _, participant := range active {
 		if participant.UserID == userID {
 			return joined
@@ -693,7 +690,7 @@ func (s *CallModel) reconcileWithLiveKit(ctx context.Context, cleanupContext fun
 			return err
 		}
 	}
-	for _, roomID := range s.projection.ActiveRoomIDs() {
+	for _, roomID := range s.callState.Projection().ActiveRoomIDs() {
 		if _, ok := observedRooms[roomID]; !ok {
 			if err := s.ReconcileRoomParticipants(ctx, roomID, nil); err != nil {
 				return err
@@ -704,7 +701,7 @@ func (s *CallModel) reconcileWithLiveKit(ctx context.Context, cleanupContext fun
 }
 
 func (s *CallModel) waitForSnapshotRoomTail(ctx context.Context, roomID string) error {
-	if roomID == "" || s.publisher == nil || s.projector == nil {
+	if roomID == "" || s.publisher == nil || s.callState.Projector() == nil {
 		return nil
 	}
 	tail, err := s.publisher.LastSubjectPosition(ctx, events.RoomAggregate(roomID).AllEventsFilter())
@@ -714,7 +711,7 @@ func (s *CallModel) waitForSnapshotRoomTail(ctx context.Context, roomID string) 
 	if tail.Seq == 0 {
 		return nil
 	}
-	if err := s.projector.WaitFor(ctx, tail); err != nil {
+	if err := s.callState.Projector().WaitFor(ctx, tail); err != nil {
 		return fmt.Errorf("wait for unmatched LiveKit room projection: %w", err)
 	}
 	return nil
@@ -769,7 +766,7 @@ func (s *CallModel) liveKitSnapshotMatchesActiveCall(snapshot liveKitParticipant
 	if snapshot.RoomID == "" {
 		return false
 	}
-	active, ok := s.projection.ActiveCall(snapshot.RoomID)
+	active, ok := s.callState.Projection().ActiveCall(snapshot.RoomID)
 	if !ok {
 		return false
 	}
@@ -841,7 +838,7 @@ func (s *CallModel) resetLiveKitListFailures(ctx context.Context) error {
 func (s *CallModel) endActiveCallsAfterLiveKitFailure(ctx context.Context) liveKitFailureCleanupSummary {
 	summary := liveKitFailureCleanupSummary{}
 	var cleanupErr error
-	roomIDs := s.projection.ActiveRoomIDs()
+	roomIDs := s.callState.Projection().ActiveRoomIDs()
 	summary.activeRooms = len(roomIDs)
 	for _, roomID := range roomIDs {
 		if err := s.ReconcileRoomParticipants(ctx, roomID, nil); err != nil {

--- a/cli/internal/core/config_model.go
+++ b/cli/internal/core/config_model.go
@@ -13,17 +13,16 @@ import (
 
 // ConfigModel owns semantic configuration/preference reads and event writes.
 type ConfigModel struct {
-	publisher  *events.Publisher
-	projector  *events.Projector
-	projection *ConfigProjection
+	publisher *events.Publisher
+	config    events.ProjectionHandle[*ConfigProjection]
 }
 
-func NewConfigModel(publisher *events.Publisher, projector *events.Projector, projection *ConfigProjection) *ConfigModel {
-	return &ConfigModel{publisher: publisher, projector: projector, projection: projection}
+func NewConfigModel(publisher *events.Publisher, config events.ProjectionHandle[*ConfigProjection]) *ConfigModel {
+	return &ConfigModel{publisher: publisher, config: config}
 }
 
 func (s *ConfigModel) prepareSubject(ctx context.Context, subject string) (events.Aggregate, string, uint64, error) {
-	if s.publisher == nil || s.projector == nil {
+	if s.publisher == nil || s.config.Projector() == nil {
 		return events.Aggregate{}, "", 0, fmt.Errorf("config service: event publisher/projector not configured")
 	}
 	if err := validateConfigSubject(subject); err != nil {
@@ -105,7 +104,7 @@ func (s *ConfigModel) updateSubject(
 }
 
 func (s *ConfigModel) waitFor(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("config", s.projector))
+	return waitForPositionAll(ctx, pos, waitForProjection("config", s.config.Projector()))
 }
 
 func validateConfigSubject(subject string) error {

--- a/cli/internal/core/config_model_test.go
+++ b/cli/internal/core/config_model_test.go
@@ -11,18 +11,18 @@ import (
 
 func TestNewConfigModelWiresDependencies(t *testing.T) {
 	publisher := testEventPublisher(t)
-	projector := testEventProjector(t)
 	projection := NewConfigProjection()
+	config := detachedTestProjectionHandle(projection)
 
-	service := NewConfigModel(publisher, projector, projection)
+	service := NewConfigModel(publisher, config)
 
 	if service.publisher != publisher {
 		t.Fatal("publisher was not wired")
 	}
-	if service.projector != projector {
+	if service.config.Projector() != config.Projector() {
 		t.Fatal("projector was not wired")
 	}
-	if service.projection != projection {
+	if service.config.Projection() != projection {
 		t.Fatal("projection was not wired")
 	}
 }
@@ -32,7 +32,7 @@ func TestConfigModelUpdateSubjectAppendsAndWaitsForProjection(t *testing.T) {
 	projection := NewConfigProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := NewConfigModel(harness.publisher, projector, projection)
+	service := newTestConfigModel(t, harness.publisher, projector, projection)
 	ctx := testContext(t)
 
 	err := service.updateSubject(ctx, ConfigSubjectServer, func(_ events.Aggregate, _ string, _ uint64) ([]*corev1.Event, error) {
@@ -62,7 +62,7 @@ func TestConfigModelPrepareSubjectValidatesDependenciesAndSubject(t *testing.T) 
 		t.Fatalf("prepareSubject missing dependencies error = %q", err.Error())
 	}
 
-	service := NewConfigModel(testEventPublisher(t), testEventProjector(t), NewConfigProjection())
+	service := NewConfigModel(testEventPublisher(t), detachedTestProjectionHandle(NewConfigProjection()))
 	if _, _, _, err := service.prepareSubject(ctx, "invalid.subject"); err == nil {
 		t.Fatal("prepareSubject with invalid subject returned nil error")
 	} else if !strings.Contains(err.Error(), "invalid config subject") {
@@ -75,7 +75,7 @@ func TestConfigModelPrepareSubjectReturnsExistingExpectedSeq(t *testing.T) {
 	projection := NewConfigProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := NewConfigModel(harness.publisher, projector, projection)
+	service := newTestConfigModel(t, harness.publisher, projector, projection)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, &corev1.Event{
@@ -106,7 +106,7 @@ func TestConfigModelPrepareSubjectReturnsExistingExpectedSeq(t *testing.T) {
 
 func TestConfigModelAppendEventsAtEmptyBatchIsNoop(t *testing.T) {
 	harness := newTestEventHarness(t)
-	service := NewConfigModel(harness.publisher, testEventProjector(t), NewConfigProjection())
+	service := NewConfigModel(harness.publisher, detachedTestProjectionHandle(NewConfigProjection()))
 	ctx := testContext(t)
 
 	if err := service.appendEventsAt(ctx, events.ConfigSubjectAggregate(ConfigSubjectServer), events.ConfigSubjectAggregate(ConfigSubjectServer).AllEventsFilter(), 0, nil); err != nil {
@@ -126,7 +126,7 @@ func TestConfigModelUpdateSubjectNoEventsIsNoop(t *testing.T) {
 	projection := NewConfigProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := NewConfigModel(harness.publisher, projector, projection)
+	service := newTestConfigModel(t, harness.publisher, projector, projection)
 	ctx := testContext(t)
 
 	if err := service.updateSubject(ctx, ConfigSubjectServer, func(events.Aggregate, string, uint64) ([]*corev1.Event, error) {
@@ -148,7 +148,7 @@ func TestConfigModelUpdateSubjectPropagatesBuildError(t *testing.T) {
 	projection := NewConfigProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := NewConfigModel(harness.publisher, projector, projection)
+	service := newTestConfigModel(t, harness.publisher, projector, projection)
 	ctx := testContext(t)
 	wantErr := errors.New("build failed")
 
@@ -165,7 +165,7 @@ func TestConfigModelUpdateSubjectRetriesConflicts(t *testing.T) {
 	projection := NewConfigProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := NewConfigModel(harness.publisher, projector, projection)
+	service := newTestConfigModel(t, harness.publisher, projector, projection)
 	ctx := testContext(t)
 	attempts := 0
 
@@ -205,7 +205,7 @@ func TestConfigModelUpdateSubjectReturnsConflictAfterRetries(t *testing.T) {
 	projection := NewConfigProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := NewConfigModel(harness.publisher, projector, projection)
+	service := newTestConfigModel(t, harness.publisher, projector, projection)
 	ctx := testContext(t)
 	attempts := 0
 

--- a/cli/internal/core/config_projection_test.go
+++ b/cli/internal/core/config_projection_test.go
@@ -19,7 +19,7 @@ func newServerNameChangedEvent(name string) *corev1.Event {
 
 func newConfigProjectionUnderModel() (*ConfigProjection, *ConfigModel) {
 	p := NewConfigProjection()
-	return p, NewConfigModel(nil, nil, p)
+	return p, NewConfigModel(nil, detachedTestProjectionHandle(p))
 }
 
 func TestConfigProjection_FreshState(t *testing.T) {

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -480,7 +480,7 @@ func (c *ChattoCore) GetLinkPreview(ctx context.Context, url string) (*corev1.Li
 // must bind one exact canonical flat NATS key; private declarations and metadata
 // always win. Only object metadata is updated—the object body is never opened.
 func (c *ChattoCore) markCachedLegacyLinkPreviewPublic(ctx context.Context, preview *corev1.LinkPreview) error {
-	if preview == nil || c.assetModel == nil || c.assetModel.projection == nil {
+	if preview == nil || c.assetModel == nil || c.assetModel.assets.Projection() == nil {
 		return nil
 	}
 	asset := preview.GetImageAsset()
@@ -707,7 +707,7 @@ func IsReservedServerAssetKey(key string) bool {
 // access, content reads, or transforms. Unknown objects fail closed.
 func (c *ChattoCore) ResolvePublicServerAsset(ctx context.Context, key string) (*PublicServerAssetLocation, bool) {
 	assetID, namespaced, ok := serverAssetRequestKey(key)
-	if !ok || c.assetModel == nil || c.assetModel.projection == nil {
+	if !ok || c.assetModel == nil || c.assetModel.assets.Projection() == nil {
 		return nil, false
 	}
 

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -23,29 +23,20 @@ func assembleCore(
 ) *ChattoCore {
 	configModel := NewConfigModel(
 		infra.eventPublisher,
-		projections.serverConfigProjector,
 		projections.serverConfig,
 	)
 	roomModel := newRoomModel(
 		projections.roomDirectory,
-		projections.roomDirectoryProjector,
 		projections.roomGroupLayout,
-		projections.roomGroupLayoutProjector,
 		projections.roomTimeline,
-		projections.roomTimelineProjector,
 		projections.threads,
-		projections.threadsProjector,
 		projections.reactions,
-		projections.reactionsProjector,
 	)
 	userModel := newUserModel(
 		infra.eventPublisher,
 		projections.users,
-		projections.usersProjector,
 		projections.userAuth,
-		projections.userAuthProjector,
 		projections.contentKeys,
-		projections.contentKeysProjector,
 	)
 
 	return &ChattoCore{
@@ -59,8 +50,8 @@ func assembleCore(
 		configModel:    configModel,
 		roomModel:      roomModel,
 		userModel:      userModel,
-		rbacModel:      newRBACModel(projections.rbac, projections.rbacProjector),
-		mentionables:   newMentionablesModel(projections.mentionables, projections.mentionablesProjector),
+		rbacModel:      newRBACModel(projections.rbac),
+		mentionables:   newMentionablesModel(projections.mentionables),
 		s3Client:       infra.s3Client,
 		EventPublisher: infra.eventPublisher,
 		projections:    projections.registrations,
@@ -107,14 +98,13 @@ func initializeCoreServices(
 	core.callModel = NewCallModel(
 		infra.eventPublisher,
 		projections.callState,
-		projections.callStateProjector,
 		infra.encryption.callKeys,
 		nil,
 		callReconcileLease,
 		infra.storage.memoryCacheKV,
 		logger.WithPrefix("core.CallModel"),
 	)
-	core.assetModel = NewAssetModel(core, projections.assets, projections.assetsProjector)
+	core.assetModel = NewAssetModel(core, projections.assets)
 	core.assetModel.cleanupLease = assetCleanupLease
 	core.assetUploadModel = &AssetUploadModel{core: core}
 	core.roomCommands = &RoomCommandModel{core: core}

--- a/cli/internal/core/event_publishing_test.go
+++ b/cli/internal/core/event_publishing_test.go
@@ -301,22 +301,20 @@ func TestStreamMyEvents_ClosesWhenLiveEVTProjectionReadinessFails(t *testing.T) 
 		t.Fatalf("Append: %v", err)
 	}
 
-	// Use a projector whose subject filters do not consume room events. The
-	// projection readiness wait fails immediately, matching the production
-	// failure mode without waiting for the timeout.
-	wrongProjector := harness.projector(NewAssetProjection())
+	timeline := NewRoomTimelineProjection()
+	timelineHandle := testProjectionHandle(harness, timeline)
+	threads := NewThreadProjection()
+	threadsHandle := testProjectionHandle(harness, threads)
+	if err := harness.js.DeleteStream(ctx, "EVT"); err != nil {
+		t.Fatalf("DeleteStream: %v", err)
+	}
 	core := &ChattoCore{logger: testCoreLogger()}
 	core.roomModel = newRoomModel(
-		nil,
-		nil,
-		nil,
-		nil,
-		NewRoomTimelineProjection(),
-		wrongProjector,
-		NewThreadProjection(),
-		wrongProjector,
-		nil,
-		nil,
+		events.ProjectionHandle[*RoomDirectoryProjection]{},
+		events.ProjectionHandle[*RoomGroupLayoutProjection]{},
+		timelineHandle,
+		threadsHandle,
+		events.ProjectionHandle[*ReactionProjection]{},
 	)
 	service := NewMyEventsModel(core)
 	msg := &nats.Msg{
@@ -357,16 +355,11 @@ func TestStreamMyEvents_ClosesWhenCallProjectionReadinessFails(t *testing.T) {
 	timelineProjection := NewRoomTimelineProjection()
 	timelineProjector := harness.projector(timelineProjection)
 	startTestProjector(t, timelineProjector)
-	wrongCallProjector := harness.projector(NewAssetProjection())
-
 	core := &ChattoCore{
-		logger: testCoreLogger(),
-		callModel: &CallModel{
-			projection: NewCallStateProjection(),
-			projector:  wrongCallProjector,
-		},
+		logger:    testCoreLogger(),
+		callModel: &CallModel{},
 	}
-	core.roomModel = newRoomModel(
+	core.roomModel = newTestRoomModel(t,
 		nil,
 		nil,
 		nil,

--- a/cli/internal/core/event_test_helpers_test.go
+++ b/cli/internal/core/event_test_helpers_test.go
@@ -54,15 +54,18 @@ func (h *testEventHarness) projector(proj events.Projection) *events.Projector {
 	return events.NewProjector(h.js, h.stream, proj, testCoreLogger())
 }
 
-func testProjectionHandle[P events.Projection](h *testEventHarness, projection P) events.ProjectionHandle[P] {
+func testProjectionHandle[T any, P events.ProjectionPointer[T]](
+	h *testEventHarness,
+	projection P,
+) events.ProjectionHandle[P] {
 	return events.NewProjectionHandle(h.js, h.stream, projection, testCoreLogger())
 }
 
-func detachedTestProjectionHandle[P events.Projection](projection P) events.ProjectionHandle[P] {
+func detachedTestProjectionHandle[T any, P events.ProjectionPointer[T]](projection P) events.ProjectionHandle[P] {
 	return events.NewProjectionHandle(nil, nil, projection, testCoreLogger())
 }
 
-func optionalTestProjectionHandle[P events.Projection](
+func optionalTestProjectionHandle[T any, P events.ProjectionPointer[T]](
 	t *testing.T,
 	projection P,
 	projector *events.Projector,

--- a/cli/internal/core/event_test_helpers_test.go
+++ b/cli/internal/core/event_test_helpers_test.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"io"
+	"reflect"
 	"testing"
 	"time"
 
@@ -49,13 +50,99 @@ func testEventPublisher(t *testing.T) *events.Publisher {
 	return newTestEventHarness(t).publisher
 }
 
-func testEventProjector(t *testing.T) *events.Projector {
-	t.Helper()
-	return newTestEventHarness(t).projector(NewRoomTimelineProjection())
-}
-
 func (h *testEventHarness) projector(proj events.Projection) *events.Projector {
 	return events.NewProjector(h.js, h.stream, proj, testCoreLogger())
+}
+
+func testProjectionHandle[P events.Projection](h *testEventHarness, projection P) events.ProjectionHandle[P] {
+	return events.NewProjectionHandle(h.js, h.stream, projection, testCoreLogger())
+}
+
+func detachedTestProjectionHandle[P events.Projection](projection P) events.ProjectionHandle[P] {
+	return events.NewProjectionHandle(nil, nil, projection, testCoreLogger())
+}
+
+func optionalTestProjectionHandle[P events.Projection](
+	t *testing.T,
+	projection P,
+	projector *events.Projector,
+) events.ProjectionHandle[P] {
+	t.Helper()
+	value := reflect.ValueOf(projection)
+	if !value.IsValid() || (value.Kind() == reflect.Pointer && value.IsNil()) {
+		var zero events.ProjectionHandle[P]
+		return zero
+	}
+	if projector == nil {
+		return detachedTestProjectionHandle(projection)
+	}
+	handle, err := events.BindProjectionHandle(projection, projector)
+	if err != nil {
+		t.Fatalf("BindProjectionHandle: %v", err)
+	}
+	return handle
+}
+
+func newTestRoomModel(
+	t *testing.T,
+	directory *RoomDirectoryProjection,
+	directoryProjector *events.Projector,
+	groupLayout *RoomGroupLayoutProjection,
+	groupLayoutProjector *events.Projector,
+	timeline *RoomTimelineProjection,
+	timelineProjector *events.Projector,
+	threads *ThreadProjection,
+	threadsProjector *events.Projector,
+	reactions *ReactionProjection,
+	reactionsProjector *events.Projector,
+) *RoomModel {
+	t.Helper()
+	return newRoomModel(
+		optionalTestProjectionHandle(t, directory, directoryProjector),
+		optionalTestProjectionHandle(t, groupLayout, groupLayoutProjector),
+		optionalTestProjectionHandle(t, timeline, timelineProjector),
+		optionalTestProjectionHandle(t, threads, threadsProjector),
+		optionalTestProjectionHandle(t, reactions, reactionsProjector),
+	)
+}
+
+func newTestUserModel(
+	t *testing.T,
+	publisher *events.Publisher,
+	users *UserProjection,
+	usersProjector *events.Projector,
+	auth *UserAuthProjection,
+	authProjector *events.Projector,
+	contentKeys *ContentKeyProjection,
+	contentKeysProjector *events.Projector,
+) *UserModel {
+	t.Helper()
+	return newUserModel(
+		publisher,
+		optionalTestProjectionHandle(t, users, usersProjector),
+		optionalTestProjectionHandle(t, auth, authProjector),
+		optionalTestProjectionHandle(t, contentKeys, contentKeysProjector),
+	)
+}
+
+func newTestConfigModel(
+	t *testing.T,
+	publisher *events.Publisher,
+	projector *events.Projector,
+	projection *ConfigProjection,
+) *ConfigModel {
+	t.Helper()
+	return NewConfigModel(publisher, optionalTestProjectionHandle(t, projection, projector))
+}
+
+func newTestRBACModel(t *testing.T, projection *RBACProjection, projector *events.Projector) *RBACModel {
+	t.Helper()
+	return newRBACModel(optionalTestProjectionHandle(t, projection, projector))
+}
+
+func newTestAssetModel(t *testing.T, core *ChattoCore, projection *AssetProjection, projector *events.Projector) *AssetModel {
+	t.Helper()
+	return NewAssetModel(core, optionalTestProjectionHandle(t, projection, projector))
 }
 
 func startTestProjector(t *testing.T, projector *events.Projector) {

--- a/cli/internal/core/linkpreview_test.go
+++ b/cli/internal/core/linkpreview_test.go
@@ -76,7 +76,7 @@ func TestGetLinkPreviewDoesNotPromotePrivateCachedNATSImage(t *testing.T) {
 					Asset: &corev1.AssetRecord{Id: assetID},
 				}},
 			})
-			_, err := core.assetModel.projector.AppendEventuallyAndWait(
+			_, err := core.assetModel.assets.Projector().AppendEventuallyAndWait(
 				testContext(t), core.EventPublisher, events.AssetAggregate(assetID), event,
 			)
 			require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestGetLinkPreviewDoesNotPromotePrivateCachedNATSImage(t *testing.T) {
 					AssetId: assetID,
 				}},
 			})
-			_, err := core.assetModel.projector.AppendEventuallyAndWait(
+			_, err := core.assetModel.assets.Projector().AppendEventuallyAndWait(
 				testContext(t), core.EventPublisher, events.AssetAggregate(assetID), event,
 			)
 			require.NoError(t, err)

--- a/cli/internal/core/media_model_test.go
+++ b/cli/internal/core/media_model_test.go
@@ -511,7 +511,7 @@ func TestAssetModelProcessedCommitSurvivesProjectionWaitFailure(t *testing.T) {
 		if strings.HasSuffix(pos.SubjectFilter, "."+events.EventAssetProcessingSucceeded) {
 			return context.DeadlineExceeded
 		}
-		return core.assetModel.projector.WaitFor(waitCtx, pos)
+		return core.assetModel.assets.Projector().WaitFor(waitCtx, pos)
 	}
 	t.Cleanup(func() { service.waitForAssetsOverride = nil })
 
@@ -568,7 +568,7 @@ func TestDerivativeCreationCommitSurvivesProjectionWaitFailure(t *testing.T) {
 		if strings.HasSuffix(pos.SubjectFilter, "."+events.EventAssetCreated) {
 			return context.DeadlineExceeded
 		}
-		return core.assetModel.projector.WaitFor(waitCtx, pos)
+		return core.assetModel.assets.Projector().WaitFor(waitCtx, pos)
 	}
 	t.Cleanup(func() { service.waitForAssetsOverride = nil })
 
@@ -801,7 +801,7 @@ func TestAssetModelDeleteVideoDerivativesUsesInheritedAssetRoom(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Append inherited thumbnail creation: %v", err)
 	}
-	if err := core.assetModel.projector.WaitFor(ctx, events.SubjectPosition(inheritedSubject, inheritedSeq)); err != nil {
+	if err := core.assetModel.assets.Projector().WaitFor(ctx, events.SubjectPosition(inheritedSubject, inheritedSeq)); err != nil {
 		t.Fatalf("Wait for inherited thumbnail creation: %v", err)
 	}
 

--- a/cli/internal/core/mentionables_projection.go
+++ b/cli/internal/core/mentionables_projection.go
@@ -302,20 +302,19 @@ type MentionableAvailability struct {
 }
 
 type MentionablesModel struct {
-	projection *MentionablesProjection
-	projector  *events.Projector
+	mentionables events.ProjectionHandle[*MentionablesProjection]
 }
 
-func newMentionablesModel(projection *MentionablesProjection, projector *events.Projector) *MentionablesModel {
-	return &MentionablesModel{projection: projection, projector: projector}
+func newMentionablesModel(mentionables events.ProjectionHandle[*MentionablesProjection]) *MentionablesModel {
+	return &MentionablesModel{mentionables: mentionables}
 }
 
 func (s *MentionablesModel) waitFor(ctx context.Context, pos events.StreamPosition) error {
-	return s.projector.WaitFor(ctx, pos)
+	return s.mentionables.Projector().WaitFor(ctx, pos)
 }
 
 func (s *MentionablesModel) Availability(handle string, allowedOwner *mentionableOwner) MentionableAvailability {
-	return s.projection.Availability(handle, allowedOwner)
+	return s.mentionables.Projection().Availability(handle, allowedOwner)
 }
 
 func normalizeMentionableHandle(handle string) string {

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -86,7 +86,7 @@ func (options postMessageOptions) shouldScheduleVideoProcessingForID(assetID str
 const maxThreadCreateAppendAttempts = 5
 
 func (c *ChattoCore) waitForMessageBodyAssets(ctx context.Context, subject string, seq uint64) error {
-	if c.assetModel == nil || c.assetModel.projector == nil {
+	if c.assetModel == nil || c.assetModel.assets.Projector() == nil {
 		return nil
 	}
 	return c.assetModel.waitForAssets(ctx, events.SubjectPosition(subject, seq))

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -118,7 +118,7 @@ func TestPostMessageWaitsForAssetProjectionMessageBody(t *testing.T) {
 	var waited events.StreamPosition
 	core.assetModel.waitForAssetsOverride = func(_ context.Context, pos events.StreamPosition) error {
 		waited = pos
-		return core.assetModel.projector.WaitFor(ctx, pos)
+		return core.assetModel.assets.Projector().WaitFor(ctx, pos)
 	}
 	if _, err := core.PostMessage(ctx, KindChannel, room.Id, user.Id, "hello", nil, "", "", nil, false); err != nil {
 		t.Fatalf("PostMessage: %v", err)

--- a/cli/internal/core/notification_level.go
+++ b/cli/internal/core/notification_level.go
@@ -177,12 +177,12 @@ func (c *ChattoCore) resolveEffectiveNotificationLevel(ctx context.Context, user
 }
 
 func (cm *ConfigModel) notificationServerLevel(userID string) corev1.NotificationLevel {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return corev1.NotificationLevel_NOTIFICATION_LEVEL_UNSPECIFIED
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	u := cm.projection.users[userID]
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	u := cm.config.Projection().users[userID]
 	if u == nil || u.serverLevel == nil {
 		return corev1.NotificationLevel_NOTIFICATION_LEVEL_UNSPECIFIED
 	}
@@ -190,12 +190,12 @@ func (cm *ConfigModel) notificationServerLevel(userID string) corev1.Notificatio
 }
 
 func (cm *ConfigModel) notificationRoomLevel(userID, roomID string) corev1.NotificationLevel {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return corev1.NotificationLevel_NOTIFICATION_LEVEL_UNSPECIFIED
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	u := cm.projection.users[userID]
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	u := cm.config.Projection().users[userID]
 	if u == nil || u.roomLevelByRoom == nil {
 		return corev1.NotificationLevel_NOTIFICATION_LEVEL_UNSPECIFIED
 	}
@@ -206,12 +206,12 @@ func (cm *ConfigModel) notificationRoomLevel(userID, roomID string) corev1.Notif
 }
 
 func (cm *ConfigModel) notificationRoomIDs(userID string) []string {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return nil
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	u := cm.projection.users[userID]
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	u := cm.config.Projection().users[userID]
 	if u == nil || len(u.roomLevelByRoom) == 0 {
 		return nil
 	}

--- a/cli/internal/core/projection_wiring.go
+++ b/cli/internal/core/projection_wiring.go
@@ -18,32 +18,19 @@ type coreProjections struct {
 	registrations []projectionRegistration
 	snapshotJobs  []projectionSnapshotJob
 
-	roomDirectory            *RoomDirectoryProjection
-	roomDirectoryProjector   *events.Projector
-	serverConfig             *ConfigProjection
-	serverConfigProjector    *events.Projector
-	roomGroupLayout          *RoomGroupLayoutProjection
-	roomGroupLayoutProjector *events.Projector
-	roomTimeline             *RoomTimelineProjection
-	roomTimelineProjector    *events.Projector
-	callState                *CallStateProjection
-	callStateProjector       *events.Projector
-	assets                   *AssetProjection
-	assetsProjector          *events.Projector
-	threads                  *ThreadProjection
-	threadsProjector         *events.Projector
-	reactions                *ReactionProjection
-	reactionsProjector       *events.Projector
-	users                    *UserProjection
-	usersProjector           *events.Projector
-	userAuth                 *UserAuthProjection
-	userAuthProjector        *events.Projector
-	contentKeys              *ContentKeyProjection
-	contentKeysProjector     *events.Projector
-	rbac                     *RBACProjection
-	rbacProjector            *events.Projector
-	mentionables             *MentionablesProjection
-	mentionablesProjector    *events.Projector
+	roomDirectory   events.ProjectionHandle[*RoomDirectoryProjection]
+	serverConfig    events.ProjectionHandle[*ConfigProjection]
+	roomGroupLayout events.ProjectionHandle[*RoomGroupLayoutProjection]
+	roomTimeline    events.ProjectionHandle[*RoomTimelineProjection]
+	callState       events.ProjectionHandle[*CallStateProjection]
+	assets          events.ProjectionHandle[*AssetProjection]
+	threads         events.ProjectionHandle[*ThreadProjection]
+	reactions       events.ProjectionHandle[*ReactionProjection]
+	users           events.ProjectionHandle[*UserProjection]
+	userAuth        events.ProjectionHandle[*UserAuthProjection]
+	contentKeys     events.ProjectionHandle[*ContentKeyProjection]
+	rbac            events.ProjectionHandle[*RBACProjection]
+	mentionables    events.ProjectionHandle[*MentionablesProjection]
 }
 
 type projectionSnapshotPolicy bool
@@ -61,15 +48,16 @@ type projectionRegistrar struct {
 	registrations []projectionRegistration
 }
 
-func (r *projectionRegistrar) register(
-	projection events.Projection,
+func registerProjection[P events.Projection](
+	r *projectionRegistrar,
+	projection P,
 	key string,
 	name string,
 	estimate func() (int64, int64, []ProjectionAdminMetric),
 	snapshotPolicy projectionSnapshotPolicy,
-) *events.Projector {
+) events.ProjectionHandle[P] {
 	loggerName := strings.ReplaceAll(name, " ", "") + "Projector"
-	projector := events.NewProjector(
+	handle := events.NewProjectionHandle(
 		r.infra.js,
 		r.infra.storage.serverEvtStream,
 		projection,
@@ -78,12 +66,12 @@ func (r *projectionRegistrar) register(
 	r.registrations = append(r.registrations, projectionRegistration{
 		key:            key,
 		name:           name,
-		projector:      projector,
+		projector:      handle.Projector(),
 		subjects:       slices.Clone(projection.Subjects()),
 		snapshotPolicy: snapshotPolicy,
 		estimate:       estimate,
 	})
-	return projector
+	return handle
 }
 
 func initializeCoreProjections(
@@ -93,119 +81,132 @@ func initializeCoreProjections(
 	registrar := &projectionRegistrar{infra: infra, logger: logger}
 	projections := &coreProjections{}
 
-	projections.roomDirectory = NewRoomDirectoryProjection()
-	projections.roomDirectoryProjector = registrar.register(
-		projections.roomDirectory,
+	roomDirectory := NewRoomDirectoryProjection()
+	projections.roomDirectory = registerProjection(
+		registrar,
+		roomDirectory,
 		projectionsnapshot.ProjectionRoomDirectoryKey,
 		"Room Directory",
-		projections.roomDirectory.adminProjectionEstimate,
+		roomDirectory.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.serverConfig = NewConfigProjection()
-	projections.serverConfigProjector = registrar.register(
-		projections.serverConfig,
+	serverConfig := NewConfigProjection()
+	projections.serverConfig = registerProjection(
+		registrar,
+		serverConfig,
 		projectionsnapshot.ProjectionServerConfigKey,
 		"Server Config",
-		projections.serverConfig.adminProjectionEstimate,
+		serverConfig.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.roomGroupLayout = NewRoomGroupLayoutProjection()
-	projections.roomGroupLayoutProjector = registrar.register(
-		projections.roomGroupLayout,
+	roomGroupLayout := NewRoomGroupLayoutProjection()
+	projections.roomGroupLayout = registerProjection(
+		registrar,
+		roomGroupLayout,
 		projectionsnapshot.ProjectionRoomGroupLayoutKey,
 		"Room Group Layout",
-		projections.roomGroupLayout.adminProjectionEstimate,
+		roomGroupLayout.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.roomTimeline = NewRoomTimelineProjection()
-	projections.roomTimelineProjector = registrar.register(
-		projections.roomTimeline,
+	roomTimeline := NewRoomTimelineProjection()
+	projections.roomTimeline = registerProjection(
+		registrar,
+		roomTimeline,
 		projectionsnapshot.ProjectionRoomTimelineKey,
 		"Room Timeline",
-		projections.roomTimeline.adminProjectionEstimate,
+		roomTimeline.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.callState = NewCallStateProjection()
-	projections.callStateProjector = registrar.register(
-		projections.callState,
+	callState := NewCallStateProjection()
+	projections.callState = registerProjection(
+		registrar,
+		callState,
 		projectionsnapshot.ProjectionCallStateKey,
 		"Call State",
-		projections.callState.adminProjectionEstimate,
+		callState.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.assets = NewAssetProjection()
-	projections.assetsProjector = registrar.register(
-		projections.assets,
+	assets := NewAssetProjection()
+	projections.assets = registerProjection(
+		registrar,
+		assets,
 		projectionsnapshot.ProjectionAssetsKey,
 		"Assets",
-		projections.assets.adminProjectionEstimate,
+		assets.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.threads = NewThreadProjection()
-	projections.threadsProjector = registrar.register(
-		projections.threads,
+	threads := NewThreadProjection()
+	projections.threads = registerProjection(
+		registrar,
+		threads,
 		projectionsnapshot.ProjectionThreadsKey,
 		"Threads",
-		projections.threads.adminProjectionEstimate,
+		threads.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.reactions = NewReactionProjection()
-	projections.reactionsProjector = registrar.register(
-		projections.reactions,
+	reactions := NewReactionProjection()
+	projections.reactions = registerProjection(
+		registrar,
+		reactions,
 		projectionsnapshot.ProjectionReactionsKey,
 		"Reactions",
-		projections.reactions.adminProjectionEstimate,
+		reactions.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.users = newUserProjectionWithDEKResolver(infra.dekResolver)
-	projections.usersProjector = registrar.register(
-		projections.users,
+	users := newUserProjectionWithDEKResolver(infra.dekResolver)
+	projections.users = registerProjection(
+		registrar,
+		users,
 		projectionsnapshot.ProjectionUsersKey,
 		"Users",
-		projections.users.adminProjectionEstimate,
+		users.adminProjectionEstimate,
 		sharedSnapshots,
 	)
-	projections.userAuth = projections.users.AuthProjection()
-	projections.userAuthProjector = registrar.register(
-		projections.userAuth,
+	userAuth := users.AuthProjection()
+	projections.userAuth = registerProjection(
+		registrar,
+		userAuth,
 		"user_auth",
 		"User Auth",
-		projections.userAuth.adminProjectionEstimate,
+		userAuth.adminProjectionEstimate,
 		coldReplayOnly,
 	)
 
-	projections.contentKeys = NewContentKeyProjection()
-	projections.contentKeysProjector = registrar.register(
-		projections.contentKeys,
+	contentKeys := NewContentKeyProjection()
+	projections.contentKeys = registerProjection(
+		registrar,
+		contentKeys,
 		projectionsnapshot.ProjectionContentKeysKey,
 		"Content Keys",
-		projections.contentKeys.adminProjectionEstimate,
+		contentKeys.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.rbac = NewRBACProjection()
-	projections.rbacProjector = registrar.register(
-		projections.rbac,
+	rbac := NewRBACProjection()
+	projections.rbac = registerProjection(
+		registrar,
+		rbac,
 		projectionsnapshot.ProjectionRBACKey,
 		"RBAC",
-		projections.rbac.adminProjectionEstimate,
+		rbac.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 
-	projections.mentionables = newMentionablesProjectionWithDEKResolver(infra.dekResolver)
-	projections.mentionablesProjector = registrar.register(
-		projections.mentionables,
+	mentionables := newMentionablesProjectionWithDEKResolver(infra.dekResolver)
+	projections.mentionables = registerProjection(
+		registrar,
+		mentionables,
 		projectionsnapshot.ProjectionMentionablesKey,
 		"Mentionables",
-		projections.mentionables.adminProjectionEstimate,
+		mentionables.adminProjectionEstimate,
 		sharedSnapshots,
 	)
 

--- a/cli/internal/core/projection_wiring.go
+++ b/cli/internal/core/projection_wiring.go
@@ -48,7 +48,7 @@ type projectionRegistrar struct {
 	registrations []projectionRegistration
 }
 
-func registerProjection[P events.Projection](
+func registerProjection[T any, P events.ProjectionPointer[T]](
 	r *projectionRegistrar,
 	projection P,
 	key string,

--- a/cli/internal/core/rbac_model.go
+++ b/cli/internal/core/rbac_model.go
@@ -9,58 +9,57 @@ import (
 
 // RBACModel owns RBAC projection reads and readiness.
 type RBACModel struct {
-	projection *RBACProjection
-	projector  *events.Projector
+	rbac events.ProjectionHandle[*RBACProjection]
 }
 
-func newRBACModel(projection *RBACProjection, projector *events.Projector) *RBACModel {
-	return &RBACModel{projection: projection, projector: projector}
+func newRBACModel(rbac events.ProjectionHandle[*RBACProjection]) *RBACModel {
+	return &RBACModel{rbac: rbac}
 }
 
 func (m *RBACModel) waitFor(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("RBAC", m.projector))
+	return waitForPositionAll(ctx, pos, waitForProjection("RBAC", m.rbac.Projector()))
 }
 
 func (m *RBACModel) role(name string) (*corev1.Role, bool) {
-	return m.projection.GetRole(name)
+	return m.rbac.Projection().GetRole(name)
 }
 
 func (m *RBACModel) roleExists(name string) bool {
-	return m.projection.RoleExists(name)
+	return m.rbac.Projection().RoleExists(name)
 }
 
 func (m *RBACModel) roles() []*corev1.Role {
-	return m.projection.ListRoles()
+	return m.rbac.Projection().ListRoles()
 }
 
 func (m *RBACModel) userRoles(userID string) []string {
-	return m.projection.GetUserRoles(userID)
+	return m.rbac.Projection().GetUserRoles(userID)
 }
 
 func (m *RBACModel) hasRole(userID, roleName string) bool {
-	return m.projection.HasRole(userID, roleName)
+	return m.rbac.Projection().HasRole(userID, roleName)
 }
 
 func (m *RBACModel) roleUsers(roleName string) []string {
-	return m.projection.GetRoleUsers(roleName)
+	return m.rbac.Projection().GetRoleUsers(roleName)
 }
 
 func (m *RBACModel) rolePermissionDecisions(roleName string) []ScopedRolePermissionDecision {
-	return m.projection.RolePermissionDecisions(roleName)
+	return m.rbac.Projection().RolePermissionDecisions(roleName)
 }
 
 func (m *RBACModel) decision(scope PermissionScope, scopeID, subject string, permission Permission) DecisionKind {
-	return m.projection.GetDecision(scope, scopeID, subject, permission)
+	return m.rbac.Projection().GetDecision(scope, scopeID, subject, permission)
 }
 
 func (m *RBACModel) decisionsFor(scope PermissionScope, scopeID, subject string) (grants, denials []Permission) {
-	return m.projection.DecisionsFor(scope, scopeID, subject)
+	return m.rbac.Projection().DecisionsFor(scope, scopeID, subject)
 }
 
 func (m *RBACModel) decisionsForRoleServer(roleName string) (grants, denials []Permission) {
-	return m.projection.DecisionsForRoleServer(roleName)
+	return m.rbac.Projection().DecisionsForRoleServer(roleName)
 }
 
 func (m *RBACModel) nextAvailablePosition() int32 {
-	return m.projection.NextAvailablePosition()
+	return m.rbac.Projection().NextAvailablePosition()
 }

--- a/cli/internal/core/rbac_model_test.go
+++ b/cli/internal/core/rbac_model_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestNewRBACModelWiresDependencies(t *testing.T) {
 	projection := NewRBACProjection()
-	projector := testEventProjector(t)
+	rbac := detachedTestProjectionHandle(projection)
 
-	service := newRBACModel(projection, projector)
+	service := newRBACModel(rbac)
 
-	if service.projection != projection {
+	if service.rbac.Projection() != projection {
 		t.Fatal("RBAC projection was not wired")
 	}
-	if service.projector != projector {
+	if service.rbac.Projector() != rbac.Projector() {
 		t.Fatal("RBAC projector was not wired")
 	}
 }
@@ -28,7 +28,7 @@ func TestRBACModelWaitForRejectsUnconsumedSubject(t *testing.T) {
 	projection := NewRBACProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := newRBACModel(projection, projector)
+	service := newTestRBACModel(t, projection, projector)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, roomCreatedEvent("R-not-rbac", "not-rbac", "", corev1.RoomKind_ROOM_KIND_CHANNEL))
@@ -49,7 +49,7 @@ func TestRBACModelWaitForProjectsRoleCreation(t *testing.T) {
 	projection := NewRBACProjection()
 	projector := harness.projector(projection)
 	startTestProjector(t, projector)
-	service := newRBACModel(projection, projector)
+	service := newTestRBACModel(t, projection, projector)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, &corev1.Event{
@@ -82,7 +82,7 @@ func TestRBACModelWaitForProjectsRoleCreation(t *testing.T) {
 
 func TestRBACModelOwnsProjectionReads(t *testing.T) {
 	projection := NewRBACProjection()
-	model := newRBACModel(projection, nil)
+	model := newTestRBACModel(t, projection, nil)
 
 	for _, event := range []*corev1.Event{
 		{Event: &corev1.Event_RbacRoleCreated{RbacRoleCreated: &corev1.RbacRoleCreatedEvent{

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -225,7 +225,7 @@ func TestChattoCore_RestartPreservesFullyClearedDefaultPermissions(t *testing.T)
 		t.Fatalf("NewChattoCore first startup: %v", err)
 	}
 	startCoreServices(t, core1)
-	for _, decision := range core1.rbacModel.projection.Decisions() {
+	for _, decision := range core1.rbacModel.rbac.Projection().Decisions() {
 		if decision.scope != ScopeServer {
 			t.Fatalf("unexpected non-server seed decision: %+v", decision)
 		}
@@ -233,7 +233,7 @@ func TestChattoCore_RestartPreservesFullyClearedDefaultPermissions(t *testing.T)
 			t.Fatalf("ClearServerPermissionState(%s, %s): %v", decision.subject, decision.permission, err)
 		}
 	}
-	if got := len(core1.rbacModel.projection.Decisions()); got != 0 {
+	if got := len(core1.rbacModel.rbac.Projection().Decisions()); got != 0 {
 		t.Fatalf("decisions after clear = %d, want 0", got)
 	}
 
@@ -242,7 +242,7 @@ func TestChattoCore_RestartPreservesFullyClearedDefaultPermissions(t *testing.T)
 		t.Fatalf("NewChattoCore restart: %v", err)
 	}
 	startCoreServices(t, core2)
-	if got := len(core2.rbacModel.projection.Decisions()); got != 0 {
+	if got := len(core2.rbacModel.rbac.Projection().Decisions()); got != 0 {
 		t.Fatalf("decisions after restart = %d, want 0", got)
 	}
 }

--- a/cli/internal/core/reactions_test.go
+++ b/cli/internal/core/reactions_test.go
@@ -159,7 +159,7 @@ func TestReactionModel_AddReactionRefreshesStaleNoopSnapshot(t *testing.T) {
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
 	}
-	core.roomModel = newRoomModel(nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
+	core.roomModel = newTestRoomModel(t, nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
 	service := &ReactionModel{core: core}
 
 	addedOnOtherReplica := newReactionAddedEvent("U1", "R1", "M1", "thumbsup")

--- a/cli/internal/core/room_attachments_test.go
+++ b/cli/internal/core/room_attachments_test.go
@@ -139,7 +139,7 @@ func TestChattoCore_GetRoomAttachmentsDoesNotDecryptNonFileMessages(t *testing.T
 		EncryptedBody:   []byte("not-valid-ciphertext"),
 		EncryptionNonce: []byte("bad-nonce"),
 	}
-	if err := core.roomModel.timeline.Apply(&corev1.Event{
+	if err := core.roomModel.timeline.Projection().Apply(&corev1.Event{
 		Id:        bodyEventID,
 		ActorId:   user.Id,
 		CreatedAt: createdAt,
@@ -153,7 +153,7 @@ func TestChattoCore_GetRoomAttachmentsDoesNotDecryptNonFileMessages(t *testing.T
 	}, 1_000_000); err != nil {
 		t.Fatalf("Apply corrupt text body: %v", err)
 	}
-	if err := core.roomModel.timeline.Apply(&corev1.Event{
+	if err := core.roomModel.timeline.Projection().Apply(&corev1.Event{
 		Id:        messageEventID,
 		ActorId:   user.Id,
 		CreatedAt: createdAt,

--- a/cli/internal/core/room_events_pagination_test.go
+++ b/cli/internal/core/room_events_pagination_test.go
@@ -331,14 +331,14 @@ func testCoreWithRoomTimeline(t *testing.T, roomID string, count int) *ChattoCor
 			t.Fatalf("apply event %s: %v", eventID, err)
 		}
 	}
-	return &ChattoCore{roomModel: newRoomModel(nil, nil, nil, nil, projection, nil, nil, nil, nil, nil)}
+	return &ChattoCore{roomModel: newTestRoomModel(t, nil, nil, nil, nil, projection, nil, nil, nil, nil, nil)}
 }
 
 func testCoreWithRoomTimelineEvents(t *testing.T, events []*corev1.Event) *ChattoCore {
 	t.Helper()
 	projection := NewRoomTimelineProjection()
 	applyAll(t, projection, events)
-	return &ChattoCore{roomModel: newRoomModel(nil, nil, nil, nil, projection, nil, nil, nil, nil, nil)}
+	return &ChattoCore{roomModel: newTestRoomModel(t, nil, nil, nil, nil, projection, nil, nil, nil, nil, nil)}
 }
 
 func reactionAddedEvent(envID, roomID, messageID, actorID, emoji string) *corev1.Event {

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -328,7 +328,7 @@ func TestMoveRoomToSet_FromSourceRejectsChangedSourceAfterOCCRetry(t *testing.T)
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
 	}
-	core.roomModel = newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+	core.roomModel = newTestRoomModel(t, nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 
 	eventsToAppend := []*corev1.Event{
 		newEvent("actor", groupCreatedEvent("G-source", "Source", "")),
@@ -392,7 +392,7 @@ func TestMoveRoomToSet_TargetCreatedBeforeProjectionCatchup(t *testing.T) {
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
 	}
-	core.roomModel = newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+	core.roomModel = newTestRoomModel(t, nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 
 	created := newEvent("actor", &corev1.Event{
 		Event: &corev1.Event_RoomGroupCreated{
@@ -442,7 +442,7 @@ func TestMoveRoomToSet_IdempotentNoopRefreshesStaleSnapshot(t *testing.T) {
 		logger:         testCoreLogger(),
 		EventPublisher: harness.publisher,
 	}
-	core.roomModel = newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+	core.roomModel = newTestRoomModel(t, nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 
 	eventsToAppend := []*corev1.Event{
 		newEvent("actor", groupCreatedEvent("G-target", "Target", "")),

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -15,54 +15,35 @@ import (
 // individual projector fields. That keeps the "which projections must catch
 // up?" knowledge with the room read models.
 type RoomModel struct {
-	directory          *RoomDirectoryProjection
-	directoryProjector *events.Projector
-
-	groupLayout          *RoomGroupLayoutProjection
-	groupLayoutProjector *events.Projector
-
-	timeline          *RoomTimelineProjection
-	timelineProjector *events.Projector
-
-	threads          *ThreadProjection
-	threadsProjector *events.Projector
-
-	reactions          *ReactionProjection
-	reactionsProjector *events.Projector
+	directory   events.ProjectionHandle[*RoomDirectoryProjection]
+	groupLayout events.ProjectionHandle[*RoomGroupLayoutProjection]
+	timeline    events.ProjectionHandle[*RoomTimelineProjection]
+	threads     events.ProjectionHandle[*ThreadProjection]
+	reactions   events.ProjectionHandle[*ReactionProjection]
 }
 
 func newRoomModel(
-	directory *RoomDirectoryProjection,
-	directoryProjector *events.Projector,
-	groupLayout *RoomGroupLayoutProjection,
-	groupLayoutProjector *events.Projector,
-	timeline *RoomTimelineProjection,
-	timelineProjector *events.Projector,
-	threads *ThreadProjection,
-	threadsProjector *events.Projector,
-	reactions *ReactionProjection,
-	reactionsProjector *events.Projector,
+	directory events.ProjectionHandle[*RoomDirectoryProjection],
+	groupLayout events.ProjectionHandle[*RoomGroupLayoutProjection],
+	timeline events.ProjectionHandle[*RoomTimelineProjection],
+	threads events.ProjectionHandle[*ThreadProjection],
+	reactions events.ProjectionHandle[*ReactionProjection],
 ) *RoomModel {
 	return &RoomModel{
-		directory:            directory,
-		directoryProjector:   directoryProjector,
-		groupLayout:          groupLayout,
-		groupLayoutProjector: groupLayoutProjector,
-		timeline:             timeline,
-		timelineProjector:    timelineProjector,
-		threads:              threads,
-		threadsProjector:     threadsProjector,
-		reactions:            reactions,
-		reactionsProjector:   reactionsProjector,
+		directory:   directory,
+		groupLayout: groupLayout,
+		timeline:    timeline,
+		threads:     threads,
+		reactions:   reactions,
 	}
 }
 
 func (m *RoomModel) waitForDirectory(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("room directory", m.directoryProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("room directory", m.directory.Projector()))
 }
 
 func (m *RoomModel) waitForGroupLayout(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("room group layout", m.groupLayoutProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("room group layout", m.groupLayout.Projector()))
 }
 
 func (m *RoomModel) waitForGroupLayoutCurrent(ctx context.Context, publisher *events.Publisher) error {
@@ -77,15 +58,15 @@ func (m *RoomModel) waitForGroupLayoutCurrent(ctx context.Context, publisher *ev
 }
 
 func (m *RoomModel) waitForTimeline(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("room timeline", m.timelineProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("room timeline", m.timeline.Projector()))
 }
 
 func (m *RoomModel) waitForThreads(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("threads", m.threadsProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("threads", m.threads.Projector()))
 }
 
 func (m *RoomModel) waitForReactions(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("reactions", m.reactionsProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("reactions", m.reactions.Projector()))
 }
 
 func (m *RoomModel) waitForReactionsCurrent(ctx context.Context, publisher *events.Publisher, roomID string) error {
@@ -101,15 +82,15 @@ func (m *RoomModel) waitForReactionsCurrent(ctx context.Context, publisher *even
 
 func (m *RoomModel) waitForDirectoryAndTimeline(ctx context.Context, pos events.StreamPosition) error {
 	return waitForPositionAll(ctx, pos,
-		waitForProjection("room directory", m.directoryProjector),
-		waitForProjection("room timeline", m.timelineProjector),
+		waitForProjection("room directory", m.directory.Projector()),
+		waitForProjection("room timeline", m.timeline.Projector()),
 	)
 }
 
 func (m *RoomModel) waitForTimelineAndThreads(ctx context.Context, pos events.StreamPosition) error {
 	return waitForPositionAll(ctx, pos,
-		waitForProjection("room timeline", m.timelineProjector),
-		waitForProjection("threads", m.threadsProjector),
+		waitForProjection("room timeline", m.timeline.Projector()),
+		waitForProjection("threads", m.threads.Projector()),
 	)
 }
 
@@ -136,63 +117,63 @@ func (m *RoomModel) waitForLiveEVTEvent(ctx context.Context, pos events.StreamPo
 }
 
 func (m *RoomModel) room(roomID string) (*corev1.Room, bool) {
-	return m.directory.Catalog.Get(roomID)
+	return m.directory.Projection().Catalog.Get(roomID)
 }
 
 func (m *RoomModel) roomsByKind(kind corev1.RoomKind) []*corev1.Room {
-	return m.directory.Catalog.AllByKind(kind)
+	return m.directory.Projection().Catalog.AllByKind(kind)
 }
 
 func (m *RoomModel) roomIDByName(name string) string {
-	return m.directory.Catalog.FindByName(name)
+	return m.directory.Projection().Catalog.FindByName(name)
 }
 
 func (m *RoomModel) nameClaimSnapshot(name string) RoomNameClaimSnapshot {
-	return m.directory.Catalog.NameClaimSnapshot(name)
+	return m.directory.Projection().Catalog.NameClaimSnapshot(name)
 }
 
 func (m *RoomModel) hasExplicitRoomMembership(roomID, userID string) bool {
-	return m.directory.Membership.IsMember(roomID, userID)
+	return m.directory.Projection().Membership.IsMember(roomID, userID)
 }
 
 func (m *RoomModel) explicitRoomIDsForUser(userID string) []string {
-	return m.directory.Membership.Rooms(userID)
+	return m.directory.Projection().Membership.Rooms(userID)
 }
 
 func (m *RoomModel) explicitRoomMemberIDs(roomID string) []string {
-	return m.directory.Membership.Members(roomID)
+	return m.directory.Projection().Membership.Members(roomID)
 }
 
 func (m *RoomModel) roomGroup(groupID string) (*corev1.RoomGroup, bool) {
-	return m.groupLayout.Groups.Get(groupID)
+	return m.groupLayout.Projection().Groups.Get(groupID)
 }
 
 func (m *RoomModel) roomGroupSnapshot(groupID string) RoomGroupSnapshot {
-	return m.groupLayout.Groups.Snapshot(groupID)
+	return m.groupLayout.Projection().Groups.Snapshot(groupID)
 }
 
 func (m *RoomModel) roomGroups() []*corev1.RoomGroup {
-	return m.groupLayout.Groups.All()
+	return m.groupLayout.Projection().Groups.All()
 }
 
 func (m *RoomModel) roomGroupForRoom(roomID string) string {
-	return m.groupLayout.Groups.GroupForRoom(roomID)
+	return m.groupLayout.Projection().Groups.GroupForRoom(roomID)
 }
 
 func (m *RoomModel) roomGroupForSidebarLink(linkID string) string {
-	return m.groupLayout.Groups.GroupForSidebarLink(linkID)
+	return m.groupLayout.Projection().Groups.GroupForSidebarLink(linkID)
 }
 
 func (m *RoomModel) roomGroupMoveSnapshot(roomID, targetGroupID string) RoomGroupMoveSnapshot {
-	return m.groupLayout.Groups.MoveSnapshot(roomID, targetGroupID)
+	return m.groupLayout.Projection().Groups.MoveSnapshot(roomID, targetGroupID)
 }
 
 func (m *RoomModel) sidebarLinkMoveSnapshot(linkID, targetGroupID string) SidebarLinkMoveSnapshot {
-	return m.groupLayout.Groups.SidebarLinkMoveSnapshot(linkID, targetGroupID)
+	return m.groupLayout.Projection().Groups.SidebarLinkMoveSnapshot(linkID, targetGroupID)
 }
 
 func (m *RoomModel) roomLayoutOrder() []string {
-	return m.groupLayout.Layout.Order()
+	return m.groupLayout.Projection().Layout.Order()
 }
 
 func (m *RoomModel) waitForDirectoryCurrent(ctx context.Context, publisher *events.Publisher) error {
@@ -207,113 +188,113 @@ func (m *RoomModel) waitForDirectoryCurrent(ctx context.Context, publisher *even
 }
 
 func (m *RoomModel) activeRoomBan(roomID, userID string, now time.Time) (RoomBan, bool) {
-	return m.directory.Bans.ActiveBan(roomID, userID, now)
+	return m.directory.Projection().Bans.ActiveBan(roomID, userID, now)
 }
 
 func (m *RoomModel) activeRoomBans(roomID string, now time.Time) []RoomBan {
-	return m.directory.Bans.ActiveRoomBans(roomID, now)
+	return m.directory.Projection().Bans.ActiveRoomBans(roomID, now)
 }
 
 func (m *RoomModel) activeBans(now time.Time) []RoomBan {
-	return m.directory.Bans.ActiveBans(now)
+	return m.directory.Projection().Bans.ActiveBans(now)
 }
 
 func (m *RoomModel) isRoomBanActive(roomID, userID string, now time.Time) bool {
-	return m.directory.Bans.IsActive(roomID, userID, now)
+	return m.directory.Projection().Bans.IsActive(roomID, userID, now)
 }
 
 func (m *RoomModel) hasTimeline() bool {
-	return m != nil && m.timeline != nil
+	return m != nil && m.timeline.Projection() != nil
 }
 
 func (m *RoomModel) timelineEntry(eventID string) (*TimelineEntry, bool) {
-	return m.timeline.Get(eventID)
+	return m.timeline.Projection().Get(eventID)
 }
 
 func (m *RoomModel) latestBody(eventID string) (*corev1.MessageBody, bool, bool) {
-	return m.timeline.LatestBody(eventID)
+	return m.timeline.Projection().LatestBody(eventID)
 }
 
 func (m *RoomModel) currentRoomAttachmentMessages(roomID string) []projectedRoomAttachmentMessage {
-	return m.timeline.CurrentRoomAttachmentMessages(roomID)
+	return m.timeline.Projection().CurrentRoomAttachmentMessages(roomID)
 }
 
 func (m *RoomModel) isEcho(eventID string) bool {
-	return m.timeline.IsEcho(eventID)
+	return m.timeline.Projection().IsEcho(eventID)
 }
 
 func (m *RoomModel) isHiddenEcho(eventID string) bool {
-	return m.timeline.IsHiddenEcho(eventID)
+	return m.timeline.Projection().IsHiddenEcho(eventID)
 }
 
 func (m *RoomModel) channelEchoEventID(eventID string) (string, bool) {
-	return m.timeline.ChannelEchoEventID(eventID)
+	return m.timeline.Projection().ChannelEchoEventID(eventID)
 }
 
 func (m *RoomModel) linkedChannelEchoEventID(eventID string) (string, bool) {
-	return m.timeline.LinkedChannelEchoEventID(eventID)
+	return m.timeline.Projection().LinkedChannelEchoEventID(eventID)
 }
 
 func (m *RoomModel) messageHydrationState(eventID string) RoomTimelineMessageHydrationState {
-	return m.timeline.MessageHydrationState(eventID)
+	return m.timeline.Projection().MessageHydrationState(eventID)
 }
 
 func (m *RoomModel) linkedEventIDs(eventID string) []string {
-	return m.timeline.LinkedEventIDs(eventID)
+	return m.timeline.Projection().LinkedEventIDs(eventID)
 }
 
 func (m *RoomModel) bodyEventSeqs(eventID string) ([]uint64, uint64, bool) {
-	return m.timeline.BodyEventSeqs(eventID)
+	return m.timeline.Projection().BodyEventSeqs(eventID)
 }
 
 func (m *RoomModel) obsoleteBodyEventSeqs(eventID string) []uint64 {
-	return m.timeline.ObsoleteBodyEventSeqs(eventID)
+	return m.timeline.Projection().ObsoleteBodyEventSeqs(eventID)
 }
 
 func (m *RoomModel) allObsoleteBodyEventSeqs() []uint64 {
-	return m.timeline.AllObsoleteBodyEventSeqs()
+	return m.timeline.Projection().AllObsoleteBodyEventSeqs()
 }
 
 func (m *RoomModel) messageTombstoned(eventID string) bool {
-	return m.timeline.MessageTombstoned(eventID)
+	return m.timeline.Projection().MessageTombstoned(eventID)
 }
 
 func (m *RoomModel) lastVisibleRoomEntry(roomID string, visible func(*corev1.Event) bool) (*TimelineEntry, bool) {
-	return m.timeline.LastVisibleRoomEntry(roomID, visible)
+	return m.timeline.Projection().LastVisibleRoomEntry(roomID, visible)
 }
 
 func (m *RoomModel) lastRoomMessageEntry(roomID string) (*TimelineEntry, bool) {
-	return m.timeline.LastRoomMessageEntry(roomID)
+	return m.timeline.Projection().LastRoomMessageEntry(roomID)
 }
 
 func (m *RoomModel) visibleRoomTimeline(roomID string, limit int, beforeStreamSeq uint64, visible func(*corev1.Event) bool) []*TimelineEntry {
-	return m.timeline.VisibleRoomTimeline(roomID, limit, beforeStreamSeq, visible)
+	return m.timeline.Projection().VisibleRoomTimeline(roomID, limit, beforeStreamSeq, visible)
 }
 
 func (m *RoomModel) roomEventCount(roomID string) int {
-	return m.timeline.RoomEventCount(roomID)
+	return m.timeline.Projection().RoomEventCount(roomID)
 }
 
 func (m *RoomModel) visibleRoomTimelineAfter(roomID string, limit int, afterStreamSeq uint64, visible func(*corev1.Event) bool) []*TimelineEntry {
-	return m.timeline.VisibleRoomTimelineAfter(roomID, limit, afterStreamSeq, visible)
+	return m.timeline.Projection().VisibleRoomTimelineAfter(roomID, limit, afterStreamSeq, visible)
 }
 
 func (m *RoomModel) visibleRoomTimelineAround(roomID, eventID string, limit int) ([]*TimelineEntry, int, bool, bool, bool) {
-	return m.timeline.VisibleRoomTimelineAround(roomID, eventID, limit)
+	return m.timeline.Projection().VisibleRoomTimelineAround(roomID, eventID, limit)
 }
 
 func (m *RoomModel) threadExists(rootEventID string) bool {
-	return m.threads.ThreadExists(rootEventID)
+	return m.threads.Projection().ThreadExists(rootEventID)
 }
 
 func (m *RoomModel) threadEvents(rootEventID string) []*TimelineEntry {
-	refs := m.threads.ThreadEvents(rootEventID)
+	refs := m.threads.Projection().ThreadEvents(rootEventID)
 	if len(refs) == 0 {
 		return nil
 	}
 	out := make([]*TimelineEntry, 0, len(refs))
 	for _, ref := range refs {
-		entry, ok := m.timeline.Get(ref.EventID)
+		entry, ok := m.timeline.Projection().Get(ref.EventID)
 		if !ok || entry == nil {
 			continue
 		}
@@ -326,35 +307,35 @@ func (m *RoomModel) threadEvents(rootEventID string) []*TimelineEntry {
 }
 
 func (m *RoomModel) threadMetadata(rootEventID string) *ThreadMetadata {
-	return m.threads.ThreadMetadata(rootEventID)
+	return m.threads.Projection().ThreadMetadata(rootEventID)
 }
 
 func (m *RoomModel) threadFollowState(userID, roomID, threadRootEventID string) ThreadFollowState {
-	return m.threads.FollowState(userID, roomID, threadRootEventID)
+	return m.threads.Projection().FollowState(userID, roomID, threadRootEventID)
 }
 
 func (m *RoomModel) threadFollowers(roomID, threadRootEventID string) []string {
-	return m.threads.ThreadFollowers(roomID, threadRootEventID)
+	return m.threads.Projection().ThreadFollowers(roomID, threadRootEventID)
 }
 
 func (m *RoomModel) followedThreadsForUser(userID string) []threadFollowRef {
-	return m.threads.FollowedThreadsForUser(userID)
+	return m.threads.Projection().FollowedThreadsForUser(userID)
 }
 
 func (m *RoomModel) reactionsForMessage(messageEventID string) []ReactionSummary {
-	return m.reactions.Reactions(messageEventID)
+	return m.reactions.Projection().Reactions(messageEventID)
 }
 
 func (m *RoomModel) reactionsBatch(eventIDs []string) map[string][]ReactionSummary {
-	return m.reactions.ReactionsBatch(eventIDs)
+	return m.reactions.Projection().ReactionsBatch(eventIDs)
 }
 
 func (m *RoomModel) hasReaction(messageEventID, emoji, userID string) bool {
-	return m.reactions.HasReaction(messageEventID, emoji, userID)
+	return m.reactions.Projection().HasReaction(messageEventID, emoji, userID)
 }
 
 func (m *RoomModel) reactionMutationSnapshot(roomID, messageEventID, emoji, userID string) ReactionMutationSnapshot {
-	return m.reactions.ReactionMutationSnapshot(roomID, messageEventID, emoji, userID)
+	return m.reactions.Projection().ReactionMutationSnapshot(roomID, messageEventID, emoji, userID)
 }
 
 func (m *RoomModel) appendDirectoryEventually(ctx context.Context, pub *events.Publisher, agg events.Aggregate, event *corev1.Event) (events.StreamPosition, error) {

--- a/cli/internal/core/room_model_test.go
+++ b/cli/internal/core/room_model_test.go
@@ -9,57 +9,52 @@ import (
 
 func TestNewRoomModelWiresDependencies(t *testing.T) {
 	directory := NewRoomDirectoryProjection()
-	directoryProjector := testEventProjector(t)
 	groupLayout := NewRoomGroupLayoutProjection()
-	groupLayoutProjector := testEventProjector(t)
 	timeline := NewRoomTimelineProjection()
-	timelineProjector := testEventProjector(t)
 	threads := NewThreadProjection()
-	threadsProjector := testEventProjector(t)
 	reactions := NewReactionProjection()
-	reactionsProjector := testEventProjector(t)
+	directoryHandle := detachedTestProjectionHandle(directory)
+	groupLayoutHandle := detachedTestProjectionHandle(groupLayout)
+	timelineHandle := detachedTestProjectionHandle(timeline)
+	threadsHandle := detachedTestProjectionHandle(threads)
+	reactionsHandle := detachedTestProjectionHandle(reactions)
 
 	service := newRoomModel(
-		directory,
-		directoryProjector,
-		groupLayout,
-		groupLayoutProjector,
-		timeline,
-		timelineProjector,
-		threads,
-		threadsProjector,
-		reactions,
-		reactionsProjector,
+		directoryHandle,
+		groupLayoutHandle,
+		timelineHandle,
+		threadsHandle,
+		reactionsHandle,
 	)
 
-	if service.directory != directory {
+	if service.directory.Projection() != directory {
 		t.Fatal("directory projection was not wired")
 	}
-	if service.directoryProjector != directoryProjector {
+	if service.directory.Projector() != directoryHandle.Projector() {
 		t.Fatal("directory projector was not wired")
 	}
-	if service.groupLayout != groupLayout {
+	if service.groupLayout.Projection() != groupLayout {
 		t.Fatal("group layout projection was not wired")
 	}
-	if service.groupLayoutProjector != groupLayoutProjector {
+	if service.groupLayout.Projector() != groupLayoutHandle.Projector() {
 		t.Fatal("group layout projector was not wired")
 	}
-	if service.timeline != timeline {
+	if service.timeline.Projection() != timeline {
 		t.Fatal("timeline projection was not wired")
 	}
-	if service.timelineProjector != timelineProjector {
+	if service.timeline.Projector() != timelineHandle.Projector() {
 		t.Fatal("timeline projector was not wired")
 	}
-	if service.threads != threads {
+	if service.threads.Projection() != threads {
 		t.Fatal("threads projection was not wired")
 	}
-	if service.threadsProjector != threadsProjector {
+	if service.threads.Projector() != threadsHandle.Projector() {
 		t.Fatal("threads projector was not wired")
 	}
-	if service.reactions != reactions {
+	if service.reactions.Projection() != reactions {
 		t.Fatal("reactions projection was not wired")
 	}
-	if service.reactionsProjector != reactionsProjector {
+	if service.reactions.Projector() != reactionsHandle.Projector() {
 		t.Fatal("reactions projector was not wired")
 	}
 }
@@ -69,7 +64,7 @@ func TestRoomModelAppendTimelineEventuallyPublishesAndWaits(t *testing.T) {
 	timeline := NewRoomTimelineProjection()
 	timelineProjector := harness.projector(timeline)
 	startTestProjector(t, timelineProjector)
-	service := newRoomModel(nil, nil, nil, nil, timeline, timelineProjector, nil, nil, nil, nil)
+	service := newTestRoomModel(t, nil, nil, nil, nil, timeline, timelineProjector, nil, nil, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, roomCreatedEvent("R-service", "service-room", "", corev1.RoomKind_ROOM_KIND_CHANNEL))
@@ -98,7 +93,7 @@ func TestRoomModelAppendDirectoryEventuallyPublishesAndWaits(t *testing.T) {
 	directory := NewRoomDirectoryProjection()
 	directoryProjector := harness.projector(directory)
 	startTestProjector(t, directoryProjector)
-	service := newRoomModel(directory, directoryProjector, nil, nil, nil, nil, nil, nil, nil, nil)
+	service := newTestRoomModel(t, directory, directoryProjector, nil, nil, nil, nil, nil, nil, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, roomCreatedEvent("R-directory", "directory-room", "Directory", corev1.RoomKind_ROOM_KIND_CHANNEL))
@@ -124,7 +119,7 @@ func TestRoomModelAppendGroupLayoutPublishesAndWaits(t *testing.T) {
 	groupLayout := NewRoomGroupLayoutProjection()
 	groupLayoutProjector := harness.projector(groupLayout)
 	startTestProjector(t, groupLayoutProjector)
-	service := newRoomModel(nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+	service := newTestRoomModel(t, nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
 	ctx := testContext(t)
 
 	created := newEvent(SystemActorID, &corev1.Event{
@@ -165,7 +160,7 @@ func TestRoomModelWaitForDirectoryAndTimeline(t *testing.T) {
 	timeline := NewRoomTimelineProjection()
 	timelineProjector := harness.projector(timeline)
 	startTestProjector(t, timelineProjector)
-	service := newRoomModel(directory, directoryProjector, nil, nil, timeline, timelineProjector, nil, nil, nil, nil)
+	service := newTestRoomModel(t, directory, directoryProjector, nil, nil, timeline, timelineProjector, nil, nil, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, roomCreatedEvent("R-both", "both-room", "", corev1.RoomKind_ROOM_KIND_CHANNEL))
@@ -194,7 +189,7 @@ func TestRoomModelWaitForTimelineAndThreads(t *testing.T) {
 	threads := NewThreadProjection()
 	threadsProjector := harness.projector(threads)
 	startTestProjector(t, threadsProjector)
-	service := newRoomModel(nil, nil, nil, nil, timeline, timelineProjector, threads, threadsProjector, nil, nil)
+	service := newTestRoomModel(t, nil, nil, nil, nil, timeline, timelineProjector, threads, threadsProjector, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, &corev1.Event{
@@ -230,7 +225,7 @@ func TestRoomModelWaitForLiveEVTEventSkipsThreadsForReaction(t *testing.T) {
 	reactions := NewReactionProjection()
 	reactionsProjector := harness.projector(reactions)
 	startTestProjector(t, reactionsProjector)
-	service := newRoomModel(nil, nil, nil, nil, timeline, timelineProjector, threads, threadsProjector, reactions, reactionsProjector)
+	service := newTestRoomModel(t, nil, nil, nil, nil, timeline, timelineProjector, threads, threadsProjector, reactions, reactionsProjector)
 	ctx := testContext(t)
 
 	event := newEvent("U-reactor", &corev1.Event{
@@ -260,7 +255,7 @@ func TestRoomModelWaitForLiveEVTEventSkipsThreadsForCall(t *testing.T) {
 	threads := NewThreadProjection()
 	threadsProjector := harness.projector(threads)
 	startTestProjector(t, threadsProjector)
-	service := newRoomModel(nil, nil, nil, nil, timeline, timelineProjector, threads, threadsProjector, nil, nil)
+	service := newTestRoomModel(t, nil, nil, nil, nil, timeline, timelineProjector, threads, threadsProjector, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent("U-caller", &corev1.Event{
@@ -284,7 +279,7 @@ func TestRoomModelWaitForThreads(t *testing.T) {
 	threads := NewThreadProjection()
 	threadsProjector := harness.projector(threads)
 	startTestProjector(t, threadsProjector)
-	service := newRoomModel(nil, nil, nil, nil, nil, nil, threads, threadsProjector, nil, nil)
+	service := newTestRoomModel(t, nil, nil, nil, nil, nil, nil, threads, threadsProjector, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, &corev1.Event{
@@ -311,7 +306,7 @@ func TestRoomModelWaitForReactionsCurrent(t *testing.T) {
 	reactions := NewReactionProjection()
 	reactionsProjector := harness.projector(reactions)
 	startTestProjector(t, reactionsProjector)
-	service := newRoomModel(nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
+	service := newTestRoomModel(t, nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
 	ctx := testContext(t)
 
 	event := newEvent("U-reactor", &corev1.Event{
@@ -336,7 +331,7 @@ func TestRoomModelWaitForReactions(t *testing.T) {
 	reactions := NewReactionProjection()
 	reactionsProjector := harness.projector(reactions)
 	startTestProjector(t, reactionsProjector)
-	service := newRoomModel(nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
+	service := newTestRoomModel(t, nil, nil, nil, nil, nil, nil, nil, nil, reactions, reactionsProjector)
 	ctx := testContext(t)
 
 	event := newEvent("U-reactor", &corev1.Event{

--- a/cli/internal/core/server_branding.go
+++ b/cli/internal/core/server_branding.go
@@ -178,15 +178,15 @@ func (c *ChattoCore) projectedServerBrandingAsset(kind string) *corev1.AssetReco
 }
 
 func (cm *ConfigModel) serverBrandingAsset(kind string) *corev1.AssetRecord {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return nil
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
 	if kind == "logo" {
-		return cloneAssetRecord(cm.projection.server.logo)
+		return cloneAssetRecord(cm.config.Projection().server.logo)
 	}
-	return cloneAssetRecord(cm.projection.server.banner)
+	return cloneAssetRecord(cm.config.Projection().server.banner)
 }
 
 // GetServerLogoURL returns the URL for the server's logo, optionally

--- a/cli/internal/core/server_config_model.go
+++ b/cli/internal/core/server_config_model.go
@@ -29,10 +29,10 @@ const maxConfigUpdateRetries = 5
 // GetServerConfig returns the raw server configuration values currently held
 // by the projection, or nil when no server config fields have been set.
 func (cm *ConfigModel) GetServerConfig() *configv1.ServerConfig {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return nil
 	}
-	p := cm.projection
+	p := cm.config.Projection()
 	p.RLock()
 	defer p.RUnlock()
 	if p.server.serverName == "" &&
@@ -206,24 +206,24 @@ func serverConfigEvents(actorID string, current, next *configv1.ServerConfig) []
 // GetEffectiveWelcomeMessage returns the welcome message from the
 // projection. Empty string if not configured.
 func (cm *ConfigModel) GetEffectiveWelcomeMessage() string {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return ""
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	return cm.projection.server.welcomeMessage
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	return cm.config.Projection().server.welcomeMessage
 }
 
 // GetEffectiveServerName returns the server name from the projection,
 // falling back to "Chatto" if unset.
 func (cm *ConfigModel) GetEffectiveServerName() string {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return "Chatto"
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	if cm.projection.server.serverName != "" {
-		return cm.projection.server.serverName
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	if cm.config.Projection().server.serverName != "" {
+		return cm.config.Projection().server.serverName
 	}
 	return "Chatto"
 }
@@ -231,12 +231,12 @@ func (cm *ConfigModel) GetEffectiveServerName() string {
 // GetEffectiveMOTD returns the Message of the Day from the projection.
 // Empty string if not configured.
 func (cm *ConfigModel) GetEffectiveMOTD() string {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return ""
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	return cm.projection.server.motd
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	return cm.config.Projection().server.motd
 }
 
 // DefaultDescription is the fallback server description used when no
@@ -247,13 +247,13 @@ const DefaultDescription = "Come join our community!"
 // GetEffectiveDescription returns the server description from the
 // projection, falling back to DefaultDescription if unset.
 func (cm *ConfigModel) GetEffectiveDescription() string {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return DefaultDescription
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	if cm.projection.server.description != "" {
-		return cm.projection.server.description
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	if cm.config.Projection().server.description != "" {
+		return cm.config.Projection().server.description
 	}
 	return DefaultDescription
 }
@@ -270,15 +270,15 @@ const DefaultBlockedUsernames = "root\nadmin\nsuperuser\nop\noperator\nsupport"
 // from the projection. Returns DefaultBlockedUsernames if no config has
 // ever been written; returns "" if the operator explicitly cleared it.
 func (cm *ConfigModel) GetEffectiveBlockedUsernames() string {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return DefaultBlockedUsernames
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	if cm.projection.server.blockedUsernames == nil {
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	if cm.config.Projection().server.blockedUsernames == nil {
 		return DefaultBlockedUsernames
 	}
-	return *cm.projection.server.blockedUsernames
+	return *cm.config.Projection().server.blockedUsernames
 }
 
 // GetBlockedUsernamesList returns the blocked usernames as a slice of

--- a/cli/internal/core/user_model.go
+++ b/cli/internal/core/user_model.go
@@ -16,73 +16,63 @@ var errContentKeyProjectionUnavailable = errors.New("content key projection is u
 type UserModel struct {
 	publisher *events.Publisher
 
-	users          *UserProjection
-	usersProjector *events.Projector
-	auth           *UserAuthProjection
-	authProjector  *events.Projector
-
-	contentKeys          *ContentKeyProjection
-	contentKeysProjector *events.Projector
+	users       events.ProjectionHandle[*UserProjection]
+	auth        events.ProjectionHandle[*UserAuthProjection]
+	contentKeys events.ProjectionHandle[*ContentKeyProjection]
 }
 
 func newUserModel(
 	publisher *events.Publisher,
-	users *UserProjection,
-	usersProjector *events.Projector,
-	auth *UserAuthProjection,
-	authProjector *events.Projector,
-	contentKeys *ContentKeyProjection,
-	contentKeysProjector *events.Projector,
+	users events.ProjectionHandle[*UserProjection],
+	auth events.ProjectionHandle[*UserAuthProjection],
+	contentKeys events.ProjectionHandle[*ContentKeyProjection],
 ) *UserModel {
 	return &UserModel{
-		publisher:            publisher,
-		users:                users,
-		usersProjector:       usersProjector,
-		auth:                 auth,
-		authProjector:        authProjector,
-		contentKeys:          contentKeys,
-		contentKeysProjector: contentKeysProjector,
+		publisher:   publisher,
+		users:       users,
+		auth:        auth,
+		contentKeys: contentKeys,
 	}
 }
 
 func (m *UserModel) waitForUsers(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("users", m.usersProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("users", m.users.Projector()))
 }
 
 func (m *UserModel) waitForContentKeys(ctx context.Context, pos events.StreamPosition) error {
-	return waitForPositionAll(ctx, pos, waitForProjection("content key", m.contentKeysProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("content key", m.contentKeys.Projector()))
 }
 
 func (m *UserModel) waitForUsersCurrent(ctx context.Context, name string, subjects ...string) error {
-	if m.publisher == nil || m.usersProjector == nil {
+	if m.publisher == nil || m.users.Projector() == nil {
 		return nil
 	}
-	if err := waitForProjectionSubjectsCurrent(ctx, m.publisher, name, m.usersProjector, subjects...); err != nil {
+	if err := waitForProjectionSubjectsCurrent(ctx, m.publisher, name, m.users.Projector(), subjects...); err != nil {
 		return err
 	}
 	return m.waitForUserAuthCurrent(ctx, name)
 }
 
 func (m *UserModel) waitForUserAuth(ctx context.Context, pos events.StreamPosition) error {
-	if m.authProjector == nil {
+	if m.auth.Projector() == nil {
 		return nil
 	}
-	return waitForPositionAll(ctx, pos, waitForProjection("user auth", m.authProjector))
+	return waitForPositionAll(ctx, pos, waitForProjection("user auth", m.auth.Projector()))
 }
 
 func (m *UserModel) waitForUserAuthCurrent(ctx context.Context, name string) error {
-	if m.publisher == nil || m.authProjector == nil || m.auth == nil {
+	if m.publisher == nil || m.auth.Projector() == nil || m.auth.Projection() == nil {
 		return nil
 	}
-	return waitForProjectionSubjectsCurrent(ctx, m.publisher, name+" auth", m.authProjector, m.auth.Subjects()...)
+	return waitForProjectionSubjectsCurrent(ctx, m.publisher, name+" auth", m.auth.Projector(), m.auth.Projection().Subjects()...)
 }
 
 func (m *UserModel) waitForContentKeysCurrent(ctx context.Context, userID string) error {
-	if m.publisher == nil || m.contentKeysProjector == nil {
+	if m.publisher == nil || m.contentKeys.Projector() == nil {
 		return nil
 	}
 	agg := events.UserAggregate(userID)
-	return waitForProjectionSubjectsCurrent(ctx, m.publisher, "content key", m.contentKeysProjector,
+	return waitForProjectionSubjectsCurrent(ctx, m.publisher, "content key", m.contentKeys.Projector(),
 		agg.Subject(events.EventUserDEKGenerated),
 		agg.Subject(events.EventUserKeyShredded),
 	)
@@ -91,20 +81,20 @@ func (m *UserModel) waitForContentKeysCurrent(ctx context.Context, userID string
 // activeContentKey returns the newest projected DEK for a purpose. The
 // projection preserves compatibility with legacy purpose-unspecified DEKs.
 func (m *UserModel) activeContentKey(userID string, purpose corev1.UserDEKPurpose) (*corev1.UserDEKGeneratedEvent, bool, error) {
-	if m.contentKeys == nil {
+	if m.contentKeys.Projection() == nil {
 		return nil, false, errContentKeyProjectionUnavailable
 	}
-	event, ok := m.contentKeys.Active(userID, purpose)
+	event, ok := m.contentKeys.Projection().Active(userID, purpose)
 	return event, ok, nil
 }
 
 // contentKeyAtEpoch returns a projected DEK at an exact epoch. The projection
 // preserves compatibility with legacy purpose-unspecified DEKs.
 func (m *UserModel) contentKeyAtEpoch(userID string, purpose corev1.UserDEKPurpose, epoch int32) (*corev1.UserDEKGeneratedEvent, bool, error) {
-	if m.contentKeys == nil {
+	if m.contentKeys.Projection() == nil {
 		return nil, false, errContentKeyProjectionUnavailable
 	}
-	event, ok := m.contentKeys.Get(userID, purpose, epoch)
+	event, ok := m.contentKeys.Projection().Get(userID, purpose, epoch)
 	return event, ok, nil
 }
 
@@ -112,118 +102,118 @@ func (m *UserModel) contentKeyAtEpoch(userID string, purpose corev1.UserDEKPurpo
 // references associated with a user. Callers still inspect stored DEK records
 // before shredding because their wrapping-key reference may be newer than EVT.
 func (m *UserModel) keyRefsForShredding(userID string) (contentKeyRefs, wrappingKeyRefs []string, err error) {
-	if m.contentKeys == nil {
+	if m.contentKeys.Projection() == nil {
 		return nil, nil, errContentKeyProjectionUnavailable
 	}
-	return m.contentKeys.ContentKeyRefs(userID), m.contentKeys.KeyRefs(userID), nil
+	return m.contentKeys.Projection().ContentKeyRefs(userID), m.contentKeys.Projection().KeyRefs(userID), nil
 }
 
 func (m *UserModel) user(ctx context.Context, userID string) (*corev1.User, bool, error) {
-	return m.users.GetContext(ctx, userID)
+	return m.users.Projection().GetContext(ctx, userID)
 }
 
 func (m *UserModel) userReference(ctx context.Context, userID string) (*corev1.User, bool, error) {
-	return m.users.GetReferenceContext(ctx, userID)
+	return m.users.Projection().GetReferenceContext(ctx, userID)
 }
 
 func (m *UserModel) userReferences(ctx context.Context, userIDs []string) ([]*corev1.User, error) {
-	return m.users.GetReferencesContext(ctx, userIDs)
+	return m.users.Projection().GetReferencesContext(ctx, userIDs)
 }
 
 func (m *UserModel) userByLogin(ctx context.Context, login string) (*corev1.User, bool, error) {
-	return m.users.GetByLoginContext(ctx, login)
+	return m.users.Projection().GetByLoginContext(ctx, login)
 }
 
 func (m *UserModel) userByEmail(ctx context.Context, email string) (*corev1.User, bool, error) {
-	return m.users.GetByEmailContext(ctx, email)
+	return m.users.Projection().GetByEmailContext(ctx, email)
 }
 
 func (m *UserModel) userByExternalIdentity(ctx context.Context, issuer, subject string) (*corev1.User, bool, error) {
-	userID, ok := m.auth.ExternalIdentityOwnerID(issuer, subject)
+	userID, ok := m.auth.Projection().ExternalIdentityOwnerID(issuer, subject)
 	if !ok {
 		return nil, false, nil
 	}
-	return m.users.GetContext(ctx, userID)
+	return m.users.Projection().GetContext(ctx, userID)
 }
 
 func (m *UserModel) loginExists(login string) bool {
-	return m.users.LoginExists(login)
+	return m.users.Projection().LoginExists(login)
 }
 
 func (m *UserModel) emailClaimed(email string) bool {
-	return m.users.EmailClaimed(email)
+	return m.users.Projection().EmailClaimed(email)
 }
 
 func (m *UserModel) emailOwnerID(email string) (string, bool) {
-	return m.users.EmailOwnerID(email)
+	return m.users.Projection().EmailOwnerID(email)
 }
 
 func (m *UserModel) externalIdentityOwnerID(issuer, subject string) (string, bool) {
-	return m.auth.ExternalIdentityOwnerID(issuer, subject)
+	return m.auth.Projection().ExternalIdentityOwnerID(issuer, subject)
 }
 
 func (m *UserModel) externalIdentities(userID string) []ExternalIdentity {
-	return m.auth.ExternalIdentities(userID)
+	return m.auth.Projection().ExternalIdentities(userID)
 }
 
 func (m *UserModel) passwordHash(userID string) ([]byte, bool) {
-	hash, _, ok := m.auth.PasswordHashWithSetAt(userID)
+	hash, _, ok := m.auth.Projection().PasswordHashWithSetAt(userID)
 	return hash, ok
 }
 
 func (m *UserModel) passwordHashWithSetAt(userID string) ([]byte, time.Time, bool) {
-	return m.auth.PasswordHashWithSetAt(userID)
+	return m.auth.Projection().PasswordHashWithSetAt(userID)
 }
 
 func (m *UserModel) authGeneration(userID string) (uint64, bool) {
-	return m.auth.AuthGeneration(userID)
+	return m.auth.Projection().AuthGeneration(userID)
 }
 
 func (m *UserModel) avatar(userID string) (*corev1.AssetRecord, bool) {
-	return m.users.Avatar(userID)
+	return m.users.Projection().Avatar(userID)
 }
 
 func (m *UserModel) isPublicAvatarAsset(assetID string) bool {
-	if m == nil || m.users == nil {
+	if m == nil || m.users.Projection() == nil {
 		return false
 	}
-	return m.users.IsPublicAvatarAsset(assetID)
+	return m.users.Projection().IsPublicAvatarAsset(assetID)
 }
 
 func (m *UserModel) verifiedEmails(ctx context.Context, userID string) ([]VerifiedEmail, error) {
-	return m.users.VerifiedEmailsContext(ctx, userID)
+	return m.users.Projection().VerifiedEmailsContext(ctx, userID)
 }
 
 func (m *UserModel) hasVerifiedEmail(userID string) bool {
-	return m.users.HasVerifiedEmail(userID)
+	return m.users.Projection().HasVerifiedEmail(userID)
 }
 
 func (m *UserModel) hasVerifiedFactor(userID string) bool {
-	return m.users.HasVerifiedEmail(userID) || m.auth.HasExternalIdentity(userID)
+	return m.users.Projection().HasVerifiedEmail(userID) || m.auth.Projection().HasExternalIdentity(userID)
 }
 
 func (m *UserModel) hasOAuthConsent(userID, redirectOrigin string) bool {
-	return m.auth.HasOAuthConsent(userID, redirectOrigin)
+	return m.auth.Projection().HasOAuthConsent(userID, redirectOrigin)
 }
 
 func (m *UserModel) loginChangedAt(userID string) time.Time {
-	return m.users.LoginChangedAt(userID)
+	return m.users.Projection().LoginChangedAt(userID)
 }
 
 func (m *UserModel) allUsers(ctx context.Context) ([]*corev1.User, error) {
-	return m.users.UsersContext(ctx)
+	return m.users.Projection().UsersContext(ctx)
 }
 
 func (m *UserModel) verifiedUserIDs() []string {
-	return m.users.VerifiedUserIDs()
+	return m.users.Projection().VerifiedUserIDs()
 }
 
 func (m *UserModel) verifiedAccountIDs() []string {
 	seen := make(map[string]struct{})
-	for _, userID := range m.users.VerifiedUserIDs() {
+	for _, userID := range m.users.Projection().VerifiedUserIDs() {
 		seen[userID] = struct{}{}
 	}
-	for _, userID := range m.auth.VerifiedAccountIDs() {
+	for _, userID := range m.auth.Projection().VerifiedAccountIDs() {
 		seen[userID] = struct{}{}
 	}
 	out := make([]string, 0, len(seen))
@@ -235,5 +225,5 @@ func (m *UserModel) verifiedAccountIDs() []string {
 }
 
 func (m *UserModel) userCount() int {
-	return m.users.Count()
+	return m.users.Projection().Count()
 }

--- a/cli/internal/core/user_model_test.go
+++ b/cli/internal/core/user_model_test.go
@@ -16,33 +16,33 @@ import (
 func TestNewUserModelWiresDependencies(t *testing.T) {
 	publisher := testEventPublisher(t)
 	users := NewUserProjection(nil, nil)
-	usersProjector := testEventProjector(t)
 	auth := users.AuthProjection()
-	authProjector := testEventProjector(t)
 	contentKeys := NewContentKeyProjection()
-	contentKeysProjector := testEventProjector(t)
+	usersHandle := detachedTestProjectionHandle(users)
+	authHandle := detachedTestProjectionHandle(auth)
+	contentKeysHandle := detachedTestProjectionHandle(contentKeys)
 
-	service := newUserModel(publisher, users, usersProjector, auth, authProjector, contentKeys, contentKeysProjector)
+	service := newUserModel(publisher, usersHandle, authHandle, contentKeysHandle)
 
 	if service.publisher != publisher {
 		t.Fatal("publisher was not wired")
 	}
-	if service.users != users {
+	if service.users.Projection() != users {
 		t.Fatal("users projection was not wired")
 	}
-	if service.usersProjector != usersProjector {
+	if service.users.Projector() != usersHandle.Projector() {
 		t.Fatal("users projector was not wired")
 	}
-	if service.auth != auth {
+	if service.auth.Projection() != auth {
 		t.Fatal("user auth projection was not wired")
 	}
-	if service.authProjector != authProjector {
+	if service.auth.Projector() != authHandle.Projector() {
 		t.Fatal("user auth projector was not wired")
 	}
-	if service.contentKeys != contentKeys {
+	if service.contentKeys.Projection() != contentKeys {
 		t.Fatal("content keys projection was not wired")
 	}
-	if service.contentKeysProjector != contentKeysProjector {
+	if service.contentKeys.Projector() != contentKeysHandle.Projector() {
 		t.Fatal("content keys projector was not wired")
 	}
 }
@@ -50,7 +50,7 @@ func TestNewUserModelWiresDependencies(t *testing.T) {
 func TestUserModelOwnsProfileAndAuthenticationReads(t *testing.T) {
 	users, contentKey := newEncryptedUserProjection(t, "U1")
 	auth := users.AuthProjection()
-	model := newUserModel(nil, users, nil, auth, nil, nil, nil)
+	model := newTestUserModel(t, nil, users, nil, auth, nil, nil, nil)
 	createdAt := time.Date(2026, 7, 30, 12, 0, 0, 0, time.UTC)
 
 	account := userEvent("E1", createdAt, accountCreated(t, contentKey, "E1", "U1", "Alice", "Alice A."))
@@ -189,7 +189,7 @@ func TestUserModelOwnsProfileAndAuthenticationReads(t *testing.T) {
 func TestUserModelPreservesPIIFailuresAndShreddedReferences(t *testing.T) {
 	users, contentKey := newEncryptedUserProjection(t, "U1")
 	auth := users.AuthProjection()
-	model := newUserModel(nil, users, nil, auth, nil, nil, nil)
+	model := newTestUserModel(t, nil, users, nil, auth, nil, nil, nil)
 	require.NoError(t, users.Apply(userEvent(
 		"E1",
 		time.Now(),
@@ -225,7 +225,7 @@ func TestUserModelWaitForContentKeysProjectsDEKGenerated(t *testing.T) {
 	contentKeys := NewContentKeyProjection()
 	contentKeysProjector := harness.projector(contentKeys)
 	startTestProjector(t, contentKeysProjector)
-	service := newUserModel(harness.publisher, nil, nil, nil, nil, contentKeys, contentKeysProjector)
+	service := newTestUserModel(t, harness.publisher, nil, nil, nil, nil, contentKeys, contentKeysProjector)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, &corev1.Event{
@@ -265,7 +265,7 @@ func TestUserModelWaitForUsersProjectsUserAvatar(t *testing.T) {
 	users := NewUserProjection(nil, nil)
 	usersProjector := harness.projector(users)
 	startTestProjector(t, usersProjector)
-	service := newUserModel(harness.publisher, users, usersProjector, users.AuthProjection(), nil, nil, nil)
+	service := newTestUserModel(t, harness.publisher, users, usersProjector, users.AuthProjection(), nil, nil, nil)
 	ctx := testContext(t)
 
 	event := newEvent(SystemActorID, &corev1.Event{
@@ -304,7 +304,7 @@ func TestUserModelCurrentWaitsUsePublisherTail(t *testing.T) {
 	contentKeys := NewContentKeyProjection()
 	contentKeysProjector := harness.projector(contentKeys)
 	startTestProjector(t, contentKeysProjector)
-	service := newUserModel(harness.publisher, users, usersProjector, users.AuthProjection(), nil, contentKeys, contentKeysProjector)
+	service := newTestUserModel(t, harness.publisher, users, usersProjector, users.AuthProjection(), nil, contentKeys, contentKeysProjector)
 	ctx := testContext(t)
 
 	avatarEvent := newEvent(SystemActorID, &corev1.Event{
@@ -354,7 +354,7 @@ func TestUserModelCurrentWaitsUsePublisherTail(t *testing.T) {
 
 func TestUserModelContentKeyReadsPreserveProjectionSemantics(t *testing.T) {
 	contentKeys := NewContentKeyProjection()
-	service := newUserModel(nil, nil, nil, nil, nil, contentKeys, nil)
+	service := newTestUserModel(t, nil, nil, nil, nil, nil, contentKeys, nil)
 	legacy := &corev1.UserDEKGeneratedEvent{
 		UserId:         "U-legacy",
 		Epoch:          2,

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -40,12 +40,12 @@ func (c *ChattoCore) GetUserSettings(_ context.Context, userID string) (*corev1.
 }
 
 func (cm *ConfigModel) userSettings(userID string) (*corev1.ServerUserPreferences, bool) {
-	if cm == nil || cm.projection == nil {
+	if cm == nil || cm.config.Projection() == nil {
 		return nil, false
 	}
-	cm.projection.RLock()
-	defer cm.projection.RUnlock()
-	u := cm.projection.users[userID]
+	cm.config.Projection().RLock()
+	defer cm.config.Projection().RUnlock()
+	u := cm.config.Projection().users[userID]
 	if u == nil || (u.timezone == nil && u.timeFormat == nil) {
 		return nil, false
 	}

--- a/cli/internal/core/voice_test.go
+++ b/cli/internal/core/voice_test.go
@@ -546,7 +546,7 @@ func TestCallModel_ReadBoundaryReturnsDetachedState(t *testing.T) {
 	}
 
 	model := &CallModel{
-		projection: projection,
+		callState: detachedTestProjectionHandle(projection),
 		callKeys: &hookedCallKeyStore{keys: map[string]string{
 			"key-ref-call-model": "key-call-model",
 		}},
@@ -670,8 +670,8 @@ func TestCallModel_GetAccessMaterialRejectsCallGenerationTransition(t *testing.T
 	}
 
 	model := &CallModel{
-		projection: projection,
-		callKeys:   keyStore,
+		callState: detachedTestProjectionHandle(projection),
+		callKeys:  keyStore,
 	}
 	core := &ChattoCore{callModel: model}
 	access, err := core.GetVoiceCallAccessMaterial(context.Background(), roomID)
@@ -733,7 +733,7 @@ func TestWaitForRoomLeaveTail_PropagatesCallProjectionReadinessFailure(t *testin
 	directoryProjector := harness.projector(directoryProjection)
 	startTestProjector(t, directoryProjector)
 	core := &ChattoCore{
-		roomModel: newRoomModel(
+		roomModel: newTestRoomModel(t,
 			directoryProjection,
 			directoryProjector,
 			nil,
@@ -745,9 +745,7 @@ func TestWaitForRoomLeaveTail_PropagatesCallProjectionReadinessFailure(t *testin
 			nil,
 			nil,
 		),
-		callModel: &CallModel{
-			projector: harness.projector(NewAssetProjection()),
-		},
+		callModel: &CallModel{},
 	}
 
 	if err := core.waitForRoomLeaveTail(ctx, subject, seq); err == nil {
@@ -895,7 +893,7 @@ func TestCallState_SnapshotTracksRoomAggregateSeq(t *testing.T) {
 			RoomUpdated: &corev1.RoomUpdatedEvent{RoomId: roomID, Name: "Room One"},
 		},
 	})
-	seq, err := core.callModel.projector.AppendEventuallyAndWait(ctx, core.EventPublisher, events.RoomAggregate(roomID), roomEvent)
+	seq, err := core.callModel.callState.Projector().AppendEventuallyAndWait(ctx, core.EventPublisher, events.RoomAggregate(roomID), roomEvent)
 	if err != nil {
 		t.Fatalf("append room event() error = %v", err)
 	}
@@ -920,7 +918,7 @@ func TestCallState_SnapshotIgnoresAssetAggregateLifecycleSeq(t *testing.T) {
 			RoomUpdated: &corev1.RoomUpdatedEvent{RoomId: roomID, Name: "Room One"},
 		},
 	})
-	roomSeq, err := core.callModel.projector.AppendEventuallyAndWait(ctx, core.EventPublisher, events.RoomAggregate(roomID), roomEvent)
+	roomSeq, err := core.callModel.callState.Projector().AppendEventuallyAndWait(ctx, core.EventPublisher, events.RoomAggregate(roomID), roomEvent)
 	if err != nil {
 		t.Fatalf("append room event() error = %v", err)
 	}
@@ -936,7 +934,7 @@ func TestCallState_SnapshotIgnoresAssetAggregateLifecycleSeq(t *testing.T) {
 	if err != nil {
 		t.Fatalf("append asset event error = %v", err)
 	}
-	if err := core.assetModel.projector.WaitFor(ctx, events.SubjectPosition(assetSubject, assetSeq)); err != nil {
+	if err := core.assetModel.assets.Projector().WaitFor(ctx, events.SubjectPosition(assetSubject, assetSeq)); err != nil {
 		t.Fatalf("wait for asset event error = %v", err)
 	}
 
@@ -1499,8 +1497,7 @@ func TestCallState_LeaseHolderDiscoversLaterReplicaKeyCleanup(t *testing.T) {
 	workingKeys := core.encryption.callKeys
 	holder := NewCallModel(
 		core.EventPublisher,
-		core.callModel.projection,
-		core.callModel.projector,
+		core.callModel.callState,
 		workingKeys,
 		nil,
 		nil,
@@ -1608,8 +1605,7 @@ func TestCallState_ReconciliationCleansHistoricalMembershipOnlyLeave(t *testing.
 
 	restarted := NewCallModel(
 		core.EventPublisher,
-		core.callModel.projection,
-		core.callModel.projector,
+		core.callModel.callState,
 		workingKeys,
 		&recordingLiveKitParticipantClient{},
 		nil,
@@ -2171,8 +2167,7 @@ func TestCallState_ReconcileWithLiveKitSuccessOnAnotherReplicaResetsListFailureC
 	liveKitErr := errors.New("livekit unavailable")
 	failingReplica := NewCallModel(
 		core.EventPublisher,
-		core.callModel.projection,
-		core.callModel.projector,
+		core.callModel.callState,
 		core.encryption.callKeys,
 		fakeLiveKitParticipantLister{err: liveKitErr},
 		nil,
@@ -2181,8 +2176,7 @@ func TestCallState_ReconcileWithLiveKitSuccessOnAnotherReplicaResetsListFailureC
 	)
 	successfulReplica := NewCallModel(
 		core.EventPublisher,
-		core.callModel.projection,
-		core.callModel.projector,
+		core.callModel.callState,
 		core.encryption.callKeys,
 		fakeLiveKitParticipantLister{snapshots: []liveKitParticipantSnapshot{{RoomID: roomID, CallID: callID, UserIDs: []string{"user1"}}}},
 		nil,

--- a/cli/internal/events/projection_handle_test.go
+++ b/cli/internal/events/projection_handle_test.go
@@ -1,0 +1,54 @@
+package events
+
+import (
+	"testing"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+type projectionHandleTestProjection struct {
+	subject string
+}
+
+func (p *projectionHandleTestProjection) Subjects() []string {
+	return []string{p.subject}
+}
+
+func (*projectionHandleTestProjection) Apply(*corev1.Event, uint64) error {
+	return nil
+}
+
+func TestProjectionHandleKeepsProjectionAndProjectorTogether(t *testing.T) {
+	projection := &projectionHandleTestProjection{subject: RoomSubjectFilter()}
+	handle := NewProjectionHandle(nil, nil, projection, testLogger())
+
+	if handle.Projection() != projection {
+		t.Fatal("Projection() did not return the constructed projection")
+	}
+	if handle.Projector() == nil {
+		t.Fatal("Projector() returned nil")
+	}
+	if rebound, err := BindProjectionHandle(projection, handle.Projector()); err != nil {
+		t.Fatalf("BindProjectionHandle() error = %v", err)
+	} else if rebound.Projection() != projection || rebound.Projector() != handle.Projector() {
+		t.Fatal("BindProjectionHandle() did not preserve the projection runtime")
+	}
+}
+
+func TestBindProjectionHandleRejectsAnotherProjection(t *testing.T) {
+	first := &projectionHandleTestProjection{subject: RoomSubjectFilter()}
+	second := &projectionHandleTestProjection{subject: UserSubjectFilter()}
+	projector := NewProjector(nil, nil, first, testLogger())
+
+	if _, err := BindProjectionHandle(second, projector); err == nil {
+		t.Fatal("BindProjectionHandle() accepted a projector for another projection")
+	}
+}
+
+func TestProjectionHandleZeroValueIsEmpty(t *testing.T) {
+	var handle ProjectionHandle[*projectionHandleTestProjection]
+
+	if handle.Projection() != nil || handle.Projector() != nil {
+		t.Fatal("zero ProjectionHandle was not empty")
+	}
+}

--- a/cli/internal/events/projection_handle_test.go
+++ b/cli/internal/events/projection_handle_test.go
@@ -45,6 +45,26 @@ func TestBindProjectionHandleRejectsAnotherProjection(t *testing.T) {
 	}
 }
 
+func TestProjectionHandleRejectsNilProjection(t *testing.T) {
+	var projection *projectionHandleTestProjection
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("NewProjectionHandle() accepted a nil projection")
+		}
+	}()
+	NewProjectionHandle(nil, nil, projection, testLogger())
+}
+
+func TestBindProjectionHandleRejectsNilProjection(t *testing.T) {
+	var projection *projectionHandleTestProjection
+	projector := NewProjector(nil, nil, &projectionHandleTestProjection{}, testLogger())
+
+	if _, err := BindProjectionHandle(projection, projector); err == nil {
+		t.Fatal("BindProjectionHandle() accepted a nil projection")
+	}
+}
+
 func TestProjectionHandleZeroValueIsEmpty(t *testing.T) {
 	var handle ProjectionHandle[*projectionHandleTestProjection]
 

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -57,6 +58,62 @@ const (
 // (KV-backed, file-backed) would have their own embed-friendly base.
 type MemoryProjection struct {
 	sync.RWMutex
+}
+
+// ProjectionHandle keeps a typed projection and the Projector constructed for
+// it together. Application wiring passes the handle as one value so a read
+// model cannot accidentally receive another projection's replay frontier.
+//
+// The zero value is valid for partial test wiring: Projection returns the zero
+// value of P and Projector returns nil.
+type ProjectionHandle[P Projection] struct {
+	projection P
+	projector  *Projector
+}
+
+// NewProjectionHandle constructs a typed projection handle and its owning
+// projector. Application-specific registration metadata and lifecycle policy
+// deliberately remain outside the handle.
+func NewProjectionHandle[P Projection](
+	js jetstream.JetStream,
+	stream jetstream.Stream,
+	projection P,
+	logger Logger,
+) ProjectionHandle[P] {
+	return ProjectionHandle[P]{
+		projection: projection,
+		projector:  NewProjector(js, stream, projection, logger),
+	}
+}
+
+// BindProjectionHandle joins a projection to an already-constructed Projector.
+// It rejects a projector that owns a different projection. Prefer
+// NewProjectionHandle when constructing a new runtime; this adapter exists for
+// lifecycle code that must configure the Projector before handing it onward.
+func BindProjectionHandle[P Projection](projection P, projector *Projector) (ProjectionHandle[P], error) {
+	if projector == nil {
+		return ProjectionHandle[P]{}, fmt.Errorf("projection projector is nil")
+	}
+	left := reflect.ValueOf(projection)
+	right := reflect.ValueOf(projector.proj)
+	if !left.IsValid() || !right.IsValid() ||
+		left.Type() != right.Type() ||
+		!left.Type().Comparable() ||
+		left.Interface() != right.Interface() {
+		return ProjectionHandle[P]{}, fmt.Errorf("projector owns a different projection")
+	}
+	return ProjectionHandle[P]{projection: projection, projector: projector}, nil
+}
+
+// Projection returns the typed read model owned by the handle.
+func (h ProjectionHandle[P]) Projection() P {
+	return h.projection
+}
+
+// Projector returns the replay, readiness, and failure lifecycle for
+// Projection.
+func (h ProjectionHandle[P]) Projector() *Projector {
+	return h.projector
 }
 
 // Projection is the read side. Implementations consume events from a subject

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"reflect"
 	"sort"
 	"strings"
 	"sync"
@@ -71,15 +70,26 @@ type ProjectionHandle[P Projection] struct {
 	projector  *Projector
 }
 
+// ProjectionPointer constrains handle construction to projection pointers.
+// Reference semantics ensure the projector mutates the same projection instance
+// returned to readers.
+type ProjectionPointer[T any] interface {
+	Projection
+	*T
+}
+
 // NewProjectionHandle constructs a typed projection handle and its owning
 // projector. Application-specific registration metadata and lifecycle policy
 // deliberately remain outside the handle.
-func NewProjectionHandle[P Projection](
+func NewProjectionHandle[T any, P ProjectionPointer[T]](
 	js jetstream.JetStream,
 	stream jetstream.Stream,
 	projection P,
 	logger Logger,
 ) ProjectionHandle[P] {
+	if projection == nil {
+		panic("events: projection handle requires a non-nil projection")
+	}
 	return ProjectionHandle[P]{
 		projection: projection,
 		projector:  NewProjector(js, stream, projection, logger),
@@ -90,16 +100,15 @@ func NewProjectionHandle[P Projection](
 // It rejects a projector that owns a different projection. Prefer
 // NewProjectionHandle when constructing a new runtime; this adapter exists for
 // lifecycle code that must configure the Projector before handing it onward.
-func BindProjectionHandle[P Projection](projection P, projector *Projector) (ProjectionHandle[P], error) {
+func BindProjectionHandle[T any, P ProjectionPointer[T]](projection P, projector *Projector) (ProjectionHandle[P], error) {
+	if projection == nil {
+		return ProjectionHandle[P]{}, fmt.Errorf("projection is nil")
+	}
 	if projector == nil {
 		return ProjectionHandle[P]{}, fmt.Errorf("projection projector is nil")
 	}
-	left := reflect.ValueOf(projection)
-	right := reflect.ValueOf(projector.proj)
-	if !left.IsValid() || !right.IsValid() ||
-		left.Type() != right.Type() ||
-		!left.Type().Comparable() ||
-		left.Interface() != right.Interface() {
+	owned, ok := projector.proj.(P)
+	if !ok || owned != projection {
 		return ProjectionHandle[P]{}, fmt.Errorf("projector owns a different projection")
 	}
 	return ProjectionHandle[P]{projection: projection, projector: projector}, nil

--- a/cli/internal/search/bleve/provider.go
+++ b/cli/internal/search/bleve/provider.go
@@ -14,19 +14,22 @@ import (
 
 // Provider exposes a projection through the provider-neutral NATS contract.
 type Provider struct {
-	Projection *Projection
-	Projector  *events.Projector
+	projection events.ProjectionHandle[*Projection]
+}
+
+func newProvider(projection events.ProjectionHandle[*Projection]) *Provider {
+	return &Provider{projection: projection}
 }
 
 func (p *Provider) Query(ctx context.Context, request *searchv1.QueryRequest) (*searchv1.QueryResponse, error) {
-	if p == nil || p.Projection == nil || p.Projector == nil {
+	if p == nil || p.projection.Projection() == nil || p.projection.Projector() == nil {
 		return nil, search.ErrProviderNotReady
 	}
-	status := p.Projector.Status()
+	status := p.projection.Projector().Status()
 	if !status.StartupComplete {
 		return nil, search.ErrProviderNotReady
 	}
-	response, err := p.Projection.query(ctx, request)
+	response, err := p.projection.Projection().query(ctx, request)
 	if errors.Is(err, errInvalidCursor) {
 		return nil, &search.ServiceError{Code: search.ErrorCodeInvalidArgument, Description: "invalid search cursor"}
 	}
@@ -34,12 +37,19 @@ func (p *Provider) Query(ctx context.Context, request *searchv1.QueryRequest) (*
 }
 
 func (p *Provider) GetStatus(context.Context, *searchv1.GetStatusRequest) (*searchv1.GetStatusResponse, error) {
+	if p == nil {
+		return providerStatus(nil), nil
+	}
+	return providerStatus(p.projection.Projector()), nil
+}
+
+func providerStatus(projector *events.Projector) *searchv1.GetStatusResponse {
 	state := searchv1.ProviderState_PROVIDER_STATE_STARTING
 	response := &searchv1.GetStatusResponse{State: state}
-	if p == nil || p.Projector == nil {
-		return response, nil
+	if projector == nil {
+		return response
 	}
-	status := p.Projector.Status()
+	status := projector.Status()
 	indexed := status.StartupMessages
 	response.IndexedEventCount = &indexed
 	switch {
@@ -53,5 +63,5 @@ func (p *Provider) GetStatus(context.Context, *searchv1.GetStatusRequest) (*sear
 		response.State = searchv1.ProviderState_PROVIDER_STATE_INDEXING
 		response.RetryAfter = durationpb.New(time.Second)
 	}
-	return response, nil
+	return response
 }

--- a/cli/internal/search/bleve/provider_test.go
+++ b/cli/internal/search/bleve/provider_test.go
@@ -15,6 +15,7 @@ import (
 	"hmans.de/chatto/internal/events"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	searchv1 "hmans.de/chatto/internal/pb/chatto/search/v1"
+	"hmans.de/chatto/internal/search"
 	"hmans.de/chatto/internal/testutil"
 )
 
@@ -38,6 +39,22 @@ func (p *blockingStatusProjection) Apply(*corev1.Event, uint64) error {
 	p.once.Do(func() { close(p.entered) })
 	<-p.release
 	return nil
+}
+
+func TestNewProviderKeepsProjectionRuntimeTogether(t *testing.T) {
+	projection := &Projection{}
+	handle := events.NewProjectionHandle(nil, nil, projection, log.New(io.Discard))
+	provider := newProvider(handle)
+
+	require.Same(t, projection, provider.projection.Projection())
+	require.Same(t, handle.Projector(), provider.projection.Projector())
+}
+
+func TestProviderQueryWithoutProjectionRuntimeIsNotReady(t *testing.T) {
+	response, err := (&Provider{}).Query(context.Background(), &searchv1.QueryRequest{})
+
+	require.Nil(t, response)
+	require.ErrorIs(t, err, search.ErrProviderNotReady)
 }
 
 func TestProviderStatusTransitionsFromIndexingToReady(t *testing.T) {
@@ -68,7 +85,6 @@ func TestProviderStatusTransitionsFromIndexingToReady(t *testing.T) {
 	}
 	t.Cleanup(releaseProjection)
 	projector := events.NewProjector(js, stream, projection, log.New(io.Discard))
-	provider := &Provider{Projector: projector}
 	runCtx, stop := context.WithCancel(context.Background())
 	t.Cleanup(stop)
 	go func() { _ = projector.Run(runCtx) }()
@@ -78,15 +94,14 @@ func TestProviderStatusTransitionsFromIndexingToReady(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("projection replay did not start")
 	}
-	status, err := provider.GetStatus(ctx, nil)
-	require.NoError(t, err)
+	status := providerStatus(projector)
 	require.Equal(t, searchv1.ProviderState_PROVIDER_STATE_INDEXING, status.GetState())
 	require.NotNil(t, status.GetRetryAfter())
 
 	releaseProjection()
 	require.Eventually(t, func() bool {
-		status, err = provider.GetStatus(ctx, nil)
-		return err == nil && status.GetState() == searchv1.ProviderState_PROVIDER_STATE_READY
+		status = providerStatus(projector)
+		return status.GetState() == searchv1.ProviderState_PROVIDER_STATE_READY
 	}, 2*time.Second, 10*time.Millisecond)
 	require.Nil(t, status.GetRetryAfter())
 }
@@ -110,12 +125,10 @@ func TestProviderReportsFailedInitialReplayAsUnavailable(t *testing.T) {
 	require.NoError(t, err)
 
 	projector := events.NewProjector(js, stream, &failingStatusProjection{}, log.New(io.Discard))
-	provider := &Provider{Projector: projector}
 	go func() { _ = projector.Run(ctx) }()
 
 	require.Eventually(t, func() bool { return projector.Status().Failed }, 2*time.Second, 10*time.Millisecond)
-	status, err := provider.GetStatus(ctx, nil)
-	require.NoError(t, err)
+	status := providerStatus(projector)
 	require.Equal(t, searchv1.ProviderState_PROVIDER_STATE_UNAVAILABLE, status.GetState())
 	require.Nil(t, status.GetRetryAfter())
 }
@@ -132,7 +145,6 @@ func TestProviderReportsFailureAfterStartupAsDegraded(t *testing.T) {
 	})
 	require.NoError(t, err)
 	projector := events.NewProjector(js, stream, &failingStatusProjection{}, log.New(io.Discard))
-	provider := &Provider{Projector: projector}
 	go func() { _ = projector.Run(ctx) }()
 	require.Eventually(t, func() bool { return projector.Status().StartupComplete }, 2*time.Second, 10*time.Millisecond)
 
@@ -144,7 +156,6 @@ func TestProviderReportsFailureAfterStartupAsDegraded(t *testing.T) {
 	require.NoError(t, err)
 	require.Eventually(t, func() bool { return projector.Status().Failed }, 2*time.Second, 10*time.Millisecond)
 
-	status, err := provider.GetStatus(ctx, nil)
-	require.NoError(t, err)
+	status := providerStatus(projector)
 	require.Equal(t, searchv1.ProviderState_PROVIDER_STATE_DEGRADED, status.GetState())
 }

--- a/cli/internal/search/bleve/unit.go
+++ b/cli/internal/search/bleve/unit.go
@@ -71,7 +71,7 @@ func (u Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 	if err := projector.ConfigureCheckpoint("message_search"); err != nil {
 		return err
 	}
-	provider := &Provider{Projection: projection, Projector: projector}
+	provider := newProvider(projectionHandle)
 	service, err := search.AddStartupStatusService(ctx, env.NC, provider, search.ServiceOptions{ImplementationVersion: env.Version})
 	if err != nil {
 		return fmt.Errorf("register search provider status service: %w", err)

--- a/cli/internal/search/bleve/unit.go
+++ b/cli/internal/search/bleve/unit.go
@@ -66,7 +66,8 @@ func (u Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 		"stage", "index_open",
 		"checkpoint_contract", projection.CheckpointContractID())
 
-	projector := events.NewProjector(env.JS, evt, projection, env.Logger)
+	projectionHandle := events.NewProjectionHandle(env.JS, evt, projection, env.Logger)
+	projector := projectionHandle.Projector()
 	if err := projector.ConfigureCheckpoint("message_search"); err != nil {
 		return err
 	}

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -1,0 +1,80 @@
+# ADR-056: Incubate an Extractable NATS Event-Sourcing Framework
+
+**Date:** 2026-07-30
+
+## Context
+
+[ADR-033](ADR-033-event-sourced-state-with-projections.md) deliberately chose a
+small internal Go package instead of a third-party event-sourcing framework.
+That package now owns proven NATS JetStream mechanics for mandatory OCC,
+ordered projection replay, read-your-writes barriers, failure propagation, and
+optional restore capabilities.
+
+Chatto's composition layer has also accumulated application policy around those
+mechanics: stable diagnostic keys, display names, memory estimates, snapshot
+eligibility, domain model ownership, and the concrete `corev1.Event` envelope.
+Combining those concerns into a richer Chatto-specific runtime abstraction
+would make today's wiring shorter but make a future standalone library harder
+to identify and extract.
+
+Projection-aware models additionally received projections and projectors as
+separate constructor arguments. Nothing in those signatures proved that the
+projector owned the supplied projection, so a wiring mistake could combine a
+read model with another projection's replay frontier.
+
+## Decision
+
+Treat `cli/internal/events` as the incubator for a small Event Sourcing on NATS
+framework that may later become a standalone Go module.
+
+Framework-owned responsibilities are:
+
+- OCC-only publishing and atomic append mechanics;
+- stream positions and projection readiness barriers;
+- ordered consumer, replay, startup batching, and failure lifecycles;
+- optional snapshot and local-checkpoint capability hooks; and
+- a typed `ProjectionHandle` that keeps a projection with the exact projector
+  constructed for it.
+
+Chatto-owned responsibilities remain:
+
+- the concrete event envelope, event vocabulary, subjects, and aggregate
+  choices;
+- domain projections, services, authorization, and response assembly;
+- stable registration keys, display names, admin memory estimates, and
+  diagnostic inventory;
+- snapshot enablement, repository, encryption, retention, and worker policy;
+  and
+- runtime composition in `ChattoCore`.
+
+`NewProjectionHandle` is the normal construction path. Code adapting an
+already-created projector may use `BindProjectionHandle`, which rejects a
+projector built for a different projection. Projection-aware models consume
+handles rather than parallel projection/projector arguments.
+
+This decision does not create or promise a public module yet. The current
+framework still decodes Chatto's `corev1.Event`. Before extraction, that
+dependency must become an explicit generic event or codec boundary, and
+Chatto-specific stream identity naming must move behind application-supplied
+configuration. We will make those changes only when concrete framework users
+show the smallest useful API.
+
+## Consequences
+
+Projection ownership and replay readiness can no longer be mismatched silently
+in normal wiring. Model constructors are shorter, and the reusable lifecycle
+unit is visible both in the core runtime and the independently runnable bundled
+search provider.
+
+New event-sourcing mechanics should be evaluated for `internal/events`; new
+Chatto policy should stay in `internal/core` or the owning runtime unit. This
+creates a reviewable extraction boundary without forcing premature package
+stability or generic abstractions.
+
+The handle adds one small generic API and an identity check for adapting
+existing projectors. It intentionally does not absorb registration metadata or
+snapshot policy, so some application composition remains explicit.
+
+Extraction still requires deliberate work. The framework cannot become a
+standalone module while it imports Chatto's protobuf event envelope or embeds
+Chatto-specific naming and validation assumptions.

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -49,8 +49,10 @@ Chatto-owned responsibilities remain:
 
 `NewProjectionHandle` is the normal construction path. Code adapting an
 already-created projector may use `BindProjectionHandle`, which rejects a
-projector built for a different projection. Projection-aware models consume
-handles rather than parallel projection/projector arguments.
+projector built for a different projection. Both constructors require pointer
+projection implementations so the projector and read side cannot receive
+separate value copies. Projection-aware models consume handles rather than
+parallel projection/projector arguments.
 
 This decision does not create or promise a public module yet. The current
 framework still decodes Chatto's `corev1.Event`. Before extraction, that

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -67,3 +67,4 @@ replace part of their original design.
 | [ADR-053](ADR-053-versioned-nats-service-namespaces.md) | Versioned NATS Service Namespaces | Accepted | 2026-07-20 |
 | [ADR-054](ADR-054-optional-projection-persistence.md) | Projection Persistence Is Optional | Accepted | 2026-07-20 |
 | [ADR-055](ADR-055-pluggable-message-search-over-nats.md) | Pluggable Message Search over NATS | Accepted | 2026-07-21 |
+| [ADR-056](ADR-056-extractable-nats-event-sourcing-framework.md) | Incubate an Extractable NATS Event-Sourcing Framework | Accepted | 2026-07-30 |

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -11,6 +11,13 @@ core runtime. Each registration also declares whether that same stable key is
 eligible for shared snapshots. Snapshot configuration iterates the registry
 directly rather than maintaining a parallel projector list.
 
+The framework constructs each projection and its exact projector as one typed
+`events.ProjectionHandle`. Projection-aware domain models receive those handles
+instead of parallel state/runner arguments. Chatto-specific keys, names, memory
+estimates, diagnostics, and snapshot policy remain in the core registration
+layer rather than becoming framework metadata. This boundary follows
+[ADR-056](../adr/ADR-056-extractable-nats-event-sourcing-framework.md).
+
 `ChattoCore.Run` starts one process-local ordered EVT consumer per registered
 projection. Each projector owns its physical filters, replay progress, failure
 state, and readiness. Chatto still waits for every registered projection to

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -11,12 +11,12 @@ core runtime. Each registration also declares whether that same stable key is
 eligible for shared snapshots. Snapshot configuration iterates the registry
 directly rather than maintaining a parallel projector list.
 
-The framework constructs each projection and its exact projector as one typed
-`events.ProjectionHandle`. Projection-aware domain models receive those handles
-instead of parallel state/runner arguments. Chatto-specific keys, names, memory
-estimates, diagnostics, and snapshot policy remain in the core registration
-layer rather than becoming framework metadata. This boundary follows
-[ADR-056](../adr/ADR-056-extractable-nats-event-sourcing-framework.md).
+Core couples each projection pointer to its exact projector as one typed
+`events.ProjectionHandle`. Projection-aware domain models and the bundled
+search provider retain those handles instead of parallel state/runner
+arguments. Chatto-specific keys, names, memory estimates, diagnostics, and
+snapshot policy remain in the core registration layer rather than becoming
+framework metadata. This boundary follows [ADR-056](../adr/ADR-056-extractable-nats-event-sourcing-framework.md).
 
 `ChattoCore.Run` starts one process-local ordered EVT consumer per registered
 projection. Each projector owns its physical filters, replay progress, failure

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -6,7 +6,8 @@ The core runtime is process-local but must be safe under multiple Chatto replica
 
 Related decisions: [ADR-033](../adr/ADR-033-event-sourced-state-with-projections.md),
 [ADR-041](../adr/ADR-041-runtime-units.md), and
-[ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md).
+[ADR-049](../adr/ADR-049-process-wide-realtime-event-hub.md), and
+[ADR-056](../adr/ADR-056-extractable-nats-event-sourcing-framework.md).
 
 `chatto run` composes optional runtime units from a validated catalogue. Each
 registration supplies the same `runtimeunit.Unit` used by its standalone
@@ -28,6 +29,7 @@ The core model inventory is a list of stable machine-readable keys such as `conf
 | `MyEventsModel`                  | [`my_events_model.go`](../../cli/internal/core/my_events_model.go), [`realtime_replay.go`](../../cli/internal/core/realtime_replay.go)                           | Eagerly wired `myEvents` live delivery, bounded EVT-gap planning, projection readiness, heartbeats, per-user authorization, and process-local stream counters |
 | Realtime projection assembler   | [`realtime_projection.go`](../../cli/internal/connectapi/realtime_projection.go), [`realtime_projection.go`](../../cli/internal/http_server/realtime_projection.go) | Caller-authorized compacted server state and current public projection operations derived from durable/live facts without exposing EVT payloads |
 | `events.Publisher`              | [`publisher.go`](../../cli/internal/events/publisher.go)                                                                                                       | OCC-only writes to `EVT`, including atomic batches and filter-scoped concurrency guards                                                        |
+| `events.ProjectionHandle` / `events.Projector` | [`projector.go`](../../cli/internal/events/projector.go)                                                                                         | Typed projection ownership plus ordered EVT replay, readiness, failure, snapshot, and checkpoint lifecycle; application registration policy remains outside the handle |
 | `ConfigModel`                    | [`config_model.go`](../../cli/internal/core/config_model.go), [`server_config_model.go`](../../cli/internal/core/server_config_model.go)                        | Sole core boundary for semantic server/user config reads and event writes, including `ConfigProjection` readiness                              |
 | `NotificationPreferencesModel`   | [`notification_level.go`](../../cli/internal/core/notification_level.go)                                                                                        | Operation-level notification preference API with authZ before config preference writes                                                         |
 | `MessageModel`                   | [`message_model.go`](../../cli/internal/core/message_model.go), [`messages.go`](../../cli/internal/core/messages.go)                                              | Operation-level message posting API with room/thread authZ, post validation, and read-marker side effects                                      |


### PR DESCRIPTION
## Why

Projection-aware models previously received a projection and projector as
separate arguments. That wiring could silently pair domain reads with another
projection's replay frontier, and it obscured the reusable Event Sourcing on
NATS lifecycle we ultimately want to extract.

## What changed

- add a typed `events.ProjectionHandle` that owns one non-nil projection pointer
  and its exact projector
- reject mismatched projectors when adapting existing lifecycle/test wiring
- make core projection registration and projection-aware models pass handles
  instead of parallel projection/projector values
- retain the handle through the bundled Bleve provider's readiness and query
  boundaries
- record the intended framework/application split in ADR-056 and update the
  runtime architecture inventory

Chatto-specific registration keys, diagnostics, snapshot policy, domain
projections, event vocabulary, and runtime composition remain outside the
framework primitive.

## Compatibility and operations

This is an internal refactor. It does not change public APIs, durable event
payloads, subjects, OCC semantics, replay/readiness behaviour, snapshot
contracts or policy, configuration, or deployment requirements.

## Test plan

- `mise test-cli`
- `mise lint`
- `mise license-check`
- `mise x -- go test -race ./internal/events ./internal/search/bleve -run 'ProjectionHandle|BindProjectionHandle|NewProvider|ProviderQuery' -count=1 -timeout=180s`
- `git diff --check origin/main...`

Architecture: [ADR-056](docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md)
