### PR TITLE
test(events): prove external framework consumer

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -118,6 +118,9 @@ authorization, live events, backup/restore, and backend tests.
   protobufs or `internal/evtstream`. Keep its production imports limited to
   the Go standard library and `github.com/nats-io/nats.go`; application-wide
   helpers must not become hidden extraction dependencies.
+- Drive reusable `internal/events` API changes from external-package consumer
+  contracts with non-Chatto envelopes. Do not add generic framework surface
+  merely to shorten Chatto wiring.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/internal/events/dependency_boundary_test.go
+++ b/cli/internal/events/dependency_boundary_test.go
@@ -69,3 +69,26 @@ func TestProductionPackageDependsOnlyOnStandardLibraryAndNATS(t *testing.T) {
 		}
 	}
 }
+
+func TestFrameworkConsumerUsesOnlyPublicFrameworkPackage(t *testing.T) {
+	source, err := parser.ParseFile(
+		token.NewFileSet(),
+		"framework_consumer_test.go",
+		nil,
+		parser.ImportsOnly,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, spec := range source.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			t.Fatalf("decode import path: %v", err)
+		}
+		if strings.HasPrefix(importPath, "hmans.de/chatto/") &&
+			importPath != "hmans.de/chatto/internal/events" {
+			t.Errorf("external consumer imports Chatto package %q", importPath)
+		}
+	}
+}

--- a/cli/internal/events/dependency_boundary_test.go
+++ b/cli/internal/events/dependency_boundary_test.go
@@ -1,6 +1,7 @@
 package events_test
 
 import (
+	"go/build"
 	"go/parser"
 	"go/token"
 	"os"
@@ -60,9 +61,8 @@ func TestProductionPackageDependsOnlyOnStandardLibraryAndNATS(t *testing.T) {
 				if err != nil {
 					t.Fatalf("%s: decode import path: %v", sourceName, err)
 				}
-				if strings.Contains(importPath, ".") &&
-					importPath != "github.com/nats-io/nats.go" &&
-					!strings.HasPrefix(importPath, "github.com/nats-io/nats.go/") {
+				if !isStandardLibraryImport(importPath, directory) &&
+					!isNATSImport(importPath) {
 					t.Errorf("%s imports non-framework dependency %q", sourceName, importPath)
 				}
 			}
@@ -80,15 +80,39 @@ func TestFrameworkConsumerUsesOnlyPublicFrameworkPackage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if source.Name.Name != "events_test" {
+		t.Fatalf(
+			"framework consumer package = %q, want external package %q",
+			source.Name.Name,
+			"events_test",
+		)
+	}
 
+	importsFramework := false
 	for _, spec := range source.Imports {
 		importPath, err := strconv.Unquote(spec.Path.Value)
 		if err != nil {
 			t.Fatalf("decode import path: %v", err)
+		}
+		if importPath == "hmans.de/chatto/internal/events" {
+			importsFramework = true
 		}
 		if strings.HasPrefix(importPath, "hmans.de/chatto/") &&
 			importPath != "hmans.de/chatto/internal/events" {
 			t.Errorf("external consumer imports Chatto package %q", importPath)
 		}
 	}
+	if !importsFramework {
+		t.Error("external consumer does not import the public events package")
+	}
+}
+
+func isStandardLibraryImport(importPath, sourceDirectory string) bool {
+	pkg, err := build.Default.Import(importPath, sourceDirectory, build.FindOnly)
+	return err == nil && pkg.Goroot
+}
+
+func isNATSImport(importPath string) bool {
+	return importPath == "github.com/nats-io/nats.go" ||
+		strings.HasPrefix(importPath, "github.com/nats-io/nats.go/")
 }

--- a/cli/internal/events/framework_consumer_test.go
+++ b/cli/internal/events/framework_consumer_test.go
@@ -1,0 +1,215 @@
+package events_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"hmans.de/chatto/internal/events"
+)
+
+const ledgerSubject = "evt.ledger.account-1.entry_recorded"
+
+type ledgerEntry struct {
+	ID    string `json:"id"`
+	Delta int    `json:"delta"`
+}
+
+type ledgerAdapter struct {
+	log *events.EncodedEventLog
+}
+
+func (a ledgerAdapter) appendAt(
+	ctx context.Context,
+	entry ledgerEntry,
+	expectedSequence uint64,
+) (events.StreamPosition, error) {
+	data, err := json.Marshal(entry)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	sequence, err := a.log.AppendAt(
+		ctx,
+		ledgerSubject,
+		events.EncodedRecord{ID: entry.ID, Data: data},
+		expectedSequence,
+	)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	return events.SubjectPosition(ledgerSubject, sequence), nil
+}
+
+func decodeLedgerEntry(data []byte) (events.DecodedEvent[ledgerEntry], error) {
+	var entry ledgerEntry
+	if err := json.Unmarshal(data, &entry); err != nil {
+		return events.DecodedEvent[ledgerEntry]{}, err
+	}
+	return events.DecodedEvent[ledgerEntry]{
+		Event: entry,
+		ID:    entry.ID,
+	}, nil
+}
+
+type ledgerBalanceProjection struct {
+	events.MemoryProjection
+	balance   int
+	entryIDs  []string
+	sequences []uint64
+}
+
+func (*ledgerBalanceProjection) Subjects() []string {
+	return []string{ledgerSubject}
+}
+
+func (p *ledgerBalanceProjection) Apply(entry ledgerEntry, sequence uint64) error {
+	p.Lock()
+	defer p.Unlock()
+	p.balance += entry.Delta
+	p.entryIDs = append(p.entryIDs, entry.ID)
+	p.sequences = append(p.sequences, sequence)
+	return nil
+}
+
+func (p *ledgerBalanceProjection) state() (int, []string, []uint64) {
+	p.RLock()
+	defer p.RUnlock()
+	return p.balance, slices.Clone(p.entryIDs), slices.Clone(p.sequences)
+}
+
+func runConsumerProjector(t *testing.T, projector *events.Projector) func() {
+	t.Helper()
+	runContext, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- projector.Run(runContext)
+	}()
+
+	var once sync.Once
+	stop := func() {
+		t.Helper()
+		once.Do(func() {
+			cancel()
+			select {
+			case err := <-errCh:
+				if !errors.Is(err, context.Canceled) {
+					t.Errorf("projector shutdown error = %v, want context cancellation", err)
+				}
+			case <-time.After(2 * time.Second):
+				t.Error("projector did not stop after context cancellation")
+			}
+		})
+	}
+	t.Cleanup(stop)
+	return stop
+}
+
+func TestFrameworkSupportsAnExternalJSONConsumer(t *testing.T) {
+	js, stream := setupTestStream(t)
+	eventLog := events.NewEncodedEventLog(js, stream, testLogger())
+	ledger := ledgerAdapter{log: eventLog}
+	ctx := testContext(t)
+
+	liveProjection := &ledgerBalanceProjection{}
+	liveHandle := events.NewDecodedProjectionHandle(
+		js,
+		stream,
+		liveProjection,
+		decodeLedgerEntry,
+		testLogger(),
+	)
+	stopLiveProjector := runConsumerProjector(t, liveHandle.Projector())
+	waitFor(t, 2*time.Second, func() bool {
+		return liveHandle.Projector().Status().StartupComplete
+	})
+
+	firstPosition, err := ledger.appendAt(ctx, ledgerEntry{ID: "entry-1", Delta: 7}, 0)
+	if err != nil {
+		t.Fatalf("append first ledger entry: %v", err)
+	}
+	if err := liveHandle.Projector().WaitFor(ctx, firstPosition); err != nil {
+		t.Fatalf("wait for first ledger entry: %v", err)
+	}
+	if balance, entryIDs, sequences := liveProjection.state(); balance != 7 ||
+		!slices.Equal(entryIDs, []string{"entry-1"}) ||
+		!slices.Equal(sequences, []uint64{firstPosition.Seq}) {
+		t.Fatalf(
+			"state after first entry = balance %d, IDs %v, sequences %v",
+			balance,
+			entryIDs,
+			sequences,
+		)
+	}
+
+	secondPosition, err := ledger.appendAt(
+		ctx,
+		ledgerEntry{ID: "entry-2", Delta: 5},
+		firstPosition.Seq,
+	)
+	if err != nil {
+		t.Fatalf("append second ledger entry: %v", err)
+	}
+	if err := liveHandle.Projector().WaitFor(ctx, secondPosition); err != nil {
+		t.Fatalf("wait for second ledger entry: %v", err)
+	}
+
+	if _, err := ledger.appendAt(
+		ctx,
+		ledgerEntry{ID: "entry-stale", Delta: 100},
+		firstPosition.Seq,
+	); !errors.Is(err, events.ErrConflict) {
+		t.Fatalf("stale ledger append error = %v, want events.ErrConflict", err)
+	}
+	tail, err := eventLog.LastSubjectPosition(ctx, ledgerSubject)
+	if err != nil {
+		t.Fatalf("read ledger tail: %v", err)
+	}
+	if tail != secondPosition {
+		t.Fatalf("ledger tail after stale append = %+v, want %+v", tail, secondPosition)
+	}
+
+	wantBalance, wantEntryIDs, wantSequences := liveProjection.state()
+	if wantBalance != 12 ||
+		!slices.Equal(wantEntryIDs, []string{"entry-1", "entry-2"}) ||
+		!slices.Equal(wantSequences, []uint64{firstPosition.Seq, secondPosition.Seq}) {
+		t.Fatalf(
+			"live state = balance %d, IDs %v, sequences %v",
+			wantBalance,
+			wantEntryIDs,
+			wantSequences,
+		)
+	}
+	stopLiveProjector()
+
+	replayedProjection := &ledgerBalanceProjection{}
+	replayedHandle := events.NewDecodedProjectionHandle(
+		js,
+		stream,
+		replayedProjection,
+		decodeLedgerEntry,
+		testLogger(),
+	)
+	runConsumerProjector(t, replayedHandle.Projector())
+	if err := replayedHandle.Projector().WaitFor(ctx, secondPosition); err != nil {
+		t.Fatalf("wait for replayed ledger history: %v", err)
+	}
+
+	gotBalance, gotEntryIDs, gotSequences := replayedProjection.state()
+	if gotBalance != wantBalance ||
+		!slices.Equal(gotEntryIDs, wantEntryIDs) ||
+		!slices.Equal(gotSequences, wantSequences) {
+		t.Fatalf(
+			"replayed state = balance %d, IDs %v, sequences %v; want balance %d, IDs %v, sequences %v",
+			gotBalance,
+			gotEntryIDs,
+			gotSequences,
+			wantBalance,
+			wantEntryIDs,
+			wantSequences,
+		)
+	}
+}

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -88,7 +88,11 @@ does not maintain a second identity value.
 This decision does not create or promise a public module yet. The physical
 package direction is application/core code to `internal/evtstream`, then to
 `internal/events`. Extraction will happen only when concrete framework users
-show the smallest useful public API.
+show the smallest useful public API. An external-package consumer contract
+acts as the first such user: it owns a non-Chatto JSON envelope, subject
+policy, typed event-log adapter, and projection while exercising only exported
+framework APIs. Future generic surface should be justified by friction in this
+kind of consumer rather than by a desire to shorten Chatto-specific wiring.
 
 ## Consequences
 
@@ -114,3 +118,8 @@ than depending on Chatto's application-wide JetStream helpers. Generic
 projection replay can use another application envelope without changing the
 ordered lifecycle, while `internal/evtstream` keeps Chatto's storage contract
 explicit and unchanged.
+
+The external consumer contract proves live OCC publication, read-your-writes
+waiting, conflict reporting, projector shutdown, and cold replay through the
+same public surface. It is an executable extraction seam, not a second
+production event model or a promise that the current package API is stable.


### PR DESCRIPTION
## Why

Before extracting `internal/events` into a standalone Event Sourcing on NATS
module, we need evidence that its exported surface works for an application
that does not share Chatto's protobufs, envelopes, or domain helpers.

## What changed

- Add an external-package JSON ledger consumer that exercises live OCC
  publication, read-your-writes waits, conflict handling, clean projector
  shutdown, and cold replay.
- Guard the contract so it remains in `events_test` and imports no Chatto
  package other than `internal/events`.
- Harden the production dependency boundary check with Go's package metadata
  instead of import-path punctuation heuristics.
- Record the consumer-driven extraction rule in `cli/AGENTS.md` and ADR-056.

## Compatibility

- No production code, public API, protobuf, subject, event envelope, persisted
  bytes, headers, OCC semantics, configuration, or user-visible behaviour
  changes.
- Existing Chatto servers and their stored events remain fully compatible.
- This establishes an executable extraction seam; it does not publish or
  promise stability for a standalone module yet.

## Test plan

- `mise x -- go test -race -count=10 ./internal/events` — passed
- Independent adversarial rerun: `go test -race -count=25 ./internal/events` — passed
- `mise x -- go test -race ./internal/events` after rebasing — passed
- `mise test-cli` after rebasing — passed
- `mise lint` — passed, including 0 Svelte errors and 0 warnings
- `mise license-check` — passed, 2,417/2,417 files compliant
- `git diff --check origin/main...HEAD` — passed

## Review

The first adversarial review found that the dependency guard did not enforce
the external package declaration. The follow-up commit now requires
`package events_test`; a second adversarial review reported no findings.
