### PR TITLE
feat(frontend): add room-scoped message search

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/search.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/search.mdx
@@ -50,6 +50,17 @@ results at a time, so most searches do not need a continuation request.
   and network access like the Chatto server itself.
 </Aside>
 
+## Search Messages
+
+Open **Search** in the server sidebar to search every room you can currently
+read. To search only the conversation you are viewing, select the magnifying
+glass in the room header and use the **Search in this room** sidebar tab. Room
+search is also available in direct-message conversations.
+
+The server-wide page and recently used rooms keep independent, transient query
+and result state. Selecting a result opens that message in its room or thread
+context. Search never combines results from different servers.
+
 ## Enable Search with Bleve
 
 For a typical single-process installation, enable the Search feature and the
@@ -73,8 +84,9 @@ what allows the provider to run elsewhere or be replaced.
 1. Add the configuration above to `chatto.toml`.
 2. Make sure the Chatto process can create and write the configured directory.
 3. Restart Chatto.
-4. Open **Search** in the server sidebar. The page reports that indexing is in
-   progress until the provider has replayed the retained `EVT` history.
+4. Open **Search** in the server sidebar or the Search tab in a room. The UI
+   reports that indexing is in progress until the provider has replayed the
+   retained `EVT` history.
 
 </Steps>
 

--- a/apps/frontend/src/lib/state/server/messageSearch.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/messageSearch.svelte.spec.ts
@@ -176,6 +176,23 @@ describe('MessageSearchStore', () => {
     expect(store.results).toEqual([]);
   });
 
+  it('can preserve the raw field value while submitting a normalized query', async () => {
+    const client = api();
+    const store = new MessageSearchStore(client);
+    store.query = 'hello ';
+
+    await store.search(
+      { query: 'hello', order: MessageSearchOrder.RELEVANCE },
+      { preserveQuery: true }
+    );
+
+    expect(client.searchMessages).toHaveBeenCalledWith({
+      query: 'hello',
+      order: MessageSearchOrder.RELEVANCE
+    });
+    expect(store.query).toBe('hello ');
+  });
+
   it('clears plaintext results and invalidates in-flight work', async () => {
     let resolveSearch!: (value: MessageSearchPage) => void;
     const pending = new Promise<MessageSearchPage>((resolve) => (resolveSearch = resolve));

--- a/apps/frontend/src/lib/state/server/messageSearch.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/messageSearch.svelte.spec.ts
@@ -229,6 +229,46 @@ describe('MessageSearchStore', () => {
     await vi.waitFor(() => expect(store.results).toEqual([]));
   });
 
+  it('fences an in-flight response while a replacement query is being composed', async () => {
+    let resolveSearch!: (value: MessageSearchPage) => void;
+    const pending = new Promise<MessageSearchPage>((resolve) => (resolveSearch = resolve));
+    const store = new MessageSearchStore(api({ searchMessages: vi.fn().mockReturnValue(pending) }));
+    const search = store.search({ query: 'old', order: MessageSearchOrder.RELEVANCE });
+
+    store.query = 'new';
+    store.prepareQueryChange();
+    resolveSearch(page([result('stale')], null));
+    await search;
+
+    expect(store.query).toBe('new');
+    expect(store.results).toEqual([]);
+    expect(store.hasSearched).toBe(false);
+    expect(store.loading).toBe(false);
+  });
+
+  it('fences and refreshes an in-flight search after a room timeline replacement', async () => {
+    let resolveFirst!: (value: MessageSearchPage) => void;
+    const firstPage = new Promise<MessageSearchPage>((resolve) => (resolveFirst = resolve));
+    const searchMessages = vi
+      .fn()
+      .mockReturnValueOnce(firstPage)
+      .mockResolvedValueOnce(page([result('fresh')], null));
+    const store = new MessageSearchStore(api({ searchMessages }));
+    const firstSearch = store.search({
+      query: 'hello',
+      roomId: 'room-1',
+      order: MessageSearchOrder.RELEVANCE
+    });
+
+    store.invalidateRoom('room-1');
+    await vi.waitFor(() => expect(store.results.map((item) => item.id)).toEqual(['fresh']));
+    resolveFirst(page([result('stale')], null));
+    await firstSearch;
+
+    expect(store.results.map((item) => item.id)).toEqual(['fresh']);
+    expect(searchMessages).toHaveBeenCalledTimes(2);
+  });
+
   it('restarts after room revocation without destroying the search session', async () => {
     const searchMessages = vi
       .fn()

--- a/apps/frontend/src/lib/state/server/messageSearch.svelte.ts
+++ b/apps/frontend/src/lib/state/server/messageSearch.svelte.ts
@@ -131,11 +131,23 @@ export class MessageSearchStore {
     this.order = MessageSearchOrder.RELEVANCE;
   }
 
+  /** Fence older responses and hide results while a replacement query is being composed. */
+  prepareQueryChange(): void {
+    this.requestId++;
+    this.activeInput = null;
+    this.results = [];
+    this.nextCursor = null;
+    this.loading = false;
+    this.loadingMore = false;
+    this.error = false;
+    this.hasSearched = false;
+  }
+
   /** Purge one room's retained plaintext and fence older responses. */
   invalidateRoom(roomId: string): void {
     const matches = (result: MessageSearchResult) => result.roomId === roomId;
-    this.refreshAfterInvalidation(matches, false);
-    this.invalidatePrivacyConsumers(matches, false);
+    this.refreshAfterInvalidation(matches, true);
+    this.invalidatePrivacyConsumers(matches, true);
   }
 
   /** Re-run the search after projected room access is revoked. */

--- a/apps/frontend/src/lib/state/server/messageSearch.svelte.ts
+++ b/apps/frontend/src/lib/state/server/messageSearch.svelte.ts
@@ -13,6 +13,11 @@ const EMPTY_STATUS: MessageSearchStatus = {
   retryAfterMs: null
 };
 
+type MessageSearchOptions = {
+  /** Keep the raw, user-visible query while submitting a normalized value. */
+  preserveQuery?: boolean;
+};
+
 /** Server-scoped search availability and transient query results. */
 export class MessageSearchStore {
   status = $state<MessageSearchStatus>(EMPTY_STATUS);
@@ -76,11 +81,14 @@ export class MessageSearchStore {
     await this.ensureStatus();
   }
 
-  async search(input: Omit<MessageSearchInput, 'cursor'>): Promise<void> {
+  async search(
+    input: Omit<MessageSearchInput, 'cursor'>,
+    { preserveQuery = false }: MessageSearchOptions = {}
+  ): Promise<void> {
     const requestId = ++this.requestId;
     this.activeInput = { ...input };
     this.hasSearched = true;
-    this.query = input.query;
+    if (!preserveQuery) this.query = input.query;
     this.order = input.order;
     this.results = [];
     this.nextCursor = null;
@@ -194,7 +202,7 @@ export class MessageSearchStore {
     this.loading = false;
     this.loadingMore = false;
     this.error = false;
-    if (input && this.hasSearched) void this.search(input);
+    if (input && this.hasSearched) void this.search(input, { preserveQuery: true });
   }
 
   /** Subscribe another transient plaintext consumer to realtime privacy fences. */

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -545,6 +545,31 @@ describe('ServerStateStore authentication state', () => {
   });
 });
 
+describe('ServerStateStore room search state', () => {
+  it('retains separate transient search state for each room', () => {
+    const store = makeStore(new FakeServerConnection([]));
+    const firstRoomSearch = store.messageSearchForRoom('R1');
+    const secondRoomSearch = store.messageSearchForRoom('R2');
+
+    firstRoomSearch.query = 'first room only';
+
+    expect(store.messageSearchForRoom('R1')).toBe(firstRoomSearch);
+    expect(secondRoomSearch).not.toBe(firstRoomSearch);
+    expect(secondRoomSearch.query).toBe('');
+    expect(store.messageSearch.query).toBe('');
+  });
+
+  it('bounds retained room search plaintext', () => {
+    const store = makeStore(new FakeServerConnection([]));
+    const oldestSearch = store.messageSearchForRoom('R1');
+    oldestSearch.query = 'sensitive result scope';
+    for (let index = 2; index <= 11; index++) store.messageSearchForRoom(`R${index}`);
+
+    expect(oldestSearch.query).toBe('');
+    expect(store.messageSearchForRoom('R1')).not.toBe(oldestSearch);
+  });
+});
+
 describe('ServerStateStore live server updates', () => {
   it('refreshes a mounted admin room layout after remote projection changes', async () => {
     vi.useFakeTimers();

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -22,7 +22,7 @@ import { createNotificationAPI } from '$lib/api-client/notifications';
 import { createVoiceCallAPI } from '$lib/api-client/voiceCalls';
 import { createAdminRoomLayoutAPI } from '$lib/api-client/adminRoomLayout';
 import { createAdminEventLogAPI } from '$lib/api-client/adminEventLog';
-import { createMessageSearchAPI } from '$lib/api-client/messageSearch';
+import { createMessageSearchAPI, type MessageSearchAPI } from '$lib/api-client/messageSearch';
 import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
 import { createRoleAPI } from '$lib/api-client/roles';
 import { eventBusManager } from './eventBus.svelte';
@@ -57,6 +57,8 @@ import { MentionRolesStore } from './mentionRoles.svelte';
  * - null = no indicator
  */
 export type ServerIndicator = 'notification' | 'unread' | null;
+
+const MAX_RETAINED_ROOM_SEARCHES = 10;
 
 const EMPTY_PERMISSIONS: ServerPermissions = {
   loaded: false,
@@ -105,6 +107,8 @@ export class ServerStateStore {
   // reactive, while selector calls may occur during derived evaluation.
   #roomMessages: Record<string, MessagesStore> = Object.create(null);
   #roomFiles: Record<string, RoomFilesStore> = Object.create(null);
+  #roomMessageSearch: Record<string, MessageSearchStore> = Object.create(null);
+  #roomMessageSearchRecency: string[] = [];
   #threadMessages: Record<string, MessagesStore> = Object.create(null);
   #threadMessageRefCounts: Record<string, number> = Object.create(null);
   #adminRoomLayoutSubscriptions = 0;
@@ -112,6 +116,7 @@ export class ServerStateStore {
   /** Disposer for the internal effect root that wires lifecycle reactivity. */
   readonly #disposeEffects: () => void;
   readonly #playedCallSoundEventIds: string[] = [];
+  readonly #messageSearchAPI: MessageSearchAPI;
 
   constructor(
     registered: RegisteredServer,
@@ -134,6 +139,7 @@ export class ServerStateStore {
     const adminRoomLayoutAPI = serverConnection.getAPI(createAdminRoomLayoutAPI);
     const adminEventLogAPI = serverConnection.getAPI(createAdminEventLogAPI);
     const messageSearchAPI = serverConnection.getAPI(createMessageSearchAPI);
+    this.#messageSearchAPI = messageSearchAPI;
     const memberDirectoryAPI = serverConnection.getAPI(createMemberDirectoryAPI);
     const roleAPI = serverConnection.getAPI(createRoleAPI);
     this.currentUser = new CurrentUserState(
@@ -194,6 +200,26 @@ export class ServerStateStore {
     if (store) return store;
     store = new RoomFilesStore(this.#serverConnection, roomId);
     this.#roomFiles[roomId] = store;
+    return store;
+  }
+
+  /** Stable transient message-search state scoped to one room. */
+  messageSearchForRoom(roomId: string): MessageSearchStore {
+    let store = this.#roomMessageSearch[roomId];
+    if (store) {
+      this.#touchRoomMessageSearch(roomId);
+      return store;
+    }
+    if (this.#roomMessageSearchRecency.length >= MAX_RETAINED_ROOM_SEARCHES) {
+      const oldestRoomId = this.#roomMessageSearchRecency.shift();
+      if (oldestRoomId) {
+        this.#roomMessageSearch[oldestRoomId]?.reset();
+        delete this.#roomMessageSearch[oldestRoomId];
+      }
+    }
+    store = new MessageSearchStore(this.#messageSearchAPI);
+    this.#roomMessageSearch[roomId] = store;
+    this.#roomMessageSearchRecency.push(roomId);
     return store;
   }
 
@@ -313,7 +339,7 @@ export class ServerStateStore {
       switch (operation.operation.case) {
         case 'reset':
           this.resetProjectionMirrors();
-          this.messageSearch.clearResults();
+          this.forEachMessageSearch((store) => store.clearResults());
           adminRoomLayoutChanged = true;
           break;
         case 'serverUpsert':
@@ -321,7 +347,7 @@ export class ServerStateStore {
           break;
         case 'serverStateUpsert':
           this.serverInfo.applyProjectionState(operation.operation.value);
-          this.messageSearch.refreshRetainedResults();
+          this.forEachMessageSearch((store) => store.refreshRetainedResults());
           break;
         case 'viewerUpsert': {
           const viewer = viewerResponseToState(operation.operation.value);
@@ -340,7 +366,7 @@ export class ServerStateStore {
         }
         case 'userRemove': {
           const userId = operation.operation.value.userId;
-          this.messageSearch.invalidateAuthor(userId);
+          this.forEachMessageSearch((store) => store.invalidateAuthor(userId));
           removeUserSummaryCacheEntry(this.serverId, userId);
           this.notifications.scrubUser(userId);
           this.activeCallRooms.scrubUser(userId);
@@ -360,7 +386,7 @@ export class ServerStateStore {
           this.roomDirectory.acknowledgeMembership(roomId, viewerState?.isMember);
           this.roomUnread.acknowledgeRoomProjection(roomId, viewerState?.hasUnread);
           if (viewerState?.isMember === false) {
-            this.messageSearch.revokeRoom(roomId);
+            this.forRoomMessageSearch(roomId, (store) => store.revokeRoom(roomId));
             this.clearRoomAccess(roomId);
           } else if (viewerState?.isMember === true) {
             this.restoreRoomAccess(roomId);
@@ -372,7 +398,7 @@ export class ServerStateStore {
           const roomId = operation.operation.value.roomId;
           this.roomDirectory.removeMembershipProjection(roomId);
           this.roomUnread.removeRoomProjection(roomId);
-          this.messageSearch.revokeRoom(roomId);
+          this.forRoomMessageSearch(roomId, (store) => store.revokeRoom(roomId));
           this.clearRoomAccess(roomId, true);
           break;
         }
@@ -382,7 +408,9 @@ export class ServerStateStore {
         }
         case 'roomTimelineReplace': {
           const replacement = operation.operation.value;
-          this.messageSearch.invalidateRoom(replacement.roomId);
+          this.forRoomMessageSearch(replacement.roomId, (store) =>
+            store.invalidateRoom(replacement.roomId)
+          );
           if (replacement.page) {
             this.#roomMessages[replacement.roomId]?.replaceRoomProjectionPage(
               replacement.roomId,
@@ -394,10 +422,13 @@ export class ServerStateStore {
         case 'roomTimelineEventUpsert': {
           const update = operation.operation.value;
           if (update.event && !update.reactionChange) {
-            this.messageSearch.invalidateMessage(
-              update.roomId,
-              update.event.id,
-              existingTimelineRows.has(`${update.roomId}\u0000${update.event.id}`)
+            const eventId = update.event.id;
+            this.forRoomMessageSearch(update.roomId, (store) =>
+              store.invalidateMessage(
+                update.roomId,
+                eventId,
+                existingTimelineRows.has(`${update.roomId}\u0000${eventId}`)
+              )
             );
           }
           if (update.event) {
@@ -446,7 +477,9 @@ export class ServerStateStore {
             replacement.viewerState?.hasUnread
           );
           if (replacement.viewerState?.isMember === false) {
-            this.messageSearch.revokeRoom(replacement.roomId);
+            this.forRoomMessageSearch(replacement.roomId, (store) =>
+              store.revokeRoom(replacement.roomId)
+            );
             this.clearRoomAccess(replacement.roomId);
           } else if (replacement.viewerState?.isMember === true) {
             this.restoreRoomAccess(replacement.roomId);
@@ -486,7 +519,9 @@ export class ServerStateStore {
         }
         case 'roomTimelineEventRemove': {
           const removal = operation.operation.value;
-          this.messageSearch.invalidateMessage(removal.roomId, removal.eventId, true);
+          this.forRoomMessageSearch(removal.roomId, (store) =>
+            store.invalidateMessage(removal.roomId, removal.eventId, true)
+          );
           this.#roomMessages[removal.roomId]?.removeRoomProjectionEvent(
             removal.roomId,
             removal.eventId
@@ -510,6 +545,26 @@ export class ServerStateStore {
 
   get #adminRoomLayoutActive(): boolean {
     return this.#adminRoomLayoutSubscriptions > 0;
+  }
+
+  private forEachMessageSearch(callback: (store: MessageSearchStore) => void): void {
+    callback(this.messageSearch);
+    for (const store of Object.values(this.#roomMessageSearch)) callback(store);
+  }
+
+  private forRoomMessageSearch(
+    roomId: string,
+    callback: (store: MessageSearchStore) => void
+  ): void {
+    callback(this.messageSearch);
+    const roomStore = this.#roomMessageSearch[roomId];
+    if (roomStore) callback(roomStore);
+  }
+
+  #touchRoomMessageSearch(roomId: string): void {
+    const currentIndex = this.#roomMessageSearchRecency.indexOf(roomId);
+    if (currentIndex >= 0) this.#roomMessageSearchRecency.splice(currentIndex, 1);
+    this.#roomMessageSearchRecency.push(roomId);
   }
 
   private scheduleAdminRoomLayoutRefresh(): void {
@@ -735,6 +790,9 @@ export class ServerStateStore {
     this.#roomMessages = Object.create(null);
     for (const store of Object.values(this.#roomFiles)) store.dispose();
     this.#roomFiles = Object.create(null);
+    for (const store of Object.values(this.#roomMessageSearch)) store.reset();
+    this.#roomMessageSearch = Object.create(null);
+    this.#roomMessageSearchRecency = [];
     for (const store of Object.values(this.#threadMessages)) store.dispose();
     this.#threadMessages = Object.create(null);
     this.#threadMessageRefCounts = Object.create(null);

--- a/apps/frontend/src/lib/storage/roomSidebarPanel.spec.ts
+++ b/apps/frontend/src/lib/storage/roomSidebarPanel.spec.ts
@@ -31,11 +31,11 @@ describe('room sidebar panel storage', () => {
 
   it('persists the selected panel per server and room', () => {
     setRoomSidebarPanelState('server-a', 'room-1', 'files');
-    setRoomSidebarPanelState('server-a', 'room-2', 'members');
+    setRoomSidebarPanelState('server-a', 'room-2', 'search');
     setRoomSidebarPanelState('server-b', 'room-1', 'call');
 
     expect(getRoomSidebarPanelState('server-a', 'room-1')).toBe('files');
-    expect(getRoomSidebarPanelState('server-a', 'room-2')).toBe('members');
+    expect(getRoomSidebarPanelState('server-a', 'room-2')).toBe('search');
     expect(getRoomSidebarPanelState('server-b', 'room-1')).toBe('call');
   });
 

--- a/apps/frontend/src/lib/storage/roomSidebarPanel.ts
+++ b/apps/frontend/src/lib/storage/roomSidebarPanel.ts
@@ -1,6 +1,6 @@
 import { serverSlot, type Codec } from './slot';
 
-export const ROOM_SIDEBAR_PANELS = ['members', 'files', 'call'] as const;
+export const ROOM_SIDEBAR_PANELS = ['members', 'search', 'files', 'call'] as const;
 
 export type RoomSidebarPanel = (typeof ROOM_SIDEBAR_PANELS)[number];
 export type RoomSidebarPanelState = RoomSidebarPanel | null;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ClampedMessagePreview.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ClampedMessagePreview.svelte
@@ -1,0 +1,43 @@
+<!--
+@component
+
+Caps a room-search result without creating a nested scroll region. A bottom
+fade is rendered only when the message presentation actually overflows.
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
+
+  let { children }: { children: Snippet } = $props();
+
+  let clipped = $state(false);
+
+  function measureOverflow(node: HTMLElement): ReturnType<Attachment> {
+    const update = () => {
+      clipped = node.scrollHeight > node.clientHeight + 1;
+    };
+
+    update();
+    queueMicrotask(update);
+    const resizeObserver = new ResizeObserver(update);
+    const mutationObserver = new MutationObserver(update);
+    resizeObserver.observe(node);
+    mutationObserver.observe(node, { childList: true, subtree: true, characterData: true });
+
+    return () => {
+      resizeObserver.disconnect();
+      mutationObserver.disconnect();
+    };
+  }
+</script>
+
+<div class="relative max-h-40 overflow-hidden" {@attach measureOverflow}>
+  {@render children()}
+  {#if clipped}
+    <div
+      class="pointer-events-none absolute inset-x-0 bottom-0 h-12 bg-gradient-to-t from-background via-background/90 to-transparent group-hover/search-result:from-surface group-hover/search-result:via-surface/90 group-focus-visible/search-result:from-surface group-focus-visible/search-result:via-surface/90"
+      aria-hidden="true"
+      data-room-search-result-fade
+    ></div>
+  {/if}
+</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -30,6 +30,7 @@
   import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import { getAppUiState } from '$lib/state/appUi.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
+  import { MessageSearchState } from '$lib/state/server/messageSearch.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
@@ -76,6 +77,7 @@
   const serverSegment = $derived(serverIdToSegment(activeServerId));
   const stores = $derived(serverScope.store);
   const roomFilesStore = $derived(stores.filesForRoom(roomId));
+  const roomMessageSearchStore = $derived(stores.messageSearchForRoom(roomId));
   const serverInfo = $derived(stores.serverInfo);
   const appUi = getAppUiState();
   const desktopRoomLayout = new MediaQuery('(min-width: 1024px)', false);
@@ -274,13 +276,34 @@
 
   // Header action visibility — flat derivations keep the template clean
   let showVoiceCall = $derived(!!room.roomData && !!serverInfo.livekitUrl);
+  const supportsMessageSearch = $derived(serverInfo.supportsFeature('messageSearch'));
+  const messageSearchAvailable = $derived(
+    supportsMessageSearch &&
+      !stores.messageSearch.statusLoading &&
+      (stores.messageSearch.statusError ||
+        (stores.messageSearch.statusLoaded &&
+          stores.messageSearch.status.state !== MessageSearchState.DISABLED))
+  );
+  $effect(() => {
+    if (supportsMessageSearch) void stores.messageSearch.ensureStatus();
+  });
   // Channel rooms can be left unless membership is granted by Universal policy.
   let showLeaveRoom = $derived(!!room.roomData && !room.isDM && !room.roomData.room.isUniversal);
   const activeRoomSidebarPanel = $derived(
-    roomSidebarPanelForRoom(room.isDM, appUi.activeDesktopRoomSidebarPanel, showVoiceCall)
+    roomSidebarPanelForRoom(
+      room.isDM,
+      appUi.activeDesktopRoomSidebarPanel,
+      showVoiceCall,
+      messageSearchAvailable
+    )
   );
   const mobileRoomSidebarPanel = $derived(
-    roomSidebarPanelForRoom(room.isDM, appUi.mobileRoomSidebarPanel, showVoiceCall)
+    roomSidebarPanelForRoom(
+      room.isDM,
+      appUi.mobileRoomSidebarPanel,
+      showVoiceCall,
+      messageSearchAvailable
+    )
   );
   const roomFilesPanelActive = $derived(
     visibleRoomSidebarPanel(
@@ -289,7 +312,9 @@
       mobileRoomSidebarPanel
     ) === 'files'
   );
-  const roomSidebarTogglePanels = $derived(roomSidebarPanelsForRoom(room.isDM, showVoiceCall));
+  const roomSidebarTogglePanels = $derived(
+    roomSidebarPanelsForRoom(room.isDM, showVoiceCall, messageSearchAvailable)
+  );
   const hasActiveRoomCall = $derived(
     stores.activeCallRooms.has(roomId) || stores.voiceCall.isInCall(roomId)
   );
@@ -302,6 +327,7 @@
     roomId,
     hasActiveCall: hasActiveRoomCall,
     loading: room.isRoomLoading,
+    searchStore: roomMessageSearchStore,
     filesStore: roomFilesStore,
     livekitUrl: serverInfo.livekitUrl ?? undefined,
     canBanRoomMembers: canBanMembersFromRoomSidebar(room.isDM, room.roomData?.canBanRoomMembers),
@@ -368,6 +394,19 @@
     if (closeMobile) {
       appUi.closeMobileRoomSidebarPanel();
     }
+  }
+
+  function openSearchResult(
+    messageEventId: string,
+    threadRootEventId: string | null,
+    closeMobile = false
+  ): void {
+    if (threadRootEventId) {
+      openThread(threadRootEventId, { highlightEventId: messageEventId });
+    } else {
+      void jumpState.jumpToMessage(messageEventId);
+    }
+    if (closeMobile) appUi.closeMobileRoomSidebarPanel();
   }
 
   // Drop zone state for drag-and-drop image uploads
@@ -596,6 +635,8 @@
               activePanel: mobileRoomSidebarPanel,
               onOpenFile: (messageEventId, threadRootEventId) =>
                 openFileMessage(messageEventId, threadRootEventId, true),
+              onOpenSearchResult: (messageEventId, threadRootEventId) =>
+                openSearchResult(messageEventId, threadRootEventId, true),
               onClose: () => appUi.closeMobileRoomSidebarPanel()
             }
           : null}
@@ -610,6 +651,7 @@
           activePanel: activeRoomSidebarPanel,
           maximized: isDesktopCallMaximized,
           onOpenFile: openFileMessage,
+          onOpenSearchResult: openSearchResult,
           onToggleMaximized: toggleDesktopCallWide,
           onClose: closeDesktopRoomSidebarPanel
         }}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -376,6 +376,26 @@
     appUi.closeDesktopRoomSidebarPanel();
   }
 
+  function handleWindowKeydown(event: KeyboardEvent): void {
+    if (
+      event.defaultPrevented ||
+      event.altKey ||
+      event.shiftKey ||
+      (!event.metaKey && !event.ctrlKey) ||
+      event.key !== '/' ||
+      !messageSearchAvailable
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    if (desktopRoomLayout.current) {
+      appUi.openDesktopRoomSidebarPanel('search');
+    } else {
+      appUi.openMobileRoomSidebarPanel('search');
+    }
+  }
+
   function toggleDesktopCallWide(): void {
     if (activeRoomSidebarPanel !== 'call' || !hasActiveRoomCall) return;
     appUi.toggleRoomCallWide(activeServerId, roomId);
@@ -434,6 +454,9 @@
 
 <svelte:window
   onkeydown={(e) => {
+    handleWindowKeydown(e);
+    if (e.defaultPrevented) return;
+
     if (e.key === 'Escape' && mobileRoomSidebarPanel && !e.defaultPrevented) {
       e.preventDefault();
       appUi.closeMobileRoomSidebarPanel();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -204,7 +204,15 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
         livekitUrl: mocks.livekitUrl,
         videoProcessingEnabled: false,
         maxUploadSize: 25 * 1024 * 1024,
-        maxVideoUploadSize: 25 * 1024 * 1024
+        maxVideoUploadSize: 25 * 1024 * 1024,
+        supportsFeature: () => false
+      },
+      messageSearch: {
+        statusLoading: false,
+        statusError: false,
+        statusLoaded: false,
+        status: { state: 0 },
+        ensureStatus: vi.fn()
       },
       notifications: mocks.notifications,
       pendingHighlights: {
@@ -219,6 +227,7 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
       mentionRoles: mocks.mentionRoles,
       messagesForRoom: mocks.messagesForRoom,
       filesForRoom: () => ({ retain: mocks.roomFilesRetain }),
+      messageSearchForRoom: () => ({}),
       restoreProjectedRoomWindow:
         serverId === 'server-2'
           ? mocks.nextServerRestoreProjectedRoomWindow

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -7,6 +7,7 @@ import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { RealtimeProjectionEvent } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { TimelineEventKind } from '$lib/render/timelineEvents';
 import { MessagesStore } from '$lib/state/room';
+import { MessageSearchState } from '$lib/state/server/messageSearch.svelte';
 
 const { mocks } = vi.hoisted(() => {
   const queryData = {
@@ -50,6 +51,7 @@ const { mocks } = vi.hoisted(() => {
         getThreadEventsAround: vi.fn()
       },
       roomFilesRetain: vi.fn(),
+      messageSearchSupported: false,
       livekitUrl: null as string | null,
       roomKind: 1,
       getAppUiState: vi.fn(),
@@ -205,13 +207,14 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
         videoProcessingEnabled: false,
         maxUploadSize: 25 * 1024 * 1024,
         maxVideoUploadSize: 25 * 1024 * 1024,
-        supportsFeature: () => false
+        supportsFeature: (feature: string) =>
+          feature === 'messageSearch' && mocks.messageSearchSupported
       },
       messageSearch: {
         statusLoading: false,
         statusError: false,
-        statusLoaded: false,
-        status: { state: 0 },
+        statusLoaded: true,
+        status: { state: MessageSearchState.READY },
         ensureStatus: vi.fn()
       },
       notifications: mocks.notifications,
@@ -405,6 +408,7 @@ beforeEach(() => {
     new MessagesStore({} as never, () => 'test-user', mocks.timeline)
   );
   mocks.livekitUrl = null;
+  mocks.messageSearchSupported = false;
   mocks.roomKind = RoomKind.CHANNEL;
   mocks.pendingHighlightConsume.mockReset();
   mocks.pendingHighlightConsume.mockReturnValue(null);
@@ -470,6 +474,45 @@ describe('Room interaction bundles', () => {
     await expect
       .element(q(container, '[data-testid="room-sidebar-desktop-pane"]'))
       .toBeInTheDocument();
+  });
+
+  it('opens the desktop room search sidebar with Cmd+/', async () => {
+    mocks.messageSearchSupported = true;
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+    const event = new KeyboardEvent('keydown', {
+      key: '/',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true
+    });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(appUi.activeDesktopRoomSidebarPanel).toBe('search');
+    expect(
+      await waitForElement(container, '[data-testid="room-sidebar-desktop-pane"]')
+    ).toBeTruthy();
+  });
+
+  it('opens the mobile room search sidebar with Ctrl+/', async () => {
+    mocks.messageSearchSupported = true;
+    stubMatchMedia(false);
+    const { container } = render(Room, { props: { roomId: 'room-1' } });
+    const event = new KeyboardEvent('keydown', {
+      key: '/',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true
+    });
+
+    window.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(appUi.mobileRoomSidebarPanel).toBe('search');
+    expect(
+      await waitForElement(container, '[data-testid="room-sidebar-mobile-pane"]')
+    ).toBeTruthy();
   });
 });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -62,6 +62,13 @@ so switching rooms cannot leak a query or plaintext results into another room.
     searchNow();
   }
 
+  const focusSearchField: Attachment<HTMLFormElement> = (form) => {
+    queueMicrotask(() => {
+      if (!form.isConnected) return;
+      form.querySelector<HTMLInputElement>('input')?.focus();
+    });
+  };
+
   function scheduleSearch(event: Event): void {
     searchDebounce.cancel();
     const query = (event.currentTarget as HTMLInputElement).value;
@@ -159,15 +166,15 @@ so switching rooms cannot leak a query or plaintext results into another room.
 {:else}
   <div class="flex min-h-0 flex-1 flex-col">
     <div class="border-b border-border p-2">
-      <form onsubmit={submit}>
+      <form onsubmit={submit} {@attach focusSearchField}>
         <TextInput
           label={m['search.query.label']()}
           labelHidden
+          testid="room-search-query"
           bind:value={store.query}
           placeholder={m['search.query.placeholder']()}
           leadingIcon="uil--search"
           autocomplete="off"
-          autofocus
           oninput={scheduleSearch}
         />
       </form>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -47,11 +47,14 @@ so switching rooms cannot leak a query or plaintext results into another room.
     searchDebounce.cancel();
     const trimmed = store.query.trim();
     if (!trimmed || !store.available) return;
-    void store.search({
-      query: trimmed,
-      roomId,
-      order: MessageSearchOrder.RELEVANCE
-    });
+    void store.search(
+      {
+        query: trimmed,
+        roomId,
+        order: MessageSearchOrder.RELEVANCE
+      },
+      { preserveQuery: true }
+    );
   }
 
   function submit(event: SubmitEvent): void {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -59,12 +59,14 @@ so switching rooms cannot leak a query or plaintext results into another room.
     searchNow();
   }
 
-  function scheduleSearch(): void {
-    if (!store.query.trim()) {
-      searchDebounce.cancel();
+  function scheduleSearch(event: Event): void {
+    searchDebounce.cancel();
+    const query = (event.currentTarget as HTMLInputElement).value;
+    if (!query.trim()) {
       store.clearResults();
       return;
     }
+    store.prepareQueryChange();
     searchDebounce.run(searchNow, 300);
   }
 
@@ -197,42 +199,45 @@ so switching rooms cannot leak a query or plaintext results into another room.
                 <div
                   role="link"
                   tabindex="0"
+                  aria-label={`${result.actor?.displayName || result.actor?.login || m['common.unknown']()}: ${result.body}`}
                   data-room-search-result-id={result.id}
                   class="group/search-result cursor-pointer selectable-list-item"
                   onclick={(event) => openResult(event, result)}
                   onkeydown={(event) => openResultFromKeyboard(event, result)}
                 >
-                  <ClampedMessagePreview>
-                    <MessageView
-                      eventId={result.id}
-                      actor={resultActor(result)}
-                      displayName={result.actor?.displayName ||
-                        result.actor?.login ||
-                        m['common.unknown']()}
-                      missingActorIsDeleted={false}
-                      body={result.body}
-                      timestampSettings={userSettings}
-                      timestampLocale={activeLocale}
-                      rowClass="hover:bg-transparent md:mx-0 md:pr-2"
-                    >
-                      {#snippet headerMeta()}
-                        {#if result.createdAt}
-                          <time class="text-xs text-muted" datetime={result.createdAt}>
-                            {formatTimestamp(result.createdAt)}
-                          </time>
-                        {/if}
-                      {/snippet}
+                  <div class="pointer-events-none" inert data-room-search-result-preview>
+                    <ClampedMessagePreview>
+                      <MessageView
+                        eventId={result.id}
+                        actor={resultActor(result)}
+                        displayName={result.actor?.displayName ||
+                          result.actor?.login ||
+                          m['common.unknown']()}
+                        missingActorIsDeleted={false}
+                        body={result.body}
+                        timestampSettings={userSettings}
+                        timestampLocale={activeLocale}
+                        rowClass="hover:bg-transparent md:mx-0 md:pr-2"
+                      >
+                        {#snippet headerMeta()}
+                          {#if result.createdAt}
+                            <time class="text-xs text-muted" datetime={result.createdAt}>
+                              {formatTimestamp(result.createdAt)}
+                            </time>
+                          {/if}
+                        {/snippet}
 
-                      {#snippet afterBody()}
-                        {#if result.attachmentCount > 0}
-                          <p class="inline-flex items-center gap-1 text-xs text-muted">
-                            <span class="iconify uil--paperclip" aria-hidden="true"></span>
-                            {m['search.attachments']({ count: result.attachmentCount })}
-                          </p>
-                        {/if}
-                      {/snippet}
-                    </MessageView>
-                  </ClampedMessagePreview>
+                        {#snippet afterBody()}
+                          {#if result.attachmentCount > 0}
+                            <p class="inline-flex items-center gap-1 text-xs text-muted">
+                              <span class="iconify uil--paperclip" aria-hidden="true"></span>
+                              {m['search.attachments']({ count: result.attachmentCount })}
+                            </p>
+                          {/if}
+                        {/snippet}
+                      </MessageView>
+                    </ClampedMessagePreview>
+                  </div>
                 </div>
               </li>
             {/each}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -37,7 +37,14 @@ so switching rooms cannot leak a query or plaintext results into another room.
 
   const userSettings = getUserSettings();
   const activeLocale = $derived(getLocale());
+  const searchTerm = $derived(store.query.trim());
   const searchDebounce = useDebounce();
+  let pendingSearchTerm: string | null = null;
+  let submittedSearchTerm: string | null = initialSubmittedSearchTerm();
+
+  function initialSubmittedSearchTerm(): string | null {
+    return store.hasSearched ? store.query.trim() : null;
+  }
 
   $effect(() => {
     void store.ensureStatus();
@@ -45,11 +52,12 @@ so switching rooms cannot leak a query or plaintext results into another room.
 
   function searchNow(): void {
     searchDebounce.cancel();
-    const trimmed = store.query.trim();
-    if (!trimmed || !store.available) return;
+    pendingSearchTerm = null;
+    if (!searchTerm || searchTerm === submittedSearchTerm || !store.available) return;
+    submittedSearchTerm = searchTerm;
     void store.search(
       {
-        query: trimmed,
+        query: searchTerm,
         roomId,
         order: MessageSearchOrder.RELEVANCE
       },
@@ -70,12 +78,22 @@ so switching rooms cannot leak a query or plaintext results into another room.
   };
 
   function scheduleSearch(event: Event): void {
-    searchDebounce.cancel();
-    const query = (event.currentTarget as HTMLInputElement).value;
-    if (!query.trim()) {
+    store.query = (event.currentTarget as HTMLInputElement).value;
+    if (!searchTerm) {
+      searchDebounce.cancel();
+      pendingSearchTerm = null;
+      submittedSearchTerm = null;
       store.clearResults();
       return;
     }
+    if (
+      searchTerm === pendingSearchTerm ||
+      (store.hasSearched && searchTerm === submittedSearchTerm)
+    ) {
+      return;
+    }
+    searchDebounce.cancel();
+    pendingSearchTerm = searchTerm;
     store.prepareQueryChange();
     searchDebounce.run(searchNow, 300);
   }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -1,0 +1,255 @@
+<!--
+@component
+
+Room-scoped message search for the room sidebar. Its store is retained per room
+so switching rooms cannot leak a query or plaintext results into another room.
+-->
+<script lang="ts">
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+  import { tick } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
+  import type { MessageSearchResult } from '$lib/api-client/messageSearch';
+  import MessageView from '$lib/components/messages/MessageView.svelte';
+  import * as m from '$lib/i18n/messages';
+  import { getLocale } from '$lib/i18n/runtime';
+  import type { UserAvatarUserView } from '$lib/render/users';
+  import {
+    MessageSearchOrder,
+    MessageSearchState,
+    type MessageSearchStore
+  } from '$lib/state/server/messageSearch.svelte';
+  import { getUserSettings } from '$lib/state/userSettings.svelte';
+  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
+  import { EmptyState, Hint, ScrollFader } from '$lib/ui';
+  import { Button, TextInput } from '$lib/ui/form';
+  import { formatDateTime } from '$lib/utils/formatTime';
+  import ClampedMessagePreview from './ClampedMessagePreview.svelte';
+
+  let {
+    roomId,
+    store,
+    onOpenResult
+  }: {
+    roomId: string;
+    store: MessageSearchStore;
+    onOpenResult?: (messageEventId: string, threadRootEventId: string | null) => void;
+  } = $props();
+
+  const userSettings = getUserSettings();
+  const activeLocale = $derived(getLocale());
+  const searchDebounce = useDebounce();
+
+  $effect(() => {
+    void store.ensureStatus();
+  });
+
+  function searchNow(): void {
+    searchDebounce.cancel();
+    const trimmed = store.query.trim();
+    if (!trimmed || !store.available) return;
+    void store.search({
+      query: trimmed,
+      roomId,
+      order: MessageSearchOrder.RELEVANCE
+    });
+  }
+
+  function submit(event: SubmitEvent): void {
+    event.preventDefault();
+    searchNow();
+  }
+
+  function scheduleSearch(): void {
+    if (!store.query.trim()) {
+      searchDebounce.cancel();
+      store.clearResults();
+      return;
+    }
+    searchDebounce.run(searchNow, 300);
+  }
+
+  function resultActor(result: MessageSearchResult): UserAvatarUserView | null {
+    if (!result.actor) return null;
+    return { ...result.actor, presenceStatus: PresenceStatus.OFFLINE };
+  }
+
+  function formatTimestamp(value: string): string {
+    return value ? formatDateTime(value, userSettings, activeLocale) : '';
+  }
+
+  function openResult(event: MouseEvent, result: MessageSearchResult): void {
+    event.preventDefault();
+    onOpenResult?.(result.id, result.threadRootEventId);
+  }
+
+  function openResultFromKeyboard(event: KeyboardEvent, result: MessageSearchResult): void {
+    if (event.target !== event.currentTarget || event.key !== 'Enter') return;
+    event.preventDefault();
+    onOpenResult?.(result.id, result.threadRootEventId);
+  }
+
+  function loadMoreWhenVisible(node: HTMLElement): ReturnType<Attachment> {
+    if (typeof IntersectionObserver === 'undefined') return;
+    let loadingVisiblePages = false;
+    const loadVisiblePages = async (): Promise<void> => {
+      if (loadingVisiblePages) return;
+      loadingVisiblePages = true;
+      try {
+        do {
+          const cursor = store.nextCursor;
+          await store.loadMore();
+          await tick();
+          if (store.error || store.nextCursor === cursor) break;
+          const bounds = node.getBoundingClientRect();
+          if (bounds.top > window.innerHeight + 160 || bounds.bottom < -160) break;
+        } while (store.nextCursor && node.isConnected);
+      } finally {
+        loadingVisiblePages = false;
+      }
+    };
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) void loadVisiblePages();
+      },
+      { rootMargin: '160px 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }
+</script>
+
+{#if store.statusLoading && !store.statusLoaded}
+  <div class="flex min-h-32 flex-1 items-center justify-center p-4 text-center text-sm text-muted">
+    <span class="mr-2 iconify animate-spin uil--spinner-alt" aria-hidden="true"></span>
+    {m['search.checking']()}
+  </div>
+{:else if store.statusError || store.status.state === MessageSearchState.UNAVAILABLE}
+  <div class="flex min-h-0 flex-1 flex-col justify-center p-4">
+    <EmptyState icon="uil--cloud-slash" title={m['search.unavailable.title']()}>
+      <p>{m['search.unavailable.description']()}</p>
+      <div class="mt-4">
+        <Button variant="secondary" onclick={() => void store.refreshStatus()}>
+          {m['common.retry']()}
+        </Button>
+      </div>
+    </EmptyState>
+  </div>
+{:else if store.status.state === MessageSearchState.DISABLED}
+  <div class="flex min-h-0 flex-1 flex-col justify-center p-4">
+    <EmptyState icon="uil--search-alt" title={m['search.disabled.title']()}>
+      {m['search.disabled.description']()}
+    </EmptyState>
+  </div>
+{:else if store.status.state === MessageSearchState.STARTING || store.status.state === MessageSearchState.INDEXING}
+  <div class="flex min-h-0 flex-1 flex-col justify-center p-4">
+    <EmptyState icon="uil--database" title={m['search.indexing.title']()}>
+      <p>{m['search.indexing.description']()}</p>
+      <div class="mt-4">
+        <Button variant="secondary" onclick={() => void store.refreshStatus()}>
+          {m['search.check_again']()}
+        </Button>
+      </div>
+    </EmptyState>
+  </div>
+{:else}
+  <div class="flex min-h-0 flex-1 flex-col">
+    <div class="border-b border-border p-2">
+      <form onsubmit={submit}>
+        <TextInput
+          label={m['search.query.label']()}
+          labelHidden
+          bind:value={store.query}
+          placeholder={m['search.query.placeholder']()}
+          leadingIcon="uil--search"
+          autocomplete="off"
+          autofocus
+          oninput={scheduleSearch}
+        />
+      </form>
+      {#if store.status.state === MessageSearchState.DEGRADED}
+        <div class="mt-2">
+          <Hint tone="warning">{m['search.degraded']()}</Hint>
+        </div>
+      {/if}
+    </div>
+
+    <ScrollFader top bottom keyboardFocusable={false} class="min-h-0 flex-1">
+      <div class="flex min-h-full flex-col" aria-live="polite">
+        {#if store.error}
+          <EmptyState icon="uil--exclamation-triangle" title={m['search.error.title']()}>
+            {m['search.error.description']()}
+          </EmptyState>
+        {:else if store.loading && store.results.length === 0}
+          <div class="flex min-h-32 flex-1 items-center justify-center p-4 text-sm text-muted">
+            <span class="mr-2 iconify animate-spin uil--spinner-alt" aria-hidden="true"></span>
+            {m['search.searching']()}
+          </div>
+        {:else if store.hasSearched && store.results.length === 0 && !store.nextCursor}
+          <EmptyState icon="uil--search-minus" title={m['search.no_results.title']()}>
+            {m['search.no_results.description']()}
+          </EmptyState>
+        {:else if !store.hasSearched}
+          <EmptyState icon="uil--search" title={m['search.prompt.title']()} />
+        {:else}
+          <ol class="selectable-list gap-3 py-2">
+            {#each store.results as result (result.id)}
+              <li>
+                <div
+                  role="link"
+                  tabindex="0"
+                  data-room-search-result-id={result.id}
+                  class="group/search-result cursor-pointer selectable-list-item"
+                  onclick={(event) => openResult(event, result)}
+                  onkeydown={(event) => openResultFromKeyboard(event, result)}
+                >
+                  <ClampedMessagePreview>
+                    <MessageView
+                      eventId={result.id}
+                      actor={resultActor(result)}
+                      displayName={result.actor?.displayName ||
+                        result.actor?.login ||
+                        m['common.unknown']()}
+                      missingActorIsDeleted={false}
+                      body={result.body}
+                      timestampSettings={userSettings}
+                      timestampLocale={activeLocale}
+                      rowClass="hover:bg-transparent md:mx-0 md:pr-2"
+                    >
+                      {#snippet headerMeta()}
+                        {#if result.createdAt}
+                          <time class="text-xs text-muted" datetime={result.createdAt}>
+                            {formatTimestamp(result.createdAt)}
+                          </time>
+                        {/if}
+                      {/snippet}
+
+                      {#snippet afterBody()}
+                        {#if result.attachmentCount > 0}
+                          <p class="inline-flex items-center gap-1 text-xs text-muted">
+                            <span class="iconify uil--paperclip" aria-hidden="true"></span>
+                            {m['search.attachments']({ count: result.attachmentCount })}
+                          </p>
+                        {/if}
+                      {/snippet}
+                    </MessageView>
+                  </ClampedMessagePreview>
+                </div>
+              </li>
+            {/each}
+          </ol>
+          {#if store.nextCursor}
+            <div
+              {@attach loadMoreWhenVisible}
+              class="flex h-12 items-center justify-center text-sm text-muted"
+            >
+              {#if store.loadingMore}
+                <span class="mr-2 iconify animate-spin uil--spinner-alt" aria-hidden="true"></span>
+                {m['search.loading_more']()}
+              {/if}
+            </div>
+          {/if}
+        {/if}
+      </div>
+    </ScrollFader>
+  </div>
+{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -8,7 +8,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
 -->
 <script module lang="ts">
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-  export type RoomSidebarPanel = 'members' | 'files' | 'call';
+  export type RoomSidebarPanel = 'members' | 'search' | 'files' | 'call';
 </script>
 
 <script lang="ts">
@@ -20,6 +20,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   import UserContextMenu from '$lib/components/menus/UserContextMenu.svelte';
 
   import type { RoomFilesStore, RoomMember, RoomMembersStore } from '$lib/state/room';
+  import type { MessageSearchStore } from '$lib/state/server/messageSearch.svelte';
   import { getPresenceCache } from '$lib/state/presenceCache.svelte';
   import {
     getLiveCustomStatus,
@@ -40,6 +41,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   import { useDebounce } from '$lib/hooks/useDebounce.svelte';
   import VoiceCallPanel from '$lib/components/voice/VoiceCallPanel.svelte';
   import RoomFilesPanel from './RoomFilesPanel.svelte';
+  import RoomSearchPanel from './RoomSearchPanel.svelte';
 
   let {
     loading = false,
@@ -51,10 +53,12 @@ calls, and similar room-specific panels can plug into the same shell. See the
     canBanRoomMembers = false,
     currentUserId = null,
     membersStore,
+    searchStore,
     filesStore,
     livekitUrl,
     fileGroupingNow,
     onOpenFile,
+    onOpenSearchResult,
     onToggleMaximized,
     onClose
   }: {
@@ -67,10 +71,12 @@ calls, and similar room-specific panels can plug into the same shell. See the
     canBanRoomMembers?: boolean;
     currentUserId?: string | null;
     membersStore: RoomMembersStore;
+    searchStore?: MessageSearchStore;
     filesStore?: RoomFilesStore;
     livekitUrl?: string;
     fileGroupingNow?: Date;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
+    onOpenSearchResult?: (messageEventId: string, threadRootEventId: string | null) => void;
     onToggleMaximized?: () => void;
     onClose?: () => void;
   } = $props();
@@ -86,6 +92,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   const memberCount = $derived(membersStore.totalCount);
   const title = $derived.by(() => {
     if (activePanel === 'members') return m['room.sidebar.members_title']({ count: memberCount });
+    if (activePanel === 'search') return m['search.in_room']();
     if (activePanel === 'files') return m['room.sidebar.files']();
     return m['room.sidebar.call']();
   });
@@ -370,6 +377,10 @@ calls, and similar room-specific panels can plug into the same shell. See the
         />
       {/if}
     </nav>
+  {:else if activePanel === 'search'}
+    {#if searchStore}
+      <RoomSearchPanel store={searchStore} {roomId} onOpenResult={onOpenSearchResult} />
+    {/if}
   {:else if activePanel === 'files'}
     {#if filesStore}
       <RoomFilesPanel store={filesStore} serverId={activeServerId} {fileGroupingNow} {onOpenFile} />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -506,7 +506,7 @@ describe('RoomSidebar', () => {
 
     await userEvent.fill(input, 'roadmap ');
     await waitForRoomSearchDebounce();
-    await vi.waitFor(() => expect(searchMessages).toHaveBeenCalledTimes(2));
+    expect(searchMessages).toHaveBeenCalledOnce();
     expect(searchMessages).toHaveBeenLastCalledWith({
       query: 'roadmap',
       roomId: 'room-1',

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -1,6 +1,7 @@
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
 import { q } from '$lib/test-utils';
@@ -9,6 +10,12 @@ import { setReactiveLocale } from '$lib/i18n/state.svelte';
 import { ROOM_MEMBERS_PAGE_SIZE, type RoomMember } from '$lib/state/room/members.svelte';
 import type { PresenceCache } from '$lib/state/presenceCache.svelte';
 import type { RoomData } from '$lib/hooks/useRoomData.svelte';
+import { RoomKind as SearchRoomKind } from '$lib/api-client/roomDirectory';
+import {
+  MessageSearchOrder,
+  MessageSearchState,
+  MessageSearchStore
+} from '$lib/state/server/messageSearch.svelte';
 
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import RoomSidebarTestHarness from './RoomSidebarTestHarness.svelte';
@@ -179,6 +186,7 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     getStore: () => callStore,
+    tryGetStore: () => callStore,
     getServer: () => ({ id: 'test-server', url: 'https://chat.example.test' })
   }
 }));
@@ -238,6 +246,11 @@ async function flushRoomFilesPanel(): Promise<void> {
 
 async function waitForMemberSearchDebounce(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 300));
+  await tick();
+}
+
+async function waitForRoomSearchDebounce(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 350));
   await tick();
 }
 
@@ -400,6 +413,93 @@ describe('RoomSidebar', () => {
     callStore.activeCallRooms.getParticipantCallPresenceInAnyRoom.mockReturnValue(null);
     callStore.handleVoiceCallJoinFailed.mockClear();
     callStore.permissions.canStartDMs = false;
+  });
+
+  it('automatically searches only the current room and clamps long matching messages', async () => {
+    const searchMessages = vi.fn().mockResolvedValue({
+      results: [
+        {
+          id: 'message-1',
+          roomId: 'room-1',
+          roomName: 'general',
+          roomKind: SearchRoomKind.CHANNEL,
+          actorId: 'user-1',
+          actor: {
+            id: 'user-1',
+            login: 'alice',
+            displayName: 'Alice',
+            deleted: false,
+            avatarUrl: null
+          },
+          body: 'A result from this room',
+          createdAt: '2026-07-31T12:00:00.000Z',
+          threadRootEventId: 'thread-root',
+          attachmentCount: 0
+        },
+        {
+          id: 'message-long',
+          roomId: 'room-1',
+          roomName: 'general',
+          roomKind: SearchRoomKind.CHANNEL,
+          actorId: 'user-1',
+          actor: {
+            id: 'user-1',
+            login: 'alice',
+            displayName: 'Alice',
+            deleted: false,
+            avatarUrl: null
+          },
+          body: 'A very long result from this room. '.repeat(80),
+          createdAt: '2026-07-31T12:01:00.000Z',
+          threadRootEventId: null,
+          attachmentCount: 0
+        }
+      ],
+      nextCursor: null
+    });
+    const searchStore = new MessageSearchStore({
+      getStatus: vi.fn().mockResolvedValue({ state: MessageSearchState.READY, retryAfterMs: null }),
+      searchMessages
+    });
+    await searchStore.ensureStatus();
+    const onOpenSearchResult = vi.fn();
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        activePanel: 'search',
+        roomData: roomData([member(1)], 1, false),
+        searchStore,
+        onOpenSearchResult
+      }
+    });
+
+    const input = container.querySelector('input') as HTMLInputElement;
+    await userEvent.fill(input, 'roadmap');
+    expect(
+      [...container.querySelectorAll('button')].some(
+        (button) => button.textContent?.trim() === 'Search'
+      )
+    ).toBe(false);
+    await waitForRoomSearchDebounce();
+
+    await vi.waitFor(() => expect(searchMessages).toHaveBeenCalledOnce());
+    expect(searchMessages).toHaveBeenCalledWith({
+      query: 'roadmap',
+      roomId: 'room-1',
+      order: MessageSearchOrder.RELEVANCE
+    });
+    await vi.waitFor(() =>
+      expect(container.querySelector('[data-room-search-result-id="message-1"]')).toBeTruthy()
+    );
+    const shortResult = container.querySelector('[data-room-search-result-id="message-1"]')!;
+    const longResult = container.querySelector('[data-room-search-result-id="message-long"]')!;
+    expect(longResult.querySelector('.max-h-40')?.classList).toContain('overflow-hidden');
+
+    await userEvent.click(shortResult);
+    expect(onOpenSearchResult).toHaveBeenCalledWith('message-1', 'thread-root');
+
+    await userEvent.clear(input);
+    expect(searchStore.hasSearched).toBe(false);
+    expect(searchStore.results).toEqual([]);
   });
 
   it('does not load room files for the Members panel', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -33,6 +33,9 @@ const callStore = vi.hoisted(() => ({
     loaded: true,
     canStartDMs: false
   },
+  currentUser: {
+    user: { id: 'viewer', login: 'viewer' }
+  },
   voiceCall: {
     roomId: null as string | null,
     connecting: false,
@@ -473,6 +476,7 @@ describe('RoomSidebar', () => {
     });
 
     const input = container.querySelector('input') as HTMLInputElement;
+    await vi.waitFor(() => expect(document.activeElement).toBe(input));
     await userEvent.fill(input, 'roadmap');
     expect(
       [...container.querySelectorAll('button')].some(

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -500,6 +500,16 @@ describe('RoomSidebar', () => {
     await userEvent.click(shortResult);
     expect(onOpenSearchResult).toHaveBeenCalledWith('message-1', 'thread-root');
 
+    await userEvent.fill(input, 'roadmap ');
+    await waitForRoomSearchDebounce();
+    await vi.waitFor(() => expect(searchMessages).toHaveBeenCalledTimes(2));
+    expect(searchMessages).toHaveBeenLastCalledWith({
+      query: 'roadmap',
+      roomId: 'room-1',
+      order: MessageSearchOrder.RELEVANCE
+    });
+    expect(input.value).toBe('roadmap ');
+
     await userEvent.clear(input);
     expect(searchStore.hasSearched).toBe(false);
     expect(searchStore.results).toEqual([]);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -492,6 +492,9 @@ describe('RoomSidebar', () => {
     );
     const shortResult = container.querySelector('[data-room-search-result-id="message-1"]')!;
     const longResult = container.querySelector('[data-room-search-result-id="message-long"]')!;
+    expect(
+      shortResult.querySelector('[data-room-search-result-preview]')?.hasAttribute('inert')
+    ).toBe(true);
     expect(longResult.querySelector('.max-h-40')?.classList).toContain('overflow-hidden');
 
     await userEvent.click(shortResult);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarTestHarness.svelte
@@ -12,6 +12,7 @@ can exercise pagination wiring without mounting the full chat room.
   import { createPresenceCache, type PresenceCache } from '$lib/state/presenceCache.svelte';
   import { useConnection } from '$lib/state/server/connection.svelte';
   import { RoomFilesStore, RoomMembersStore, setRoomMembersStore } from '$lib/state/room';
+  import { MessageSearchState, MessageSearchStore } from '$lib/state/server/messageSearch.svelte';
   import { setUserSettings, UserSettingsState } from '$lib/state/userSettings.svelte';
   import RoomSidebar, { type RoomSidebarPanel } from './RoomSidebar.svelte';
 
@@ -24,10 +25,15 @@ can exercise pagination wiring without mounting the full chat room.
     hasActiveCall = false,
     currentUserId = 'viewer',
     canBanRoomMembers = false,
+    searchStore = new MessageSearchStore({
+      getStatus: async () => ({ state: MessageSearchState.READY, retryAfterMs: null }),
+      searchMessages: async () => ({ results: [], nextCursor: null })
+    }),
     livekitUrl,
     fileGroupingNow,
     onPresenceCacheReady,
     onOpenFile,
+    onOpenSearchResult,
     onToggleMaximized,
     onClose
   }: {
@@ -39,10 +45,12 @@ can exercise pagination wiring without mounting the full chat room.
     hasActiveCall?: boolean;
     currentUserId?: string | null;
     canBanRoomMembers?: boolean;
+    searchStore?: MessageSearchStore;
     livekitUrl?: string;
     fileGroupingNow?: Date;
     onPresenceCacheReady?: (cache: PresenceCache) => void;
     onOpenFile?: (messageEventId: string, threadRootEventId: string | null) => void;
+    onOpenSearchResult?: (messageEventId: string, threadRootEventId: string | null) => void;
     onToggleMaximized?: () => void;
     onClose?: () => void;
   } = $props();
@@ -82,10 +90,12 @@ can exercise pagination wiring without mounting the full chat room.
     {canBanRoomMembers}
     {currentUserId}
     membersStore={roomMembersStore}
+    {searchStore}
     filesStore={roomFilesStore}
     {livekitUrl}
     {fileGroupingNow}
     {onOpenFile}
+    {onOpenSearchResult}
     {onToggleMaximized}
     {onClose}
   />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
@@ -27,12 +27,14 @@ Room header affordance for opening or hiding room extras panels.
     hasActiveCall?: boolean;
   } = $props();
 
-  const panelDefinitions: {
-    id: RoomSidebarPanel;
-    icon: string;
-    showLabel: string;
-    hideLabel: string;
-  }[] = [
+  const panelDefinitions = $derived<
+    {
+      id: RoomSidebarPanel;
+      icon: string;
+      showLabel: string;
+      hideLabel: string;
+    }[]
+  >([
     {
       id: 'members',
       icon: 'uil--users-alt',
@@ -57,7 +59,7 @@ Room header affordance for opening or hiding room extras panels.
       showLabel: 'Show call',
       hideLabel: 'Hide call'
     }
-  ];
+  ]);
 
   const visiblePanels = $derived(
     panels ? panelDefinitions.filter((panel) => panels.includes(panel.id)) : panelDefinitions

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte
@@ -10,6 +10,7 @@ Room header affordance for opening or hiding room extras panels.
 - `mode` - Responsive visibility for the toggle group.
 -->
 <script lang="ts">
+  import * as m from '$lib/i18n/messages';
   import type { RoomSidebarPanel } from './RoomSidebar.svelte';
 
   let {
@@ -37,6 +38,12 @@ Room header affordance for opening or hiding room extras panels.
       icon: 'uil--users-alt',
       showLabel: 'Show members',
       hideLabel: 'Hide members'
+    },
+    {
+      id: 'search',
+      icon: 'uil--search',
+      showLabel: m['search.in_room'](),
+      hideLabel: m['room.sidebar.hide']()
     },
     {
       id: 'files',

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { tick } from 'svelte';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
 import RoomSidebarToggle from './RoomSidebarToggle.svelte';
 
 describe('RoomSidebarToggle', () => {
@@ -71,6 +73,22 @@ describe('RoomSidebarToggle', () => {
     await tick();
 
     expect(onToggle).toHaveBeenCalledWith('search');
+  });
+
+  it('updates the search label when the active locale changes', async () => {
+    await loadLocaleMessages('en-GB');
+    setReactiveLocale('en-GB');
+    const { container } = render(RoomSidebarToggle, {
+      props: { activePanel: null, onToggle: vi.fn() }
+    });
+
+    expect(container.querySelector('[aria-label="Search in this room"]')).toBeTruthy();
+    await loadLocaleMessages('de-DE');
+    setReactiveLocale('de-DE');
+    await tick();
+
+    expect(container.querySelector('[aria-label="In diesem Raum suchen"]')).toBeTruthy();
+    setReactiveLocale('en-GB');
   });
 
   it('switches to the call panel', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarToggle.svelte.spec.ts
@@ -53,6 +53,26 @@ describe('RoomSidebarToggle', () => {
     expect(onToggle).toHaveBeenCalledWith('files');
   });
 
+  it('switches to room-scoped search', async () => {
+    const onToggle = vi.fn();
+    const { container } = render(RoomSidebarToggle, {
+      props: {
+        activePanel: 'members',
+        onToggle
+      }
+    });
+
+    const button = container.querySelector(
+      '[aria-label="Search in this room"]'
+    ) as HTMLButtonElement | null;
+    expect(button).toBeTruthy();
+
+    button!.click();
+    await tick();
+
+    expect(onToggle).toHaveBeenCalledWith('search');
+  });
+
   it('switches to the call panel', async () => {
     const onToggle = vi.fn();
     const { container } = render(RoomSidebarToggle, {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.spec.ts
@@ -24,11 +24,12 @@ describe('room sidebar behavior', () => {
   });
 
   it('exposes files and calls as DM room sidebar panels', () => {
-    expect(DM_ROOM_SIDEBAR_PANELS).toEqual(['files', 'call']);
+    expect(DM_ROOM_SIDEBAR_PANELS).toEqual(['search', 'files', 'call']);
   });
 
   it('keeps channel room sidebar panels unchanged', () => {
     expect(roomSidebarPanelForRoom(false, 'members')).toBe('members');
+    expect(roomSidebarPanelForRoom(false, 'search')).toBe('search');
     expect(roomSidebarPanelForRoom(false, 'files')).toBe('files');
     expect(roomSidebarPanelForRoom(false, 'call')).toBe('call');
     expect(roomSidebarPanelForRoom(false, null)).toBeNull();
@@ -43,6 +44,17 @@ describe('room sidebar behavior', () => {
     expect(roomSidebarPanelForRoom(true, 'files')).toBe('files');
   });
 
+  it('allows room search in channels and direct messages when Search is available', () => {
+    expect(roomSidebarPanelForRoom(false, 'search', true, true)).toBe('search');
+    expect(roomSidebarPanelForRoom(true, 'search', true, true)).toBe('search');
+  });
+
+  it('hides room search when Search is unavailable', () => {
+    expect(roomSidebarPanelForRoom(false, 'search', true, false)).toBeNull();
+    expect(roomSidebarPanelsForRoom(false, true, false)).toEqual(['members', 'files', 'call']);
+    expect(roomSidebarPanelsForRoom(true, true, false)).toEqual(['files', 'call']);
+  });
+
   it('allows the call panel to open for DM rooms when LiveKit is configured', () => {
     expect(roomSidebarPanelForRoom(true, 'call', true)).toBe('call');
   });
@@ -50,13 +62,13 @@ describe('room sidebar behavior', () => {
   it('hides the call panel when LiveKit is not configured', () => {
     expect(roomSidebarPanelForRoom(false, 'call', false)).toBeNull();
     expect(roomSidebarPanelForRoom(true, 'call', false)).toBeNull();
-    expect(roomSidebarPanelsForRoom(false, false)).toEqual(['members', 'files']);
-    expect(roomSidebarPanelsForRoom(true, false)).toEqual(['files']);
+    expect(roomSidebarPanelsForRoom(false, false)).toEqual(['members', 'search', 'files']);
+    expect(roomSidebarPanelsForRoom(true, false)).toEqual(['search', 'files']);
   });
 
   it('returns all channel panels when LiveKit is configured', () => {
-    expect(CHANNEL_ROOM_SIDEBAR_PANELS).toEqual(['members', 'files', 'call']);
-    expect(roomSidebarPanelsForRoom(false, true)).toEqual(['members', 'files', 'call']);
+    expect(CHANNEL_ROOM_SIDEBAR_PANELS).toEqual(['members', 'search', 'files', 'call']);
+    expect(roomSidebarPanelsForRoom(false, true)).toEqual(['members', 'search', 'files', 'call']);
   });
 
   it('uses only the desktop sidebar selection on desktop', () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/roomSidebarBehavior.ts
@@ -1,7 +1,12 @@
 import type { RoomSidebarPanel, RoomSidebarPanelState } from '$lib/storage/roomSidebarPanel';
 
-export const CHANNEL_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['members', 'files', 'call'];
-export const DM_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['files', 'call'];
+export const CHANNEL_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = [
+  'members',
+  'search',
+  'files',
+  'call'
+];
+export const DM_ROOM_SIDEBAR_PANELS: RoomSidebarPanel[] = ['search', 'files', 'call'];
 
 export function canBanMembersFromRoomSidebar(
   isDM: boolean,
@@ -13,18 +18,26 @@ export function canBanMembersFromRoomSidebar(
 export function roomSidebarPanelForRoom(
   isDM: boolean,
   panel: RoomSidebarPanelState,
-  livekitEnabled = true
+  livekitEnabled = true,
+  messageSearchEnabled = true
 ): RoomSidebarPanelState {
   if (panel === null) return null;
   const panels = isDM ? DM_ROOM_SIDEBAR_PANELS : CHANNEL_ROOM_SIDEBAR_PANELS;
   if (!panels.includes(panel)) return null;
   if (panel === 'call' && !livekitEnabled) return null;
+  if (panel === 'search' && !messageSearchEnabled) return null;
   return panel;
 }
 
-export function roomSidebarPanelsForRoom(isDM: boolean, livekitEnabled: boolean): RoomSidebarPanel[] {
+export function roomSidebarPanelsForRoom(
+  isDM: boolean,
+  livekitEnabled: boolean,
+  messageSearchEnabled = true
+): RoomSidebarPanel[] {
   const panels = isDM ? DM_ROOM_SIDEBAR_PANELS : CHANNEL_ROOM_SIDEBAR_PANELS;
-  return livekitEnabled ? panels : panels.filter((panel) => panel !== 'call');
+  return panels.filter(
+    (panel) => (livekitEnabled || panel !== 'call') && (messageSearchEnabled || panel !== 'search')
+  );
 }
 
 export function visibleRoomSidebarPanel(

--- a/docs/fdr/FDR-033-message-search.md
+++ b/docs/fdr/FDR-033-message-search.md
@@ -26,11 +26,14 @@ provider supplies results.
   longer words. The bundled provider enables all analyzers by default.
 - Structured filters support a room (`in:`), author (`from:`), messages before
   or after a date, and messages with attachments.
-- Search is a server-level page reached from the server sidebar between
-  Overview and My Threads. It starts without a room filter.
-- Each registered server retains its own transient query, ordering, and result
-  state. Switching servers never carries a query into another server; returning
-  to a server can restore its previous search.
+- Search is available as a server-level page reached from the server sidebar
+  between Overview and My Threads, and as a room-sidebar tab that searches only
+  the current room or direct-message conversation.
+- Each registered server retains its own transient server-wide query, ordering,
+  and result state. Recently used rooms also retain separate transient sidebar
+  search state. Switching servers or rooms never carries plaintext results into
+  a different scope; returning to a retained scope can restore its previous
+  search.
 - Results show the current message, author, room, and timestamp. The bundled
   client requests 50 at a time, loads more automatically, and can order them by
   relevance or newest first. Pagination reads the live provider index rather
@@ -112,10 +115,10 @@ should not need to emit a backend-specific query language.
 **Tradeoff:** Recall and ranking may still vary by provider because analysis
 features such as stemming and typo tolerance are implementation details.
 
-### 7. Search has a dedicated server page
+### 7. Server-wide Search has a dedicated page
 
-**Decision:** Search lives in the server sidebar and opens as a full page rather
-than a modal or part of the quick switcher.
+**Decision:** Search across rooms lives in the server sidebar and opens as a full
+page rather than a modal or part of the quick switcher.
 **Why:** Searching message history is an extended reading task whose query,
 results, filters, and future conversation context need durable screen space.
 **Tradeoff:** Opening a result leaves the Search page; each server's transient
@@ -133,6 +136,17 @@ inventing a weaker client-side relevance model.
 comparable. The initial 0.5 design optimizes for the bundled Bleve provider;
 federation-wide calibration can be added later if implementation diversity
 makes it necessary.
+
+### 9. Room search stays beside the conversation
+
+**Decision:** The room-sidebar Search tab always applies the current room as its
+scope, including when the room is a direct-message conversation.
+**Why:** People searching while reading a conversation usually want local
+context and should not need to construct or clear an `in:` filter. Keeping the
+results beside the timeline also makes it quick to inspect several matches in
+the same conversation.
+**Tradeoff:** Server-wide and room-scoped Search are two entry points with
+independent transient query state.
 
 ## Related
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -42,4 +42,4 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-030](FDR-030-inline-message-timestamps.md) | Inline Message Timestamps | Active | 2026-07-12 |
 | [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-07-30 |
 | [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-07-19 |
-| [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-07-21 |
+| [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-07-31 |


### PR DESCRIPTION
## Why

Room members should be able to find a message without leaving the current conversation or searching across rooms. The narrow sidebar also needs compact previews so one long message cannot dominate the results list.

## What changed

- add a Search tab to the room and conversation right sidebar, scoped to the current room
- run searches automatically after a 300 ms debounce while preserving Enter as an immediate shortcut
- derive a trimmed search term so whitespace-only edits neither restart the debounce nor repeat a request
- focus the query field whenever the Search sidebar opens and support Cmd/Ctrl+/ to open it directly
- preserve the user's exact field text, including trailing spaces, while submitting a trimmed query
- retain bounded per-room search state and apply realtime privacy/content invalidation to every retained room search
- cap long result previews behind a non-scrollable bottom fade while keeping each result a single accessible navigation target
- document the room-scoped workflow and update [FDR-033](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-033-message-search.md)

## Compatibility and operations

- no public API, protocol, persistence, configuration, or migration changes
- the tab remains capability- and status-gated for older or search-disabled servers
- transient plaintext is isolated per room, bounded to ten retained room stores, and purged by existing privacy/realtime invalidation paths

## Test plan

- `mise test-frontend` — 308 files, 2,602 tests passed
- targeted post-rebase frontend tests — 6 files, 125 tests passed
- focused whitespace regression tests — 2 files, 50 tests passed
- focused rebased search/sidebar tests — 3 files, 85 tests passed
- full room-sidebar component spec after normalized-term deduplication — 39 tests passed
- `mise x -- pnpm check` — 0 errors, 0 warnings
- `mise x -- pnpm lint`
- Svelte autofixer on every changed Svelte component/module
- desktop and narrow browser verification of debounce, result navigation semantics, overflow clipping/fade, and accessibility tree
- two adversarial review passes; the final pass reported no findings
