### PR TITLE
feat(datacrypto): extract shared encryption primitives

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
-        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum') }}
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/datacrypto/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum') }}
         restore-keys: |
           go-mod-${{ runner.os }}-${{ runner.arch }}-
 
@@ -30,7 +30,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum', 'cli/**/*.go', 'authling/**/*.go', 'pkg/events/**/*.go', 'pkg/natsruntime/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'package.json', 'pnpm-lock.yaml', 'apps/frontend/package.json', 'apps/frontend/src/**', 'apps/frontend/static/**', 'apps/frontend/svelte.config.js', 'apps/frontend/tsconfig.json', 'apps/frontend/vite.config.ts', 'mise.toml') }}
+        key: go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/datacrypto/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum', 'cli/**/*.go', 'authling/**/*.go', 'pkg/datacrypto/**/*.go', 'pkg/events/**/*.go', 'pkg/natsruntime/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'package.json', 'pnpm-lock.yaml', 'apps/frontend/package.json', 'apps/frontend/src/**', 'apps/frontend/static/**', 'apps/frontend/svelte.config.js', 'apps/frontend/tsconfig.json', 'apps/frontend/vite.config.ts', 'mise.toml') }}
         restore-keys: |
           go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-
           go-build-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,9 @@ jobs:
       - name: Run Authling tests
         run: mise test-authling
 
+      - name: Run data cryptography tests
+        run: mise test-datacrypto
+
       - name: Run event framework tests
         run: mise test-events
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,6 +18,7 @@
       "changelog-path": "CHANGELOG.md",
       "exclude-paths": [
         "authling",
+        "pkg/datacrypto",
         "pkg/events",
         "pkg/natsruntime",
         ".agents/skills"
@@ -47,6 +48,16 @@
           "path": "version.go"
         }
       ]
+    },
+    "pkg/datacrypto": {
+      "release-type": "go",
+      "package-name": "datacrypto",
+      "component": "pkg/datacrypto",
+      "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0-alpha.1",
+      "draft": false,
+      "include-component-in-tag": true,
+      "tag-separator": "/"
     },
     "pkg/events": {
       "release-type": "go",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   ".": "0.4.8",
   "authling": "0.0.0",
+  "pkg/datacrypto": "0.0.0",
   "pkg/events": "0.0.0",
   "pkg/natsruntime": "0.0.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,10 +13,10 @@ framework boundary:
   repository content belongs to Chatto.
 - **Authling** is the independent identity-provider product under `authling/`.
   It is not a Chatto component, runtime unit, feature, or deployment mode.
-- **Shared framework code** is application-neutral NATS, JetStream, and
-  event-sourcing machinery intended for consumption by both products. The
-  independently versioned but unstable modules live under `pkg/events/` and
-  `pkg/natsruntime/`.
+- **Shared framework code** is application-neutral event-sourcing, embedded
+  NATS, and data-cryptography machinery intended for consumption by both
+  products. The independently versioned but unstable modules live under
+  `pkg/events/`, `pkg/natsruntime/`, and `pkg/datacrypto/`.
 
 Authling's presence in this repository is explicitly temporary. It is being
 incubated here only while Authling provides the concrete second application
@@ -49,8 +49,9 @@ or repository-wide work. Follow these routing rules:
    `adr`, `fdr`, or `glossary`.
 5. A shared-framework change must read both `cli/AGENTS.md` and
    `authling/AGENTS.md`, the target module's `AGENTS.md`, ADR-057, and the
-   module-specific ADR: ADR-056 for `pkg/events` or ADR-058 for
-   `pkg/natsruntime`. Shared packages must not import either product's domain,
+   module-specific ADR: ADR-056 for `pkg/events`, ADR-058 for
+   `pkg/natsruntime`, or ADR-060 for `pkg/datacrypto`. Shared packages must not
+   import either product's domain,
    configuration, protobuf envelopes, subjects, resource names, or lifecycle
    policy.
 6. Cross-product decisions may be recorded in root ADRs. Product-specific
@@ -84,6 +85,8 @@ permission to reorganize unrelated product code.
   boundary, compatibility, and verification rules.
 - [pkg/natsruntime/AGENTS.md](pkg/natsruntime/AGENTS.md) — shared embedded-NATS
   lifecycle module boundary and verification rules.
+- [pkg/datacrypto/AGENTS.md](pkg/datacrypto/AGENTS.md) — shared authenticated
+  encryption and key-wrapping boundary and verification rules.
 - [cli/AGENTS.md](cli/AGENTS.md) — Go backend, ConnectRPC, NATS/JetStream, authz, live events, backup/restore, and backend tests.
 - [apps/frontend/AGENTS.md](apps/frontend/AGENTS.md) — SvelteKit frontend, Tailwind, i18n, browser verification, frontend tests, e2e, and Storybook.
 - [proto/AGENTS.md](proto/AGENTS.md) — protobuf and generated public API reference guidance.
@@ -151,6 +154,7 @@ mise test-authling
 mise test-cli
 mise test-events
 mise test-natsruntime
+mise test-datacrypto
 mise test-frontend
 mise test-e2e
 mise build-authling
@@ -287,10 +291,10 @@ leave a dev stack running in a detached or yielded terminal session.
 - Files are AGPL-3.0-or-later by default unless `REUSE.toml`, an SPDX header,
   or an adjacent `.license` file says otherwise.
 - Apache-2.0 applies to the independently versioned shared framework modules
-  under `pkg/events/` and `pkg/natsruntime/`, plus explicit integration and
-  documentation surfaces such as the standalone frontend source and image,
-  public protocol/API definitions, generated TypeScript API clients,
-  documentation, and examples.
+  under `pkg/events/`, `pkg/natsruntime/`, and `pkg/datacrypto/`, plus explicit
+  integration and documentation surfaces such as the standalone frontend
+  source and image, public protocol/API definitions, generated TypeScript API
+  clients, documentation, and examples.
 - The Chatto server, CLI, and bundled server release artifacts should stay
   AGPL-3.0-or-later unless the license boundary is deliberately changed.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -10,9 +10,9 @@ CLI, and bundled server release artifacts unless a more specific license is
 declared.
 
 Apache-2.0 exceptions are used where permissive reuse is intentional. These
-include the independently versioned `pkg/events` and `pkg/natsruntime` shared
-framework modules, the standalone frontend source and image, public
-protocol/API definitions, generated TypeScript API client/types,
+include the independently versioned `pkg/events`, `pkg/natsruntime`, and
+`pkg/datacrypto` shared framework modules, the standalone frontend source and
+image, public protocol/API definitions, generated TypeScript API client/types,
 documentation, and deployment examples. The shared modules remain explicitly
 pre-1.0; their permissive license does not imply API stability.
 

--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ This repository temporarily incubates the early
 [Authling](authling/README.md) identity-provider module. Authling is developed
 and released independently from Chatto and is intended to move to its own
 repository once it no longer needs frequent atomic changes with the shared
-[event-sourcing framework](pkg/events/README.md) and
-[embedded NATS runtime](pkg/natsruntime/README.md).
+[event-sourcing framework](pkg/events/README.md),
+[embedded NATS runtime](pkg/natsruntime/README.md), and
+[data-cryptography primitives](pkg/datacrypto/README.md).
 
 ## License
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,6 +20,7 @@ path = [
   "examples/**",
   "LICENSING.md",
   "packages/api-types/**",
+  "pkg/datacrypto/**",
   "pkg/events/**",
   "pkg/natsruntime/**",
   "README.md",
@@ -50,6 +51,7 @@ SPDX-License-Identifier = "AGPL-3.0-or-later"
 [[annotations]]
 path = [
   "pkg/events/LICENSE",
+  "pkg/datacrypto/LICENSE",
   "pkg/natsruntime/LICENSE",
 ]
 SPDX-FileCopyrightText = "2004 Apache Software Foundation"

--- a/authling/AGENTS.md
+++ b/authling/AGENTS.md
@@ -52,8 +52,10 @@ to its own repository.
   boundaries, runtime-state keys, or diagnostic identities into Authling.
 - Reusable mechanics must move behind explicitly application-neutral shared
   package boundaries. The unstable `hmans.de/chatto/pkg/events` module owns
-  generic event-sourcing mechanics, while
-  `hmans.de/chatto/pkg/natsruntime` owns embedded NATS lifecycle mechanics.
+  generic event-sourcing mechanics,
+  `hmans.de/chatto/pkg/natsruntime` owns embedded NATS lifecycle mechanics, and
+  `hmans.de/chatto/pkg/datacrypto` owns raw XChaCha20-Poly1305 and 256-bit key
+  wrapping primitives; Authling owns its associated data and key hierarchy.
   Authling should consume them only for concrete use cases. Each product owns
   its event vocabulary, storage coordinates, identity formats, configuration,
   policy, and composition.
@@ -64,6 +66,8 @@ to its own repository.
   [ADR-057](../docs/adr/ADR-057-temporarily-incubate-authling.md). Embedded
   NATS runtime changes additionally follow
   [ADR-058](../docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md).
+  Data-cryptography changes additionally follow
+  [ADR-060](../docs/adr/ADR-060-application-neutral-data-cryptography.md).
 - Keep Authling independently buildable and testable from its module directory.
   The root `go.work` is a development convenience, not permission to blur module
   dependencies.

--- a/authling/TODO.md
+++ b/authling/TODO.md
@@ -9,7 +9,7 @@ current runtime in `docs/architecture/`.
 
 - [ ] Define Authling's initial product milestone
 - [ ] Establish canonical identity, application, client, account, and document terminology
-- [ ] Extract the application-neutral encryption and key-management mechanics Authling needs
+- [ ] Extract the application-neutral KMS, wrapped-key storage, key-cache, and durable-erasure mechanics Authling needs
 - [ ] Evaluate extracting the shared TOML and environment configuration mechanics
 - [ ] Add standalone diagnostics and backup behavior
 

--- a/authling/docs/adr/ADR-002-hierarchical-keys-and-cryptographic-erasure.md
+++ b/authling/docs/adr/ADR-002-hierarchical-keys-and-cryptographic-erasure.md
@@ -187,10 +187,14 @@ unavailability fails closed.
 
 ### Extraction boundary
 
-Authling may drive extraction of these application-neutral mechanics from
-Chatto:
+ADR-060 extracts the first application-neutral mechanics into
+`hmans.de/chatto/pkg/datacrypto`:
 
-- versioned authenticated-encryption and key-wrapping primitives;
+- authenticated-encryption and key-wrapping primitives.
+
+Authling may drive extraction of the remaining mechanics from Chatto once both
+products prove their boundaries:
+
 - opaque KMS key-reference interfaces and a self-hosted provider;
 - wrapped data-key storage and validation;
 - bounded unwrapped-key resolution and cache invalidation; and

--- a/authling/docs/adr/INDEX.md
+++ b/authling/docs/adr/INDEX.md
@@ -8,6 +8,8 @@ Repository-wide decisions currently live in:
 - [Root ADR-056: Incubate an Extractable NATS Event-Sourcing Framework](../../../docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md)
 - [Root ADR-057: Temporarily Incubate Authling in the Chatto Repository](../../../docs/adr/ADR-057-temporarily-incubate-authling.md)
 - [Root ADR-058: Extract an Application-Neutral Embedded NATS Runtime](../../../docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md)
+- [Root ADR-059: License Shared Framework Modules under Apache-2.0](../../../docs/adr/ADR-059-apache-license-shared-framework-modules.md)
+- [Root ADR-060: Extract Application-Neutral Data Cryptography](../../../docs/adr/ADR-060-application-neutral-data-cryptography.md)
 
 ## Decisions
 

--- a/authling/go.mod
+++ b/authling/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/nats-io/nats.go v1.52.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 	google.golang.org/protobuf v1.36.11
+	hmans.de/chatto/pkg/datacrypto v0.0.0
 	hmans.de/chatto/pkg/events v0.0.0
 	hmans.de/chatto/pkg/natsruntime v0.0.0
 )
@@ -28,5 +29,7 @@ require (
 )
 
 replace hmans.de/chatto/pkg/events => ../pkg/events
+
+replace hmans.de/chatto/pkg/datacrypto => ../pkg/datacrypto
 
 replace hmans.de/chatto/pkg/natsruntime => ../pkg/natsruntime

--- a/authling/internal/datacrypto/contract_test.go
+++ b/authling/internal/datacrypto/contract_test.go
@@ -1,0 +1,97 @@
+// Package datacrypto_test exercises Authling's planned cryptographic hierarchy
+// against the shared primitive without claiming a production implementation.
+package datacrypto_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"testing"
+
+	"hmans.de/chatto/pkg/datacrypto"
+)
+
+func TestHierarchicalKeyConsumerContract(t *testing.T) {
+	userKey := generateKey(t)
+	dataKey := generateKey(t)
+	accountID := "acct_example"
+
+	keyAAD := authlingAAD("authling:user-data-key:v1", accountID, "profile", "epoch-1")
+	wrappedDataKey, err := datacrypto.WrapKey(userKey, dataKey, keyAAD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unwrappedDataKey, err := datacrypto.UnwrapKey(
+		userKey,
+		wrappedDataKey.Ciphertext,
+		wrappedDataKey.Nonce,
+		keyAAD,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(unwrappedDataKey, dataKey) {
+		t.Fatal("unwrapped data key differs")
+	}
+
+	fieldAAD := authlingAAD(
+		"authling:protected-field:v1",
+		"event-type:account-profile-updated",
+		accountID,
+		"purpose:core-profile",
+		"epoch:1",
+		"evt_example",
+		"email",
+	)
+	sealed, err := datacrypto.Seal(dataKey, []byte("person@example.invalid"), fieldAAD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := datacrypto.Open(dataKey, sealed.Ciphertext, sealed.Nonce, fieldAAD); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, substitutedAAD := range map[string][]byte{
+		"event type": authlingAAD("authling:protected-field:v1", "event-type:credential-linked", accountID, "purpose:core-profile", "epoch:1", "evt_example", "email"),
+		"account":    authlingAAD("authling:protected-field:v1", "event-type:account-profile-updated", "acct_other", "purpose:core-profile", "epoch:1", "evt_example", "email"),
+		"purpose":    authlingAAD("authling:protected-field:v1", "event-type:account-profile-updated", accountID, "purpose:credentials", "epoch:1", "evt_example", "email"),
+		"epoch":      authlingAAD("authling:protected-field:v1", "event-type:account-profile-updated", accountID, "purpose:core-profile", "epoch:2", "evt_example", "email"),
+		"event ID":   authlingAAD("authling:protected-field:v1", "event-type:account-profile-updated", accountID, "purpose:core-profile", "epoch:1", "evt_other", "email"),
+		"field":      authlingAAD("authling:protected-field:v1", "event-type:account-profile-updated", accountID, "purpose:core-profile", "epoch:1", "evt_example", "display-name"),
+	} {
+		t.Run("reject "+name+" substitution", func(t *testing.T) {
+			_, err := datacrypto.Open(dataKey, sealed.Ciphertext, sealed.Nonce, substitutedAAD)
+			if !errors.Is(err, datacrypto.ErrDecryptionFailed) {
+				t.Fatalf("substitution error = %v, want ErrDecryptionFailed", err)
+			}
+		})
+	}
+
+	wrongKeyAAD := authlingAAD("authling:user-data-key:v1", "acct_other", "profile", "epoch-1")
+	_, err = datacrypto.UnwrapKey(userKey, wrappedDataKey.Ciphertext, wrappedDataKey.Nonce, wrongKeyAAD)
+	if !errors.Is(err, datacrypto.ErrDecryptionFailed) {
+		t.Fatalf("key substitution error = %v, want ErrDecryptionFailed", err)
+	}
+}
+
+func authlingAAD(domain string, fields ...string) []byte {
+	result := appendLengthPrefixed(nil, domain)
+	for _, field := range fields {
+		result = appendLengthPrefixed(result, field)
+	}
+	return result
+}
+
+func appendLengthPrefixed(destination []byte, value string) []byte {
+	destination = binary.BigEndian.AppendUint32(destination, uint32(len(value)))
+	return append(destination, value...)
+}
+
+func generateKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := datacrypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -130,6 +130,12 @@ authorization, live events, backup/restore, and backend tests.
   configuration, listener, authentication, monitoring, logging, storage, and
   deployment policy in `internal/embedded_nats`; the shared module must not
   import Chatto packages.
+- Keep raw XChaCha20-Poly1305 and 256-bit key-wrapping primitives behind the
+  independently versioned `hmans.de/chatto/pkg/datacrypto` module from
+  ADR-060. Chatto retains its associated-data formats, legacy cipher path,
+  key references and hierarchy, envelope serialization, storage, KMS, cache,
+  rotation, and cryptographic-erasure policy in `internal/encryption`; the
+  shared module must not import Chatto packages.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -63,6 +63,7 @@ require (
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
 	google.golang.org/protobuf v1.36.11
+	hmans.de/chatto/pkg/datacrypto v0.0.0
 	hmans.de/chatto/pkg/events v0.0.0
 	hmans.de/chatto/pkg/natsruntime v0.0.0
 )
@@ -225,5 +226,7 @@ require (
 )
 
 replace hmans.de/chatto/pkg/events => ../pkg/events
+
+replace hmans.de/chatto/pkg/datacrypto => ../pkg/datacrypto
 
 replace hmans.de/chatto/pkg/natsruntime => ../pkg/natsruntime

--- a/cli/internal/encryption/encryption.go
+++ b/cli/internal/encryption/encryption.go
@@ -7,17 +7,18 @@ import (
 	"fmt"
 
 	"golang.org/x/crypto/chacha20poly1305"
+	"hmans.de/chatto/pkg/datacrypto"
 )
 
 const (
 	// KeySize is the size of ChaCha20-Poly1305 keys (256 bits).
-	KeySize = chacha20poly1305.KeySize // 32 bytes
+	KeySize = datacrypto.KeySize // 32 bytes
 
 	// NonceSize is the size of the nonce (96 bits).
 	NonceSize = chacha20poly1305.NonceSize // 12 bytes
 
 	// XNonceSize is the size of the XChaCha20-Poly1305 nonce (192 bits).
-	XNonceSize = chacha20poly1305.NonceSizeX // 24 bytes
+	XNonceSize = datacrypto.NonceSize // 24 bytes
 
 	// EnvelopeVersionV2 identifies the content-key epoch message body format.
 	EnvelopeVersionV2 int32 = 2
@@ -91,82 +92,32 @@ func Decrypt(key, ciphertext, nonce []byte) ([]byte, error) {
 
 // WrapContentKey encrypts a content key with a key encryption key.
 func WrapContentKey(kek, contentKey, aad []byte) (*WrappedContentKey, error) {
-	if len(kek) != KeySize {
-		return nil, fmt.Errorf("%w: expected %d, got %d", ErrInvalidKeySize, KeySize, len(kek))
-	}
-	if len(contentKey) != KeySize {
-		return nil, fmt.Errorf("%w: expected content key size %d, got %d", ErrInvalidKeySize, KeySize, len(contentKey))
-	}
-	wrapAEAD, err := chacha20poly1305.NewX(kek)
+	wrapped, err := datacrypto.WrapKey(kek, contentKey, aadForContentKey(aad))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create key wrap AEAD cipher: %w", err)
+		return nil, err
 	}
-	nonce, err := randomBytes(XNonceSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate content key nonce: %w", err)
-	}
-	encryptedContentKey := wrapAEAD.Seal(nil, nonce, contentKey, aadForContentKey(aad))
-	return &WrappedContentKey{EncryptedContentKey: encryptedContentKey, Nonce: nonce}, nil
+	return &WrappedContentKey{EncryptedContentKey: wrapped.Ciphertext, Nonce: wrapped.Nonce}, nil
 }
 
 // UnwrapContentKey decrypts a content key with a key encryption key.
 func UnwrapContentKey(kek, encryptedContentKey, nonce, aad []byte) ([]byte, error) {
-	if len(kek) != KeySize {
-		return nil, fmt.Errorf("%w: expected %d, got %d", ErrInvalidKeySize, KeySize, len(kek))
-	}
-	if len(nonce) != XNonceSize {
-		return nil, fmt.Errorf("%w: expected %d-byte XChaCha nonces", ErrInvalidNonceSize, XNonceSize)
-	}
-	wrapAEAD, err := chacha20poly1305.NewX(kek)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create key wrap AEAD cipher: %w", err)
-	}
-	contentKey, err := wrapAEAD.Open(nil, nonce, encryptedContentKey, aadForContentKey(aad))
-	if err != nil {
-		return nil, ErrDecryptionFailed
-	}
-	if len(contentKey) != KeySize {
-		return nil, fmt.Errorf("%w: expected content key size %d, got %d", ErrInvalidKeySize, KeySize, len(contentKey))
-	}
-	return contentKey, nil
+	return datacrypto.UnwrapKey(kek, encryptedContentKey, nonce, aadForContentKey(aad))
 }
 
 // EncryptXChaCha20Poly1305 encrypts plaintext with XChaCha20-Poly1305.
 // aad is authenticated as supplied by the caller.
 func EncryptXChaCha20Poly1305(key, plaintext, aad []byte) (*EncryptedData, error) {
-	if len(key) != KeySize {
-		return nil, fmt.Errorf("%w: expected %d, got %d", ErrInvalidKeySize, KeySize, len(key))
-	}
-	bodyAEAD, err := chacha20poly1305.NewX(key)
+	sealed, err := datacrypto.Seal(key, plaintext, aad)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create body AEAD cipher: %w", err)
+		return nil, err
 	}
-	nonce, err := randomBytes(XNonceSize)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate body nonce: %w", err)
-	}
-	ciphertext := bodyAEAD.Seal(nil, nonce, plaintext, aad)
-	return &EncryptedData{Ciphertext: ciphertext, Nonce: nonce}, nil
+	return &EncryptedData{Ciphertext: sealed.Ciphertext, Nonce: sealed.Nonce}, nil
 }
 
 // DecryptXChaCha20Poly1305 decrypts ciphertext with XChaCha20-Poly1305.
 // aad must match the encryption context exactly.
 func DecryptXChaCha20Poly1305(key, ciphertext, nonce, aad []byte) ([]byte, error) {
-	if len(key) != KeySize {
-		return nil, fmt.Errorf("%w: expected %d, got %d", ErrInvalidKeySize, KeySize, len(key))
-	}
-	if len(nonce) != XNonceSize {
-		return nil, fmt.Errorf("%w: expected %d-byte XChaCha nonces", ErrInvalidNonceSize, XNonceSize)
-	}
-	bodyAEAD, err := chacha20poly1305.NewX(key)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create body AEAD cipher: %w", err)
-	}
-	plaintext, err := bodyAEAD.Open(nil, nonce, ciphertext, aad)
-	if err != nil {
-		return nil, ErrDecryptionFailed
-	}
-	return plaintext, nil
+	return datacrypto.Open(key, ciphertext, nonce, aad)
 }
 
 // EncryptWithContentKey encrypts plaintext with an already-selected content
@@ -182,7 +133,7 @@ func DecryptWithContentKey(contentKey, ciphertext, nonce, aad []byte) ([]byte, e
 
 // GenerateKey generates a cryptographically secure random key.
 func GenerateKey() ([]byte, error) {
-	key, err := randomBytes(KeySize)
+	key, err := datacrypto.GenerateKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate key: %w", err)
 	}

--- a/cli/internal/encryption/encryption_test.go
+++ b/cli/internal/encryption/encryption_test.go
@@ -1,12 +1,59 @@
 package encryption
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/chacha20poly1305"
 )
+
+func TestSharedBodyEncryptionPreservesRawCipherFormat(t *testing.T) {
+	key := bytes.Repeat([]byte{0x11}, KeySize)
+	nonce := bytes.Repeat([]byte{0x22}, XNonceSize)
+	plaintext := []byte("persisted message body")
+	applicationAAD := []byte("event=E123\x00room=R123\x00author=U123")
+	rawAAD := []byte("chatto:message-body:v2\x00event=E123\x00room=R123\x00author=U123")
+	require.Equal(t, rawAAD, aadForBody(applicationAAD))
+
+	aead, err := chacha20poly1305.NewX(key)
+	require.NoError(t, err)
+	rawCiphertext := aead.Seal(nil, nonce, plaintext, rawAAD)
+
+	opened, err := DecryptWithContentKey(key, rawCiphertext, nonce, applicationAAD)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, opened)
+
+	sealed, err := EncryptWithContentKey(key, plaintext, applicationAAD)
+	require.NoError(t, err)
+	opened, err = aead.Open(nil, sealed.Nonce, sealed.Ciphertext, rawAAD)
+	require.NoError(t, err)
+	require.Equal(t, plaintext, opened)
+}
+
+func TestSharedKeyWrappingPreservesRawCipherFormat(t *testing.T) {
+	wrappingKey := bytes.Repeat([]byte{0x33}, KeySize)
+	contentKey := bytes.Repeat([]byte{0x44}, KeySize)
+	nonce := bytes.Repeat([]byte{0x55}, XNonceSize)
+	applicationAAD := []byte("user=U123\x00epoch=1")
+	rawAAD := []byte("chatto:content-key:v2\x00user=U123\x00epoch=1")
+	require.Equal(t, rawAAD, aadForContentKey(applicationAAD))
+
+	aead, err := chacha20poly1305.NewX(wrappingKey)
+	require.NoError(t, err)
+	rawCiphertext := aead.Seal(nil, nonce, contentKey, rawAAD)
+
+	unwrapped, err := UnwrapContentKey(wrappingKey, rawCiphertext, nonce, applicationAAD)
+	require.NoError(t, err)
+	require.Equal(t, contentKey, unwrapped)
+
+	wrapped, err := WrapContentKey(wrappingKey, contentKey, applicationAAD)
+	require.NoError(t, err)
+	unwrapped, err = aead.Open(nil, wrapped.Nonce, wrapped.EncryptedContentKey, rawAAD)
+	require.NoError(t, err)
+	require.Equal(t, contentKey, unwrapped)
+}
 
 func TestEncryptDecrypt(t *testing.T) {
 	tests := []struct {

--- a/cli/internal/encryption/errors.go
+++ b/cli/internal/encryption/errors.go
@@ -1,18 +1,22 @@
 package encryption
 
-import "errors"
+import (
+	"errors"
+
+	"hmans.de/chatto/pkg/datacrypto"
+)
 
 var (
 	// ErrDecryptionFailed indicates the ciphertext couldn't be decrypted
 	// (wrong key, corrupted data, or tampered ciphertext).
-	ErrDecryptionFailed = errors.New("decryption failed: invalid key or corrupted data")
+	ErrDecryptionFailed = datacrypto.ErrDecryptionFailed
 
 	// ErrKeyNotFound indicates no encryption key exists for the requested entity.
 	ErrKeyNotFound = errors.New("encryption key not found")
 
 	// ErrInvalidKeySize indicates the provided key has an incorrect size.
-	ErrInvalidKeySize = errors.New("invalid key size")
+	ErrInvalidKeySize = datacrypto.ErrInvalidKeySize
 
 	// ErrInvalidNonceSize indicates the provided nonce has an incorrect size.
-	ErrInvalidNonceSize = errors.New("invalid nonce size")
+	ErrInvalidNonceSize = datacrypto.ErrInvalidNonceSize
 )

--- a/docs/adr/ADR-057-temporarily-incubate-authling.md
+++ b/docs/adr/ADR-057-temporarily-incubate-authling.md
@@ -20,8 +20,9 @@ the architecture should not make future process-level composition impossible.
 
 Temporarily incubate Authling in this repository as a separate Go module under
 `authling/`. The repository-level `go.work` file composes the Chatto, Authling,
-shared `pkg/events/`, and shared `pkg/natsruntime/` modules for local
-development without merging their module or package boundaries.
+shared `pkg/events/`, shared `pkg/natsruntime/`, and shared `pkg/datacrypto/`
+modules for local development without merging their module or package
+boundaries.
 
 Authling is a separate product and executable. It owns its configuration,
 application composition, HTTP surface, lifecycle, and NATS credentials. It
@@ -30,6 +31,8 @@ must not import Chatto domain packages or any package beneath Chatto's
 independently versioned but unstable `hmans.de/chatto/pkg/events` module
 boundary described by ADR-056. Reusable embedded NATS lifecycle mechanics live
 in the separate `hmans.de/chatto/pkg/natsruntime` module described by ADR-058.
+Reusable authenticated-encryption primitives live in the separate
+`hmans.de/chatto/pkg/datacrypto` module described by ADR-060.
 Authling should consume shared modules only when a concrete use case needs
 them.
 
@@ -44,7 +47,7 @@ components, versions, changelogs, release pull requests, and tags:
 
 - Chatto remains the root component and uses `v<version>` tags. Its release
   component excludes commits whose files are entirely under `authling/`,
-  `pkg/events/`, `pkg/natsruntime/`, or `.agents/skills/`.
+  `pkg/events/`, `pkg/natsruntime/`, `pkg/datacrypto/`, or `.agents/skills/`.
 - Authling uses the `authling/` component and `authling/v<version>` tags. The
   slash follows Go's nested-module tag convention and keeps module versions
   consumable through normal Go tooling.
@@ -53,6 +56,8 @@ components, versions, changelogs, release pull requests, and tags:
 - The embedded NATS runtime uses the `pkg/natsruntime/` component and
   `pkg/natsruntime/v<version>` tags, matching its nested-module repository
   path.
+- The data-cryptography module uses the `pkg/datacrypto/` component and
+  `pkg/datacrypto/v<version>` tags, matching its nested-module repository path.
 
 Release Please does not infer dependencies between Go workspace modules. A
 change to a shared module that requires a new Chatto or Authling version must
@@ -84,7 +89,7 @@ development while remaining independently deployable and releasable. Its
 security and operational lifecycle cannot become accidentally coupled to a
 Chatto server or Chatto's NATS account.
 
-The repository now contains four Go modules and four release lines. CI and
+The repository now contains five Go modules and five release lines. CI and
 developer tasks must cover the relevant modules, and release automation must
 preserve the separate tag namespaces.
 

--- a/docs/adr/ADR-059-apache-license-shared-framework-modules.md
+++ b/docs/adr/ADR-059-apache-license-shared-framework-modules.md
@@ -4,10 +4,11 @@
 
 ## Context
 
-ADR-056 and ADR-058 establish `pkg/events` and `pkg/natsruntime` as
-independently versioned, application-neutral modules intended for use outside
-Chatto and Authling. Both modules began under the repository's default
-AGPL-3.0-or-later license while their boundaries were being identified.
+ADR-056, ADR-058, and ADR-060 establish `pkg/events`, `pkg/natsruntime`, and
+`pkg/datacrypto` as independently versioned, application-neutral modules
+intended for use outside Chatto and Authling. The first two modules began under
+the repository's default AGPL-3.0-or-later license while their boundaries were
+being identified; `pkg/datacrypto` begins under Apache-2.0.
 
 The modules need additional consumers to mature. Requiring an application's
 combined work to follow the repository's strong copyleft terms would
@@ -19,9 +20,9 @@ can be established before outside contributions make a later change harder.
 
 ## Decision
 
-License the complete `pkg/events` and `pkg/natsruntime` modules under the
-Apache License 2.0. This includes their source, tests, documentation, module
-metadata, and standalone license files.
+License the complete `pkg/events`, `pkg/natsruntime`, and `pkg/datacrypto`
+modules under the Apache License 2.0. This includes their source, tests,
+documentation, module metadata, and standalone license files.
 
 The modules remain independently versioned, pre-1.0 incubation surfaces with
 no API stability promise. Their README files must state both the permissive
@@ -48,5 +49,5 @@ rather than copyleft requirements.
 
 The repository has a deliberate mixed-license boundary. REUSE metadata,
 module-local license files, public README files, and agent instructions must
-keep the two shared modules Apache-2.0 while preserving AGPL-3.0-or-later as
+keep the shared modules Apache-2.0 while preserving AGPL-3.0-or-later as
 the default for product-owned server code.

--- a/docs/adr/ADR-060-application-neutral-data-cryptography.md
+++ b/docs/adr/ADR-060-application-neutral-data-cryptography.md
@@ -1,0 +1,65 @@
+# ADR-060: Extract Application-Neutral Data Cryptography
+
+**Date:** 2026-07-31
+
+## Context
+
+Chatto already protects message bodies and user data with random 256-bit keys,
+XChaCha20-Poly1305, authenticated key wrapping, and product-specific associated
+data. Authling ADR-002 chooses the same primitives for its planned hierarchical
+user and data keys. Keeping two implementations would duplicate
+security-sensitive code, while moving Chatto's complete encryption subsystem
+would wrongly couple a shared package to Chatto's persisted formats, key
+references, KMS boundary, storage, caching, and cryptographic-erasure policy.
+
+The extraction must preserve every existing Chatto ciphertext, nonce, and
+associated-data byte. Authling does not yet persist protected user data, so it
+needs a concrete consumer contract without representing the planned hierarchy
+as implemented runtime behavior.
+
+## Decision
+
+Create the independently versioned `hmans.de/chatto/pkg/datacrypto` module. It
+owns only:
+
+- cryptographically random 256-bit key generation;
+- XChaCha20-Poly1305 seal and open operations with caller-supplied associated
+  data; and
+- authenticated wrapping and unwrapping of 256-bit keys.
+
+The module does not construct associated data or serialize envelopes.
+Applications own domain separation, identifiers, key hierarchies and
+references, epochs and purposes, persistence, KMS integration, caching,
+rotation, deletion, and erasure workflows. Its API returns ciphertext and
+nonce as separate byte slices so consumers retain their existing storage
+formats.
+
+Chatto keeps `cli/internal/encryption` as its product facade. The facade
+delegates XChaCha encryption, key wrapping, and key generation to the shared
+module while retaining Chatto's exact associated-data prefixes and envelope
+fields. Its legacy 96-bit-nonce ChaCha20-Poly1305 path remains internal for
+persisted-data compatibility. Existing error sentinels alias the shared
+sentinels so `errors.Is` compatibility is preserved.
+
+Authling establishes the second consumer through a test-only external-package
+contract. The contract exercises the hierarchy and substitution resistance
+from Authling ADR-002 with Authling-owned associated data; it does not add a
+production encryption subsystem or claim protected data is implemented.
+
+License the complete module under Apache-2.0 in accordance with ADR-059. It is
+a pre-1.0 incubation surface without an API stability promise.
+
+## Consequences
+
+Chatto's facade and Authling's planned-hierarchy consumer contract exercise one
+small, independently testable implementation of the cryptographic primitives
+while keeping product policy and durable formats out of the shared boundary.
+Raw-cipher compatibility tests protect Chatto's existing data from accidental
+format drift, and Authling's contract tests protect the package from becoming
+shaped only around Chatto.
+
+The module deliberately does not yet extract KMS interfaces, wrapped-key
+records, caches, key stores, or erasure orchestration. Those boundaries need a
+second concrete implementation before extraction. Callers must construct
+unambiguous, versioned associated data and persist nonces alongside
+ciphertexts; the shared package cannot enforce product-specific correctness.

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -71,3 +71,4 @@ replace part of their original design.
 | [ADR-057](ADR-057-temporarily-incubate-authling.md) | Temporarily Incubate Authling in the Chatto Repository | Accepted | 2026-07-30 |
 | [ADR-058](ADR-058-application-neutral-embedded-nats-runtime.md) | Extract an Application-Neutral Embedded NATS Runtime | Accepted | 2026-07-31 |
 | [ADR-059](ADR-059-apache-license-shared-framework-modules.md) | License Shared Framework Modules under Apache-2.0 | Accepted | 2026-07-31 |
+| [ADR-060](ADR-060-application-neutral-data-cryptography.md) | Extract Application-Neutral Data Cryptography | Accepted | 2026-07-31 |

--- a/docs/fdr/FDR-018-account-lifecycle.md
+++ b/docs/fdr/FDR-018-account-lifecycle.md
@@ -101,7 +101,8 @@ This FDR covers the user account from registration through deletion: signup, ema
 
 ## Related
 
-- **ADRs:** ADR-007 (per-user encryption with crypto-shredding)
+- **ADRs:** ADR-007 (per-user encryption with crypto-shredding), ADR-060
+  (application-neutral data cryptography)
 - **FDRs:** FDR-001 (Roles & Permissions), FDR-022 (User Profile), FDR-023 (Authentication & Sessions)
 
 ## Open Questions

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.26.0
 use (
 	./authling
 	./cli
+	./pkg/datacrypto
 	./pkg/events
 	./pkg/natsruntime
 )

--- a/mise.toml
+++ b/mise.toml
@@ -19,6 +19,7 @@ description = "Set up the development environment"
 run = [
     { task = "setup-authling" },
     { task = "setup-cli" },
+    { task = "setup-datacrypto" },
     { task = "setup-events" },
     { task = "setup-natsruntime" },
     { task = "setup-frontend" },
@@ -33,6 +34,12 @@ run = [
 description = "Install Go dependencies"
 dir = "cli"
 run = "go mod download"
+sources = ["go.mod", "go.sum"]
+
+[tasks.deps-datacrypto]
+description = "Install data cryptography dependencies"
+dir = "pkg/datacrypto"
+run = "GOWORK=off go mod download"
 sources = ["go.mod", "go.sum"]
 
 [tasks.deps-authling]
@@ -68,6 +75,10 @@ run = { task = "deps-*" }
 [tasks.setup-cli]
 description = "Set up the CLI module"
 depends = ["deps-cli", "sync-cli-legal"]
+
+[tasks.setup-datacrypto]
+description = "Set up the data cryptography module"
+depends = ["deps-datacrypto"]
 
 [tasks.setup-authling]
 description = "Set up the Authling module"
@@ -411,6 +422,16 @@ run = [
 ]
 sources = ["go.mod", "go.sum", "**/*.go"]
 
+[tasks.test-datacrypto]
+description = "Run data cryptography tests standalone and in the repository workspace"
+depends = ["setup-datacrypto"]
+dir = "pkg/datacrypto"
+run = [
+    "GOWORK=off go test -trimpath ./...",
+    "go test -trimpath ./...",
+]
+sources = ["go.mod", "go.sum", "**/*.go"]
+
 [tasks.test-natsruntime]
 description = "Run embedded NATS runtime tests standalone and in the repository workspace"
 depends = ["setup-natsruntime"]
@@ -459,6 +480,7 @@ run = "pnpm exec playwright test"
 description = "Run all tests"
 run = [
     { task = "test-authling" },
+    { task = "test-datacrypto" },
     { task = "test-events" },
     { task = "test-natsruntime" },
     { task = "test-cli" },

--- a/pkg/datacrypto/AGENTS.md
+++ b/pkg/datacrypto/AGENTS.md
@@ -1,0 +1,35 @@
+# Instructions for Agents Working in `pkg/datacrypto/`
+
+Read the repository-root [`AGENTS.md`](../../AGENTS.md),
+[`cli/AGENTS.md`](../../cli/AGENTS.md), and
+[`authling/AGENTS.md`](../../authling/AGENTS.md) before changing this shared
+module. Also follow
+[ADR-060](../../docs/adr/ADR-060-application-neutral-data-cryptography.md).
+
+## Boundary
+
+- Keep production code application-neutral.
+- This module owns only random 256-bit key generation, XChaCha20-Poly1305
+  authenticated encryption, and authenticated wrapping of 256-bit keys.
+- Applications own associated-data construction and domain separation, key
+  identities and hierarchies, envelope serialization, storage, KMS
+  integration, caching, rotation, and erasure policy.
+- Do not import Chatto or Authling packages or encode either product's
+  identifiers, formats, or policies.
+- The module is independently versioned but pre-1.0 and has no API stability
+  promise yet.
+- The complete module is licensed under Apache-2.0. Keep its source, tests,
+  documentation, and standalone license metadata inside that permissive
+  boundary.
+
+## Verification
+
+Run:
+
+```sh
+mise test-datacrypto
+mise test-authling
+mise test-cli
+mise license-check
+```
+

--- a/pkg/datacrypto/CHANGELOG.md
+++ b/pkg/datacrypto/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this module will be documented in this file by Release
+Please.
+

--- a/pkg/datacrypto/LICENSE
+++ b/pkg/datacrypto/LICENSE
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/pkg/datacrypto/README.md
+++ b/pkg/datacrypto/README.md
@@ -1,0 +1,39 @@
+# Data Cryptography
+
+`hmans.de/chatto/pkg/datacrypto` provides small, application-neutral
+cryptographic primitives for protected data:
+
+- cryptographically random 256-bit keys;
+- XChaCha20-Poly1305 authenticated encryption; and
+- authenticated wrapping and unwrapping of 256-bit keys.
+
+Applications retain ownership of associated-data construction, domain
+separation, key identities, key hierarchies, storage, KMS integration, caching,
+rotation, and erasure policy. The package does not serialize an envelope;
+callers persist the returned ciphertext and nonce in their own formats.
+
+## Status
+
+This module is an incubation surface shared by Chatto and Authling. Its API is
+not yet covered by a stability promise, and releases remain pre-1.0 while both
+applications establish the smallest useful contract.
+
+## Development
+
+Run the module tests independently:
+
+```sh
+mise test-datacrypto
+```
+
+From this directory, the equivalent standalone check is:
+
+```sh
+GOWORK=off go test ./...
+```
+
+## License
+
+The module is licensed under [`Apache-2.0`](LICENSE). Its permissive license
+does not imply API stability.
+

--- a/pkg/datacrypto/datacrypto.go
+++ b/pkg/datacrypto/datacrypto.go
@@ -1,0 +1,104 @@
+package datacrypto
+
+import (
+	"crypto/rand"
+	"fmt"
+
+	"golang.org/x/crypto/chacha20poly1305"
+)
+
+const (
+	// KeySize is the required size of encryption and wrapping keys in bytes.
+	KeySize = chacha20poly1305.KeySize
+
+	// NonceSize is the size of an XChaCha20-Poly1305 nonce in bytes.
+	NonceSize = chacha20poly1305.NonceSizeX
+)
+
+// SealedData contains an authenticated ciphertext and its random nonce.
+// Callers must persist both values and reconstruct the same associated data
+// when opening the ciphertext.
+type SealedData struct {
+	Ciphertext []byte
+	Nonce      []byte
+}
+
+// GenerateKey returns a cryptographically random 256-bit key.
+func GenerateKey() ([]byte, error) {
+	key := make([]byte, KeySize)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generate key: %w", err)
+	}
+	return key, nil
+}
+
+// Seal encrypts and authenticates plaintext with XChaCha20-Poly1305. The
+// caller owns associated-data construction and domain separation.
+func Seal(key, plaintext, associatedData []byte) (*SealedData, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, fmt.Errorf("create XChaCha20-Poly1305 cipher: %w", err)
+	}
+	nonce := make([]byte, NonceSize)
+	if _, err := rand.Read(nonce); err != nil {
+		return nil, fmt.Errorf("generate nonce: %w", err)
+	}
+
+	return &SealedData{
+		Ciphertext: aead.Seal(nil, nonce, plaintext, associatedData),
+		Nonce:      nonce,
+	}, nil
+}
+
+// Open authenticates and decrypts an XChaCha20-Poly1305 ciphertext. The
+// associated data must exactly match the bytes supplied to [Seal].
+func Open(key, ciphertext, nonce, associatedData []byte) ([]byte, error) {
+	if err := validateKey(key); err != nil {
+		return nil, err
+	}
+	if len(nonce) != NonceSize {
+		return nil, fmt.Errorf("%w: expected %d, got %d", ErrInvalidNonceSize, NonceSize, len(nonce))
+	}
+
+	aead, err := chacha20poly1305.NewX(key)
+	if err != nil {
+		return nil, fmt.Errorf("create XChaCha20-Poly1305 cipher: %w", err)
+	}
+	plaintext, err := aead.Open(nil, nonce, ciphertext, associatedData)
+	if err != nil {
+		return nil, ErrDecryptionFailed
+	}
+	return plaintext, nil
+}
+
+// WrapKey encrypts and authenticates a 256-bit key with a 256-bit wrapping
+// key. The caller owns associated-data construction and domain separation.
+func WrapKey(wrappingKey, key, associatedData []byte) (*SealedData, error) {
+	if err := validateKey(key); err != nil {
+		return nil, fmt.Errorf("wrapped key: %w", err)
+	}
+	return Seal(wrappingKey, key, associatedData)
+}
+
+// UnwrapKey authenticates and decrypts a 256-bit wrapped key.
+func UnwrapKey(wrappingKey, ciphertext, nonce, associatedData []byte) ([]byte, error) {
+	key, err := Open(wrappingKey, ciphertext, nonce, associatedData)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateKey(key); err != nil {
+		return nil, fmt.Errorf("wrapped key: %w", err)
+	}
+	return key, nil
+}
+
+func validateKey(key []byte) error {
+	if len(key) != KeySize {
+		return fmt.Errorf("%w: expected %d, got %d", ErrInvalidKeySize, KeySize, len(key))
+	}
+	return nil
+}

--- a/pkg/datacrypto/datacrypto_test.go
+++ b/pkg/datacrypto/datacrypto_test.go
@@ -1,0 +1,198 @@
+package datacrypto_test
+
+import (
+	"bytes"
+	"errors"
+	"strconv"
+	"testing"
+
+	"golang.org/x/crypto/chacha20poly1305"
+	"hmans.de/chatto/pkg/datacrypto"
+)
+
+func TestSealAndOpen(t *testing.T) {
+	key := mustGenerateKey(t)
+
+	for _, plaintext := range [][]byte{nil, {}, []byte("protected data"), bytes.Repeat([]byte{0xa5}, 1<<20)} {
+		plaintext := plaintext
+		t.Run(testName(len(plaintext)), func(t *testing.T) {
+			associatedData := []byte("application-owned context")
+			sealed, err := datacrypto.Seal(key, plaintext, associatedData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(sealed.Nonce) != datacrypto.NonceSize {
+				t.Fatalf("nonce length = %d, want %d", len(sealed.Nonce), datacrypto.NonceSize)
+			}
+
+			opened, err := datacrypto.Open(key, sealed.Ciphertext, sealed.Nonce, associatedData)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(opened, plaintext) {
+				t.Fatalf("opened plaintext differs")
+			}
+		})
+	}
+}
+
+func TestOpenRejectsSubstitutionAndTampering(t *testing.T) {
+	key := mustGenerateKey(t)
+	sealed, err := datacrypto.Seal(key, []byte("secret"), []byte("account:a"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := map[string]struct {
+		key        []byte
+		ciphertext []byte
+		nonce      []byte
+		aad        []byte
+	}{
+		"wrong key": {
+			key: mustGenerateKey(t), ciphertext: sealed.Ciphertext, nonce: sealed.Nonce, aad: []byte("account:a"),
+		},
+		"wrong associated data": {
+			key: key, ciphertext: sealed.Ciphertext, nonce: sealed.Nonce, aad: []byte("account:b"),
+		},
+		"tampered ciphertext": {
+			key: key, ciphertext: flippedCopy(sealed.Ciphertext), nonce: sealed.Nonce, aad: []byte("account:a"),
+		},
+		"tampered nonce": {
+			key: key, ciphertext: sealed.Ciphertext, nonce: flippedCopy(sealed.Nonce), aad: []byte("account:a"),
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := datacrypto.Open(test.key, test.ciphertext, test.nonce, test.aad)
+			if !errors.Is(err, datacrypto.ErrDecryptionFailed) {
+				t.Fatalf("Open error = %v, want ErrDecryptionFailed", err)
+			}
+		})
+	}
+}
+
+func TestInvalidSizes(t *testing.T) {
+	validKey := mustGenerateKey(t)
+
+	for _, size := range []int{0, datacrypto.KeySize - 1, datacrypto.KeySize + 1} {
+		_, err := datacrypto.Seal(make([]byte, size), nil, nil)
+		if !errors.Is(err, datacrypto.ErrInvalidKeySize) {
+			t.Fatalf("Seal key size %d error = %v, want ErrInvalidKeySize", size, err)
+		}
+		_, err = datacrypto.WrapKey(validKey, make([]byte, size), nil)
+		if !errors.Is(err, datacrypto.ErrInvalidKeySize) {
+			t.Fatalf("WrapKey key size %d error = %v, want ErrInvalidKeySize", size, err)
+		}
+	}
+
+	_, err := datacrypto.Open(validKey, nil, make([]byte, datacrypto.NonceSize-1), nil)
+	if !errors.Is(err, datacrypto.ErrInvalidNonceSize) {
+		t.Fatalf("Open error = %v, want ErrInvalidNonceSize", err)
+	}
+}
+
+func TestWrapAndUnwrapKey(t *testing.T) {
+	wrappingKey := mustGenerateKey(t)
+	key := mustGenerateKey(t)
+	aad := []byte("authling:user-key:account-1:epoch-2")
+
+	wrapped, err := datacrypto.WrapKey(wrappingKey, key, aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unwrapped, err := datacrypto.UnwrapKey(wrappingKey, wrapped.Ciphertext, wrapped.Nonce, aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(unwrapped, key) {
+		t.Fatal("unwrapped key differs")
+	}
+}
+
+func TestUnwrapRejectsAuthenticatedNonKeyPayload(t *testing.T) {
+	wrappingKey := mustGenerateKey(t)
+	aead, err := chacha20poly1305.NewX(wrappingKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := bytes.Repeat([]byte{1}, datacrypto.NonceSize)
+	ciphertext := aead.Seal(nil, nonce, []byte("not a 256-bit key"), nil)
+
+	_, err = datacrypto.UnwrapKey(wrappingKey, ciphertext, nonce, nil)
+	if !errors.Is(err, datacrypto.ErrInvalidKeySize) {
+		t.Fatalf("UnwrapKey error = %v, want ErrInvalidKeySize", err)
+	}
+}
+
+func TestRandomValuesAreUnique(t *testing.T) {
+	keys := make(map[string]struct{}, 1000)
+	nonces := make(map[string]struct{}, 1000)
+	key := mustGenerateKey(t)
+	for range 1000 {
+		generated := mustGenerateKey(t)
+		if _, exists := keys[string(generated)]; exists {
+			t.Fatal("GenerateKey returned a duplicate")
+		}
+		keys[string(generated)] = struct{}{}
+
+		sealed, err := datacrypto.Seal(key, nil, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, exists := nonces[string(sealed.Nonce)]; exists {
+			t.Fatal("Seal returned a duplicate nonce")
+		}
+		nonces[string(sealed.Nonce)] = struct{}{}
+	}
+}
+
+func TestSealDoesNotMutateOrAliasInputs(t *testing.T) {
+	key := bytes.Repeat([]byte{1}, datacrypto.KeySize)
+	plaintext := []byte("plaintext")
+	aad := []byte("associated data")
+	wantKey := bytes.Clone(key)
+	wantPlaintext := bytes.Clone(plaintext)
+	wantAAD := bytes.Clone(aad)
+
+	sealed, err := datacrypto.Seal(key, plaintext, aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sealed.Ciphertext[0] ^= 1
+	sealed.Nonce[0] ^= 1
+
+	if !bytes.Equal(key, wantKey) || !bytes.Equal(plaintext, wantPlaintext) || !bytes.Equal(aad, wantAAD) {
+		t.Fatal("Seal output aliases or mutated caller input")
+	}
+}
+
+func mustGenerateKey(t *testing.T) []byte {
+	t.Helper()
+	key, err := datacrypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(key) != datacrypto.KeySize {
+		t.Fatalf("key length = %d, want %d", len(key), datacrypto.KeySize)
+	}
+	return key
+}
+
+func flippedCopy(value []byte) []byte {
+	copy := bytes.Clone(value)
+	copy[0] ^= 1
+	return copy
+}
+
+func testName(size int) string {
+	switch size {
+	case 0:
+		return "empty"
+	case 1 << 20:
+		return "large"
+	default:
+		return "size_" + strconv.Itoa(size)
+	}
+}

--- a/pkg/datacrypto/dependency_boundary_test.go
+++ b/pkg/datacrypto/dependency_boundary_test.go
@@ -1,0 +1,44 @@
+package datacrypto_test
+
+import (
+	"go/build"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPackageDependenciesAreApplicationNeutral(t *testing.T) {
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packages, err := parser.ParseDir(token.NewFileSet(), directory, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pkg := range packages {
+		for sourceName, source := range pkg.Files {
+			for _, spec := range source.Imports {
+				importPath, err := strconv.Unquote(spec.Path.Value)
+				if err != nil {
+					t.Fatalf("%s: decode import path: %v", sourceName, err)
+				}
+				if isStandardLibraryImport(importPath, directory) ||
+					strings.HasPrefix(importPath, "golang.org/x/crypto/") ||
+					strings.HasSuffix(sourceName, "_test.go") && importPath == "hmans.de/chatto/pkg/datacrypto" {
+					continue
+				}
+				t.Errorf("%s imports non-portable dependency %q", sourceName, importPath)
+			}
+		}
+	}
+}
+
+func isStandardLibraryImport(importPath, sourceDirectory string) bool {
+	pkg, err := build.Default.Import(importPath, sourceDirectory, build.FindOnly)
+	return err == nil && pkg.Goroot
+}

--- a/pkg/datacrypto/errors.go
+++ b/pkg/datacrypto/errors.go
@@ -1,0 +1,17 @@
+// Package datacrypto provides application-neutral authenticated-encryption
+// primitives for protected application data and key wrapping.
+package datacrypto
+
+import "errors"
+
+var (
+	// ErrDecryptionFailed indicates authentication failed because the key,
+	// nonce, ciphertext, or associated data did not match.
+	ErrDecryptionFailed = errors.New("decryption failed: invalid key or corrupted data")
+
+	// ErrInvalidKeySize indicates a key was not exactly [KeySize] bytes.
+	ErrInvalidKeySize = errors.New("invalid key size")
+
+	// ErrInvalidNonceSize indicates a nonce was not exactly [NonceSize] bytes.
+	ErrInvalidNonceSize = errors.New("invalid nonce size")
+)

--- a/pkg/datacrypto/go.mod
+++ b/pkg/datacrypto/go.mod
@@ -1,0 +1,7 @@
+module hmans.de/chatto/pkg/datacrypto
+
+go 1.26.0
+
+require golang.org/x/crypto v0.54.0
+
+require golang.org/x/sys v0.47.0 // indirect

--- a/pkg/datacrypto/go.sum
+++ b/pkg/datacrypto/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/crypto v0.54.0 h1:YLIA59K4fiNzHzjnZt2tUJQjQtUWfWbeHBqKtk3eScw=
+golang.org/x/crypto v0.54.0/go.mod h1:KWL8ny2AZdGR2cWmzeHrp2azQPGogOv+HeQaVEXC2dk=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=


### PR DESCRIPTION
## Why

Chatto and Authling need the same small set of authenticated-encryption
primitives, but duplicating security-sensitive code or sharing Chatto's full
encryption subsystem would couple product-owned formats, storage, and erasure
policy. This extracts the application-neutral boundary while using Authling as
the concrete second consumer.

## What changed

- added the independently versioned Apache-2.0
  `hmans.de/chatto/pkg/datacrypto` module for random 256-bit keys,
  XChaCha20-Poly1305 seal/open, and authenticated 256-bit key wrapping;
- kept associated-data construction, key hierarchy, envelopes, KMS, storage,
  caching, rotation, and erasure policy in each product;
- changed Chatto's existing internal encryption facade to consume the shared
  module while retaining its legacy ChaCha path and exact persisted XChaCha
  ciphertext, nonce, and AAD formats;
- added an Authling test-only consumer contract for ADR-002's planned
  hierarchical user/data keys and substitution resistance, without claiming a
  production encryption runtime;
- added ADR-060 and updated shared-module routing, licensing, workspace, CI,
  caching, Release Please, and development tasks.

## Compatibility and security

- No protobuf, public API, event, NATS resource, configuration, or migration
  changes.
- Existing Chatto ciphertext and AAD bytes are pinned by independent raw-cipher
  fixtures; the legacy 96-bit-nonce ChaCha20-Poly1305 reader remains internal.
- Existing Chatto encryption error sentinels alias the shared sentinels, so
  `errors.Is` behavior is preserved.
- The shared module deliberately does not invent domain separation. Each
  product remains responsible for unambiguous, versioned AAD.
- An independent adversarial review found two test-coverage gaps; both were
  fixed, and re-review completed without further findings.

## Test plan

Passed locally:

- `mise test-datacrypto`
- `GOWORK=off go test -race ./...` in `pkg/datacrypto`
- `mise test-authling`
- `mise test-events`
- `mise test-natsruntime`
- `mise test-cli`
- focused race tests for Authling's consumer contract and Chatto encryption
- `go vet ./...` in `pkg/datacrypto`
- `mise license-check`
- `actionlint .github/workflows/ci.yml`
- Release Please JSON validation and `git diff --check`

