### PR TITLE
perf(frontend): preserve lazy chunk boundaries

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -162,8 +162,7 @@ export default defineConfig({
         manualChunks(id) {
           const locale = id.match(/src\/lib\/paraglide\/messages\/([^/]+)\.js$/)?.[1];
           if (locale && locale !== i18nSettings.baseLocale) return `i18n-${locale.toLowerCase()}`;
-        },
-        experimentalMinChunkSize: 20_000
+        }
       }
     }
   },


### PR DESCRIPTION
## Why

Rollup's experimental 20 KiB minimum chunk size merged route-specific and lazy modules into initial route graphs. This reduced request counts, but increased cold-load transfer size by roughly 193–203 KiB gzip on representative routes.

## What changed

- Remove `experimentalMinChunkSize` from the frontend Rollup output configuration.
- Keep the existing explicit locale chunking unchanged.
- Allow Vite and SvelteKit to preserve their natural route and dynamic-import boundaries.

Measured initial static graphs:

| Route | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Login | 645.9 KiB gzip | 444.4 KiB gzip | 201.5 KiB |
| Overview | 674.2 KiB gzip | 471.5 KiB gzip | 202.7 KiB |
| Room | 818.4 KiB gzip | 625.2 KiB gzip | 193.2 KiB |

The resulting graphs contain more small files (for example, login increases from 49 to 58), preserving lazy boundaries instead of transferring unrelated code up front.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec eslint vite.config.ts`
- `mise x -- pnpm --filter chatto-frontend build`
- Inspect the generated Vite manifest and total the gzip-compressed static import closure for login, overview, and room routes.

No public API, persistence, migration, security, or rollout compatibility implications.
