### PR TITLE
refactor(frontend): unify timeline return control

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -153,6 +153,7 @@
       ? formatDayLabel(viewport.firstVisibleAt, userSettings, activeLocale)
       : null
   );
+  const reloadsTimelineOnReturn = $derived(isJumpedMode && !!onJumpToPresent);
 
   // First apply structural timeline filtering. Tombstone expiry is a separate
   // stage so row removal cannot be mistaken for a newly arrived message.
@@ -811,26 +812,10 @@
 
   <TypingIndicator {typingUserIds} members={typingMembers} />
 
-  {#if isJumpedMode && !viewport.shouldScrollToBottom && onJumpToPresent}
+  {#if !viewport.shouldScrollToBottom && (reloadsTimelineOnReturn || !alwaysScrollToBottom)}
     <button
       transition:fade={{ duration: 150 }}
-      onclick={handleJumpToPresentClick}
-      data-testid="jump-to-present"
-      class="absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer menu whitespace-nowrap"
-    >
-      <div class="flex items-center gap-2 menu-section px-3 py-1">
-        {#if firstVisibleDate}
-          <span class="text-muted">{firstVisibleDate}</span>
-          <span class="text-muted/40">|</span>
-        {/if}
-        <span>{m['room.jump_to_present']()}</span>
-        <span class="iconify uil--arrow-down"></span>
-      </div>
-    </button>
-  {:else if !alwaysScrollToBottom && !viewport.shouldScrollToBottom}
-    <button
-      transition:fade={{ duration: 150 }}
-      onclick={scrollToBottom}
+      onclick={reloadsTimelineOnReturn ? handleJumpToPresentClick : scrollToBottom}
       data-testid="jump-to-present"
       class="absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer menu whitespace-nowrap"
     >
@@ -840,7 +825,7 @@
           <span class="text-muted/40">|</span>
         {/if}
         <span>
-          {viewport.hasNewMessages
+          {!reloadsTimelineOnReturn && viewport.hasNewMessages
             ? m['room.unread_separator']()
             : m['room.jump_to_present']()}
         </span>


### PR DESCRIPTION
## Why

The message timeline maintained two complete render branches for the same
floating return control. They differed only in which existing action ran and
whether the label said “New messages” or “Jump to Present”.

Keeping the decision separate from the shared presentation removes duplication
from an interaction used throughout rooms, DMs, and threads.

## What changed

- replaced the duplicated return-control markup with one rendering path
- derived whether the control must reload the latest timeline window
- preserved the existing visibility rules, callback selection, labels,
  first-visible-date display, transition, styling, and test selector

The production frontend is 15 lines smaller. This is frontend-only and has no
API, persistence, migration, rollout, security, operational, documentation, or
user-visible copy impact.

## Test plan

- Svelte autofixer on both inspected Svelte components (no issues)
- focused `EventList.svelte.spec.ts`: 8 tests passed
- targeted Playwright:
  - `does not auto-scroll when user is scrolled up viewing history`
  - `Jump to Present returns to latest messages`
- `mise lint-frontend`: zero errors and warnings
- `mise test-frontend`: 302 files and 2,551 tests passed
- `mise knip`: completed with existing repository findings only
- `mise license-check`: passed
- independent review: no significant findings after the final pass

