### PR TITLE
perf(frontend): defer room interaction bundles

### DIFF
--- a/apps/frontend/scripts/check-bundle-size.mjs
+++ b/apps/frontend/scripts/check-bundle-size.mjs
@@ -27,7 +27,7 @@ const routes = [
   },
   {
     name: 'room',
-    budgetKiB: 540,
+    budgetKiB: 510,
     additionalEntries: ['src/routes/chat/AuthenticatedRoot.svelte'],
     components: [
       'src/routes/+layout.svelte',
@@ -81,6 +81,30 @@ if (!liveKitEntry || !liveKitEntry[1].isDynamicEntry) {
 for (const result of routeResults) {
   if (result.initialFiles.has(liveKitEntry[1].file)) {
     throw new Error(`Expected livekit-client to stay outside the ${result.name} initial bundle`);
+  }
+}
+
+const roomResult = routeResults.find(({ name }) => name === 'room');
+const deferredRoomInteractionSources = [
+  'src/lib/components/EmojiPicker.svelte',
+  'src/lib/components/chat/VideoPlayer.svelte',
+  'src/lib/components/menus/UserContextMenu.svelte',
+  'src/lib/components/moderation/BanRoomMemberModal.svelte',
+  'src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte',
+  'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte',
+  'src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte'
+];
+
+for (const source of deferredRoomInteractionSources) {
+  const [, entry] =
+    Object.entries(manifest).find(([, candidate]) => candidate.src === source) ?? [];
+  if (!entry || !entry.isDynamicEntry) {
+    throw new Error(`Expected ${source} to remain a dynamic production entry`);
+  }
+  for (const file of [entry.file, ...(entry.css ?? [])]) {
+    if (roomResult.initialFiles.has(file)) {
+      throw new Error(`Expected ${source} to stay outside the room initial bundle`);
+    }
   }
 }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -3,7 +3,6 @@
   import type { ImageItem } from '$lib/ui/ImageModal.svelte';
 
   type RawAttachment = MessageAttachmentView;
-  import VideoPlayer from '$lib/components/chat/VideoPlayer.svelte';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { pushState } from '$app/navigation';
@@ -24,6 +23,20 @@
   import { createAttachmentAPI } from '$lib/api-client/attachments';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
   import { useExpiringAssetUrlRefresh } from '$lib/attachments/useExpiringAssetUrlRefresh.svelte';
+
+  let videoPlayerModule: Promise<typeof import('$lib/components/chat/VideoPlayer.svelte')> | null =
+    null;
+  let videoPlayerLoadAttempt = $state(0);
+
+  function loadVideoPlayer(_attempt: number) {
+    videoPlayerModule ??= import('$lib/components/chat/VideoPlayer.svelte').catch(
+      (error: unknown) => {
+        videoPlayerModule = null;
+        throw error;
+      }
+    );
+    return videoPlayerModule;
+  }
 
   let {
     attachments: rawAttachments,
@@ -511,25 +524,47 @@
     {#if attachment.videoProcessing && (attachment.contentType === 'image/gif' || attachment.contentType.startsWith('video/'))}
       {@const autoLoop = attachment.contentType === 'image/gif'}
       <div class="group/attachment relative min-w-0">
-        <VideoPlayer
-          status={attachment.videoProcessing.status}
-          variants={attachment.videoProcessing.variants}
-          thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
-          hlsUrl={attachment.videoProcessing.hlsUrl}
-          fallbackUrl={attachment.url}
-          fallbackContentType={attachment.contentType}
-          width={attachment.videoProcessing.width}
-          height={attachment.videoProcessing.height}
-          reasonCode={attachment.videoProcessing.reasonCode}
-          filename={attachment.filename}
-          {autoLoop}
-          onPosterError={autoLoop ? undefined : () => refreshAfterAssetError(attachment, 'video')}
-          onMediaError={() =>
-            refreshAfterAssetError(
-              attachment,
-              !autoLoop && attachment.videoProcessing?.hlsUrl ? 'hls' : 'video'
-            )}
-        />
+        {#await loadVideoPlayer(videoPlayerLoadAttempt)}
+          <div
+            class="embed-frame flex min-h-32 min-w-48 items-center justify-center p-4 text-sm text-muted"
+            aria-busy="true"
+          >
+            {m['common.loading']()}
+          </div>
+        {:then { default: VideoPlayer }}
+          <VideoPlayer
+            status={attachment.videoProcessing.status}
+            variants={attachment.videoProcessing.variants}
+            thumbnailUrl={attachment.videoProcessing.thumbnailUrl}
+            hlsUrl={attachment.videoProcessing.hlsUrl}
+            fallbackUrl={attachment.url}
+            fallbackContentType={attachment.contentType}
+            width={attachment.videoProcessing.width}
+            height={attachment.videoProcessing.height}
+            reasonCode={attachment.videoProcessing.reasonCode}
+            filename={attachment.filename}
+            {autoLoop}
+            onPosterError={autoLoop ? undefined : () => refreshAfterAssetError(attachment, 'video')}
+            onMediaError={() =>
+              refreshAfterAssetError(
+                attachment,
+                !autoLoop && attachment.videoProcessing?.hlsUrl ? 'hls' : 'video'
+              )}
+          />
+        {:catch}
+          <div
+            class="embed-frame flex min-h-32 min-w-48 flex-col items-center justify-center gap-3 p-4 text-center"
+          >
+            <p class="text-sm text-muted">{m['common.error.network']()}</p>
+            <button
+              type="button"
+              class="btn-secondary"
+              onclick={() => (videoPlayerLoadAttempt += 1)}
+            >
+              {m['common.retry']()}
+            </button>
+          </div>
+        {/await}
         {@render deleteAttachmentButton(attachment, autoLoop ? '' : 'z-10')}
       </div>
     {:else if attachment.contentType.startsWith('image/')}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -1,16 +1,15 @@
 import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
+import { tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import MessageAttachments from './MessageAttachments.svelte';
-import {
-  VideoProcessingStatus,
-  type MessageAttachmentView
-} from '$lib/render/messageAttachments';
+import { VideoProcessingStatus, type MessageAttachmentView } from '$lib/render/messageAttachments';
 import type { RefreshedAttachmentUrls } from '$lib/attachments/attachmentUrls';
 
 const attachmentMocks = vi.hoisted(() => ({
   pushState: vi.fn(),
-  refreshAssetUrls: vi.fn()
+  refreshAssetUrls: vi.fn(),
+  videoPlayerModuleLoaded: vi.fn()
 }));
 
 vi.mock('$app/navigation', () => ({
@@ -26,9 +25,12 @@ vi.mock('$lib/api-client/attachments', async (importActual) => ({
   }))
 }));
 
-vi.mock('$lib/components/chat/VideoPlayer.svelte', async () => ({
-  default: (await import('./MessageAttachmentsVideoPlayerStub.svelte')).default
-}));
+vi.mock('$lib/components/chat/VideoPlayer.svelte', async () => {
+  attachmentMocks.videoPlayerModuleLoaded();
+  return {
+    default: (await import('./MessageAttachmentsVideoPlayerStub.svelte')).default
+  };
+});
 
 vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
@@ -148,7 +150,17 @@ describe('MessageAttachments', () => {
   beforeEach(() => {
     attachmentMocks.pushState.mockReset();
     attachmentMocks.refreshAssetUrls.mockReset();
+    attachmentMocks.videoPlayerModuleLoaded.mockReset();
     attachmentMocks.refreshAssetUrls.mockResolvedValue(new Map());
+  });
+
+  it('keeps the video player module out of non-video attachment rendering', async () => {
+    renderAttachment(fileAttachment({}));
+
+    await tick();
+    await Promise.resolve();
+
+    expect(attachmentMocks.videoPlayerModuleLoaded).not.toHaveBeenCalled();
   });
 
   it('renders very tall portrait images as contained narrow strips', () => {
@@ -208,12 +220,15 @@ describe('MessageAttachments', () => {
   });
 
   it('uses a subtle attachment remove control when deletion is allowed', () => {
-    const { container } = renderAttachments([
-      imageAttachment({
-        filename: 'delete-me.jpg'
-      }),
-      fileAttachment({ filename: 'delete-me.pdf' })
-    ], { canDeleteAttachment: true });
+    const { container } = renderAttachments(
+      [
+        imageAttachment({
+          filename: 'delete-me.jpg'
+        }),
+        fileAttachment({ filename: 'delete-me.pdf' })
+      ],
+      { canDeleteAttachment: true }
+    );
 
     const deleteControls = container.querySelectorAll<HTMLElement>(
       '[aria-label="Delete attachment"]'
@@ -227,7 +242,7 @@ describe('MessageAttachments', () => {
     expect(deleteControls[1].className).not.toContain('embed-control-button');
   });
 
-  it('keeps processed GIFs autolooping and processed videos using standard playback', () => {
+  it('keeps processed GIFs autolooping and processed videos using standard playback', async () => {
     const gif = hlsVideoAttachment({
       id: 'gif_1',
       filename: 'animated.gif',
@@ -239,6 +254,12 @@ describe('MessageAttachments', () => {
     });
     const { container } = renderAttachments([gif, hlsVideoAttachment()]);
 
+    await vi.waitFor(() => {
+      expect(attachmentMocks.videoPlayerModuleLoaded).toHaveBeenCalledOnce();
+      expect(
+        container.querySelectorAll('[data-testid="message-attachments-video-player"]')
+      ).toHaveLength(2);
+    });
     const players = container.querySelectorAll<HTMLElement>(
       '[data-testid="message-attachments-video-player"]'
     );
@@ -298,10 +319,13 @@ describe('MessageAttachments', () => {
       );
     const { container } = renderAttachment(hlsVideoAttachment());
 
-    const player = container.querySelector<HTMLButtonElement>(
-      '[data-testid="message-attachments-video-player"]'
-    );
-    expect(player).not.toBeNull();
+    let player: HTMLButtonElement | null = null;
+    await vi.waitFor(() => {
+      player = container.querySelector<HTMLButtonElement>(
+        '[data-testid="message-attachments-video-player"]'
+      );
+      expect(player).not.toBeNull();
+    });
 
     player!.click();
     await vi.waitFor(() => expect(attachmentMocks.refreshAssetUrls).toHaveBeenCalledTimes(1));

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
@@ -1,11 +1,31 @@
 <script lang="ts">
   import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
-  import EmojiPicker from '$lib/components/EmojiPicker.svelte';
+  import * as m from '$lib/i18n/messages';
   import type { ReactionSummaryView } from '$lib/render/reactions';
   import type { MessagesStore } from '$lib/state/room';
-  import MessageActionMenu from './MessageActionMenu.svelte';
   import type { MessageEventInteractionState } from './messageEventInteractions.svelte';
+
+  let messageActionMenuModule: Promise<typeof import('./MessageActionMenu.svelte')> | null = null;
+  let messageActionMenuLoadAttempt = $state(0);
+  let emojiPickerModule: Promise<typeof import('$lib/components/EmojiPicker.svelte')> | null = null;
+  let emojiPickerLoadAttempt = $state(0);
+
+  function loadMessageActionMenu(_attempt: number) {
+    messageActionMenuModule ??= import('./MessageActionMenu.svelte').catch((error: unknown) => {
+      messageActionMenuModule = null;
+      throw error;
+    });
+    return messageActionMenuModule;
+  }
+
+  function loadEmojiPicker(_attempt: number) {
+    emojiPickerModule ??= import('$lib/components/EmojiPicker.svelte').catch((error: unknown) => {
+      emojiPickerModule = null;
+      throw error;
+    });
+    return emojiPickerModule;
+  }
 
   let {
     interactions,
@@ -80,13 +100,21 @@
   }
 </script>
 
-{#if interactions.contextMenuPosition}
-  <ContextMenu
-    position={interactions.contextMenuPosition}
-    class="min-w-72"
-    onclose={closeContextMenu}
-  >
+{#snippet loadError(onretry: () => void)}
+  <div class="flex flex-col items-center gap-3 p-4 text-center" role="alert">
+    <p class="text-sm text-muted">{m['common.error.network']()}</p>
+    <button type="button" class="btn-secondary" onclick={onretry}>
+      {m['common.retry']()}
+    </button>
+  </div>
+{/snippet}
+
+{#snippet actionMenu(presentation: 'menu' | 'sheet' = 'menu')}
+  {#await loadMessageActionMenu(messageActionMenuLoadAttempt)}
+    <p class="p-4 text-center text-sm text-muted" aria-busy="true">{m['common.loading']()}</p>
+  {:then { default: MessageActionMenu }}
     <MessageActionMenu
+      presentation={presentation === 'sheet' ? 'sheet' : undefined}
       {serverId}
       {roomId}
       {messageEventId}
@@ -106,9 +134,25 @@
       {replyThreadLabel}
       {onReplyInRoom}
       {onReply}
-      onOpenEmojiPicker={canReact ? () => interactions.openEmojiPicker() : undefined}
-      onClose={closeContextMenu}
+      onOpenEmojiPicker={canReact
+        ? presentation === 'sheet'
+          ? openSheetEmojiPicker
+          : () => interactions.openEmojiPicker()
+        : undefined}
+      onClose={presentation === 'sheet' ? closeActionSheet : closeContextMenu}
     />
+  {:catch}
+    {@render loadError(() => (messageActionMenuLoadAttempt += 1))}
+  {/await}
+{/snippet}
+
+{#if interactions.contextMenuPosition}
+  <ContextMenu
+    position={interactions.contextMenuPosition}
+    class="min-w-72"
+    onclose={closeContextMenu}
+  >
+    {@render actionMenu()}
   </ContextMenu>
 {/if}
 
@@ -119,35 +163,18 @@
     scrollDismissal="user"
     onclose={closeEmojiPicker}
   >
-    <EmojiPicker {serverId} onSelect={handleEmojiSelect} onClose={closeEmojiPicker} />
+    {#await loadEmojiPicker(emojiPickerLoadAttempt)}
+      <p class="p-4 text-center text-sm text-muted" aria-busy="true">{m['common.loading']()}</p>
+    {:then { default: EmojiPicker }}
+      <EmojiPicker {serverId} onSelect={handleEmojiSelect} onClose={closeEmojiPicker} />
+    {:catch}
+      {@render loadError(() => (emojiPickerLoadAttempt += 1))}
+    {/await}
   </ContextMenu>
 {/if}
 
 {#if interactions.showActionSheet}
   <BottomSheet bind:visible={interactions.showActionSheet} onclose={closeActionSheet}>
-    <MessageActionMenu
-      presentation="sheet"
-      {serverId}
-      {roomId}
-      {messageEventId}
-      {eventId}
-      {deleteEventId}
-      {messageBody}
-      {permalinkThreadRootEventId}
-      {threadRootEventId}
-      {channelEchoEventId}
-      {canAddChannelEcho}
-      {messageStore}
-      {reactions}
-      {canReact}
-      {canEdit}
-      {canDelete}
-      {replyInRoomLabel}
-      {replyThreadLabel}
-      {onReplyInRoom}
-      {onReply}
-      onOpenEmojiPicker={canReact ? openSheetEmojiPicker : undefined}
-      onClose={closeActionSheet}
-    />
+    {@render actionMenu('sheet')}
   </BottomSheet>
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
@@ -10,16 +10,20 @@
   import type { MessageUserInteractionState } from './messageUserInteractions.svelte';
 
   type UserContextMenuModule = typeof import('$lib/components/menus/UserContextMenu.svelte');
+  type BanRoomMemberModalModule =
+    typeof import('$lib/components/moderation/BanRoomMemberModal.svelte');
 
   let userContextMenuModule: Promise<UserContextMenuModule> | null = null;
   let userContextMenuLoadAttempt = $state(0);
-  let banRoomMemberModalModule: Promise<
-    typeof import('$lib/components/moderation/BanRoomMemberModal.svelte')
-  > | null = null;
+  let banRoomMemberModalModule: Promise<BanRoomMemberModalModule> | null = null;
   let banRoomMemberModalLoadAttempt = $state(0);
 
   function importUserContextMenu(): Promise<UserContextMenuModule> {
     return import('$lib/components/menus/UserContextMenu.svelte');
+  }
+
+  function importBanRoomMemberModal(): Promise<BanRoomMemberModalModule> {
+    return import('$lib/components/moderation/BanRoomMemberModal.svelte');
   }
 
   function loadUserContextMenu(_attempt: number) {
@@ -31,11 +35,10 @@
   }
 
   function loadBanRoomMemberModal(_attempt: number) {
-    banRoomMemberModalModule ??=
-      import('$lib/components/moderation/BanRoomMemberModal.svelte').catch((error: unknown) => {
-        banRoomMemberModalModule = null;
-        throw error;
-      });
+    banRoomMemberModalModule ??= banRoomMemberModalLoader().catch((error: unknown) => {
+      banRoomMemberModalModule = null;
+      throw error;
+    });
     return banRoomMemberModalModule;
   }
 
@@ -46,7 +49,8 @@
     currentUserId,
     canStartDMs,
     canBanRoomMembers,
-    userContextMenuLoader = importUserContextMenu
+    userContextMenuLoader = importUserContextMenu,
+    banRoomMemberModalLoader = importBanRoomMemberModal
   }: {
     interactions: MessageUserInteractionState;
     serverId: string;
@@ -55,6 +59,7 @@
     canStartDMs: boolean;
     canBanRoomMembers: boolean;
     userContextMenuLoader?: () => Promise<UserContextMenuModule>;
+    banRoomMemberModalLoader?: () => Promise<BanRoomMemberModalModule>;
   } = $props();
 
   const connection = useConnection();
@@ -151,7 +156,13 @@
 
 {#if banDialogUser}
   {#await loadBanRoomMemberModal(banRoomMemberModalLoadAttempt)}
-    <span class="sr-only" aria-busy="true">{m['common.loading']()}</span>
+    <Dialog
+      visible
+      title={m['admin.moderation.ban_action']()}
+      onclose={() => (banDialogUser = null)}
+    >
+      <p class="text-sm text-muted" aria-busy="true">{m['common.loading']()}</p>
+    </Dialog>
   {:then { default: BanRoomMemberModal }}
     <BanRoomMemberModal
       user={banDialogUser}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
@@ -1,13 +1,41 @@
 <script lang="ts">
   import { startDMWith } from '$lib/dm/startDM';
-  import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
-  import BanRoomMemberModal from '$lib/components/moderation/BanRoomMemberModal.svelte';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import type { RoomMember } from '$lib/state/room';
+  import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import Dialog from '$lib/ui/Dialog.svelte';
   import { toast } from '$lib/ui/toast';
   import * as m from '$lib/i18n/messages';
   import type { MessageUserInteractionState } from './messageUserInteractions.svelte';
+
+  let userContextMenuModule: Promise<
+    typeof import('$lib/components/menus/UserContextMenu.svelte')
+  > | null = null;
+  let userContextMenuLoadAttempt = $state(0);
+  let banRoomMemberModalModule: Promise<
+    typeof import('$lib/components/moderation/BanRoomMemberModal.svelte')
+  > | null = null;
+  let banRoomMemberModalLoadAttempt = $state(0);
+
+  function loadUserContextMenu(_attempt: number) {
+    userContextMenuModule ??= import('$lib/components/menus/UserContextMenu.svelte').catch(
+      (error: unknown) => {
+        userContextMenuModule = null;
+        throw error;
+      }
+    );
+    return userContextMenuModule;
+  }
+
+  function loadBanRoomMemberModal(_attempt: number) {
+    banRoomMemberModalModule ??=
+      import('$lib/components/moderation/BanRoomMemberModal.svelte').catch((error: unknown) => {
+        banRoomMemberModalModule = null;
+        throw error;
+      });
+    return banRoomMemberModalModule;
+  }
 
   let {
     interactions,
@@ -76,25 +104,55 @@
   }
 </script>
 
+{#snippet loadError(onretry: () => void)}
+  <div class="flex flex-col items-center gap-3 p-4 text-center" role="alert">
+    <p class="text-sm text-muted">{m['common.error.network']()}</p>
+    <button type="button" class="btn-secondary" onclick={onretry}>
+      {m['common.retry']()}
+    </button>
+  </div>
+{/snippet}
+
 {#if interactions.user && interactions.anchorRect}
-  <UserContextMenu
-    user={interactions.user}
-    anchorRect={interactions.anchorRect}
-    canSendMessage={canStartDMs && !interactions.user.deleted}
-    canBanFromRoom={canBanPopoverUser}
-    banningFromRoom={banningMemberId === interactions.user.id}
-    onSendMessage={() => startDMWith(serverId, interactions.user!.id)}
-    onBanFromRoom={() => openBanDialog(interactions.user!)}
-    onClose={() => interactions.close()}
-  />
+  {#await loadUserContextMenu(userContextMenuLoadAttempt)}
+    <span class="sr-only" aria-busy="true">{m['common.loading']()}</span>
+  {:then { default: UserContextMenu }}
+    <UserContextMenu
+      user={interactions.user}
+      anchorRect={interactions.anchorRect}
+      canSendMessage={canStartDMs && !interactions.user.deleted}
+      canBanFromRoom={canBanPopoverUser}
+      banningFromRoom={banningMemberId === interactions.user.id}
+      onSendMessage={() => startDMWith(serverId, interactions.user!.id)}
+      onBanFromRoom={() => openBanDialog(interactions.user!)}
+      onClose={() => interactions.close()}
+    />
+  {:catch}
+    <ContextMenu
+      anchor={interactions.anchorRect}
+      role="alertdialog"
+      ariaLabel={m['common.error.generic']()}
+      onclose={() => interactions.close()}
+    >
+      {@render loadError(() => (userContextMenuLoadAttempt += 1))}
+    </ContextMenu>
+  {/await}
 {/if}
 
 {#if banDialogUser}
-  <BanRoomMemberModal
-    user={banDialogUser}
-    submitting={banningMemberId === banDialogUser.id}
-    error={banError}
-    onconfirm={(reason, expiresAt) => banFromRoom(banDialogUser!, reason, expiresAt)}
-    onclose={() => (banDialogUser = null)}
-  />
+  {#await loadBanRoomMemberModal(banRoomMemberModalLoadAttempt)}
+    <span class="sr-only" aria-busy="true">{m['common.loading']()}</span>
+  {:then { default: BanRoomMemberModal }}
+    <BanRoomMemberModal
+      user={banDialogUser}
+      submitting={banningMemberId === banDialogUser.id}
+      error={banError}
+      onconfirm={(reason, expiresAt) => banFromRoom(banDialogUser!, reason, expiresAt)}
+      onclose={() => (banDialogUser = null)}
+    />
+  {:catch}
+    <Dialog visible title={m['common.error.generic']()} onclose={() => (banDialogUser = null)}>
+      {@render loadError(() => (banRoomMemberModalLoadAttempt += 1))}
+    </Dialog>
+  {/await}
 {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
@@ -9,22 +9,24 @@
   import * as m from '$lib/i18n/messages';
   import type { MessageUserInteractionState } from './messageUserInteractions.svelte';
 
-  let userContextMenuModule: Promise<
-    typeof import('$lib/components/menus/UserContextMenu.svelte')
-  > | null = null;
+  type UserContextMenuModule = typeof import('$lib/components/menus/UserContextMenu.svelte');
+
+  let userContextMenuModule: Promise<UserContextMenuModule> | null = null;
   let userContextMenuLoadAttempt = $state(0);
   let banRoomMemberModalModule: Promise<
     typeof import('$lib/components/moderation/BanRoomMemberModal.svelte')
   > | null = null;
   let banRoomMemberModalLoadAttempt = $state(0);
 
+  function importUserContextMenu(): Promise<UserContextMenuModule> {
+    return import('$lib/components/menus/UserContextMenu.svelte');
+  }
+
   function loadUserContextMenu(_attempt: number) {
-    userContextMenuModule ??= import('$lib/components/menus/UserContextMenu.svelte').catch(
-      (error: unknown) => {
-        userContextMenuModule = null;
-        throw error;
-      }
-    );
+    userContextMenuModule ??= userContextMenuLoader().catch((error: unknown) => {
+      userContextMenuModule = null;
+      throw error;
+    });
     return userContextMenuModule;
   }
 
@@ -43,7 +45,8 @@
     roomId,
     currentUserId,
     canStartDMs,
-    canBanRoomMembers
+    canBanRoomMembers,
+    userContextMenuLoader = importUserContextMenu
   }: {
     interactions: MessageUserInteractionState;
     serverId: string;
@@ -51,6 +54,7 @@
     currentUserId?: string;
     canStartDMs: boolean;
     canBanRoomMembers: boolean;
+    userContextMenuLoader?: () => Promise<UserContextMenuModule>;
   } = $props();
 
   const connection = useConnection();
@@ -115,7 +119,13 @@
 
 {#if interactions.user && interactions.anchorRect}
   {#await loadUserContextMenu(userContextMenuLoadAttempt)}
-    <span class="sr-only" aria-busy="true">{m['common.loading']()}</span>
+    <ContextMenu
+      anchor={interactions.anchorRect}
+      ariaLabel={m['common.loading']()}
+      onclose={() => interactions.close()}
+    >
+      <p class="p-4 text-center text-sm text-muted" aria-busy="true">{m['common.loading']()}</p>
+    </ContextMenu>
   {:then { default: UserContextMenu }}
     <UserContextMenu
       user={interactions.user}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import type { RoomMember } from '$lib/state/room';
+import { MessageUserInteractionState } from './messageUserInteractions.svelte';
+
+vi.mock('$lib/state/server/connection.svelte', () => ({
+  useConnection: () => () => ({
+    getAPI: vi.fn()
+  })
+}));
+
+import MessageUserOverlays from './MessageUserOverlays.svelte';
+
+const member: RoomMember = {
+  id: 'user-1',
+  login: 'alice',
+  displayName: 'Alice',
+  deleted: false,
+  avatarUrl: null,
+  customStatus: null,
+  presenceStatus: PresenceStatus.ONLINE
+};
+
+describe('MessageUserOverlays', () => {
+  it('can dismiss the user menu while its deferred module is still loading', async () => {
+    const interactions = new MessageUserInteractionState(() => [member]);
+    interactions.showUser(member, new DOMRect(20, 20, 40, 40));
+
+    render(MessageUserOverlays, {
+      props: {
+        interactions,
+        serverId: 'server-1',
+        roomId: 'room-1',
+        currentUserId: 'current-user',
+        canStartDMs: true,
+        canBanRoomMembers: true,
+        userContextMenuLoader: () => new Promise(() => {})
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(document.querySelector('[aria-busy="true"]')).not.toBeNull();
+    });
+
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+    await vi.waitFor(() => {
+      expect(interactions.user).toBeNull();
+      expect(interactions.anchorRect).toBeNull();
+    });
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte.spec.ts
@@ -3,6 +3,7 @@ import { render } from 'vitest-browser-svelte';
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import type { RoomMember } from '$lib/state/room';
 import { MessageUserInteractionState } from './messageUserInteractions.svelte';
+import UserContextMenuStub from './MessageUserOverlaysUserContextMenuStub.svelte';
 
 vi.mock('$lib/state/server/connection.svelte', () => ({
   useConnection: () => () => ({
@@ -24,6 +25,14 @@ const member: RoomMember = {
 
 describe('MessageUserOverlays', () => {
   it('can dismiss the user menu while its deferred module is still loading', async () => {
+    let resolveUserMenu!: (
+      module: typeof import('$lib/components/menus/UserContextMenu.svelte')
+    ) => void;
+    const userMenuModule = new Promise<
+      typeof import('$lib/components/menus/UserContextMenu.svelte')
+    >((resolve) => {
+      resolveUserMenu = resolve;
+    });
     const interactions = new MessageUserInteractionState(() => [member]);
     interactions.showUser(member, new DOMRect(20, 20, 40, 40));
 
@@ -35,7 +44,7 @@ describe('MessageUserOverlays', () => {
         currentUserId: 'current-user',
         canStartDMs: true,
         canBanRoomMembers: true,
-        userContextMenuLoader: () => new Promise(() => {})
+        userContextMenuLoader: () => userMenuModule
       }
     });
 
@@ -48,6 +57,53 @@ describe('MessageUserOverlays', () => {
     await vi.waitFor(() => {
       expect(interactions.user).toBeNull();
       expect(interactions.anchorRect).toBeNull();
+    });
+
+    resolveUserMenu({
+      default: UserContextMenuStub
+    } as unknown as typeof import('$lib/components/menus/UserContextMenu.svelte'));
+  });
+
+  it('shows a dismissible dialog while the deferred ban modal is loading', async () => {
+    const interactions = new MessageUserInteractionState(() => [member]);
+    interactions.showUser(member, new DOMRect(20, 20, 40, 40));
+
+    render(MessageUserOverlays, {
+      props: {
+        interactions,
+        serverId: 'server-1',
+        roomId: 'room-1',
+        currentUserId: 'current-user',
+        canStartDMs: true,
+        canBanRoomMembers: true,
+        userContextMenuLoader: async () =>
+          ({
+            default: UserContextMenuStub
+          }) as unknown as typeof import('$lib/components/menus/UserContextMenu.svelte'),
+        banRoomMemberModalLoader: () => new Promise(() => {})
+      }
+    });
+
+    let banButton: HTMLButtonElement | null = null;
+    await vi.waitFor(() => {
+      banButton =
+        Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(
+          (button) => button.textContent?.trim() === 'Ban from room'
+        ) ?? null;
+      expect(banButton).not.toBeNull();
+    });
+    banButton!.click();
+
+    let dialog: HTMLDialogElement | null = null;
+    await vi.waitFor(() => {
+      dialog = document.querySelector<HTMLDialogElement>('dialog[open]');
+      expect(dialog?.querySelector('[aria-busy="true"]')?.textContent).toContain('Loading');
+    });
+
+    dialog!.dispatchEvent(new Event('cancel', { cancelable: true }));
+
+    await vi.waitFor(() => {
+      expect(dialog?.open).toBe(false);
     });
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlaysUserContextMenuStub.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlaysUserContextMenuStub.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  let { onBanFromRoom }: { onBanFromRoom?: () => void } = $props();
+</script>
+
+<button type="button" onclick={() => onBanFromRoom?.()}>Ban from room</button>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -57,8 +57,18 @@
   } from './roomSidebarBehavior';
   import { RoomNavigationState } from './roomNavigationState.svelte';
   import { buildRoomPresentation } from './roomPresentation';
-  import ThreadPane from './ThreadPane.svelte';
   import type { ThreadOpenOptions } from './threadOpenOptions';
+
+  let threadPaneModule: Promise<typeof import('./ThreadPane.svelte')> | null = null;
+  let threadPaneLoadAttempt = $state(0);
+
+  function loadThreadPane(_attempt: number) {
+    threadPaneModule ??= import('./ThreadPane.svelte').catch((error: unknown) => {
+      threadPaneModule = null;
+      throw error;
+    });
+    return threadPaneModule;
+  }
 
   let {
     roomId,
@@ -565,21 +575,45 @@
       </div>
 
       {#if threadId && room.roomData}
-        <ThreadPane
-          {roomId}
-          roomName={room.roomData.room.name}
-          threadRootEventId={threadId}
-          onClose={closeThread}
-          canPostInThread={room.roomData.canPostInThread}
-          canAttach={room.roomData.canAttach}
-          canEchoMessage={room.roomData.canEchoMessage && room.roomData.canPostMessage}
-          highlightEventId={navigation.pendingThreadHighlight}
-          pendingQuote={navigation.pendingThreadQuote}
-          pendingReply={navigation.pendingThreadReply}
-          onHighlightComplete={() => navigation.clearThreadHighlight()}
-          onQuoteConsumed={() => navigation.clearThreadQuote()}
-          onReplyConsumed={() => navigation.clearThreadReply()}
-        />
+        {#await loadThreadPane(threadPaneLoadAttempt)}
+          <div
+            class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center overflow-hidden border-l border-border bg-background p-4 text-sm text-muted shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%]"
+            data-testid="thread-pane"
+            aria-busy="true"
+          >
+            {m['common.loading']()}
+          </div>
+        {:then { default: ThreadPane }}
+          <ThreadPane
+            {roomId}
+            roomName={room.roomData.room.name}
+            threadRootEventId={threadId}
+            onClose={closeThread}
+            canPostInThread={room.roomData.canPostInThread}
+            canAttach={room.roomData.canAttach}
+            canEchoMessage={room.roomData.canEchoMessage && room.roomData.canPostMessage}
+            highlightEventId={navigation.pendingThreadHighlight}
+            pendingQuote={navigation.pendingThreadQuote}
+            pendingReply={navigation.pendingThreadReply}
+            onHighlightComplete={() => navigation.clearThreadHighlight()}
+            onQuoteConsumed={() => navigation.clearThreadQuote()}
+            onReplyConsumed={() => navigation.clearThreadReply()}
+          />
+        {:catch}
+          <div
+            class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center gap-3 overflow-hidden border-l border-border bg-background p-4 text-center shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%]"
+            data-testid="thread-pane"
+          >
+            <p class="text-sm text-muted">{m['common.error.network']()}</p>
+            <button
+              type="button"
+              class="btn-secondary"
+              onclick={() => (threadPaneLoadAttempt += 1)}
+            >
+              {m['common.retry']()}
+            </button>
+          </div>
+        {/await}
       {/if}
 
       <RoomSidebarPane

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -58,6 +58,8 @@ const { mocks } = vi.hoisted(() => {
       getAppUiState: vi.fn(),
       activeCallRoomIds: new Set<string>(),
       joinedCallRoomIds: new Set<string>(),
+      threadPaneModuleLoaded: vi.fn(),
+      roomSidebarModuleLoaded: vi.fn(),
       pendingHighlightConsume: vi.fn(
         (_roomId: string, _threadRootId: string | null): string | null => null
       ),
@@ -246,11 +248,13 @@ vi.mock('./RoomEventsPane.svelte', async () => {
 });
 
 vi.mock('./ThreadPane.svelte', async () => {
+  mocks.threadPaneModuleLoaded();
   const { default: ThreadPaneMock } = await import('./RoomThreadPaneMock.svelte');
   return { default: ThreadPaneMock };
 });
 
 vi.mock('./RoomSidebar.svelte', async () => {
+  mocks.roomSidebarModuleLoaded();
   const { default: RoomSidebarMock } = await import('./RoomLocalEchoRoomSidebarMock.svelte');
   return { default: RoomSidebarMock };
 });
@@ -338,6 +342,18 @@ function stubMatchMedia(matches: boolean): void {
   );
 }
 
+async function waitForElement<T extends Element>(
+  container: HTMLElement,
+  selector: string
+): Promise<T> {
+  let element: T | null = null;
+  await vi.waitFor(() => {
+    element = container.querySelector<T>(selector);
+    expect(element).not.toBeNull();
+  });
+  return element!;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   localStorage.clear();
@@ -370,29 +386,66 @@ beforeEach(() => {
   stubMatchMedia(true);
 });
 
+describe('Room interaction bundles', () => {
+  it('does not load thread or sidebar panes for the default room view', async () => {
+    render(Room, { props: { roomId: 'room-1' } });
+
+    await tick();
+    await Promise.resolve();
+
+    expect(mocks.threadPaneModuleLoaded).not.toHaveBeenCalled();
+    expect(mocks.roomSidebarModuleLoaded).not.toHaveBeenCalled();
+  });
+
+  it('loads the thread pane when the thread route is active', async () => {
+    const { container } = render(Room, {
+      props: { roomId: 'room-1', threadId: 'thread-root' }
+    });
+
+    await vi.waitFor(() => expect(mocks.threadPaneModuleLoaded).toHaveBeenCalledOnce());
+    expect(
+      (await waitForElement(container, '[data-testid="thread-pane-root-id"]')).textContent
+    ).toBe('thread-root');
+    expect(mocks.roomSidebarModuleLoaded).not.toHaveBeenCalled();
+  });
+
+  it('loads the room sidebar when a desktop panel is active', async () => {
+    appUi.openDesktopRoomSidebarPanel('files');
+
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+
+    await vi.waitFor(() => expect(mocks.roomSidebarModuleLoaded).toHaveBeenCalledOnce());
+    await expect
+      .element(q(container, '[data-testid="room-sidebar-desktop-pane"]'))
+      .toBeInTheDocument();
+  });
+});
+
 describe('Room local message echo', () => {
   it('anchors projected row replacements to the room timeline event ID', async () => {
     render(Room, { props: { roomId: 'room-1' } });
     await tick();
 
-    mocks.projectionEventHandler?.(new RealtimeProjectionEvent({
-      id: 'asset-processing-succeeded-id',
-      actorId: 'system',
-      operations: [
-        {
-          operation: {
-            case: 'roomTimelineEventUpsert',
-            value: {
-              roomId: 'room-1',
-              event: {
-                id: 'message-event-id',
-                event: { case: 'messagePosted', value: { message: { threadRootEventId: '' } } }
+    mocks.projectionEventHandler?.(
+      new RealtimeProjectionEvent({
+        id: 'asset-processing-succeeded-id',
+        actorId: 'system',
+        operations: [
+          {
+            operation: {
+              case: 'roomTimelineEventUpsert',
+              value: {
+                roomId: 'room-1',
+                event: {
+                  id: 'message-event-id',
+                  event: { case: 'messagePosted', value: { message: { threadRootEventId: '' } } }
+                }
               }
             }
           }
-        }
-      ]
-    }));
+        ]
+      })
+    );
 
     expect(mocks.markRoomAsRead).toHaveBeenCalledWith('room-1', 'message-event-id');
   });
@@ -406,12 +459,12 @@ describe('Room local message echo', () => {
       }
     });
 
-    await expect
-      .element(q(container, '[data-testid="thread-pane-root-id"]'))
-      .toHaveTextContent('thread-root');
-    await expect
-      .element(q(container, '[data-testid="thread-pane-highlight-id"]'))
-      .toHaveTextContent('thread-message');
+    expect(
+      (await waitForElement(container, '[data-testid="thread-pane-root-id"]')).textContent
+    ).toBe('thread-root');
+    expect(
+      (await waitForElement(container, '[data-testid="thread-pane-highlight-id"]')).textContent
+    ).toBe('thread-message');
     expect(mocks.pendingHighlightConsume).not.toHaveBeenCalled();
   });
 
@@ -629,10 +682,10 @@ describe('Room local message echo', () => {
     await tick();
     mocks.goto.mockClear();
 
-    const closeSidebar = q(
+    const closeSidebar = await waitForElement<HTMLButtonElement>(
       container,
       '[data-testid="close-room-sidebar"]'
-    ) as HTMLButtonElement;
+    );
     closeSidebar.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
     closeSidebar.click();
 
@@ -651,10 +704,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(
+    const maximizeButton = await waitForElement<HTMLButtonElement>(
       container,
       '[data-testid="toggle-maximized-call"]'
-    ) as HTMLButtonElement;
+    );
 
     await expect.element(desktopSidebarPane).toBeInTheDocument();
     expect(roomRegion.className).not.toContain('lg:hidden');
@@ -678,10 +731,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(
+    const maximizeButton = await waitForElement<HTMLButtonElement>(
       container,
       '[data-testid="toggle-maximized-call"]'
-    ) as HTMLButtonElement;
+    );
 
     maximizeButton.click();
 
@@ -707,10 +760,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(
+    const maximizeButton = await waitForElement<HTMLButtonElement>(
       container,
       '[data-testid="toggle-maximized-call"]'
-    ) as HTMLButtonElement;
+    );
 
     maximizeButton.click();
 
@@ -736,10 +789,10 @@ describe('Room local message echo', () => {
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const desktopSidebarPane = q(container, '[data-testid="room-sidebar-desktop-pane"]')!;
-    const maximizeButton = q(
+    const maximizeButton = await waitForElement<HTMLButtonElement>(
       container,
       '[data-testid="toggle-maximized-call"]'
-    ) as HTMLButtonElement;
+    );
 
     maximizeButton.click();
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
@@ -1,8 +1,19 @@
 <script lang="ts">
   import type { ComponentProps } from 'svelte';
+  import type RoomSidebar from './RoomSidebar.svelte';
   import { fly } from 'svelte/transition';
   import * as m from '$lib/i18n/messages';
-  import RoomSidebar from './RoomSidebar.svelte';
+
+  let roomSidebarModule: Promise<typeof import('./RoomSidebar.svelte')> | null = null;
+  let roomSidebarLoadAttempt = $state(0);
+
+  function loadRoomSidebar(_attempt: number) {
+    roomSidebarModule ??= import('./RoomSidebar.svelte').catch((error: unknown) => {
+      roomSidebarModule = null;
+      throw error;
+    });
+    return roomSidebarModule;
+  }
 
   let {
     presentation,
@@ -16,7 +27,23 @@
 </script>
 
 {#snippet sidebar(props: NonNullable<typeof sidebarProps>)}
-  <RoomSidebar {...props} presentation={presentation === 'mobile' ? 'overlay' : 'desktop'} />
+  {#await loadRoomSidebar(roomSidebarLoadAttempt)}
+    <div
+      class="flex min-h-0 flex-1 items-center justify-center p-4 text-sm text-muted"
+      aria-busy="true"
+    >
+      {m['common.loading']()}
+    </div>
+  {:then { default: RoomSidebar }}
+    <RoomSidebar {...props} presentation={presentation === 'mobile' ? 'overlay' : 'desktop'} />
+  {:catch}
+    <div class="flex min-h-0 flex-1 flex-col items-center justify-center gap-3 p-4 text-center">
+      <p class="text-sm text-muted">{m['common.error.network']()}</p>
+      <button type="button" class="btn-secondary" onclick={() => (roomSidebarLoadAttempt += 1)}>
+        {m['common.retry']()}
+      </button>
+    </div>
+  {/await}
 {/snippet}
 
 {#if presentation === 'mobile'}


### PR DESCRIPTION
## Why

The default room route still downloaded interaction code that most room visits
do not use: threads, room extras, message menus, moderation dialogs, emoji
selection, and video playback. Deferring those surfaces reduces initial
download and parse work without turning the core timeline renderer into a
waterfall.

## What changed

- Load the thread pane only for thread routes and the room sidebar only while a
  desktop or mobile panel is active.
- Load message action menus, emoji selection, user profile actions, room-ban
  confirmation, and processed video playback only when requested.
- Keep requested floating UI visible and dismissible while its module loads,
  and provide translated loading, network-error, and retry states.
- Require all seven deferred components and their component CSS to remain
  outside the room's initial production graph.
- Tighten the room gzip budget from 540 KiB to 510 KiB. The measured initial
  room payload is 464.3 KiB, down from the 492.3 KiB starting baseline.

There are no API, persistence, compatibility, migration, security, or
operational changes.

## Test plan

- `mise lint-frontend` — passed (Svelte: 0 errors, 0 warnings; ESLint passed)
- `mise test-frontend` — passed (304 files, 2,563 tests)
- `mise x -- pnpm --dir apps/frontend build` — passed, including bundle graph
  invariants and all route budgets
- `mise license-check` — passed
- Chrome DevTools: verified default room entry, deferred members sidebar,
  deferred message action menu, thread navigation, and a clean console
- Independent review loop — two slow-import dismissal findings fixed; final
  review reported no findings
