### PR TITLE
refactor(events): make stream identity application-owned

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -105,7 +105,9 @@ authorization, live events, backup/restore, and backend tests.
   projector restore mechanics receive an application resolver and treat its
   result as an opaque, non-empty value. Resolve identity from the same fresh
   `StreamInfo` as restore sequence bounds; framework code must not impose
-  Chatto's metadata key or identity syntax.
+  Chatto's metadata key or identity syntax. Bind the resolved identity to the
+  projector run, capture it with snapshot state and cutoff, and publish that
+  captured value rather than caching an identity separately in worker wiring.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -108,6 +108,8 @@ authorization, live events, backup/restore, and backend tests.
   Chatto's metadata key or identity syntax. Bind the resolved identity to the
   projector run, capture it with snapshot state and cutoff, and publish that
   captured value rather than caching an identity separately in worker wiring.
+  Check identity immediately before and after the capture barrier; never hold
+  the projection apply barrier across NATS or other external I/O.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -100,6 +100,11 @@ authorization, live events, backup/restore, and backend tests.
   as the stream name and cutoff sequence; reject missing, corrupt,
   incompatible, or future snapshots by replaying EVT. Do not use
   `StreamInfo.Created` as a persisted identity.
+- Keep Chatto's EVT incarnation metadata key, generation, format validation,
+  and lookup in `internal/evtstream` or application composition. Reusable
+  projector and persistence mechanics receive that identity as an opaque,
+  non-empty value and must not discover it from JetStream metadata or impose
+  Chatto's identity syntax.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -102,9 +102,10 @@ authorization, live events, backup/restore, and backend tests.
   `StreamInfo.Created` as a persisted identity.
 - Keep Chatto's EVT incarnation metadata key, generation, format validation,
   and lookup in `internal/evtstream` or application composition. Reusable
-  projector and persistence mechanics receive that identity as an opaque,
-  non-empty value and must not discover it from JetStream metadata or impose
-  Chatto's identity syntax.
+  projector restore mechanics receive an application resolver and treat its
+  result as an opaque, non-empty value. Resolve identity from the same fresh
+  `StreamInfo` as restore sequence bounds; framework code must not impose
+  Chatto's metadata key or identity syntax.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/cmd/backup_test.go
+++ b/cli/cmd/backup_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/nats-io/nats-server/v2/server"
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/jetstreamutil"
 	"hmans.de/chatto/internal/projectionsnapshot"
 	"hmans.de/chatto/internal/testutil"
@@ -438,7 +438,7 @@ func TestBackupRestoreRoundTrip(t *testing.T) {
 		Subjects: []string{"events.>"},
 		Storage:  jetstream.FileStorage,
 		Metadata: map[string]string{
-			events.EVTStreamIdentityMetadataKey: "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+			evtstream.IdentityMetadataKey: "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		},
 	})
 	if err != nil {
@@ -648,7 +648,7 @@ func TestBackupRestoreRoundTrip(t *testing.T) {
 	if info.State.Msgs != uint64(len(testMessages)) {
 		t.Errorf("Stream has %d messages, want %d", info.State.Msgs, len(testMessages))
 	}
-	if got := info.Config.Metadata[events.EVTStreamIdentityMetadataKey]; got != "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
+	if got := info.Config.Metadata[evtstream.IdentityMetadataKey]; got != "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" {
 		t.Errorf("Restored EVT stream identity = %q", got)
 	}
 

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -21,6 +21,7 @@ import (
 	"hmans.de/chatto/internal/core/linkpreview"
 	"hmans.de/chatto/internal/dekstore"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/kms"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
@@ -1186,16 +1187,16 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	if err != nil {
 		return nil, fmt.Errorf("failed to create EVT stream: %w", err)
 	}
-	if !events.ValidStreamIdentity(evtConfig.Metadata[events.EVTStreamIdentityMetadataKey]) {
+	if !evtstream.ValidIdentity(evtConfig.Metadata[evtstream.IdentityMetadataKey]) {
 		info := serverEvtStream.CachedInfo()
 		if info == nil {
 			return nil, fmt.Errorf("created EVT stream info is unavailable")
 		}
-		identity, identityErr := events.NewStreamIdentity(info.Created)
+		identity, identityErr := evtstream.NewIdentity(info.Created)
 		if identityErr != nil {
 			return nil, identityErr
 		}
-		evtConfig.Metadata[events.EVTStreamIdentityMetadataKey] = identity
+		evtConfig.Metadata[evtstream.IdentityMetadataKey] = identity
 		serverEvtStream, err = createJetStreamResourceWithRetry(ctx, func(ctx context.Context) (jetstream.Stream, error) {
 			return js.CreateOrUpdateStream(ctx, evtConfig)
 		})
@@ -1230,7 +1231,7 @@ func prepareEVTStreamMetadata(ctx context.Context, js jetstream.JetStream) (map[
 	case err != nil:
 		return nil, fmt.Errorf("open existing EVT stream: %w", err)
 	}
-	if events.ValidStreamIdentity(metadata[events.EVTStreamIdentityMetadataKey]) {
+	if evtstream.ValidIdentity(metadata[evtstream.IdentityMetadataKey]) {
 		return metadata, nil
 	}
 	if stream == nil {
@@ -1239,11 +1240,11 @@ func prepareEVTStreamMetadata(ctx context.Context, js jetstream.JetStream) (map[
 	if stream.CachedInfo() == nil {
 		return nil, fmt.Errorf("existing EVT stream info is unavailable")
 	}
-	identity, err := events.NewStreamIdentity(stream.CachedInfo().Created)
+	identity, err := evtstream.NewIdentity(stream.CachedInfo().Created)
 	if err != nil {
 		return nil, err
 	}
-	metadata[events.EVTStreamIdentityMetadataKey] = identity
+	metadata[evtstream.IdentityMetadataKey] = identity
 	return metadata, nil
 }
 

--- a/cli/internal/core/core_infrastructure.go
+++ b/cli/internal/core/core_infrastructure.go
@@ -12,6 +12,7 @@ import (
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/dekstore"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/kms"
 	"hmans.de/chatto/internal/projectionsnapshot"
 )
@@ -154,7 +155,7 @@ func initializeProjectionSnapshotRepository(
 		return nil, ""
 	}
 
-	streamIdentity, err := events.StreamIdentity(storage.serverEvtStream)
+	streamIdentity, err := evtstream.Identity(storage.serverEvtStream)
 	if err != nil {
 		logger.Warn("Projection snapshots disabled after EVT identity read failure",
 			"stage", "stream_identity",

--- a/cli/internal/core/core_infrastructure.go
+++ b/cli/internal/core/core_infrastructure.go
@@ -20,14 +20,13 @@ import (
 // coreInfrastructure contains the storage and event-sourcing primitives that
 // must exist before projections and domain services can be constructed.
 type coreInfrastructure struct {
-	js                     jetstream.JetStream
-	storage                *storage
-	encryption             *encryptionManager
-	dekResolver            *unwrappedDEKResolver
-	s3Client               *S3Client
-	eventPublisher         *events.Publisher
-	snapshotRepository     *projectionsnapshot.Repository
-	snapshotStreamIdentity string
+	js                 jetstream.JetStream
+	storage            *storage
+	encryption         *encryptionManager
+	dekResolver        *unwrappedDEKResolver
+	s3Client           *S3Client
+	eventPublisher     *events.Publisher
+	snapshotRepository *projectionsnapshot.Repository
 }
 
 func initializeCoreInfrastructure(
@@ -59,7 +58,7 @@ func initializeCoreInfrastructure(
 		return nil, err
 	}
 
-	snapshotRepository, snapshotStreamIdentity := initializeProjectionSnapshotRepository(
+	snapshotRepository := initializeProjectionSnapshotRepository(
 		ctx,
 		js,
 		storage,
@@ -70,14 +69,13 @@ func initializeCoreInfrastructure(
 	dekResolver := newUnwrappedDEKResolver(encryption.keyWrapper, encryption.contentKeys)
 
 	return &coreInfrastructure{
-		js:                     js,
-		storage:                storage,
-		encryption:             encryption,
-		dekResolver:            dekResolver,
-		s3Client:               s3Client,
-		eventPublisher:         events.NewPublisher(js, storage.serverEvtStream, logger),
-		snapshotRepository:     snapshotRepository,
-		snapshotStreamIdentity: snapshotStreamIdentity,
+		js:                 js,
+		storage:            storage,
+		encryption:         encryption,
+		dekResolver:        dekResolver,
+		s3Client:           s3Client,
+		eventPublisher:     events.NewPublisher(js, storage.serverEvtStream, logger),
+		snapshotRepository: snapshotRepository,
 	}, nil
 }
 
@@ -113,9 +111,9 @@ func initializeProjectionSnapshotRepository(
 	s3Client *S3Client,
 	cfg config.CoreConfig,
 	logger *log.Logger,
-) (*projectionsnapshot.Repository, string) {
+) *projectionsnapshot.Repository {
 	if !cfg.ProjectionSnapshots {
-		return nil, ""
+		return nil
 	}
 
 	var snapshotBlobs projectionsnapshot.BlobStore
@@ -137,7 +135,7 @@ func initializeProjectionSnapshotRepository(
 				"backend", "nats",
 				"stage", "storage_initialize",
 				"error", err)
-			return nil, ""
+			return nil
 		}
 		snapshotBlobs = natsSnapshotBlobStore{store: snapshotStore}
 	}
@@ -152,17 +150,16 @@ func initializeProjectionSnapshotRepository(
 		logger.Warn("Projection snapshots disabled after initialization failure",
 			"stage", "initialize",
 			"error", err)
-		return nil, ""
+		return nil
 	}
 
-	streamIdentity, err := evtstream.Identity(storage.serverEvtStream)
-	if err != nil {
+	if _, err := evtstream.Identity(storage.serverEvtStream); err != nil {
 		logger.Warn("Projection snapshots disabled after EVT identity read failure",
 			"stage", "stream_identity",
 			"error", err)
-		return nil, ""
+		return nil
 	}
 
 	logger.Info("Projection snapshot storage initialized", "backend", repository.Backend())
-	return repository, streamIdentity
+	return repository
 }

--- a/cli/internal/core/projection_snapshot_integration_test.go
+++ b/cli/internal/core/projection_snapshot_integration_test.go
@@ -394,6 +394,74 @@ func TestProjectionSnapshotsRejectRecreatedEVTHistory(t *testing.T) {
 	}
 }
 
+func TestProjectionSnapshotsPublishIdentityBoundToRecreatedEVT(t *testing.T) {
+	_, nc := testutil.StartNATS(t)
+	ctx := testContext(t)
+	cfg := config.CoreConfig{
+		SecretKey: "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+		Assets: config.AssetsConfig{
+			SigningSecret:  "test-signing-secret",
+			StorageBackend: config.StorageBackendNATS,
+		},
+		ProjectionSnapshots: true,
+		Version:             "snapshot-integration-test",
+	}
+
+	configuredBeforeRecreation, err := NewChattoCore(ctx, nc, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalIdentity, err := evtstream.Identity(configuredBeforeRecreation.storage.serverEvtStream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := configuredBeforeRecreation.js.DeleteStream(ctx, "EVT"); err != nil {
+		t.Fatal(err)
+	}
+
+	recreator, err := NewChattoCore(ctx, nc, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recreatedIdentity, err := evtstream.Identity(recreator.storage.serverEvtStream)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recreatedIdentity == originalIdentity {
+		t.Fatal("recreated EVT stream reused its prior identity")
+	}
+	for _, event := range []*corev1.Event{
+		threadCreatedEvent("THREAD-CREATED", "R1", "ROOT", "U1", 1),
+		postedEvent(postedOpts{envelopeID: "REPLY-1", eventID: "REPLY-1", roomID: "R1", actorID: "U2", inThread: "ROOT", at: 2}),
+	} {
+		if _, err := recreator.EventPublisher.AppendEventually(ctx, events.RoomAggregate("R1").SubjectFor(event), event); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	stopConfigured := startSnapshotTestCore(t, configuredBeforeRecreation)
+	select {
+	case <-configuredBeforeRecreation.projectionSnapshotWorker.done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshot worker did not publish recreated-stream state")
+	}
+	stopConfigured()
+
+	verifier, err := NewChattoCore(ctx, nc, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopVerifier := startSnapshotTestCore(t, verifier)
+	defer stopVerifier()
+	status := registeredProjector(t, verifier, projectionsnapshot.ProjectionThreadsKey).Status()
+	if !status.SnapshotRestored || status.SnapshotCutoffSeq == 0 {
+		t.Fatalf("Thread projector did not restore recreated-stream snapshot: %#v", status)
+	}
+	if got := timelineEventIDs(verifier.roomModel.threadEvents("ROOT")); !slices.Equal(got, []string{"REPLY-1"}) {
+		t.Fatalf("restored Thread events = %v", got)
+	}
+}
+
 func TestConcurrentCoreInitializationConvergesOnEVTIdentity(t *testing.T) {
 	_, nc := testutil.StartNATS(t)
 	ctx := testContext(t)

--- a/cli/internal/core/projection_snapshot_integration_test.go
+++ b/cli/internal/core/projection_snapshot_integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"hmans.de/chatto/internal/config"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/projectionsnapshot"
 	"hmans.de/chatto/internal/testutil"
@@ -63,7 +64,7 @@ func TestProjectionSnapshotsPersistAndRestoreCohort(t *testing.T) {
 			t.Fatalf("snapshot object %q leaked into shared SERVER_ASSETS: %v", name, err)
 		}
 	}
-	firstIdentity, err := events.StreamIdentity(first.storage.serverEvtStream)
+	firstIdentity, err := evtstream.Identity(first.storage.serverEvtStream)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +82,7 @@ func TestProjectionSnapshotsPersistAndRestoreCohort(t *testing.T) {
 	}
 	stopSecond := startSnapshotTestCore(t, second)
 	t.Cleanup(stopSecond)
-	secondIdentity, err := events.StreamIdentity(second.storage.serverEvtStream)
+	secondIdentity, err := evtstream.Identity(second.storage.serverEvtStream)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -359,7 +360,7 @@ func TestProjectionSnapshotsRejectRecreatedEVTHistory(t *testing.T) {
 	}
 	stopFirst := startSnapshotTestCore(t, first)
 	waitForSnapshotObjects(t, ctx, first, 1)
-	firstIdentity, err := events.StreamIdentity(first.storage.serverEvtStream)
+	firstIdentity, err := evtstream.Identity(first.storage.serverEvtStream)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -372,7 +373,7 @@ func TestProjectionSnapshotsRejectRecreatedEVTHistory(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	recreatedIdentity, err := events.StreamIdentity(recreated.storage.serverEvtStream)
+	recreatedIdentity, err := evtstream.Identity(recreated.storage.serverEvtStream)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +426,7 @@ func TestConcurrentCoreInitializationConvergesOnEVTIdentity(t *testing.T) {
 	}
 	identities := make([]string, 0, len(cores))
 	for _, core := range cores {
-		identity, err := events.StreamIdentity(core.storage.serverEvtStream)
+		identity, err := evtstream.Identity(core.storage.serverEvtStream)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -439,7 +440,7 @@ func TestConcurrentCoreInitializationConvergesOnEVTIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	thirdIdentity, err := events.StreamIdentity(third.storage.serverEvtStream)
+	thirdIdentity, err := evtstream.Identity(third.storage.serverEvtStream)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cli/internal/core/projection_snapshot_worker.go
+++ b/cli/internal/core/projection_snapshot_worker.go
@@ -29,11 +29,10 @@ const (
 )
 
 type projectionSnapshotJob struct {
-	projector      *events.Projector
-	repository     *projectionsnapshot.Repository
-	projectionKey  string
-	streamName     string
-	streamIdentity string
+	projector     *events.Projector
+	repository    *projectionsnapshot.Repository
+	projectionKey string
+	streamName    string
 }
 
 type projectionSnapshotWorker struct {
@@ -212,7 +211,7 @@ func (w *projectionSnapshotWorker) generateJob(ctx context.Context, job projecti
 			"refresh_age", projectionSnapshotRefreshAge)
 		return nil
 	}
-	captured, err := job.projector.CaptureSnapshot()
+	captured, err := job.projector.CaptureSnapshot(ctx)
 	if err != nil {
 		return fmt.Errorf("capture projection snapshot: %w", err)
 	}
@@ -223,7 +222,7 @@ func (w *projectionSnapshotWorker) generateJob(ctx context.Context, job projecti
 		ProjectionKey:  job.projectionKey,
 		ContractID:     job.projector.SnapshotContractID(),
 		StreamName:     job.streamName,
-		StreamIdentity: job.streamIdentity,
+		StreamIdentity: captured.StreamIdentity,
 		CutoffSequence: captured.CutoffSequence,
 		Payload:        captured.Payload,
 		RefreshAge:     projectionSnapshotRefreshAge,

--- a/cli/internal/core/projection_wiring.go
+++ b/cli/internal/core/projection_wiring.go
@@ -8,6 +8,7 @@ import (
 	"github.com/charmbracelet/log"
 
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/projectionsnapshot"
 )
 
@@ -234,7 +235,7 @@ func configureProjectionSnapshots(
 		if err := registration.projector.ConfigureSnapshots(
 			registration.key,
 			projectionSnapshotSource{repository: infra.snapshotRepository},
-			infra.snapshotStreamIdentity,
+			evtstream.IdentityFromInfo,
 		); err != nil {
 			return fmt.Errorf("configure %s projection snapshots: %w", registration.key, err)
 		}

--- a/cli/internal/core/projection_wiring.go
+++ b/cli/internal/core/projection_wiring.go
@@ -240,11 +240,10 @@ func configureProjectionSnapshots(
 			return fmt.Errorf("configure %s projection snapshots: %w", registration.key, err)
 		}
 		projections.snapshotJobs = append(projections.snapshotJobs, projectionSnapshotJob{
-			projector:      registration.projector,
-			repository:     infra.snapshotRepository,
-			projectionKey:  registration.key,
-			streamName:     streamName,
-			streamIdentity: infra.snapshotStreamIdentity,
+			projector:     registration.projector,
+			repository:    infra.snapshotRepository,
+			projectionKey: registration.key,
+			streamName:    streamName,
 		})
 		registration.snapshotEnabled = true
 	}

--- a/cli/internal/core/realtime_replay.go
+++ b/cli/internal/core/realtime_replay.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/publiccursor"
 )
@@ -68,7 +69,7 @@ type RealtimeReplayPlan struct {
 // RealtimeCursorForSequence returns the opaque public cursor for one durable
 // EVT delivery sequence.
 func (c *ChattoCore) RealtimeCursorForSequence(userID string, sequence uint64) (string, error) {
-	identity, err := events.StreamIdentity(c.storage.serverEvtStream)
+	identity, err := evtstream.Identity(c.storage.serverEvtStream)
 	if err != nil {
 		return "", fmt.Errorf("read EVT stream identity: %w", err)
 	}
@@ -90,7 +91,7 @@ func (c *ChattoCore) RealtimeCursorAtCurrentBoundary(ctx context.Context, userID
 		// safe compacted reset.
 		return false, nil
 	}
-	identity, err := events.StreamIdentity(c.storage.serverEvtStream)
+	identity, err := evtstream.Identity(c.storage.serverEvtStream)
 	if err != nil {
 		return false, fmt.Errorf("read EVT stream identity: %w", err)
 	}
@@ -113,7 +114,7 @@ func (c *ChattoCore) RealtimeCursorAtCurrentBoundary(ctx context.Context, userID
 // It is suitable for reconnect gaps, not bulk event-log export.
 func (c *ChattoCore) PlanRealtimeReplay(ctx context.Context, userID, resumeCursor string) (RealtimeReplayPlan, error) {
 	stream := c.storage.serverEvtStream
-	identity, err := events.StreamIdentity(stream)
+	identity, err := evtstream.Identity(stream)
 	if err != nil {
 		return RealtimeReplayPlan{}, fmt.Errorf("read EVT stream identity: %w", err)
 	}
@@ -311,7 +312,7 @@ func (c *ChattoCore) encodeRealtimeCursor(userID, streamIdentity string, sequenc
 }
 
 func (c *ChattoCore) encodeRealtimeCursorAt(userID, streamIdentity string, sequence uint64, now time.Time) (string, error) {
-	if userID == "" || !events.ValidStreamIdentity(streamIdentity) {
+	if userID == "" || !evtstream.ValidIdentity(streamIdentity) {
 		return "", ErrRealtimeCursorInvalid
 	}
 	payload, err := json.Marshal(realtimeCursorPayload{
@@ -341,7 +342,7 @@ func (c *ChattoCore) decodeRealtimeCursorAt(userID, cursor string, now time.Time
 		return realtimeCursorPayload{}, ErrRealtimeCursorInvalid
 	}
 	var decoded realtimeCursorPayload
-	if err := json.Unmarshal(payload, &decoded); err != nil || decoded.Version != realtimeCursorVersion || decoded.UserID != userID || decoded.IssuedAtUnix <= 0 || !events.ValidStreamIdentity(decoded.StreamIdentity) {
+	if err := json.Unmarshal(payload, &decoded); err != nil || decoded.Version != realtimeCursorVersion || decoded.UserID != userID || decoded.IssuedAtUnix <= 0 || !evtstream.ValidIdentity(decoded.StreamIdentity) {
 		return realtimeCursorPayload{}, ErrRealtimeCursorInvalid
 	}
 	issuedAt := time.Unix(decoded.IssuedAtUnix, 0)

--- a/cli/internal/core/realtime_replay_test.go
+++ b/cli/internal/core/realtime_replay_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -178,7 +179,7 @@ func TestPlanRealtimeReplayReportsRetentionResetGap(t *testing.T) {
 func TestPlanRealtimeReplayResetsForExpiredPublicCursor(t *testing.T) {
 	chatto, _ := setupTestCore(t)
 	ctx := testContext(t)
-	identity, err := events.StreamIdentity(chatto.storage.serverEvtStream)
+	identity, err := evtstream.Identity(chatto.storage.serverEvtStream)
 	if err != nil {
 		t.Fatalf("StreamIdentity: %v", err)
 	}

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -57,9 +57,6 @@ func setupTestStream(t *testing.T) (jetstream.JetStream, jetstream.Stream) {
 		Subjects:           []string{SubjectRoot + ">"},
 		Storage:            jetstream.FileStorage,
 		AllowAtomicPublish: true, // exercise AppendBatch in tests
-		Metadata: map[string]string{
-			EVTStreamIdentityMetadataKey: "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		},
 	})
 	if err != nil {
 		t.Fatalf("create test stream: %v", err)
@@ -70,11 +67,10 @@ func setupTestStream(t *testing.T) (jetstream.JetStream, jetstream.Stream) {
 
 func testStreamIdentity(t *testing.T, stream jetstream.Stream) string {
 	t.Helper()
-	identity, err := StreamIdentity(stream)
-	if err != nil {
-		t.Fatal(err)
+	if stream == nil {
+		t.Fatal("test stream is nil")
 	}
-	return identity
+	return "test-application/stream-incarnation-1"
 }
 
 // makeEvent constructs a minimal event with a UserJoinedRoom payload so
@@ -1070,7 +1066,7 @@ func TestProjectorRestoresLocalCheckpointAndReplaysTail(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = seqs[1]
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search"); err != nil {
+	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	// Configuration captures the contract before the projection can change it.
@@ -1119,7 +1115,7 @@ func TestProjectorRestoresLocalCheckpointBeyondFilteredTail(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = unrelatedSeq
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search"); err != nil {
+	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1155,7 +1151,7 @@ func TestProjectorResetsInvalidLocalCheckpoint(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.restoreErr = fmt.Errorf("%w: contract mismatch", ErrProjectionCheckpointInvalid)
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search"); err != nil {
+	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1177,7 +1173,7 @@ func TestProjectorDoesNotResetCheckpointOnOperationalRestoreFailure(t *testing.T
 	projection := newCheckpointTrackingProjection(RoomSubjectFilter())
 	projection.restoreErr = errors.New("local volume unavailable")
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search"); err != nil {
+	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 
@@ -1207,7 +1203,7 @@ func TestProjectorResetsFutureLocalCheckpoint(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = seq + 1
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search"); err != nil {
+	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1241,7 +1237,7 @@ func TestProjectorResetsCheckpointBehindRetainedEVT(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = seqs[0]
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search"); err != nil {
+	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1265,7 +1261,7 @@ func TestProjectorRejectsCompetingRestoreAuthorities(t *testing.T) {
 	identity := testStreamIdentity(t, stream)
 
 	checkpointFirst := NewProjector(js, stream, newCheckpointTrackingProjection(RoomSubjectFilter()), testLogger())
-	if err := checkpointFirst.ConfigureCheckpoint("search"); err != nil {
+	if err := checkpointFirst.ConfigureCheckpoint("search", identity); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	if err := checkpointFirst.ConfigureSnapshots("search", source, identity); err == nil {
@@ -1276,8 +1272,22 @@ func TestProjectorRejectsCompetingRestoreAuthorities(t *testing.T) {
 	if err := snapshotFirst.ConfigureSnapshots("search", source, identity); err != nil {
 		t.Fatalf("ConfigureSnapshots: %v", err)
 	}
-	if err := snapshotFirst.ConfigureCheckpoint("search"); err == nil {
+	if err := snapshotFirst.ConfigureCheckpoint("search", identity); err == nil {
 		t.Fatal("ConfigureCheckpoint succeeded after ConfigureSnapshots")
+	}
+}
+
+func TestProjectorRequiresStreamIdentityForPersistence(t *testing.T) {
+	js, stream := setupTestStream(t)
+
+	checkpoint := NewProjector(js, stream, newCheckpointTrackingProjection(RoomSubjectFilter()), testLogger())
+	if err := checkpoint.ConfigureCheckpoint("search", ""); err == nil {
+		t.Fatal("ConfigureCheckpoint accepted an empty stream identity")
+	}
+
+	snapshot := NewProjector(js, stream, newSnapshotTrackingProjection(RoomSubjectFilter()), testLogger())
+	if err := snapshot.ConfigureSnapshots("tracking", &staticSnapshotSource{}, ""); err == nil {
+		t.Fatal("ConfigureSnapshots accepted an empty stream identity")
 	}
 }
 
@@ -1330,7 +1340,7 @@ func TestProjectorsRestoreAndReplayIndependently(t *testing.T) {
 	if status.LatestSnapshotSeq != seqs[1] || !status.LatestSnapshotAt.Equal(createdAt) {
 		t.Fatalf("latest snapshot status = %#v", status)
 	}
-	if source.request.StreamName != "EVT_TEST" || !ValidStreamIdentity(source.request.StreamIdentity) || source.request.MaxCutoff != seqs[2] || source.request.ContractID != "tracking-v1" {
+	if source.request.StreamName != "EVT_TEST" || source.request.StreamIdentity != testStreamIdentity(t, stream) || source.request.MaxCutoff != seqs[2] || source.request.ContractID != "tracking-v1" {
 		t.Fatalf("snapshot load request = %#v", source.request)
 	}
 }

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -1411,6 +1411,104 @@ func TestProjectorResolvesSnapshotIdentityFromRecreatedStream(t *testing.T) {
 	}
 }
 
+func TestProjectorSnapshotPublicationRecoversAfterTransientIdentityFailure(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	pub := NewPublisher(js, stream, testLogger())
+	if _, err := pub.AppendEventually(ctx, RoomAggregate("R-transient").Subject(EventUserJoinedRoom), makeEvent("R-transient", "U1")); err != nil {
+		t.Fatal(err)
+	}
+
+	resolverCalls := 0
+	resolveIdentity := func(info *jetstream.StreamInfo) (string, error) {
+		resolverCalls++
+		if resolverCalls == 2 {
+			return "", errors.New("transient stream info failure")
+		}
+		return createdStreamIdentity(info)
+	}
+	projection := newSnapshotTrackingProjection(RoomSubjectFilter())
+	source := &staticSnapshotSource{}
+	projector := NewProjector(js, stream, projection, testLogger())
+	if err := projector.ConfigureSnapshots("tracking", source, resolveIdentity); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = projector.Run(runCtx) }()
+	waitFor(t, 2*time.Second, func() bool {
+		return projector.Status().StartupComplete
+	})
+	if projection.Count() != 1 || source.request.StreamIdentity != "" {
+		t.Fatalf("cold replay count/request = %d/%+v, want 1 and no snapshot request", projection.Count(), source.request)
+	}
+
+	captured, err := projector.CaptureSnapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantIdentity := testCreatedStreamIdentity(t, ctx, stream)
+	if captured.StreamIdentity != wantIdentity {
+		t.Fatalf("captured identity = %q, want configured fallback %q", captured.StreamIdentity, wantIdentity)
+	}
+}
+
+func TestProjectorSnapshotIdentityLookupDoesNotHoldApplyBarrier(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	identityLookupStarted := make(chan struct{})
+	releaseIdentityLookup := make(chan struct{})
+	resolverCalls := 0
+	resolveIdentity := func(info *jetstream.StreamInfo) (string, error) {
+		resolverCalls++
+		if resolverCalls == 3 {
+			close(identityLookupStarted)
+			<-releaseIdentityLookup
+		}
+		return createdStreamIdentity(info)
+	}
+
+	projection := newSnapshotTrackingProjection(RoomSubjectFilter())
+	projector := NewProjector(js, stream, projection, testLogger())
+	if err := projector.ConfigureSnapshots("tracking", &staticSnapshotSource{err: errors.New("snapshot unavailable")}, resolveIdentity); err != nil {
+		t.Fatal(err)
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = projector.Run(runCtx) }()
+	waitFor(t, 2*time.Second, func() bool {
+		return projector.Status().StartupComplete
+	})
+
+	captureDone := make(chan error, 1)
+	go func() {
+		_, err := projector.CaptureSnapshot(ctx)
+		captureDone <- err
+	}()
+	select {
+	case <-identityLookupStarted:
+	case <-ctx.Done():
+		t.Fatal("snapshot identity lookup did not start")
+	}
+
+	barrierAvailable := make(chan struct{})
+	go func() {
+		projector.applyMu.Lock()
+		projector.applyMu.Unlock()
+		close(barrierAvailable)
+	}()
+	select {
+	case <-barrierAvailable:
+	case <-time.After(time.Second):
+		t.Fatal("snapshot identity lookup held the projection apply barrier")
+	}
+	close(releaseIdentityLookup)
+	if err := <-captureDone; err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestProjectorRejectsCompetingRestoreAuthorities(t *testing.T) {
 	js, stream := setupTestStream(t)
 	source := &staticSnapshotSource{}

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -73,6 +73,57 @@ func testStreamIdentity(t *testing.T, stream jetstream.Stream) string {
 	return "test-application/stream-incarnation-1"
 }
 
+func fixedStreamIdentity(identity string) StreamIdentityResolver {
+	return func(*jetstream.StreamInfo) (string, error) {
+		return identity, nil
+	}
+}
+
+func createdStreamIdentity(info *jetstream.StreamInfo) (string, error) {
+	if info == nil || info.Created.IsZero() {
+		return "", errors.New("stream creation time is unavailable")
+	}
+	return fmt.Sprintf("test-application/created/%d", info.Created.UnixNano()), nil
+}
+
+func testCreatedStreamIdentity(t *testing.T, ctx context.Context, stream jetstream.Stream) string {
+	t.Helper()
+	info, err := stream.Info(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := createdStreamIdentity(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return identity
+}
+
+func recreateTestStream(t *testing.T, ctx context.Context, js jetstream.JetStream) jetstream.Stream {
+	t.Helper()
+	if err := js.DeleteStream(ctx, "EVT_TEST"); err != nil {
+		t.Fatalf("delete original stream: %v", err)
+	}
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:               "EVT_TEST",
+		Subjects:           []string{SubjectRoot + ">"},
+		Storage:            jetstream.FileStorage,
+		AllowAtomicPublish: true,
+	})
+	if err != nil {
+		t.Fatalf("recreate stream: %v", err)
+	}
+	return stream
+}
+
+func appendRecreatedStreamEvent(t *testing.T, ctx context.Context, js jetstream.JetStream, stream jetstream.Stream) {
+	t.Helper()
+	pub := NewPublisher(js, stream, testLogger())
+	if _, err := pub.AppendEventually(ctx, RoomAggregate("R-recreated").Subject(EventUserJoinedRoom), makeEvent("R-recreated", "U1")); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // makeEvent constructs a minimal event with a UserJoinedRoom payload so
 // validateEvent passes. The room_id field is what tests typically assert on.
 func makeEvent(roomID, userID string) *corev1.Event {
@@ -644,12 +695,13 @@ func (p *minimalProjection) Count() int {
 
 type checkpointTrackingProjection struct {
 	*trackingProjection
-	contractID string
-	checkpoint uint64
-	restoreErr error
-	resetErr   error
-	request    ProjectionCheckpointRequest
-	resets     int
+	contractID             string
+	checkpoint             uint64
+	expectedStreamIdentity string
+	restoreErr             error
+	resetErr               error
+	request                ProjectionCheckpointRequest
+	resets                 int
 }
 
 type startupBatchTrackingProjection struct {
@@ -722,6 +774,9 @@ func (*checkpointTrackingProjection) SnapshotContractID() string     { return "s
 
 func (p *checkpointTrackingProjection) RestoreCheckpoint(_ context.Context, request ProjectionCheckpointRequest) (ProjectionCheckpoint, error) {
 	p.request = request
+	if p.expectedStreamIdentity != "" && request.StreamIdentity != p.expectedStreamIdentity {
+		return ProjectionCheckpoint{}, fmt.Errorf("%w: stream identity changed", ErrProjectionCheckpointInvalid)
+	}
 	return ProjectionCheckpoint{CutoffSequence: p.checkpoint}, p.restoreErr
 }
 
@@ -787,6 +842,12 @@ type staticSnapshotSource struct {
 	request  ProjectionSnapshotLoadRequest
 }
 
+type identityBoundSnapshotSource struct {
+	streamIdentity string
+	snapshot       ProjectionSnapshot
+	request        ProjectionSnapshotLoadRequest
+}
+
 type blockingSnapshotSource struct {
 	canceled chan struct{}
 }
@@ -816,6 +877,14 @@ func (s *blockingSnapshotSource) LoadProjectionSnapshot(ctx context.Context, _ P
 func (s *staticSnapshotSource) LoadProjectionSnapshot(_ context.Context, request ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
 	s.request = request
 	return s.snapshot, s.err
+}
+
+func (s *identityBoundSnapshotSource) LoadProjectionSnapshot(_ context.Context, request ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
+	s.request = request
+	if request.StreamIdentity != s.streamIdentity {
+		return ProjectionSnapshot{}, errors.New("snapshot stream identity changed")
+	}
+	return s.snapshot, nil
 }
 
 func newBlockingProjection(subs ...string) *blockingProjection {
@@ -1066,7 +1135,7 @@ func TestProjectorRestoresLocalCheckpointAndReplaysTail(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = seqs[1]
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureCheckpoint("search", fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	// Configuration captures the contract before the projection can change it.
@@ -1115,7 +1184,7 @@ func TestProjectorRestoresLocalCheckpointBeyondFilteredTail(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = unrelatedSeq
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureCheckpoint("search", fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1151,7 +1220,7 @@ func TestProjectorResetsInvalidLocalCheckpoint(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.restoreErr = fmt.Errorf("%w: contract mismatch", ErrProjectionCheckpointInvalid)
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureCheckpoint("search", fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1173,7 +1242,7 @@ func TestProjectorDoesNotResetCheckpointOnOperationalRestoreFailure(t *testing.T
 	projection := newCheckpointTrackingProjection(RoomSubjectFilter())
 	projection.restoreErr = errors.New("local volume unavailable")
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureCheckpoint("search", fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 
@@ -1203,7 +1272,7 @@ func TestProjectorResetsFutureLocalCheckpoint(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = seq + 1
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureCheckpoint("search", fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1237,7 +1306,7 @@ func TestProjectorResetsCheckpointBehindRetainedEVT(t *testing.T) {
 	projection := newCheckpointTrackingProjection(subject)
 	projection.checkpoint = seqs[0]
 	projector := NewProjector(js, stream, projection, testLogger())
-	if err := projector.ConfigureCheckpoint("search", testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureCheckpoint("search", fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
 	runCtx, cancel := context.WithCancel(ctx)
@@ -1255,24 +1324,100 @@ func TestProjectorResetsCheckpointBehindRetainedEVT(t *testing.T) {
 	}
 }
 
+func TestProjectorResolvesCheckpointIdentityWithFreshStreamBounds(t *testing.T) {
+	js, originalStream := setupTestStream(t)
+	ctx := testContext(t)
+	originalIdentity := testCreatedStreamIdentity(t, ctx, originalStream)
+
+	projection := newCheckpointTrackingProjection(RoomSubjectFilter())
+	projection.checkpoint = 1
+	projection.expectedStreamIdentity = originalIdentity
+	projector := NewProjector(js, originalStream, projection, testLogger())
+	if err := projector.ConfigureCheckpoint("search", createdStreamIdentity); err != nil {
+		t.Fatal(err)
+	}
+
+	recreatedStream := recreateTestStream(t, ctx, js)
+	recreatedIdentity := testCreatedStreamIdentity(t, ctx, recreatedStream)
+	if recreatedIdentity == originalIdentity {
+		t.Fatalf("recreated identity = original identity %q", originalIdentity)
+	}
+	appendRecreatedStreamEvent(t, ctx, js, recreatedStream)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = projector.Run(runCtx) }()
+	waitFor(t, 2*time.Second, func() bool {
+		return projector.Status().StartupComplete
+	})
+
+	if projection.request.StreamIdentity != recreatedIdentity {
+		t.Fatalf("checkpoint request identity = %q, want recreated %q", projection.request.StreamIdentity, recreatedIdentity)
+	}
+	if projection.resets != 1 || projection.Count() != 1 {
+		t.Fatalf("checkpoint resets/count = %d/%d, want 1/1", projection.resets, projection.Count())
+	}
+}
+
+func TestProjectorResolvesSnapshotIdentityFromRecreatedStream(t *testing.T) {
+	js, originalStream := setupTestStream(t)
+	ctx := testContext(t)
+	originalIdentity := testCreatedStreamIdentity(t, ctx, originalStream)
+
+	projection := newSnapshotTrackingProjection(RoomSubjectFilter())
+	source := &identityBoundSnapshotSource{
+		streamIdentity: originalIdentity,
+		snapshot: ProjectionSnapshot{
+			GenerationID:   "old-generation",
+			CutoffSequence: 1,
+			Payload:        []byte("old-state"),
+		},
+	}
+	projector := NewProjector(js, originalStream, projection, testLogger())
+	if err := projector.ConfigureSnapshots("tracking", source, createdStreamIdentity); err != nil {
+		t.Fatal(err)
+	}
+
+	recreatedStream := recreateTestStream(t, ctx, js)
+	recreatedIdentity := testCreatedStreamIdentity(t, ctx, recreatedStream)
+	if recreatedIdentity == originalIdentity {
+		t.Fatalf("recreated identity = original identity %q", originalIdentity)
+	}
+	appendRecreatedStreamEvent(t, ctx, js, recreatedStream)
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go func() { _ = projector.Run(runCtx) }()
+	waitFor(t, 2*time.Second, func() bool {
+		return projector.Status().StartupComplete
+	})
+
+	if source.request.StreamIdentity != recreatedIdentity {
+		t.Fatalf("snapshot request identity = %q, want recreated %q", source.request.StreamIdentity, recreatedIdentity)
+	}
+	if projector.Status().SnapshotRestored || projection.Count() != 1 || len(projection.restored) != 0 {
+		t.Fatalf("snapshot status/count/restored = %+v/%d/%q, want cold replay of recreated stream", projector.Status(), projection.Count(), projection.restored)
+	}
+}
+
 func TestProjectorRejectsCompetingRestoreAuthorities(t *testing.T) {
 	js, stream := setupTestStream(t)
 	source := &staticSnapshotSource{}
 	identity := testStreamIdentity(t, stream)
 
 	checkpointFirst := NewProjector(js, stream, newCheckpointTrackingProjection(RoomSubjectFilter()), testLogger())
-	if err := checkpointFirst.ConfigureCheckpoint("search", identity); err != nil {
+	if err := checkpointFirst.ConfigureCheckpoint("search", fixedStreamIdentity(identity)); err != nil {
 		t.Fatalf("ConfigureCheckpoint: %v", err)
 	}
-	if err := checkpointFirst.ConfigureSnapshots("search", source, identity); err == nil {
+	if err := checkpointFirst.ConfigureSnapshots("search", source, fixedStreamIdentity(identity)); err == nil {
 		t.Fatal("ConfigureSnapshots succeeded after ConfigureCheckpoint")
 	}
 
 	snapshotFirst := NewProjector(js, stream, newCheckpointTrackingProjection(RoomSubjectFilter()), testLogger())
-	if err := snapshotFirst.ConfigureSnapshots("search", source, identity); err != nil {
+	if err := snapshotFirst.ConfigureSnapshots("search", source, fixedStreamIdentity(identity)); err != nil {
 		t.Fatalf("ConfigureSnapshots: %v", err)
 	}
-	if err := snapshotFirst.ConfigureCheckpoint("search", identity); err == nil {
+	if err := snapshotFirst.ConfigureCheckpoint("search", fixedStreamIdentity(identity)); err == nil {
 		t.Fatal("ConfigureCheckpoint succeeded after ConfigureSnapshots")
 	}
 }
@@ -1281,13 +1426,13 @@ func TestProjectorRequiresStreamIdentityForPersistence(t *testing.T) {
 	js, stream := setupTestStream(t)
 
 	checkpoint := NewProjector(js, stream, newCheckpointTrackingProjection(RoomSubjectFilter()), testLogger())
-	if err := checkpoint.ConfigureCheckpoint("search", ""); err == nil {
-		t.Fatal("ConfigureCheckpoint accepted an empty stream identity")
+	if err := checkpoint.ConfigureCheckpoint("search", nil); err == nil {
+		t.Fatal("ConfigureCheckpoint accepted a nil stream identity resolver")
 	}
 
 	snapshot := NewProjector(js, stream, newSnapshotTrackingProjection(RoomSubjectFilter()), testLogger())
-	if err := snapshot.ConfigureSnapshots("tracking", &staticSnapshotSource{}, ""); err == nil {
-		t.Fatal("ConfigureSnapshots accepted an empty stream identity")
+	if err := snapshot.ConfigureSnapshots("tracking", &staticSnapshotSource{}, nil); err == nil {
+		t.Fatal("ConfigureSnapshots accepted a nil stream identity resolver")
 	}
 }
 
@@ -1310,7 +1455,7 @@ func TestProjectorsRestoreAndReplayIndependently(t *testing.T) {
 	coldProjector := NewProjector(js, stream, coldProjection, testLogger())
 	createdAt := time.Date(2026, 7, 15, 12, 0, 0, 0, time.UTC)
 	source := &staticSnapshotSource{snapshot: ProjectionSnapshot{GenerationID: "generation", CutoffSequence: seqs[1], CreatedAt: createdAt, Payload: []byte("restored")}}
-	if err := restoredProjector.ConfigureSnapshots("tracking", source, testStreamIdentity(t, stream)); err != nil {
+	if err := restoredProjector.ConfigureSnapshots("tracking", source, fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatal(err)
 	}
 	// Configuration captures the contract once so restore and publication cannot
@@ -1365,7 +1510,7 @@ func TestProjectorsStartAfterTheirOwnSnapshotCutoffs(t *testing.T) {
 	second := NewProjector(js, stream, secondProjection, testLogger())
 	for projector, cutoff := range map[*Projector]uint64{first: malformedSeq, second: lastSeq} {
 		source := &staticSnapshotSource{snapshot: ProjectionSnapshot{GenerationID: "generation", CutoffSequence: cutoff, Payload: []byte("restored")}}
-		if err := projector.ConfigureSnapshots("tracking", source, testStreamIdentity(t, stream)); err != nil {
+		if err := projector.ConfigureSnapshots("tracking", source, fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -1409,7 +1554,7 @@ func TestProjectorConfiguresRestoredConsumerAfterItsCutoff(t *testing.T) {
 		CutoffSequence: seqs[1],
 		Payload:        []byte("restored"),
 	}}
-	if err := projector.ConfigureSnapshots("tracking", source, testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureSnapshots("tracking", source, fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatal(err)
 	}
 	runCtx, cancel := context.WithCancel(context.Background())
@@ -1445,7 +1590,7 @@ func TestProjectorRestoreReleasesWaiterRegisteredInFlight(t *testing.T) {
 	projection := newSnapshotTrackingProjection(RoomSubjectFilter())
 	projector := NewProjector(js, stream, projection, testLogger())
 	source := &gatedSnapshotSource{started: make(chan struct{}), release: make(chan struct{}), snapshot: ProjectionSnapshot{GenerationID: "generation", CutoffSequence: seq, Payload: []byte("restored")}}
-	if err := projector.ConfigureSnapshots("tracking", source, testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureSnapshots("tracking", source, fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatal(err)
 	}
 	runCtx, cancel := context.WithCancel(context.Background())
@@ -1527,7 +1672,7 @@ func TestProjectorRejectsFutureSnapshotAndFallsBackAfterRestoreFailure(t *testin
 			projection.restoreErr = test.restoreErr
 			projector := NewProjector(js, stream, projection, testLogger())
 			source := &staticSnapshotSource{snapshot: ProjectionSnapshot{GenerationID: "generation", CutoffSequence: seq + test.cutoffDelta, Payload: []byte("bad")}}
-			if err := projector.ConfigureSnapshots("tracking", source, testStreamIdentity(t, stream)); err != nil {
+			if err := projector.ConfigureSnapshots("tracking", source, fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 				t.Fatal(err)
 			}
 			runCtx, cancel := context.WithCancel(context.Background())
@@ -1555,7 +1700,7 @@ func TestProjectorSnapshotLoadTimeoutFallsBackToColdReplay(t *testing.T) {
 	projection := newSnapshotTrackingProjection(RoomSubjectFilter())
 	projector := NewProjector(js, stream, projection, testLogger())
 	source := &blockingSnapshotSource{canceled: make(chan struct{})}
-	if err := projector.ConfigureSnapshots("tracking", source, testStreamIdentity(t, stream)); err != nil {
+	if err := projector.ConfigureSnapshots("tracking", source, fixedStreamIdentity(testStreamIdentity(t, stream))); err != nil {
 		t.Fatal(err)
 	}
 	projector.snapshotLoadTimeout = 20 * time.Millisecond

--- a/cli/internal/events/events_test.go
+++ b/cli/internal/events/events_test.go
@@ -996,7 +996,7 @@ func TestProjectorRunsProjectionWithoutSnapshotMethods(t *testing.T) {
 	if got := projection.Count(); got != 1 {
 		t.Fatalf("Apply count = %d, want 1", got)
 	}
-	if _, err := projector.CaptureSnapshot(); err == nil {
+	if _, err := projector.CaptureSnapshot(context.Background()); err == nil {
 		t.Fatal("CaptureSnapshot succeeded for projection without snapshot methods")
 	}
 }
@@ -1398,6 +1398,17 @@ func TestProjectorResolvesSnapshotIdentityFromRecreatedStream(t *testing.T) {
 	if projector.Status().SnapshotRestored || projection.Count() != 1 || len(projection.restored) != 0 {
 		t.Fatalf("snapshot status/count/restored = %+v/%d/%q, want cold replay of recreated stream", projector.Status(), projection.Count(), projection.restored)
 	}
+	captured, err := projector.CaptureSnapshot(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if captured.StreamIdentity != recreatedIdentity {
+		t.Fatalf("captured snapshot identity = %q, want recreated %q", captured.StreamIdentity, recreatedIdentity)
+	}
+	recreateTestStream(t, ctx, js)
+	if _, err := projector.CaptureSnapshot(ctx); err == nil || !strings.Contains(err.Error(), "stream identity changed") {
+		t.Fatalf("CaptureSnapshot after another recreation error = %v, want stream identity change", err)
+	}
 }
 
 func TestProjectorRejectsCompetingRestoreAuthorities(t *testing.T) {
@@ -1642,7 +1653,7 @@ func TestProjectorSnapshotCutoffTracksItsLogicalEvents(t *testing.T) {
 	if got := projector.LastSeq(); got != joinedSeq {
 		t.Fatalf("projection replay watermark = %d, want last logical event %d", got, joinedSeq)
 	}
-	captured, err := projector.CaptureSnapshot()
+	captured, err := projector.CaptureSnapshot(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1738,7 +1749,7 @@ func TestProjectorCaptureWaitsForApplyBarrier(t *testing.T) {
 		t.Fatal("Apply did not enter")
 	}
 	capturedCh := make(chan ProjectionSnapshot, 1)
-	go func() { captured, _ := projector.CaptureSnapshot(); capturedCh <- captured }()
+	go func() { captured, _ := projector.CaptureSnapshot(context.Background()); capturedCh <- captured }()
 	select {
 	case <-capturedCh:
 		t.Fatal("CaptureSnapshot crossed an in-progress Apply")

--- a/cli/internal/events/projection_checkpoint.go
+++ b/cli/internal/events/projection_checkpoint.go
@@ -14,7 +14,7 @@ import (
 var ErrProjectionCheckpointInvalid = errors.New("projection checkpoint is invalid")
 
 // ProjectionCheckpointRequest binds local derived state to one projection
-// contract and one EVT stream incarnation.
+// contract and one application-supplied stream incarnation.
 type ProjectionCheckpointRequest struct {
 	ProjectionKey  string
 	ContractID     string
@@ -46,11 +46,15 @@ type checkpointedProjectionState interface {
 	ResetCheckpoint(context.Context, ProjectionCheckpointRequest) error
 }
 
-// ConfigureCheckpoint enables projection-owned local checkpoint restore. It
-// must be called before Run and cannot be combined with ADR-050 snapshots.
-func (p *Projector) ConfigureCheckpoint(key string) error {
+// ConfigureCheckpoint enables projection-owned local checkpoint restore for
+// an opaque application-supplied stream identity. It must be called before Run
+// and cannot be combined with ADR-050 snapshots.
+func (p *Projector) ConfigureCheckpoint(key, streamIdentity string) error {
 	if key == "" {
 		return fmt.Errorf("projection checkpoint key is required")
+	}
+	if streamIdentity == "" {
+		return fmt.Errorf("projection checkpoint stream identity is required")
 	}
 	projection, ok := p.proj.(checkpointedProjectionState)
 	if !ok {
@@ -74,6 +78,7 @@ func (p *Projector) ConfigureCheckpoint(key string) error {
 	}
 	p.checkpointKey = key
 	p.checkpointContractID = contractID
+	p.checkpointStreamID = streamIdentity
 	return nil
 }
 
@@ -81,6 +86,7 @@ func (p *Projector) restoreCheckpointForRun(ctx context.Context, targetSeq uint6
 	p.mu.Lock()
 	key := p.checkpointKey
 	contractID := p.checkpointContractID
+	streamIdentity := p.checkpointStreamID
 	p.mu.Unlock()
 	if key == "" {
 		return fmt.Errorf("projection checkpoint is not configured")
@@ -94,15 +100,11 @@ func (p *Projector) restoreCheckpointForRun(ctx context.Context, targetSeq uint6
 	if err != nil {
 		return fmt.Errorf("read EVT stream info for projection checkpoint: %w", err)
 	}
-	identity := info.Config.Metadata[EVTStreamIdentityMetadataKey]
-	if !ValidStreamIdentity(identity) {
-		return fmt.Errorf("projection checkpoint EVT stream identity is missing or invalid")
-	}
 	request := ProjectionCheckpointRequest{
 		ProjectionKey:  key,
 		ContractID:     contractID,
 		StreamName:     info.Config.Name,
-		StreamIdentity: identity,
+		StreamIdentity: streamIdentity,
 		FirstSequence:  info.State.FirstSeq,
 		LastSequence:   info.State.LastSeq,
 	}

--- a/cli/internal/events/projection_checkpoint.go
+++ b/cli/internal/events/projection_checkpoint.go
@@ -46,15 +46,17 @@ type checkpointedProjectionState interface {
 	ResetCheckpoint(context.Context, ProjectionCheckpointRequest) error
 }
 
-// ConfigureCheckpoint enables projection-owned local checkpoint restore for
-// an opaque application-supplied stream identity. It must be called before Run
-// and cannot be combined with ADR-050 snapshots.
-func (p *Projector) ConfigureCheckpoint(key, streamIdentity string) error {
+// ConfigureCheckpoint enables projection-owned local checkpoint restore. The
+// identity resolver receives the same fresh stream information used for the
+// checkpoint bounds; its opaque result binds the local state to that stream
+// incarnation. It must be called before Run and cannot be combined with
+// ADR-050 snapshots.
+func (p *Projector) ConfigureCheckpoint(key string, resolveStreamIdentity StreamIdentityResolver) error {
 	if key == "" {
 		return fmt.Errorf("projection checkpoint key is required")
 	}
-	if streamIdentity == "" {
-		return fmt.Errorf("projection checkpoint stream identity is required")
+	if resolveStreamIdentity == nil {
+		return fmt.Errorf("projection checkpoint stream identity resolver is required")
 	}
 	projection, ok := p.proj.(checkpointedProjectionState)
 	if !ok {
@@ -78,7 +80,7 @@ func (p *Projector) ConfigureCheckpoint(key, streamIdentity string) error {
 	}
 	p.checkpointKey = key
 	p.checkpointContractID = contractID
-	p.checkpointStreamID = streamIdentity
+	p.checkpointIdentityResolver = resolveStreamIdentity
 	return nil
 }
 
@@ -86,7 +88,7 @@ func (p *Projector) restoreCheckpointForRun(ctx context.Context, targetSeq uint6
 	p.mu.Lock()
 	key := p.checkpointKey
 	contractID := p.checkpointContractID
-	streamIdentity := p.checkpointStreamID
+	resolveStreamIdentity := p.checkpointIdentityResolver
 	p.mu.Unlock()
 	if key == "" {
 		return fmt.Errorf("projection checkpoint is not configured")
@@ -99,6 +101,10 @@ func (p *Projector) restoreCheckpointForRun(ctx context.Context, targetSeq uint6
 	info, err := p.stream.Info(ctx)
 	if err != nil {
 		return fmt.Errorf("read EVT stream info for projection checkpoint: %w", err)
+	}
+	streamIdentity, err := resolveProjectionStreamIdentity(info, resolveStreamIdentity)
+	if err != nil {
+		return fmt.Errorf("resolve projection checkpoint stream identity: %w", err)
 	}
 	request := ProjectionCheckpointRequest{
 		ProjectionKey:  key,

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -284,8 +284,8 @@ type ProjectionSnapshotSource interface {
 }
 
 // StreamIdentityResolver resolves an application's opaque stream incarnation
-// from the same StreamInfo snapshot used to validate persisted projection
-// state.
+// from supplied stream information. Restore invokes it with the same fresh
+// StreamInfo used to validate persisted projection state.
 type StreamIdentityResolver func(*jetstream.StreamInfo) (string, error)
 
 func resolveProjectionStreamIdentity(info *jetstream.StreamInfo, resolve StreamIdentityResolver) (string, error) {
@@ -378,6 +378,7 @@ type Projector struct {
 	snapshotContractID        string
 	snapshotSource            ProjectionSnapshotSource
 	snapshotIdentityResolver  StreamIdentityResolver
+	snapshotConfiguredID      string
 	snapshotRunStreamIdentity string
 	snapshotLoadTimeout       time.Duration
 	restoredSeq               uint64
@@ -525,6 +526,10 @@ func (p *Projector) ConfigureSnapshots(key string, source ProjectionSnapshotSour
 	if resolveStreamIdentity == nil {
 		return fmt.Errorf("projection snapshot stream identity resolver is required")
 	}
+	configuredStreamIdentity, err := resolveProjectionStreamIdentity(p.stream.CachedInfo(), resolveStreamIdentity)
+	if err != nil {
+		return fmt.Errorf("resolve projection snapshot stream identity: %w", err)
+	}
 	contractProjection, ok := p.proj.(snapshotContractProjectionState)
 	if !ok {
 		return fmt.Errorf("projection %q does not declare a snapshot contract", key)
@@ -545,6 +550,7 @@ func (p *Projector) ConfigureSnapshots(key string, source ProjectionSnapshotSour
 	p.snapshotContractID = contractID
 	p.snapshotSource = source
 	p.snapshotIdentityResolver = resolveStreamIdentity
+	p.snapshotConfiguredID = configuredStreamIdentity
 	p.snapshotLoadTimeout = projectionSnapshotLoadTimeout
 	return nil
 }
@@ -562,36 +568,58 @@ func (p *Projector) SnapshotContractID() string {
 // protobuf payload is valid canonical state and still carries the projection's
 // replay cutoff.
 func (p *Projector) CaptureSnapshot(ctx context.Context) (ProjectionSnapshot, error) {
-	p.applyMu.Lock()
-	defer p.applyMu.Unlock()
-
-	projection, ok := p.proj.(snapshotProjectionState)
-	if !ok {
-		return ProjectionSnapshot{}, fmt.Errorf("projection does not support snapshots")
-	}
-	payload, err := projection.Snapshot()
-	if err != nil {
-		return ProjectionSnapshot{}, err
-	}
 	p.mu.Lock()
-	seq := p.lastSeq
-	streamIdentity := p.snapshotRunStreamIdentity
 	resolveStreamIdentity := p.snapshotIdentityResolver
+	streamIdentity := p.snapshotRunStreamIdentity
 	p.mu.Unlock()
 	if resolveStreamIdentity != nil {
-		info, err := p.stream.Info(ctx)
+		currentIdentity, err := p.resolveCurrentStreamIdentity(ctx, resolveStreamIdentity)
 		if err != nil {
-			return ProjectionSnapshot{}, fmt.Errorf("read stream info for snapshot capture: %w", err)
-		}
-		currentIdentity, err := resolveProjectionStreamIdentity(info, resolveStreamIdentity)
-		if err != nil {
-			return ProjectionSnapshot{}, fmt.Errorf("resolve stream identity for snapshot capture: %w", err)
+			return ProjectionSnapshot{}, fmt.Errorf("resolve stream identity before snapshot capture: %w", err)
 		}
 		if streamIdentity == "" || currentIdentity != streamIdentity {
 			return ProjectionSnapshot{}, fmt.Errorf("stream identity changed during projector run")
 		}
 	}
+
+	payload, seq, err := func() ([]byte, uint64, error) {
+		p.applyMu.Lock()
+		defer p.applyMu.Unlock()
+		projection, ok := p.proj.(snapshotProjectionState)
+		if !ok {
+			return nil, 0, fmt.Errorf("projection does not support snapshots")
+		}
+		payload, err := projection.Snapshot()
+		if err != nil {
+			return nil, 0, err
+		}
+		p.mu.Lock()
+		seq := p.lastSeq
+		p.mu.Unlock()
+		return payload, seq, nil
+	}()
+	if err != nil {
+		return ProjectionSnapshot{}, err
+	}
+
+	if resolveStreamIdentity != nil {
+		currentIdentity, err := p.resolveCurrentStreamIdentity(ctx, resolveStreamIdentity)
+		if err != nil {
+			return ProjectionSnapshot{}, fmt.Errorf("resolve stream identity after snapshot capture: %w", err)
+		}
+		if currentIdentity != streamIdentity {
+			return ProjectionSnapshot{}, fmt.Errorf("stream identity changed during projector run")
+		}
+	}
 	return ProjectionSnapshot{CutoffSequence: seq, StreamIdentity: streamIdentity, Payload: payload}, nil
+}
+
+func (p *Projector) resolveCurrentStreamIdentity(ctx context.Context, resolve StreamIdentityResolver) (string, error) {
+	info, err := p.stream.Info(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resolveProjectionStreamIdentity(info, resolve)
 }
 
 // Status returns the projector's current lifecycle state. Safe to call from
@@ -1267,6 +1295,7 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 	key := p.snapshotKey
 	contractID := p.snapshotContractID
 	resolveStreamIdentity := p.snapshotIdentityResolver
+	configuredStreamIdentity := p.snapshotConfiguredID
 	loadTimeout := p.snapshotLoadTimeout
 	p.mu.Unlock()
 	if checkpointKey != "" {
@@ -1282,6 +1311,9 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 	defer cancelLoad()
 	info, err := p.stream.Info(loadCtx)
 	if err != nil {
+		p.mu.Lock()
+		p.snapshotRunStreamIdentity = configuredStreamIdentity
+		p.mu.Unlock()
 		p.logger.Info("Projection snapshot stream info unavailable; replaying EVT",
 			"projection", key,
 			"stage", "restore_stream_info",
@@ -1290,6 +1322,9 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 	}
 	streamIdentity, err := resolveProjectionStreamIdentity(info, resolveStreamIdentity)
 	if err != nil {
+		p.mu.Lock()
+		p.snapshotRunStreamIdentity = configuredStreamIdentity
+		p.mu.Unlock()
 		p.logger.Info("Projection snapshot stream identity unavailable; replaying EVT",
 			"projection", key,
 			"stage", "restore_stream_identity",

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -257,10 +257,13 @@ type snapshotContractProjectionState interface {
 	SnapshotContractID() string
 }
 
-// ProjectionSnapshot is a validated snapshot returned by a snapshot source.
+// ProjectionSnapshot is projection state restored from a source or captured
+// for publication. Captures include the stream identity bound to the projector
+// run; restored snapshots rely on the identity already validated by the source.
 type ProjectionSnapshot struct {
 	GenerationID   string
 	CutoffSequence uint64
+	StreamIdentity string
 	CreatedAt      time.Time
 	Payload        []byte
 }
@@ -371,16 +374,17 @@ type Projector struct {
 	startupBatchSize int
 	startupBatch     []sequencedDecodedEvent
 
-	snapshotKey              string
-	snapshotContractID       string
-	snapshotSource           ProjectionSnapshotSource
-	snapshotIdentityResolver StreamIdentityResolver
-	snapshotLoadTimeout      time.Duration
-	restoredSeq              uint64
-	restoredGenerationID     string
-	snapshotRestored         bool
-	latestSnapshotSeq        uint64
-	latestSnapshotAt         time.Time
+	snapshotKey               string
+	snapshotContractID        string
+	snapshotSource            ProjectionSnapshotSource
+	snapshotIdentityResolver  StreamIdentityResolver
+	snapshotRunStreamIdentity string
+	snapshotLoadTimeout       time.Duration
+	restoredSeq               uint64
+	restoredGenerationID      string
+	snapshotRestored          bool
+	latestSnapshotSeq         uint64
+	latestSnapshotAt          time.Time
 
 	checkpointKey              string
 	checkpointContractID       string
@@ -553,10 +557,11 @@ func (p *Projector) SnapshotContractID() string {
 	return p.snapshotContractID
 }
 
-// CaptureSnapshot serializes projection state and the corresponding applied
-// EVT sequence at one barrier. An empty protobuf payload is valid canonical
-// state and still carries the projection's replay cutoff.
-func (p *Projector) CaptureSnapshot() (ProjectionSnapshot, error) {
+// CaptureSnapshot serializes projection state, the corresponding applied EVT
+// sequence, and the stream identity bound to this run at one barrier. An empty
+// protobuf payload is valid canonical state and still carries the projection's
+// replay cutoff.
+func (p *Projector) CaptureSnapshot(ctx context.Context) (ProjectionSnapshot, error) {
 	p.applyMu.Lock()
 	defer p.applyMu.Unlock()
 
@@ -570,8 +575,23 @@ func (p *Projector) CaptureSnapshot() (ProjectionSnapshot, error) {
 	}
 	p.mu.Lock()
 	seq := p.lastSeq
+	streamIdentity := p.snapshotRunStreamIdentity
+	resolveStreamIdentity := p.snapshotIdentityResolver
 	p.mu.Unlock()
-	return ProjectionSnapshot{CutoffSequence: seq, Payload: payload}, nil
+	if resolveStreamIdentity != nil {
+		info, err := p.stream.Info(ctx)
+		if err != nil {
+			return ProjectionSnapshot{}, fmt.Errorf("read stream info for snapshot capture: %w", err)
+		}
+		currentIdentity, err := resolveProjectionStreamIdentity(info, resolveStreamIdentity)
+		if err != nil {
+			return ProjectionSnapshot{}, fmt.Errorf("resolve stream identity for snapshot capture: %w", err)
+		}
+		if streamIdentity == "" || currentIdentity != streamIdentity {
+			return ProjectionSnapshot{}, fmt.Errorf("stream identity changed during projector run")
+		}
+	}
+	return ProjectionSnapshot{CutoffSequence: seq, StreamIdentity: streamIdentity, Payload: payload}, nil
 }
 
 // Status returns the projector's current lifecycle state. Safe to call from
@@ -1276,6 +1296,9 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 			"error", err)
 		return coldRestore()
 	}
+	p.mu.Lock()
+	p.snapshotRunStreamIdentity = streamIdentity
+	p.mu.Unlock()
 	snapshot, err := source.LoadProjectionSnapshot(loadCtx, ProjectionSnapshotLoadRequest{
 		ProjectionKey:  key,
 		ContractID:     contractID,

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -280,6 +280,25 @@ type ProjectionSnapshotSource interface {
 	LoadProjectionSnapshot(context.Context, ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error)
 }
 
+// StreamIdentityResolver resolves an application's opaque stream incarnation
+// from the same StreamInfo snapshot used to validate persisted projection
+// state.
+type StreamIdentityResolver func(*jetstream.StreamInfo) (string, error)
+
+func resolveProjectionStreamIdentity(info *jetstream.StreamInfo, resolve StreamIdentityResolver) (string, error) {
+	if resolve == nil {
+		return "", fmt.Errorf("stream identity resolver is not configured")
+	}
+	identity, err := resolve(info)
+	if err != nil {
+		return "", err
+	}
+	if identity == "" {
+		return "", fmt.Errorf("stream identity is empty")
+	}
+	return identity, nil
+}
+
 // ReplaySubjectProjection can be implemented when a projection's logical
 // consumed subjects are narrower than the physical filters its ordered
 // consumer should use. Waits and diagnostics still report the narrower
@@ -352,22 +371,22 @@ type Projector struct {
 	startupBatchSize int
 	startupBatch     []sequencedDecodedEvent
 
-	snapshotKey          string
-	snapshotContractID   string
-	snapshotSource       ProjectionSnapshotSource
-	snapshotStreamID     string
-	snapshotLoadTimeout  time.Duration
-	restoredSeq          uint64
-	restoredGenerationID string
-	snapshotRestored     bool
-	latestSnapshotSeq    uint64
-	latestSnapshotAt     time.Time
+	snapshotKey              string
+	snapshotContractID       string
+	snapshotSource           ProjectionSnapshotSource
+	snapshotIdentityResolver StreamIdentityResolver
+	snapshotLoadTimeout      time.Duration
+	restoredSeq              uint64
+	restoredGenerationID     string
+	snapshotRestored         bool
+	latestSnapshotSeq        uint64
+	latestSnapshotAt         time.Time
 
-	checkpointKey        string
-	checkpointContractID string
-	checkpointStreamID   string
-	checkpointRestored   bool
-	checkpointCutoffSeq  uint64
+	checkpointKey              string
+	checkpointContractID       string
+	checkpointIdentityResolver StreamIdentityResolver
+	checkpointRestored         bool
+	checkpointCutoffSeq        uint64
 }
 
 // ProjectorStatus is a concurrency-safe snapshot of a projector's
@@ -489,17 +508,18 @@ func decodeCoreEvent(data []byte) (DecodedEvent[*corev1.Event], error) {
 }
 
 // ConfigureSnapshots enables best-effort bootstrap restore for this projector.
-// It must be called before Run. A load or restore failure is logged and falls
-// back to an empty projection followed by full EVT replay.
-func (p *Projector) ConfigureSnapshots(key string, source ProjectionSnapshotSource, streamIdentity string) error {
+// The identity resolver receives the same fresh stream information used by the
+// restore request. It must be called before Run. A load or restore failure is
+// logged and falls back to an empty projection followed by full EVT replay.
+func (p *Projector) ConfigureSnapshots(key string, source ProjectionSnapshotSource, resolveStreamIdentity StreamIdentityResolver) error {
 	if key == "" {
 		return fmt.Errorf("projection snapshot key is required")
 	}
 	if source == nil {
 		return fmt.Errorf("projection snapshot source is nil")
 	}
-	if streamIdentity == "" {
-		return fmt.Errorf("projection snapshot stream identity is required")
+	if resolveStreamIdentity == nil {
+		return fmt.Errorf("projection snapshot stream identity resolver is required")
 	}
 	contractProjection, ok := p.proj.(snapshotContractProjectionState)
 	if !ok {
@@ -520,7 +540,7 @@ func (p *Projector) ConfigureSnapshots(key string, source ProjectionSnapshotSour
 	p.snapshotKey = key
 	p.snapshotContractID = contractID
 	p.snapshotSource = source
-	p.snapshotStreamID = streamIdentity
+	p.snapshotIdentityResolver = resolveStreamIdentity
 	p.snapshotLoadTimeout = projectionSnapshotLoadTimeout
 	return nil
 }
@@ -1226,7 +1246,7 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 	checkpointKey := p.checkpointKey
 	key := p.snapshotKey
 	contractID := p.snapshotContractID
-	streamIdentity := p.snapshotStreamID
+	resolveStreamIdentity := p.snapshotIdentityResolver
 	loadTimeout := p.snapshotLoadTimeout
 	p.mu.Unlock()
 	if checkpointKey != "" {
@@ -1235,19 +1255,31 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 	if source == nil {
 		return coldRestore()
 	}
-	streamName := ""
-	if info := p.stream.CachedInfo(); info != nil {
-		streamName = info.Config.Name
-	}
 	if loadTimeout <= 0 {
 		loadTimeout = projectionSnapshotLoadTimeout
 	}
 	loadCtx, cancelLoad := context.WithTimeout(ctx, loadTimeout)
 	defer cancelLoad()
+	info, err := p.stream.Info(loadCtx)
+	if err != nil {
+		p.logger.Info("Projection snapshot stream info unavailable; replaying EVT",
+			"projection", key,
+			"stage", "restore_stream_info",
+			"error", err)
+		return coldRestore()
+	}
+	streamIdentity, err := resolveProjectionStreamIdentity(info, resolveStreamIdentity)
+	if err != nil {
+		p.logger.Info("Projection snapshot stream identity unavailable; replaying EVT",
+			"projection", key,
+			"stage", "restore_stream_identity",
+			"error", err)
+		return coldRestore()
+	}
 	snapshot, err := source.LoadProjectionSnapshot(loadCtx, ProjectionSnapshotLoadRequest{
 		ProjectionKey:  key,
 		ContractID:     contractID,
-		StreamName:     streamName,
+		StreamName:     info.Config.Name,
 		StreamIdentity: streamIdentity,
 		MaxCutoff:      targetSeq,
 	})

--- a/cli/internal/events/projector.go
+++ b/cli/internal/events/projector.go
@@ -2,13 +2,10 @@ package events
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
 	"sort"
-	"strings"
 	"sync"
 	"time"
 
@@ -42,10 +39,6 @@ const (
 	// projection Apply is running. Keep their cleanup window comfortably above
 	// slow disk-backed commits so NATS cannot delete a live projector consumer.
 	projectionConsumerInactiveThreshold = 5 * time.Minute
-	// EVTStreamIdentityMetadataKey stores the durable stream incarnation used to
-	// reject projection snapshots after EVT is deleted and recreated.
-	EVTStreamIdentityMetadataKey = "chatto.evt.incarnation"
-	streamIdentityPrefix         = "evt-incarnation-v1:"
 )
 
 // MemoryProjection is an embeddable base for projections whose state lives
@@ -372,6 +365,7 @@ type Projector struct {
 
 	checkpointKey        string
 	checkpointContractID string
+	checkpointStreamID   string
 	checkpointRestored   bool
 	checkpointCutoffSeq  uint64
 }
@@ -504,8 +498,8 @@ func (p *Projector) ConfigureSnapshots(key string, source ProjectionSnapshotSour
 	if source == nil {
 		return fmt.Errorf("projection snapshot source is nil")
 	}
-	if !ValidStreamIdentity(streamIdentity) {
-		return fmt.Errorf("projection snapshot EVT stream identity is invalid")
+	if streamIdentity == "" {
+		return fmt.Errorf("projection snapshot stream identity is required")
 	}
 	contractProjection, ok := p.proj.(snapshotContractProjectionState)
 	if !ok {
@@ -558,45 +552,6 @@ func (p *Projector) CaptureSnapshot() (ProjectionSnapshot, error) {
 	seq := p.lastSeq
 	p.mu.Unlock()
 	return ProjectionSnapshot{CutoffSequence: seq, Payload: payload}, nil
-}
-
-// NewStreamIdentity deterministically derives an opaque identity for one EVT
-// stream incarnation. created is used only when initializing missing metadata;
-// normal restarts read the persisted identity instead.
-func NewStreamIdentity(created time.Time) (string, error) {
-	if created.IsZero() {
-		return "", fmt.Errorf("EVT stream creation time is required")
-	}
-	sum := sha256.Sum256([]byte("chatto/evt-incarnation/v1\x00" + created.UTC().Format(time.RFC3339Nano)))
-	return streamIdentityPrefix + hex.EncodeToString(sum[:16]), nil
-}
-
-// ValidStreamIdentity reports whether identity has Chatto's versioned EVT
-// stream-incarnation format.
-func ValidStreamIdentity(identity string) bool {
-	if len(identity) != len(streamIdentityPrefix)+32 || !strings.HasPrefix(identity, streamIdentityPrefix) {
-		return false
-	}
-	_, err := hex.DecodeString(identity[len(streamIdentityPrefix):])
-	return err == nil
-}
-
-// StreamIdentity reads the durable incarnation identity cached when EVT was
-// opened. Unlike StreamInfo.Created, this value survives process reconstruction
-// and backup restore.
-func StreamIdentity(stream jetstream.Stream) (string, error) {
-	if stream == nil {
-		return "", fmt.Errorf("EVT stream is required")
-	}
-	info := stream.CachedInfo()
-	if info == nil {
-		return "", fmt.Errorf("EVT stream info is unavailable")
-	}
-	identity := info.Config.Metadata[EVTStreamIdentityMetadataKey]
-	if !ValidStreamIdentity(identity) {
-		return "", fmt.Errorf("EVT stream identity is missing or invalid")
-	}
-	return identity, nil
 }
 
 // Status returns the projector's current lifecycle state. Safe to call from

--- a/cli/internal/events/projector_codec_test.go
+++ b/cli/internal/events/projector_codec_test.go
@@ -169,7 +169,7 @@ func TestDecodedProjectorReplaysApplicationCodecInOrder(t *testing.T) {
 	if !slices.Equal(sequences, wantSequences) {
 		t.Fatalf("sequences = %v, want %v", sequences, wantSequences)
 	}
-	snapshot, err := projector.CaptureSnapshot()
+	snapshot, err := projector.CaptureSnapshot(context.Background())
 	if err != nil {
 		t.Fatalf("capture decoded projection snapshot: %v", err)
 	}

--- a/cli/internal/evtstream/identity.go
+++ b/cli/internal/evtstream/identity.go
@@ -1,0 +1,54 @@
+package evtstream
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	// IdentityMetadataKey stores Chatto's durable EVT stream incarnation.
+	IdentityMetadataKey = "chatto.evt.incarnation"
+	identityPrefix      = "evt-incarnation-v1:"
+)
+
+// NewIdentity deterministically derives Chatto's identity for one EVT stream
+// incarnation. created is used only when initializing missing metadata.
+func NewIdentity(created time.Time) (string, error) {
+	if created.IsZero() {
+		return "", fmt.Errorf("EVT stream creation time is required")
+	}
+	sum := sha256.Sum256([]byte("chatto/evt-incarnation/v1\x00" + created.UTC().Format(time.RFC3339Nano)))
+	return identityPrefix + hex.EncodeToString(sum[:16]), nil
+}
+
+// ValidIdentity reports whether identity has Chatto's versioned EVT
+// stream-incarnation format.
+func ValidIdentity(identity string) bool {
+	if len(identity) != len(identityPrefix)+32 || !strings.HasPrefix(identity, identityPrefix) {
+		return false
+	}
+	_, err := hex.DecodeString(identity[len(identityPrefix):])
+	return err == nil
+}
+
+// Identity reads the durable Chatto EVT incarnation cached when the stream was
+// opened. Unlike StreamInfo.Created, it survives backup and restore.
+func Identity(stream jetstream.Stream) (string, error) {
+	if stream == nil {
+		return "", fmt.Errorf("EVT stream is required")
+	}
+	info := stream.CachedInfo()
+	if info == nil {
+		return "", fmt.Errorf("EVT stream info is unavailable")
+	}
+	identity := info.Config.Metadata[IdentityMetadataKey]
+	if !ValidIdentity(identity) {
+		return "", fmt.Errorf("EVT stream identity is missing or invalid")
+	}
+	return identity, nil
+}

--- a/cli/internal/evtstream/identity.go
+++ b/cli/internal/evtstream/identity.go
@@ -42,7 +42,12 @@ func Identity(stream jetstream.Stream) (string, error) {
 	if stream == nil {
 		return "", fmt.Errorf("EVT stream is required")
 	}
-	info := stream.CachedInfo()
+	return IdentityFromInfo(stream.CachedInfo())
+}
+
+// IdentityFromInfo resolves and validates Chatto's EVT incarnation from one
+// StreamInfo snapshot so callers can bind it to the same sequence bounds.
+func IdentityFromInfo(info *jetstream.StreamInfo) (string, error) {
 	if info == nil {
 		return "", fmt.Errorf("EVT stream info is unavailable")
 	}

--- a/cli/internal/evtstream/identity_test.go
+++ b/cli/internal/evtstream/identity_test.go
@@ -1,0 +1,41 @@
+package evtstream
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewIdentityPreservesPersistedFormat(t *testing.T) {
+	created := time.Date(2026, time.July, 30, 12, 34, 56, 789, time.UTC)
+
+	first, err := NewIdentity(created)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewIdentity(created)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const want = "evt-incarnation-v1:157fc22df9796d187e95310191fc0ebe"
+	if first != want || second != want {
+		t.Fatalf("NewIdentity() = %q, %q; want persisted-compatible %q", first, second, want)
+	}
+	if !ValidIdentity(first) {
+		t.Fatalf("generated identity %q is invalid", first)
+	}
+}
+
+func TestValidIdentityRejectsMalformedValues(t *testing.T) {
+	for _, identity := range []string{
+		"",
+		"application-defined",
+		"evt-incarnation-v1:",
+		"evt-incarnation-v1:gggggggggggggggggggggggggggggggg",
+		"evt-incarnation-v2:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		if ValidIdentity(identity) {
+			t.Errorf("ValidIdentity(%q) = true", identity)
+		}
+	}
+}

--- a/cli/internal/evtstream/identity_test.go
+++ b/cli/internal/evtstream/identity_test.go
@@ -3,6 +3,8 @@ package evtstream
 import (
 	"testing"
 	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
 )
 
 func TestNewIdentityPreservesPersistedFormat(t *testing.T) {
@@ -37,5 +39,22 @@ func TestValidIdentityRejectsMalformedValues(t *testing.T) {
 		if ValidIdentity(identity) {
 			t.Errorf("ValidIdentity(%q) = true", identity)
 		}
+	}
+}
+
+func TestIdentityFromInfoReadsChattoMetadata(t *testing.T) {
+	const want = "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	info := &jetstream.StreamInfo{
+		Config: jetstream.StreamConfig{
+			Metadata: map[string]string{IdentityMetadataKey: want},
+		},
+	}
+
+	got, err := IdentityFromInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("IdentityFromInfo() = %q, want %q", got, want)
 	}
 }

--- a/cli/internal/projectionsnapshot/repository.go
+++ b/cli/internal/projectionsnapshot/repository.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"strings"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -20,13 +19,12 @@ import (
 )
 
 const (
-	objectRootPrefix     = "internal/projection-snapshots/"
-	maxPayloadSize       = 64 << 20
-	maxEncryptedSize     = 80 << 20
-	maxDecompressedSize  = 72 << 20
-	contentType          = "application/vnd.chatto.projection-snapshot"
-	streamIdentityPrefix = "evt-incarnation-v1:"
-	objectPurpose        = "projection-snapshot"
+	objectRootPrefix    = "internal/projection-snapshots/"
+	maxPayloadSize      = 64 << 20
+	maxEncryptedSize    = 80 << 20
+	maxDecompressedSize = 72 << 20
+	contentType         = "application/vnd.chatto.projection-snapshot"
+	objectPurpose       = "projection-snapshot"
 )
 
 // ObjectContentType and object-purpose metadata identify encrypted snapshot
@@ -181,8 +179,8 @@ func (r *Repository) Save(ctx context.Context, input SaveInput) (LoadedSnapshot,
 	if !validProjectionKey(input.ProjectionKey) || !validContractID(input.ContractID) || input.StreamName == "" {
 		return LoadedSnapshot{}, fmt.Errorf("snapshot projection key, contract id, and stream name are required")
 	}
-	if !validStreamIdentity(input.StreamIdentity) {
-		return LoadedSnapshot{}, fmt.Errorf("snapshot EVT cutoff identity is invalid")
+	if input.StreamIdentity == "" {
+		return LoadedSnapshot{}, fmt.Errorf("snapshot stream identity is required")
 	}
 	if len(input.Payload) > r.maxPayloadSize {
 		return LoadedSnapshot{}, fmt.Errorf("snapshot payload exceeds %d bytes", r.maxPayloadSize)
@@ -373,11 +371,11 @@ func (r *Repository) loadGeneration(ctx context.Context, id, projectionKey, cont
 	if generation.GetStreamName() != streamName {
 		return LoadedSnapshot{}, fmt.Errorf("%w: stream name %q does not match %q", ErrIncompatible, generation.GetStreamName(), streamName)
 	}
-	if !validStreamIdentity(generation.GetStreamIdentity()) {
-		return LoadedSnapshot{}, fmt.Errorf("%w: EVT stream identity is invalid", ErrIncompatible)
+	if generation.GetStreamIdentity() == "" {
+		return LoadedSnapshot{}, fmt.Errorf("%w: stream identity is missing", ErrIncompatible)
 	}
 	if generation.GetStreamIdentity() != streamIdentity {
-		return LoadedSnapshot{}, fmt.Errorf("%w: EVT stream identity changed", ErrIncompatible)
+		return LoadedSnapshot{}, fmt.Errorf("%w: stream identity changed", ErrIncompatible)
 	}
 	if generation.GetCutoffSequence() > maxCutoff {
 		return LoadedSnapshot{}, fmt.Errorf("%w: cutoff %d exceeds stream target %d", ErrIncompatible, generation.GetCutoffSequence(), maxCutoff)
@@ -396,14 +394,6 @@ func (r *Repository) loadGeneration(ctx context.Context, id, projectionKey, cont
 		return LoadedSnapshot{}, fmt.Errorf("snapshot creation time: %w", err)
 	}
 	return LoadedSnapshot{GenerationID: id, CutoffSequence: generation.GetCutoffSequence(), StreamIdentity: generation.GetStreamIdentity(), Payload: generation.GetPayload(), CreatedAt: generation.GetCreatedAt().AsTime(), ProducerVersion: generation.GetProducerVersion()}, nil
-}
-
-func validStreamIdentity(identity string) bool {
-	if len(identity) != len(streamIdentityPrefix)+32 || !strings.HasPrefix(identity, streamIdentityPrefix) {
-		return false
-	}
-	_, err := hex.DecodeString(identity[len(streamIdentityPrefix):])
-	return err == nil
 }
 
 func (r *Repository) loadPointer(ctx context.Context, projectionKey, contractID string) (*corev1.ProjectionSnapshotPointer, error) {
@@ -461,7 +451,7 @@ func (r *Repository) loadPointerAtRevision(ctx context.Context, projectionKey, c
 			}
 			continue
 		}
-		if !validStreamIdentity(position.streamIdentity) || position.contractID != contractID {
+		if position.streamIdentity == "" || position.contractID != contractID {
 			return nil, revision, fmt.Errorf("%w: %s generation metadata is incomplete", errInvalidPointer, position.name)
 		}
 		if position.createdAt != nil {

--- a/cli/internal/projectionsnapshot/repository_test.go
+++ b/cli/internal/projectionsnapshot/repository_test.go
@@ -11,8 +11,8 @@ import (
 )
 
 const testSecret = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
-const testStreamIdentity = "evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-const otherStreamIdentity = "evt-incarnation-v1:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+const testStreamIdentity = "test-application/stream-incarnation-1"
+const otherStreamIdentity = "test-application/stream-incarnation-2"
 const testContractID = "v1"
 
 func testSaveInput(seq uint64, payload []byte) SaveInput {

--- a/cli/internal/search/bleve/provider_test.go
+++ b/cli/internal/search/bleve/provider_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	searchv1 "hmans.de/chatto/internal/pb/chatto/search/v1"
 	"hmans.de/chatto/internal/search"
@@ -65,7 +66,7 @@ func TestProviderStatusTransitionsFromIndexingToReady(t *testing.T) {
 	t.Cleanup(cancel)
 	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
 		Name: "EVT", Subjects: []string{"evt.>"}, Storage: jetstream.MemoryStorage,
-		Metadata: map[string]string{events.EVTStreamIdentityMetadataKey: "evt-incarnation-v1:dddddddddddddddddddddddddddddddd"},
+		Metadata: map[string]string{evtstream.IdentityMetadataKey: "evt-incarnation-v1:dddddddddddddddddddddddddddddddd"},
 	})
 	require.NoError(t, err)
 	publisher := events.NewPublisher(js, stream, log.New(io.Discard))
@@ -114,7 +115,7 @@ func TestProviderReportsFailedInitialReplayAsUnavailable(t *testing.T) {
 	t.Cleanup(cancel)
 	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
 		Name: "EVT", Subjects: []string{"evt.>"}, Storage: jetstream.MemoryStorage,
-		Metadata: map[string]string{events.EVTStreamIdentityMetadataKey: "evt-incarnation-v1:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
+		Metadata: map[string]string{evtstream.IdentityMetadataKey: "evt-incarnation-v1:eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"},
 	})
 	require.NoError(t, err)
 	publisher := events.NewPublisher(js, stream, log.New(io.Discard))
@@ -141,7 +142,7 @@ func TestProviderReportsFailureAfterStartupAsDegraded(t *testing.T) {
 	t.Cleanup(cancel)
 	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
 		Name: "EVT", Subjects: []string{"evt.>"}, Storage: jetstream.MemoryStorage,
-		Metadata: map[string]string{events.EVTStreamIdentityMetadataKey: "evt-incarnation-v1:ffffffffffffffffffffffffffffffff"},
+		Metadata: map[string]string{evtstream.IdentityMetadataKey: "evt-incarnation-v1:ffffffffffffffffffffffffffffffff"},
 	})
 	require.NoError(t, err)
 	projector := events.NewProjector(js, stream, &failingStatusProjection{}, log.New(io.Discard))

--- a/cli/internal/search/bleve/unit.go
+++ b/cli/internal/search/bleve/unit.go
@@ -69,11 +69,7 @@ func (u Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 
 	projectionHandle := events.NewProjectionHandle(env.JS, evt, projection, env.Logger)
 	projector := projectionHandle.Projector()
-	streamIdentity, err := evtstream.Identity(evt)
-	if err != nil {
-		return fmt.Errorf("read EVT stream identity: %w", err)
-	}
-	if err := projector.ConfigureCheckpoint("message_search", streamIdentity); err != nil {
+	if err := projector.ConfigureCheckpoint("message_search", evtstream.IdentityFromInfo); err != nil {
 		return err
 	}
 	provider := newProvider(projectionHandle)

--- a/cli/internal/search/bleve/unit.go
+++ b/cli/internal/search/bleve/unit.go
@@ -8,6 +8,7 @@ import (
 
 	"hmans.de/chatto/internal/dekstore"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/kms"
 	"hmans.de/chatto/internal/runtimeunit"
 	"hmans.de/chatto/internal/search"
@@ -68,7 +69,11 @@ func (u Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 
 	projectionHandle := events.NewProjectionHandle(env.JS, evt, projection, env.Logger)
 	projector := projectionHandle.Projector()
-	if err := projector.ConfigureCheckpoint("message_search"); err != nil {
+	streamIdentity, err := evtstream.Identity(evt)
+	if err != nil {
+		return fmt.Errorf("read EVT stream identity: %w", err)
+	}
+	if err := projector.ConfigureCheckpoint("message_search", streamIdentity); err != nil {
 		return err
 	}
 	provider := newProvider(projectionHandle)

--- a/cli/internal/search/bleve/unit_test.go
+++ b/cli/internal/search/bleve/unit_test.go
@@ -20,6 +20,7 @@ import (
 	"hmans.de/chatto/internal/dekstore"
 	"hmans.de/chatto/internal/encryption"
 	"hmans.de/chatto/internal/events"
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/kms"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	searchv1 "hmans.de/chatto/internal/pb/chatto/search/v1"
@@ -57,7 +58,7 @@ func TestUnitReplaysEVTAndServesNATSContract(t *testing.T) {
 	t.Cleanup(cancel)
 	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
 		Name: "EVT", Subjects: []string{"evt.>"}, Storage: jetstream.MemoryStorage,
-		Metadata: map[string]string{events.EVTStreamIdentityMetadataKey: "evt-incarnation-v1:cccccccccccccccccccccccccccccccc"},
+		Metadata: map[string]string{evtstream.IdentityMetadataKey: "evt-incarnation-v1:cccccccccccccccccccccccccccccccc"},
 	})
 	require.NoError(t, err)
 	encryptionKeys, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "ENCRYPTION_KEYS", Storage: jetstream.MemoryStorage})
@@ -183,7 +184,7 @@ func TestUnitReplaysEVTAndServesNATSContract(t *testing.T) {
 		ProjectionKey:  "message_search",
 		ContractID:     legacyProjection.CheckpointContractID(),
 		StreamName:     streamInfo.Config.Name,
-		StreamIdentity: streamInfo.Config.Metadata[events.EVTStreamIdentityMetadataKey],
+		StreamIdentity: streamInfo.Config.Metadata[evtstream.IdentityMetadataKey],
 		FirstSequence:  streamInfo.State.FirstSeq,
 		LastSequence:   streamInfo.State.LastSeq,
 	})
@@ -223,7 +224,7 @@ func TestUnitFailsClosedWhenCheckpointPrecedesRetainedEVT(t *testing.T) {
 	t.Cleanup(cancel)
 	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
 		Name: "EVT", Subjects: []string{"evt.>"}, Storage: jetstream.MemoryStorage,
-		Metadata: map[string]string{events.EVTStreamIdentityMetadataKey: "evt-incarnation-v1:dddddddddddddddddddddddddddddddd"},
+		Metadata: map[string]string{evtstream.IdentityMetadataKey: "evt-incarnation-v1:dddddddddddddddddddddddddddddddd"},
 	})
 	require.NoError(t, err)
 	encryptionKeys, err := js.CreateKeyValue(ctx, jetstream.KeyValueConfig{Bucket: "ENCRYPTION_KEYS", Storage: jetstream.MemoryStorage})
@@ -265,7 +266,7 @@ func TestUnitFailsClosedWhenCheckpointPrecedesRetainedEVT(t *testing.T) {
 		ProjectionKey:  "message_search",
 		ContractID:     projection.CheckpointContractID(),
 		StreamName:     streamInfo.Config.Name,
-		StreamIdentity: streamInfo.Config.Metadata[events.EVTStreamIdentityMetadataKey],
+		StreamIdentity: streamInfo.Config.Metadata[evtstream.IdentityMetadataKey],
 		FirstSequence:  streamInfo.State.FirstSeq,
 		LastSequence:   streamInfo.State.LastSeq,
 	})

--- a/docs/adr/ADR-054-optional-projection-persistence.md
+++ b/docs/adr/ADR-054-optional-projection-persistence.md
@@ -49,6 +49,13 @@ interpret stream metadata. The projection owns reset policy. The framework
 never assumes it may delete local files: an implementation may explicitly
 reset safe derived state or fail startup and require operator intervention.
 
+For portable snapshots, the successfully resolved identity is bound to the
+projector run. Capture re-resolves it while holding the projection barrier,
+rejects an incarnation change, and returns the bound identity with projection
+state and its cutoff. Publication uses that captured value, so application
+worker wiring cannot label replayed state with an identity cached before stream
+recreation.
+
 A successful checkpointed `Apply` or startup batch commits the materialized
 changes and final EVT sequence atomically. Returning success before both are
 durable could skip events after restart and is therefore invalid.

--- a/docs/adr/ADR-054-optional-projection-persistence.md
+++ b/docs/adr/ADR-054-optional-projection-persistence.md
@@ -38,14 +38,16 @@ Persistence is opt-in through separate interfaces:
 One projector may use at most one restore authority. It can use a portable
 snapshot, a local checkpoint, or neither, but never both.
 
-The application supplies the projector with an opaque, non-empty stream
-identity when configuring persistence. The projector validates a local
-checkpoint against that value, its registration key, opaque projection
-contract ID, and retained sequence bounds. Identity discovery, format, and
-validation belong to the application; the persistence mechanics do not inspect
-stream metadata. The projection owns reset policy. The framework never assumes
-it may delete local files: an implementation may explicitly reset safe derived
-state or fail startup and require operator intervention.
+The application supplies the projector with a stream-identity resolver when
+configuring persistence. At restore time, the projector passes that resolver
+the same fresh JetStream stream-info snapshot used for the retained sequence
+bounds and treats its result as an opaque, non-empty value. The projector
+validates a local checkpoint against that value, its registration key, opaque
+projection contract ID, and retained sequence bounds. Identity discovery,
+format, and validation belong to the application; framework code does not
+interpret stream metadata. The projection owns reset policy. The framework
+never assumes it may delete local files: an implementation may explicitly
+reset safe derived state or fail startup and require operator intervention.
 
 A successful checkpointed `Apply` or startup batch commits the materialized
 changes and final EVT sequence atomically. Returning success before both are

--- a/docs/adr/ADR-054-optional-projection-persistence.md
+++ b/docs/adr/ADR-054-optional-projection-persistence.md
@@ -38,11 +38,14 @@ Persistence is opt-in through separate interfaces:
 One projector may use at most one restore authority. It can use a portable
 snapshot, a local checkpoint, or neither, but never both.
 
-The projector validates a local checkpoint against its registration key,
-opaque projection contract ID, EVT stream identity, and retained sequence
-bounds. The projection owns reset policy. The framework never assumes it may
-delete local files: an implementation may explicitly reset safe derived state
-or fail startup and require operator intervention.
+The application supplies the projector with an opaque, non-empty stream
+identity when configuring persistence. The projector validates a local
+checkpoint against that value, its registration key, opaque projection
+contract ID, and retained sequence bounds. Identity discovery, format, and
+validation belong to the application; the persistence mechanics do not inspect
+stream metadata. The projection owns reset policy. The framework never assumes
+it may delete local files: an implementation may explicitly reset safe derived
+state or fail startup and require operator intervention.
 
 A successful checkpointed `Apply` or startup batch commits the materialized
 changes and final EVT sequence atomically. Returning success before both are

--- a/docs/adr/ADR-054-optional-projection-persistence.md
+++ b/docs/adr/ADR-054-optional-projection-persistence.md
@@ -50,11 +50,14 @@ never assumes it may delete local files: an implementation may explicitly
 reset safe derived state or fail startup and require operator intervention.
 
 For portable snapshots, the successfully resolved identity is bound to the
-projector run. Capture re-resolves it while holding the projection barrier,
-rejects an incarnation change, and returns the bound identity with projection
-state and its cutoff. Publication uses that captured value, so application
-worker wiring cannot label replayed state with an identity cached before stream
-recreation.
+projector run. Capture resolves identity immediately before and after the short
+projection state/cutoff barrier, rejects an incarnation change, and performs no
+NATS I/O while blocking event application. Publication uses the captured bound
+value, so application worker wiring cannot label replayed state with an
+identity cached before stream recreation. If fresh identity lookup fails during
+best-effort startup restore, the already validated configuration identity
+remains the run fence; later capture can recover once lookup succeeds, but
+refuses publication if the stream was actually recreated.
 
 A successful checkpointed `Apply` or startup batch commits the materialized
 changes and final EVT sequence atomically. Returning success before both are

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -78,7 +78,9 @@ configuration. At restore time the projector invokes it with the same fresh
 `StreamInfo` used for sequence bounds, preventing an old identity from being
 combined with a recreated stream's bounds. The projector and snapshot
 repository require only a non-empty opaque result and never impose Chatto's
-metadata key or identity syntax.
+metadata key or identity syntax. Snapshot capture carries the identity bound to
+that projector run alongside its state and cutoff; application publication
+does not maintain a second identity value.
 
 This decision does not create or promise a public module yet. The current
 package still contains Chatto-specific typed convenience adapters. Extraction

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -33,7 +33,8 @@ Framework-owned responsibilities are:
   mechanics;
 - stream positions and projection readiness barriers;
 - ordered consumer, replay, startup batching, and failure lifecycles;
-- optional snapshot and local-checkpoint capability hooks; and
+- optional snapshot and local-checkpoint capability hooks that bind persisted
+  state to an opaque application-supplied stream identity; and
 - a typed `ProjectionHandle` that keeps a projection with the exact projector
   constructed for it.
 
@@ -44,6 +45,7 @@ Chatto-owned responsibilities remain:
 - domain projections, services, authorization, and response assembly;
 - stable registration keys, display names, admin memory estimates, and
   diagnostic inventory;
+- stream identity discovery, metadata naming, format, and validation;
 - snapshot enablement, repository, encryption, retention, and worker policy;
   and
 - runtime composition in `ChattoCore`.
@@ -69,11 +71,17 @@ readiness, snapshots, checkpoints, and failure handling. Chatto's existing
 `NewProjector`, `Projection`, `SequencedEvent`, and `ProjectionHandle` APIs are
 specializations over `corev1.Event` and its unchanged protobuf codec.
 
+Chatto owns its versioned EVT incarnation format and the
+`chatto.evt.incarnation` stream metadata through `internal/evtstream`.
+Composition resolves and validates that value, then passes it into snapshot
+and checkpoint configuration. The projector and snapshot repository require
+only a non-empty opaque value and never inspect JetStream metadata or impose
+Chatto's identity syntax.
+
 This decision does not create or promise a public module yet. The current
-package still contains Chatto-specific stream identity naming and typed
-convenience adapters. Before extraction, stream identity naming must move
-behind application-supplied configuration. We will make that change only when
-concrete framework users show the smallest useful API.
+package still contains Chatto-specific typed convenience adapters. Extraction
+will happen only when concrete framework users show the smallest useful public
+API.
 
 ## Consequences
 
@@ -92,7 +100,7 @@ existing projectors. It intentionally does not absorb registration metadata or
 snapshot policy, so some application composition remains explicit.
 
 Extraction still requires deliberate work. The write mechanics no longer
-depend on Chatto's protobuf event envelope, and generic projection replay can
-use another application envelope without changing the ordered lifecycle.
-Chatto-specific typed adapters, naming, and validation assumptions remain in
-the incubating package.
+depend on Chatto's protobuf event envelope, generic projection replay can use
+another application envelope without changing the ordered lifecycle, and
+persistence accepts an application-defined stream identity. Chatto-specific
+typed adapters remain in the incubating package.

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -73,10 +73,12 @@ specializations over `corev1.Event` and its unchanged protobuf codec.
 
 Chatto owns its versioned EVT incarnation format and the
 `chatto.evt.incarnation` stream metadata through `internal/evtstream`.
-Composition resolves and validates that value, then passes it into snapshot
-and checkpoint configuration. The projector and snapshot repository require
-only a non-empty opaque value and never inspect JetStream metadata or impose
-Chatto's identity syntax.
+Composition passes Chatto's resolver into snapshot and checkpoint
+configuration. At restore time the projector invokes it with the same fresh
+`StreamInfo` used for sequence bounds, preventing an old identity from being
+combined with a recreated stream's bounds. The projector and snapshot
+repository require only a non-empty opaque result and never impose Chatto's
+metadata key or identity syntax.
 
 This decision does not create or promise a public module yet. The current
 package still contains Chatto-specific typed convenience adapters. Extraction

--- a/docs/architecture/nats-resources.md
+++ b/docs/architecture/nats-resources.md
@@ -1,6 +1,6 @@
 # NATS Resource Inventory
 
-Key files: [`cli/internal/core/core.go`](../../cli/internal/core/core.go), [`cli/internal/events/subjects.go`](../../cli/internal/events/subjects.go), [`proto/chatto/core/v1/event.proto`](../../proto/chatto/core/v1/event.proto), [`cli/internal/core/subjects/subjects.go`](../../cli/internal/core/subjects/subjects.go)
+Key files: [`cli/internal/core/core.go`](../../cli/internal/core/core.go), [`cli/internal/evtstream/identity.go`](../../cli/internal/evtstream/identity.go), [`cli/internal/events/subjects.go`](../../cli/internal/events/subjects.go), [`proto/chatto/core/v1/event.proto`](../../proto/chatto/core/v1/event.proto), [`cli/internal/core/subjects/subjects.go`](../../cli/internal/core/subjects/subjects.go)
 
 Related decisions: [ADR-001](../adr/ADR-001-nats-jetstream-as-primary-data-store.md),
 [ADR-034](../adr/ADR-034-single-event-stream.md), and
@@ -23,3 +23,13 @@ inventories.
 | Object store | `ASSET_CACHE`       | File    | No     | Optional TTL cache for transformed image bytes                               |
 | NATS Core    | `live.sync.>`       | None    | No     | Transient `corev1.LiveEvent` pubsub signals                                  |
 | Republish    | `live.evt.>`        | None    | No     | Raw committed `EVT` facts republished by JetStream for server-side live delivery |
+
+## EVT stream identity
+
+`EVT` metadata key `chatto.evt.incarnation` stores a versioned identity with
+the existing `evt-incarnation-v1:` format. Chatto creates the value from the
+stream creation timestamp when metadata is missing, preserves it through
+normal updates and backups, and changes it when the stream is recreated.
+`internal/evtstream` is the application-owned authority for this metadata and
+format. Projection persistence receives the validated identity from
+composition and treats it as opaque.

--- a/docs/architecture/nats-resources.md
+++ b/docs/architecture/nats-resources.md
@@ -31,5 +31,6 @@ the existing `evt-incarnation-v1:` format. Chatto creates the value from the
 stream creation timestamp when metadata is missing, preserves it through
 normal updates and backups, and changes it when the stream is recreated.
 `internal/evtstream` is the application-owned authority for this metadata and
-format. Projection persistence receives the validated identity from
-composition and treats it as opaque.
+format. Projector restore resolves it from the same fresh stream-info snapshot
+as the relevant sequence bounds; projection persistence treats the validated
+result as opaque.

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -88,12 +88,12 @@ The projector framework also supports a projection-owned local checkpoint.
 The checkpoint contract binds the derived state and its highest atomically
 applied EVT sequence to a stable projection key, a projection contract ID, and
 the current EVT stream incarnation and retained sequence bounds. Chatto
-resolves and validates the incarnation before configuring the projector; the
-projector carries it as an opaque value and does not inspect JetStream
-metadata. A valid checkpoint replays only the remaining EVT tail. Its global
-stream cutoff may be newer than the last event matching the projection's
-current filters; only a cutoff beyond the EVT stream tail is a future
-checkpoint.
+supplies the identity resolver; at restore time the projector invokes it with
+the same fresh stream-info snapshot that supplies the sequence bounds, then
+carries the result as an opaque value. A valid checkpoint replays only the
+remaining EVT tail. Its global stream cutoff may be newer than the last event
+matching the projection's current filters; only a cutoff beyond the EVT stream
+tail is a future checkpoint.
 
 A projection uses at most one restore authority: ADR-050 snapshots, a local
 checkpoint, or neither. A projection without either starts empty and cold-replays
@@ -192,8 +192,9 @@ A new secret uses a different generation epoch and pointer locator. EVT carries
 a versioned opaque incarnation ID so snapshot validation survives process
 reconstruction and backup restore but changes when EVT is recreated.
 `internal/evtstream` owns Chatto's metadata key, format, generation, and
-validation. Core composition passes the resolved value into the snapshot
-repository and projector, whose persistence mechanics treat it as opaque.
+validation. Core composition passes its resolver into projector restore
+configuration and the resolved value into snapshot publication. Persistence
+mechanics treat the result as opaque.
 
 `core.projection_snapshot_retention` defaults to seven days. NATS applies it as
 the Object Store TTL. S3 uses a bounded age-expiry pass after daily publication

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -87,10 +87,13 @@ Related decisions: [ADR-007](../adr/ADR-007-per-user-encryption-with-crypto-shre
 The projector framework also supports a projection-owned local checkpoint.
 The checkpoint contract binds the derived state and its highest atomically
 applied EVT sequence to a stable projection key, a projection contract ID, and
-the current EVT stream incarnation and retained sequence bounds. A valid
-checkpoint replays only the remaining EVT tail. Its global stream cutoff may
-be newer than the last event matching the projection's current filters; only a
-cutoff beyond the EVT stream tail is a future checkpoint.
+the current EVT stream incarnation and retained sequence bounds. Chatto
+resolves and validates the incarnation before configuring the projector; the
+projector carries it as an opaque value and does not inspect JetStream
+metadata. A valid checkpoint replays only the remaining EVT tail. Its global
+stream cutoff may be newer than the last event matching the projection's
+current filters; only a cutoff beyond the EVT stream tail is a future
+checkpoint.
 
 A projection uses at most one restore authority: ADR-050 snapshots, a local
 checkpoint, or neither. A projection without either starts empty and cold-replays
@@ -188,6 +191,9 @@ cannot read, rotate, or compare each other's generations.
 A new secret uses a different generation epoch and pointer locator. EVT carries
 a versioned opaque incarnation ID so snapshot validation survives process
 reconstruction and backup restore but changes when EVT is recreated.
+`internal/evtstream` owns Chatto's metadata key, format, generation, and
+validation. Core composition passes the resolved value into the snapshot
+repository and projector, whose persistence mechanics treat it as opaque.
 
 `core.projection_snapshot_retention` defaults to seven days. NATS applies it as
 the Object Store TTL. S3 uses a bounded age-expiry pass after daily publication

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -193,8 +193,11 @@ a versioned opaque incarnation ID so snapshot validation survives process
 reconstruction and backup restore but changes when EVT is recreated.
 `internal/evtstream` owns Chatto's metadata key, format, generation, and
 validation. Core composition passes its resolver into projector restore
-configuration and the resolved value into snapshot publication. Persistence
-mechanics treat the result as opaque.
+configuration. The projector binds the resolved value to its run and captures
+it with snapshot state and cutoff. Capture re-resolves the current incarnation
+under the projection barrier and refuses publication if it differs; the worker
+publishes the captured value. Persistence mechanics treat the identity as
+opaque.
 
 `core.projection_snapshot_retention` defaults to seven days. NATS applies it as
 the Object Store TTL. S3 uses a bounded age-expiry pass after daily publication

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -194,10 +194,13 @@ reconstruction and backup restore but changes when EVT is recreated.
 `internal/evtstream` owns Chatto's metadata key, format, generation, and
 validation. Core composition passes its resolver into projector restore
 configuration. The projector binds the resolved value to its run and captures
-it with snapshot state and cutoff. Capture re-resolves the current incarnation
-under the projection barrier and refuses publication if it differs; the worker
-publishes the captured value. Persistence mechanics treat the identity as
-opaque.
+it with snapshot state and cutoff. Capture checks the current incarnation
+immediately before and after the projection barrier, performs no NATS I/O while
+holding that barrier, and refuses publication if the identity differs. The
+worker publishes the captured value. A transient lookup failure during
+best-effort restore falls back to the identity validated at configuration, so
+publication can recover after cold replay without accepting an actual stream
+recreation. Persistence mechanics treat the identity as opaque.
 
 `core.projection_snapshot_retention` defaults to seven days. NATS applies it as
 the Object Store TTL. S3 uses a bounded age-expiry pass after daily publication


### PR DESCRIPTION
## Why

`internal/events` is incubating the reusable Event Sourcing on NATS mechanics,
but it still owned Chatto's `chatto.evt.incarnation` metadata key, identity
format, and validation rules. That coupling made the extraction boundary
application-specific and encouraged persistence code to rediscover identity
instead of receiving it from composition.

## What changed

- Added `internal/evtstream` as Chatto's single owner for EVT identity metadata,
  deterministic generation, lookup, and `evt-incarnation-v1:` validation.
- Made projector checkpoint and snapshot restore use an application-supplied
  identity resolver against the same fresh `StreamInfo` as restore bounds.
- Made snapshot capture carry the identity bound to the projector run; capture
  checks identity before and after its short in-memory barrier, while the worker
  publishes the captured value instead of a separately cached startup value.
- Made generic projector and snapshot-repository mechanics treat stream
  identities as opaque, non-empty values.
- Updated ADR-054, ADR-056, the projection and NATS-resource inventories, and
  backend agent guidance to preserve the boundary.
- Added recreation, publication/restore, transient-failure recovery, exact
  persisted-format, and apply-barrier availability coverage.

## Compatibility and operations

- The persisted metadata key remains exactly `chatto.evt.incarnation`.
- Identity generation remains exactly the existing
  `evt-incarnation-v1:<32 hex characters>` algorithm and has a golden test.
- Existing snapshot/checkpoint namespaces, realtime cursor validation,
  backup/restore behavior, and stream-recreation invalidation remain compatible.
- There are no protobuf, persisted event, subject, public API, configuration,
  migration, or user-visible behavior changes.
- Mixed-version rollout and rollback remain safe because old and new binaries
  read and write the same EVT metadata value.

## Test plan

- `mise test-cli` — passed after the final changes.
- `mise lint` — passed.
- `mise license-check` — passed.
- `mise x -- go test -race ./internal/events -run 'TestProjectorSnapshot(PublicationRecoversAfterTransientIdentityFailure|IdentityLookupDoesNotHoldApplyBarrier)|TestProjectorResolvesSnapshotIdentityFromRecreatedStream' -count=1 -timeout 60s` — passed.
- Four adversarial review passes; restore freshness, publication freshness, and
  capture availability findings were fixed, and the final pass had no
  actionable findings.
