### PR TITLE
test(events): make framework tests portable

### DIFF
--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -117,7 +117,9 @@ authorization, live events, backup/restore, and backend tests.
   `internal/events` must remain envelope-neutral and must not import Chatto
   protobufs or `internal/evtstream`. Keep its production imports limited to
   the Go standard library and `github.com/nats-io/nats.go`; application-wide
-  helpers must not become hidden extraction dependencies.
+  helpers must not become hidden extraction dependencies. Keep its tests
+  portable too: test infrastructure may add `nats-server/v2`, but must not
+  borrow other Chatto packages or unrelated third-party helpers.
 - Drive reusable `internal/events` API changes from external-package consumer
   contracts with non-Chatto envelopes. Do not add generic framework surface
   merely to shorten Chatto wiring.

--- a/cli/internal/events/dependency_boundary_test.go
+++ b/cli/internal/events/dependency_boundary_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 )
 
-func TestPackageAndTestsDoNotImportChattoApplicationContracts(t *testing.T) {
+const frameworkImportPath = "hmans.de/chatto/internal/events"
+
+func TestPackageDependenciesArePortable(t *testing.T) {
 	directory, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)
@@ -22,49 +24,19 @@ func TestPackageAndTestsDoNotImportChattoApplicationContracts(t *testing.T) {
 
 	for _, pkg := range packages {
 		for sourceName, source := range pkg.Files {
+			isTest := strings.HasSuffix(sourceName, "_test.go")
 			for _, spec := range source.Imports {
 				importPath, err := strconv.Unquote(spec.Path.Value)
 				if err != nil {
 					t.Fatalf("%s: decode import path: %v", sourceName, err)
 				}
-				if strings.Contains(importPath, "/internal/pb/chatto/") ||
-					importPath == "hmans.de/chatto/internal/evtstream" {
-					t.Errorf("%s imports application contract %q", sourceName, importPath)
+				if isStandardLibraryImport(importPath, directory) ||
+					isNATSImport(importPath) ||
+					isTest && (isNATSServerImport(importPath) ||
+						importPath == frameworkImportPath) {
+					continue
 				}
-			}
-		}
-	}
-}
-
-func TestProductionPackageDependsOnlyOnStandardLibraryAndNATS(t *testing.T) {
-	directory, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	packages, err := parser.ParseDir(
-		token.NewFileSet(),
-		directory,
-		func(info os.FileInfo) bool {
-			return strings.HasSuffix(info.Name(), ".go") &&
-				!strings.HasSuffix(info.Name(), "_test.go")
-		},
-		parser.ImportsOnly,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, pkg := range packages {
-		for sourceName, source := range pkg.Files {
-			for _, spec := range source.Imports {
-				importPath, err := strconv.Unquote(spec.Path.Value)
-				if err != nil {
-					t.Fatalf("%s: decode import path: %v", sourceName, err)
-				}
-				if !isStandardLibraryImport(importPath, directory) &&
-					!isNATSImport(importPath) {
-					t.Errorf("%s imports non-framework dependency %q", sourceName, importPath)
-				}
+				t.Errorf("%s imports non-portable dependency %q", sourceName, importPath)
 			}
 		}
 	}
@@ -94,11 +66,11 @@ func TestFrameworkConsumerUsesOnlyPublicFrameworkPackage(t *testing.T) {
 		if err != nil {
 			t.Fatalf("decode import path: %v", err)
 		}
-		if importPath == "hmans.de/chatto/internal/events" {
+		if importPath == frameworkImportPath {
 			importsFramework = true
 		}
 		if strings.HasPrefix(importPath, "hmans.de/chatto/") &&
-			importPath != "hmans.de/chatto/internal/events" {
+			importPath != frameworkImportPath {
 			t.Errorf("external consumer imports Chatto package %q", importPath)
 		}
 	}
@@ -115,4 +87,9 @@ func isStandardLibraryImport(importPath, sourceDirectory string) bool {
 func isNATSImport(importPath string) bool {
 	return importPath == "github.com/nats-io/nats.go" ||
 		strings.HasPrefix(importPath, "github.com/nats-io/nats.go/")
+}
+
+func isNATSServerImport(importPath string) bool {
+	return importPath == "github.com/nats-io/nats-server/v2" ||
+		strings.HasPrefix(importPath, "github.com/nats-io/nats-server/v2/")
 }

--- a/cli/internal/events/internal_test_helpers_test.go
+++ b/cli/internal/events/internal_test_helpers_test.go
@@ -1,0 +1,46 @@
+package events
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
+)
+
+type discardLogger struct{}
+
+func (discardLogger) Debug(interface{}, ...interface{}) {}
+func (discardLogger) Info(interface{}, ...interface{})  {}
+func (discardLogger) Warn(interface{}, ...interface{})  {}
+func (discardLogger) Error(interface{}, ...interface{}) {}
+
+func startTestNATS(t *testing.T) *nats.Conn {
+	t.Helper()
+	natsServer, err := server.NewServer(&server.Options{
+		JetStream:  true,
+		DontListen: true,
+		StoreDir:   t.TempDir(),
+		NoSigs:     true,
+	})
+	if err != nil {
+		t.Fatalf("create NATS server: %v", err)
+	}
+	natsServer.Start()
+	if !natsServer.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server did not become ready")
+	}
+
+	connection, err := nats.Connect(nats.DefaultURL, nats.InProcessServer(natsServer))
+	if err != nil {
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+		t.Fatalf("connect to NATS server: %v", err)
+	}
+	t.Cleanup(func() {
+		connection.Close()
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+	})
+	return connection
+}

--- a/cli/internal/events/internal_test_helpers_test.go
+++ b/cli/internal/events/internal_test_helpers_test.go
@@ -27,20 +27,18 @@ func startTestNATS(t *testing.T) *nats.Conn {
 		t.Fatalf("create NATS server: %v", err)
 	}
 	natsServer.Start()
+	t.Cleanup(func() {
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+	})
 	if !natsServer.ReadyForConnections(5 * time.Second) {
 		t.Fatal("NATS server did not become ready")
 	}
 
 	connection, err := nats.Connect(nats.DefaultURL, nats.InProcessServer(natsServer))
 	if err != nil {
-		natsServer.Shutdown()
-		natsServer.WaitForShutdown()
 		t.Fatalf("connect to NATS server: %v", err)
 	}
-	t.Cleanup(func() {
-		connection.Close()
-		natsServer.Shutdown()
-		natsServer.WaitForShutdown()
-	})
+	t.Cleanup(connection.Close)
 	return connection
 }

--- a/cli/internal/events/projector_internal_test.go
+++ b/cli/internal/events/projector_internal_test.go
@@ -1,11 +1,8 @@
 package events
 
 import (
-	"io"
 	"testing"
 	"time"
-
-	"github.com/charmbracelet/log"
 )
 
 type startupCompletionProjection struct {
@@ -33,7 +30,7 @@ func TestProjectorCompletesStartupReplayOnceAcrossReentry(t *testing.T) {
 		func([]byte) (DecodedEvent[struct{}], error) {
 			return DecodedEvent[struct{}]{Event: struct{}{}, ID: "test"}, nil
 		},
-		log.New(io.Discard),
+		discardLogger{},
 	)
 	projector.started = true
 

--- a/cli/internal/events/projector_timeout_test.go
+++ b/cli/internal/events/projector_timeout_test.go
@@ -2,15 +2,11 @@ package events
 
 import (
 	"context"
-	"io"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/log"
 	"github.com/nats-io/nats.go/jetstream"
-
-	"hmans.de/chatto/internal/testutil"
 )
 
 type timeoutTestProjection struct {
@@ -39,7 +35,7 @@ func (s *timeoutSnapshotSource) LoadProjectionSnapshot(ctx context.Context, _ Pr
 }
 
 func TestProjectorSnapshotLoadTimeoutFallsBackToColdReplay(t *testing.T) {
-	_, connection := testutil.StartNATS(t)
+	connection := startTestNATS(t)
 	js, err := jetstream.New(connection)
 	if err != nil {
 		t.Fatal(err)
@@ -54,7 +50,7 @@ func TestProjectorSnapshotLoadTimeoutFallsBackToColdReplay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	eventLog := NewEncodedEventLog(js, stream, log.New(io.Discard))
+	eventLog := NewEncodedEventLog(js, stream, discardLogger{})
 	if _, err := eventLog.Append(ctx, "evt.timeout.aggregate.created", EncodedRecord{ID: "timeout-event", Data: []byte("event")}); err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +63,7 @@ func TestProjectorSnapshotLoadTimeoutFallsBackToColdReplay(t *testing.T) {
 		func(data []byte) (DecodedEvent[string], error) {
 			return DecodedEvent[string]{Event: string(data), ID: string(data)}, nil
 		},
-		log.New(io.Discard),
+		discardLogger{},
 	)
 	source := &timeoutSnapshotSource{canceled: make(chan struct{})}
 	if err := projector.ConfigureSnapshots(

--- a/cli/internal/events/test_helpers_test.go
+++ b/cli/internal/events/test_helpers_test.go
@@ -42,21 +42,19 @@ func startTestNATS(t *testing.T) *nats.Conn {
 		t.Fatalf("create NATS server: %v", err)
 	}
 	natsServer.Start()
+	t.Cleanup(func() {
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+	})
 	if !natsServer.ReadyForConnections(5 * time.Second) {
 		t.Fatal("NATS server did not become ready")
 	}
 
 	connection, err := nats.Connect(nats.DefaultURL, nats.InProcessServer(natsServer))
 	if err != nil {
-		natsServer.Shutdown()
-		natsServer.WaitForShutdown()
 		t.Fatalf("connect to NATS server: %v", err)
 	}
-	t.Cleanup(func() {
-		connection.Close()
-		natsServer.Shutdown()
-		natsServer.WaitForShutdown()
-	})
+	t.Cleanup(connection.Close)
 	return connection
 }
 

--- a/cli/internal/events/test_helpers_test.go
+++ b/cli/internal/events/test_helpers_test.go
@@ -2,16 +2,22 @@ package events_test
 
 import (
 	"context"
-	"io"
 	"testing"
 	"time"
 
-	"github.com/charmbracelet/log"
+	"github.com/nats-io/nats-server/v2/server"
+	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 
 	. "hmans.de/chatto/internal/events"
-	"hmans.de/chatto/internal/testutil"
 )
+
+type discardLogger struct{}
+
+func (discardLogger) Debug(interface{}, ...interface{}) {}
+func (discardLogger) Info(interface{}, ...interface{})  {}
+func (discardLogger) Warn(interface{}, ...interface{})  {}
+func (discardLogger) Error(interface{}, ...interface{}) {}
 
 func testContext(t *testing.T) context.Context {
 	t.Helper()
@@ -21,12 +27,42 @@ func testContext(t *testing.T) context.Context {
 }
 
 func testLogger() Logger {
-	return log.New(io.Discard)
+	return discardLogger{}
+}
+
+func startTestNATS(t *testing.T) *nats.Conn {
+	t.Helper()
+	natsServer, err := server.NewServer(&server.Options{
+		JetStream:  true,
+		DontListen: true,
+		StoreDir:   t.TempDir(),
+		NoSigs:     true,
+	})
+	if err != nil {
+		t.Fatalf("create NATS server: %v", err)
+	}
+	natsServer.Start()
+	if !natsServer.ReadyForConnections(5 * time.Second) {
+		t.Fatal("NATS server did not become ready")
+	}
+
+	connection, err := nats.Connect(nats.DefaultURL, nats.InProcessServer(natsServer))
+	if err != nil {
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+		t.Fatalf("connect to NATS server: %v", err)
+	}
+	t.Cleanup(func() {
+		connection.Close()
+		natsServer.Shutdown()
+		natsServer.WaitForShutdown()
+	})
+	return connection
 }
 
 func setupTestStream(t *testing.T) (jetstream.JetStream, jetstream.Stream) {
 	t.Helper()
-	_, connection := testutil.StartNATS(t)
+	connection := startTestNATS(t)
 	js, err := jetstream.New(connection)
 	if err != nil {
 		t.Fatalf("create JetStream context: %v", err)

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -123,3 +123,9 @@ The external consumer contract proves live OCC publication, read-your-writes
 waiting, conflict reporting, projector shutdown, and cold replay through the
 same public surface. It is an executable extraction seam, not a second
 production event model or a promise that the current package API is stable.
+
+The framework test suite is portable with the package: it owns its in-process
+JetStream fixture and no-op logger instead of borrowing Chatto test helpers.
+Tests add only `nats-server/v2` to the standard library and `nats.go`
+dependencies allowed in production, so copying the package does not leave its
+verification coupled to the Chatto source tree.


### PR DESCRIPTION
## Why

`internal/events` production code was self-contained, but its tests still
borrowed Chatto's shared NATS fixture and Charm logger. Copying the framework
package toward a standalone module would therefore leave its verification
coupled to the Chatto source tree.

## What changed

- Give both internal- and external-package framework tests their own
  in-process JetStream fixtures.
- Replace Charm test loggers with local no-op implementations.
- Enforce portable imports across the complete package: production permits
  only the standard library and `nats.go`; tests additionally permit
  `nats-server/v2` and the external package's framework self-import.
- Record the portable-test boundary in `cli/AGENTS.md` and ADR-056.
- Register NATS server cleanup immediately after startup so readiness and
  connection failures cannot leak server goroutines or open storage files.

## Compatibility

- Test and documentation infrastructure only.
- No production code, public API, protobuf, subject, envelope, persisted byte,
  OCC, projection, configuration, migration, or user-visible behaviour
  changes.
- Existing Chatto servers and stored event histories remain fully compatible.

## Test plan

- `mise x -- go test -race -count=10 ./internal/events -timeout 2m` — passed
  before and after the review fix
- Independent adversarial rerun:
  `go test -race -count=25 ./internal/events` — passed
- `mise test-cli` — passed before and after rebasing onto current `main`
- `mise x -- go test -race ./internal/events -timeout 2m` after rebasing —
  passed
- `mise lint` — passed, including 0 Svelte errors and 0 warnings
- `mise license-check` — passed, 2,419/2,419 files compliant
- `git diff --check origin/main...HEAD` — passed

## Review

The first adversarial review found one low-severity cleanup gap when an
embedded NATS server failed readiness. Cleanup is now registered immediately
after `Start`, and connection cleanup runs first through LIFO ordering. The
follow-up review reported no findings.
