### PR TITLE
refactor(frontend): remove mirrored chrome permissions

### DIFF
--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -7,7 +7,10 @@
   import { serverIdToSegment } from '$lib/navigation';
   import ServerSidebar from '$lib/components/ServerSidebar.svelte';
   import { ScrollFader } from '$lib/ui';
-  import { createChromePermissions } from '$lib/state/server/chromePermissions.svelte';
+  import {
+    createChromePermissions,
+    type ChromePermissions
+  } from '$lib/state/server/chromePermissions.svelte';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
   import RoomList from '$lib/RoomList.svelte';
   import ServerHeader from './ServerHeader.svelte';
@@ -93,19 +96,9 @@
     page.url.pathname === resolve('/chat/[serverId]/threads', { serverId: serverSegment })
   );
 
-  // Create server chrome permissions context (must be synchronous during init)
-  const updateChromePermissions = createChromePermissions();
-
-  type ServerChromeData = {
+  type ServerChromeData = ChromePermissions & {
     name: string;
     bannerUrl: string | null;
-    canViewAdmin: boolean;
-    canManage: boolean;
-    canManageRooms: boolean;
-    canManageRoles: boolean;
-    canAssignRoles: boolean;
-    canManageUserAccounts: boolean;
-    canManageUserPermissions: boolean;
   };
 
   // Server chrome is part of the canonical retained projection. Switching a
@@ -129,20 +122,9 @@
     };
   });
 
-  // Update server chrome permissions context when serverData changes
-  $effect(() => {
-    if (serverData) {
-      updateChromePermissions({
-        canViewAdmin: serverData.canViewAdmin,
-        canManage: serverData.canManage,
-        canManageRooms: serverData.canManageRooms,
-        canManageRoles: serverData.canManageRoles,
-        canAssignRoles: serverData.canAssignRoles,
-        canManageUserAccounts: serverData.canManageUserAccounts,
-        canManageUserPermissions: serverData.canManageUserPermissions
-      });
-    }
-  });
+  // Descendants read the canonical derived state directly, without a mirrored
+  // permission object or post-render synchronization effect.
+  createChromePermissions(() => serverData);
 
   // Server updates mutate the retained projection, so these derived values
   // update without a separate validation query.

--- a/apps/frontend/src/lib/state/server/chromePermissions.svelte.ts
+++ b/apps/frontend/src/lib/state/server/chromePermissions.svelte.ts
@@ -1,13 +1,6 @@
 import { createContext } from 'svelte';
 
 export type ChromePermissions = {
-  /**
-   * True once the server chrome permissions have been loaded. Use
-   * this to gate "Access Denied" / loading-skeleton rendering — defaulting
-   * to false would flash a denial during the brief window between layout
-   * mount and the validateServer query returning.
-   */
-  loaded: boolean;
   canViewAdmin: boolean;
   canManage: boolean;
   canManageRooms: boolean;
@@ -17,39 +10,23 @@ export type ChromePermissions = {
   canManageUserPermissions: boolean;
 };
 
-const [getChromePermissionsState, setChromePermissionsState] = createContext<{
-  current: ChromePermissions;
-}>();
+export type ChromePermissionsState = ChromePermissions | null;
+
+const [getChromePermissionsGetter, setChromePermissionsGetter] =
+  createContext<() => ChromePermissionsState>();
 
 /**
  * Creates and sets the server chrome permissions context.
  * Must be called synchronously during component initialization.
- * Returns a function to update the permissions.
+ *
+ * The getter returns `null` until permissions are available, allowing consumers
+ * to distinguish loading from an explicit denial.
  */
-export function createChromePermissions(): (permissions: Omit<ChromePermissions, 'loaded'>) => void {
-  const state = $state<{ current: ChromePermissions }>({
-    current: {
-      loaded: false,
-      canViewAdmin: false,
-      canManage: false,
-      canManageRooms: false,
-      canManageRoles: false,
-      canAssignRoles: false,
-      canManageUserAccounts: false,
-      canManageUserPermissions: false
-    }
-  });
-  setChromePermissionsState(state);
-
-  return (permissions: Omit<ChromePermissions, 'loaded'>) => {
-    state.current = { ...permissions, loaded: true };
-  };
+export function createChromePermissions(getPermissions: () => ChromePermissionsState): void {
+  setChromePermissionsGetter(getPermissions);
 }
 
-/**
- * Gets the reactive server chrome permissions state from context.
- * Returns the wrapper object so consumers can access `.current` reactively.
- */
-export function getChromePermissions(): { current: ChromePermissions } {
-  return getChromePermissionsState();
+/** Gets the reactive server chrome permissions getter from context. */
+export function getChromePermissions(): () => ChromePermissionsState {
+  return getChromePermissionsGetter();
 }

--- a/apps/frontend/src/routes/chat/[serverId]/manage/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/+layout.svelte
@@ -11,7 +11,8 @@
 
   let { children } = $props();
 
-  const chromePermissions = getChromePermissions();
+  const getChromePermissionsState = getChromePermissions();
+  const chromePermissions = $derived(getChromePermissionsState());
   const serverPerms = getServerPermissions();
 
   // Server management routes are gated here. Resource-scoped room routes
@@ -33,7 +34,7 @@
 
     // General settings page requires server manage permission
     if (pathname.startsWith(generalBase)) {
-      return () => chromePermissions.current.canManage;
+      return () => chromePermissions?.canManage ?? false;
     }
 
     // Members pages call AdminUserService.ListMembers/GetMember, which
@@ -45,7 +46,7 @@
     // The room collection is a server-wide layout editor. Individual room
     // pages allow delegated managers and enforce access after loading the room.
     if (pathname === roomsBase || pathname === `${roomsBase}/`) {
-      return () => chromePermissions.current.canManageRooms;
+      return () => chromePermissions?.canManageRooms ?? false;
     }
     if (pathname.startsWith(`${roomsBase}/`)) return () => true;
 
@@ -56,18 +57,18 @@
 
     // Moderation pages: the resolver enforces server-scope room.ban-member.
     if (pathname.startsWith(moderationBase)) {
-      return () => chromePermissions.current.canViewAdmin;
+      return () => chromePermissions?.canViewAdmin ?? false;
     }
 
     // Permissions pages call the server/group role permission matrix APIs,
     // which require role.manage.
     if (pathname.startsWith(permissionsBase)) {
-      return () => chromePermissions.current.canManageRoles;
+      return () => chromePermissions?.canManageRoles ?? false;
     }
 
     // Security (blocked usernames) — server.manage
     if (pathname.startsWith(securityBase)) {
-      return () => chromePermissions.current.canManage;
+      return () => chromePermissions?.canManage ?? false;
     }
 
     // System info (NATS/JetStream stats) — owner-only for now.
@@ -81,14 +82,12 @@
     }
 
     // Default: require server manage for unknown management routes.
-    return () => chromePermissions.current.canManage;
+    return () => chromePermissions?.canManage ?? false;
   }
 
   const hasPermission = $derived(getRoutePermissionCheck(page.url.pathname)());
 
-  const permissionsLoaded = $derived(
-    chromePermissions.current.loaded && serverPerms.current.loaded
-  );
+  const permissionsLoaded = $derived(chromePermissions !== null && serverPerms.current.loaded);
 </script>
 
 {#if !permissionsLoaded}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -41,7 +41,8 @@
   const roomId = $derived(page.params.roomId!);
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
-  const chromePermissions = getChromePermissions();
+  const getChromePermissionsState = getChromePermissions();
+  const chromePermissions = $derived(getChromePermissionsState());
 
   let room = $state<AdminManagedRoom | null>(null);
   let loading = $state(true);
@@ -74,7 +75,7 @@
     return supportsRoomManagerMemberReads(info.protocolCapabilities, info.version);
   });
   const backHref = $derived(
-    chromePermissions.current.canManageRooms
+    chromePermissions?.canManageRooms
       ? resolve('/chat/[serverId]/manage/rooms', { serverId: serverSegment })
       : resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId })
   );

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -68,9 +68,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
 }));
 
 vi.mock('$lib/state/server/chromePermissions.svelte', () => ({
-  getChromePermissions: () => ({
-    current: { canManageRooms: true, canManageRoles: true }
-  })
+  getChromePermissions: () => () => ({ canManageRooms: true, canManageRoles: true })
 }));
 
 vi.mock('$lib/api-client/adminRoomLayout', () => ({


### PR DESCRIPTION
## Why

The shared chat shell derived viewer permissions from the canonical server
projection, then copied them into a second reactive object through `$effect`.
That duplicate state added code and could retain permissions from the previous
server until the post-render synchronization ran.

## What changed

- Changed the chrome permission context to expose a reactive getter over the
  canonical derived server data.
- Represents unavailable permissions as `null`, preserving the distinction
  between loading and explicit denial.
- Removed the mirrored `$state` object, default permission object, updater
  callback, and synchronization `$effect`.
- Updated management-route and managed-room consumers plus the focused test
  mock to use the getter contract.
- Reduced the affected frontend code by 43 net lines.

Permission policy and backend authorization are unchanged.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest --run 'src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts'`
  — 7 tests passed.
- `mise x -- pnpm --dir apps/frontend check` — design-system guardrails passed;
  Svelte check reported 0 errors and 0 warnings.
- `mise x -- pnpm --dir apps/frontend lint` — passed.
- Svelte autofixer — no issues in the changed state/context flow.
- Browser verification — owner Alice reached General administration; non-admin
  Bob received the expected Access Denied boundary; no console errors.
- Independent adversarial code review — no findings.

This is a frontend-only refactor with no public API, persistence, compatibility,
migration, security-policy, rollout, or operational implications.
