### PR TITLE
refactor(frontend): unify voice call controls

### DIFF
--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -33,6 +33,7 @@ to the user settings page for the active server.
   import UserAvatar from './UserAvatar.svelte';
   import UserCustomStatusBadge from './UserCustomStatusBadge.svelte';
   import UserCustomStatusEditor from './UserCustomStatusEditor.svelte';
+  import VoiceCallControlButton from './voice/VoiceCallControlButton.svelte';
 
   const connection = useConnection();
   const presenceCache = getPresenceCache();
@@ -194,98 +195,53 @@ to the user settings page for the active server.
   <div class="flex shrink-0 flex-col gap-1 p-2">
     {#if activeCallRoomId && voiceCallState}
       <div class="grid min-w-0 grid-cols-5 gap-1.5" data-testid="current-user-call-card">
-        <button
-          type="button"
+        <VoiceCallControlButton
           class={compactCallButtonClass}
-          title={`Open ${activeCallRoomName}`}
-          aria-label={`Open ${activeCallRoomName}`}
-          data-testid="current-user-call-link"
+          label={`Open ${activeCallRoomName}`}
+          testId="current-user-call-link"
+          icon="uil--phone"
+          iconClass="text-action"
           onclick={openActiveCallRoom}
-        >
-          <span class="iconify text-action uil--phone" aria-hidden="true"></span>
-        </button>
-        <button
-          type="button"
+        />
+        <VoiceCallControlButton
           class={voiceCallState.isMuted ? compactCallButtonClass : compactCallActiveButtonClass}
-          title={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
-          aria-label={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
-          data-testid="current-user-call-mute"
+          label={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
+          testId="current-user-call-mute"
+          icon={voiceCallState.isMuted ? 'uil--microphone-slash' : 'uil--microphone'}
           onclick={() => voiceCallState.toggleMute()}
-          disabled={voiceCallState.isMicrophonePending}
-          aria-busy={voiceCallState.isMicrophonePending || undefined}
-        >
-          {#if voiceCallState.isMicrophonePending}
-            <span class="iconify animate-spin uil--spinner" aria-hidden="true"></span>
-          {:else}
-            <span
-              class={[
-                'iconify',
-                voiceCallState.isMuted ? 'uil--microphone-slash' : 'uil--microphone'
-              ]}
-              aria-hidden="true"
-            ></span>
-          {/if}
-        </button>
-        <button
-          type="button"
+          pending={voiceCallState.isMicrophonePending}
+        />
+        <VoiceCallControlButton
           class={voiceCallState.isCameraEnabled
             ? compactCallActiveButtonClass
             : compactCallButtonClass}
-          title={voiceCallState.isCameraEnabled
+          label={voiceCallState.isCameraEnabled
             ? m['voice.turn_off_camera']()
             : m['voice.turn_on_camera']()}
-          aria-label={voiceCallState.isCameraEnabled
-            ? m['voice.turn_off_camera']()
-            : m['voice.turn_on_camera']()}
-          data-testid="current-user-call-camera"
+          testId="current-user-call-camera"
+          icon={voiceCallState.isCameraEnabled ? 'uil--video' : 'uil--video-slash'}
           onclick={() => voiceCallState.toggleCamera()}
-          disabled={voiceCallState.isCameraPending}
-          aria-busy={voiceCallState.isCameraPending || undefined}
-        >
-          {#if voiceCallState.isCameraPending}
-            <span class="iconify animate-spin uil--spinner" aria-hidden="true"></span>
-          {:else}
-            <span
-              class={[
-                'iconify',
-                voiceCallState.isCameraEnabled ? 'uil--video' : 'uil--video-slash'
-              ]}
-              aria-hidden="true"
-            ></span>
-          {/if}
-        </button>
-        <button
-          type="button"
+          pending={voiceCallState.isCameraPending}
+        />
+        <VoiceCallControlButton
           class={voiceCallState.isScreenShareEnabled
             ? compactCallActiveButtonClass
             : compactCallButtonClass}
-          title={voiceCallState.isScreenShareEnabled
+          label={voiceCallState.isScreenShareEnabled
             ? m['voice.stop_share_screen']()
             : m['voice.share_screen']()}
-          aria-label={voiceCallState.isScreenShareEnabled
-            ? m['voice.stop_share_screen']()
-            : m['voice.share_screen']()}
-          data-testid="current-user-call-screen-share"
+          testId="current-user-call-screen-share"
+          icon="uil--desktop"
           onclick={() => voiceCallState.toggleScreenShare()}
-          disabled={voiceCallState.isScreenSharePending}
-          aria-busy={voiceCallState.isScreenSharePending || undefined}
-        >
-          {#if voiceCallState.isScreenSharePending}
-            <span class="iconify animate-spin uil--spinner" aria-hidden="true"></span>
-          {:else}
-            <span class="iconify uil--desktop" aria-hidden="true"></span>
-          {/if}
-        </button>
-        <button
-          type="button"
+          pending={voiceCallState.isScreenSharePending}
+        />
+        <VoiceCallControlButton
           class={compactCallDangerButtonClass}
-          title={m['voice.leave']()}
-          aria-label={m['voice.leave']()}
-          data-testid="current-user-call-leave"
+          label={m['voice.leave']()}
+          testId="current-user-call-leave"
+          icon="uil--phone-slash"
           onclick={() => voiceCallState.leave()}
-        >
-          <span class="iconify uil--phone-slash" aria-hidden="true"></span>
-        </button>
+        />
       </div>
     {/if}
 

--- a/apps/frontend/src/lib/components/voice/VoiceCallControlButton.svelte
+++ b/apps/frontend/src/lib/components/voice/VoiceCallControlButton.svelte
@@ -1,0 +1,43 @@
+<!--
+@component
+
+Shared icon button for the call panel and persistent current-user call controls.
+Keeps labels, pending state, and icon presentation consistent across both surfaces.
+-->
+<script lang="ts">
+  import type { MouseEventHandler } from 'svelte/elements';
+
+  let {
+    label,
+    testId,
+    icon,
+    class: className,
+    iconClass,
+    pending = false,
+    onclick
+  }: {
+    label: string;
+    testId: string;
+    icon: string;
+    class: string;
+    iconClass?: string;
+    pending?: boolean;
+    onclick: MouseEventHandler<HTMLButtonElement>;
+  } = $props();
+</script>
+
+<button
+  type="button"
+  class={className}
+  title={label}
+  aria-label={label}
+  data-testid={testId}
+  {onclick}
+  disabled={pending}
+  aria-busy={pending || undefined}
+>
+  <span
+    class={['iconify', iconClass, pending ? 'animate-spin uil--spinner' : icon]}
+    aria-hidden="true"
+  ></span>
+</button>

--- a/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -27,6 +27,7 @@ Room sidebar panel for voice/video calls.
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import VideoThumbnail from './VideoThumbnail.svelte';
   import AudioDeviceMenu from './AudioDeviceMenu.svelte';
+  import VoiceCallControlButton from './VoiceCallControlButton.svelte';
   import CallTileActionButton from './CallTileActionButton.svelte';
   import CallTileActionToolbar from './CallTileActionToolbar.svelte';
   import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
@@ -572,100 +573,59 @@ Room sidebar panel for voice/video calls.
   {#if isInThisCall}
     <div class={isStageLayout ? 'mx-auto max-w-2xl' : ''}>
       <div class="grid grid-cols-5 gap-2">
-        <button
-          type="button"
+        <VoiceCallControlButton
           class={controlButtonClass}
-          title={m['voice.devices']()}
-          aria-label={m['voice.devices']()}
-          data-testid="call-device-menu-button"
+          label={m['voice.devices']()}
+          testId="call-device-menu-button"
+          icon="uil--setting"
+          iconClass="text-lg"
           onclick={openDeviceMenu}
-        >
-          <span class="iconify text-lg uil--setting" aria-hidden="true"></span>
-        </button>
+        />
 
-        <button
-          type="button"
+        <VoiceCallControlButton
           class={voiceCallState.isCameraEnabled ? activeControlButtonClass : controlButtonClass}
-          title={voiceCallState.isCameraEnabled
+          label={voiceCallState.isCameraEnabled
             ? m['voice.turn_off_camera']()
             : m['voice.turn_on_camera']()}
-          aria-label={voiceCallState.isCameraEnabled
-            ? m['voice.turn_off_camera']()
-            : m['voice.turn_on_camera']()}
-          data-testid="call-camera-toggle"
+          testId="call-camera-toggle"
+          icon={voiceCallState.isCameraEnabled ? 'uil--video' : 'uil--video-slash'}
+          iconClass="text-lg"
           onclick={() => voiceCallState.toggleCamera()}
-          disabled={voiceCallState.isCameraPending}
-          aria-busy={voiceCallState.isCameraPending || undefined}
-        >
-          {#if voiceCallState.isCameraPending}
-            <span class="iconify animate-spin text-lg uil--spinner" aria-hidden="true"></span>
-          {:else}
-            <span
-              class={[
-                'iconify text-lg',
-                voiceCallState.isCameraEnabled ? 'uil--video' : 'uil--video-slash'
-              ]}
-              aria-hidden="true"
-            ></span>
-          {/if}
-        </button>
+          pending={voiceCallState.isCameraPending}
+        />
 
-        <button
-          type="button"
+        <VoiceCallControlButton
           class={voiceCallState.isMuted ? controlButtonClass : activeControlButtonClass}
-          title={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
-          aria-label={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
-          data-testid="call-mute-toggle"
+          label={voiceCallState.isMuted ? m['voice.unmute']() : m['voice.mute']()}
+          testId="call-mute-toggle"
+          icon={voiceCallState.isMuted ? 'uil--microphone-slash' : 'uil--microphone'}
+          iconClass="text-lg"
           onclick={() => voiceCallState.toggleMute()}
-          disabled={voiceCallState.isMicrophonePending}
-          aria-busy={voiceCallState.isMicrophonePending || undefined}
-        >
-          {#if voiceCallState.isMicrophonePending}
-            <span class="iconify animate-spin text-lg uil--spinner" aria-hidden="true"></span>
-          {:else}
-            <span
-              class={[
-                'iconify text-lg',
-                voiceCallState.isMuted ? 'uil--microphone-slash' : 'uil--microphone'
-              ]}
-              aria-hidden="true"
-            ></span>
-          {/if}
-        </button>
+          pending={voiceCallState.isMicrophonePending}
+        />
 
-        <button
-          type="button"
+        <VoiceCallControlButton
           class={voiceCallState.isScreenShareEnabled
             ? activeControlButtonClass
             : controlButtonClass}
-          title={voiceCallState.isScreenShareEnabled
+          label={voiceCallState.isScreenShareEnabled
             ? m['voice.stop_share_screen']()
             : m['voice.share_screen']()}
-          aria-label={voiceCallState.isScreenShareEnabled
-            ? m['voice.stop_share_screen']()
-            : m['voice.share_screen']()}
-          data-testid="call-screen-share-toggle"
+          testId="call-screen-share-toggle"
+          icon="uil--desktop"
+          iconClass="text-lg"
           onclick={() => voiceCallState.toggleScreenShare()}
-          disabled={voiceCallState.isScreenSharePending}
-          aria-busy={voiceCallState.isScreenSharePending || undefined}
-        >
-          {#if voiceCallState.isScreenSharePending}
-            <span class="iconify animate-spin text-lg uil--spinner" aria-hidden="true"></span>
-          {:else}
-            <span class="iconify text-lg uil--desktop" aria-hidden="true"></span>
-          {/if}
-        </button>
+          pending={voiceCallState.isScreenSharePending}
+        />
 
-        <button
-          type="button"
+        <VoiceCallControlButton
           class={dangerControlButtonClass}
           onclick={() => voiceCallState.leave()}
-          title={m['voice.leave']()}
-          aria-label={m['voice.leave']()}
-          data-testid="call-leave-button"
-        >
-          <span class="iconify text-lg uil--phone-slash" aria-hidden="true"></span>
-        </button>
+          label={m['voice.leave']()}
+          testId="call-leave-button"
+          icon="uil--phone-slash"
+          iconClass="text-lg"
+        />
       </div>
     </div>
   {:else}


### PR DESCRIPTION
## Why

The main call panel and persistent current-user bar independently implemented
the same icon-button contract for voice-call controls. That duplicated labels,
accessibility attributes, test hooks, pending state, spinners, and icon markup
across ten buttons.

A focused shared component keeps those semantics consistent while leaving each
surface in control of layout, active-state styling, and call actions.

## What changed

- added a voice-specific `VoiceCallControlButton` for the shared native-button
  contract
- reused it for device, mute, camera, screen-share, open-call, and leave
  controls across both existing surfaces
- preserved every label, test ID, handler, semantic class, icon and icon size,
  pending spinner, disabled state, and `aria-busy` value

The production frontend is 41 lines smaller. This is a frontend-only refactor
with no user-visible redesign, copy, API, persistence, compatibility,
migration, rollout, security, operational, or documentation impact.

## Test plan

- Svelte autofixer on all three changed components: no issues or suggestions
- focused component tests: 2 files and 52 tests passed
- `mise lint-frontend`: design-system guardrails and ESLint passed; Svelte
  reported 0 errors and 0 warnings
- `mise test-frontend`: 302 files and 2,551 tests passed
- production frontend build passed; generated CSS retains every extracted
  call-control icon
- `mise knip`: completed with existing repository findings only
- `mise license-check`: passed
- `git diff --check`: passed
- independent adversarial review: no findings
- GitHub Actions: all required checks passed; the frontend-unit job passed on
  rerun after an unrelated Vidstack HLS teardown rejection occurred after all
  2,551 tests had passed on the first attempt
