### PR TITLE
refactor(frontend): centralize composer state

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -52,23 +52,15 @@
 	const userSettings = getUserSettings();
 	const composerContext = getComposerContext();
 	const state = new MessageComposerState({
-		getProps: () => ({
-			roomId,
-			inThread,
-			inReplyTo,
-			replyDisplayName,
-			replyExcerpt,
-			placeholder,
-			canPost,
-			canAttach,
-			autoFocus,
-			onReady,
-			onTyping,
-			onMessageSent,
-			onCancelReply,
-			onEscape,
-			showAlsoSendToChannel
-		}),
+		getRoomId: () => roomId,
+		getThreadRootEventId: () => inThread,
+		getReplyEventId: () => inReplyTo,
+		getCanPost: () => canPost,
+		getCanAttach: () => canAttach,
+		getAutoFocus: () => autoFocus,
+		getPlaceholder: () => placeholder,
+		getOnReady: () => onReady,
+		getCallbacks: () => ({ onTyping, onMessageSent, onCancelReply, onEscape }),
 		context: composerContext,
 		getMembers: getRoomMembers,
 		membersStore: getRoomMembersStore(),

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -1,779 +1,208 @@
+<script module lang="ts">
+	export type { MessageComposerApi } from './messageComposerState.svelte';
+</script>
+
 <script lang="ts">
-  import { tick, untrack } from 'svelte';
-  import type { TimelineEventView } from '$lib/render/timelineEvents';
-  import { createMessageAPI, type UpdateMessageInput } from '$lib/api-client/messages';
-  import { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
-  import * as m from '$lib/i18n/messages';
-  import { useConnection } from '$lib/state/server/connection.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
-  import { toast } from '$lib/ui/toast';
-  import {
-    getRoomMembers,
-    getRoomMembersStore,
-    getComposerContext,
-    type QuoteInsertionContent,
-    type RoomMember
-  } from '$lib/state/room';
-  import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
-  import { prefersTouchActions } from '$lib/utils/inputCapabilities';
-  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
-  import { hasVisibleContent } from '$lib/validation';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { getUserSettings } from '$lib/state/userSettings.svelte';
-  import EmojiAutocomplete from '$lib/components/composer/EmojiAutocomplete.svelte';
-  import MentionAutocomplete from '$lib/components/composer/MentionAutocomplete.svelte';
-  import type { ComposerFormattingState, TipTapEditorApi } from './editorTypes';
-  import { DraftState, draftKey } from './draft.svelte';
-  import { AttachmentsState } from './attachments.svelte';
-  import { LinkPreviewState } from './linkPreviews.svelte';
-  import { AutocompleteState, type MentionRole } from './autocomplete.svelte';
-  import ComposerLinkPreview from './ComposerLinkPreview.svelte';
-  import ComposerAttachmentPreviews from './ComposerAttachmentPreviews.svelte';
-  import ComposerToolbar from './ComposerToolbar.svelte';
-  import ComposerModeIndicators from './ComposerModeIndicators.svelte';
-  import { ComposerSubmissionState, type PreparedPost } from './submission.svelte';
-
-  const tipTapEditorModule = import('./TipTapEditor.svelte');
-  const emptyFormattingState: ComposerFormattingState = {
-    bold: false,
-    italic: false,
-    inlineCode: false,
-    heading: false,
-    bulletList: false,
-    orderedList: false,
-    blockquote: false,
-    codeBlock: false
-  };
-  const stores = serverRegistry.getStore(getActiveServer());
-  const serverInfo = stores.serverInfo;
-  const roomUnreadStore = stores.roomUnread;
-  const mentionRolesStore = stores.mentionRoles;
-
-  export type MessageComposerApi = {
-    addFiles: (files: File[]) => void;
-    focus: () => void;
-    insertQuote: (text: QuoteInsertionContent) => void;
-  };
-
-  let {
-    roomId,
-    inThread,
-    inReplyTo,
-    replyDisplayName,
-    replyExcerpt,
-    placeholder: customPlaceholder,
-    canPost = true,
-    canAttach = true,
-    autoFocus = true,
-    onReady,
-    onTyping,
-    onMessageSent,
-    onCancelReply,
-    onEscape,
-    showAlsoSendToChannel = false
-  }: {
-    roomId: string;
-    inThread?: string;
-    inReplyTo?: string;
-    replyDisplayName?: string;
-    replyExcerpt?: string;
-    placeholder?: string;
-    canPost?: boolean;
-    canAttach?: boolean;
-    autoFocus?: boolean;
-    onReady?: (api: MessageComposerApi) => void;
-    onTyping?: () => void;
-    onMessageSent?: (event: TimelineEventView | null) => void;
-    onCancelReply?: () => void;
-    onEscape?: () => void;
-    showAlsoSendToChannel?: boolean;
-  } = $props();
-
-  const connection = useConnection();
-  const userSettings = getUserSettings();
-
-  let alsoSendToChannel = $state(false);
-
-  // Get room members from context (provided by Room.svelte)
-  const members = $derived(getRoomMembers());
-  const membersStore = getRoomMembersStore();
-  let mentionSearchMembers = $state.raw<RoomMember[]>([]);
-  const mentionSearchDebounce = useDebounce();
-  let mentionSearchRequestId = 0;
-  const mentionCandidateMembers = $derived(
-    mentionSearchMembers.length > 0 ? mentionSearchMembers : members
-  );
-
-  const composerContext = getComposerContext();
-  const editState = composerContext.editState;
-  const quoteInsertionState = composerContext.quoteInsertionState;
-  const lastEditableMessageCtx = composerContext.lastEditableMessage;
-  const scrollState = composerContext.scrollState;
-  const isEditing = $derived(editState.eventId !== null);
-  const showEditEchoCheckbox = $derived(
-    isEditing &&
-      editState.threadRootEventId !== null &&
-      (editState.channelEchoEventId !== null || editState.canAddChannelEcho)
-  );
-
-  // When the composer resizes (editor grows/shrinks, attachments added/removed),
-  // scroll to bottom if sticky. This replaces the synchronous scrollToBottomIfSticky()
-  // that was lost when the old textarea's autoResize() was removed during TipTap migration.
-  function observeComposerResize(node: HTMLDivElement) {
-    if (!scrollState) return;
-    const observer = new ResizeObserver(() => {
-      scrollState.scrollToBottomIfSticky();
-    });
-    observer.observe(node);
-    return () => observer.disconnect();
-  }
-
-  const DRAFT_KEY = $derived(draftKey(roomId, inThread));
-  let message = $state('');
-
-  // TipTap editor API (received via onReady callback)
-  let editorApi = $state<TipTapEditorApi | null>(null);
-  const draftState = new DraftState();
-  const attachments = new AttachmentsState(() => serverInfo);
-  const linkPreviews = new LinkPreviewState(() => connection().getAPI(createLinkPreviewAPI));
-  const autocomplete = new AutocompleteState(
-    () => editorApi,
-    () => mentionCandidateMembers,
-    () => mentionRoles
-  );
-  const mentionRoles = $derived<MentionRole[]>(mentionRolesStore.roles);
-
-  $effect(() => {
-    const query = autocomplete.mention?.query ?? null;
-    const requestId = ++mentionSearchRequestId;
-
-    mentionSearchDebounce.cancel();
-
-    if (!query) {
-      mentionSearchMembers = [];
-      return;
-    }
-
-    mentionSearchDebounce.run(() => {
-      void membersStore.searchMembers(query).then((results) => {
-        if (requestId !== mentionSearchRequestId) return;
-        mentionSearchMembers = results;
-      });
-    }, 150);
-  });
-
-  // Dynamic placeholder changes between normal and edit mode
-  let currentPlaceholder = $derived(
-    isEditing
-      ? m['composer.editing_placeholder']()
-      : (customPlaceholder ?? m['composer.placeholder']())
-  );
-
-  // Testid for E2E tests - distinguishes main input from thread reply input
-  let testid = $derived(inThread ? 'thread-reply-input' : 'message-input');
-
-  // Track editing transitions by event identity so editor setContent() doesn't
-  // run repeatedly while TipTap echoes updates back through onUpdate.
-  let editSeededForEvent = '';
-
-  // When entering edit mode, pre-fill with original message body and clear any pending attachments.
-  // When exiting edit mode (cancelled or message deleted), clear the input.
-  $effect(() => {
-    const eventId = editState.eventId;
-    const originalBody = editState.originalBody;
-    const api = editorApi;
-
-    if (eventId && originalBody && editSeededForEvent !== eventId) {
-      editSeededForEvent = eventId;
-      autocomplete.reset();
-      draftState.clearText();
-      message = originalBody;
-      manualRichMode = false;
-      alsoSendToChannel = editState.channelEchoEventId !== null;
-      api?.setContent(originalBody);
-      tick().then(() => api?.focus('end'));
-      attachments.clear();
-      linkPreviews.clear();
-    } else if (editSeededForEvent && !eventId) {
-      // Exiting edit mode - clear the input
-      autocomplete.reset();
-      message = '';
-      manualRichMode = false;
-      alsoSendToChannel = false;
-      editSeededForEvent = '';
-      api?.setContent('');
-    }
-  });
-
-  // Load draft from sessionStorage when room changes
-  // Using sessionStorage (not localStorage) so drafts are tab-specific
-  let autocompleteResetRoomId = '';
-  $effect(() => {
-    if (autocompleteResetRoomId !== roomId) {
-      autocompleteResetRoomId = roomId;
-      autocomplete.resetForRoom();
-    }
-
-    if (isEditing) {
-      draftState.switchKey(DRAFT_KEY);
-      attachments.restore([]);
-      return;
-    }
-
-    const draft = draftState.switchKey(DRAFT_KEY);
-    message = draft;
-    manualRichMode = false;
-    editorApi?.setContent(draft);
-    attachments.restore(untrack(() => draftState.takeFiles()));
-
-    return () => {
-      draftState.stashFiles(untrack(() => attachments.filesWithUrls));
-    };
-  });
-
-  // Persist draft to sessionStorage
-  $effect(() => {
-    void DRAFT_KEY;
-    if (isEditing) return;
-    draftState.persistText(message);
-  });
-
-  $effect(() => {
-    return linkPreviews.scheduleDetection(message, isEditing);
-  });
-
-  $effect(() => {
-    void mentionRolesStore.load();
-  });
-
-  let fileInputElement = $state<HTMLInputElement>();
-  let formattingState = $state<ComposerFormattingState>({ ...emptyFormattingState });
-  const submission = new ComposerSubmissionState({
-    getAPI: () => connection().getAPI(createMessageAPI),
-    getMentionRoleStatus: () => mentionRolesStore.status,
-    loadMentionRoles: () => mentionRolesStore.load(),
-    getMentionRoleNames: () => mentionRoles.map((role) => role.name),
-    onPostSuccess: handlePostSuccess,
-    onEditSuccess: handleEditSuccess
-  });
-
-  // Keep the submitted draft stable while its message and attachments are in flight.
-  let inputDisabled = $derived(
-    submission.loading || !canPost || connection().showConnectionLostBanner
-  );
-
-  let hasSendableAttachments = $derived(canAttach && attachments.selectedFiles.length > 0);
-
-  // Can submit when there's content, not currently sending, and input is enabled.
-  // hasVisibleContent rejects messages with only invisible Unicode characters.
-  let canSubmit = $derived(
-    !submission.loading &&
-      !submission.roleMentionCheckLoading &&
-      !inputDisabled &&
-      attachments.pendingCount === 0 &&
-      (hasVisibleContent(message) || hasSendableAttachments || isEditing)
-  );
-  let editorNextEnterWillSend = $state(false);
-  let manualRichMode = $state(false);
-  let editorHasRichStructure = $state(false);
-  let isRichComposer = $derived(manualRichMode || editorHasRichStructure);
-  let nextEnterWillSend = $derived(canSubmit && isRichComposer && editorNextEnterWillSend);
-
-  $effect(() => {
-    if (!canAttach && attachments.filesWithUrls.length > 0) {
-      attachments.clear();
-    }
-  });
-
-  // Auto-focus the input when the component mounts, room changes, a reply
-  // starts, or the editor becomes editable (canPost loads async after a
-  // navigation, so on sidebar/quick-switcher room changes the editor is
-  // briefly contenteditable=false — calling focus() then is a no-op).
-  // Skip on touch devices where the keyboard popup would be jarring.
-  $effect(() => {
-    if (!autoFocus || !shouldAutoFocus()) return;
-
-    // Tracked as dependencies so the effect re-fires on each of these.
-    void roomId;
-    void inReplyTo;
-
-    if (editorApi && !inputDisabled) {
-      tick().then(() => editorApi?.focus());
-    }
-  });
-
-  // Handle emoji selection from autocomplete
-  function handleEmojiSelect(emoji: string, _name: string) {
-    autocomplete.selectEmoji(emoji);
-  }
-
-  function closeEmojiAutocomplete() {
-    autocomplete.closeEmoji();
-  }
-
-  // Handle mention selection from autocomplete
-  function handleMentionSelect(login: string, viaTab: boolean) {
-    autocomplete.selectMention(login, viaTab);
-  }
-
-  function closeMentionAutocomplete() {
-    autocomplete.closeMention();
-  }
-
-  function handleFileSelect(event: Event) {
-    const target = event.target as HTMLInputElement;
-    if (!canAttach || inputDisabled) {
-      target.value = '';
-      return;
-    }
-    if (target.files) {
-      void attachments.stageFiles(Array.from(target.files));
-    }
-    // Reset input so same file can be selected again
-    target.value = '';
-  }
-
-  function removeFile(index: number) {
-    attachments.removeFile(index);
-  }
-
-  /**
-   * Add files from an external source (e.g., drag-and-drop).
-   * Creates object URLs for preview and adds to the attachment list.
-   */
-  async function addFiles(files: File[]) {
-    if (!canAttach || inputDisabled) return;
-    await attachments.stageFiles(files);
-  }
-
-  // Focus the input programmatically (e.g., when opening thread from mobile action sheet)
-  function focus() {
-    tick().then(() => editorApi?.focus());
-  }
-
-  function insertQuote(text: QuoteInsertionContent) {
-    tick().then(() => editorApi?.insertQuote(text));
-  }
-
-  let insertedQuoteRequestId = 0;
-  $effect(() => {
-    const request = quoteInsertionState.request;
-    const api = editorApi;
-    if (!request || !api || request.id === insertedQuoteRequestId) return;
-
-    insertedQuoteRequestId = request.id;
-    api.insertQuote(request.text);
-  });
-
-  // Expose API to parent via onReady callback
-  $effect(() => {
-    onReady?.({ addFiles, focus, insertQuote });
-  });
-
-  // Handle paste events - intercept images before TipTap processes them
-  function handlePaste(event: ClipboardEvent): boolean {
-    // Don't accept file attachments in edit mode (editMessage only supports text)
-    if (isEditing || inputDisabled) return false;
-
-    const items = event.clipboardData?.items;
-    if (!items) return false;
-
-    const pastedFiles: File[] = [];
-
-    for (let i = 0; i < items.length; i++) {
-      const item = items[i];
-      if (item.type.startsWith('image/')) {
-        const file = item.getAsFile();
-        if (file) {
-          pastedFiles.push(file);
-        }
-      }
-    }
-
-    if (pastedFiles.length > 0) {
-      if (!canAttach) return true;
-      void attachments.stageFiles(pastedFiles);
-      return true; // Prevent TipTap from processing the paste
-    }
-    return false; // Let TipTap handle text pastes
-  }
-
-  // Collapse runs of 3+ newlines down to 2 (one blank line max).
-  // Applied symmetrically on post and edit so blank-line runs don't
-  // accumulate over time and pasted blank-line runs stay reasonable.
-  function normalizeMessageBody(text: string): string {
-    return text.replace(/\n{3,}/g, '\n\n');
-  }
-
-  function hasStructuralMarkdownBody(text: string): boolean {
-    return text
-      .split('\n')
-      .some((line) => /^ {0,3}(?:#{1,6}|[-+*]|\d{1,9}[.)]|>)[ \t]$/.test(line));
-  }
-
-  function bodyForSend(text: string): string {
-    const normalized = normalizeMessageBody(text);
-    if (hasStructuralMarkdownBody(normalized)) return normalized;
-    return normalizeMessageBody(text.trim());
-  }
-
-  function handlePostSuccess(post: PreparedPost, event: TimelineEventView | null): void {
-    const activeDraftWasSent = DRAFT_KEY === post.draftKey;
-    const stashedFiles = draftState.discardFiles(post.draftKey);
-    draftState.clearText(post.draftKey);
-
-    if (activeDraftWasSent) {
-      autocomplete.reset();
-      message = '';
-      editorApi?.setContent('');
-      attachments.clear();
-      linkPreviews.clear();
-
-      // Notify the still-active parent before scrolling so it can synchronously
-      // ingest the returned event and make the target row available.
-      onMessageSent?.(event);
-
-      // The composer reads `scrollState` from its surrounding ComposerContext,
-      // so this targets the active room or thread EventList.
-      scrollState?.requestScrollToBottom();
-
-      // Clear reply-in-room state after sending.
-      onCancelReply?.();
-
-      // Reset active composer options after successful send.
-      alsoSendToChannel = false;
-      manualRichMode = false;
-    } else {
-      for (const { url } of stashedFiles) URL.revokeObjectURL(url);
-    }
-
-    // Mark the submitted room as read even if the user navigated away while sending.
-    roomUnreadStore.setRoomUnread(post.roomId, false);
-  }
-
-  function handleEditSuccess(): void {
-    autocomplete.reset();
-    message = '';
-    editorApi?.setContent('');
-    editState.cancelEdit();
-  }
-
-  async function createMessage() {
-    // Require either non-empty message body or attachments.
-    // hasVisibleContent rejects messages with only invisible Unicode characters.
-    const bodyToSend = bodyForSend(message);
-    const hasBody = hasVisibleContent(bodyToSend);
-    const filesToSend = hasSendableAttachments ? [...attachments.selectedFiles] : null;
-    if (!hasBody && !filesToSend) return;
-
-    const preparedPost: PreparedPost = {
-      draftKey: DRAFT_KEY,
-      roomId,
-      bodyToSend,
-      filesToSend,
-      threadRootEventId: inThread ?? null,
-      inReplyTo: inReplyTo ?? null,
-      linkPreviewToken: linkPreviews.buildToken(),
-      alsoSendToChannel
-    };
-
-    await submission.requestPost(preparedPost);
-  }
-
-  async function editMessage() {
-    const trimmedBody = bodyForSend(message);
-    if (!trimmedBody) {
-      toast.error('Message cannot be empty');
-      return;
-    }
-
-    const eventId = editState.eventId;
-    if (!eventId) return;
-
-    const input: UpdateMessageInput = { roomId, eventId, body: trimmedBody };
-    if (showEditEchoCheckbox) {
-      input.alsoSendToChannel = alsoSendToChannel;
-    }
-
-    await submission.editMessage(input);
-  }
-
-  async function handleSubmit() {
-    // Guard against double-sends while editor stays editable, and against
-    // submitting before pasted/dropped/selected files have finished staging.
-    if (
-      submission.loading ||
-      submission.roleMentionCheckLoading ||
-      submission.roleMentionConfirmationLoading ||
-      submission.pendingRoleMentionConfirmation ||
-      inputDisabled ||
-      attachments.pendingCount > 0
-    )
-      return;
-    if (isEditing) {
-      await editMessage();
-    } else {
-      await createMessage();
-    }
-  }
-
-  function cancelEdit() {
-    autocomplete.reset();
-    editState.cancelEdit();
-    message = '';
-    manualRichMode = false;
-    editorApi?.setContent('');
-  }
-
-  // Handle keyboard events from TipTap editor.
-  // Return true to prevent TipTap's default handling.
-  function handleEditorKeyDown(event: KeyboardEvent): boolean {
-    // Handle emoji autocomplete keyboard events first
-    if (autocomplete.emoji && autocomplete.emojiRef) {
-      if (autocomplete.emojiRef.handleKeyDown(event)) {
-        return true;
-      }
-    }
-
-    // Handle mention autocomplete keyboard events
-    if (autocomplete.mention && autocomplete.mentionRef) {
-      if (autocomplete.mentionRef.handleKeyDown(event)) {
-        return true;
-      }
-    }
-
-    if (event.key === 'Enter' && !event.ctrlKey && !event.metaKey && prefersTouchActions()) {
-      return false;
-    }
-
-    if (event.key === 'Enter' && !event.shiftKey) {
-      if (event.metaKey || event.ctrlKey) {
-        if (isRichComposer) {
-          handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-        } else {
-          if (hasVisibleContent(message)) {
-            editorApi?.insertBlockBreak();
-          }
-          // TipTap reports an empty document while inserting the first block break,
-          // so commit manual rich mode after that update has had a chance to clear it.
-          manualRichMode = true;
-        }
-        return true;
-      }
-
-      if (!isRichComposer) {
-        if (canSubmit) {
-          handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-          return true;
-        }
-      } else if (nextEnterWillSend) {
-        handleSubmit(); // Fire-and-forget (async, but keydown must return sync)
-        return true;
-      }
-    }
-
-    // Handle Tab for @mention autocomplete
-    if (event.key === 'Tab') {
-      if (autocomplete.handleTabCompletion(event)) {
-        return true;
-      }
-      // If no completion happened, let default Tab behavior occur
-    }
-
-    // Reset tab-completion state on any other key
-    if (event.key !== 'Tab') {
-      autocomplete.resetTabCompletion();
-    }
-
-    if (event.key === 'Escape') {
-      if (isEditing) {
-        cancelEdit();
-        return true;
-      }
-      if (inReplyTo && onCancelReply) {
-        onCancelReply();
-        return true;
-      }
-      if (onEscape) {
-        onEscape();
-        return true;
-      }
-    }
-
-    // Up arrow on empty input: edit last message
-    if (event.key === 'ArrowUp' && !isEditing && (editorApi?.getText() ?? '').trim() === '') {
-      const lastMsg = lastEditableMessageCtx?.getLastEditableMessage();
-      if (lastMsg) {
-        editState.startEdit(lastMsg.eventId, lastMsg.body, {
-          threadRootEventId: lastMsg.threadRootEventId,
-          channelEchoEventId: lastMsg.channelEchoEventId,
-          canAddChannelEcho: lastMsg.canAddChannelEcho
-        });
-        return true;
-      }
-    }
-
-    return false; // Let TipTap handle it (e.g., Shift+Enter for hard break)
-  }
-
-  // Handle content updates from TipTap editor
-  function handleEditorUpdate(text: string) {
-    const previousMessage = message;
-    message = text;
-    if (!text) {
-      manualRichMode = false;
-    }
-    // Only trigger typing indicator for actual user input.
-    // Programmatic setContent calls suppress TipTap update events, but this
-    // guard still protects any same-value editor update from emitting typing.
-    if (text !== previousMessage) {
-      onTyping?.();
-    }
-    autocomplete.update();
-  }
-
-  function handleRichStructureChange(value: boolean) {
-    editorHasRichStructure = value;
-  }
-
-  // Called when TipTap editor is ready - sync any pending state
-  function handleEditorReady(api: TipTapEditorApi) {
-    editorApi = api;
-    // Sync current message state (may have draft loaded before editor was ready)
-    if (message) {
-      api.setContent(message);
-    }
-  }
+	import { createMessageAPI } from '$lib/api-client/messages';
+	import { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
+	import * as m from '$lib/i18n/messages';
+	import { useConnection } from '$lib/state/server/connection.svelte';
+	import { serverRegistry } from '$lib/state/server/registry.svelte';
+	import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+	import { getRoomMembers, getRoomMembersStore, getComposerContext } from '$lib/state/room';
+	import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
+	import { getActiveServer } from '$lib/state/activeServer.svelte';
+	import { getUserSettings } from '$lib/state/userSettings.svelte';
+	import EmojiAutocomplete from './EmojiAutocomplete.svelte';
+	import MentionAutocomplete from './MentionAutocomplete.svelte';
+	import ComposerLinkPreview from './ComposerLinkPreview.svelte';
+	import ComposerAttachmentPreviews from './ComposerAttachmentPreviews.svelte';
+	import ComposerToolbar from './ComposerToolbar.svelte';
+	import ComposerModeIndicators from './ComposerModeIndicators.svelte';
+	import {
+		MessageComposerState,
+		type MessageComposerProps
+	} from './messageComposerState.svelte';
+
+	const tipTapEditorModule = import('./TipTapEditor.svelte');
+	const stores = serverRegistry.getStore(getActiveServer());
+	const serverInfo = stores.serverInfo;
+	const roomUnreadStore = stores.roomUnread;
+	const mentionRolesStore = stores.mentionRoles;
+
+	let {
+		roomId,
+		inThread,
+		inReplyTo,
+		replyDisplayName,
+		replyExcerpt,
+		placeholder,
+		canPost = true,
+		canAttach = true,
+		autoFocus = true,
+		onReady,
+		onTyping,
+		onMessageSent,
+		onCancelReply,
+		onEscape,
+		showAlsoSendToChannel = false
+	}: MessageComposerProps = $props();
+
+	const connection = useConnection();
+	const userSettings = getUserSettings();
+	const composerContext = getComposerContext();
+	const state = new MessageComposerState({
+		getProps: () => ({
+			roomId,
+			inThread,
+			inReplyTo,
+			replyDisplayName,
+			replyExcerpt,
+			placeholder,
+			canPost,
+			canAttach,
+			autoFocus,
+			onReady,
+			onTyping,
+			onMessageSent,
+			onCancelReply,
+			onEscape,
+			showAlsoSendToChannel
+		}),
+		context: composerContext,
+		getMembers: getRoomMembers,
+		membersStore: getRoomMembersStore(),
+		mentionRolesStore,
+		serverInfo,
+		roomUnreadStore,
+		getMessageAPI: () => connection().getAPI(createMessageAPI),
+		getLinkPreviewAPI: () => connection().getAPI(createLinkPreviewAPI),
+		isConnectionLost: () => connection().showConnectionLostBanner
+	});
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  {@attach observeComposerResize}
-  class="flex flex-col gap-2 p-2"
-  onclick={(e) => {
-    if (!(e.target as HTMLElement).closest('button, a, input, label, select, .tiptap')) {
-      editorApi?.focus();
-    }
-  }}
+	{@attach state.observeResize}
+	class="flex flex-col gap-2 p-2"
+	onclick={(event) => {
+		if (!(event.target as HTMLElement).closest('button, a, input, label, select, .tiptap')) {
+			state.editorApi?.focus();
+		}
+	}}
 >
-  <ComposerLinkPreview state={linkPreviews} />
-  <ComposerAttachmentPreviews
-    {attachments}
-    disabled={submission.loading}
-    getSubmissionStatus={(file) => submission.attachmentStatus(file)}
-    onremove={removeFile}
-  />
+	<ComposerLinkPreview state={state.linkPreviews} />
+	<ComposerAttachmentPreviews
+		attachments={state.attachments}
+		disabled={state.submission.loading}
+		getSubmissionStatus={(file) => state.submission.attachmentStatus(file)}
+		onremove={(index) => state.attachments.removeFile(index)}
+	/>
 
-  <!-- Hidden file input -->
-  {#if canAttach && !isEditing}
-    <input
-      bind:this={fileInputElement}
-      type="file"
-      multiple
-      onchange={handleFileSelect}
-      class="hidden"
-    />
-  {/if}
+	{#if canAttach && !state.isEditing}
+		<input
+			bind:this={state.fileInputElement}
+			type="file"
+			multiple
+			onchange={(event) => state.handleFileSelect(event)}
+			class="hidden"
+		/>
+	{/if}
 
-  <!-- Unified composer surface -->
-  <div
-    data-testid="composer-input-surface"
-    data-composer-mode={isRichComposer ? 'rich' : 'simple'}
-    class="composer-mode-surface relative flex flex-col rounded-lg bg-surface px-2.5 py-1.5"
-    class:opacity-50={inputDisabled}
-  >
-    <!-- Emoji autocomplete popup -->
-    {#if autocomplete.emoji}
-      <EmojiAutocomplete
-        bind:this={autocomplete.emojiRef}
-        query={autocomplete.emoji.query}
-        onSelect={handleEmojiSelect}
-        onClose={closeEmojiAutocomplete}
-      />
-    {/if}
+	<div
+		data-testid="composer-input-surface"
+		data-composer-mode={state.isRichComposer ? 'rich' : 'simple'}
+		class="composer-mode-surface relative flex flex-col rounded-lg bg-surface px-2.5 py-1.5"
+		class:opacity-50={state.inputDisabled}
+	>
+		{#if state.autocomplete.emoji}
+			<EmojiAutocomplete
+				bind:this={state.autocomplete.emojiRef}
+				query={state.autocomplete.emoji.query}
+				onSelect={(emoji) => state.autocomplete.selectEmoji(emoji)}
+				onClose={() => state.autocomplete.closeEmoji()}
+			/>
+		{/if}
 
-    <!-- Mention autocomplete popup -->
-    {#if autocomplete.mention}
-      <MentionAutocomplete
-        bind:this={autocomplete.mentionRef}
-        query={autocomplete.mention.query}
-        members={mentionCandidateMembers}
-        roles={mentionRoles}
-        onSelect={handleMentionSelect}
-        onClose={closeMentionAutocomplete}
-      />
-    {/if}
-    <!-- Text input (TipTap editor) -->
-    <div class="min-h-9 min-w-0 px-0.5 py-0.5" data-testid="composer-editor-row">
-      {#await tipTapEditorModule}
-        <div class="min-h-8 min-w-0" aria-hidden="true"></div>
-      {:then { default: TipTapEditor }}
-        <TipTapEditor
-          placeholder={currentPlaceholder}
-          editable={!inputDisabled}
-          autofocus={autoFocus && shouldAutoFocus()}
-          {testid}
-          onUpdate={handleEditorUpdate}
-          onKeyDown={handleEditorKeyDown}
-          onPaste={handlePaste}
-          onNextEnterWillSendChange={(value) => (editorNextEnterWillSend = value)}
-          onRichStructureChange={handleRichStructureChange}
-          onFormattingStateChange={(state) => (formattingState = { ...state })}
-          onReady={handleEditorReady}
-        />
-      {/await}
-    </div>
+		{#if state.autocomplete.mention}
+			<MentionAutocomplete
+				bind:this={state.autocomplete.mentionRef}
+				query={state.autocomplete.mention.query}
+				members={state.mentionCandidates}
+				roles={state.mentionRoles}
+				onSelect={(login, viaTab) => state.autocomplete.selectMention(login, viaTab)}
+				onClose={() => state.autocomplete.closeMention()}
+			/>
+		{/if}
 
-    <ComposerToolbar
-      {formattingState}
-      {editorApi}
-      {inputDisabled}
-      {canAttach}
-      {isEditing}
-      {canSubmit}
-      {isRichComposer}
-      {nextEnterWillSend}
-      {fileInputElement}
-      effectiveTimezone={userSettings.effectiveTimezone}
-      onsubmit={handleSubmit}
-    />
-  </div>
+		<div class="min-h-9 min-w-0 px-0.5 py-0.5" data-testid="composer-editor-row">
+			{#await tipTapEditorModule}
+				<div class="min-h-8 min-w-0" aria-hidden="true"></div>
+			{:then { default: TipTapEditor }}
+				<TipTapEditor
+					placeholder={state.currentPlaceholder}
+					editable={!state.inputDisabled}
+					autofocus={autoFocus && shouldAutoFocus()}
+					testid={state.testid}
+					onUpdate={(text) => state.handleEditorUpdate(text)}
+					onKeyDown={(event) => state.handleEditorKeyDown(event)}
+					onPaste={(event) => state.handlePaste(event)}
+					onNextEnterWillSendChange={(value) => (state.editorNextEnterWillSend = value)}
+					onRichStructureChange={(value) => (state.editorHasRichStructure = value)}
+					onFormattingStateChange={(formatting) => (state.formattingState = { ...formatting })}
+					onReady={(api) => state.handleEditorReady(api)}
+				/>
+			{/await}
+		</div>
 
-  <!-- Also send to channel checkbox (thread replies only, when permitted) -->
-  {#if (showAlsoSendToChannel && !isEditing) || showEditEchoCheckbox}
-    <label class="flex cursor-pointer items-center gap-2 px-3 text-sm text-muted">
-      <input
-        type="checkbox"
-        bind:checked={alsoSendToChannel}
-        disabled={inputDisabled}
-        class="cursor-pointer accent-neutral-action"
-      />
-      {m['composer.also_send_to_channel']()}
-    </label>
-  {/if}
+		<ComposerToolbar
+			formattingState={state.formattingState}
+			editorApi={state.editorApi}
+			inputDisabled={state.inputDisabled}
+			{canAttach}
+			isEditing={state.isEditing}
+			canSubmit={state.canSubmit}
+			isRichComposer={state.isRichComposer}
+			nextEnterWillSend={state.nextEnterWillSend}
+			fileInputElement={state.fileInputElement}
+			effectiveTimezone={userSettings.effectiveTimezone}
+			onsubmit={() => state.submit()}
+		/>
+	</div>
 
-  <ComposerModeIndicators
-    {inReplyTo}
-    {replyDisplayName}
-    {replyExcerpt}
-    {isEditing}
-    oncancelreply={() => onCancelReply?.()}
-    oncanceledit={cancelEdit}
-  />
+	{#if (showAlsoSendToChannel && !state.isEditing) || state.showEditEchoCheckbox}
+		<label class="flex cursor-pointer items-center gap-2 px-3 text-sm text-muted">
+			<input
+				type="checkbox"
+				bind:checked={state.alsoSendToChannel}
+				disabled={state.inputDisabled}
+				class="cursor-pointer accent-neutral-action"
+			/>
+			{m['composer.also_send_to_channel']()}
+		</label>
+	{/if}
+
+	<ComposerModeIndicators
+		{inReplyTo}
+		{replyDisplayName}
+		{replyExcerpt}
+		isEditing={state.isEditing}
+		oncancelreply={() => onCancelReply?.()}
+		oncanceledit={() => state.cancelEdit()}
+	/>
 </div>
 
-{#if submission.pendingRoleMentionConfirmation}
-  <ConfirmDialog
-    title={m['composer.role_mention_confirm_title']()}
-    tone="warning"
-    actionLabel={m['composer.send_anyway']()}
-    actionIcon="iconify uil--telegram-alt"
-    loading={submission.roleMentionConfirmationLoading}
-    onconfirm={() => submission.confirmRoleMentionSend()}
-    onclose={() => submission.cancelRoleMentionConfirmation()}
-  >
-    {m['composer.role_mention_confirm_body']()}
-  </ConfirmDialog>
+{#if state.submission.pendingRoleMentionConfirmation}
+	<ConfirmDialog
+		title={m['composer.role_mention_confirm_title']()}
+		tone="warning"
+		actionLabel={m['composer.send_anyway']()}
+		actionIcon="iconify uil--telegram-alt"
+		loading={state.submission.roleMentionConfirmationLoading}
+		onconfirm={() => state.submission.confirmRoleMentionSend()}
+		onclose={() => state.submission.cancelRoleMentionConfirmation()}
+	>
+		{m['composer.role_mention_confirm_body']()}
+	</ConfirmDialog>
 {/if}

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -573,6 +573,25 @@ describe('MessageComposer', () => {
   });
 
   describe('initial state', () => {
+    it('publishes its API after initial synchronization and republishes it to replacement callbacks', async () => {
+      const firstReady = vi.fn((api: MessageComposerApi) => {
+        void api.addFiles([imageFile('ready.png')]);
+      });
+      const secondReady = vi.fn();
+      const rendered = renderMessageComposer(
+        { roomId: 'room-ready', onReady: firstReady },
+        { exactRoomId: true }
+      );
+
+      await findEditor(rendered.container);
+      await vi.waitFor(() => expect(firstReady).toHaveBeenCalledOnce());
+      await expect.element(rendered.container).toHaveTextContent('ready.png');
+
+      await rendered.rerender({ roomId: 'room-ready', onReady: secondReady });
+
+      await vi.waitFor(() => expect(secondReady).toHaveBeenCalledOnce());
+    });
+
     it('editor is editable initially', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
 

--- a/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
+++ b/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
@@ -1,0 +1,540 @@
+import { tick, untrack } from 'svelte';
+import type { TimelineEventView } from '$lib/render/timelineEvents';
+import type {
+	ComposerContext,
+	QuoteInsertionContent,
+	RoomMember,
+	RoomMembersStore
+} from '$lib/state/room';
+import type { MentionRolesStore } from '$lib/state/server/mentionRoles.svelte';
+import type { RoomUnreadStore } from '$lib/state/server/roomUnread.svelte';
+import type { ServerInfoState } from '$lib/state/server/state.svelte';
+import type { createMessageAPI, UpdateMessageInput } from '$lib/api-client/messages';
+import type { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
+import { hasVisibleContent } from '$lib/validation';
+import { prefersTouchActions } from '$lib/utils/inputCapabilities';
+import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
+import { useDebounce } from '$lib/hooks/useDebounce.svelte';
+import { toast } from '$lib/ui/toast';
+import * as m from '$lib/i18n/messages';
+import { AttachmentsState } from './attachments.svelte';
+import { AutocompleteState, type MentionRole } from './autocomplete.svelte';
+import { DraftState, draftKey } from './draft.svelte';
+import type { ComposerFormattingState, TipTapEditorApi } from './editorTypes';
+import { LinkPreviewState } from './linkPreviews.svelte';
+import { ComposerSubmissionState, type PreparedPost } from './submission.svelte';
+
+const emptyFormattingState: ComposerFormattingState = {
+	bold: false,
+	italic: false,
+	inlineCode: false,
+	heading: false,
+	bulletList: false,
+	orderedList: false,
+	blockquote: false,
+	codeBlock: false
+};
+
+export type MessageComposerApi = {
+	addFiles: (files: File[]) => void;
+	focus: () => void;
+	insertQuote: (text: QuoteInsertionContent) => void;
+};
+
+export type MessageComposerProps = {
+	roomId: string;
+	inThread?: string;
+	inReplyTo?: string;
+	replyDisplayName?: string;
+	replyExcerpt?: string;
+	placeholder?: string;
+	canPost?: boolean;
+	canAttach?: boolean;
+	autoFocus?: boolean;
+	onReady?: (api: MessageComposerApi) => void;
+	onTyping?: () => void;
+	onMessageSent?: (event: TimelineEventView | null) => void;
+	onCancelReply?: () => void;
+	onEscape?: () => void;
+	showAlsoSendToChannel?: boolean;
+};
+
+type MessageComposerDependencies = {
+	getProps: () => Required<
+		Pick<MessageComposerProps, 'roomId' | 'canPost' | 'canAttach' | 'autoFocus'>
+	> &
+		Omit<MessageComposerProps, 'roomId' | 'canPost' | 'canAttach' | 'autoFocus'>;
+	context: ComposerContext;
+	getMembers: () => RoomMember[];
+	membersStore: RoomMembersStore;
+	mentionRolesStore: MentionRolesStore;
+	serverInfo: ServerInfoState;
+	roomUnreadStore: RoomUnreadStore;
+	getMessageAPI: () => ReturnType<typeof createMessageAPI>;
+	getLinkPreviewAPI: () => ReturnType<typeof createLinkPreviewAPI>;
+	isConnectionLost: () => boolean;
+};
+
+export function bodyForSend(text: string): string {
+	const normalized = text.replace(/\n{3,}/g, '\n\n');
+	const hasStructuralBody = normalized
+		.split('\n')
+		.some((line) => /^ {0,3}(?:#{1,6}|[-+*]|\d{1,9}[.)]|>)[ \t]$/.test(line));
+	return hasStructuralBody ? normalized : text.trim().replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Owns the state transitions for one mounted room or thread composer.
+ *
+ * The Svelte component remains the DOM and context boundary. This class keeps
+ * draft, edit, autocomplete, attachment, preview, and submission transitions
+ * together so every reset follows the same path.
+ */
+export class MessageComposerState {
+	message = $state('');
+	editorApi = $state<TipTapEditorApi | null>(null);
+	fileInputElement = $state<HTMLInputElement>();
+	formattingState = $state<ComposerFormattingState>({ ...emptyFormattingState });
+	alsoSendToChannel = $state(false);
+	editorNextEnterWillSend = $state(false);
+	manualRichMode = $state(false);
+	editorHasRichStructure = $state(false);
+	mentionSearchMembers = $state.raw<RoomMember[]>([]);
+
+	readonly draft = new DraftState();
+	readonly attachments: AttachmentsState;
+	readonly linkPreviews: LinkPreviewState;
+	readonly autocomplete: AutocompleteState;
+	readonly submission: ComposerSubmissionState;
+
+	readonly #dependencies: MessageComposerDependencies;
+	readonly #mentionSearchDebounce = useDebounce();
+	#mentionSearchRequestId = 0;
+	#editSeededForEvent = '';
+	#autocompleteRoomId = '';
+	#insertedQuoteRequestId = 0;
+
+	constructor(dependencies: MessageComposerDependencies) {
+		this.#dependencies = dependencies;
+		this.attachments = new AttachmentsState(() => dependencies.serverInfo);
+		this.linkPreviews = new LinkPreviewState(dependencies.getLinkPreviewAPI);
+		this.autocomplete = new AutocompleteState(
+			() => this.editorApi,
+			() => this.mentionCandidates,
+			() => this.mentionRoles
+		);
+		this.submission = new ComposerSubmissionState({
+			getAPI: dependencies.getMessageAPI,
+			getMentionRoleStatus: () => dependencies.mentionRolesStore.status,
+			loadMentionRoles: () => dependencies.mentionRolesStore.load(),
+			getMentionRoleNames: () => this.mentionRoles.map((role) => role.name),
+			onPostSuccess: (post, event) => this.#handlePostSuccess(post, event),
+			onEditSuccess: () => this.#handleEditSuccess()
+		});
+
+		dependencies.getProps().onReady?.({
+			addFiles: (files) => void this.addFiles(files),
+			focus: () => this.focus(),
+			insertQuote: (text) => this.insertQuote(text)
+		});
+		void dependencies.mentionRolesStore.load();
+		this.#synchronizeMentionSearch();
+		this.#synchronizeEditState();
+		this.#synchronizeDraft();
+		this.#synchronizeDraftText();
+		this.#synchronizeLinkPreviews();
+		this.#synchronizeAttachmentPermission();
+		this.#synchronizeAutoFocus();
+		this.#synchronizeQuoteInsertion();
+	}
+
+	get props() {
+		return this.#dependencies.getProps();
+	}
+
+	get editState() {
+		return this.#dependencies.context.editState;
+	}
+
+	get isEditing(): boolean {
+		return this.editState.eventId !== null;
+	}
+
+	get mentionRoles(): MentionRole[] {
+		return this.#dependencies.mentionRolesStore.roles;
+	}
+
+	get mentionCandidates(): RoomMember[] {
+		return this.mentionSearchMembers.length > 0
+			? this.mentionSearchMembers
+			: this.#dependencies.getMembers();
+	}
+
+	get draftKey(): string {
+		return draftKey(this.props.roomId, this.props.inThread);
+	}
+
+	get currentPlaceholder(): string {
+		return this.isEditing
+			? m['composer.editing_placeholder']()
+			: (this.props.placeholder ?? m['composer.placeholder']());
+	}
+
+	get testid(): string {
+		return this.props.inThread ? 'thread-reply-input' : 'message-input';
+	}
+
+	get showEditEchoCheckbox(): boolean {
+		return (
+			this.isEditing &&
+			this.editState.threadRootEventId !== null &&
+			(this.editState.channelEchoEventId !== null || this.editState.canAddChannelEcho)
+		);
+	}
+
+	get inputDisabled(): boolean {
+		return (
+			this.submission.loading ||
+			!this.props.canPost ||
+			this.#dependencies.isConnectionLost()
+		);
+	}
+
+	get hasSendableAttachments(): boolean {
+		return this.props.canAttach && this.attachments.selectedFiles.length > 0;
+	}
+
+	get canSubmit(): boolean {
+		return (
+			!this.submission.loading &&
+			!this.submission.roleMentionCheckLoading &&
+			!this.inputDisabled &&
+			this.attachments.pendingCount === 0 &&
+			(hasVisibleContent(this.message) || this.hasSendableAttachments || this.isEditing)
+		);
+	}
+
+	get isRichComposer(): boolean {
+		return this.manualRichMode || this.editorHasRichStructure;
+	}
+
+	get nextEnterWillSend(): boolean {
+		return this.canSubmit && this.isRichComposer && this.editorNextEnterWillSend;
+	}
+
+	observeResize = (node: HTMLDivElement) => {
+		const scrollState = this.#dependencies.context.scrollState;
+		if (!scrollState) return;
+		const observer = new ResizeObserver(() => scrollState.scrollToBottomIfSticky());
+		observer.observe(node);
+		return () => observer.disconnect();
+	};
+
+	handleFileSelect(event: Event): void {
+		const input = event.target as HTMLInputElement;
+		if (!this.props.canAttach || this.inputDisabled) {
+			input.value = '';
+			return;
+		}
+		if (input.files) void this.attachments.stageFiles(Array.from(input.files));
+		input.value = '';
+	}
+
+	async addFiles(files: File[]): Promise<void> {
+		if (!this.props.canAttach || this.inputDisabled) return;
+		await this.attachments.stageFiles(files);
+	}
+
+	focus(): void {
+		tick().then(() => this.editorApi?.focus());
+	}
+
+	insertQuote(text: QuoteInsertionContent): void {
+		tick().then(() => this.editorApi?.insertQuote(text));
+	}
+
+	handlePaste(event: ClipboardEvent): boolean {
+		if (this.isEditing || this.inputDisabled) return false;
+		const items = event.clipboardData?.items;
+		if (!items) return false;
+
+		const files = Array.from(items)
+			.filter((item) => item.type.startsWith('image/'))
+			.map((item) => item.getAsFile())
+			.filter((file): file is File => file !== null);
+		if (files.length === 0) return false;
+		if (this.props.canAttach) void this.attachments.stageFiles(files);
+		return true;
+	}
+
+	async submit(): Promise<void> {
+		if (
+			this.submission.loading ||
+			this.submission.roleMentionCheckLoading ||
+			this.submission.roleMentionConfirmationLoading ||
+			this.submission.pendingRoleMentionConfirmation ||
+			this.inputDisabled ||
+			this.attachments.pendingCount > 0
+		) {
+			return;
+		}
+		await (this.isEditing ? this.#editMessage() : this.#createMessage());
+	}
+
+	cancelEdit(): void {
+		this.#resetEditor();
+		this.editState.cancelEdit();
+	}
+
+	handleEditorKeyDown(event: KeyboardEvent): boolean {
+		if (this.autocomplete.emoji?.query && this.autocomplete.emojiRef?.handleKeyDown(event)) {
+			return true;
+		}
+		if (
+			this.autocomplete.mention?.query &&
+			this.autocomplete.mentionRef?.handleKeyDown(event)
+		) {
+			return true;
+		}
+		if (event.key === 'Enter' && !event.ctrlKey && !event.metaKey && prefersTouchActions()) {
+			return false;
+		}
+		if (event.key === 'Enter' && !event.shiftKey && this.#handleEnter(event)) return true;
+		if (event.key === 'Tab' && this.autocomplete.handleTabCompletion(event)) return true;
+		if (event.key !== 'Tab') this.autocomplete.resetTabCompletion();
+		if (event.key === 'Escape' && this.#handleEscape()) return true;
+		if (event.key === 'ArrowUp' && this.#editLastMessage()) return true;
+		return false;
+	}
+
+	handleEditorUpdate(text: string): void {
+		const changed = text !== this.message;
+		this.message = text;
+		if (!text) this.manualRichMode = false;
+		if (changed) this.props.onTyping?.();
+		this.autocomplete.update();
+	}
+
+	handleEditorReady(api: TipTapEditorApi): void {
+		this.editorApi = api;
+		if (this.message) api.setContent(this.message);
+	}
+
+	#synchronizeMentionSearch(): void {
+		$effect(() => {
+			const query = this.autocomplete.mention?.query ?? null;
+			const requestId = ++this.#mentionSearchRequestId;
+			this.#mentionSearchDebounce.cancel();
+			if (!query) {
+				this.mentionSearchMembers = [];
+				return;
+			}
+			this.#mentionSearchDebounce.run(() => {
+				void this.#dependencies.membersStore.searchMembers(query).then((results) => {
+					if (requestId === this.#mentionSearchRequestId) this.mentionSearchMembers = results;
+				});
+			}, 150);
+		});
+	}
+
+	#synchronizeEditState(): void {
+		$effect(() => {
+			const eventId = this.editState.eventId;
+			const originalBody = this.editState.originalBody;
+			const api = this.editorApi;
+			if (eventId && originalBody && this.#editSeededForEvent !== eventId) {
+				this.#editSeededForEvent = eventId;
+				this.autocomplete.reset();
+				this.draft.clearText();
+				this.message = originalBody;
+				this.manualRichMode = false;
+				this.alsoSendToChannel = this.editState.channelEchoEventId !== null;
+				api?.setContent(originalBody);
+				tick().then(() => api?.focus('end'));
+				this.attachments.clear();
+				this.linkPreviews.clear();
+			} else if (this.#editSeededForEvent && !eventId) {
+				this.#resetEditor();
+				this.#editSeededForEvent = '';
+			}
+		});
+	}
+
+	#synchronizeDraft(): void {
+		$effect(() => {
+			const { roomId } = this.props;
+			if (this.#autocompleteRoomId !== roomId) {
+				this.#autocompleteRoomId = roomId;
+				this.autocomplete.resetForRoom();
+			}
+			if (this.isEditing) {
+				this.draft.switchKey(this.draftKey);
+				this.attachments.restore([]);
+				return;
+			}
+			const draftMessage = this.draft.switchKey(this.draftKey);
+			this.message = draftMessage;
+			this.manualRichMode = false;
+			this.editorApi?.setContent(draftMessage);
+			this.attachments.restore(untrack(() => this.draft.takeFiles()));
+			return () => this.draft.stashFiles(untrack(() => this.attachments.filesWithUrls));
+		});
+	}
+
+	#synchronizeDraftText(): void {
+		$effect(() => {
+			void this.draftKey;
+			if (!this.isEditing) this.draft.persistText(this.message);
+		});
+	}
+
+	#synchronizeLinkPreviews(): void {
+		$effect(() => this.linkPreviews.scheduleDetection(this.message, this.isEditing));
+	}
+
+	#synchronizeAttachmentPermission(): void {
+		$effect(() => {
+			if (!this.props.canAttach && this.attachments.filesWithUrls.length > 0) {
+				this.attachments.clear();
+			}
+		});
+	}
+
+	#synchronizeAutoFocus(): void {
+		$effect(() => {
+			const { autoFocus, roomId, inReplyTo } = this.props;
+			void roomId;
+			void inReplyTo;
+			if (autoFocus && shouldAutoFocus() && this.editorApi && !this.inputDisabled) {
+				tick().then(() => this.editorApi?.focus());
+			}
+		});
+	}
+
+	#synchronizeQuoteInsertion(): void {
+		$effect(() => {
+			const request = this.#dependencies.context.quoteInsertionState.request;
+			const api = this.editorApi;
+			if (!request || !api || request.id === this.#insertedQuoteRequestId) return;
+			this.#insertedQuoteRequestId = request.id;
+			api.insertQuote(request.text);
+		});
+	}
+
+	#resetEditor(): void {
+		this.autocomplete.reset();
+		this.message = '';
+		this.manualRichMode = false;
+		this.alsoSendToChannel = false;
+		this.editorApi?.setContent('');
+	}
+
+	#handlePostSuccess(post: PreparedPost, event: TimelineEventView | null): void {
+		const activeDraftWasSent = this.draftKey === post.draftKey;
+		const stashedFiles = this.draft.discardFiles(post.draftKey);
+		this.draft.clearText(post.draftKey);
+		if (activeDraftWasSent) {
+			this.#resetEditor();
+			this.attachments.clear();
+			this.linkPreviews.clear();
+			this.props.onMessageSent?.(event);
+			this.#dependencies.context.scrollState?.requestScrollToBottom();
+			this.props.onCancelReply?.();
+		} else {
+			for (const { url } of stashedFiles) URL.revokeObjectURL(url);
+		}
+		this.#dependencies.roomUnreadStore.setRoomUnread(post.roomId, false);
+	}
+
+	#handleEditSuccess(): void {
+		this.#resetEditor();
+		this.editState.cancelEdit();
+	}
+
+	async #createMessage(): Promise<void> {
+		const bodyToSend = bodyForSend(this.message);
+		const filesToSend = this.hasSendableAttachments
+			? [...this.attachments.selectedFiles]
+			: null;
+		if (!hasVisibleContent(bodyToSend) && !filesToSend) return;
+
+		await this.submission.requestPost({
+			draftKey: this.draftKey,
+			roomId: this.props.roomId,
+			bodyToSend,
+			filesToSend,
+			threadRootEventId: this.props.inThread ?? null,
+			inReplyTo: this.props.inReplyTo ?? null,
+			linkPreviewToken: this.linkPreviews.buildToken(),
+			alsoSendToChannel: this.alsoSendToChannel
+		});
+	}
+
+	async #editMessage(): Promise<void> {
+		const body = bodyForSend(this.message);
+		if (!body) {
+			toast.error('Message cannot be empty');
+			return;
+		}
+		const eventId = this.editState.eventId;
+		if (!eventId) return;
+		const input: UpdateMessageInput = { roomId: this.props.roomId, eventId, body };
+		if (this.showEditEchoCheckbox) input.alsoSendToChannel = this.alsoSendToChannel;
+		await this.submission.editMessage(input);
+	}
+
+	#handleEnter(event: KeyboardEvent): boolean {
+		if (event.metaKey || event.ctrlKey) {
+			if (this.isRichComposer) {
+				void this.submit();
+			} else {
+				if (hasVisibleContent(this.message)) this.editorApi?.insertBlockBreak();
+				this.manualRichMode = true;
+			}
+			return true;
+		}
+		if (!this.isRichComposer && this.canSubmit) {
+			void this.submit();
+			return true;
+		}
+		if (this.isRichComposer && this.nextEnterWillSend) {
+			void this.submit();
+			return true;
+		}
+		return false;
+	}
+
+	#handleEscape(): boolean {
+		if (this.isEditing) {
+			this.cancelEdit();
+			return true;
+		}
+		if (this.props.inReplyTo && this.props.onCancelReply) {
+			this.props.onCancelReply();
+			return true;
+		}
+		if (this.props.onEscape) {
+			this.props.onEscape();
+			return true;
+		}
+		return false;
+	}
+
+	#editLastMessage(): boolean {
+		if (
+			this.isEditing ||
+			(this.editorApi?.getText() ?? '').trim() !== '' ||
+			!this.#dependencies.context.lastEditableMessage
+		) {
+			return false;
+		}
+		const message = this.#dependencies.context.lastEditableMessage.getLastEditableMessage();
+		if (!message) return false;
+		this.editState.startEdit(message.eventId, message.body, {
+			threadRootEventId: message.threadRootEventId,
+			channelEchoEventId: message.channelEchoEventId,
+			canAddChannelEcho: message.canAddChannelEcho
+		});
+		return true;
+	}
+}

--- a/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
+++ b/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
@@ -60,10 +60,18 @@ export type MessageComposerProps = {
 };
 
 type MessageComposerDependencies = {
-	getProps: () => Required<
-		Pick<MessageComposerProps, 'roomId' | 'canPost' | 'canAttach' | 'autoFocus'>
-	> &
-		Omit<MessageComposerProps, 'roomId' | 'canPost' | 'canAttach' | 'autoFocus'>;
+	getRoomId: () => string;
+	getThreadRootEventId: () => string | undefined;
+	getReplyEventId: () => string | undefined;
+	getCanPost: () => boolean;
+	getCanAttach: () => boolean;
+	getAutoFocus: () => boolean;
+	getPlaceholder: () => string | undefined;
+	getOnReady: () => MessageComposerProps['onReady'];
+	getCallbacks: () => Pick<
+		MessageComposerProps,
+		'onTyping' | 'onMessageSent' | 'onCancelReply' | 'onEscape'
+	>;
 	context: ComposerContext;
 	getMembers: () => RoomMember[];
 	membersStore: RoomMembersStore;
@@ -132,11 +140,6 @@ export class MessageComposerState {
 			onEditSuccess: () => this.#handleEditSuccess()
 		});
 
-		dependencies.getProps().onReady?.({
-			addFiles: (files) => void this.addFiles(files),
-			focus: () => this.focus(),
-			insertQuote: (text) => this.insertQuote(text)
-		});
 		void dependencies.mentionRolesStore.load();
 		this.#synchronizeMentionSearch();
 		this.#synchronizeEditState();
@@ -146,10 +149,7 @@ export class MessageComposerState {
 		this.#synchronizeAttachmentPermission();
 		this.#synchronizeAutoFocus();
 		this.#synchronizeQuoteInsertion();
-	}
-
-	get props() {
-		return this.#dependencies.getProps();
+		this.#synchronizePublicApi();
 	}
 
 	get editState() {
@@ -171,17 +171,20 @@ export class MessageComposerState {
 	}
 
 	get draftKey(): string {
-		return draftKey(this.props.roomId, this.props.inThread);
+		return draftKey(
+			this.#dependencies.getRoomId(),
+			this.#dependencies.getThreadRootEventId()
+		);
 	}
 
 	get currentPlaceholder(): string {
 		return this.isEditing
 			? m['composer.editing_placeholder']()
-			: (this.props.placeholder ?? m['composer.placeholder']());
+			: (this.#dependencies.getPlaceholder() ?? m['composer.placeholder']());
 	}
 
 	get testid(): string {
-		return this.props.inThread ? 'thread-reply-input' : 'message-input';
+		return this.#dependencies.getThreadRootEventId() ? 'thread-reply-input' : 'message-input';
 	}
 
 	get showEditEchoCheckbox(): boolean {
@@ -195,13 +198,13 @@ export class MessageComposerState {
 	get inputDisabled(): boolean {
 		return (
 			this.submission.loading ||
-			!this.props.canPost ||
+			!this.#dependencies.getCanPost() ||
 			this.#dependencies.isConnectionLost()
 		);
 	}
 
 	get hasSendableAttachments(): boolean {
-		return this.props.canAttach && this.attachments.selectedFiles.length > 0;
+		return this.#dependencies.getCanAttach() && this.attachments.selectedFiles.length > 0;
 	}
 
 	get canSubmit(): boolean {
@@ -232,7 +235,7 @@ export class MessageComposerState {
 
 	handleFileSelect(event: Event): void {
 		const input = event.target as HTMLInputElement;
-		if (!this.props.canAttach || this.inputDisabled) {
+		if (!this.#dependencies.getCanAttach() || this.inputDisabled) {
 			input.value = '';
 			return;
 		}
@@ -241,7 +244,7 @@ export class MessageComposerState {
 	}
 
 	async addFiles(files: File[]): Promise<void> {
-		if (!this.props.canAttach || this.inputDisabled) return;
+		if (!this.#dependencies.getCanAttach() || this.inputDisabled) return;
 		await this.attachments.stageFiles(files);
 	}
 
@@ -263,7 +266,7 @@ export class MessageComposerState {
 			.map((item) => item.getAsFile())
 			.filter((file): file is File => file !== null);
 		if (files.length === 0) return false;
-		if (this.props.canAttach) void this.attachments.stageFiles(files);
+		if (this.#dependencies.getCanAttach()) void this.attachments.stageFiles(files);
 		return true;
 	}
 
@@ -311,7 +314,7 @@ export class MessageComposerState {
 		const changed = text !== this.message;
 		this.message = text;
 		if (!text) this.manualRichMode = false;
-		if (changed) this.props.onTyping?.();
+		if (changed) this.#dependencies.getCallbacks().onTyping?.();
 		this.autocomplete.update();
 	}
 
@@ -362,7 +365,7 @@ export class MessageComposerState {
 
 	#synchronizeDraft(): void {
 		$effect(() => {
-			const { roomId } = this.props;
+			const roomId = this.#dependencies.getRoomId();
 			if (this.#autocompleteRoomId !== roomId) {
 				this.#autocompleteRoomId = roomId;
 				this.autocomplete.resetForRoom();
@@ -394,7 +397,7 @@ export class MessageComposerState {
 
 	#synchronizeAttachmentPermission(): void {
 		$effect(() => {
-			if (!this.props.canAttach && this.attachments.filesWithUrls.length > 0) {
+			if (!this.#dependencies.getCanAttach() && this.attachments.filesWithUrls.length > 0) {
 				this.attachments.clear();
 			}
 		});
@@ -402,7 +405,9 @@ export class MessageComposerState {
 
 	#synchronizeAutoFocus(): void {
 		$effect(() => {
-			const { autoFocus, roomId, inReplyTo } = this.props;
+			const autoFocus = this.#dependencies.getAutoFocus();
+			const roomId = this.#dependencies.getRoomId();
+			const inReplyTo = this.#dependencies.getReplyEventId();
 			void roomId;
 			void inReplyTo;
 			if (autoFocus && shouldAutoFocus() && this.editorApi && !this.inputDisabled) {
@@ -418,6 +423,19 @@ export class MessageComposerState {
 			if (!request || !api || request.id === this.#insertedQuoteRequestId) return;
 			this.#insertedQuoteRequestId = request.id;
 			api.insertQuote(request.text);
+		});
+	}
+
+	#synchronizePublicApi(): void {
+		$effect(() => {
+			const onReady = this.#dependencies.getOnReady();
+			untrack(() => {
+				onReady?.({
+					addFiles: (files) => void this.addFiles(files),
+					focus: () => this.focus(),
+					insertQuote: (text) => this.insertQuote(text)
+				});
+			});
 		});
 	}
 
@@ -437,9 +455,9 @@ export class MessageComposerState {
 			this.#resetEditor();
 			this.attachments.clear();
 			this.linkPreviews.clear();
-			this.props.onMessageSent?.(event);
+			this.#dependencies.getCallbacks().onMessageSent?.(event);
 			this.#dependencies.context.scrollState?.requestScrollToBottom();
-			this.props.onCancelReply?.();
+			this.#dependencies.getCallbacks().onCancelReply?.();
 		} else {
 			for (const { url } of stashedFiles) URL.revokeObjectURL(url);
 		}
@@ -460,11 +478,11 @@ export class MessageComposerState {
 
 		await this.submission.requestPost({
 			draftKey: this.draftKey,
-			roomId: this.props.roomId,
+			roomId: this.#dependencies.getRoomId(),
 			bodyToSend,
 			filesToSend,
-			threadRootEventId: this.props.inThread ?? null,
-			inReplyTo: this.props.inReplyTo ?? null,
+			threadRootEventId: this.#dependencies.getThreadRootEventId() ?? null,
+			inReplyTo: this.#dependencies.getReplyEventId() ?? null,
 			linkPreviewToken: this.linkPreviews.buildToken(),
 			alsoSendToChannel: this.alsoSendToChannel
 		});
@@ -478,7 +496,11 @@ export class MessageComposerState {
 		}
 		const eventId = this.editState.eventId;
 		if (!eventId) return;
-		const input: UpdateMessageInput = { roomId: this.props.roomId, eventId, body };
+		const input: UpdateMessageInput = {
+			roomId: this.#dependencies.getRoomId(),
+			eventId,
+			body
+		};
 		if (this.showEditEchoCheckbox) input.alsoSendToChannel = this.alsoSendToChannel;
 		await this.submission.editMessage(input);
 	}
@@ -509,12 +531,13 @@ export class MessageComposerState {
 			this.cancelEdit();
 			return true;
 		}
-		if (this.props.inReplyTo && this.props.onCancelReply) {
-			this.props.onCancelReply();
+		const callbacks = this.#dependencies.getCallbacks();
+		if (this.#dependencies.getReplyEventId() && callbacks.onCancelReply) {
+			callbacks.onCancelReply();
 			return true;
 		}
-		if (this.props.onEscape) {
-			this.props.onEscape();
+		if (callbacks.onEscape) {
+			callbacks.onEscape();
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## Why

The first composer split separated its UI and submission pieces, but
`MessageComposer.svelte` still coordinated drafts, editing, attachments, link
previews, autocomplete, keyboard modes, and editor synchronization in one
779-line component. That made everyday composer changes depend on a dense set
of interleaved transitions.

## What changed

- Added a focused `MessageComposerState` that owns the remaining composer
  lifecycle and composes the existing draft, attachment, autocomplete,
  link-preview, and submission states.
- Reduced `MessageComposer.svelte` to a roughly 200-line rendering, context,
  and editor boundary.
- Consolidated repeated reset, edit, send, and keyboard transitions behind
  named state methods.
- Passed reactive inputs through narrow getters so unrelated callback changes
  cannot restart draft or room synchronization.
- Kept the public composer API lifecycle reactive and untracked callback
  execution, allowing immediate API use without contaminating effect
  dependencies.
- Preserved all visible UI and behaviour. Production frontend code is 16 lines
  smaller overall.

This is an internal frontend-only refactor. It changes no public API,
persistence, permissions, copy, compatibility, migration, security boundary,
or operational behaviour.

## Test plan

- `mise lint-frontend` — passed; Svelte reported 0 errors and 0 warnings, and
  ESLint passed.
- `mise test-frontend` — passed; 303 files and 2,558 tests.
- Focused mounted composer suite — passed; 127 tests.
- `mise x -- pnpm exec playwright test e2e/composer.test.ts e2e/message-editing.test.ts --retries=0`
  — passed; 29 tests.
- Production frontend build and bundle budgets — passed as part of the
  Playwright run.
- `mise license-check` — passed.
- Svelte autofixer — no issues in the changed component or Svelte state
  module.

An earlier full frontend run hit the existing network-backed search timeout;
that spec passed 4/4 immediately in isolation, and the final full run passed
cleanly.
