### PR TITLE
feat(appconfig): extract shared configuration loading

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -21,7 +21,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/go/pkg/mod
-        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/datacrypto/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum') }}
+        key: go-mod-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/appconfig/go.sum', 'pkg/datacrypto/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum') }}
         restore-keys: |
           go-mod-${{ runner.os }}-${{ runner.arch }}-
 
@@ -30,7 +30,7 @@ runs:
       uses: actions/cache@v5
       with:
         path: ~/.cache/go-build
-        key: go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/datacrypto/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum', 'cli/**/*.go', 'authling/**/*.go', 'pkg/datacrypto/**/*.go', 'pkg/events/**/*.go', 'pkg/natsruntime/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'package.json', 'pnpm-lock.yaml', 'apps/frontend/package.json', 'apps/frontend/src/**', 'apps/frontend/static/**', 'apps/frontend/svelte.config.js', 'apps/frontend/tsconfig.json', 'apps/frontend/vite.config.ts', 'mise.toml') }}
+        key: go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cli/go.sum', 'authling/go.sum', 'pkg/appconfig/go.sum', 'pkg/datacrypto/go.sum', 'pkg/events/go.sum', 'pkg/natsruntime/go.sum', 'go.work.sum', 'cli/**/*.go', 'authling/**/*.go', 'pkg/appconfig/**/*.go', 'pkg/datacrypto/**/*.go', 'pkg/events/**/*.go', 'pkg/natsruntime/**/*.go', 'proto/**/*.go', 'proto/**/*.proto', 'package.json', 'pnpm-lock.yaml', 'apps/frontend/package.json', 'apps/frontend/src/**', 'apps/frontend/static/**', 'apps/frontend/svelte.config.js', 'apps/frontend/tsconfig.json', 'apps/frontend/vite.config.ts', 'mise.toml') }}
         restore-keys: |
           go-build-${{ github.job }}-${{ runner.os }}-${{ runner.arch }}-
           go-build-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,9 @@ jobs:
       - name: Run Authling tests
         run: mise test-authling
 
+      - name: Run application configuration tests
+        run: mise test-appconfig
+
       - name: Run data cryptography tests
         run: mise test-datacrypto
 

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -18,6 +18,7 @@
       "changelog-path": "CHANGELOG.md",
       "exclude-paths": [
         "authling",
+        "pkg/appconfig",
         "pkg/datacrypto",
         "pkg/events",
         "pkg/natsruntime",
@@ -48,6 +49,16 @@
           "path": "version.go"
         }
       ]
+    },
+    "pkg/appconfig": {
+      "release-type": "go",
+      "package-name": "appconfig",
+      "component": "pkg/appconfig",
+      "changelog-path": "CHANGELOG.md",
+      "initial-version": "0.1.0-alpha.1",
+      "draft": false,
+      "include-component-in-tag": true,
+      "tag-separator": "/"
     },
     "pkg/datacrypto": {
       "release-type": "go",

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,6 +1,7 @@
 {
   ".": "0.4.8",
   "authling": "0.0.0",
+  "pkg/appconfig": "0.0.0",
   "pkg/datacrypto": "0.0.0",
   "pkg/events": "0.0.0",
   "pkg/natsruntime": "0.0.0"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,9 +14,10 @@ framework boundary:
 - **Authling** is the independent identity-provider product under `authling/`.
   It is not a Chatto component, runtime unit, feature, or deployment mode.
 - **Shared framework code** is application-neutral event-sourcing, embedded
-  NATS, and data-cryptography machinery intended for consumption by both
-  products. The independently versioned but unstable modules live under
-  `pkg/events/`, `pkg/natsruntime/`, and `pkg/datacrypto/`.
+  NATS, data-cryptography, and configuration-loading machinery intended for
+  consumption by both products. The independently versioned but unstable
+  modules live under `pkg/events/`, `pkg/natsruntime/`, `pkg/datacrypto/`, and
+  `pkg/appconfig/`.
 
 Authling's presence in this repository is explicitly temporary. It is being
 incubated here only while Authling provides the concrete second application
@@ -50,8 +51,8 @@ or repository-wide work. Follow these routing rules:
 5. A shared-framework change must read both `cli/AGENTS.md` and
    `authling/AGENTS.md`, the target module's `AGENTS.md`, ADR-057, and the
    module-specific ADR: ADR-056 for `pkg/events`, ADR-058 for
-   `pkg/natsruntime`, or ADR-060 for `pkg/datacrypto`. Shared packages must not
-   import either product's domain,
+   `pkg/natsruntime`, ADR-060 for `pkg/datacrypto`, or ADR-061 for
+   `pkg/appconfig`. Shared packages must not import either product's domain,
    configuration, protobuf envelopes, subjects, resource names, or lifecycle
    policy.
 6. Cross-product decisions may be recorded in root ADRs. Product-specific
@@ -87,6 +88,8 @@ permission to reorganize unrelated product code.
   lifecycle module boundary and verification rules.
 - [pkg/datacrypto/AGENTS.md](pkg/datacrypto/AGENTS.md) — shared authenticated
   encryption and key-wrapping boundary and verification rules.
+- [pkg/appconfig/AGENTS.md](pkg/appconfig/AGENTS.md) — shared TOML and
+  environment configuration-loading boundary and verification rules.
 - [cli/AGENTS.md](cli/AGENTS.md) — Go backend, ConnectRPC, NATS/JetStream, authz, live events, backup/restore, and backend tests.
 - [apps/frontend/AGENTS.md](apps/frontend/AGENTS.md) — SvelteKit frontend, Tailwind, i18n, browser verification, frontend tests, e2e, and Storybook.
 - [proto/AGENTS.md](proto/AGENTS.md) — protobuf and generated public API reference guidance.
@@ -155,6 +158,7 @@ mise test-cli
 mise test-events
 mise test-natsruntime
 mise test-datacrypto
+mise test-appconfig
 mise test-frontend
 mise test-e2e
 mise build-authling
@@ -291,10 +295,10 @@ leave a dev stack running in a detached or yielded terminal session.
 - Files are AGPL-3.0-or-later by default unless `REUSE.toml`, an SPDX header,
   or an adjacent `.license` file says otherwise.
 - Apache-2.0 applies to the independently versioned shared framework modules
-  under `pkg/events/`, `pkg/natsruntime/`, and `pkg/datacrypto/`, plus explicit
-  integration and documentation surfaces such as the standalone frontend
-  source and image, public protocol/API definitions, generated TypeScript API
-  clients, documentation, and examples.
+  under `pkg/events/`, `pkg/natsruntime/`, `pkg/datacrypto/`, and
+  `pkg/appconfig/`, plus explicit integration and documentation surfaces such
+  as the standalone frontend source and image, public protocol/API definitions,
+  generated TypeScript API clients, documentation, and examples.
 - The Chatto server, CLI, and bundled server release artifacts should stay
   AGPL-3.0-or-later unless the license boundary is deliberately changed.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -10,10 +10,11 @@ CLI, and bundled server release artifacts unless a more specific license is
 declared.
 
 Apache-2.0 exceptions are used where permissive reuse is intentional. These
-include the independently versioned `pkg/events`, `pkg/natsruntime`, and
-`pkg/datacrypto` shared framework modules, the standalone frontend source and
-image, public protocol/API definitions, generated TypeScript API client/types,
-documentation, and deployment examples. The shared modules remain explicitly
-pre-1.0; their permissive license does not imply API stability.
+include the independently versioned `pkg/events`, `pkg/natsruntime`,
+`pkg/datacrypto`, and `pkg/appconfig` shared framework modules, the standalone
+frontend source and image, public protocol/API definitions, generated
+TypeScript API client/types, documentation, and deployment examples. The
+shared modules remain explicitly pre-1.0; their permissive license does not
+imply API stability.
 
 Full license texts are available in [LICENSE](LICENSE) and [LICENSES/](LICENSES/).

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ This repository temporarily incubates the early
 and released independently from Chatto and is intended to move to its own
 repository once it no longer needs frequent atomic changes with the shared
 [event-sourcing framework](pkg/events/README.md),
-[embedded NATS runtime](pkg/natsruntime/README.md), and
-[data-cryptography primitives](pkg/datacrypto/README.md).
+[embedded NATS runtime](pkg/natsruntime/README.md),
+[data-cryptography primitives](pkg/datacrypto/README.md), and
+[application-configuration loader](pkg/appconfig/README.md).
 
 ## License
 

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,6 +20,7 @@ path = [
   "examples/**",
   "LICENSING.md",
   "packages/api-types/**",
+  "pkg/appconfig/**",
   "pkg/datacrypto/**",
   "pkg/events/**",
   "pkg/natsruntime/**",
@@ -51,6 +52,7 @@ SPDX-License-Identifier = "AGPL-3.0-or-later"
 [[annotations]]
 path = [
   "pkg/events/LICENSE",
+  "pkg/appconfig/LICENSE",
   "pkg/datacrypto/LICENSE",
   "pkg/natsruntime/LICENSE",
 ]

--- a/authling/AGENTS.md
+++ b/authling/AGENTS.md
@@ -55,7 +55,10 @@ to its own repository.
   generic event-sourcing mechanics,
   `hmans.de/chatto/pkg/natsruntime` owns embedded NATS lifecycle mechanics, and
   `hmans.de/chatto/pkg/datacrypto` owns raw XChaCha20-Poly1305 and 256-bit key
-  wrapping primitives; Authling owns its associated data and key hierarchy.
+  wrapping primitives. `hmans.de/chatto/pkg/appconfig` owns TOML and
+  environment loading mechanics. Authling owns its associated data, key
+  hierarchy, configuration schema, environment names, defaults, and
+  validation.
   Authling should consume them only for concrete use cases. Each product owns
   its event vocabulary, storage coordinates, identity formats, configuration,
   policy, and composition.
@@ -68,6 +71,8 @@ to its own repository.
   [ADR-058](../docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md).
   Data-cryptography changes additionally follow
   [ADR-060](../docs/adr/ADR-060-application-neutral-data-cryptography.md).
+  Configuration-loading changes additionally follow
+  [ADR-061](../docs/adr/ADR-061-application-neutral-configuration-loading.md).
 - Keep Authling independently buildable and testable from its module directory.
   The root `go.work` is a development convenience, not permission to blur module
   dependencies.

--- a/authling/TODO.md
+++ b/authling/TODO.md
@@ -10,7 +10,6 @@ current runtime in `docs/architecture/`.
 - [ ] Define Authling's initial product milestone
 - [ ] Establish canonical identity, application, client, account, and document terminology
 - [ ] Extract the application-neutral KMS, wrapped-key storage, key-cache, and durable-erasure mechanics Authling needs
-- [ ] Evaluate extracting the shared TOML and environment configuration mechanics
 - [ ] Add standalone diagnostics and backup behavior
 
 ## Accounts and authentication

--- a/authling/docs/adr/INDEX.md
+++ b/authling/docs/adr/INDEX.md
@@ -10,6 +10,7 @@ Repository-wide decisions currently live in:
 - [Root ADR-058: Extract an Application-Neutral Embedded NATS Runtime](../../../docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md)
 - [Root ADR-059: License Shared Framework Modules under Apache-2.0](../../../docs/adr/ADR-059-apache-license-shared-framework-modules.md)
 - [Root ADR-060: Extract Application-Neutral Data Cryptography](../../../docs/adr/ADR-060-application-neutral-data-cryptography.md)
+- [Root ADR-061: Extract Application-Neutral Configuration Loading](../../../docs/adr/ADR-061-application-neutral-configuration-loading.md)
 
 ## Decisions
 

--- a/authling/docs/fdr/FDR-001-standalone-account-runtime.md
+++ b/authling/docs/fdr/FDR-001-standalone-account-runtime.md
@@ -69,7 +69,8 @@ snapshots are implemented.
 ## Related
 
 - **ADRs:** [ADR-001](../adr/ADR-001-event-sourced-nats-architecture.md),
-  [Root ADR-058](../../../docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md)
+  [Root ADR-058](../../../docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md),
+  [Root ADR-061](../../../docs/adr/ADR-061-application-neutral-configuration-loading.md)
 
 ## Open Questions
 

--- a/authling/go.mod
+++ b/authling/go.mod
@@ -5,11 +5,10 @@ go 1.26.0
 tool google.golang.org/protobuf/cmd/protoc-gen-go
 
 require (
-	github.com/caarlos0/env/v11 v11.4.1
 	github.com/nats-io/nats-server/v2 v2.14.3
 	github.com/nats-io/nats.go v1.52.0
-	github.com/pelletier/go-toml/v2 v2.4.3
 	google.golang.org/protobuf v1.36.11
+	hmans.de/chatto/pkg/appconfig v0.0.0
 	hmans.de/chatto/pkg/datacrypto v0.0.0
 	hmans.de/chatto/pkg/events v0.0.0
 	hmans.de/chatto/pkg/natsruntime v0.0.0
@@ -17,18 +16,22 @@ require (
 
 require (
 	github.com/antithesishq/antithesis-sdk-go v0.7.2 // indirect
+	github.com/caarlos0/env/v11 v11.4.1 // indirect
 	github.com/google/go-tpm v0.9.8 // indirect
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/minio/highwayhash v1.0.4 // indirect
 	github.com/nats-io/jwt/v2 v2.8.2 // indirect
 	github.com/nats-io/nkeys v0.4.16 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	golang.org/x/crypto v0.54.0 // indirect
 	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )
 
 replace hmans.de/chatto/pkg/events => ../pkg/events
+
+replace hmans.de/chatto/pkg/appconfig => ../pkg/appconfig
 
 replace hmans.de/chatto/pkg/datacrypto => ../pkg/datacrypto
 

--- a/authling/internal/config/config.go
+++ b/authling/internal/config/config.go
@@ -2,14 +2,11 @@
 package config
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"strings"
 
-	"github.com/caarlos0/env/v11"
-	"github.com/pelletier/go-toml/v2"
+	"hmans.de/chatto/pkg/appconfig"
 )
 
 const DefaultPath = "authling.toml"
@@ -51,27 +48,14 @@ type EmbeddedNATSConfig struct {
 // validates the result. A missing default file is allowed for environment-only
 // deployments; an explicitly named missing file is an error.
 func Read(path string) (Config, error) {
-	var cfg Config
-	explicitPath := path != ""
-	if path == "" {
-		path = DefaultPath
-	}
-
-	data, err := os.ReadFile(path)
-	switch {
-	case err == nil:
-		decoder := toml.NewDecoder(strings.NewReader(string(data)))
-		decoder.DisallowUnknownFields()
-		if err := decoder.Decode(&cfg); err != nil {
-			return Config{}, fmt.Errorf("decode %s: %w", path, err)
-		}
-	case errors.Is(err, os.ErrNotExist) && !explicitPath:
-	case err != nil:
-		return Config{}, fmt.Errorf("read %s: %w", path, err)
-	}
-
-	if err := env.Parse(&cfg); err != nil {
-		return Config{}, fmt.Errorf("parse environment: %w", err)
+	cfg, err := appconfig.Load[Config](appconfig.Options{
+		Path:                  path,
+		DefaultPath:           DefaultPath,
+		RequireExplicitFile:   true,
+		DisallowUnknownFields: true,
+	})
+	if err != nil {
+		return Config{}, err
 	}
 	cfg.applyDefaults()
 	if err := cfg.Validate(); err != nil {

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -136,6 +136,12 @@ authorization, live events, backup/restore, and backend tests.
   key references and hierarchy, envelope serialization, storage, KMS, cache,
   rotation, and cryptographic-erasure policy in `internal/encryption`; the
   shared module must not import Chatto packages.
+- Keep TOML file loading and struct-tagged environment overrides behind the
+  independently versioned `hmans.de/chatto/pkg/appconfig` module from ADR-061.
+  Chatto retains its configuration schema, environment names, compatibility
+  aliases, defaults, normalization, validation, generated examples, and CLI
+  flag policy in `internal/config` and `cmd`; the shared module must not import
+  Chatto packages or tighten existing configuration compatibility implicitly.
 - Snapshot restore codecs must be transactional on error and must account for
   compatibility state preloaded before projector startup. Privacy-review every
   persisted field: do not snapshot decrypted bodies, raw PII, credentials,

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -26,7 +26,6 @@ require (
 	github.com/blevesearch/bleve/v2 v2.6.0
 	github.com/blevesearch/bleve_index_api v1.3.11
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500
-	github.com/caarlos0/env/v11 v11.4.1
 	github.com/charmbracelet/log v1.0.0
 	github.com/coreos/go-oidc/v3 v3.20.0
 	github.com/disintegration/imageorient v0.0.0-20180920195336-8147d86e83ec
@@ -63,6 +62,7 @@ require (
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.40.0
 	google.golang.org/protobuf v1.36.11
+	hmans.de/chatto/pkg/appconfig v0.0.0
 	hmans.de/chatto/pkg/datacrypto v0.0.0
 	hmans.de/chatto/pkg/events v0.0.0
 	hmans.de/chatto/pkg/natsruntime v0.0.0
@@ -113,6 +113,7 @@ require (
 	github.com/bytedance/gopkg v0.1.4 // indirect
 	github.com/bytedance/sonic v1.15.2 // indirect
 	github.com/bytedance/sonic/loader v0.5.1 // indirect
+	github.com/caarlos0/env/v11 v11.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/colorprofile v0.4.3 // indirect
 	github.com/charmbracelet/lipgloss v1.1.0 // indirect
@@ -226,6 +227,8 @@ require (
 )
 
 replace hmans.de/chatto/pkg/events => ../pkg/events
+
+replace hmans.de/chatto/pkg/appconfig => ../pkg/appconfig
 
 replace hmans.de/chatto/pkg/datacrypto => ../pkg/datacrypto
 

--- a/cli/internal/config/config.go
+++ b/cli/internal/config/config.go
@@ -4,12 +4,10 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/caarlos0/env/v11"
-	"github.com/pelletier/go-toml/v2"
+	"hmans.de/chatto/pkg/appconfig"
 	"hmans.de/chatto/pkg/natsauth"
 )
 
@@ -417,37 +415,25 @@ func (c *ChattoConfig) Validate() error {
 // ReadConfig reads configuration from the specified file path (or "chatto.toml" if empty),
 // then overrides with environment variables, and validates the result.
 func ReadConfig(configPath string) (ChattoConfig, error) {
-	var cfg ChattoConfig
-
-	if configPath == "" {
-		configPath = "chatto.toml"
+	cfg, err := appconfig.Load[ChattoConfig](appconfig.Options{
+		Path:        configPath,
+		DefaultPath: "chatto.toml",
+	})
+	if err != nil {
+		return ChattoConfig{}, err
 	}
 
-	// 1. Read TOML file if it exists (base config)
-	b, err := os.ReadFile(configPath)
-	if err != nil && !os.IsNotExist(err) {
-		return cfg, err // Real error, not just missing file
-	}
-	if err == nil {
-		if err := toml.Unmarshal(b, &cfg); err != nil {
-			return cfg, err
-		}
-	}
-	// If file doesn't exist, cfg remains zero-valued and env vars provide all config
-
-	// 2. Override with environment variables
-	if err := env.Parse(&cfg); err != nil {
-		return cfg, fmt.Errorf("failed to parse environment variables: %w", err)
-	}
+	// Apply Chatto-specific compatibility environment variables that cannot be
+	// represented by fixed struct tags.
 	if err := applyAuthProviderEnv(&cfg); err != nil {
 		return cfg, err
 	}
 
-	// 3. Apply derived defaults and normalize harmless spelling differences
+	// Apply derived defaults and normalize harmless spelling differences.
 	cfg.ApplyDefaults()
 	cfg.Normalize()
 
-	// 4. Validate
+	// Validate the product-owned schema.
 	if err := cfg.Validate(); err != nil {
 		return cfg, err
 	}

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -75,6 +75,29 @@ func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	}
 }
 
+func TestReadConfig_AllowsUnknownTOMLFieldsForCompatibility(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "chatto.toml")
+	if err := os.WriteFile(path, []byte(`
+future_option = true
+
+[webserver]
+port = 4000
+cookie_signing_secret = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+[core]
+secret_key = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+
+[core.assets]
+signing_secret = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ReadConfig(path); err != nil {
+		t.Fatalf("ReadConfig() rejected an unknown compatibility field: %v", err)
+	}
+}
+
 func TestReadConfig_WithConfigFile(t *testing.T) {
 	// Create a temp directory with a config file
 	tmpDir := t.TempDir()

--- a/docs/adr/ADR-057-temporarily-incubate-authling.md
+++ b/docs/adr/ADR-057-temporarily-incubate-authling.md
@@ -20,9 +20,9 @@ the architecture should not make future process-level composition impossible.
 
 Temporarily incubate Authling in this repository as a separate Go module under
 `authling/`. The repository-level `go.work` file composes the Chatto, Authling,
-shared `pkg/events/`, shared `pkg/natsruntime/`, and shared `pkg/datacrypto/`
-modules for local development without merging their module or package
-boundaries.
+shared `pkg/events/`, shared `pkg/natsruntime/`, shared `pkg/datacrypto/`, and
+shared `pkg/appconfig/` modules for local development without merging their
+module or package boundaries.
 
 Authling is a separate product and executable. It owns its configuration,
 application composition, HTTP surface, lifecycle, and NATS credentials. It
@@ -33,6 +33,8 @@ boundary described by ADR-056. Reusable embedded NATS lifecycle mechanics live
 in the separate `hmans.de/chatto/pkg/natsruntime` module described by ADR-058.
 Reusable authenticated-encryption primitives live in the separate
 `hmans.de/chatto/pkg/datacrypto` module described by ADR-060.
+Reusable TOML and environment configuration loading lives in the separate
+`hmans.de/chatto/pkg/appconfig` module described by ADR-061.
 Authling should consume shared modules only when a concrete use case needs
 them.
 
@@ -47,7 +49,8 @@ components, versions, changelogs, release pull requests, and tags:
 
 - Chatto remains the root component and uses `v<version>` tags. Its release
   component excludes commits whose files are entirely under `authling/`,
-  `pkg/events/`, `pkg/natsruntime/`, `pkg/datacrypto/`, or `.agents/skills/`.
+  `pkg/events/`, `pkg/natsruntime/`, `pkg/datacrypto/`, `pkg/appconfig/`, or
+  `.agents/skills/`.
 - Authling uses the `authling/` component and `authling/v<version>` tags. The
   slash follows Go's nested-module tag convention and keeps module versions
   consumable through normal Go tooling.
@@ -58,6 +61,8 @@ components, versions, changelogs, release pull requests, and tags:
   path.
 - The data-cryptography module uses the `pkg/datacrypto/` component and
   `pkg/datacrypto/v<version>` tags, matching its nested-module repository path.
+- The application-configuration module uses the `pkg/appconfig/` component and
+  `pkg/appconfig/v<version>` tags, matching its nested-module repository path.
 
 Release Please does not infer dependencies between Go workspace modules. A
 change to a shared module that requires a new Chatto or Authling version must
@@ -89,7 +94,7 @@ development while remaining independently deployable and releasable. Its
 security and operational lifecycle cannot become accidentally coupled to a
 Chatto server or Chatto's NATS account.
 
-The repository now contains five Go modules and five release lines. CI and
+The repository now contains six Go modules and six release lines. CI and
 developer tasks must cover the relevant modules, and release automation must
 preserve the separate tag namespaces.
 

--- a/docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md
+++ b/docs/adr/ADR-058-application-neutral-embedded-nats-runtime.md
@@ -48,8 +48,8 @@ co-developed here.
 existing production dependency boundary. Neither shared module imports product
 configuration or domain packages.
 
-ADR-059 licenses both shared modules under Apache-2.0. Their permissive
-licensing is independent of their pre-1.0 API stability.
+ADR-059 licenses the shared framework modules under Apache-2.0. Their
+permissive licensing is independent of their pre-1.0 API stability.
 
 ## Consequences
 

--- a/docs/adr/ADR-059-apache-license-shared-framework-modules.md
+++ b/docs/adr/ADR-059-apache-license-shared-framework-modules.md
@@ -4,11 +4,12 @@
 
 ## Context
 
-ADR-056, ADR-058, and ADR-060 establish `pkg/events`, `pkg/natsruntime`, and
-`pkg/datacrypto` as independently versioned, application-neutral modules
+ADR-056, ADR-058, ADR-060, and ADR-061 establish `pkg/events`,
+`pkg/natsruntime`, `pkg/datacrypto`, and `pkg/appconfig` as independently
+versioned, application-neutral modules
 intended for use outside Chatto and Authling. The first two modules began under
 the repository's default AGPL-3.0-or-later license while their boundaries were
-being identified; `pkg/datacrypto` begins under Apache-2.0.
+being identified; `pkg/datacrypto` and `pkg/appconfig` begin under Apache-2.0.
 
 The modules need additional consumers to mature. Requiring an application's
 combined work to follow the repository's strong copyleft terms would
@@ -20,9 +21,9 @@ can be established before outside contributions make a later change harder.
 
 ## Decision
 
-License the complete `pkg/events`, `pkg/natsruntime`, and `pkg/datacrypto`
-modules under the Apache License 2.0. This includes their source, tests,
-documentation, module metadata, and standalone license files.
+License the complete `pkg/events`, `pkg/natsruntime`, `pkg/datacrypto`, and
+`pkg/appconfig` modules under the Apache License 2.0. This includes their
+source, tests, documentation, module metadata, and standalone license files.
 
 The modules remain independently versioned, pre-1.0 incubation surfaces with
 no API stability promise. Their README files must state both the permissive

--- a/docs/adr/ADR-061-application-neutral-configuration-loading.md
+++ b/docs/adr/ADR-061-application-neutral-configuration-loading.md
@@ -54,4 +54,3 @@ rather than attempting to model every configuration system. Future features
 such as secret providers, live reload, generated examples, or remote sources
 remain product-owned until multiple consumers establish another useful
 boundary.
-

--- a/docs/adr/ADR-061-application-neutral-configuration-loading.md
+++ b/docs/adr/ADR-061-application-neutral-configuration-loading.md
@@ -1,0 +1,57 @@
+# ADR-061: Extract Application-Neutral Configuration Loading
+
+**Date:** 2026-07-31
+
+## Context
+
+Chatto and Authling both load an application-owned Go configuration struct
+from a conventional TOML file and then apply environment-variable overrides.
+The products duplicated the file selection, TOML decoding, and environment
+parsing mechanics, but intentionally differ in compatibility policy: Chatto
+allows missing explicitly selected files and ignores unknown TOML fields,
+while Authling requires explicitly selected files and rejects unknown fields.
+
+The products also have different schemas, environment names, defaults,
+normalization, validation, compatibility aliases, and configuration generators.
+Moving those policies into a shared package would create coupling and could
+silently break existing deployments.
+
+## Decision
+
+Create the independently versioned `hmans.de/chatto/pkg/appconfig` module. It
+owns only:
+
+- selecting an explicit configuration path or an application-supplied default;
+- optionally requiring an explicitly selected file to exist;
+- decoding TOML, with a caller-selected unknown-field policy; and
+- applying environment overrides described by the target struct's `env` tags.
+
+The generic loader returns the fully populated target value only on success.
+On file, TOML, or environment failure it returns the target type's zero value,
+preventing callers from accidentally continuing with partially decoded
+configuration.
+
+Chatto keeps permissive missing-file and unknown-field behavior, along with its
+provider-environment compatibility hook, defaults, normalization, validation,
+schema, and generated configuration. Authling keeps its stricter explicit-file
+and unknown-field behavior, defaults, validation, schema, and environment
+namespace.
+
+The module does not own command-line flags, watch/reload behavior, secret
+resolution, logging, or application lifecycle. License the complete module
+under Apache-2.0 in accordance with ADR-059. It remains pre-1.0 without an API
+stability promise.
+
+## Consequences
+
+The shared precedence and error-handling mechanics have one independently
+tested implementation, while each product retains its existing operator-facing
+configuration contract. New consumers can opt into strict behavior without
+forcing it on compatibility-sensitive applications.
+
+The option surface reflects concrete differences between Chatto and Authling
+rather than attempting to model every configuration system. Future features
+such as secret providers, live reload, generated examples, or remote sources
+remain product-owned until multiple consumers establish another useful
+boundary.
+

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -72,3 +72,4 @@ replace part of their original design.
 | [ADR-058](ADR-058-application-neutral-embedded-nats-runtime.md) | Extract an Application-Neutral Embedded NATS Runtime | Accepted | 2026-07-31 |
 | [ADR-059](ADR-059-apache-license-shared-framework-modules.md) | License Shared Framework Modules under Apache-2.0 | Accepted | 2026-07-31 |
 | [ADR-060](ADR-060-application-neutral-data-cryptography.md) | Extract Application-Neutral Data Cryptography | Accepted | 2026-07-31 |
+| [ADR-061](ADR-061-application-neutral-configuration-loading.md) | Extract Application-Neutral Configuration Loading | Accepted | 2026-07-31 |

--- a/go.work
+++ b/go.work
@@ -3,6 +3,7 @@ go 1.26.0
 use (
 	./authling
 	./cli
+	./pkg/appconfig
 	./pkg/datacrypto
 	./pkg/events
 	./pkg/natsruntime

--- a/mise.toml
+++ b/mise.toml
@@ -18,6 +18,7 @@ CHATTO_DEVELOPMENT_VERSION = "0.5.0-dev"
 description = "Set up the development environment"
 run = [
     { task = "setup-authling" },
+    { task = "setup-appconfig" },
     { task = "setup-cli" },
     { task = "setup-datacrypto" },
     { task = "setup-events" },
@@ -34,6 +35,12 @@ run = [
 description = "Install Go dependencies"
 dir = "cli"
 run = "go mod download"
+sources = ["go.mod", "go.sum"]
+
+[tasks.deps-appconfig]
+description = "Install application configuration dependencies"
+dir = "pkg/appconfig"
+run = "GOWORK=off go mod download"
 sources = ["go.mod", "go.sum"]
 
 [tasks.deps-datacrypto]
@@ -75,6 +82,10 @@ run = { task = "deps-*" }
 [tasks.setup-cli]
 description = "Set up the CLI module"
 depends = ["deps-cli", "sync-cli-legal"]
+
+[tasks.setup-appconfig]
+description = "Set up the application configuration module"
+depends = ["deps-appconfig"]
 
 [tasks.setup-datacrypto]
 description = "Set up the data cryptography module"
@@ -412,6 +423,16 @@ run = [
 ]
 sources = ["go.mod", "**/*.go"]
 
+[tasks.test-appconfig]
+description = "Run application configuration tests standalone and in the repository workspace"
+depends = ["setup-appconfig"]
+dir = "pkg/appconfig"
+run = [
+    "GOWORK=off go test -trimpath ./...",
+    "go test -trimpath ./...",
+]
+sources = ["go.mod", "go.sum", "**/*.go"]
+
 [tasks.test-events]
 description = "Run event framework tests standalone and in the repository workspace"
 depends = ["setup-events"]
@@ -480,6 +501,7 @@ run = "pnpm exec playwright test"
 description = "Run all tests"
 run = [
     { task = "test-authling" },
+    { task = "test-appconfig" },
     { task = "test-datacrypto" },
     { task = "test-events" },
     { task = "test-natsruntime" },

--- a/pkg/appconfig/AGENTS.md
+++ b/pkg/appconfig/AGENTS.md
@@ -1,0 +1,36 @@
+# Instructions for Agents Working in `pkg/appconfig/`
+
+Read the repository-root [`AGENTS.md`](../../AGENTS.md),
+[`cli/AGENTS.md`](../../cli/AGENTS.md), and
+[`authling/AGENTS.md`](../../authling/AGENTS.md) before changing this shared
+module. Also follow
+[ADR-061](../../docs/adr/ADR-061-application-neutral-configuration-loading.md).
+
+## Boundary
+
+- Keep production code application-neutral.
+- This module owns only TOML file selection and decoding followed by
+  struct-tagged environment-variable overrides.
+- Applications own their configuration types, field and environment names,
+  defaults, normalization, validation, compatibility aliases, generated
+  examples, and command-line flag policy.
+- Preserve consumer compatibility through explicit loader options. Do not
+  tighten or relax a product's unknown-field or missing-file behavior as a
+  side effect of framework work.
+- Do not import Chatto or Authling packages or encode either product's paths,
+  prefixes, schemas, or policies.
+- The module is independently versioned but pre-1.0 and has no API stability
+  promise yet.
+- The complete module is licensed under Apache-2.0.
+
+## Verification
+
+Run:
+
+```sh
+mise test-appconfig
+mise test-authling
+mise test-cli
+mise license-check
+```
+

--- a/pkg/appconfig/AGENTS.md
+++ b/pkg/appconfig/AGENTS.md
@@ -33,4 +33,3 @@ mise test-authling
 mise test-cli
 mise license-check
 ```
-

--- a/pkg/appconfig/CHANGELOG.md
+++ b/pkg/appconfig/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this module will be documented in this file by Release
+Please.
+

--- a/pkg/appconfig/CHANGELOG.md
+++ b/pkg/appconfig/CHANGELOG.md
@@ -2,4 +2,3 @@
 
 All notable changes to this module will be documented in this file by Release
 Please.
-

--- a/pkg/appconfig/LICENSE
+++ b/pkg/appconfig/LICENSE
@@ -1,0 +1,73 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+     (d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets "[]" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same "printed page" as the copyright notice for easier identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/pkg/appconfig/README.md
+++ b/pkg/appconfig/README.md
@@ -33,4 +33,3 @@ GOWORK=off go test ./...
 
 The module is licensed under [`Apache-2.0`](LICENSE). Its permissive license
 does not imply API stability.
-

--- a/pkg/appconfig/README.md
+++ b/pkg/appconfig/README.md
@@ -1,0 +1,36 @@
+# Application Configuration
+
+`hmans.de/chatto/pkg/appconfig` loads application-owned Go configuration
+structs from TOML files and then applies struct-tagged environment-variable
+overrides.
+
+The caller selects its explicit and default file paths and whether an explicit
+file is required or unknown TOML fields are rejected. Applications retain
+ownership of configuration schemas, environment names, defaults,
+normalization, validation, compatibility aliases, and generated examples.
+
+## Status
+
+This module is an incubation surface shared by Chatto and Authling. Its API is
+not yet covered by a stability promise, and releases remain pre-1.0 while both
+applications establish the smallest useful contract.
+
+## Development
+
+Run the module tests independently:
+
+```sh
+mise test-appconfig
+```
+
+From this directory, the equivalent standalone check is:
+
+```sh
+GOWORK=off go test ./...
+```
+
+## License
+
+The module is licensed under [`Apache-2.0`](LICENSE). Its permissive license
+does not imply API stability.
+

--- a/pkg/appconfig/appconfig.go
+++ b/pkg/appconfig/appconfig.go
@@ -1,0 +1,76 @@
+// Package appconfig loads application-owned configuration structs from TOML
+// files with environment-variable overrides.
+package appconfig
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/caarlos0/env/v11"
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Options controls file selection and TOML compatibility policy. Configuration
+// schemas, environment names, defaults, normalization, and validation remain
+// the caller's responsibility.
+type Options struct {
+	// Path is an explicitly selected configuration file. When empty,
+	// DefaultPath is used instead.
+	Path string
+
+	// DefaultPath is the application-owned conventional configuration path.
+	// When both paths are empty, loading proceeds from the environment only.
+	DefaultPath string
+
+	// RequireExplicitFile makes a missing Path an error. A missing DefaultPath
+	// remains allowed for environment-only deployments.
+	RequireExplicitFile bool
+
+	// DisallowUnknownFields rejects TOML keys that do not map to the target
+	// configuration type.
+	DisallowUnknownFields bool
+}
+
+// Load decodes TOML into T and then applies environment-variable overrides
+// described by T's env tags. It returns a zero T on every error so callers
+// cannot accidentally use partially decoded configuration.
+func Load[T any](options Options) (T, error) {
+	var config T
+	explicitPath := options.Path != ""
+	path := options.Path
+	if !explicitPath {
+		path = options.DefaultPath
+	}
+
+	if path != "" {
+		data, err := os.ReadFile(path)
+		switch {
+		case err == nil:
+			if err := decodeTOML(data, &config, options.DisallowUnknownFields); err != nil {
+				var zero T
+				return zero, fmt.Errorf("decode %s: %w", path, err)
+			}
+		case errors.Is(err, os.ErrNotExist) && (!explicitPath || !options.RequireExplicitFile):
+		case err != nil:
+			var zero T
+			return zero, fmt.Errorf("read %s: %w", path, err)
+		}
+	}
+
+	if err := env.Parse(&config); err != nil {
+		var zero T
+		return zero, fmt.Errorf("parse environment: %w", err)
+	}
+	return config, nil
+}
+
+func decodeTOML(data []byte, target any, disallowUnknownFields bool) error {
+	if !disallowUnknownFields {
+		return toml.Unmarshal(data, target)
+	}
+	decoder := toml.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	return decoder.Decode(target)
+}

--- a/pkg/appconfig/appconfig_test.go
+++ b/pkg/appconfig/appconfig_test.go
@@ -1,0 +1,159 @@
+package appconfig_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"hmans.de/chatto/pkg/appconfig"
+)
+
+type testConfig struct {
+	Name string `toml:"name" env:"APPCONFIG_TEST_NAME"`
+	Port int    `toml:"port" env:"APPCONFIG_TEST_PORT"`
+}
+
+func TestLoadAppliesEnvironmentAfterTOML(t *testing.T) {
+	path := writeConfig(t, "name = \"from-toml\"\nport = 4222\n")
+	t.Setenv("APPCONFIG_TEST_NAME", "from-environment")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Name != "from-environment" {
+		t.Fatalf("name = %q, want environment override", config.Name)
+	}
+	if config.Port != 4222 {
+		t.Fatalf("port = %d, want TOML value", config.Port)
+	}
+}
+
+func TestLoadUsesDefaultPath(t *testing.T) {
+	path := writeConfig(t, "name = \"default-file\"\n")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{DefaultPath: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Name != "default-file" {
+		t.Fatalf("name = %q, want default-file", config.Name)
+	}
+}
+
+func TestLoadExplicitPathTakesPrecedenceOverDefaultPath(t *testing.T) {
+	explicitPath := writeConfig(t, "name = \"explicit-file\"\n")
+	defaultPath := writeConfig(t, "name = \"default-file\"\n")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{
+		Path:        explicitPath,
+		DefaultPath: defaultPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Name != "explicit-file" {
+		t.Fatalf("name = %q, want explicit-file", config.Name)
+	}
+}
+
+func TestLoadAllowsMissingDefaultFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.toml")
+	t.Setenv("APPCONFIG_TEST_NAME", "environment-only")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{DefaultPath: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Name != "environment-only" {
+		t.Fatalf("name = %q, want environment-only", config.Name)
+	}
+}
+
+func TestLoadExplicitMissingFilePolicy(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.toml")
+
+	_, err := appconfig.Load[testConfig](appconfig.Options{
+		Path:                path,
+		RequireExplicitFile: true,
+	})
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("required explicit file error = %v, want os.ErrNotExist", err)
+	}
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{Path: path})
+	if err != nil {
+		t.Fatalf("optional explicit file: %v", err)
+	}
+	if config != (testConfig{}) {
+		t.Fatalf("config = %#v, want zero value", config)
+	}
+}
+
+func TestLoadUnknownFieldPolicy(t *testing.T) {
+	path := writeConfig(t, "name = \"known\"\nsurprise = true\n")
+
+	_, err := appconfig.Load[testConfig](appconfig.Options{
+		Path:                  path,
+		DisallowUnknownFields: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "strict mode") {
+		t.Fatalf("strict error = %v, want unknown-field error", err)
+	}
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{Path: path})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Name != "known" {
+		t.Fatalf("name = %q, want known", config.Name)
+	}
+}
+
+func TestLoadReturnsZeroValueAfterDecodeFailure(t *testing.T) {
+	path := writeConfig(t, "name = \"partially-decoded\"\nport = \"not-an-integer\"\n")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{Path: path})
+	if err == nil || !strings.Contains(err.Error(), "decode "+path) {
+		t.Fatalf("decode error = %v", err)
+	}
+	if config != (testConfig{}) {
+		t.Fatalf("config = %#v, want zero value", config)
+	}
+}
+
+func TestLoadReturnsZeroValueAfterEnvironmentFailure(t *testing.T) {
+	path := writeConfig(t, "name = \"partially-decoded\"\nport = 4222\n")
+	t.Setenv("APPCONFIG_TEST_PORT", "not-an-integer")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{Path: path})
+	if err == nil || !strings.Contains(err.Error(), "parse environment") {
+		t.Fatalf("environment error = %v", err)
+	}
+	if config != (testConfig{}) {
+		t.Fatalf("config = %#v, want zero value", config)
+	}
+}
+
+func TestLoadWithoutPathsUsesEnvironmentOnly(t *testing.T) {
+	t.Setenv("APPCONFIG_TEST_NAME", "environment-only")
+
+	config, err := appconfig.Load[testConfig](appconfig.Options{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if config.Name != "environment-only" {
+		t.Fatalf("name = %q, want environment-only", config.Name)
+	}
+}
+
+func writeConfig(t *testing.T, contents string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/pkg/appconfig/dependency_boundary_test.go
+++ b/pkg/appconfig/dependency_boundary_test.go
@@ -1,0 +1,45 @@
+package appconfig_test
+
+import (
+	"go/build"
+	"go/parser"
+	"go/token"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestPackageDependenciesAreApplicationNeutral(t *testing.T) {
+	directory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	packages, err := parser.ParseDir(token.NewFileSet(), directory, nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, pkg := range packages {
+		for sourceName, source := range pkg.Files {
+			for _, spec := range source.Imports {
+				importPath, err := strconv.Unquote(spec.Path.Value)
+				if err != nil {
+					t.Fatalf("%s: decode import path: %v", sourceName, err)
+				}
+				if isStandardLibraryImport(importPath, directory) ||
+					importPath == "github.com/caarlos0/env/v11" ||
+					strings.HasPrefix(importPath, "github.com/pelletier/go-toml/v2") ||
+					strings.HasSuffix(sourceName, "_test.go") && importPath == "hmans.de/chatto/pkg/appconfig" {
+					continue
+				}
+				t.Errorf("%s imports non-portable dependency %q", sourceName, importPath)
+			}
+		}
+	}
+}
+
+func isStandardLibraryImport(importPath, sourceDirectory string) bool {
+	pkg, err := build.Default.Import(importPath, sourceDirectory, build.FindOnly)
+	return err == nil && pkg.Goroot
+}

--- a/pkg/appconfig/go.mod
+++ b/pkg/appconfig/go.mod
@@ -1,0 +1,8 @@
+module hmans.de/chatto/pkg/appconfig
+
+go 1.26.0
+
+require (
+	github.com/caarlos0/env/v11 v11.4.1
+	github.com/pelletier/go-toml/v2 v2.4.3
+)

--- a/pkg/appconfig/go.sum
+++ b/pkg/appconfig/go.sum
@@ -1,0 +1,4 @@
+github.com/caarlos0/env/v11 v11.4.1 h1:fYwH0sWEsBSMPG7t4e/PEfTFzrWrpjyygXyUnWiSwEw=
+github.com/caarlos0/env/v11 v11.4.1/go.mod h1:qupehSf/Y0TUTsxKywqRt/vJjN5nz6vauiYEUUr8P4U=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=


### PR DESCRIPTION
## Why

Chatto and Authling independently implemented the same TOML-file plus
environment-overlay mechanics. Extracting that proven overlap gives the two
products one small, reusable loading boundary while keeping their distinct
configuration policy and schemas independent.

## What changed

- add the independently versioned, Apache-2.0
  `hmans.de/chatto/pkg/appconfig` module with a generic TOML-then-ENV loader
- expose explicit options for default paths, required explicitly selected
  files, and strict unknown-field handling
- migrate Chatto while preserving its permissive missing-file and unknown-field
  compatibility behavior
- migrate Authling while preserving its required explicit-file and strict
  unknown-field behavior
- keep schemas, environment names, defaults, normalization, validation, and
  compatibility aliases product-owned
- add ADR-061 and wire the sixth Go module into the workspace, mise tasks, CI
  and caches, Release Please, REUSE, licensing docs, and agent instructions
- remove the completed Authling extraction item from `authling/TODO.md`

## Compatibility and operations

- no configuration keys, environment variable names, defaults, validation,
  protobufs, events, NATS resources, persisted data, or public APIs change
- file errors retain `errors.Is` support; shared loader errors may add stage and
  path context
- no migration or rollout coordination is required
- Chatto and Authling licensing is unchanged; only the new pre-1.0 shared
  module is Apache-2.0

## Test plan

All checks passed locally:

- `mise test-appconfig`
- `mise test-authling`
- `mise test-cli`
- `mise test-datacrypto`
- `mise test-events`
- `mise test-natsruntime`
- `mise license-check`
- standalone `go test -race ./...` and `go vet ./...` in `pkg/appconfig`
- `actionlint .github/workflows/ci.yml`
- Release Please JSON parsing, standalone module tidiness, `gofmt`, and
  `git diff --check origin/main...HEAD`
- independent adversarial review, followed by a clean re-review after resolving
  its sole low-severity Markdown hygiene finding

GitHub Actions passed. The first `test-cli` attempt hit the unrelated flaky
`TestAttachment_MultipleInSpace` nil-pointer panic; the failed job passed on
rerun without code changes.
