### PR TITLE
fix(calls): restore missed DM call indicators

### DIFF
--- a/apps/frontend/e2e/voice-call.spec.ts
+++ b/apps/frontend/e2e/voice-call.spec.ts
@@ -457,6 +457,48 @@ test.describe('Voice calls', () => {
     });
   });
 
+  test('active-call icon appears when the DM participant opens Chatto after the call starts', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    const userB = await createAndLoginTestUser(page);
+    await chatPage.goto();
+
+    await withServerUser(browser!, serverURL, async ({ page: page2, user: userA }) => {
+      const roomA = await new DMPage(page2).startConversation(userB.login);
+      await roomA.sendMessage(`seed offline DM call indicator ${Date.now()}`);
+      const { roomId } = await getIdsFromUrlViaConnect(page2);
+
+      await expect(new DMPage(page).getConversation(userA.displayName)).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await page.close();
+
+      const joinResponse = await page2.request.post('/webhooks/test/call-join', {
+        data: {
+          spaceId: 'DM',
+          roomId,
+          userId: userA.id,
+          displayName: userA.displayName,
+          login: userA.login
+        }
+      });
+      expect(joinResponse.ok()).toBe(true);
+
+      const reopenedPage = await page.context().newPage();
+      await reopenedPage.goto('/chat');
+
+      const dmRow = new DMPage(reopenedPage).getConversation(userA.displayName);
+      await expect(dmRow).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(dmRow.getByTestId('room-call-icon')).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await expect(dmRow.getByTestId('room-call-participants')).toBeVisible();
+    });
+  });
+
   test('livekitUrl is exposed in instance info', async ({ page, chatPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -4561,6 +4561,40 @@ func TestVoiceCallServiceRecordsAndListsCalls(t *testing.T) {
 	}
 }
 
+func TestVoiceCallServiceListsActiveDMCalls(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	ctx := withCaller(env.ctx, env.viewer)
+	env.api.config.LiveKit = config.LiveKitConfig{
+		Enabled:   true,
+		URL:       "ws://livekit.test",
+		APIKey:    "test-key",
+		APISecret: "test-secret",
+		ServerID:  "test-server",
+	}
+
+	participant, err := env.core.CreateUser(env.ctx, core.SystemActorID, "voice-dm-participant", "Voice DM Participant", "password")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	dm, _, err := env.core.FindOrCreateDM(env.ctx, env.viewer.Id, []string{participant.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	if _, err := env.voice.JoinCall(ctx, connect.NewRequest(&apiv1.JoinCallRequest{
+		RoomId: dm.Id,
+	})); err != nil {
+		t.Fatalf("JoinCall: %v", err)
+	}
+
+	activeResp, err := env.voice.ListActiveCalls(ctx, connect.NewRequest(&apiv1.ListActiveCallsRequest{}))
+	if err != nil {
+		t.Fatalf("ListActiveCalls: %v", err)
+	}
+	if calls := activeResp.Msg.GetCalls(); len(calls) != 1 || calls[0].GetRoom().GetId() != dm.Id || calls[0].GetCallId() == "" {
+		t.Fatalf("active calls = %v, want one call for DM %s", calls, dm.Id)
+	}
+}
+
 func TestVoiceCallServiceRoomRemovalClearsCallParticipant(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	ctx := withCaller(env.ctx, env.viewer)

--- a/cli/internal/connectapi/voice_calls.go
+++ b/cli/internal/connectapi/voice_calls.go
@@ -26,7 +26,7 @@ func (s *voiceCallService) ListActiveCalls(ctx context.Context, _ *connect.Reque
 		return connect.NewResponse(&apiv1.ListActiveCallsResponse{}), nil
 	}
 
-	roomIDs, err := s.api.core.GetActiveCallRoomIDs(ctx, core.LegacySpaceIDForRoomKind(core.KindChannel))
+	roomIDs, err := s.api.core.GetActiveCallRoomIDs(ctx)
 	if err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/core/voice.go
+++ b/cli/internal/core/voice.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"time"
 
@@ -219,24 +218,11 @@ func (c *ChattoCore) GetCallParticipants(ctx context.Context, spaceID, roomID st
 	return c.CallState.Participants(roomID), nil
 }
 
-// GetActiveCallRoomIDs returns the room IDs in a space that have active voice calls.
+// GetActiveCallRoomIDs returns every room ID that has an active voice call.
 // Reads from the call-state projection, not MEMORY_CACHE.
-// Authorization: Caller must verify space membership before calling.
-func (c *ChattoCore) GetActiveCallRoomIDs(ctx context.Context, spaceID string) ([]string, error) {
-	kind := RoomKindFromLegacySpaceID(spaceID)
-	roomIDs := c.CallState.ActiveRoomIDs()
-	if c.RoomCatalog == nil {
-		return roomIDs, nil
-	}
-	filtered := make([]string, 0, len(roomIDs))
-	for _, roomID := range roomIDs {
-		room, ok := c.RoomCatalog.Get(roomID)
-		if !ok || KindOfRoom(room) == kind {
-			filtered = append(filtered, roomID)
-		}
-	}
-	sort.Strings(filtered)
-	return filtered, nil
+// Authorization: Caller must filter the result to rooms visible to the viewer.
+func (c *ChattoCore) GetActiveCallRoomIDs(context.Context) ([]string, error) {
+	return c.CallState.ActiveRoomIDs(), nil
 }
 
 func appendCallJoinedEventForTest(ctx context.Context, publisher *events.Publisher, projector *events.Projector, roomID, userID string, source corev1.CallParticipantEventSource) error {


### PR DESCRIPTION
## Why

Users who open Chatto after another participant starts a DM call should see the active-call indicator instead of having to start the call themselves.

## What changed

Make `ListActiveCalls` consider every active room before applying its existing per-viewer membership filter, and add focused ConnectRPC plus browser regressions for the offline-recipient DM scenario.

## API compatibility

- Behavioural change; this corrects an existing endpoint without changing its wire format.

Older client → newer server: existing 0.4 clients now discover active DM calls during startup.

Newer client → older server: the older server continues to omit DM calls from startup discovery.

Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- go test ./internal/core ./internal/connectapi -timeout 120s`
- `mise x -- pnpm --filter chatto-frontend exec playwright test voice-call.spec.ts`
- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/RoomList.svelte --svelte-version 5`
