### PR TITLE
test(frontend): cover call indicator after reopening

### DIFF
--- a/apps/frontend/e2e/voice-call.spec.ts
+++ b/apps/frontend/e2e/voice-call.spec.ts
@@ -507,6 +507,48 @@ test.describe('Voice calls', () => {
     });
   });
 
+  test('active-call icon appears when the DM participant opens Chatto after the call starts', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    const userB = await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    await withServerUser(browser!, serverURL, async ({ page: page2, user: userA }) => {
+      const roomA = await new DMPage(page2).startConversation(userB.login);
+      await roomA.sendMessage(`seed offline DM call indicator ${Date.now()}`);
+      const { roomId } = await getIdsFromUrlViaConnect(page2);
+
+      await expect(new DMPage(page).getConversation(userA.displayName)).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await page.close();
+
+      const joinResponse = await page2.request.post('/webhooks/test/call-join', {
+        data: {
+          spaceId: 'DM',
+          roomId,
+          userId: userA.id,
+          displayName: userA.displayName,
+          login: userA.login
+        }
+      });
+      expect(joinResponse.ok()).toBe(true);
+
+      const reopenedPage = await page.context().newPage();
+      await reopenedPage.goto('/chat');
+
+      const dmRow = new DMPage(reopenedPage).getConversation(userA.displayName);
+      await expect(dmRow).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(dmRow.getByTestId('room-call-icon')).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await expect(dmRow.getByTestId('room-call-participants')).toBeVisible();
+    });
+  });
+
   test('livekitUrl is exposed in instance info', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();


### PR DESCRIPTION
## Why

Users reopening Chatto after another participant started a DM call must see the active-call indicator, and this startup path previously lacked regression coverage.

## What changed

Added an E2E scenario that closes the observing user's Chatto window, starts a DM call from another browser session, reopens Chatto in the original browser profile, and verifies the call icon and participant display are restored by the realtime projection bootstrap.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: Not applicable.
- Newer client → older server: Not applicable.
- Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm exec playwright test e2e/voice-call.spec.ts --retries=0` — 13 passed.
- `mise x -- pnpm --filter chatto-frontend exec prettier --check e2e/voice-call.spec.ts` — passed.
- `git diff --check origin/main...` — passed.
