### PR TITLE
refactor(events): make framework package self-contained

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -115,7 +115,9 @@ authorization, live events, backup/restore, and backend tests.
   aggregate subjects, event tokens, typed publisher/projector constructors, and
   envelope-aware effect consumers belong in `internal/evtstream`.
   `internal/events` must remain envelope-neutral and must not import Chatto
-  protobufs or `internal/evtstream`.
+  protobufs or `internal/evtstream`. Keep its production imports limited to
+  the Go standard library and `github.com/nats-io/nats.go`; application-wide
+  helpers must not become hidden extraction dependencies.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/internal/events/dependency_boundary_test.go
+++ b/cli/internal/events/dependency_boundary_test.go
@@ -34,3 +34,38 @@ func TestPackageAndTestsDoNotImportChattoApplicationContracts(t *testing.T) {
 		}
 	}
 }
+
+func TestProductionPackageDependsOnlyOnStandardLibraryAndNATS(t *testing.T) {
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packages, err := parser.ParseDir(
+		token.NewFileSet(),
+		directory,
+		func(info os.FileInfo) bool {
+			return strings.HasSuffix(info.Name(), ".go") &&
+				!strings.HasSuffix(info.Name(), "_test.go")
+		},
+		parser.ImportsOnly,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pkg := range packages {
+		for sourceName, source := range pkg.Files {
+			for _, spec := range source.Imports {
+				importPath, err := strconv.Unquote(spec.Path.Value)
+				if err != nil {
+					t.Fatalf("%s: decode import path: %v", sourceName, err)
+				}
+				if strings.Contains(importPath, ".") &&
+					importPath != "github.com/nats-io/nats.go" &&
+					!strings.HasPrefix(importPath, "github.com/nats-io/nats.go/") {
+					t.Errorf("%s imports non-framework dependency %q", sourceName, importPath)
+				}
+			}
+		}
+	}
+}

--- a/cli/internal/events/encoded_event_log.go
+++ b/cli/internal/events/encoded_event_log.go
@@ -14,8 +14,6 @@ import (
 
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
-
-	"hmans.de/chatto/internal/jetstreamutil"
 )
 
 // ErrConflict marks an optimistic-concurrency mismatch. Callers can use
@@ -330,7 +328,7 @@ func buildEncodedBatchMsg(
 }
 
 func sequenceConflictError(err error, target string, expectedSeq uint64) error {
-	if !jetstreamutil.IsSequenceConflict(err) {
+	if !isSequenceConflict(err) {
 		return nil
 	}
 	return fmt.Errorf("%s at expected seq %d: %w", target, expectedSeq, ErrConflict)

--- a/cli/internal/events/nats_errors.go
+++ b/cli/internal/events/nats_errors.go
@@ -1,0 +1,27 @@
+package events
+
+import (
+	"errors"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// constantWrongLastSequenceErrorCode is returned by newer NATS Server
+// versions for a wrong expected last sequence without sequence details.
+// nats.go v1.52.0 only exposes and maps the older detailed form (10071) to
+// ErrKeyExists, so retain the constant-form classification here until the
+// client library provides one.
+const constantWrongLastSequenceErrorCode jetstream.ErrorCode = 10164
+
+func isSequenceConflict(err error) bool {
+	if errors.Is(err, jetstream.ErrKeyExists) {
+		return true
+	}
+
+	var apiErr *jetstream.APIError
+	if !errors.As(err, &apiErr) {
+		return false
+	}
+	return apiErr.ErrorCode == jetstream.JSErrCodeStreamWrongLastSequence ||
+		apiErr.ErrorCode == constantWrongLastSequenceErrorCode
+}

--- a/cli/internal/events/publisher_conflict_test.go
+++ b/cli/internal/events/publisher_conflict_test.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/nats-io/nats.go"
@@ -11,18 +12,52 @@ import (
 func TestSequenceConflictErrorTranslatesWrongLastSequenceVariants(t *testing.T) {
 	tests := []struct {
 		name string
-		code jetstream.ErrorCode
+		err  error
 		want bool
 	}{
-		{name: "detailed form", code: jetstream.ErrorCode(10071), want: true},
-		{name: "constant form", code: jetstream.ErrorCode(10164), want: true},
-		{name: "unrelated", code: jetstream.JSErrCodeJetStreamNotEnabled},
+		{
+			name: "nats.go key exists sentinel",
+			err:  jetstream.ErrKeyExists,
+			want: true,
+		},
+		{
+			name: "wrapped nats.go key exists sentinel",
+			err:  fmt.Errorf("publish: %w", jetstream.ErrKeyExists),
+			want: true,
+		},
+		{
+			name: "detailed wrong last sequence",
+			err:  &jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10071)},
+			want: true,
+		},
+		{
+			name: "constant wrong last sequence",
+			err:  &jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10164)},
+			want: true,
+		},
+		{
+			name: "wrapped constant wrong last sequence",
+			err: fmt.Errorf(
+				"publish: %w",
+				&jetstream.APIError{Code: 400, ErrorCode: jetstream.ErrorCode(10164)},
+			),
+			want: true,
+		},
+		{
+			name: "unrelated API error",
+			err: &jetstream.APIError{
+				Code:      503,
+				ErrorCode: jetstream.JSErrCodeJetStreamNotEnabled,
+			},
+		},
+		{name: "unrelated error", err: errors.New("boom")},
+		{name: "nil"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			err := sequenceConflictError(
-				&jetstream.APIError{Code: 400, ErrorCode: tt.code},
+				tt.err,
 				"evt.room.R1.message_sent",
 				42,
 			)
@@ -33,10 +68,40 @@ func TestSequenceConflictErrorTranslatesWrongLastSequenceVariants(t *testing.T) 
 	}
 }
 
-func TestDecodeBatchAckTranslatesConstantWrongLastSequence(t *testing.T) {
-	msg := &nats.Msg{Data: []byte(`{"error":{"code":400,"err_code":10164,"description":"wrong last sequence"}}`)}
-	_, err := decodeBatchAck(msg, EncodedBatchEntry{Subject: "evt.room.R1.message_sent", ExpectedSeq: 42})
-	if !errors.Is(err, ErrConflict) {
-		t.Fatalf("decodeBatchAck error = %v, want ErrConflict", err)
+func TestDecodeBatchAckTranslatesWrongLastSequenceVariants(t *testing.T) {
+	for _, code := range []jetstream.ErrorCode{
+		jetstream.ErrorCode(10071),
+		jetstream.ErrorCode(10164),
+	} {
+		t.Run(fmt.Sprintf("error code %d", code), func(t *testing.T) {
+			msg := &nats.Msg{Data: []byte(fmt.Sprintf(
+				`{"error":{"code":400,"err_code":%d,"description":"wrong last sequence"}}`,
+				code,
+			))}
+			_, err := decodeBatchAck(msg, EncodedBatchEntry{
+				Subject:     "evt.room.R1.message_sent",
+				ExpectedSeq: 42,
+			})
+			if !errors.Is(err, ErrConflict) {
+				t.Fatalf("decodeBatchAck error = %v, want ErrConflict", err)
+			}
+		})
+	}
+}
+
+func TestDecodeBatchAckPreservesUnrelatedServerErrors(t *testing.T) {
+	msg := &nats.Msg{Data: []byte(fmt.Sprintf(
+		`{"error":{"code":503,"err_code":%d,"description":"JetStream unavailable"}}`,
+		jetstream.JSErrCodeJetStreamNotEnabled,
+	))}
+	_, err := decodeBatchAck(msg, EncodedBatchEntry{
+		Subject:     "evt.room.R1.message_sent",
+		ExpectedSeq: 42,
+	})
+	if err == nil {
+		t.Fatal("decodeBatchAck error = nil, want server error")
+	}
+	if errors.Is(err, ErrConflict) {
+		t.Fatalf("decodeBatchAck error = %v, unexpectedly wraps ErrConflict", err)
 	}
 }

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -107,7 +107,10 @@ existing projectors. It intentionally does not absorb registration metadata or
 snapshot policy, so some application composition remains explicit.
 
 Extraction still requires deliberate work. The reusable package no longer
-depends on Chatto's protobuf event envelope, subject vocabulary, or stream
-identity. Generic projection replay can use another application envelope
-without changing the ordered lifecycle, while `internal/evtstream` keeps
-Chatto's storage contract explicit and unchanged.
+depends on any other Chatto production package: its production imports are
+limited to the Go standard library and `nats.go`. It privately classifies the
+JetStream wrong-last-sequence errors needed to preserve `ErrConflict` rather
+than depending on Chatto's application-wide JetStream helpers. Generic
+projection replay can use another application envelope without changing the
+ordered lifecycle, while `internal/evtstream` keeps Chatto's storage contract
+explicit and unchanged.


### PR DESCRIPTION
## Why

`internal/events` is the incubator for Chatto's eventual standalone NATS
event-sourcing framework, but its production code still depended on one
Chatto-internal utility to classify JetStream optimistic-concurrency errors.
That hidden dependency made the package boundary less extractable than its API
and documentation suggested.

## What changed

- Replace the `internal/jetstreamutil` dependency with a private
  event-log-owned classifier for the same JetStream conflict forms.
- Preserve conflict handling for `jetstream.ErrKeyExists`, wrapped errors, and
  wrong-last-sequence codes `10071` and `10164`.
- Expand ordinary publish and atomic-batch acknowledgement tests to cover both
  conflict variants and unrelated server errors.
- Strengthen the dependency guard so production `internal/events` files may
  import only the Go standard library and `github.com/nats-io/nats.go`.
- Update ADR-056 and backend agent guidance to record the enforced boundary.

## Compatibility and rollout

- No public API, protobuf, NATS subject, payload, message ID, header, OCC
  filter, retry, stream-position, configuration, or migration changes.
- `events.ErrConflict` identity and wrapping remain unchanged for ordinary and
  atomic writes.
- Stored data, replay, mixed-version operation, backup/restore, and rollback
  behavior are unchanged.
- This is an internal dependency refactor and requires no rollout
  coordination.

## Test plan

- `mise x -- go test ./internal/events ./internal/evtstream ./internal/jetstreamutil`
- `mise x -- go test -race ./internal/events`
- `mise test-cli`
- `mise lint`
- `mise license-check`
- `git diff --check origin/main...HEAD`
- Adversarial review completed with no findings.
