### PR TITLE
refactor(frontend): unify thread follow state

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -39,7 +39,6 @@
   import { roomReplyTargetEventId } from './messageReplyTarget';
   import { selectedQuoteTextForMessageBody } from './selectedReplyQuote';
   import type { OpenThreadHandler } from './threadOpenOptions';
-  import { createThreadAPI } from '$lib/api-client/threads';
   import { isMessagePostedEvent } from '$lib/render/timelineEvents';
   import * as m from '$lib/i18n/messages';
   import MessageReplyAttribution from './MessageReplyAttribution.svelte';
@@ -54,6 +53,7 @@
     isDeletedMessage,
     resolveMessageEventReferences
   } from './messageEventModel';
+  import { ThreadFollowState } from './threadFollowState.svelte';
 
   let {
     event,
@@ -246,7 +246,6 @@
     );
   }
 
-  // Check if message has been edited (updatedAt is non-null)
   const isEdited = $derived(msg?.updatedAt != null);
 
   // Threading: check if this is a root message with replies (echoes never have replies)
@@ -272,47 +271,24 @@
       : roomPermissions.canPostInThread && !!onOpenThread
   );
 
-  // Overridable derived state: backing event data is the default, while
-  // mutations/live events can update the row immediately.
-  let isFollowingThread = $derived(messageEvent?.viewerIsFollowingThread ?? false);
-  let threadFollowRequestId = 0;
-  let isThreadFollowPending = $state(false);
+  const threadFollow = new ThreadFollowState({
+    getConnection: connection,
+    getSnapshot: () => ({
+      roomId,
+      threadRootEventId: event.id,
+      following: messageEvent ? (messageEvent.viewerIsFollowingThread ?? false) : null
+    }),
+    beginOptimistic: ({ threadRootEventId }, following) =>
+      messageStore?.beginOptimisticThreadFollow(threadRootEventId, following),
+    commit: ({ threadRootEventId }, following) =>
+      messageStore?.setThreadRootFollowState(threadRootEventId, following)
+  });
 
-  function setThreadFollowState(value: boolean) {
-    if (!event) return;
-    threadFollowRequestId += 1;
-    isThreadFollowPending = false;
-    isFollowingThread = value;
-    messageStore?.setThreadRootFollowState(event.id, value);
-  }
-
-  async function toggleThreadFollow(e: MouseEvent) {
+  function toggleThreadFollow(e: MouseEvent) {
     e.stopPropagation();
-    if (!event || isThreadFollowPending) return;
-
-    const wasFollowing = isFollowingThread;
-    const nextFollowing = !wasFollowing;
-    const requestId = ++threadFollowRequestId;
-    const optimistic = messageStore?.beginOptimisticThreadFollow(event.id, nextFollowing);
-
-    isThreadFollowPending = true;
-    isFollowingThread = nextFollowing;
-
-    try {
-      const api = connection().getAPI(createThreadAPI);
-      const input = { roomId, threadRootEventId: event.id };
-      const result = wasFollowing ? await api.unfollowThread(input) : await api.followThread(input);
-      if (threadFollowRequestId !== requestId) return;
-      setThreadFollowState(result.following);
-    } catch {
-      if (threadFollowRequestId !== requestId) return;
-      isThreadFollowPending = false;
-      isFollowingThread = wasFollowing;
-      optimistic?.rollback();
-    }
+    void threadFollow.toggle();
   }
 
-  // Check if message has attachments
   const hasAttachments = $derived((msg?.attachments?.length ?? 0) > 0);
   const hasVisualEmbed = $derived(
     hasAttachments || !!messageEvent?.linkPreview || messageLinks.length > 0
@@ -612,8 +588,8 @@
           {hasThreadNotification}
           canReact={roomPermissions.canReact}
           {messageStore}
-          {isFollowingThread}
-          {isThreadFollowPending}
+          isFollowingThread={threadFollow.following}
+          isThreadFollowPending={threadFollow.pending}
           onToggleThreadFollow={hasReplies ? toggleThreadFollow : undefined}
           onOpenThread={onOpenThread ? handleOpenThread : undefined}
           onOpenEmojiPicker={roomPermissions.canReact

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -1,12 +1,7 @@
 <script lang="ts">
   import { fly } from 'svelte/transition';
   import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
-  import { createThreadAPI } from '$lib/api-client/threads';
-  import {
-    useProjectionEvent,
-    createTypingIndicator,
-    useUnreadMarker
-  } from '$lib/hooks';
+  import { useProjectionEvent, createTypingIndicator, useUnreadMarker } from '$lib/hooks';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
@@ -29,6 +24,7 @@
   } from '$lib/components/composer/MessageComposer.svelte';
   import TimelineEventsPane from './TimelineEventsPane.svelte';
   import type { PendingThreadReplyRequest } from './threadOpenOptions';
+  import { ThreadFollowState } from './threadFollowState.svelte';
 
   let {
     roomId,
@@ -224,63 +220,17 @@
     }
   });
 
-  // -- Thread follow state --
-  // The lazy thread root and later projection upserts both carry the current
-  // viewer follow state. Observe each new authoritative row version so a
-  // follow change after the initial thread query updates the pane as well.
-  let isFollowingThread = $state(false);
-  let _observedFollowThread = '';
-  let _observedFollowValue: boolean | undefined;
-  let threadFollowRequestId = 0;
-  let isThreadFollowPending = $state(false);
-
-  function setAuthoritativeThreadFollowState(value: boolean) {
-    threadFollowRequestId += 1;
-    isThreadFollowPending = false;
-    isFollowingThread = value;
-  }
-
-  $effect(() => {
-    const threadId = threadRootEventId;
-    if (threadId !== _observedFollowThread) {
-      threadFollowRequestId += 1;
-      isThreadFollowPending = false;
-      isFollowingThread = false;
-      _observedFollowThread = threadId;
-      _observedFollowValue = undefined;
+  const threadFollow = new ThreadFollowState({
+    getConnection: connection,
+    getSnapshot: () => {
+      const rootEvent = threadEvents.find((event) => event.id === threadRootEventId);
+      const following =
+        !store.isInitialLoading && isMessagePostedEvent(rootEvent?.event)
+          ? (rootEvent.event.viewerIsFollowingThread ?? false)
+          : null;
+      return { roomId, threadRootEventId, following };
     }
-
-    if (store.isInitialLoading || isThreadFollowPending) return;
-    const rootEvent = threadEvents.find((event) => event.id === threadId);
-    if (!isMessagePostedEvent(rootEvent?.event)) return;
-    const nextFollowing = rootEvent.event.viewerIsFollowingThread ?? false;
-    if (_observedFollowValue === nextFollowing) return;
-    _observedFollowValue = nextFollowing;
-    setAuthoritativeThreadFollowState(nextFollowing);
   });
-
-  async function toggleThreadFollow() {
-    if (isThreadFollowPending) return;
-
-    const wasFollowing = isFollowingThread;
-    const nextFollowing = !wasFollowing;
-    const requestId = ++threadFollowRequestId;
-
-    isThreadFollowPending = true;
-    isFollowingThread = nextFollowing;
-
-    try {
-      const api = connection().getAPI(createThreadAPI);
-      const input = { roomId, threadRootEventId };
-      const result = wasFollowing ? await api.unfollowThread(input) : await api.followThread(input);
-      if (threadFollowRequestId !== requestId) return;
-      setAuthoritativeThreadFollowState(result.following);
-    } catch {
-      if (threadFollowRequestId !== requestId) return;
-      isThreadFollowPending = false;
-      isFollowingThread = wasFollowing;
-    }
-  }
 
   async function markThreadAsRead(
     currentThreadId: string,
@@ -311,11 +261,11 @@
   >
     {#snippet actions()}
       <HeaderIconButton
-        icon={isFollowingThread ? 'uil--bell' : 'uil--bell-slash'}
-        label={isFollowingThread ? m['room.thread.unfollow']() : m['room.thread.follow']()}
-        tone={isFollowingThread ? 'active' : 'default'}
-        onclick={toggleThreadFollow}
-        disabled={isThreadFollowPending}
+        icon={threadFollow.following ? 'uil--bell' : 'uil--bell-slash'}
+        label={threadFollow.following ? m['room.thread.unfollow']() : m['room.thread.follow']()}
+        tone={threadFollow.following ? 'active' : 'default'}
+        onclick={() => void threadFollow.toggle()}
+        disabled={threadFollow.pending}
       />
       <HeaderIconButton icon="uil--times" label={m['room.thread.close']()} onclick={onClose} />
     {/snippet}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -97,7 +97,6 @@
       result.previousReadAt ? { afterTime: result.previousReadAt, beforeTime: markedAtMs } : null
   });
 
-  // Typing indicator for this thread
   const typingIndicator = createTypingIndicator(() => ({
     roomId,
     threadRootEventId,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.spec.ts
@@ -1,0 +1,172 @@
+import { flushSync } from 'svelte';
+import { describe, expect, it, onTestFinished, vi } from 'vitest';
+import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+import { ThreadFollowState, type ThreadFollowSnapshot } from './threadFollowState.svelte';
+
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve(value: T): void;
+  reject(error: Error): void;
+};
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+function setup(
+  initial: ThreadFollowSnapshot = {
+    roomId: 'room-1',
+    threadRootEventId: 'thread-1',
+    following: false
+  }
+) {
+  const followRequest = deferred<{ following: boolean }>();
+  const unfollowRequest = deferred<{ following: boolean }>();
+  const api = {
+    followThread: vi.fn(() => followRequest.promise),
+    unfollowThread: vi.fn(() => unfollowRequest.promise)
+  };
+  const rollback = vi.fn();
+  const beginOptimistic = vi.fn(() => ({ rollback }));
+  const commit = vi.fn();
+  const connection = {
+    getAPI: vi.fn(() => api)
+  } as unknown as ServerConnection;
+  let snapshot = $state(initial);
+  let state!: ThreadFollowState;
+  const dispose = $effect.root(() => {
+    state = new ThreadFollowState({
+      getConnection: () => connection,
+      getSnapshot: () => snapshot,
+      beginOptimistic,
+      commit
+    });
+  });
+  onTestFinished(dispose);
+  flushSync();
+
+  return {
+    api,
+    beginOptimistic,
+    commit,
+    followRequest,
+    rollback,
+    setSnapshot(next: ThreadFollowSnapshot) {
+      snapshot = next;
+      flushSync();
+    },
+    state,
+    unfollowRequest
+  };
+}
+
+describe('ThreadFollowState', () => {
+  it('optimistically follows and commits the server result', async () => {
+    const { api, beginOptimistic, commit, followRequest, state } = setup();
+
+    const request = state.toggle();
+
+    expect(state.following).toBe(true);
+    expect(state.pending).toBe(true);
+    expect(beginOptimistic).toHaveBeenCalledWith(
+      { roomId: 'room-1', threadRootEventId: 'thread-1' },
+      true
+    );
+    expect(api.followThread).toHaveBeenCalledWith({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-1'
+    });
+
+    followRequest.resolve({ following: true });
+    await request;
+
+    expect(state.following).toBe(true);
+    expect(state.pending).toBe(false);
+    expect(commit).toHaveBeenCalledWith({ roomId: 'room-1', threadRootEventId: 'thread-1' }, true);
+  });
+
+  it('rolls an optimistic update back when the request fails', async () => {
+    const { followRequest, rollback, state } = setup();
+
+    const request = state.toggle();
+    followRequest.reject(new Error('request failed'));
+    await request;
+
+    expect(state.following).toBe(false);
+    expect(state.pending).toBe(false);
+    expect(rollback).toHaveBeenCalledOnce();
+  });
+
+  it('unfollows from an authoritative followed state', async () => {
+    const { api, state, unfollowRequest } = setup({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-1',
+      following: true
+    });
+
+    const request = state.toggle();
+    expect(state.following).toBe(false);
+    expect(api.unfollowThread).toHaveBeenCalledOnce();
+
+    unfollowRequest.resolve({ following: false });
+    await request;
+    expect(state.following).toBe(false);
+    expect(state.pending).toBe(false);
+  });
+
+  it('reconciles distinct authoritative updates without replaying stale input', async () => {
+    const { followRequest, setSnapshot, state } = setup();
+
+    const request = state.toggle();
+    followRequest.resolve({ following: true });
+    await request;
+
+    setSnapshot({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-1',
+      following: false
+    });
+    expect(state.following).toBe(true);
+
+    setSnapshot({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-1',
+      following: true
+    });
+    expect(state.following).toBe(true);
+
+    setSnapshot({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-1',
+      following: false
+    });
+    expect(state.following).toBe(false);
+  });
+
+  it('fences an in-flight request when the component switches threads', async () => {
+    const { commit, followRequest, rollback, setSnapshot, state } = setup();
+
+    const request = state.toggle();
+    setSnapshot({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-2',
+      following: true
+    });
+
+    expect(state.following).toBe(true);
+    expect(state.pending).toBe(false);
+    expect(rollback).toHaveBeenCalledOnce();
+
+    followRequest.resolve({ following: true });
+    await request;
+
+    expect(state.following).toBe(true);
+    expect(commit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.spec.ts
@@ -103,6 +103,25 @@ describe('ThreadFollowState', () => {
     expect(rollback).toHaveBeenCalledOnce();
   });
 
+  it('adopts an authoritative update after a concurrent request fails', async () => {
+    const { followRequest, setSnapshot, state } = setup();
+
+    const request = state.toggle();
+    setSnapshot({
+      roomId: 'room-1',
+      threadRootEventId: 'thread-1',
+      following: true
+    });
+    expect(state.pending).toBe(true);
+
+    followRequest.reject(new Error('response lost'));
+    await request;
+    flushSync();
+
+    expect(state.following).toBe(true);
+    expect(state.pending).toBe(false);
+  });
+
   it('unfollows from an authoritative followed state', async () => {
     const { api, state, unfollowRequest } = setup({
       roomId: 'room-1',

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.ts
@@ -54,6 +54,7 @@ export class ThreadFollowState {
 
   #observe(snapshot: ThreadFollowSnapshot): void {
     const current = this.#snapshot;
+    const authoritative = snapshot.following;
     const changed =
       !current ||
       snapshot.roomId !== current.roomId ||
@@ -65,9 +66,9 @@ export class ThreadFollowState {
       this.#request.optimistic = undefined;
       this.#snapshot = snapshot;
       this.following = snapshot.following ?? false;
-    } else if (snapshot.following !== null && snapshot.following !== current.following) {
+    } else if (!this.pending && authoritative !== null && authoritative !== current.following) {
       this.#snapshot = snapshot;
-      if (!this.pending) this.following = snapshot.following;
+      this.following = authoritative;
     }
   }
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.ts
@@ -1,0 +1,73 @@
+import { createThreadAPI } from '$lib/api-client/threads';
+import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+
+type Target = { roomId: string; threadRootEventId: string };
+export type ThreadFollowSnapshot = Target & { following: boolean | null };
+
+type Optimistic = { rollback(): void };
+type ThreadFollowOptions = {
+  getConnection: () => ServerConnection;
+  getSnapshot: () => ThreadFollowSnapshot;
+  beginOptimistic?: (target: Target, following: boolean) => Optimistic | undefined;
+  commit?: (target: Target, following: boolean) => void;
+};
+
+export class ThreadFollowState {
+  following = $state(false);
+  pending = $state(false);
+
+  #snapshot: ThreadFollowSnapshot | null = null;
+  #request = { id: 0, optimistic: undefined as Optimistic | undefined };
+  #options: ThreadFollowOptions;
+
+  constructor(options: ThreadFollowOptions) {
+    this.#options = options;
+    $effect(() => this.#observe(options.getSnapshot()));
+  }
+
+  toggle = async (): Promise<void> => {
+    const snapshot = this.#snapshot;
+    if (!snapshot || this.pending) return;
+    const { following: _, ...target } = snapshot;
+    const wasFollowing = this.following;
+    const nextFollowing = !wasFollowing;
+    const requestId = ++this.#request.id;
+    this.#request.optimistic = this.#options.beginOptimistic?.(target, nextFollowing);
+    this.pending = true;
+    this.following = nextFollowing;
+    try {
+      const api = this.#options.getConnection().getAPI(createThreadAPI);
+      const result = await (wasFollowing ? api.unfollowThread : api.followThread)(target);
+      if (requestId !== this.#request.id) return;
+      this.#request.optimistic = undefined;
+      this.pending = false;
+      this.following = result.following;
+      this.#options.commit?.(target, result.following);
+    } catch {
+      if (requestId !== this.#request.id) return;
+      this.pending = false;
+      this.following = wasFollowing;
+      this.#request.optimistic?.rollback();
+      this.#request.optimistic = undefined;
+    }
+  };
+
+  #observe(snapshot: ThreadFollowSnapshot): void {
+    const current = this.#snapshot;
+    const changed =
+      !current ||
+      snapshot.roomId !== current.roomId ||
+      snapshot.threadRootEventId !== current.threadRootEventId;
+    if (changed) {
+      this.#request.id += 1;
+      this.pending = false;
+      this.#request.optimistic?.rollback();
+      this.#request.optimistic = undefined;
+      this.#snapshot = snapshot;
+      this.following = snapshot.following ?? false;
+    } else if (snapshot.following !== null && snapshot.following !== current.following) {
+      this.#snapshot = snapshot;
+      if (!this.pending) this.following = snapshot.following;
+    }
+  }
+}


### PR DESCRIPTION
## Why

Message rows and the thread pane independently implemented the same optimistic
follow/unfollow lifecycle. Their request fencing, authoritative reconciliation,
and rollback behavior had already started to differ, making a shared user
interaction harder to reason about and change safely.

## What changed

- centralize follow/unfollow API dispatch, optimistic state, pending state,
  rollback, and stale-response fencing in `ThreadFollowState`
- feed both message rows and the thread pane through the same authoritative
  projection reconciliation path
- fence in-flight work when a virtualized row or thread pane changes identity
- keep mouse-event propagation local to the message-row component
- add direct lifecycle coverage while reducing production frontend LOC by one

This is a frontend-only, behavior-preserving refactor. It changes no public API,
persistence, permissions, user-facing copy, compatibility, migration, rollout,
security boundary, or operational behavior.

## Test plan

- `mise lint-frontend` — passed; Svelte Check reported 0 errors and 0 warnings,
  and ESLint passed
- focused state and mounted thread-pane Vitest — 12 tests passed
- `mise test-frontend` — 2,570 tests across 305 files passed
- `e2e/thread-following.test.ts --retries=0` — 10 tests passed
- production frontend build and bundle budgets — passed
- Svelte autofixer — no issues in changed Svelte files
- `mise license-check` — passed
