### PR TITLE
perf(frontend): defer custom status editor

### DIFF
--- a/apps/frontend/scripts/check-bundle-size.mjs
+++ b/apps/frontend/scripts/check-bundle-size.mjs
@@ -16,7 +16,7 @@ const routes = [
   },
   {
     name: 'overview',
-    budgetKiB: 370,
+    budgetKiB: 325,
     additionalEntries: ['src/routes/chat/AuthenticatedRoot.svelte'],
     components: [
       'src/routes/+layout.svelte',

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -37,9 +37,15 @@ to the user settings page for the active server.
 
   let customStatusEditorModule: Promise<typeof import('./UserCustomStatusEditor.svelte')> | null =
     null;
+  let customStatusEditorLoadAttempt = $state(0);
 
-  function loadCustomStatusEditor() {
-    customStatusEditorModule ??= import('./UserCustomStatusEditor.svelte');
+  function loadCustomStatusEditor(_attempt: number) {
+    customStatusEditorModule ??= import('./UserCustomStatusEditor.svelte').catch(
+      (error: unknown) => {
+        customStatusEditorModule = null;
+        throw error;
+      }
+    );
     return customStatusEditorModule;
   }
 
@@ -189,7 +195,7 @@ to the user settings page for the active server.
 
 {#snippet customStatusEditor(sheet = false)}
   {#if activeServerUser && customStatusDialogVisible}
-    {#await loadCustomStatusEditor() then { default: UserCustomStatusEditor }}
+    {#await loadCustomStatusEditor(customStatusEditorLoadAttempt) then { default: UserCustomStatusEditor }}
       <UserCustomStatusEditor
         status={activeServerUser.customStatus}
         config={customStatusAPIConfig()}
@@ -197,6 +203,17 @@ to the user settings page for the active server.
         onChange={updateCurrentCustomStatus}
         onClose={() => (customStatusDialogVisible = false)}
       />
+    {:catch}
+      <div class="flex flex-col items-center gap-3 p-4 text-center" role="alert">
+        <p class="text-sm text-muted">{m['common.error.network']()}</p>
+        <button
+          type="button"
+          class="btn-secondary"
+          onclick={() => (customStatusEditorLoadAttempt += 1)}
+        >
+          {m['common.retry']()}
+        </button>
+      </div>
     {/await}
   {/if}
 {/snippet}

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -33,8 +33,15 @@ to the user settings page for the active server.
   import Dialog from '$lib/ui/Dialog.svelte';
   import UserAvatar from './UserAvatar.svelte';
   import UserCustomStatusBadge from './UserCustomStatusBadge.svelte';
-  import UserCustomStatusEditor from './UserCustomStatusEditor.svelte';
   import VoiceCallControlButton from './voice/VoiceCallControlButton.svelte';
+
+  let customStatusEditorModule: Promise<typeof import('./UserCustomStatusEditor.svelte')> | null =
+    null;
+
+  function loadCustomStatusEditor() {
+    customStatusEditorModule ??= import('./UserCustomStatusEditor.svelte');
+    return customStatusEditorModule;
+  }
 
   const connection = useConnection();
   const presenceCache = getPresenceCache();
@@ -181,14 +188,16 @@ to the user settings page for the active server.
 </script>
 
 {#snippet customStatusEditor(sheet = false)}
-  {#if activeServerUser}
-    <UserCustomStatusEditor
-      status={activeServerUser.customStatus}
-      config={customStatusAPIConfig()}
-      {sheet}
-      onChange={updateCurrentCustomStatus}
-      onClose={() => (customStatusDialogVisible = false)}
-    />
+  {#if activeServerUser && customStatusDialogVisible}
+    {#await loadCustomStatusEditor() then { default: UserCustomStatusEditor }}
+      <UserCustomStatusEditor
+        status={activeServerUser.customStatus}
+        config={customStatusAPIConfig()}
+        {sheet}
+        onChange={updateCurrentCustomStatus}
+        onClose={() => (customStatusDialogVisible = false)}
+      />
+    {/await}
   {/if}
 {/snippet}
 

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -1,5 +1,6 @@
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import '../../app.css';
@@ -38,7 +39,13 @@ type MockRoom = {
   members: MockRoomMember[];
 };
 
-const { currentUserState, voiceCallState, roomsState, inputCapabilities } = vi.hoisted(() => ({
+const {
+  currentUserState,
+  voiceCallState,
+  roomsState,
+  inputCapabilities,
+  customStatusEditorModuleLoaded
+} = vi.hoisted(() => ({
   currentUserState: {
     user: null as {
       id: string;
@@ -84,7 +91,8 @@ const { currentUserState, voiceCallState, roomsState, inputCapabilities } = vi.h
   inputCapabilities: {
     prefersTouchActions: false,
     supportsHoverActions: true
-  }
+  },
+  customStatusEditorModuleLoaded: vi.fn()
 }));
 const navigation = vi.hoisted(() => ({
   goto: vi.fn(),
@@ -134,6 +142,11 @@ vi.mock('$lib/utils/inputCapabilities', () => ({
   supportsHoverActions: () => inputCapabilities.supportsHoverActions
 }));
 
+vi.mock('./UserCustomStatusEditor.svelte', async (importOriginal) => {
+  customStatusEditorModuleLoaded();
+  return importOriginal();
+});
+
 describe('CurrentUserBar', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -174,6 +187,7 @@ describe('CurrentUserBar', () => {
     ];
     inputCapabilities.prefersTouchActions = false;
     inputCapabilities.supportsHoverActions = true;
+    customStatusEditorModuleLoaded.mockClear();
   });
 
   it('uses the seeded presence cache instead of the first-login offline fallback', () => {
@@ -284,6 +298,31 @@ describe('CurrentUserBar', () => {
     expect(presencePreference.mode).toBe('away');
   });
 
+  it('loads the custom status editor only after opening the touch bottom sheet', async () => {
+    inputCapabilities.prefersTouchActions = true;
+    inputCapabilities.supportsHoverActions = false;
+
+    const { container } = render(CurrentUserBarTestHarness);
+
+    await tick();
+    await Promise.resolve();
+    expect(customStatusEditorModuleLoaded).not.toHaveBeenCalled();
+    expect(q(container, '[data-testid="custom-status-editor"]')).toBeFalsy();
+
+    (q(container, '[data-testid="current-user-presence-menu"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      expect(q(container, '[data-testid="current-user-custom-status-action"]')).toBeTruthy();
+    });
+    (
+      q(container, '[data-testid="current-user-custom-status-action"]') as HTMLButtonElement
+    ).click();
+
+    await vi.waitFor(() => {
+      expect(customStatusEditorModuleLoaded).toHaveBeenCalledOnce();
+      expect(q(container, '[data-testid="custom-status-editor"]')).toBeTruthy();
+    });
+  });
+
   it('opens the custom status dialog from the status menu', async () => {
     currentUserState.user = {
       ...currentUserState.user!,
@@ -309,28 +348,6 @@ describe('CurrentUserBar', () => {
       expect(container.textContent).toContain('Set a status');
       expect(container.textContent).toContain('Suggestions');
       expect(container.textContent).toContain('Clear Status');
-      expect(q(container, '[data-testid="custom-status-editor"]')).toBeTruthy();
-    });
-  });
-
-  it('loads the custom status editor only after opening the touch bottom sheet', async () => {
-    inputCapabilities.prefersTouchActions = true;
-    inputCapabilities.supportsHoverActions = false;
-
-    const { container } = render(CurrentUserBarTestHarness);
-
-    await new Promise((resolve) => setTimeout(resolve, 50));
-    expect(q(container, '[data-testid="custom-status-editor"]')).toBeFalsy();
-
-    (q(container, '[data-testid="current-user-presence-menu"]') as HTMLButtonElement).click();
-    await vi.waitFor(() => {
-      expect(q(container, '[data-testid="current-user-custom-status-action"]')).toBeTruthy();
-    });
-    (
-      q(container, '[data-testid="current-user-custom-status-action"]') as HTMLButtonElement
-    ).click();
-
-    await vi.waitFor(() => {
       expect(q(container, '[data-testid="custom-status-editor"]')).toBeTruthy();
     });
   });

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -320,7 +320,7 @@ describe('CurrentUserBar', () => {
     await vi.waitFor(() => {
       expect(customStatusEditorModuleLoaded).toHaveBeenCalledOnce();
       expect(q(container, '[data-testid="custom-status-editor"]')).toBeTruthy();
-    });
+    }, 10_000);
   });
 
   it('opens the custom status dialog from the status menu', async () => {

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -38,7 +38,7 @@ type MockRoom = {
   members: MockRoomMember[];
 };
 
-const { currentUserState, voiceCallState, roomsState } = vi.hoisted(() => ({
+const { currentUserState, voiceCallState, roomsState, inputCapabilities } = vi.hoisted(() => ({
   currentUserState: {
     user: null as {
       id: string;
@@ -80,6 +80,10 @@ const { currentUserState, voiceCallState, roomsState } = vi.hoisted(() => ({
         members: []
       }
     ] as MockRoom[]
+  },
+  inputCapabilities: {
+    prefersTouchActions: false,
+    supportsHoverActions: true
   }
 }));
 const navigation = vi.hoisted(() => ({
@@ -125,6 +129,11 @@ vi.mock('$lib/state/userProfiles.svelte', () => ({
   getLiveDisplayName: (_userId: string, fallback: string) => fallback
 }));
 
+vi.mock('$lib/utils/inputCapabilities', () => ({
+  prefersTouchActions: () => inputCapabilities.prefersTouchActions,
+  supportsHoverActions: () => inputCapabilities.supportsHoverActions
+}));
+
 describe('CurrentUserBar', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -163,6 +172,8 @@ describe('CurrentUserBar', () => {
         members: []
       }
     ];
+    inputCapabilities.prefersTouchActions = false;
+    inputCapabilities.supportsHoverActions = true;
   });
 
   it('uses the seeded presence cache instead of the first-login offline fallback', () => {
@@ -298,6 +309,28 @@ describe('CurrentUserBar', () => {
       expect(container.textContent).toContain('Set a status');
       expect(container.textContent).toContain('Suggestions');
       expect(container.textContent).toContain('Clear Status');
+      expect(q(container, '[data-testid="custom-status-editor"]')).toBeTruthy();
+    });
+  });
+
+  it('loads the custom status editor only after opening the touch bottom sheet', async () => {
+    inputCapabilities.prefersTouchActions = true;
+    inputCapabilities.supportsHoverActions = false;
+
+    const { container } = render(CurrentUserBarTestHarness);
+
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(q(container, '[data-testid="custom-status-editor"]')).toBeFalsy();
+
+    (q(container, '[data-testid="current-user-presence-menu"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => {
+      expect(q(container, '[data-testid="current-user-custom-status-action"]')).toBeTruthy();
+    });
+    (
+      q(container, '[data-testid="current-user-custom-status-action"]') as HTMLButtonElement
+    ).click();
+
+    await vi.waitFor(() => {
       expect(q(container, '[data-testid="custom-status-editor"]')).toBeTruthy();
     });
   });

--- a/apps/frontend/src/lib/components/chat/ServerEventProvider.svelte
+++ b/apps/frontend/src/lib/components/chat/ServerEventProvider.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { provideEventBus } from '$lib/eventBus.svelte';
-  import { usePresenceChange, useProjectionEvent } from '$lib/hooks';
+  import { usePresenceChange, useProjectionEvent } from '$lib/hooks/useEvent.svelte';
   import { apiPresenceStatus } from '$lib/api-client/memberDirectory';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -13,7 +13,7 @@
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { provideEventBus } from '$lib/eventBus.svelte';
   import { eventBusManager } from '$lib/state/server/eventBus.svelte';
-  import { useProjectionEvent, useSessionTerminated } from '$lib/hooks';
+  import { useProjectionEvent, useSessionTerminated } from '$lib/hooks/useEvent.svelte';
   import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
   import { createPresenceAPI } from '$lib/api-client/presence';
   import { viewerResponseToState } from '$lib/api-client/viewer';
@@ -175,9 +175,7 @@
     () =>
       serverRegistry.servers
         .filter((server) => serverRegistry.tryGetStore(server.id)?.isAuthenticated)
-        .map((server) =>
-          serverConnectionManager.getClient(server.id).getAPI(createPresenceAPI)
-        ),
+        .map((server) => serverConnectionManager.getClient(server.id).getAPI(createPresenceAPI)),
     (status) => {
       updateAuthenticatedCurrentUserPresenceEntries(
         presenceCache,


### PR DESCRIPTION
## Why

The authenticated overview route downloaded the custom-status editor and its
emoji dataset even when the editor was never opened. That feature-only path
accounted for roughly 50 KiB of initial gzip payload.

## What changed

- Lazy-load the custom-status editor only while its desktop dialog or touch
  bottom sheet is open.
- Keep failed chunk loads retryable with an actionable, translated error state.
- Import event hooks from their focused module instead of the hooks barrel,
  preventing unrelated emoji helpers from re-entering the authenticated shell.
- Add touch-path coverage that proves the editor module is not requested while
  the bottom sheet is closed.
- Tighten the overview initial gzip budget from 370 KiB to 325 KiB.

The measured overview bundle falls from 342.5 KiB to 292.1 KiB gzip. Login
remains 264.6 KiB and the room route remains 492.9 KiB because room rendering
legitimately uses emoji data.

This is an internal frontend loading change with no public API, migration,
rollout, security, or operational compatibility impact.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/components/CurrentUserBar.svelte.spec.ts` — 17 tests passed
- `mise x -- pnpm --filter chatto-frontend test:unit --run` — 303 files and 2,556 tests passed
- `mise x -- pnpm --filter chatto-frontend check` — 0 errors and 0 warnings
- `mise x -- pnpm --filter chatto-frontend lint` — passed
- `mise x -- pnpm --filter chatto-frontend build` — passed; all route bundle budgets passed
- `mise license-check` — passed
