### PR TITLE
refactor(frontend): unify direct message presentation

### DIFF
--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -26,7 +26,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     setRoomSidebarPanel
   } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
-  import type { UserAvatarUserView } from '$lib/render/users';
+  import { buildDirectMessagePresentation, type UserAvatarUserView } from '$lib/render/users';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import NotificationBadge from '$lib/ui/NotificationBadge.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
@@ -176,30 +176,17 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   // When no layout exists, display channels alphabetically
   let sortedRooms = $derived([...channels].sort((a, b) => a.name.localeCompare(b.name)));
 
-  // DM display name: comma-joined participants other than the current user
-  // (or "You" for self-DMs).
-  //
-  // `meId` and DM members come from the same server projection prefix.
+  // The viewer ID and DM members must come from the same server projection.
   // Reading the viewer ID from a global auth context here is unsafe — the
   // [serverId] layout intentionally renders children while the per-instance
-  // CurrentUserState is still loading, so `currentUserState.user?.id` can be
-  // undefined for the first render and the filter would include self in the
-  // label/avatars (e.g. a 1:1 with Teal rendering as "Teal, hmans").
-  function dmDisplayName(room: RoomsListItem): string {
-    const meId = navigation.currentUserId;
-    const others = room.members.filter((m) => m.id !== meId);
-    if (others.length === 0) return m['common.you']();
-    return others.map((m) => getLiveDisplayName(m.id, m.displayName || m.login)).join(', ');
-  }
-
-  function dmAvatarParticipants(room: RoomsListItem) {
-    const meId = navigation.currentUserId;
-    const others = room.members.filter((m) => m.id !== meId);
-    if (others.length === 0) {
-      // Self-DM: show own avatar
-      return room.members.slice(0, 1);
-    }
-    return others.slice(0, 3);
+  // CurrentUserState is still loading.
+  function dmPresentation(room: RoomsListItem) {
+    return buildDirectMessagePresentation(
+      room.members,
+      navigation.currentUserId,
+      m['common.you'](),
+      getLiveDisplayName
+    );
   }
 
   function callParticipantAvatarUser(participant: CallRoomParticipant): UserAvatarUserView {
@@ -408,6 +395,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   {@const hasActiveCall = activeCallRooms.has(room.id)}
   {@const hasUnread = roomUnreadStore.roomIsUnread(room.id)}
   {@const hasUnreadAttention = hasUnread && room.id !== activeRoomId}
+  {@const presentation = dmPresentation(room)}
   <a
     href={resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId: room.id })}
     class={[
@@ -421,11 +409,11 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     {@attach roomMenuTrigger(room)}
   >
     <div class="flex shrink-0 -space-x-1">
-      {#each dmAvatarParticipants(room) as participant (participant.id)}
+      {#each presentation.visibleParticipants.slice(0, 3) as participant (participant.id)}
         <UserAvatar user={participant} size="xs" />
       {/each}
     </div>
-    <span class="flex-1 truncate">{dmDisplayName(room)}</span>
+    <span class="flex-1 truncate">{presentation.label}</span>
     {#if hasActiveCall}
       {@render activeCallParticipants(room.id)}
       {@render activeCallIcon()}

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -18,6 +18,7 @@ to the user settings page for the active server.
   import { getLiveDisplayName, type CustomUserStatus } from '$lib/state/userProfiles.svelte';
   import { setPresenceMode } from '$lib/presenceTracking';
   import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
+  import { buildDirectMessagePresentation } from '$lib/render/users';
 
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import {
@@ -66,12 +67,12 @@ to the user settings page for the active server.
     const room = activeCallRoom;
     if (!room) return m['common.current_call']();
     if (room.type === RoomKind.DM) {
-      const meId = navigation?.currentUserId;
-      const others = room.members.filter((member) => member.id !== meId);
-      if (others.length === 0) return m['common.you']();
-      return others
-        .map((member) => getLiveDisplayName(member.id, member.displayName || member.login))
-        .join(', ');
+      return buildDirectMessagePresentation(
+        room.members,
+        navigation?.currentUserId,
+        m['common.you'](),
+        getLiveDisplayName
+      ).label;
     }
     return `# ${room.name}`;
   });

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -10,6 +10,7 @@
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
   import { getAvatarInitials } from '$lib/utils/initials';
   import { getGradientForName } from '$lib/utils/gradients';
+  import { buildDirectMessagePresentation } from '$lib/render/users';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
   import { useDebounce } from '$lib/hooks/useDebounce.svelte';
@@ -86,15 +87,19 @@
         if (room.type === RoomKind.DM) {
           if (!isNavigationVisibleRoom(room)) continue;
           const participants = room.members.map(avatarUser);
+          const presentation = buildDirectMessagePresentation(
+            participants,
+            currentUserId,
+            m['common.you']()
+          );
           items.push({
             kind: 'dm',
             id: room.id,
-            label: dmLabel(participants, currentUserId),
+            label: presentation.label,
             detail: serverLabel,
             serverId: instance.id,
             serverName,
-            participants,
-            currentUserId,
+            participants: presentation.visibleParticipants.slice(0, 2),
             score: 0
           });
           continue;
@@ -202,15 +207,6 @@
     } catch {
       return url;
     }
-  }
-
-  function dmLabel(participants: AvatarUser[], currentUserId: string | undefined): string {
-    const others = participants.filter((p) => p.id !== currentUserId);
-    if (others.length === 0) {
-      const self = participants.find((p) => p.id === currentUserId);
-      return self ? self.displayName || self.login : 'You';
-    }
-    return others.map((p) => p.displayName || p.login).join(', ');
   }
 
   // --- Filtering ---
@@ -454,12 +450,6 @@
     return null;
   }
 
-  function dmAvatarParticipants(item: ResultItem): AvatarUser[] {
-    if (!item.participants) return [];
-    const others = item.participants.filter((p) => p.id !== item.currentUserId);
-    return others.length === 0 ? item.participants.slice(0, 1) : others.slice(0, 2);
-  }
-
   function userAvatarParticipant(item: ResultItem): AvatarUser | null {
     return item.participants?.[0] ?? null;
   }
@@ -569,7 +559,7 @@
                 {:else if item.kind === 'dm' && item.participants}
                   <span class="sidebar-icon">
                     <div class="flex -space-x-2">
-                      {#each dmAvatarParticipants(item) as participant (participant.id)}
+                      {#each item.participants as participant (participant.id)}
                         {@render avatar(participant)}
                       {/each}
                     </div>

--- a/apps/frontend/src/lib/render/users.spec.ts
+++ b/apps/frontend/src/lib/render/users.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildDirectMessagePresentation } from './users';
+
+const participants = [
+  { id: 'self', login: 'me', displayName: 'Me' },
+  { id: 'friend', login: 'friend', displayName: 'Friend' },
+  { id: 'colleague', login: 'colleague', displayName: '' }
+];
+
+describe('buildDirectMessagePresentation', () => {
+  it('builds a label and visible participant list from the other users', () => {
+    const getDisplayName = vi.fn((_userId: string, fallback: string) => `Live ${fallback}`);
+
+    expect(buildDirectMessagePresentation(participants, 'self', 'You', getDisplayName)).toEqual({
+      label: 'Live Friend, Live colleague',
+      visibleParticipants: participants.slice(1)
+    });
+    expect(getDisplayName).toHaveBeenNthCalledWith(1, 'friend', 'Friend');
+    expect(getDisplayName).toHaveBeenNthCalledWith(2, 'colleague', 'colleague');
+  });
+
+  it('uses the localized current-user label and avatar for a self-DM', () => {
+    expect(buildDirectMessagePresentation(participants.slice(0, 1), 'self', 'You')).toEqual({
+      label: 'You',
+      visibleParticipants: participants.slice(0, 1)
+    });
+  });
+
+  it('keeps an empty participant list empty', () => {
+    expect(buildDirectMessagePresentation([], 'self', 'You')).toEqual({
+      label: 'You',
+      visibleParticipants: []
+    });
+  });
+
+  it('shows all participants while the current user is unknown', () => {
+    expect(buildDirectMessagePresentation(participants, undefined, 'You')).toEqual({
+      label: 'Me, Friend, colleague',
+      visibleParticipants: participants
+    });
+  });
+});

--- a/apps/frontend/src/lib/render/users.ts
+++ b/apps/frontend/src/lib/render/users.ts
@@ -18,3 +18,26 @@ export type UserAvatarUserView = {
   presenceStatus: PresenceStatus;
   customStatus?: CustomUserStatusView | null;
 };
+
+type DirectMessageParticipant = Pick<UserAvatarUserView, 'id' | 'login' | 'displayName'>;
+
+/** Builds the shared label and avatar participants for a direct message. */
+export function buildDirectMessagePresentation<T extends DirectMessageParticipant>(
+  participants: readonly T[],
+  currentUserId: string | null | undefined,
+  currentUserLabel: string,
+  getDisplayName: (userId: string, fallback: string) => string = (_userId, fallback) => fallback
+) {
+  const others = participants.filter((participant) => participant.id !== currentUserId);
+  return {
+    label:
+      others.length > 0
+        ? others
+            .map((participant) =>
+              getDisplayName(participant.id, participant.displayName || participant.login)
+            )
+            .join(', ')
+        : currentUserLabel,
+    visibleParticipants: others.length > 0 ? others : participants.slice(0, 1)
+  };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.spec.ts
@@ -99,7 +99,7 @@ describe('buildRoomPresentation', () => {
     expect(getDisplayName).toHaveBeenCalledWith('other', 'Friend');
   });
 
-  it('uses the current participant for a self direct message', () => {
+  it('uses the localized current-user label for a self direct message', () => {
     expect(
       build(roomData(), true, {
         currentUserId: 'self',
@@ -113,9 +113,9 @@ describe('buildRoomPresentation', () => {
         ]
       })
     ).toEqual({
-      title: 'Me',
+      title: 'You',
       description: undefined,
-      pageTitle: 'Me'
+      pageTitle: 'You'
     });
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomPresentation.ts
@@ -1,4 +1,5 @@
 import type { DMData, RoomData } from '$lib/hooks/useRoomData.svelte';
+import { buildDirectMessagePresentation } from '$lib/render/users';
 
 export type RoomPresentation = {
   title: string;
@@ -33,18 +34,14 @@ export function buildRoomPresentation({
   }
 
   const participants = dmData?.participants ?? [];
-  const currentUserId = dmData?.currentUserId ?? null;
-  const others = participants.filter((participant) => participant.id !== currentUserId);
   let title = directMessageLabel;
-  if (others.length > 0) {
-    title = others
-      .map((participant) =>
-        getDisplayName(participant.id, participant.displayName || participant.login)
-      )
-      .join(', ');
-  } else if (participants.length > 0) {
-    const self = participants.find((participant) => participant.id === currentUserId);
-    title = self?.displayName || self?.login || currentUserLabel;
+  if (participants.length > 0) {
+    title = buildDirectMessagePresentation(
+      participants,
+      dmData?.currentUserId,
+      currentUserLabel,
+      getDisplayName
+    ).label;
   }
 
   return { title, description: undefined, pageTitle: title };


### PR DESCRIPTION
## Why

Direct-message labels and avatar participants were derived independently in the
room list, quick switcher, active-call bar, and room header. Those copies could
drift, and self-DMs already appeared as a display name in some surfaces and
“You” in others.

## What changed

- Added one pure presentation helper for selecting the other DM participants,
  retaining the current user's avatar for self-DMs, and building display labels.
- Reused that rule across all four frontend surfaces.
- Standardized self-DMs on the localized “You” label.
- Preserved the generic “Direct message” room-header fallback while participant
  data is unavailable.
- Added focused unit coverage for multi-user DMs, self-DMs, empty participant
  data, live display names, and loading without a known viewer.

This is frontend-only and has no API, persistence, migration, rollout, security,
or operational implications.

## Test plan

- Full frontend unit suite: 303 files and 2,555 tests passed.
- Focused helper and room-presentation suite: 2 files and 10 tests passed.
- `mise x -- pnpm --dir apps/frontend check` — passed with zero errors and
  warnings.
- `mise x -- pnpm --dir apps/frontend lint` — passed.
- Svelte autofixer — no issues in the three changed Svelte components.
- Browser smoke test — created and opened a self-DM and verified localized
  “You” in the room header, room list, and quick switcher; no console warnings
  or errors.
