### PR TITLE
perf(frontend): reduce initial route bundles

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev",
-    "build": "vite build",
+    "build": "vite build && pnpm check:bundle",
+    "check:bundle": "node scripts/check-bundle-size.mjs",
     "preview": "vite preview",
     "paraglide": "paraglide-js compile --project ./project.inlang --outdir ./src/lib/paraglide --strategy localStorage preferredLanguage baseLocale --no-emit-ts-declarations --output-structure locale-modules --silent && node scripts/generate-i18n-facade.mjs",
     "prepare": "svelte-kit sync || echo ''",

--- a/apps/frontend/scripts/check-bundle-size.mjs
+++ b/apps/frontend/scripts/check-bundle-size.mjs
@@ -17,6 +17,7 @@ const routes = [
   {
     name: 'overview',
     budgetKiB: 370,
+    additionalEntries: ['src/routes/chat/AuthenticatedRoot.svelte'],
     components: [
       'src/routes/+layout.svelte',
       'src/routes/chat/+layout.svelte',
@@ -27,6 +28,7 @@ const routes = [
   {
     name: 'room',
     budgetKiB: 540,
+    additionalEntries: ['src/routes/chat/AuthenticatedRoot.svelte'],
     components: [
       'src/routes/+layout.svelte',
       'src/routes/chat/+layout.svelte',
@@ -53,6 +55,9 @@ const routeResults = [];
 for (const route of routes) {
   const entryKeys = [
     ...sharedEntryKeys,
+    ...(route.additionalEntries ?? []).map((source) =>
+      findManifestKey((entry) => entry.src === source)
+    ),
     ...route.components.map((component) => {
       const nodeFile = nodeEntries.get(component);
       if (!nodeFile) throw new Error(`Could not find generated SvelteKit node for ${component}`);

--- a/apps/frontend/scripts/check-bundle-size.mjs
+++ b/apps/frontend/scripts/check-bundle-size.mjs
@@ -1,0 +1,166 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { gzipSync } from 'node:zlib';
+
+const frontendRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const clientRoot = resolve(frontendRoot, '.svelte-kit/output/client');
+const generatedNodesRoot = resolve(frontendRoot, '.svelte-kit/generated/client-optimized/nodes');
+const manifestPath = resolve(clientRoot, '.vite/manifest.json');
+
+const routes = [
+  {
+    name: 'login',
+    budgetKiB: 290,
+    components: ['src/routes/+layout.svelte', 'src/routes/login/+page.svelte']
+  },
+  {
+    name: 'overview',
+    budgetKiB: 370,
+    components: [
+      'src/routes/+layout.svelte',
+      'src/routes/chat/+layout.svelte',
+      'src/routes/chat/[serverId]/+layout.svelte',
+      'src/routes/chat/[serverId]/overview/+page.svelte'
+    ]
+  },
+  {
+    name: 'room',
+    budgetKiB: 540,
+    components: [
+      'src/routes/+layout.svelte',
+      'src/routes/chat/+layout.svelte',
+      'src/routes/chat/[serverId]/+layout.svelte',
+      'src/routes/chat/[serverId]/[roomId]/+layout.svelte',
+      'src/routes/chat/[serverId]/[roomId]/+page.svelte'
+    ]
+  }
+];
+
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+const manifestByFile = new Map(
+  Object.entries(manifest).map(([key, entry]) => [entry.file, { key, entry }])
+);
+const nodeEntries = await discoverNodeEntries();
+const sharedEntryKeys = [
+  findManifestKey((entry) => entry.name === 'entry/start'),
+  findManifestKey((entry) => entry.name === 'entry/app')
+];
+
+let failed = false;
+const routeResults = [];
+
+for (const route of routes) {
+  const entryKeys = [
+    ...sharedEntryKeys,
+    ...route.components.map((component) => {
+      const nodeFile = nodeEntries.get(component);
+      if (!nodeFile) throw new Error(`Could not find generated SvelteKit node for ${component}`);
+      return findManifestKey((entry) => entry.src?.endsWith(`/nodes/${nodeFile}`));
+    })
+  ];
+  const files = collectInitialFiles(entryKeys);
+  const gzipBytes = await gzipFiles(files);
+  const budgetBytes = route.budgetKiB * 1024;
+
+  routeResults.push({ ...route, initialFiles: files, gzipBytes });
+  if (gzipBytes > budgetBytes) failed = true;
+}
+
+const liveKitEntry = Object.entries(manifest).find(([, entry]) =>
+  entry.src?.includes('/livekit-client/dist/livekit-client.esm.mjs')
+);
+if (!liveKitEntry || !liveKitEntry[1].isDynamicEntry) {
+  throw new Error('Expected livekit-client to remain a dynamic production entry');
+}
+for (const result of routeResults) {
+  if (result.initialFiles.has(liveKitEntry[1].file)) {
+    throw new Error(`Expected livekit-client to stay outside the ${result.name} initial bundle`);
+  }
+}
+
+const widestRouteNameLength = Math.max(...routeResults.map(({ name }) => name.length));
+for (const result of routeResults) {
+  const actual = formatKiB(result.gzipBytes).padStart(9);
+  const budget = `${result.budgetKiB.toFixed(1)} KiB`.padStart(9);
+  const status = result.gzipBytes <= result.budgetKiB * 1024 ? 'PASS' : 'FAIL';
+  console.log(
+    `${result.name.padEnd(widestRouteNameLength)}  ${actual} / ${budget}  ` +
+      `${String(result.initialFiles.size).padStart(2)} initial files  ${status}`
+  );
+}
+
+if (failed) {
+  console.error('\nProduction bundle budget exceeded.');
+  process.exitCode = 1;
+}
+
+async function discoverNodeEntries() {
+  const entries = new Map();
+  const filenames = await readdir(generatedNodesRoot);
+
+  await Promise.all(
+    filenames
+      .filter((filename) => filename.endsWith('.js'))
+      .map(async (filename) => {
+        const source = await readFile(resolve(generatedNodesRoot, filename), 'utf8');
+        for (const route of routes) {
+          for (const component of route.components) {
+            if (source.includes(component)) entries.set(component, filename);
+          }
+        }
+      })
+  );
+
+  return entries;
+}
+
+function findManifestKey(predicate) {
+  const match = Object.entries(manifest).find(([, entry]) => predicate(entry));
+  if (!match) throw new Error('Could not find expected entry in the Vite manifest');
+  return match[0];
+}
+
+function collectInitialFiles(entryKeys) {
+  const visitedEntries = new Set();
+  const files = new Set();
+  const pending = [...entryKeys];
+
+  while (pending.length > 0) {
+    const key = pending.pop();
+    if (visitedEntries.has(key)) continue;
+    visitedEntries.add(key);
+
+    const entry = manifest[key];
+    if (!entry) throw new Error(`Could not resolve Vite manifest entry ${key}`);
+    files.add(entry.file);
+    for (const cssFile of entry.css ?? []) files.add(cssFile);
+
+    for (const importReference of entry.imports ?? []) {
+      const imported = manifest[importReference] ?? manifestByFile.get(importReference)?.entry;
+      const importedKey =
+        manifest[importReference] !== undefined
+          ? importReference
+          : manifestByFile.get(importReference)?.key;
+      if (!imported || !importedKey) {
+        throw new Error(`Could not resolve Vite manifest import ${importReference}`);
+      }
+      pending.push(importedKey);
+    }
+  }
+
+  return files;
+}
+
+async function gzipFiles(files) {
+  let total = 0;
+  for (const file of files) {
+    const contents = await readFile(resolve(clientRoot, file));
+    total += gzipSync(contents, { level: 9 }).byteLength;
+  }
+  return total;
+}
+
+function formatKiB(bytes) {
+  return `${(bytes / 1024).toFixed(1)} KiB`;
+}

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -350,6 +350,8 @@ describe('VoiceCallState', () => {
     const state = new VoiceCallState(client);
 
     const join = state.join('wss://livekit.example.test', 'R1');
+    expect(state.connecting).toBe(true);
+    expect(state.roomId).toBe('R1');
     await flushPromises();
 
     expect(state.callTransitionSoundDecision('join', 'R1', 'call-1', true)).toBe('defer');

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -56,10 +56,15 @@ let liveKitModule: LiveKitModule | null = null;
 let liveKitModulePromise: Promise<LiveKitModule> | null = null;
 
 async function loadLiveKit(): Promise<LiveKitModule> {
-  liveKitModulePromise ??= import('livekit-client').then((module) => {
-    liveKitModule = module;
-    return module;
-  });
+  liveKitModulePromise ??= import('livekit-client')
+    .then((module) => {
+      liveKitModule = module;
+      return module;
+    })
+    .catch((error: unknown) => {
+      liveKitModulePromise = null;
+      throw error;
+    });
   return liveKitModulePromise;
 }
 
@@ -363,7 +368,6 @@ export class VoiceCallState {
 
   private async performJoin(livekitUrl: string, roomId: string): Promise<void> {
     assertLiveKitE2EESupported();
-    const { AudioPresets, ExternalE2EEKeyProvider, Room, VideoPresets } = await loadLiveKit();
 
     // Leave existing call first
     if (this.connected) {
@@ -375,6 +379,8 @@ export class VoiceCallState {
     let joinIntentRecorded = false;
 
     try {
+      const { AudioPresets, ExternalE2EEKeyProvider, Room, VideoPresets } = await loadLiveKit();
+
       await this.#api.joinCall(roomId);
       joinIntentRecorded = true;
 

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -6,17 +6,13 @@
  * screen share toggle, and audio/video device selection.
  */
 
-import {
+import type {
+  Participant,
+  RemoteTrack,
+  RemoteTrackPublication,
+  RemoteParticipant,
   Room,
-  RoomEvent,
-  Track,
-  AudioPresets,
-  VideoPresets,
-  ExternalE2EEKeyProvider,
-  type Participant,
-  type RemoteTrack,
-  type RemoteTrackPublication,
-  type RemoteParticipant
+  Track
 } from 'livekit-client';
 import { toast } from '$lib/ui/toast';
 import { playCallSound } from '$lib/audio/callSounds';
@@ -52,18 +48,32 @@ type ParticipantMetadata = {
   avatarUrl?: string;
 };
 
+type LiveKitModule = typeof import('livekit-client');
+
 const RECENTLY_DISCONNECTED_CALL_SOUND_MS = 5_000;
 const MEDIA_DEVICE_TOAST_DEDUPLICATION_MS = 1_500;
+let liveKitModule: LiveKitModule | null = null;
+let liveKitModulePromise: Promise<LiveKitModule> | null = null;
+
+async function loadLiveKit(): Promise<LiveKitModule> {
+  liveKitModulePromise ??= import('livekit-client').then((module) => {
+    liveKitModule = module;
+    return module;
+  });
+  return liveKitModulePromise;
+}
+
+function getLoadedLiveKit(): LiveKitModule {
+  if (!liveKitModule) {
+    throw new Error('LiveKit must be loaded before using an active call');
+  }
+  return liveKitModule;
+}
 
 type VoiceCallMediaDeviceTarget = 'microphone' | 'camera' | 'screen' | 'speaker' | 'device';
 type VoiceCallMediaDeviceContext = 'join' | 'enable' | 'switch' | 'event';
 type MediaDeviceFailureKind =
-  | 'permission-denied'
-  | 'not-found'
-  | 'in-use'
-  | 'constraint'
-  | 'aborted'
-  | 'unknown';
+  'permission-denied' | 'not-found' | 'in-use' | 'constraint' | 'aborted' | 'unknown';
 
 export class VoiceCallJoinError extends Error {
   readonly userMessage: string;
@@ -353,6 +363,7 @@ export class VoiceCallState {
 
   private async performJoin(livekitUrl: string, roomId: string): Promise<void> {
     assertLiveKitE2EESupported();
+    const { AudioPresets, ExternalE2EEKeyProvider, Room, VideoPresets } = await loadLiveKit();
 
     // Leave existing call first
     if (this.connected) {
@@ -642,6 +653,7 @@ export class VoiceCallState {
 
   private async performToggleScreenShare(room: Room): Promise<void> {
     const newEnabled = !this.isScreenShareEnabled;
+    const { AudioPresets } = getLoadedLiveKit();
     try {
       await this.runExplicitMediaDeviceOperation(() =>
         room.localParticipant.setScreenShareEnabled(
@@ -682,6 +694,7 @@ export class VoiceCallState {
    */
   async refreshDevices(options: { requestVideoPermissions?: boolean } = {}): Promise<void> {
     try {
+      const { Room } = await loadLiveKit();
       const requestVideoPermissions = options.requestVideoPermissions ?? this.isCameraEnabled;
       const [inputDevices, outputDevices, videoInputDevices] = await Promise.all([
         Room.getLocalDevices('audioinput'),
@@ -766,6 +779,7 @@ export class VoiceCallState {
 
   private setupRoomEventListeners(): void {
     if (!this.room) return;
+    const { RoomEvent, Track } = getLoadedLiveKit();
 
     this.room.on(RoomEvent.ParticipantConnected, () => {
       this.updateParticipants();
@@ -898,6 +912,7 @@ export class VoiceCallState {
   }
 
   private applyRemoteParticipantAudioVolume(participant: RemoteParticipant): void {
+    const { Track } = getLoadedLiveKit();
     const volume = this.isParticipantLocallyMuted(participant.identity) ? 0 : 1;
     participant.setVolume(volume, Track.Source.Microphone);
     participant.setVolume(volume, Track.Source.ScreenShareAudio);
@@ -935,6 +950,7 @@ export class VoiceCallState {
     this.teardownLocalAudioAnalyser();
     if (!this.room) return;
 
+    const { Track } = getLoadedLiveKit();
     const micPub = this.room.localParticipant.getTrackPublication(Track.Source.Microphone);
     const mediaStreamTrack = micPub?.track?.mediaStreamTrack;
     if (!mediaStreamTrack) return;
@@ -1103,6 +1119,7 @@ function parseParticipantMetadata(metadata: string | undefined): ParticipantMeta
 }
 
 function isParticipantMuted(participant: Participant): boolean {
+  const { Track } = getLoadedLiveKit();
   for (const pub of participant.getTrackPublications()) {
     if (pub.track?.source === Track.Source.Microphone) {
       return pub.isMuted;
@@ -1113,6 +1130,7 @@ function isParticipantMuted(participant: Participant): boolean {
 }
 
 function isParticipantCameraEnabled(participant: Participant): boolean {
+  const { Track } = getLoadedLiveKit();
   for (const pub of participant.getTrackPublications()) {
     if (pub.track?.source === Track.Source.Camera) {
       return !pub.isMuted;
@@ -1122,6 +1140,7 @@ function isParticipantCameraEnabled(participant: Participant): boolean {
 }
 
 function getParticipantCameraTrack(participant: Participant): Track | null {
+  const { Track } = getLoadedLiveKit();
   for (const pub of participant.getTrackPublications()) {
     if (pub.track?.source === Track.Source.Camera && !pub.isMuted) {
       return pub.track;
@@ -1131,6 +1150,7 @@ function getParticipantCameraTrack(participant: Participant): Track | null {
 }
 
 function isParticipantScreenShareEnabled(participant: Participant): boolean {
+  const { Track } = getLoadedLiveKit();
   for (const pub of participant.getTrackPublications()) {
     if (pub.track?.source === Track.Source.ScreenShare) {
       return !pub.isMuted;
@@ -1140,6 +1160,7 @@ function isParticipantScreenShareEnabled(participant: Participant): boolean {
 }
 
 function getParticipantScreenShareTrack(participant: Participant): Track | null {
+  const { Track } = getLoadedLiveKit();
   for (const pub of participant.getTrackPublications()) {
     if (pub.track?.source === Track.Source.ScreenShare && !pub.isMuted) {
       return pub.track;

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -11,15 +11,18 @@
   import MobileSidebarChrome from '$lib/components/MobileSidebarChrome.svelte';
   import NotificationSync from '$lib/components/NotificationSync.svelte';
   import UpdateNotifier from '$lib/components/UpdateNotifier.svelte';
-  import { usePageTitle, usePinchZoomPrevention, useVisualViewport } from '$lib/hooks';
+  import { usePageTitle } from '$lib/hooks/usePageTitle.svelte';
+  import { usePinchZoomPrevention } from '$lib/hooks/usePinchZoomPrevention.svelte';
   import { sidebarSwipe } from '$lib/hooks/useSidebarSwipe.svelte';
+  import { useVisualViewport } from '$lib/hooks/useVisualViewport.svelte';
   import { chatRoomIdFromRoute } from '$lib/navigation/chatRoomRoute';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { sidebarNav } from '$lib/state/globals.svelte';
   import { provideAppUiState } from '$lib/state/appUi.svelte';
   import { useServerRegistry } from '$lib/state/server/useServerRegistry.svelte';
   import { ToastContainer } from '$lib/ui/toast';
-  import { AppHeader, Frame } from '$lib/ui';
+  import AppHeader from '$lib/ui/AppHeader.svelte';
+  import Frame from '$lib/ui/Frame.svelte';
   import '../app.css';
 
   let { data, children } = $props();

--- a/apps/frontend/src/routes/layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/layout.svelte.spec.ts
@@ -46,9 +46,15 @@ vi.mock('$app/state', () => ({
   }
 }));
 
-vi.mock('$lib/hooks', () => ({
-  usePageTitle: () => () => 'Chatto',
-  usePinchZoomPrevention: vi.fn(),
+vi.mock('$lib/hooks/usePageTitle.svelte', () => ({
+  usePageTitle: () => () => 'Chatto'
+}));
+
+vi.mock('$lib/hooks/usePinchZoomPrevention.svelte', () => ({
+  usePinchZoomPrevention: vi.fn()
+}));
+
+vi.mock('$lib/hooks/useVisualViewport.svelte', () => ({
   useVisualViewport: vi.fn()
 }));
 
@@ -269,8 +275,6 @@ describe('root layout notification synchronization', () => {
   it('mounts badge synchronization for a signed-out page', async () => {
     renderLayout();
 
-    await vi.waitFor(() =>
-      expect(mocks.updateAppBadge).toHaveBeenCalledWith({ kind: 'clear' })
-    );
+    await vi.waitFor(() => expect(mocks.updateAppBadge).toHaveBeenCalledWith({ kind: 'clear' }));
   });
 });

--- a/mise.toml
+++ b/mise.toml
@@ -131,6 +131,7 @@ sources = [
     "package.json",
     "messages/**/*",
     "project.inlang/**/*",
+    "scripts/check-bundle-size.mjs",
     "scripts/generate-i18n-facade.mjs",
     "src/**/*",
     "!src/**/*.spec.*",


### PR DESCRIPTION
## Why

The root application shell accidentally retained feature-only code through
broad hook/UI barrels, and every `VoiceCallState` eagerly imported LiveKit even
when voice calls were never used. That inflated the initial JavaScript graph
for login and authenticated routes, while CI had no regression guard for
route-level transfer size.

## What changed

- Replace critical root-layout barrel imports with focused hook and component
  imports.
- Load `livekit-client` on the first voice/device operation, cache successful
  loads, allow retries after a failed chunk fetch, and expose the existing
  connecting state while the chunk loads.
- Add a production-manifest analyser that sums per-file gzip sizes across
  representative route static graphs, including the immediately loaded
  authenticated shell.
- Enforce budgets for login (290 KiB), overview (370 KiB), and room (540 KiB),
  and assert that LiveKit remains a dynamic entry outside those initial graphs.
- Run the budget gate from the normal frontend build and include the checker in
  mise build-cache invalidation.

Measured initial gzip changed as follows (the authenticated post-change graph
uses the stricter shell-inclusive measurement):

| Route | Previous baseline | Current |
| --- | ---: | ---: |
| Login | 444.4 KiB | 264.6 KiB |
| Overview | 471.2 KiB | 342.5 KiB |
| Room | 624.9 KiB | 496.2 KiB |

There are no public API, persistence, migration, security, or user-visible
behaviour changes. LiveKit is downloaded when voice/device functionality is
first used.

## Test plan

- `mise x -- pnpm --filter chatto-frontend test:unit --run` — 303 files and
  2,555 tests passed before review hardening.
- `mise x -- pnpm --filter chatto-frontend test:unit --run
  src/lib/state/server/voiceCall.svelte.spec.ts src/routes/layout.svelte.spec.ts`
  — 35 tests passed after review fixes.
- `mise x -- pnpm --filter chatto-frontend check` — zero errors and warnings.
- `mise x -- pnpm --filter chatto-frontend lint` — passed.
- `mise x -- pnpm --filter chatto-frontend build` — production build and all
  three bundle budgets passed.
- `mise license-check` — REUSE validation passed.
- Svelte autofixer — no issues in the changed component/module.
