### PR TITLE
refactor(frontend): scope core chat state to routes

### DIFF
--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -16,8 +16,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     sidebarLinkAnchorAttributes,
     sidebarLinkTarget
   } from '$lib/navigation/sidebarLinkTarget';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
   import EmptyState from '$lib/ui/EmptyState.svelte';
   import { serverStorageKey } from '$lib/storage/serverStorage';
@@ -45,16 +45,17 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { markNavigationRoomAsRead } from '$lib/navigation/readActions';
   import { toast } from '$lib/ui/toast';
 
-  // No props — RoomList reads everything from the active server's stores.
-  // All store references go through `stores` ($derived), so when the active
-  // server changes (URL [serverId] param changes), every derived read in the
-  // template re-evaluates against the new server's state automatically.
+  // No props — RoomList reads everything from the route's server scope.
+  // All store references go through `stores` ($derived), so when the URL
+  // [serverId] param changes, every derived read in the template re-evaluates
+  // against the new server's state automatically.
 
-  const activeServerId = $derived(getActiveServer());
+  const serverScope = useServerScope();
+  const activeServerId = $derived(serverScope.serverId);
   const serverSegment = $derived(serverIdToSegment(activeServerId));
   const activeServer = $derived(serverRegistry.getServer(activeServerId));
   const activeServerBaseURL = $derived(activeServer?.url ?? null);
-  const stores = $derived(serverRegistry.getStore(activeServerId));
+  const stores = $derived(serverScope.store);
   const notificationStore = $derived(stores.notifications);
   const notificationLevelStore = $derived(stores.notificationLevels);
   const activeCallRooms = $derived(stores.activeCallRooms);
@@ -252,8 +253,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     }
     void notificationStore.dismiss(notification.id);
 
-    const path = notificationStore.getCleanPath(getActiveServer(), notification);
-    // eslint-disable-next-line svelte/no-navigation-without-resolve -- path from getCleanPath() is already resolved
+    const path = notificationStore.getCleanPath(activeServerId, notification);
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- getCleanPath() returns a resolved app path
     await goto(path);
   }
 </script>

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -106,13 +106,15 @@ vi.mock('$lib/navigation', () => ({
   segmentToServerId: () => 'origin'
 }));
 
-vi.mock('$lib/state/activeServer.svelte', () => ({
-  getActiveServer: () => 'origin'
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({
+    serverId: 'origin',
+    store: mocks.store
+  })
 }));
 
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
-    getStore: vi.fn(() => mocks.store),
     isOriginServer: vi.fn(() => true),
     getServer: vi.fn(() => ({ id: 'origin', url: 'https://chat.example.test' })),
     originServer: { id: 'origin' },
@@ -913,6 +915,10 @@ describe('RoomList', () => {
         mocks.goto.mock.invocationCallOrder[0]
       );
       expect(mocks.store.notifications.dismiss).toHaveBeenCalledWith('mention-1');
+      expect(mocks.store.notifications.getCleanPath).toHaveBeenCalledWith(
+        'origin',
+        roomNotification
+      );
       expect(mocks.goto).toHaveBeenCalledWith('/chat/-/channel-1/thread-1');
     });
   });

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -12,9 +12,7 @@ to the user settings page for the active server.
   import { goto } from '$app/navigation';
   import { serverIdToSegment } from '$lib/navigation';
   import * as m from '$lib/i18n/messages';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { useConnection } from '$lib/state/server/connection.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { getLiveDisplayName, type CustomUserStatus } from '$lib/state/userProfiles.svelte';
   import { setPresenceMode } from '$lib/presenceTracking';
   import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
@@ -44,15 +42,15 @@ to the user settings page for the active server.
     return customStatusEditorModule;
   }
 
-  const connection = useConnection();
+  const serverScope = useServerScope();
   const appUi = getAppUiState();
   const presenceCache = getPresenceCache();
-  const activeServerId = $derived(getActiveServer());
+  const activeServerId = $derived(serverScope.serverId);
   const serverSegment = $derived(serverIdToSegment(activeServerId));
-  const activeStore = $derived(serverRegistry.tryGetStore(activeServerId));
-  const activeServerUser = $derived(activeStore?.currentUser.user);
-  const voiceCallState = $derived(activeStore?.voiceCall);
-  const navigation = $derived(activeStore?.navigation);
+  const activeStore = $derived(serverScope.store);
+  const activeServerUser = $derived(activeStore.currentUser.user);
+  const voiceCallState = $derived(activeStore.voiceCall);
+  const navigation = $derived(activeStore.navigation);
 
   const displayName = $derived(
     activeServerUser
@@ -102,7 +100,7 @@ to the user settings page for the active server.
   let customStatusDialogVisible = $state(false);
 
   function customStatusAPIConfig() {
-    return { ...connection().apiConfig, serverId: activeServerId };
+    return { ...serverScope.connection.apiConfig, serverId: activeServerId };
   }
 
   function openStatusMenu(event: MouseEvent) {
@@ -161,7 +159,7 @@ to the user settings page for the active server.
 
   function updateCurrentCustomStatus(status: CustomUserStatus | null) {
     const store = activeStore;
-    if (!store?.currentUser.user) return;
+    if (!store.currentUser.user) return;
     store.currentUser.user = {
       ...store.currentUser.user,
       customStatus: status

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -98,14 +98,22 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
   getActiveServer: () => 'origin'
 }));
 
-vi.mock('$lib/state/server/connection.svelte', () => ({
-  useConnection: () => () => ({
-    connectBaseUrl: 'https://chat.example.test',
-    bearerToken: 'token',
-    apiConfig: {
-      serverId: 'origin',
-      baseUrl: 'https://chat.example.test',
-      bearerToken: 'token'
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({
+    serverId: 'origin',
+    store: {
+      currentUser: currentUserState,
+      voiceCall: voiceCallState,
+      navigation: roomsState
+    },
+    connection: {
+      connectBaseUrl: 'https://chat.example.test',
+      bearerToken: 'token',
+      apiConfig: {
+        serverId: 'origin',
+        baseUrl: 'https://chat.example.test',
+        bearerToken: 'token'
+      }
     }
   })
 }));
@@ -113,17 +121,6 @@ vi.mock('$lib/state/server/connection.svelte', () => ({
 vi.mock('$app/navigation', () => ({
   goto: navigation.goto,
   pushState: navigation.pushState
-}));
-
-vi.mock('$lib/state/server/registry.svelte', () => ({
-  serverRegistry: {
-    isOriginServer: () => true,
-    tryGetStore: () => ({
-      currentUser: currentUserState,
-      voiceCall: voiceCallState,
-      navigation: roomsState
-    })
-  }
 }));
 
 vi.mock('$lib/state/userProfiles.svelte', () => ({

--- a/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte
+++ b/apps/frontend/src/lib/components/chat/MyThreadsNavItem.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
-  import { getActiveServer } from '$lib/state/activeServer.svelte';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
+  import { useServerScope } from '$lib/state/server/scope.svelte';
   import { notificationTarget } from '$lib/state/server/notifications.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import * as m from '$lib/i18n/messages';
 
   let { active }: { active: boolean } = $props();
 
-  const notificationStore = serverRegistry.getStore(getActiveServer()).notifications;
+  const serverScope = useServerScope();
+  const serverId = $derived(serverScope.serverId);
+  const notificationStore = $derived(serverScope.store.notifications);
 
   const hasUnread = $derived(
     notificationStore.notifications.some((n) => notificationTarget(n).threadRootId !== null)
@@ -17,7 +18,7 @@
 </script>
 
 <a
-  href={resolve('/chat/[serverId]/threads', { serverId: serverIdToSegment(getActiveServer()) })}
+  href={resolve('/chat/[serverId]/threads', { serverId: serverIdToSegment(serverId) })}
   class={['sidebar-item', active ? 'bg-surface' : '']}
 >
   <span class="sidebar-icon iconify uil--comment-alt-lines"></span>

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -6,12 +6,10 @@
 	import { createMessageAPI } from '$lib/api-client/messages';
 	import { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
 	import * as m from '$lib/i18n/messages';
-	import { useConnection } from '$lib/state/server/connection.svelte';
-	import { serverRegistry } from '$lib/state/server/registry.svelte';
+	import { useServerScope } from '$lib/state/server/scope.svelte';
 	import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
 	import { getRoomMembers, getRoomMembersStore, getComposerContext } from '$lib/state/room';
 	import { shouldAutoFocus } from '$lib/utils/shouldAutoFocus';
-	import { getActiveServer } from '$lib/state/activeServer.svelte';
 	import { getUserSettings } from '$lib/state/userSettings.svelte';
 	import EmojiAutocomplete from './EmojiAutocomplete.svelte';
 	import MentionAutocomplete from './MentionAutocomplete.svelte';
@@ -19,13 +17,11 @@
 	import ComposerAttachmentPreviews from './ComposerAttachmentPreviews.svelte';
 	import ComposerToolbar from './ComposerToolbar.svelte';
 	import ComposerModeIndicators from './ComposerModeIndicators.svelte';
-	import {
-		MessageComposerState,
-		type MessageComposerProps
-	} from './messageComposerState.svelte';
+	import { MessageComposerState, type MessageComposerProps } from './messageComposerState.svelte';
 
 	const tipTapEditorModule = import('./TipTapEditor.svelte');
-	const stores = serverRegistry.getStore(getActiveServer());
+	const serverScope = useServerScope();
+	const stores = serverScope.store;
 	const serverInfo = stores.serverInfo;
 	const roomUnreadStore = stores.roomUnread;
 	const mentionRolesStore = stores.mentionRoles;
@@ -48,7 +44,6 @@
 		showAlsoSendToChannel = false
 	}: MessageComposerProps = $props();
 
-	const connection = useConnection();
 	const userSettings = getUserSettings();
 	const composerContext = getComposerContext();
 	const state = new MessageComposerState({
@@ -67,9 +62,9 @@
 		mentionRolesStore,
 		serverInfo,
 		roomUnreadStore,
-		getMessageAPI: () => connection().getAPI(createMessageAPI),
-		getLinkPreviewAPI: () => connection().getAPI(createLinkPreviewAPI),
-		isConnectionLost: () => connection().showConnectionLostBanner
+		getMessageAPI: () => serverScope.connection.getAPI(createMessageAPI),
+		getLinkPreviewAPI: () => serverScope.connection.getAPI(createLinkPreviewAPI),
+		isConnectionLost: () => serverScope.connection.showConnectionLostBanner
 	});
 </script>
 

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -97,19 +97,23 @@ const mockInstanceStores = {
   }
 };
 
-vi.mock('$lib/state/server/connection.svelte', () => ({
-  useConnection: () => () => ({
-    isConnected: true,
-    showConnectionLostBanner: false,
-    client: {
-      query: queryMock,
-      mutation: mutationMock,
-      subscription: vi.fn()
-    },
-    connectBaseUrl: 'http://localhost/api/connect',
-    bearerToken: null,
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({
     serverId: 'test-instance',
-    getAPI: (factory: (config: never) => unknown) => factory({} as never)
+    store: mockInstanceStores,
+    connection: {
+      isConnected: true,
+      showConnectionLostBanner: false,
+      client: {
+        query: queryMock,
+        mutation: mutationMock,
+        subscription: vi.fn()
+      },
+      connectBaseUrl: 'http://localhost/api/connect',
+      bearerToken: null,
+      serverId: 'test-instance',
+      getAPI: (factory: (config: never) => unknown) => factory({} as never)
+    }
   })
 }));
 
@@ -136,20 +140,6 @@ vi.mock('$lib/attachments/prepareFiles', () => ({
   prepareFiles: prepareFilesMock
 }));
 
-vi.mock('$lib/state/server/registry.svelte', () => ({
-  serverRegistry: {
-    getStore: () => mockInstanceStores,
-    getServer: () => ({ id: 'test-instance', url: 'http://localhost' }),
-    isOriginServer: () => true,
-    originServer: { id: 'test-instance', url: 'http://localhost' },
-    servers: [{ id: 'test-instance', url: 'http://localhost' }]
-  }
-}));
-
-vi.mock('$lib/state/activeServer.svelte', () => ({
-  getActiveServer: () => () => 'test-instance'
-}));
-
 vi.mock('$lib/state/userSettings.svelte', () => ({
   getUserSettings: () => ({
     get effectiveTimezone() {
@@ -162,6 +152,8 @@ vi.mock('$lib/state/userSettings.svelte', () => ({
 }));
 
 vi.mock('$lib/state/room', () => ({
+  MessagesStore: class {},
+  RoomFilesStore: class {},
   getRoomMembers: () => roomStateMock.members,
   getRoomMembersStore: () => ({
     searchMembers: vi.fn(async () => roomStateMock.members)

--- a/apps/frontend/src/lib/hooks/useRoomData.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useRoomData.svelte.spec.ts
@@ -21,14 +21,8 @@ const { mocks } = vi.hoisted(() => ({
   }
 }));
 
-vi.mock('$lib/state/server/connection.svelte', () => ({
-  useConnection: () => () => ({ serverId: 'server-1' })
-}));
-
-vi.mock('$lib/state/server/registry.svelte', () => ({
-  serverRegistry: {
-    tryGetStore: () => mocks.store
-  }
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({ store: mocks.store })
 }));
 
 function projectedRoom(roomId: string, kind = RoomKind.DM) {

--- a/apps/frontend/src/lib/hooks/useRoomData.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomData.svelte.ts
@@ -1,7 +1,6 @@
 import type { DirectoryMember } from '$lib/api-client/memberDirectory';
 import { mapDirectoryRoomDetails, RoomKind } from '$lib/api-client/roomDirectory';
-import { getActiveServer } from '$lib/state/activeServer.svelte';
-import { serverRegistry } from '$lib/state/server/registry.svelte';
+import { useServerScope } from '$lib/state/server/scope.svelte';
 
 export type RoomData = {
   room: {
@@ -42,13 +41,12 @@ export type DMData = {
  * ready projection contains no visible room, and an object is renderable data.
  */
 export function useRoomData(getProps: () => { roomId: string }) {
-  // The registry is keyed by the frontend registration ID (the URL segment),
-  // not by the backend identity advertised through ServerConnection.
-  const store = $derived(serverRegistry.tryGetStore(getActiveServer()));
+  const serverScope = useServerScope();
+  const store = $derived(serverScope.store);
 
   const roomData = $derived.by<RoomData | null | undefined>(() => {
     const currentStore = store;
-    if (!currentStore?.realtimeSync.hasUsableProjection) return undefined;
+    if (!currentStore.realtimeSync.hasUsableProjection) return undefined;
     const projectedRoom = currentStore.projection.rooms.get(getProps().roomId)?.room;
     const room = mapDirectoryRoomDetails(projectedRoom);
     // A stale projection can render known rooms immediately, but absence is
@@ -77,7 +75,7 @@ export function useRoomData(getProps: () => { roomId: string }) {
   const isDM = $derived(roomData?.room.type === RoomKind.DM);
   const dmData = $derived.by<DMData | null>(() => {
     const currentStore = store;
-    if (!isDM || !currentStore?.realtimeSync.hasUsableProjection) return null;
+    if (!isDM || !currentStore.realtimeSync.hasUsableProjection) return null;
     return {
       participants: currentStore.projectedMembersForRoom(getProps().roomId),
       currentUserId: currentStore.currentUser.user?.id ?? null

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
@@ -15,23 +15,20 @@ vi.mock('$lib/api-client/readState', () => ({
   createReadStateAPI: () => ({ markRoomAsRead: mocks.markRoomAsRead })
 }));
 
-vi.mock('$lib/state/server/connection.svelte', () => ({
-  useConnection: () => () => ({
-    serverId: 'server-1',
-    connectBaseUrl: '/api/connect',
-    bearerToken: 'token',
-    getAPI: (factory: (config: never) => unknown) => factory({} as never)
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({
+    store: {
+      get roomUnread() {
+        return mocks.roomUnread;
+      }
+    },
+    connection: {
+      serverId: 'server-1',
+      connectBaseUrl: '/api/connect',
+      bearerToken: 'token',
+      getAPI: (factory: (config: never) => unknown) => factory({} as never)
+    }
   })
-}));
-
-vi.mock('$lib/state/activeServer.svelte', () => ({
-  getActiveServer: () => 'server-1'
-}));
-
-vi.mock('$lib/state/server/registry.svelte', () => ({
-  serverRegistry: {
-    getStore: () => ({ roomUnread: mocks.roomUnread })
-  }
 }));
 
 function deferred<T>() {

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -1,7 +1,5 @@
 import { createReadStateAPI, type MarkRoomAsReadResult } from '$lib/api-client/readState';
-import { useConnection } from '$lib/state/server/connection.svelte';
-import { serverRegistry } from '$lib/state/server/registry.svelte';
-import { getActiveServer } from '$lib/state/activeServer.svelte';
+import { useServerScope } from '$lib/state/server/scope.svelte';
 import { useUnreadMarker, type UnreadMarkerEvent } from './useUnreadMarker.svelte';
 
 /**
@@ -14,15 +12,15 @@ import { useUnreadMarker, type UnreadMarkerEvent } from './useUnreadMarker.svelt
 export function useRoomUnread(
   getProps: () => { roomId: string; events: readonly UnreadMarkerEvent[] }
 ) {
-  const connection = useConnection();
-  const roomUnreadStore = serverRegistry.getStore(getActiveServer()).roomUnread;
+  const serverScope = useServerScope();
+  const roomUnreadStore = serverScope.store.roomUnread;
 
   const unread = useUnreadMarker(() => getProps().roomId, {
     markAsRead: async (targetRoomId: string, upToEventId?: string) => {
       const optimisticRead = roomUnreadStore.beginOptimisticRead(targetRoomId);
 
       try {
-        const result = await connection()
+        const result = await serverScope.connection
           .getAPI(createReadStateAPI)
           .markRoomAsRead({ roomId: targetRoomId, upToEventId });
         optimisticRead.commit();


### PR DESCRIPTION
## Why

The core chat tree already receives the URL-selected server through
`ServerScope`, but several everyday consumers independently reconstructed the
same selection through `getActiveServer()`, `serverRegistry`, and the connection
context. Keeping both access paths made route-scoped state harder to follow and
left tests mocking more global infrastructure than the components required.

## What changed

- Read the selected server ID, state store, and connection from `ServerScope`
  in the room list, current-user bar, My Threads navigation, and message
  composer.
- Use the same scope in the room data and unread hooks.
- Keep RoomList's explicit registry lookup only for registered-server URL
  metadata used to classify external sidebar links.
- Simplify focused test fixtures around the single scoped dependency.
- Preserve existing UI and notification behavior; the production diff removes
  nine lines and the complete diff removes 23 lines.

This is an internal frontend refactor. It changes no public API, persistence,
configuration, rollout, or migration behavior.

## Test plan

- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- `mise test-frontend` — 309 test files and 2,602 tests passed.
- Focused changed-component/hook Vitest run — 5 files and 180 tests passed.
- Anonymous-origin/authenticated-remote Playwright scenario — passed.
- Remote message composer/identity Playwright scenario — passed.
- Svelte autofixer — no actionable issues in the six changed production files.
- Independent adversarial code review — no actionable findings.
