### PR TITLE
refactor(frontend): remove redundant event bus context

### DIFF
--- a/apps/frontend/e2e/dm.test.ts
+++ b/apps/frontend/e2e/dm.test.ts
@@ -67,7 +67,7 @@ test.describe('Direct Messages (room-shaped)', () => {
       await page.goto(routes.room(conversationId));
       await page.waitForURL(routes.patterns.anyRoom);
 
-      // Bug #1 (the silent post): the ServerEventProvider must subscribe to
+      // Bug #1 (the silent post): ServerPresenceSync must subscribe to
       // DM events too, so MessagePostedEvent reaches RoomEventsPane
       // and the new message renders without a reload.
       const roomA = new RoomPage(page);

--- a/apps/frontend/e2e/fixtures/realtimeSync.ts
+++ b/apps/frontend/e2e/fixtures/realtimeSync.ts
@@ -76,7 +76,7 @@ export async function waitForRoomReady(
   // if the user doesn't have posting permission (e.g., announcements room).
   await expect(page.getByTestId('message-input')).toBeVisible({ timeout });
 
-  // Wait for ServerEventProvider to have mounted and initiated the subscription.
+  // Wait for ServerPresenceSync to have mounted and initiated the subscription.
   // The hidden marker element proves the component rendered, and since
   // the `myEvents` subscription is started in the first $effect cycle after
   // render, the subscription request has been sent by the time this resolves.

--- a/apps/frontend/src/lib/components/UserAvatar.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte
@@ -90,7 +90,7 @@
   );
 
   // Use live presence from global cache if available, otherwise fall back to the initial value.
-  // The global cache is populated by ServerEventProvider, so all UserAvatar instances — including
+  // The global cache is populated by ServerPresenceSync, so all UserAvatar instances — including
   // newly-mounted ones like popovers — see the latest presence immediately.
   const presence = $derived.by(() => {
     if (!user || user.deleted) return undefined;

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -15,7 +15,7 @@
   import RoomList from '$lib/RoomList.svelte';
   import ServerHeader from './ServerHeader.svelte';
   import ServerBanner from './ServerBanner.svelte';
-  import ServerEventProvider from './ServerEventProvider.svelte';
+  import ServerPresenceSync from './ServerPresenceSync.svelte';
   import SidebarNav from '$lib/components/SidebarNav.svelte';
   import MyThreadsNavItem from './MyThreadsNavItem.svelte';
   import { MessageSearchState } from '$lib/state/server/messageSearch.svelte';
@@ -183,7 +183,7 @@
   }
 </script>
 
-<ServerEventProvider>
+<ServerPresenceSync>
   <!-- Sidebar -->
   <ServerSidebar>
     {#if isSettingsMode}
@@ -263,4 +263,4 @@
   <div class="flex min-h-0 min-w-0 flex-1 flex-col">
     {@render children?.()}
   </div>
-</ServerEventProvider>
+</ServerPresenceSync>

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -71,9 +71,7 @@
     page.url.pathname === resolve('/chat/[serverId]/overview', { serverId: serverSegment })
   );
 
-  const searchHref = $derived(
-    resolve('/chat/[serverId]/search', { serverId: serverSegment })
-  );
+  const searchHref = $derived(resolve('/chat/[serverId]/search', { serverId: serverSegment }));
   const isSearchActive = $derived(page.url.pathname === searchHref);
   const supportsMessageSearch = $derived(activeStore.serverInfo.supportsFeature('messageSearch'));
   const messageSearchAvailable = $derived(
@@ -146,7 +144,8 @@
   );
   const managedGroup = $derived(
     page.params.groupId
-      ? (activeStore.navigation.roomGroups.find((group) => group.id === page.params.groupId) ?? null)
+      ? (activeStore.navigation.roomGroups.find((group) => group.id === page.params.groupId) ??
+          null)
       : null
   );
   const managementNavItems = $derived(
@@ -174,7 +173,7 @@
                 icon: 'iconify uil--setting'
               }
             ]
-        : []
+          : []
   );
   const adminHref = $derived(adminNavItems[0]?.href);
 
@@ -183,84 +182,83 @@
   }
 </script>
 
-<ServerPresenceSync>
-  <!-- Sidebar -->
-  <ServerSidebar>
-    {#if isSettingsMode}
-      <SidebarNav
-        title={m['settings.nav.title']()}
-        items={settingsNavItems}
-        backHref={resolve('/chat/[serverId]', { serverId: serverSegment })}
-        backLabel={m['settings.nav.back_to_server']()}
-      />
-    {:else if !serverData}
-      <!-- Skeleton sidebar while server data is loading -->
-      <ServerHeader serverName="" loading />
+<ServerPresenceSync />
+<!-- Sidebar -->
+<ServerSidebar>
+  {#if isSettingsMode}
+    <SidebarNav
+      title={m['settings.nav.title']()}
+      items={settingsNavItems}
+      backHref={resolve('/chat/[serverId]', { serverId: serverSegment })}
+      backLabel={m['settings.nav.back_to_server']()}
+    />
+  {:else if !serverData}
+    <!-- Skeleton sidebar while server data is loading -->
+    <ServerHeader serverName="" loading />
 
-      <ScrollFader top bottom>
-        <div class="p-2">
-          <div class="skeleton h-40 w-full rounded-md"></div>
+    <ScrollFader top bottom>
+      <div class="p-2">
+        <div class="skeleton h-40 w-full rounded-md"></div>
+      </div>
+
+      {#each Array(2) as _, i (i)}
+        <div class="flex items-center gap-2 rounded-md px-4 py-2">
+          <div class="skeleton h-5 w-5 shrink-0 rounded"></div>
+          <div class="skeleton h-5 flex-1 rounded"></div>
         </div>
+      {/each}
+      <hr class="my-2 border-border" />
+      {#each Array(5) as _, i (i)}
+        <div class="flex items-center gap-2 rounded-md px-4 py-2">
+          <div class="skeleton h-5 w-5 shrink-0 rounded"></div>
+          <div class="skeleton h-5 flex-1 rounded"></div>
+        </div>
+      {/each}
+    </ScrollFader>
+  {:else if isManageMode}
+    <SidebarNav
+      title={serverName ?? m['chat.server_nav.server_fallback']()}
+      items={managementNavItems}
+      backHref={resolve('/chat/[serverId]', { serverId: serverSegment })}
+      backLabel={m['chat.server_nav.back_to_server']()}
+      isActive={isAdminNavActive}
+    />
+  {:else}
+    <!-- Server header - fixed at top -->
+    <ServerHeader serverName={serverName ?? ''} {adminHref} />
 
-        {#each Array(2) as _, i (i)}
-          <div class="flex items-center gap-2 rounded-md px-4 py-2">
-            <div class="skeleton h-5 w-5 shrink-0 rounded"></div>
-            <div class="skeleton h-5 flex-1 rounded"></div>
-          </div>
-        {/each}
-        <hr class="my-2 border-border" />
-        {#each Array(5) as _, i (i)}
-          <div class="flex items-center gap-2 rounded-md px-4 py-2">
-            <div class="skeleton h-5 w-5 shrink-0 rounded"></div>
-            <div class="skeleton h-5 flex-1 rounded"></div>
-          </div>
-        {/each}
-      </ScrollFader>
-    {:else if isManageMode}
-      <SidebarNav
-        title={serverName ?? m['chat.server_nav.server_fallback']()}
-        items={managementNavItems}
-        backHref={resolve('/chat/[serverId]', { serverId: serverSegment })}
-        backLabel={m['chat.server_nav.back_to_server']()}
-        isActive={isAdminNavActive}
-      />
-    {:else}
-      <!-- Server header - fixed at top -->
-      <ServerHeader serverName={serverName ?? ''} {adminHref} />
+    <!-- Scrollable area for room list sidebar -->
+    <ScrollFader top bottom>
+      {#if bannerUrl}
+        <ServerBanner url={bannerUrl} />
+      {/if}
 
-      <!-- Scrollable area for room list sidebar -->
-      <ScrollFader top bottom>
-        {#if bannerUrl}
-          <ServerBanner url={bannerUrl} />
-        {/if}
-
-        <nav class="sidebar-nav p-2">
-          <a
-            href={resolve('/chat/[serverId]/overview', { serverId: serverSegment })}
-            class={['sidebar-item', isHomeActive ? 'bg-surface' : '']}
-          >
-            <span class="sidebar-icon iconify uil--estate"></span>
-            {m['chat.overview.title']()}
+      <nav class="sidebar-nav p-2">
+        <a
+          href={resolve('/chat/[serverId]/overview', { serverId: serverSegment })}
+          class={['sidebar-item', isHomeActive ? 'bg-surface' : '']}
+        >
+          <span class="sidebar-icon iconify uil--estate"></span>
+          {m['chat.overview.title']()}
+        </a>
+        {#if messageSearchAvailable}
+          <a href={searchHref} class={['sidebar-item', isSearchActive ? 'bg-surface' : '']}>
+            <span class="sidebar-icon iconify uil--search" aria-hidden="true"></span>
+            {m['search.action']()}
           </a>
-          {#if messageSearchAvailable}
-            <a href={searchHref} class={['sidebar-item', isSearchActive ? 'bg-surface' : '']}>
-              <span class="sidebar-icon iconify uil--search" aria-hidden="true"></span>
-              {m['search.action']()}
-            </a>
-          {/if}
-          <MyThreadsNavItem active={isMyThreadsActive} />
-        </nav>
+        {/if}
+        <MyThreadsNavItem active={isMyThreadsActive} />
+      </nav>
 
-        <hr class="border-border" />
+      <hr class="border-border" />
 
-        <!-- Room List - always visible to server members (shows rooms user has joined) -->
-        <RoomList />
-      </ScrollFader>
-    {/if}
-  </ServerSidebar>
+      <!-- Room List - always visible to server members (shows rooms user has joined) -->
+      <RoomList />
+    </ScrollFader>
+  {/if}
+</ServerSidebar>
 
-  <!-- Main content - always renders so room can load in parallel -->
-  <div class="flex min-h-0 min-w-0 flex-1 flex-col">
-    {@render children?.()}
-  </div>
-</ServerPresenceSync>
+<!-- Main content - always renders so room can load in parallel -->
+<div class="flex min-h-0 min-w-0 flex-1 flex-col">
+  {@render children?.()}
+</div>

--- a/apps/frontend/src/lib/components/chat/ServerPresenceSync.svelte
+++ b/apps/frontend/src/lib/components/chat/ServerPresenceSync.svelte
@@ -3,19 +3,10 @@
   import { apiPresenceStatus } from '$lib/api-client/memberDirectory';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import type { Snippet } from 'svelte';
-
-  let { children }: { children: Snippet } = $props();
 
   // Capture route and presence contexts during component initialization.
   const serverScope = useServerScope();
   const presenceCache = getPresenceCache();
-
-  // Per-server stores (rooms list, room directory, …) self-manage their
-  // refresh and event-ingestion lifecycles from inside `ServerStateStore`
-  // — every server keeps itself in sync with its own bus, so consumers
-  // here and below just read `serverRegistry.getStore(...)` and don't
-  // wire any additional `$effect` for that purpose.
 
   // Populate global presence cache from server events so that any UserAvatar
   // (including newly-mounted ones like popovers) sees the latest presence.
@@ -43,4 +34,3 @@
 </script>
 
 <div data-testid="server-subscription-active" class="hidden"></div>
-{@render children()}

--- a/apps/frontend/src/lib/components/chat/ServerPresenceSync.svelte
+++ b/apps/frontend/src/lib/components/chat/ServerPresenceSync.svelte
@@ -1,22 +1,14 @@
 <script lang="ts">
-  import { provideEventBus } from '$lib/eventBus.svelte';
   import { usePresenceChange, useProjectionEvent } from '$lib/hooks/useEvent.svelte';
   import { apiPresenceStatus } from '$lib/api-client/memberDirectory';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import type { Snippet } from 'svelte';
 
   let { children }: { children: Snippet } = $props();
 
-  // The myEvents subscription was started by the registry when this server
-  // got connected; here we just expose its bus via Svelte context so
-  // descendant components can register handlers without going through the
-  // manager directly. The getter form keeps the bus reactive across
-  // `[serverId]` URL changes — typed-event consumers below
-  // automatically follow the active server.
-  provideEventBus(getActiveServer);
-
-  // Capture presence cache during init (context must be read synchronously)
+  // Capture route and presence contexts during component initialization.
+  const serverScope = useServerScope();
   const presenceCache = getPresenceCache();
 
   // Per-server stores (rooms list, room directory, …) self-manage their
@@ -28,7 +20,7 @@
   // Populate global presence cache from server events so that any UserAvatar
   // (including newly-mounted ones like popovers) sees the latest presence.
   usePresenceChange((userId, status) => {
-    presenceCache.update({ serverId: getActiveServer(), userId }, status);
+    presenceCache.update({ serverId: serverScope.serverId, userId }, status);
   });
 
   // Presence is transient rather than EVT-backed. Every subscription sends a
@@ -38,7 +30,7 @@
     for (const operation of event.operations) {
       if (operation.operation.case !== 'presencesReplace') continue;
       presenceCache.replaceServer(
-        getActiveServer(),
+        serverScope.serverId,
         new Map(
           Object.entries(operation.operation.value.statuses).map(([userId, status]) => [
             userId,

--- a/apps/frontend/src/lib/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/eventBus.svelte.ts
@@ -2,13 +2,11 @@
  * Single realtime stream per connected server, covering everything the user
  * can receive (deployment-wide events and room-scoped events over one stream).
  *
- * The manager keeps one bus per registered server. Consumers register
- * handlers either via Svelte context (current active server) or directly
- * against a specific server's bus through the manager (used by the
- * cross-server sidebar wiring).
+ * The manager keeps one bus per registered server. Route hooks select their
+ * bus from `ServerScope`; origin-global and cross-server consumers select a
+ * server explicitly.
  */
 
-import { createContext } from 'svelte';
 import { SvelteSet } from 'svelte/reactivity';
 import type { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { eventBusManager } from './state/server/eventBus.svelte';
@@ -28,37 +26,16 @@ export interface EventBus {
   projectionHandlers: SvelteSet<ProjectionHandler>;
 }
 
-// The context holds a getter — not a fixed bus — so reads from inside a
-// consumer's $effect track whatever reactive state the getter touches
-// (typically `page.params.serverId` via `getActiveServer`). When the URL
-// `[serverId]` param changes, every typed-event consumer
-// re-subscribes against the new server's bus without needing a remount or
-// a context refresh.
-const [getServerBusGetter, setServerBusGetter] = createContext<() => EventBus | undefined>();
-
-/**
- * Expose the active server's event bus to descendants via Svelte context.
- * Takes a getter so the context follows the active server reactively —
- * pass `() => activeServerId` (e.g. `getActiveServer()`) inside the
- * `[serverId]` tree, or `() => originServerId` at the top of the
- * authenticated app where the bus is fixed to the origin.
- */
-export function provideEventBus(getServerId: () => string): void {
-  setServerBusGetter(() => {
-    const id = getServerId();
-    return id ? eventBusManager.getBus(id) : undefined;
-  });
+function selectedBus(serverId: string): EventBus | undefined {
+  return serverId ? eventBusManager.getBus(serverId) : undefined;
 }
 
-/** Register a handler for canonical projection operations on the active server. */
-export function onProjectionEvent(handler: ProjectionHandler): () => void {
-  let getBus: () => EventBus | undefined;
-  try {
-    getBus = getServerBusGetter();
-  } catch {
-    return () => {};
-  }
-  const bus = getBus();
+/** Register a handler for canonical projection operations on the selected server. */
+export function onProjectionEvent(
+  serverId: string,
+  handler: ProjectionHandler
+): () => void {
+  const bus = selectedBus(serverId);
   if (!bus) return () => {};
   bus.projectionHandlers.add(handler);
   return () => {
@@ -74,6 +51,7 @@ export function onProjectionEvent(handler: ProjectionHandler): () => void {
 // fields (actorId, etc.) read them from the closure instead.
 
 function onTypedEvent<TKind extends TransientEventPayload['kind'], T>(
+  serverId: string,
   kind: TKind,
   extract: (
     envelope: TransientEventEnvelope,
@@ -81,13 +59,7 @@ function onTypedEvent<TKind extends TransientEventPayload['kind'], T>(
   ) => T,
   handler: (data: T) => void
 ): () => void {
-  let getBus: () => EventBus | undefined;
-  try {
-    getBus = getServerBusGetter();
-  } catch {
-    return () => {};
-  }
-  const bus = getBus();
+  const bus = selectedBus(serverId);
   if (!bus) return () => {};
 
   const wrapper: EventHandler = (envelope) => {
@@ -106,8 +78,12 @@ function onTypedEvent<TKind extends TransientEventPayload['kind'], T>(
 // Typed event handler exports
 // ---------------------------------------------------------------------------
 
-export function onSessionTerminated(handler: (reason: string) => void): () => void {
+export function onSessionTerminated(
+  serverId: string,
+  handler: (reason: string) => void
+): () => void {
   return onTypedEvent(
+    serverId,
     TransientEventKind.SessionTerminated,
     (_env, e) => {
       return e.reason;
@@ -122,8 +98,12 @@ export function onSessionTerminated(handler: (reason: string) => void): () => vo
 
 type PresenceHandler = (userId: string, status: PresenceStatus) => void;
 
-export function onPresenceChange(handler: PresenceHandler): () => void {
+export function onPresenceChange(
+  serverId: string,
+  handler: PresenceHandler
+): () => void {
   return onTypedEvent(
+    serverId,
     TransientEventKind.PresenceChanged,
     (envelope, e) => {
       return { userId: envelope.actorId, status: e.status as PresenceStatus };
@@ -143,14 +123,11 @@ export interface TypingEventData {
 
 type TypingHandler = (data: TypingEventData) => void;
 
-export function onTypingEvent(handler: TypingHandler): () => void {
-  let getBus: () => EventBus | undefined;
-  try {
-    getBus = getServerBusGetter();
-  } catch {
-    return () => {};
-  }
-  const bus = getBus();
+export function onTypingEvent(
+  serverId: string,
+  handler: TypingHandler
+): () => void {
+  const bus = selectedBus(serverId);
   if (!bus) return () => {};
   const wrapper: EventHandler = (event) => {
     if (transientEventKind(event.event) !== TransientEventKind.UserTyping) return;

--- a/apps/frontend/src/lib/hooks/useEvent.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useEvent.svelte.spec.ts
@@ -1,0 +1,74 @@
+import { flushSync } from 'svelte';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectionHandler } from '$lib/eventBus.svelte';
+
+const serverScope = $state({ serverId: 'origin' });
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    onProjectionEvent: vi.fn(),
+    useServerScope: vi.fn()
+  }
+}));
+
+vi.mock('$lib/eventBus.svelte', () => ({
+  onProjectionEvent: mocks.onProjectionEvent,
+  onPresenceChange: vi.fn(),
+  onSessionTerminated: vi.fn(),
+  onTypingEvent: vi.fn()
+}));
+
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: mocks.useServerScope
+}));
+
+import { useProjectionEvent } from './useEvent.svelte';
+
+describe('useProjectionEvent', () => {
+  beforeEach(() => {
+    serverScope.serverId = 'origin';
+    mocks.useServerScope.mockReset();
+    mocks.useServerScope.mockImplementation(() => serverScope);
+    mocks.onProjectionEvent.mockReset();
+  });
+
+  it('moves the subscription when the route server scope changes', () => {
+    const cleanups: Array<ReturnType<typeof vi.fn>> = [];
+    mocks.onProjectionEvent.mockImplementation(() => {
+      const cleanup = vi.fn();
+      cleanups.push(cleanup);
+      return cleanup;
+    });
+
+    const dispose = $effect.root(() => {
+      useProjectionEvent(vi.fn() as ProjectionHandler);
+    });
+    flushSync();
+
+    expect(mocks.onProjectionEvent).toHaveBeenCalledOnce();
+    expect(mocks.onProjectionEvent.mock.calls[0]?.[0]).toBe('origin');
+
+    serverScope.serverId = 'remote';
+    flushSync();
+
+    expect(cleanups[0]).toHaveBeenCalledOnce();
+    expect(mocks.onProjectionEvent).toHaveBeenCalledTimes(2);
+    expect(mocks.onProjectionEvent.mock.calls[1]?.[0]).toBe('remote');
+
+    dispose();
+    expect(cleanups[1]).toHaveBeenCalledOnce();
+  });
+
+  it('uses an explicit origin selector without reading route context', () => {
+    mocks.onProjectionEvent.mockImplementation(() => vi.fn());
+
+    const dispose = $effect.root(() => {
+      useProjectionEvent(vi.fn() as ProjectionHandler, () => 'origin');
+    });
+    flushSync();
+
+    expect(mocks.useServerScope).not.toHaveBeenCalled();
+    expect(mocks.onProjectionEvent.mock.calls[0]?.[0]).toBe('origin');
+    dispose();
+  });
+});

--- a/apps/frontend/src/lib/hooks/useEvent.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useEvent.svelte.ts
@@ -3,27 +3,57 @@ import {
   onProjectionEvent,
   onPresenceChange,
   onSessionTerminated,
-  type ProjectionHandler
+  onTypingEvent,
+  type ProjectionHandler,
+  type TypingEventData
 } from '$lib/eventBus.svelte';
+import { useServerScope } from '$lib/state/server/scope.svelte';
 
-/** Subscribe to canonical projection operations on the active server. */
-export function useProjectionEvent(handler: ProjectionHandler) {
-  $effect(() => onProjectionEvent(handler));
+type ServerIdSelector = () => string;
+type EventSubscription<Handler> = (serverId: string, handler: Handler) => () => void;
+type PresenceHandler = (userId: string, status: PresenceStatus) => void;
+type SessionTerminatedHandler = (reason: string) => void;
+type TypingHandler = (data: TypingEventData) => void;
+
+function resolveServerIdSelector(getServerId?: ServerIdSelector): ServerIdSelector {
+  if (getServerId) return getServerId;
+  const serverScope = useServerScope();
+  return () => serverScope.serverId;
+}
+
+function useServerEvent<Handler>(
+  handler: Handler,
+  subscribe: EventSubscription<Handler>,
+  getServerId?: ServerIdSelector
+): void {
+  const selectServerId = resolveServerIdSelector(getServerId);
+  $effect(() => subscribe(selectServerId(), handler));
+}
+
+/** Subscribe to canonical projection operations on the route or explicitly selected server. */
+export function useProjectionEvent(handler: ProjectionHandler, getServerId?: ServerIdSelector): void {
+  useServerEvent(handler, onProjectionEvent, getServerId);
+}
+
+/** Subscribe to presence changes on the route or explicitly selected server. */
+export function usePresenceChange(handler: PresenceHandler, getServerId?: ServerIdSelector): void {
+  useServerEvent(handler, onPresenceChange, getServerId);
 }
 
 /**
- * Hook to subscribe to presence-change events with automatic cleanup.
- * Must be called during component initialization.
+ * Subscribe to session termination from another device, an admin boot, or
+ * account deletion on the route or explicitly selected server.
  */
-export function usePresenceChange(handler: (userId: string, status: PresenceStatus) => void) {
-  $effect(() => onPresenceChange(handler));
+export function useSessionTerminated(
+  handler: SessionTerminatedHandler,
+  getServerId?: ServerIdSelector
+): void {
+  useServerEvent(handler, onSessionTerminated, getServerId);
 }
 
-/**
- * Hook to subscribe to session terminated events.
- * Fired when the server terminates the user's session (logout from another tab,
- * admin boot, account deletion). Must be called during component initialization.
- */
-export function useSessionTerminated(handler: (reason: string) => void) {
-  $effect(() => onSessionTerminated(handler));
+/** Subscribe to typing signals on the selected server with automatic cleanup. */
+export function useTypingEvent(handler: TypingHandler, getServerId?: ServerIdSelector): void {
+  useServerEvent(handler, onTypingEvent, getServerId);
 }
+
+export type { TypingEventData };

--- a/apps/frontend/src/lib/hooks/useEvent.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useEvent.svelte.ts
@@ -31,7 +31,10 @@ function useServerEvent<Handler>(
 }
 
 /** Subscribe to canonical projection operations on the route or explicitly selected server. */
-export function useProjectionEvent(handler: ProjectionHandler, getServerId?: ServerIdSelector): void {
+export function useProjectionEvent(
+  handler: ProjectionHandler,
+  getServerId?: ServerIdSelector
+): void {
   useServerEvent(handler, onProjectionEvent, getServerId);
 }
 

--- a/apps/frontend/src/lib/hooks/useTypingIndicator.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useTypingIndicator.svelte.ts
@@ -1,7 +1,7 @@
 import { SvelteMap } from 'svelte/reactivity';
-import { onTypingEvent, type TypingEventData } from '$lib/eventBus.svelte';
 import { useConnection } from '$lib/state/server/connection.svelte';
 import { createRoomCommandAPI } from '$lib/api-client/rooms';
+import { useTypingEvent, type TypingEventData } from './useEvent.svelte';
 
 /** How long to display typing indicator after receiving an event (ms) */
 export const TYPING_TIMEOUT_MS = 6000;
@@ -82,8 +82,7 @@ export function createTypingIndicator(getConfig: () => TypingIndicatorConfig) {
     }
   }
 
-  // Subscribe to typing events
-  const unsubscribe = onTypingEvent(handleTypingEvent);
+  useTypingEvent(handleTypingEvent);
   const cleanupInterval = setInterval(cleanupExpired, 1000);
 
   // Sync config reactively — getConfig() is called inside the $effect,
@@ -107,7 +106,6 @@ export function createTypingIndicator(getConfig: () => TypingIndicatorConfig) {
   // Cleanup on destroy
   $effect(() => {
     return () => {
-      unsubscribe();
       clearInterval(cleanupInterval);
       typingUsers.clear();
     };

--- a/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
+++ b/apps/frontend/src/routes/chat/AuthenticatedChatProvider.svelte
@@ -11,7 +11,6 @@
   import type { UserSettingsState } from '$lib/state/userSettings.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
-  import { provideEventBus } from '$lib/eventBus.svelte';
   import { eventBusManager } from '$lib/state/server/eventBus.svelte';
   import { useProjectionEvent, useSessionTerminated } from '$lib/hooks/useEvent.svelte';
   import { mapDirectoryMember } from '$lib/api-client/memberDirectory';
@@ -113,7 +112,7 @@
       serverRegistry.getStore(authenticatedOriginServerId).serverInfo.supportsRealtimeProjection,
       serverRegistry.getStore(authenticatedOriginServerId).realtimeSync
     );
-    provideEventBus(() => authenticatedOriginServerId);
+    const getAuthenticatedOriginServerId = () => authenticatedOriginServerId;
 
     function clearTerminatedOriginSession() {
       clearCachedUser();
@@ -123,43 +122,49 @@
 
     // Keep origin-global profile/settings caches synchronized with the same
     // projection operations that own each server-scoped store.
-    useProjectionEvent((event) => {
-      for (const operation of event.operations) {
-        if (operation.operation.case === 'reset') {
-          profileCache.clear();
-        } else if (operation.operation.case === 'userUpsert') {
-          const member = mapDirectoryMember(operation.operation.value);
-          if (!member.id) continue;
-          profileCache.update(
-            member.id,
-            member.displayName,
-            member.avatarUrl,
-            member.login,
-            member.customStatus
-          );
-        } else if (operation.operation.case === 'viewerUpsert') {
-          const viewer = viewerResponseToState(operation.operation.value);
-          currentUserState.user = viewer.user;
-          profileCache.update(
-            viewer.user.id,
-            viewer.user.displayName,
-            viewer.user.avatarUrl ?? null,
-            viewer.user.login,
-            viewer.user.customStatus ?? null
-          );
-          userSettings.updateFromData(viewer.user.settings);
-        } else if (operation.operation.case === 'userRemove') {
-          profileCache.remove(operation.operation.value.userId);
+    useProjectionEvent(
+      (event) => {
+        for (const operation of event.operations) {
+          if (operation.operation.case === 'reset') {
+            profileCache.clear();
+          } else if (operation.operation.case === 'userUpsert') {
+            const member = mapDirectoryMember(operation.operation.value);
+            if (!member.id) continue;
+            profileCache.update(
+              member.id,
+              member.displayName,
+              member.avatarUrl,
+              member.login,
+              member.customStatus
+            );
+          } else if (operation.operation.case === 'viewerUpsert') {
+            const viewer = viewerResponseToState(operation.operation.value);
+            currentUserState.user = viewer.user;
+            profileCache.update(
+              viewer.user.id,
+              viewer.user.displayName,
+              viewer.user.avatarUrl ?? null,
+              viewer.user.login,
+              viewer.user.customStatus ?? null
+            );
+            userSettings.updateFromData(viewer.user.settings);
+          } else if (operation.operation.case === 'userRemove') {
+            profileCache.remove(operation.operation.value.userId);
+          }
         }
-      }
-    });
+      },
+      getAuthenticatedOriginServerId
+    );
 
     // Handle session terminated events from server (logout from another tab/device, admin boot)
-    useSessionTerminated((reason) => {
-      console.log('Session terminated by server:', reason);
-      if (isExplicitSignOutRedirectInProgress()) return;
-      clearTerminatedOriginSession();
-    });
+    useSessionTerminated(
+      (reason) => {
+        console.log('Session terminated by server:', reason);
+        if (isExplicitSignOutRedirectInProgress()) return;
+        clearTerminatedOriginSession();
+      },
+      getAuthenticatedOriginServerId
+    );
 
     // Handle logout from another tab in the same browser (instant, no server round-trip)
     $effect(() =>

--- a/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/+layout.svelte
@@ -8,7 +8,6 @@
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import { provideServerScope, type ServerScope } from '$lib/state/server/scope.svelte';
   import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { provideEventBus } from '$lib/eventBus.svelte';
   import Chrome from '$lib/components/chat/Chrome.svelte';
 
   let { children } = $props();
@@ -59,13 +58,6 @@
     }
   };
   provideServerScope(serverScope);
-
-  // Provide the active server's event bus to child components via Svelte
-  // context. Passing a getter (not a fixed serverId) means typed-event /
-  // `onEvent` consumers below this point automatically migrate to the new
-  // server's bus when the URL `[serverId]` param changes — the bus lookup
-  // re-runs inside each consumer's `$effect`.
-  provideEventBus(() => serverScope.serverId);
 
   // Auth guard: redirect unauthenticated users to /login and save the return URL.
   const currentUserState = $derived(serverStore?.currentUser);

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -19,7 +19,7 @@
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { formatDate } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
-  import { onProjectionEvent } from '$lib/eventBus.svelte';
+  import { useProjectionEvent } from '$lib/hooks/useEvent.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import {
     createRoomPermissions,
@@ -201,37 +201,35 @@
   // Apply live root-message summaries directly from projection operations.
   // The canonical store reconciliation below also covers summaries that
   // arrived before this page mounted.
-  $effect(() =>
-    onProjectionEvent((event) => {
-      for (const operation of event.operations) {
-        if (operation.operation.case === 'threadViewerStatesReplace') {
-          const states = new Map(
-            operation.operation.value.states.map((state) => [
-              `${state.roomId}\u0000${state.threadRootEventId}`,
-              state.viewerState ?? {}
-            ])
-          );
-          if (reconcileThreadViewerStates(states)) void loadThreads();
-          continue;
-        }
-        if (operation.operation.case !== 'roomTimelineEventUpsert') continue;
-        const update = operation.operation.value;
-        const timelineEvent = update.event;
-        if (timelineEvent?.event.case !== 'messagePosted') continue;
-        const message = timelineEvent.event.value.message;
-        const summary = message?.thread;
-        if (!message || message.threadRootEventId || !summary) continue;
-
-        applyThreadSummary(
-          update.roomId,
-          timelineEvent.id,
-          summary.replyCount,
-          summary.lastReplyAt?.toDate().toISOString() ?? null,
-          summary.viewerState?.hasUnread
+  useProjectionEvent((event) => {
+    for (const operation of event.operations) {
+      if (operation.operation.case === 'threadViewerStatesReplace') {
+        const states = new Map(
+          operation.operation.value.states.map((state) => [
+            `${state.roomId}\u0000${state.threadRootEventId}`,
+            state.viewerState ?? {}
+          ])
         );
+        if (reconcileThreadViewerStates(states)) void loadThreads();
+        continue;
       }
-    })
-  );
+      if (operation.operation.case !== 'roomTimelineEventUpsert') continue;
+      const update = operation.operation.value;
+      const timelineEvent = update.event;
+      if (timelineEvent?.event.case !== 'messagePosted') continue;
+      const message = timelineEvent.event.value.message;
+      const summary = message?.thread;
+      if (!message || message.threadRootEventId || !summary) continue;
+
+      applyThreadSummary(
+        update.roomId,
+        timelineEvent.id,
+        summary.replyCount,
+        summary.lastReplyAt?.toDate().toISOString() ?? null,
+        summary.viewerState?.hasUnread
+      );
+    }
+  });
 
   // Reconcile followed-thread summaries from the same canonical room
   // projection that feeds every room timeline.


### PR DESCRIPTION
## Why

`ServerScope` already owns the active server identity, but realtime consumers
also depended on a second Svelte context carrying only a derived event-bus
getter. That duplicated route ownership and made route-versus-origin
subscriptions harder to follow.

## What changed

- Resolve route event subscriptions from `ServerScope`, with an explicit
  selector for origin-global subscriptions.
- Remove the event-bus context and its provider wiring.
- Centralize projection, presence, session, and typing subscription lifecycle
  in the event hooks, including migration when SvelteKit reuses a server route.
- Keep authenticated profile, settings, and session subscriptions pinned to
  the origin server.
- Replace the old provider wrapper with a self-contained presence-sync
  component.
- Add focused coverage for server switching, cleanup, and explicit origin
  selection.

This is a frontend-only internal refactor. It does not change UI copy,
notifications, backend APIs, persistence, or permissions, and it preserves the
authenticated-remote/anonymous-origin flow.

## Verification

- `mise lint-frontend`
- `mise test-frontend` (2,596 tests)
- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/hooks/useEvent.svelte.spec.ts`
- `mise build-frontend` (all bundle budgets passed)
- Targeted E2E: remote sign-in with anonymous origin and remote typing updates
- Svelte autofixer on every changed Svelte component and module
- `mise license-check`
- `mise knip` (existing baseline findings only)

An independent code review reported no findings.
