### PR TITLE
refactor(frontend): scope room state to server routes

### DIFF
--- a/apps/frontend/src/lib/state/server/scope.svelte.ts
+++ b/apps/frontend/src/lib/state/server/scope.svelte.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'svelte';
+import type { ServerConnection } from './serverConnection.svelte';
+import type { ServerStateStore } from './store.svelte';
+
+/** The URL-selected server resources owned by a `/chat/[serverId]` route subtree. */
+export interface ServerScope {
+  readonly serverId: string;
+  readonly connection: ServerConnection;
+  readonly store: ServerStateStore;
+}
+
+/** Access and provide the current route's reactive server scope. */
+export const [useServerScope, provideServerScope] = createContext<ServerScope>();

--- a/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
@@ -7,6 +7,7 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { provideConnection } from '$lib/state/server/connection.svelte';
+  import { provideServerScope, type ServerScope } from '$lib/state/server/scope.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { provideEventBus } from '$lib/eventBus.svelte';
   import Chrome from '$lib/components/chat/Chrome.svelte';
@@ -44,18 +45,32 @@
     }
   });
 
-  // The active instance context is provided by the root layout. We just
-  // override the parent's ConnectionProvider with the correct client for
-  // this instance — origin paths get the origin client; hostname paths get
-  // that instance's client.
-  provideConnection(() => serverConnectionManager.getClient(serverId));
+  // Keep all server-owned resources behind one route-scoped context. Getter
+  // properties preserve reactivity when SvelteKit reuses this layout for a
+  // different `[serverId]` parameter.
+  const serverScope: ServerScope = {
+    get serverId() {
+      return serverId;
+    },
+    get connection() {
+      return serverConnectionManager.getClient(serverId);
+    },
+    get store() {
+      return serverRegistry.getStore(serverId);
+    }
+  };
+  provideServerScope(serverScope);
+
+  // Preserve the narrower connection context for shared components outside
+  // the room route while ensuring it resolves through the same server scope.
+  provideConnection(() => serverScope.connection);
 
   // Provide the active server's event bus to child components via Svelte
   // context. Passing a getter (not a fixed serverId) means typed-event /
   // `onEvent` consumers below this point automatically migrate to the new
   // server's bus when the URL `[serverId]` param changes — the bus lookup
   // re-runs inside each consumer's `$effect`.
-  provideEventBus(getActiveServer);
+  provideEventBus(() => serverScope.serverId);
 
   // Auth guard: redirect unauthenticated users to /login and save the return URL.
   const currentUserState = $derived(serverStore?.currentUser);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/+layout.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { roomRouteAccess } from '$lib/navigation/roomLinkAccess';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import Room from './Room.svelte';
   import RoomJoinScreen from './RoomJoinScreen.svelte';
 
@@ -10,11 +9,12 @@
 
   let { roomId } = $derived(data);
 
-  const activeServerId = $derived(getActiveServer());
+  const serverScope = useServerScope();
+  const activeServerId = $derived(serverScope.serverId);
 
   // Wait for the active server projection to contain its viewer prefix before
   // treating room absence as authoritative.
-  const serverStore = $derived(serverRegistry.getStore(activeServerId));
+  const serverStore = $derived(serverScope.store);
   const navigation = $derived(serverStore.navigation);
   const ready = $derived(
     !navigation.isInitialLoading &&

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -5,10 +5,7 @@
   import { Virtualizer, type VirtualizerHandle } from 'virtua/svelte';
   import * as m from '$lib/i18n/messages';
   import { getLocale } from '$lib/i18n/runtime';
-  import {
-    isMessagePostedEvent,
-    type TimelineEventView
-  } from '$lib/render/timelineEvents';
+  import { isMessagePostedEvent, type TimelineEventView } from '$lib/render/timelineEvents';
   import type { MessagesStore, RoomMember } from '$lib/state/room';
   import { getComposerContext, getRoomPermissions } from '$lib/state/room';
   import RoomEvent from './RoomEvent.svelte';
@@ -20,8 +17,7 @@
   import { buildVirtualItems, type VirtualItem } from './virtualItems';
   import { findLastEditableMessage } from './lastEditableMessage';
   import { ScrollFader } from '$lib/ui';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { INITIAL_ROOM_MESSAGE_BACKFILL_TARGET } from '$lib/state/room/messages/queries';
   import { formatDayLabel } from '$lib/utils/formatTime';
@@ -233,9 +229,10 @@
 
   // Register finder for up-arrow-to-edit (computed on-demand, not reactively)
   const lastEditableMessageCtx = composerContext.lastEditableMessage;
-  const stores = serverRegistry.getStore(getActiveServer());
+  const serverScope = useServerScope();
+  const stores = $derived(serverScope.store);
   const currentUser = $derived(stores.currentUser);
-  const serverInfo = stores.serverInfo;
+  const serverInfo = $derived(stores.serverInfo);
   const roomPermissions = $derived(getRoomPermissions());
 
   $effect(() => {
@@ -318,11 +315,9 @@
         if (!(target instanceof HTMLElement)) continue;
 
         target.classList.add('highlight-flash');
-        target.addEventListener(
-          'animationend',
-          () => target.classList.remove('highlight-flash'),
-          { once: true }
-        );
+        target.addEventListener('animationend', () => target.classList.remove('highlight-flash'), {
+          once: true
+        });
 
         await new Promise((resolve) => setTimeout(resolve, 200));
         if (cancelled) return;
@@ -422,9 +417,7 @@
     if (pendingHighlightId) return;
 
     if (virtualItems.length > 0 && virtualizerHandle) {
-      const shouldScroll = untrack(
-        () => alwaysScrollToBottom || viewport.shouldScrollToBottom
-      );
+      const shouldScroll = untrack(() => alwaysScrollToBottom || viewport.shouldScrollToBottom);
       if (shouldScroll) {
         void requestBottomScroll();
       }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -34,6 +34,19 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
   }
 }));
 
+vi.mock('$lib/state/server/scope.svelte', async () => {
+  const { serverRegistry } = await import('$lib/state/server/registry.svelte');
+  return {
+    useServerScope: () => ({
+      serverId: 'server-1',
+      connection: {},
+      get store() {
+        return serverRegistry.getStore('server-1');
+      }
+    })
+  };
+});
+
 vi.mock('$lib/state/userProfiles.svelte', () => ({
   getLiveDisplayName: (_userId: string, fallback: string) => fallback,
   getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback,
@@ -277,7 +290,9 @@ describe('EventList localisation', () => {
         }
       });
 
-      await expect.element(page.getByText('Dies ist der Anfang dieser Unterhaltung.')).toBeVisible();
+      await expect
+        .element(page.getByText('Dies ist der Anfang dieser Unterhaltung.'))
+        .toBeVisible();
     } finally {
       setVirtualizerForcedRenderedIndex(null);
       await loadLocaleMessages('en-GB');

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -12,15 +12,14 @@
     type MessagesStore,
     type QuoteInsertionContent
   } from '$lib/state/room';
-  import { useConnection } from '$lib/state/server/connection.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
 
-  const stores = serverRegistry.getStore(getActiveServer());
-  const notificationStore = stores.notifications;
-  const serverInfo = stores.serverInfo;
-  const activeCallRooms = stores.activeCallRooms;
+  const serverScope = useServerScope();
+  const stores = $derived(serverScope.store);
+  const notificationStore = $derived(stores.notifications);
+  const serverInfo = $derived(stores.serverInfo);
+  const activeCallRooms = $derived(stores.activeCallRooms);
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import MessageHoverBar from './MessageHoverBar.svelte';
   import MessageAttachments from './MessageAttachments.svelte';
@@ -71,8 +70,9 @@
     onOpenThread?: OpenThreadHandler;
   } = $props();
 
-  const connection = useConnection();
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const connection = () => serverScope.connection;
+  const activeServerId = $derived(serverScope.serverId);
+  const currentUser = $derived(stores.currentUser);
   const roomPermissions = $derived(getRoomPermissions());
   const composerContext = getComposerContext();
   const replyState = composerContext.replyState;
@@ -130,7 +130,7 @@
     if (!msg) return;
 
     const params = {
-      serverId: getActiveServer(),
+      serverId: activeServerId,
       roomId,
       messageEventId: event.id,
       eventId: isEcho ? messageEvent!.echoOfEventId! : event.id,
@@ -238,12 +238,7 @@
     if (!event) return;
     e.preventDefault();
     e.stopPropagation();
-    await copyMessageLinkToClipboard(
-      getActiveServer(),
-      roomId,
-      event.id,
-      permalinkThreadRootEventId
-    );
+    await copyMessageLinkToClipboard(activeServerId, roomId, event.id, permalinkThreadRootEventId);
   }
 
   const isEdited = $derived(msg?.updatedAt != null);
@@ -502,7 +497,7 @@
     {#snippet compactLeading()}
       <a
         href={resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-          serverId: serverIdToSegment(getActiveServer()),
+          serverId: serverIdToSegment(activeServerId),
           roomId,
           messageId: event.id
         })}
@@ -536,7 +531,7 @@
     {#snippet headerMeta()}
       <a
         href={resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-          serverId: serverIdToSegment(getActiveServer()),
+          serverId: serverIdToSegment(activeServerId),
           roomId,
           messageId: event.id
         })}
@@ -552,7 +547,7 @@
     {#snippet afterBody()}
       <MessageAttachments
         attachments={msg.attachments ?? []}
-        serverId={getActiveServer()}
+        serverId={activeServerId}
         {roomId}
         eventId={isEcho ? messageEvent!.echoOfEventId! : event.id}
         canDeleteAttachment={isAuthor}
@@ -564,7 +559,7 @@
             preview={messageEvent.linkPreview}
             showDismiss={false}
             canDelete={isAuthor}
-            serverId={getActiveServer()}
+            serverId={activeServerId}
             {roomId}
             eventId={event.id}
           />
@@ -581,7 +576,7 @@
         <MessageMetaBar
           {roomId}
           messageEventId={event.id}
-          serverSegment={serverIdToSegment(getActiveServer())}
+          serverSegment={serverIdToSegment(activeServerId)}
           {threadRootEventId}
           reactions={msg?.reactions ?? []}
           replyCount={messageEvent?.replyCount}
@@ -604,7 +599,7 @@
     {#snippet actions()}
       {#if !isDeleted && canUseHoverActions}
         <MessageHoverBar
-          serverId={getActiveServer()}
+          serverId={activeServerId}
           {roomId}
           messageEventId={event.id}
           eventId={editEventId}
@@ -633,7 +628,7 @@
 
   <MessageUserOverlays
     interactions={userInteractions}
-    serverId={getActiveServer()}
+    serverId={activeServerId}
     {roomId}
     currentUserId={currentUser.user?.id}
     {canStartDMs}
@@ -643,7 +638,7 @@
   {#if !isDeleted}
     <MessageEventActionOverlays
       {interactions}
-      serverId={getActiveServer()}
+      serverId={activeServerId}
       {roomId}
       messageEventId={event.id}
       eventId={editEventId}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -107,13 +107,14 @@
   const roomMessageStore = $derived(stores.messagesForRoom(roomId));
 
   $effect(() => {
+    const mountedStores = stores;
     const selectedRoomId = roomId;
-    untrack(() => stores.restoreProjectedRoomWindow(selectedRoomId));
+    untrack(() => mountedStores.restoreProjectedRoomWindow(selectedRoomId));
     return () => {
       // Invalidate any historical-window request before this room becomes
       // inactive. Its late response must not replace the retained latest
       // projection while another room is being rendered.
-      untrack(() => stores.restoreProjectedRoomWindow(selectedRoomId));
+      untrack(() => mountedStores.restoreProjectedRoomWindow(selectedRoomId));
     };
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -29,12 +29,10 @@
   } from '$lib/state/room';
   import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import { getAppUiState } from '$lib/state/appUi.svelte';
-  import { useConnection } from '$lib/state/server/connection.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { clearLastRoom, setLastRoom } from '$lib/storage/lastRoom';
   import type { RoomSidebarPanel } from '$lib/storage/roomSidebarPanel';
   import { toast } from '$lib/ui/toast';
@@ -71,12 +69,14 @@
     routeMessageId
   }: { roomId: string; threadId?: string; routeMessageId?: string } = $props();
 
-  const connection = useConnection();
+  const serverScope = useServerScope();
+  const connection = () => serverScope.connection;
   const roomMembersStore = setRoomMembersStore(new RoomMembersStore(connection()));
-  const serverSegment = $derived(serverIdToSegment(getActiveServer()));
-  const stores = serverRegistry.getStore(getActiveServer());
+  const activeServerId = $derived(serverScope.serverId);
+  const serverSegment = $derived(serverIdToSegment(activeServerId));
+  const stores = $derived(serverScope.store);
   const roomFilesStore = $derived(stores.filesForRoom(roomId));
-  const serverInfo = stores.serverInfo;
+  const serverInfo = $derived(stores.serverInfo);
   const appUi = getAppUiState();
   const desktopRoomLayout = new MediaQuery('(min-width: 1024px)', false);
 
@@ -103,7 +103,7 @@
   const replyState = composerContext.replyState;
   let replyStateRoomId: string | null = null;
   const jumpState = composerContext.jumpState;
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const currentUser = $derived(stores.currentUser);
   const roomMessageStore = $derived(stores.messagesForRoom(roomId));
 
   $effect(() => {
@@ -119,7 +119,7 @@
 
   $effect(() =>
     onRoomMessageMutated((detail) => {
-      if (detail.serverId !== getActiveServer() || detail.roomId !== roomId) return;
+      if (detail.serverId !== activeServerId || detail.roomId !== roomId) return;
       if (detail.reason === 'message-deleted') {
         roomMessageStore.applyLocalMessageDeletion(detail.eventId);
         return;
@@ -162,7 +162,7 @@
   // back here in an infinite loop.
   $effect.pre(() => {
     if (room.roomData === null) {
-      clearLastRoom(getActiveServer());
+      clearLastRoom(activeServerId);
       goto(resolve('/chat/[serverId]', { serverId: serverSegment }), { replaceState: true });
     }
   });
@@ -183,7 +183,7 @@
   // the loaded room data to catch up to the current route before writing.
   $effect(() => {
     if (room.roomData?.room.id === roomId) {
-      setLastRoom(getActiveServer(), roomId);
+      setLastRoom(activeServerId, roomId);
     }
   });
 
@@ -295,7 +295,7 @@
   const isDesktopCallMaximized = $derived(
     activeRoomSidebarPanel === 'call' &&
       hasActiveRoomCall &&
-      appUi.isRoomCallWideFor(getActiveServer(), roomId)
+      appUi.isRoomCallWideFor(activeServerId, roomId)
   );
   const sharedRoomSidebarProps = $derived({
     roomId,
@@ -332,7 +332,7 @@
 
   const syncRoomCallWide: Attachment = () => {
     const active = hasActiveRoomCall;
-    const serverId = getActiveServer();
+    const serverId = activeServerId;
     const selectedRoomId = roomId;
     if (!active) {
       untrack(() => appUi.disableRoomCallWideFor(serverId, selectedRoomId));
@@ -351,7 +351,7 @@
 
   function toggleDesktopCallWide(): void {
     if (activeRoomSidebarPanel !== 'call' || !hasActiveRoomCall) return;
-    appUi.toggleRoomCallWide(getActiveServer(), roomId);
+    appUi.toggleRoomCallWide(activeServerId, roomId);
   }
 
   function openFileMessage(
@@ -497,7 +497,7 @@
                   pushState('', {
                     modal: {
                       type: 'leaveRoom',
-                      serverId: getActiveServer(),
+                      serverId: activeServerId,
                       roomId,
                       roomName: room.roomData!.room.name
                     }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import { q } from '$lib/test-utils';
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { RealtimeProjectionEvent } from '@chatto/api-types/realtime/v1/realtime_pb';
@@ -68,6 +69,7 @@ const { mocks } = vi.hoisted(() => {
       },
       messagesForRoom: vi.fn(),
       restoreProjectedRoomWindow: vi.fn(),
+      nextServerRestoreProjectedRoomWindow: vi.fn(),
       projectedMembersForRoom: vi.fn(() => []),
       hasCompleteProjectedRoomMembership: vi.fn(() => true),
       mentionRoles: {
@@ -77,6 +79,8 @@ const { mocks } = vi.hoisted(() => {
     }
   };
 });
+
+const scopeState = new SvelteMap([['serverId', 'server-1']]);
 
 vi.mock('$app/state', () => ({
   page: {
@@ -171,12 +175,14 @@ vi.mock('$lib/state/server/scope.svelte', async () => {
   ]);
   return {
     useServerScope: () => ({
-      serverId: 'server-1',
+      get serverId() {
+        return scopeState.get('serverId')!;
+      },
       get connection() {
         return useConnection()();
       },
       get store() {
-        return serverRegistry.getStore('server-1');
+        return serverRegistry.getStore(scopeState.get('serverId')!);
       }
     })
   };
@@ -192,7 +198,7 @@ vi.mock('$lib/api-client/roomTimeline', async (importActual) => {
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
-    getStore: () => ({
+    getStore: (serverId: string) => ({
       currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
       serverInfo: {
         livekitUrl: mocks.livekitUrl,
@@ -213,7 +219,10 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
       mentionRoles: mocks.mentionRoles,
       messagesForRoom: mocks.messagesForRoom,
       filesForRoom: () => ({ retain: mocks.roomFilesRetain }),
-      restoreProjectedRoomWindow: mocks.restoreProjectedRoomWindow,
+      restoreProjectedRoomWindow:
+        serverId === 'server-2'
+          ? mocks.nextServerRestoreProjectedRoomWindow
+          : mocks.restoreProjectedRoomWindow,
       projectedMembersForRoom: mocks.projectedMembersForRoom,
       hasCompleteProjectedRoomMembership: mocks.hasCompleteProjectedRoomMembership
     }),
@@ -400,10 +409,27 @@ beforeEach(() => {
   mocks.notifications.dismissMentionNotifications.mockResolvedValue({ byRoom: {} });
   mocks.notifications.dismissRoomReplyNotifications.mockResolvedValue({ byRoom: {} });
   mocks.notifications.dismissRoomMessageNotifications.mockResolvedValue({ byRoom: {} });
+  scopeState.set('serverId', 'server-1');
   stubMatchMedia(true);
 });
 
 describe('Room interaction bundles', () => {
+  it('restores projected windows through the store that mounted them', async () => {
+    const rendered = render(Room, { props: { roomId: 'room-1' } });
+
+    await vi.waitFor(() => expect(mocks.restoreProjectedRoomWindow).toHaveBeenCalledOnce());
+
+    scopeState.set('serverId', 'server-2');
+
+    await vi.waitFor(() =>
+      expect(mocks.nextServerRestoreProjectedRoomWindow).toHaveBeenCalledOnce()
+    );
+    expect(mocks.restoreProjectedRoomWindow).toHaveBeenCalledTimes(2);
+
+    rendered.unmount();
+    expect(mocks.nextServerRestoreProjectedRoomWindow).toHaveBeenCalledTimes(2);
+  });
+
   it('does not load thread or sidebar panes for the default room view', async () => {
     render(Room, { props: { roomId: 'room-1' } });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -164,6 +164,24 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   })
 }));
 
+vi.mock('$lib/state/server/scope.svelte', async () => {
+  const [{ useConnection }, { serverRegistry }] = await Promise.all([
+    import('$lib/state/server/connection.svelte'),
+    import('$lib/state/server/registry.svelte')
+  ]);
+  return {
+    useServerScope: () => ({
+      serverId: 'server-1',
+      get connection() {
+        return useConnection()();
+      },
+      get store() {
+        return serverRegistry.getStore('server-1');
+      }
+    })
+  };
+});
+
 vi.mock('$lib/api-client/roomTimeline', async (importActual) => {
   const actual = await importActual<typeof import('$lib/api-client/roomTimeline')>();
   return {
@@ -205,7 +223,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
 }));
 
 vi.mock('$lib/state/activeServer.svelte', () => ({
-  getActiveServer: () => 'server-1'
+  getActiveServer: () => 'wrong-server'
 }));
 
 vi.mock('$lib/state/globals.svelte', () => ({

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomJoinScreen.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomJoinScreen.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import * as m from '$lib/i18n/messages';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { Button } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast';
   import PageTitle from '$lib/ui/PageTitle.svelte';
@@ -17,8 +16,8 @@
     serverSegment: string;
   } = $props();
 
-  const activeServerId = $derived(getActiveServer());
-  const stores = $derived(serverRegistry.getStore(activeServerId));
+  const serverScope = useServerScope();
+  const stores = $derived(serverScope.store);
   const overviewPath = $derived(resolve('/chat/[serverId]', { serverId: serverSegment }));
   const title = $derived(`#${room.name}`);
   let joining = $state(false);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -27,13 +27,11 @@ calls, and similar room-specific panels can plug into the same shell. See the
     getLiveLogin
   } from '$lib/state/userProfiles.svelte';
   import { getServerPermissions } from '$lib/state/server/permissions.svelte';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import ResizeHandle from '$lib/components/ResizeHandle.svelte';
   import { roomSidebarWidth } from '$lib/state/roomSidebarWidth.svelte';
-  import { useConnection } from '$lib/state/server/connection.svelte';
   import { ROOM_SIDEBAR_MAX_WIDTH, ROOM_SIDEBAR_MIN_WIDTH } from '$lib/storage/roomSidebarWidth';
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import { toast } from '$lib/ui/toast';
@@ -78,10 +76,11 @@ calls, and similar room-specific panels can plug into the same shell. See the
     onClose?: () => void;
   } = $props();
 
-  const connection = useConnection();
+  const serverScope = useServerScope();
+  const connection = () => serverScope.connection;
   const presenceCache = getPresenceCache();
-  const activeServerId = $derived(getActiveServer());
-  const activeCallRooms = serverRegistry.getStore(getActiveServer()).activeCallRooms;
+  const activeServerId = $derived(serverScope.serverId);
+  const activeCallRooms = $derived(serverScope.store.activeCallRooms);
 
   const members = $derived(membersStore.filteredMembers);
   const allMembers = $derived(membersStore.members);
@@ -345,7 +344,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
             label={m['room.sidebar.online']({ count: onlineMembers.length })}
             items={onlineMembers}
             item={memberRow}
-            persistKey={serverStorageKey(getActiveServer(), 'collapsible:room-members:online')}
+            persistKey={serverStorageKey(activeServerId, 'collapsible:room-members:online')}
           />
         {/if}
 
@@ -354,7 +353,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
             label={m['room.sidebar.offline']({ count: offlineMembers.length })}
             items={offlineMembers}
             item={memberRow}
-            persistKey={serverStorageKey(getActiveServer(), 'collapsible:room-members:offline')}
+            persistKey={serverStorageKey(activeServerId, 'collapsible:room-members:offline')}
             defaultCollapsed
             class="mt-4"
           />
@@ -368,7 +367,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
           canSendMessage={canStartDMs}
           canBanFromRoom={canRemovePopoverMember}
           banningFromRoom={banningMemberId === popoverMember.id}
-          onSendMessage={() => startDMWith(getActiveServer(), popoverMember!.id)}
+          onSendMessage={() => startDMWith(activeServerId, popoverMember!.id)}
           onBanFromRoom={() => openBanDialog(popoverMember!)}
           onClose={closePopover}
         />
@@ -376,12 +375,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
     </nav>
   {:else if activePanel === 'files'}
     {#if filesStore}
-      <RoomFilesPanel
-        store={filesStore}
-        serverId={getActiveServer()}
-        {fileGroupingNow}
-        {onOpenFile}
-      />
+      <RoomFilesPanel store={filesStore} serverId={activeServerId} {fileGroupingNow} {onOpenFile} />
     {:else}
       <div class="flex min-h-0 flex-1 items-center justify-center p-4 text-sm text-muted">
         {m['room.sidebar.no_files']()}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -135,6 +135,24 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   })
 }));
 
+vi.mock('$lib/state/server/scope.svelte', async () => {
+  const [{ useConnection }, { serverRegistry }] = await Promise.all([
+    import('$lib/state/server/connection.svelte'),
+    import('$lib/state/server/registry.svelte')
+  ]);
+  return {
+    useServerScope: () => ({
+      serverId: 'test-server',
+      get connection() {
+        return useConnection()();
+      },
+      get store() {
+        return serverRegistry.getStore('test-server');
+      }
+    })
+  };
+});
+
 vi.mock('$lib/api-client/attachments', async (importActual) => ({
   ...(await importActual<typeof import('$lib/api-client/attachments')>()),
   createAttachmentAPI: vi.fn(() => ({

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -67,12 +67,13 @@
   // pane renders them. Ref-count the stable selector so closing or switching
   // a pane releases its store instead of retaining every thread ever opened.
   $effect(() => {
+    const mountedStores = stores;
     const mountedStore = store;
     const mountedRoomId = roomId;
     const mountedThreadRootEventId = threadRootEventId;
-    stores.retainMessagesForThread(mountedRoomId, mountedThreadRootEventId, mountedStore);
+    mountedStores.retainMessagesForThread(mountedRoomId, mountedThreadRootEventId, mountedStore);
     return () =>
-      stores.releaseMessagesForThread(mountedRoomId, mountedThreadRootEventId, mountedStore);
+      mountedStores.releaseMessagesForThread(mountedRoomId, mountedThreadRootEventId, mountedStore);
   });
 
   $effect(() =>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -2,9 +2,7 @@
   import { fly } from 'svelte/transition';
   import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
   import { useProjectionEvent, createTypingIndicator, useUnreadMarker } from '$lib/hooks';
-  import { useConnection } from '$lib/state/server/connection.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { isMessagePostedEvent } from '$lib/render/timelineEvents';
   import * as m from '$lib/i18n/messages';
   import { dropZone } from '$lib/attachments/dropZone.svelte';
@@ -56,11 +54,13 @@
     onReplyConsumed?: () => void;
   } = $props();
 
-  const connection = useConnection();
+  const serverScope = useServerScope();
+  const connection = () => serverScope.connection;
+  const activeServerId = $derived(serverScope.serverId);
   const members = $derived(getRoomMembers());
-  const currentUser = $derived(serverRegistry.getStore(getActiveServer()).currentUser);
+  const stores = $derived(serverScope.store);
+  const currentUser = $derived(stores.currentUser);
 
-  const stores = serverRegistry.getStore(getActiveServer());
   const store = $derived(stores.messagesForThread(roomId, threadRootEventId));
 
   // Thread timelines contain decrypted history and are useful only while a
@@ -77,7 +77,7 @@
 
   $effect(() =>
     onRoomMessageMutated((detail) => {
-      if (detail.serverId !== getActiveServer() || detail.roomId !== roomId) return;
+      if (detail.serverId !== activeServerId || detail.roomId !== roomId) return;
       if (detail.reason === 'message-deleted') {
         store.applyLocalMessageDeletion(detail.eventId);
         return;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -82,6 +82,24 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
   })
 }));
 
+vi.mock('$lib/state/server/scope.svelte', async () => {
+  const [{ useConnection }, { serverRegistry }] = await Promise.all([
+    import('$lib/state/server/connection.svelte'),
+    import('$lib/state/server/registry.svelte')
+  ]);
+  return {
+    useServerScope: () => ({
+      serverId: 'server-1',
+      get connection() {
+        return useConnection()();
+      },
+      get store() {
+        return serverRegistry.getStore('server-1');
+      }
+    })
+  };
+});
+
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     getStore: () => ({

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { SvelteMap } from 'svelte/reactivity';
 import { q } from '$lib/test-utils';
 import { TimelineEventKind } from '$lib/render/timelineEvents';
 import ThreadPane from './ThreadPane.svelte';
@@ -14,6 +15,8 @@ const { mocks } = vi.hoisted(() => {
       setThread: vi.fn(),
       retainMessagesForThread: vi.fn(),
       releaseMessagesForThread: vi.fn(),
+      nextServerRetainMessagesForThread: vi.fn(),
+      nextServerReleaseMessagesForThread: vi.fn(),
       disposeMessagesStore: vi.fn(),
       ingestEvent: vi.fn(),
       refreshCurrentWindow: vi.fn(),
@@ -34,10 +37,13 @@ const { mocks } = vi.hoisted(() => {
       appState: {
         isPresent: true
       },
-      threadStore: null as ThreadPaneTestStore | null
+      threadStore: null as ThreadPaneTestStore | null,
+      nextServerThreadStore: null as ThreadPaneTestStore | null
     }
   };
 });
+
+const scopeState = new SvelteMap([['serverId', 'server-1']]);
 
 vi.mock('$lib/api-client/readState', () => ({
   createReadStateAPI: () => ({
@@ -89,12 +95,14 @@ vi.mock('$lib/state/server/scope.svelte', async () => {
   ]);
   return {
     useServerScope: () => ({
-      serverId: 'server-1',
+      get serverId() {
+        return scopeState.get('serverId')!;
+      },
       get connection() {
         return useConnection()();
       },
       get store() {
-        return serverRegistry.getStore('server-1');
+        return serverRegistry.getStore(scopeState.get('serverId')!);
       }
     })
   };
@@ -102,13 +110,19 @@ vi.mock('$lib/state/server/scope.svelte', async () => {
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
-    getStore: () => ({
+    getStore: (serverId: string) => ({
       currentUser: { user: { id: 'test-user', login: 'testuser' }, loading: false },
       notifications: mocks.notifications,
-      retainMessagesForThread: mocks.retainMessagesForThread,
-      releaseMessagesForThread: mocks.releaseMessagesForThread,
+      retainMessagesForThread:
+        serverId === 'server-2'
+          ? mocks.nextServerRetainMessagesForThread
+          : mocks.retainMessagesForThread,
+      releaseMessagesForThread:
+        serverId === 'server-2'
+          ? mocks.nextServerReleaseMessagesForThread
+          : mocks.releaseMessagesForThread,
       messagesForThread: () =>
-        Object.assign(mocks.threadStore!, {
+        Object.assign(serverId === 'server-2' ? mocks.nextServerThreadStore! : mocks.threadStore!, {
           isLoadingMore: false,
           hasReachedStart: true,
           setThread: mocks.setThread,
@@ -185,6 +199,8 @@ describe('ThreadPane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.threadStore = new ThreadPaneTestStore();
+    mocks.nextServerThreadStore = new ThreadPaneTestStore();
+    scopeState.set('serverId', 'server-1');
     mocks.appState.isPresent = true;
     mocks.unreadMarkerEventId = null;
     mocks.markThreadAsRead.mockResolvedValue({
@@ -265,6 +281,37 @@ describe('ThreadPane', () => {
       'room-1',
       'thread-root',
       mountedStore
+    );
+  });
+
+  it('releases decrypted thread history through its owning server store', async () => {
+    const rendered = render(ThreadPane, {
+      props: {
+        roomId: 'room-1',
+        roomName: 'General',
+        threadRootEventId: 'thread-root',
+        onClose: mocks.onClose
+      }
+    });
+
+    await vi.waitFor(() => expect(mocks.retainMessagesForThread).toHaveBeenCalledOnce());
+    const firstServerStore = mocks.threadStore;
+
+    scopeState.set('serverId', 'server-2');
+
+    await vi.waitFor(() => expect(mocks.nextServerRetainMessagesForThread).toHaveBeenCalledOnce());
+    expect(mocks.releaseMessagesForThread).toHaveBeenCalledWith(
+      'room-1',
+      'thread-root',
+      firstServerStore
+    );
+    expect(mocks.nextServerReleaseMessagesForThread).not.toHaveBeenCalled();
+
+    rendered.unmount();
+    expect(mocks.nextServerReleaseMessagesForThread).toHaveBeenCalledWith(
+      'room-1',
+      'thread-root',
+      mocks.nextServerThreadStore
     );
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/m/[messageId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/m/[messageId]/+page.svelte
@@ -8,10 +8,7 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { TimelineEventKind } from '$lib/render/timelineEvents';
-  import {
-    createRoomTimelineAPI,
-    type RoomTimelineAPI
-  } from '$lib/api-client/roomTimeline';
+  import { createRoomTimelineAPI, type RoomTimelineAPI } from '$lib/api-client/roomTimeline';
   import type { PendingHighlightStore } from '$lib/state/server/pendingHighlight.svelte';
 
   /**
@@ -67,12 +64,10 @@
 
 <script lang="ts">
   import { page } from '$app/state';
-  import { useConnection } from '$lib/state/server/connection.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
 
-  const connection = useConnection();
-  const stores = $derived(serverRegistry.getStore(getActiveServer()));
+  const serverScope = useServerScope();
+  const stores = $derived(serverScope.store);
 
   // Wait for the active server projection to settle before redirecting,
   // so a deep-link to a DM doesn't briefly resolve as a missing channel
@@ -82,7 +77,7 @@
   $effect(() => {
     if (navigation.isInitialLoading) return;
     resolveAndRedirect(
-      connection().getAPI(createRoomTimelineAPI),
+      serverScope.connection.getAPI(createRoomTimelineAPI),
       stores.pendingHighlights,
       page.params.serverId!,
       page.params.roomId!,

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/room-route.layout.svelte.spec.ts
@@ -92,6 +92,19 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
   }
 }));
 
+vi.mock('$lib/state/server/scope.svelte', async () => {
+  const { serverRegistry } = await import('$lib/state/server/registry.svelte');
+  return {
+    useServerScope: () => ({
+      serverId: 'origin',
+      connection: {},
+      get store() {
+        return serverRegistry.getStore('origin');
+      }
+    })
+  };
+});
+
 vi.mock('$lib/ui/toast', () => ({
   toast: {
     success: mocks.toastSuccess,


### PR DESCRIPTION
## Why

Room UI code repeatedly rediscovered the URL-selected server through the global
active-server helper and then looked up its connection and state store
independently. That duplicated route ownership across message, thread, sidebar,
join, and deep-link code and made cross-server consistency harder to reason
about.

## What changed

- add a typed, reactive server scope owned by the `/chat/[serverId]` layout
- resolve the existing connection and event-bus contexts through that same
  route scope
- migrate the complete room route subtree to consume scoped server identity,
  connection, and state instead of global lookups
- preserve SvelteKit route reuse with getter-backed scope values and keep the
  room keyed by server identity
- bind projected-window and decrypted-thread teardown to the server store that
  originally mounted each resource
- extend component fixtures so a deliberately incorrect global active server
  cannot silently satisfy scoped room behavior, including two-server lifecycle
  coverage

This is a frontend-only ownership refactor. It does not change rendered UI,
copy, backend APIs, persistence, permissions, or multi-server routing behavior.

## Test plan

- `mise lint-frontend` — passed with 0 Svelte errors and 0 warnings
- focused room route suite — 5 files and 93 tests passed
- `mise test-frontend` — 308 files and 2,593 tests passed
- `mise build-frontend` — production build and all bundle budgets passed
- Svelte autofixer — no issues in changed components/modules
- `mise license-check` — passed
- `mise knip` — passed
