### PR TITLE
docs(core): refresh stale migration comments

### DIFF
--- a/cli/internal/config/policy.go
+++ b/cli/internal/config/policy.go
@@ -9,8 +9,8 @@ import "strings"
 // Enforcement note: limits are checked at the entry point of each gated operation
 // (CreateUser) by counting current entries in KV. The check is not atomic with
 // the subsequent write, so a burst of concurrent requests at the boundary can
-// briefly overshoot by one or two. Tightening this requires an instance-stats
-// counter system with CAS-incrementing gates — tracked as a follow-up to this PR.
+// briefly overshoot by one or two. This soft-limit tradeoff is intentional at
+// the current scale; GitHub issue #247 records when a CAS counter is warranted.
 type LimitsConfig struct {
 	MaxUsers *int `toml:"max_users,commented" env:"CHATTO_LIMITS_MAX_USERS" comment:"Maximum number of verified accounts allowed in this instance. -1 = unlimited (default), 0 = no new signups, positive = cap. Counts users with at least one verified email or linked SSO identity."`
 }

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -500,13 +500,10 @@ func (c *ChattoCore) initializeRoomReadMarker(ctx context.Context, kind RoomKind
 }
 
 // GetUserRoomMemberships retrieves all room memberships for a given user of a
-// given kind. The projection (ADR-035 phase 5) doesn't track kind, so the
-// caller's set of roomIDs is filtered against the Room KV via GetRoom.
-// This is O(N) lookups in the user's room count — acceptable for the
-// resolvers that use it (each user has a bounded number of rooms).
-//
-// Once a RoomKind projection lands (or kind moves into the Room proto so
-// a kind check is local), this can become a single projection read.
+// given kind. The membership projection doesn't track kind, so ListMemberRooms
+// filters the user's projected room IDs through RoomModel's projected room
+// catalog. This is O(N) in the user's room count and uses local projection
+// reads; each user has a bounded number of rooms.
 func (c *ChattoCore) GetUserRoomMemberships(ctx context.Context, kind RoomKind, user_id string) ([]*corev1.RoomMembership, error) {
 	rooms, err := c.ListMemberRooms(ctx, kind, user_id, MemberRoomListOptions{})
 	if err != nil {

--- a/cli/internal/core/room_membership_projection.go
+++ b/cli/internal/core/room_membership_projection.go
@@ -19,10 +19,8 @@ import (
 //
 // Room kind ("channel" or "dm") is intentionally NOT tracked here. The
 // subject scheme is `evt.room.{roomID}.{eventType}` — kind is a property
-// of the room itself, not of any individual event. Kind-filtered
-// membership queries (e.g. "list this user's DMs") still consult the
-// Room KV during the transition; a follow-up can either add a small
-// RoomKind projection or fold the lookup into the resolver layer.
+// of the room itself, not of any individual event. Kind-filtered membership
+// queries compose this index with RoomModel's projected room catalog.
 type RoomMembershipProjection struct {
 	events.MemoryProjection
 	// byRoom: room ID → set of user IDs in that room.


### PR DESCRIPTION
## Why

Two backend comments still described superseded migration plans after the
configuration and room-model cleanup series. They could send maintainers toward
work that was deliberately deferred or imply that current reads still depend
on the retired Room KV path.

## What changed

- describe the max-user limit as an intentional soft limit and point to the
  deferred CAS-counter decision in issue #247
- describe kind-filtered membership reads as composition between the
  membership index and RoomModel's projected room catalog
- remove obsolete references to Room KV and a future RoomKind projection

This changes comments only. Runtime behavior, configuration contracts,
persisted data, public APIs, rollout, security, and operations are unaffected.

## Test plan

- `gofmt -d` on all touched Go files — clean
- `go test ./internal/config ./internal/core -run '^$' -timeout 2m` — passed
- stale-comment search — no obsolete phrases remain
- `git diff --check` — passed
