### PR TITLE
refactor(frontend): centralize room sidebar requests

### DIFF
--- a/apps/frontend/e2e/voice-call.spec.ts
+++ b/apps/frontend/e2e/voice-call.spec.ts
@@ -448,6 +448,9 @@ test.describe('Voice calls', () => {
       await expect(callIcon.locator('.uil--phone').first()).toBeVisible();
       await expect(callIcon.getByTestId('active-call-pulse-icon')).toBeVisible();
 
+      await callIcon.click();
+      await expect(page.getByTestId('call-observer-panel')).toBeVisible();
+
       // Simulate User B leaving — active-call icon should disappear
       await page.request.post('/webhooks/test/call-leave', {
         data: { spaceId, roomId, userId: userB.id }

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -20,11 +20,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
   import EmptyState from '$lib/ui/EmptyState.svelte';
-  import {
-    roomSidebarPanelStorageSuffix,
-    setPendingRoomSidebarPanel,
-    setRoomSidebarPanel
-  } from '$lib/storage/roomSidebarPanel';
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import { buildDirectMessagePresentation, type UserAvatarUserView } from '$lib/render/users';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
@@ -32,7 +27,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import { notificationTarget } from '$lib/state/server/notifications.svelte';
   import { prepareUiForNotificationTarget } from '$lib/notifications/notificationNavigationUi';
-  import { getAppUiState } from '$lib/state/appUi.svelte';
+  import { getAppUiState, getRoomSidebarPresentation } from '$lib/state/appUi.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import {
     isNavigationVisibleRoom,
@@ -214,14 +209,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   }
 
   async function openRoomCallPanel(roomId: string): Promise<void> {
-    setRoomSidebarPanel(activeServerId, roomId, 'call');
-    setPendingRoomSidebarPanel(activeServerId, roomId, 'call');
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: serverStorageKey(activeServerId, roomSidebarPanelStorageSuffix(roomId)),
-        newValue: 'call'
-      })
-    );
+    appUi.requestRoomSidebarPanel(activeServerId, roomId, 'call', getRoomSidebarPresentation());
     await goto(resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId }));
   }
 

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -4,11 +4,6 @@ import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 
 import { NotificationItemKind } from '$lib/api-client/notifications';
-import { serverStorageKey } from '$lib/storage/serverStorage';
-import {
-  consumePendingRoomSidebarPanel,
-  roomSidebarPanelStorageSuffix
-} from '$lib/storage/roomSidebarPanel';
 import type { RoomsListGroup } from '$lib/state/server/rooms.svelte';
 
 const { mocks } = vi.hoisted(() => ({
@@ -20,7 +15,8 @@ const { mocks } = vi.hoisted(() => ({
     pushState: vi.fn(),
     goto: vi.fn(),
     appUi: {
-      disableRoomCallWideFor: vi.fn()
+      disableRoomCallWideFor: vi.fn(),
+      requestRoomSidebarPanel: vi.fn()
     },
     store: {
       currentUser: { user: { id: 'me' } },
@@ -125,7 +121,8 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
 }));
 
 vi.mock('$lib/state/appUi.svelte', () => ({
-  getAppUiState: () => mocks.appUi
+  getAppUiState: () => mocks.appUi,
+  getRoomSidebarPresentation: () => 'desktop'
 }));
 
 vi.mock('$lib/state/presenceCache.svelte', () => ({
@@ -661,10 +658,12 @@ describe('RoomList', () => {
     await vi.waitFor(() => {
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
     });
-    expect(
-      localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
-    ).toBe('call');
-    expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
+    expect(mocks.appUi.requestRoomSidebarPanel).toHaveBeenCalledWith(
+      'origin',
+      'channel-1',
+      'call',
+      'desktop'
+    );
   });
 
   it('opens the call panel when an active-call DM icon is clicked', async () => {
@@ -682,12 +681,12 @@ describe('RoomList', () => {
     await vi.waitFor(() => {
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/dm-with-participants');
     });
-    expect(
-      localStorage.getItem(
-        serverStorageKey('origin', roomSidebarPanelStorageSuffix('dm-with-participants'))
-      )
-    ).toBe('call');
-    expect(consumePendingRoomSidebarPanel('origin', 'dm-with-participants')).toBe('call');
+    expect(mocks.appUi.requestRoomSidebarPanel).toHaveBeenCalledWith(
+      'origin',
+      'dm-with-participants',
+      'call',
+      'desktop'
+    );
   });
 
   it.each([
@@ -710,10 +709,12 @@ describe('RoomList', () => {
       await vi.waitFor(() => {
         expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1');
       });
-      expect(
-        localStorage.getItem(serverStorageKey('origin', roomSidebarPanelStorageSuffix('channel-1')))
-      ).toBe('call');
-      expect(consumePendingRoomSidebarPanel('origin', 'channel-1')).toBe('call');
+      expect(mocks.appUi.requestRoomSidebarPanel).toHaveBeenCalledWith(
+        'origin',
+        'channel-1',
+        'call',
+        'desktop'
+      );
     }
   );
 

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -21,12 +21,7 @@ to the user settings page for the active server.
   import { buildDirectMessagePresentation } from '$lib/render/users';
 
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
-  import {
-    roomSidebarPanelStorageSuffix,
-    setPendingRoomSidebarPanel,
-    setRoomSidebarPanel
-  } from '$lib/storage/roomSidebarPanel';
-  import { serverStorageKey } from '$lib/storage/serverStorage';
+  import { getAppUiState, getRoomSidebarPresentation } from '$lib/state/appUi.svelte';
   import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
   import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
@@ -50,6 +45,7 @@ to the user settings page for the active server.
   }
 
   const connection = useConnection();
+  const appUi = getAppUiState();
   const presenceCache = getPresenceCache();
   const activeServerId = $derived(getActiveServer());
   const serverSegment = $derived(serverIdToSegment(activeServerId));
@@ -176,14 +172,7 @@ to the user settings page for the active server.
     const roomId = activeCallRoomId;
     if (!roomId) return;
 
-    setRoomSidebarPanel(activeServerId, roomId, 'call');
-    setPendingRoomSidebarPanel(activeServerId, roomId, 'call');
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: serverStorageKey(activeServerId, roomSidebarPanelStorageSuffix(roomId)),
-        newValue: 'call'
-      })
-    );
+    appUi.requestRoomSidebarPanel(activeServerId, roomId, 'call', getRoomSidebarPresentation());
     goto(
       resolve('/chat/[serverId]/[roomId]', {
         serverId: serverSegment,

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -7,12 +7,7 @@ import '../../app.css';
 import { q } from '$lib/test-utils';
 
 import { presencePreference } from '$lib/state/presencePreference.svelte';
-import {
-  consumePendingRoomSidebarPanel,
-  getRoomSidebarPanelState,
-  roomSidebarPanelStorageSuffix
-} from '$lib/storage/roomSidebarPanel';
-import { serverStorageKey } from '$lib/storage/serverStorage';
+import { getRoomSidebarPanelState } from '$lib/storage/roomSidebarPanel';
 import CurrentUserBarTestHarness from './CurrentUserBarTestHarness.svelte';
 
 function computedBackgroundColor(color: string): string {
@@ -438,9 +433,6 @@ describe('CurrentUserBar', () => {
   it('shows active call controls and links to the call room', async () => {
     voiceCallState.connected = true;
     voiceCallState.roomId = 'room-1';
-    const storageEvents: StorageEvent[] = [];
-    const listener = (event: StorageEvent) => storageEvents.push(event);
-    window.addEventListener('storage', listener);
 
     const { container } = render(CurrentUserBarTestHarness);
 
@@ -477,17 +469,10 @@ describe('CurrentUserBar', () => {
 
     expect(navigation.goto).toHaveBeenCalledWith('/chat/-/room-1');
     expect(getRoomSidebarPanelState('origin', 'room-1')).toBe('call');
-    expect(consumePendingRoomSidebarPanel('origin', 'room-1')).toBe('call');
-    expect(storageEvents).toHaveLength(1);
-    expect(storageEvents[0].key).toBe(
-      serverStorageKey('origin', roomSidebarPanelStorageSuffix('room-1'))
-    );
-    expect(storageEvents[0].newValue).toBe('call');
     expect(voiceCallState.toggleMute).toHaveBeenCalledOnce();
     expect(voiceCallState.toggleCamera).toHaveBeenCalledOnce();
     expect(voiceCallState.toggleScreenShare).toHaveBeenCalledOnce();
     expect(voiceCallState.leave).toHaveBeenCalledOnce();
-    window.removeEventListener('storage', listener);
   });
 
   it('aligns the equal-width call controls with the user card', () => {

--- a/apps/frontend/src/lib/components/CurrentUserBarTestHarness.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBarTestHarness.svelte
@@ -8,11 +8,14 @@ before the bar mounts so specs can exercise first-login presence fallbacks.
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
+  import { provideAppUiState } from '$lib/state/appUi.svelte';
   import CurrentUserBar from './CurrentUserBar.svelte';
 
   let { cachedPresence = PresenceStatus.ONLINE }: { cachedPresence?: PresenceStatus } = $props();
 
   const presenceCache = createPresenceCache();
+  const appUi = provideAppUiState();
+  appUi.setActiveRoomScope('origin', 'room-1');
   // svelte-ignore state_referenced_locally
   presenceCache.update({ serverId: 'origin', userId: 'user-1' }, cachedPresence);
 </script>

--- a/apps/frontend/src/lib/state/appUi.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/appUi.svelte.spec.ts
@@ -85,6 +85,46 @@ describe('AppUiState', () => {
     expect(appUi.mobileRoomSidebarPanel).toBe(null);
   });
 
+  it('applies a desktop sidebar request when its room becomes active', () => {
+    const appUi = new AppUiState();
+
+    appUi.setActiveRoomScope('server-a', 'room-1');
+    appUi.requestRoomSidebarPanel('server-a', 'room-2', 'call', 'desktop');
+
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe(null);
+
+    appUi.setActiveRoomScope('server-a', 'room-2');
+
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe('call');
+    expect(mocks.setRoomSidebarPanelState).toHaveBeenCalledWith('server-a', 'room-2', 'call');
+  });
+
+  it('applies a mobile sidebar request once', () => {
+    const appUi = new AppUiState();
+
+    appUi.setActiveRoomScope('server-a', 'room-1');
+    appUi.requestRoomSidebarPanel('server-a', 'room-2', 'files', 'mobile');
+    appUi.setActiveRoomScope('server-a', 'room-2');
+
+    expect(appUi.mobileRoomSidebarPanel).toBe('files');
+    expect(mocks.setRoomSidebarPanelState).toHaveBeenCalledWith('server-a', 'room-2', 'files');
+
+    appUi.closeMobileRoomSidebarPanel();
+    appUi.setActiveRoomScope('server-a', 'room-1');
+    appUi.setActiveRoomScope('server-a', 'room-2');
+
+    expect(appUi.mobileRoomSidebarPanel).toBe(null);
+  });
+
+  it('applies a sidebar request immediately for the active room', () => {
+    const appUi = new AppUiState();
+
+    appUi.setActiveRoomScope('server-a', 'room-1');
+    appUi.requestRoomSidebarPanel('server-a', 'room-1', 'files', 'desktop');
+
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe('files');
+  });
+
   it('tracks the scoped wide call room', () => {
     const appUi = new AppUiState();
 

--- a/apps/frontend/src/lib/state/appUi.svelte.ts
+++ b/apps/frontend/src/lib/state/appUi.svelte.ts
@@ -10,6 +10,18 @@ export type AppRoomScope = {
   roomId: string;
 };
 
+export type RoomSidebarPresentation = 'desktop' | 'mobile';
+
+/** Return the room sidebar presentation used at the current Tailwind `lg` breakpoint. */
+export function getRoomSidebarPresentation(): RoomSidebarPresentation {
+  return window.matchMedia('(min-width: 1024px)').matches ? 'desktop' : 'mobile';
+}
+
+type RoomSidebarPanelRequest = AppRoomScope & {
+  panel: RoomSidebarPanel;
+  presentation: RoomSidebarPresentation;
+};
+
 export type AppFullscreenSurface = {
   id?: string;
   surface: string;
@@ -30,6 +42,7 @@ export class AppUiState {
   #mobileRoomSidebarScope = $state<string | null>(null);
   #roomCallWideScope = $state<AppRoomScope | null>(null);
   #fullscreenSurface = $state<AppFullscreenSurface | null>(null);
+  #roomSidebarPanelRequest: RoomSidebarPanelRequest | null = null;
 
   get activeServerId(): string | null {
     return this.#activeServerId;
@@ -56,6 +69,7 @@ export class AppUiState {
     const previousScope = this.#activeRoomScopeKey;
     this.#activeServerId = serverId;
     this.#activeRoomId = roomId;
+    this.#applyRoomSidebarPanelRequest();
 
     const nextScope = this.#activeRoomScopeKey;
     if (previousScope !== null && previousScope !== nextScope) {
@@ -118,6 +132,22 @@ export class AppUiState {
 
   closeMobileRoomSidebarPanel(): void {
     this.#mobileRoomSidebarPanel = null;
+  }
+
+  /**
+   * Open a room sidebar panel now or when its target room becomes active.
+   *
+   * This keeps cross-room navigation requests inside the app-scoped UI owner
+   * instead of relaying them through browser storage events.
+   */
+  requestRoomSidebarPanel(
+    serverId: string,
+    roomId: string,
+    panel: RoomSidebarPanel,
+    presentation: RoomSidebarPresentation
+  ): void {
+    this.#roomSidebarPanelRequest = { serverId, roomId, panel, presentation };
+    this.#applyRoomSidebarPanelRequest();
   }
 
   get roomCallWideScope(): AppRoomScope | null {
@@ -187,6 +217,26 @@ export class AppUiState {
       ...this.#desktopRoomSidebarSessionState,
       [roomScopeKey(scope.serverId, scope.roomId)]: panel
     };
+  }
+
+  #applyRoomSidebarPanelRequest(): void {
+    const request = this.#roomSidebarPanelRequest;
+    if (
+      !request ||
+      request.serverId !== this.#activeServerId ||
+      request.roomId !== this.#activeRoomId
+    ) {
+      return;
+    }
+
+    this.#roomSidebarPanelRequest = null;
+    if (request.presentation === 'desktop') {
+      this.openDesktopRoomSidebarPanel(request.panel);
+      return;
+    }
+
+    setRoomSidebarPanelState(request.serverId, request.roomId, request.panel);
+    this.openMobileRoomSidebarPanel(request.panel);
   }
 }
 

--- a/apps/frontend/src/lib/storage/roomSidebarPanel.spec.ts
+++ b/apps/frontend/src/lib/storage/roomSidebarPanel.spec.ts
@@ -1,18 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { serverStorageKey } from './serverStorage';
 import {
-  consumePendingRoomSidebarPanel,
-  getRoomSidebarPanel,
   getRoomSidebarPanelState,
   ROOM_SIDEBAR_DEFAULT_PANEL,
   roomSidebarPanelStorageSuffix,
-  setPendingRoomSidebarPanel,
-  setRoomSidebarPanel,
   setRoomSidebarPanelState
 } from './roomSidebarPanel';
 
 const storage = new Map<string, string>();
-const sessionStorageMap = new Map<string, string>();
 const localStorageMock: Storage = {
   getItem: (key) => storage.get(key) ?? null,
   setItem: (key, value) => storage.set(key, value),
@@ -23,42 +18,29 @@ const localStorageMock: Storage = {
   },
   key: (index) => [...storage.keys()][index] ?? null
 };
-const sessionStorageMock: Storage = {
-  getItem: (key) => sessionStorageMap.get(key) ?? null,
-  setItem: (key, value) => sessionStorageMap.set(key, value),
-  removeItem: (key) => sessionStorageMap.delete(key),
-  clear: () => sessionStorageMap.clear(),
-  get length() {
-    return sessionStorageMap.size;
-  },
-  key: (index) => [...sessionStorageMap.keys()][index] ?? null
-};
 vi.stubGlobal('localStorage', localStorageMock);
-vi.stubGlobal('sessionStorage', sessionStorageMock);
 
 beforeEach(() => {
   storage.clear();
-  sessionStorageMap.clear();
 });
 
 describe('room sidebar panel storage', () => {
   it('defaults to members', () => {
-    expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('members');
     expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe(ROOM_SIDEBAR_DEFAULT_PANEL);
   });
 
   it('persists the selected panel per server and room', () => {
-    setRoomSidebarPanel('server-a', 'room-1', 'files');
-    setRoomSidebarPanel('server-a', 'room-2', 'members');
-    setRoomSidebarPanel('server-b', 'room-1', 'call');
+    setRoomSidebarPanelState('server-a', 'room-1', 'files');
+    setRoomSidebarPanelState('server-a', 'room-2', 'members');
+    setRoomSidebarPanelState('server-b', 'room-1', 'call');
 
-    expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('files');
-    expect(getRoomSidebarPanel('server-a', 'room-2')).toBe('members');
-    expect(getRoomSidebarPanel('server-b', 'room-1')).toBe('call');
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('files');
+    expect(getRoomSidebarPanelState('server-a', 'room-2')).toBe('members');
+    expect(getRoomSidebarPanelState('server-b', 'room-1')).toBe('call');
   });
 
   it('does not persist closed state across sessions', () => {
-    setRoomSidebarPanel('server-a', 'room-1', 'files');
+    setRoomSidebarPanelState('server-a', 'room-1', 'files');
     setRoomSidebarPanelState('server-a', 'room-1', null);
 
     const key = serverStorageKey('server-a', roomSidebarPanelStorageSuffix('room-1'));
@@ -72,21 +54,12 @@ describe('room sidebar panel storage', () => {
 
     localStorage.setItem(key, 'closed');
     expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('members');
-    expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('members');
   });
 
   it('falls back to members for unknown stored values', () => {
     const key = serverStorageKey('server-a', roomSidebarPanelStorageSuffix('room-1'));
 
     localStorage.setItem(key, 'calendar');
-    expect(getRoomSidebarPanel('server-a', 'room-1')).toBe('members');
-  });
-
-  it('stores and consumes a pending panel open request for a specific room', () => {
-    setPendingRoomSidebarPanel('server-a', 'room-1', 'call');
-
-    expect(consumePendingRoomSidebarPanel('server-a', 'room-2')).toBeNull();
-    expect(consumePendingRoomSidebarPanel('server-a', 'room-1')).toBe('call');
-    expect(consumePendingRoomSidebarPanel('server-a', 'room-1')).toBeNull();
+    expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('members');
   });
 });

--- a/apps/frontend/src/lib/storage/roomSidebarPanel.ts
+++ b/apps/frontend/src/lib/storage/roomSidebarPanel.ts
@@ -1,5 +1,4 @@
 import { serverSlot, type Codec } from './slot';
-import { serverStorageKey } from './serverStorage';
 
 export const ROOM_SIDEBAR_PANELS = ['members', 'files', 'call'] as const;
 
@@ -7,12 +6,6 @@ export type RoomSidebarPanel = (typeof ROOM_SIDEBAR_PANELS)[number];
 export type RoomSidebarPanelState = RoomSidebarPanel | null;
 
 export const ROOM_SIDEBAR_DEFAULT_PANEL: RoomSidebarPanel = 'members';
-const PENDING_ROOM_SIDEBAR_PANEL_SUFFIX = 'roomSidebarPanel:pendingOpen';
-
-type PendingRoomSidebarPanel = {
-  roomId: string;
-  panel: RoomSidebarPanel;
-};
 
 function isRoomSidebarPanel(value: unknown): value is RoomSidebarPanel {
   return typeof value === 'string' && ROOM_SIDEBAR_PANELS.includes(value as RoomSidebarPanel);
@@ -52,69 +45,4 @@ export function setRoomSidebarPanelState(
     ROOM_SIDEBAR_DEFAULT_PANEL,
     codec
   ).set(panel);
-}
-
-export function getRoomSidebarPanel(serverId: string, roomId: string): RoomSidebarPanel {
-  return getRoomSidebarPanelState(serverId, roomId) ?? ROOM_SIDEBAR_DEFAULT_PANEL;
-}
-
-export function setRoomSidebarPanel(
-  serverId: string,
-  roomId: string,
-  panel: RoomSidebarPanel
-): void {
-  setRoomSidebarPanelState(serverId, roomId, panel);
-}
-
-export function setPendingRoomSidebarPanel(
-  serverId: string,
-  roomId: string,
-  panel: RoomSidebarPanel
-): void {
-  const storage = getSessionStorage();
-  if (!storage) return;
-
-  storage.setItem(
-    serverSlotKey(serverId),
-    JSON.stringify({
-      roomId,
-      panel
-    } satisfies PendingRoomSidebarPanel)
-  );
-}
-
-export function consumePendingRoomSidebarPanel(
-  serverId: string,
-  roomId: string
-): RoomSidebarPanelState {
-  const storage = getSessionStorage();
-  if (!storage) return null;
-
-  const key = serverSlotKey(serverId);
-  const raw = storage.getItem(key);
-  if (!raw) return null;
-
-  let pending: Partial<PendingRoomSidebarPanel>;
-  try {
-    pending = JSON.parse(raw) as Partial<PendingRoomSidebarPanel>;
-  } catch {
-    storage.removeItem(key);
-    return null;
-  }
-
-  if (pending.roomId !== roomId) return null;
-  storage.removeItem(key);
-  return isRoomSidebarPanel(pending.panel) ? pending.panel : null;
-}
-
-function serverSlotKey(serverId: string): string {
-  return serverStorageKey(serverId, PENDING_ROOM_SIDEBAR_PANEL_SUFFIX);
-}
-
-function getSessionStorage(): Storage | null {
-  try {
-    return globalThis.sessionStorage ?? null;
-  } catch {
-    return null;
-  }
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -36,12 +36,7 @@
   import { serverIdToSegment } from '$lib/navigation';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
-  import {
-    consumePendingRoomSidebarPanel,
-    roomSidebarPanelStorageSuffix,
-    type RoomSidebarPanel
-  } from '$lib/storage/roomSidebarPanel';
-  import { serverStorageKey } from '$lib/storage/serverStorage';
+  import type { RoomSidebarPanel } from '$lib/storage/roomSidebarPanel';
   import { toast } from '$lib/ui/toast';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
@@ -359,28 +354,6 @@
     appUi.toggleRoomCallWide(getActiveServer(), roomId);
   }
 
-  function openRoomSidebarPanel(panel: RoomSidebarPanel): void {
-    if (window.matchMedia('(min-width: 1024px)').matches) {
-      appUi.openDesktopRoomSidebarPanel(panel);
-    } else {
-      appUi.openMobileRoomSidebarPanel(panel);
-    }
-  }
-
-  function handleRoomSidebarPanelStorage(event: StorageEvent): void {
-    const key = serverStorageKey(getActiveServer(), roomSidebarPanelStorageSuffix(roomId));
-    if (event.key !== key) return;
-    if (event.newValue !== 'call') return;
-
-    consumePendingRoomSidebarPanel(getActiveServer(), roomId);
-    openRoomSidebarPanel('call');
-  }
-
-  $effect(() => {
-    const pendingPanel = consumePendingRoomSidebarPanel(getActiveServer(), roomId);
-    if (pendingPanel) openRoomSidebarPanel(pendingPanel);
-  });
-
   function openFileMessage(
     messageEventId: string,
     threadRootEventId: string | null,
@@ -420,7 +393,6 @@
 </script>
 
 <svelte:window
-  onstorage={handleRoomSidebarPanelStorage}
   onkeydown={(e) => {
     if (e.key === 'Escape' && mobileRoomSidebarPanel && !e.defaultPrevented) {
       e.preventDefault();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -343,10 +343,13 @@ async function waitForElement<T extends Element>(
   selector: string
 ): Promise<T> {
   let element: T | null = null;
-  await vi.waitFor(() => {
-    element = container.querySelector<T>(selector);
-    expect(element).not.toBeNull();
-  });
+  await vi.waitFor(
+    () => {
+      element = container.querySelector<T>(selector);
+      expect(element).not.toBeNull();
+    },
+    { timeout: 5_000 }
+  );
   return element!;
 }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -6,10 +6,6 @@ import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { RealtimeProjectionEvent } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { TimelineEventKind } from '$lib/render/timelineEvents';
 import { MessagesStore } from '$lib/state/room';
-import {
-  consumePendingRoomSidebarPanel,
-  setPendingRoomSidebarPanel
-} from '$lib/storage/roomSidebarPanel';
 
 const { mocks } = vi.hoisted(() => {
   const queryData = {
@@ -572,20 +568,19 @@ describe('Room local message echo', () => {
   it('opens a pending call panel request as a mobile sidebar after navigation', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     stubMatchMedia(false);
-    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+    appUi.requestRoomSidebarPanel('server-1', 'room-1', 'call', 'mobile');
 
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 
     await expect
       .element(q(container, '[data-testid="room-sidebar-mobile-pane"]'))
       .toBeInTheDocument();
-    expect(consumePendingRoomSidebarPanel('server-1', 'room-1')).toBeNull();
   });
 
   it('keeps the mobile sidebar mounted during its close transition', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     stubMatchMedia(false);
-    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+    appUi.requestRoomSidebarPanel('server-1', 'room-1', 'call', 'mobile');
 
     const { container } = render(Room, { props: { roomId: 'room-1' } });
     const pane = q(container, '[data-testid="room-sidebar-mobile-pane"]') as HTMLElement;
@@ -698,7 +693,7 @@ describe('Room local message echo', () => {
   it('lets a maximized desktop call sidebar fill the room route content area', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     mocks.activeCallRoomIds.add('room-1');
-    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+    appUi.requestRoomSidebarPanel('server-1', 'room-1', 'call', 'desktop');
 
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 
@@ -724,7 +719,7 @@ describe('Room local message echo', () => {
   it('restores the room view when a maximized desktop call ends', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     mocks.activeCallRoomIds.add('room-1');
-    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+    appUi.requestRoomSidebarPanel('server-1', 'room-1', 'call', 'desktop');
 
     const rendered = render(Room, { props: { roomId: 'room-1' } });
     const { container } = rendered;
@@ -754,7 +749,7 @@ describe('Room local message echo', () => {
   it('reveals the room view when call wide mode is disabled for the current room', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     mocks.activeCallRoomIds.add('room-1');
-    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+    appUi.requestRoomSidebarPanel('server-1', 'room-1', 'call', 'desktop');
 
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 
@@ -783,7 +778,7 @@ describe('Room local message echo', () => {
   it('keeps the call maximized when call wide mode is disabled for another room', async () => {
     mocks.livekitUrl = 'wss://livekit.example.test';
     mocks.activeCallRoomIds.add('room-1');
-    setPendingRoomSidebarPanel('server-1', 'room-1', 'call');
+    appUi.requestRoomSidebarPanel('server-1', 'room-1', 'call', 'desktop');
 
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 


### PR DESCRIPTION
## Why

Opening an active call from the room list or current-user bar duplicated a
browser-storage relay: write the selected panel, persist a pending request,
dispatch a synthetic `StorageEvent`, navigate, then have the room shell listen
and consume the request. This split transient UI ownership across components
and storage and made a common navigation path harder to reason about.

## What changed

- Added one-shot room sidebar panel requests to the context-scoped
  `AppUiState`, applying them immediately for the active room or when the
  requested room becomes active.
- Routed room-list and current-user active-call navigation through that owner
  for both desktop and mobile presentations.
- Removed the pending session-storage API, synthetic storage events, room-level
  storage listener, and the effect that consumed pending panel requests.
- Added state, component, and browser coverage for same-room and cross-room
  requests and opening the active-call panel.
- Reduced production frontend code by 73 lines.

## Test plan

- `mise test-frontend` — 306 test files and 2,576 tests passed.
- `mise x -- pnpm --dir apps/frontend check` — 0 errors and 0 warnings.
- `mise x -- pnpm --dir apps/frontend lint` — passed.
- `mise x -- pnpm --dir apps/frontend build` — passed; login, overview, and
  room bundle budgets passed.
- `mise test-e2e -- e2e/voice-call.spec.ts --grep 'active-call icon appears in room list sidebar during active call'`
  — passed.
- Svelte autofixer — no issues in changed Svelte components or modules.

This is a frontend-internal refactor with no protocol, compatibility, migration,
security, rollout, or operational implications.
