### PR TITLE
feat(frontend): debounce server message search

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/search.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/search.mdx
@@ -57,6 +57,9 @@ read. To search only the conversation you are viewing, select the magnifying
 glass in the room header and use the **Search in this room** sidebar tab. Room
 search is also available in direct-message conversations.
 
+Search runs automatically after a short pause while you type, or immediately
+when you press Enter. Leading and trailing spaces do not repeat the same search.
+
 The server-wide page and recently used rooms keep independent, transient query
 and result state. Selecting a result opens that message in its room or thread
 context. Search never combines results from different servers.

--- a/apps/frontend/e2e/search.test.ts
+++ b/apps/frontend/e2e/search.test.ts
@@ -24,8 +24,9 @@ async function openSearch(page: Page): Promise<void> {
 }
 
 async function submitSearch(page: Page, query: string): Promise<void> {
-  await page.getByPlaceholder(SEARCH_PLACEHOLDER).fill(query);
-  await page.getByRole('button', { name: 'Search', exact: true }).click();
+  const input = page.getByPlaceholder(SEARCH_PLACEHOLDER);
+  await input.fill(query);
+  await input.press('Enter');
 }
 
 async function expectSearchResult(page: Page, query: string, body: string): Promise<Locator> {

--- a/apps/frontend/src/lib/hooks/useDebouncedMessageSearch.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useDebouncedMessageSearch.svelte.ts
@@ -34,11 +34,18 @@ export function useDebouncedMessageSearch({
     submittedKey = store.hasSearched ? inputKey(getInput(searchTerm)) : null;
   }
 
-  function runSearch(store: MessageSearchStore, input: SearchInput, key: string): void {
+  function runSearch(
+    store: MessageSearchStore,
+    input: SearchInput,
+    key: string,
+    force = false
+  ): void {
     if (getStore() !== store || activeStore !== store) return;
     pendingKey = null;
     if (!searchTerm || inputKey(getInput(searchTerm)) !== key) return;
-    if (!store.available || (key === submittedKey && store.hasSearched && !store.error)) return;
+    if (!store.available || (!force && key === submittedKey && store.hasSearched && !store.error)) {
+      return;
+    }
     submittedKey = key;
     void store.search(input, { preserveQuery: true });
   }
@@ -75,7 +82,7 @@ export function useDebouncedMessageSearch({
     const query = searchTerm;
     if (!query || !store.available) return;
     const input = getInput(query);
-    runSearch(store, input, inputKey(input));
+    runSearch(store, input, inputKey(input), true);
   }
 
   return {

--- a/apps/frontend/src/lib/hooks/useDebouncedMessageSearch.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useDebouncedMessageSearch.svelte.ts
@@ -1,0 +1,85 @@
+import type { MessageSearchInput } from '$lib/api-client/messageSearch';
+import type { MessageSearchStore } from '$lib/state/server/messageSearch.svelte';
+import { useDebounce } from './useDebounce.svelte';
+
+type SearchInput = Omit<MessageSearchInput, 'cursor'>;
+
+type DebouncedMessageSearchOptions = {
+  getStore: () => MessageSearchStore;
+  getInput: (query: string) => SearchInput;
+  delay?: number;
+};
+
+/** Coordinate normalized, debounced searches without replacing the raw input value. */
+export function useDebouncedMessageSearch({
+  getStore,
+  getInput,
+  delay = 300
+}: DebouncedMessageSearchOptions) {
+  const debounce = useDebounce();
+  let activeStore: MessageSearchStore | null = null;
+  let pendingKey: string | null = null;
+  let submittedKey: string | null = null;
+  const searchTerm = $derived.by(() => getStore().query.trim());
+
+  function inputKey(input: SearchInput): string {
+    return JSON.stringify(input);
+  }
+
+  function syncStore(store: MessageSearchStore): void {
+    if (store === activeStore) return;
+    debounce.cancel();
+    activeStore = store;
+    pendingKey = null;
+    submittedKey = store.hasSearched ? inputKey(getInput(searchTerm)) : null;
+  }
+
+  function runSearch(store: MessageSearchStore, input: SearchInput, key: string): void {
+    if (getStore() !== store || activeStore !== store) return;
+    pendingKey = null;
+    if (!store.available || key === submittedKey) return;
+    submittedKey = key;
+    void store.search(input, { preserveQuery: true });
+  }
+
+  function schedule(rawQuery: string): void {
+    const store = getStore();
+    syncStore(store);
+    store.query = rawQuery;
+    const query = searchTerm;
+    if (!query) {
+      debounce.cancel();
+      pendingKey = null;
+      submittedKey = null;
+      store.clearResults();
+      return;
+    }
+
+    const input = getInput(query);
+    const key = inputKey(input);
+    if (key === pendingKey || key === submittedKey) return;
+
+    debounce.cancel();
+    pendingKey = key;
+    submittedKey = null;
+    store.prepareQueryChange();
+    debounce.run(() => runSearch(store, input, key), delay);
+  }
+
+  function submitNow(): void {
+    const store = getStore();
+    syncStore(store);
+    debounce.cancel();
+    pendingKey = null;
+    const query = searchTerm;
+    if (!query || !store.available) return;
+    const input = getInput(query);
+    runSearch(store, input, inputKey(input));
+  }
+
+  return {
+    schedule,
+    submitNow,
+    sync: () => syncStore(getStore())
+  };
+}

--- a/apps/frontend/src/lib/hooks/useDebouncedMessageSearch.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useDebouncedMessageSearch.svelte.ts
@@ -37,7 +37,8 @@ export function useDebouncedMessageSearch({
   function runSearch(store: MessageSearchStore, input: SearchInput, key: string): void {
     if (getStore() !== store || activeStore !== store) return;
     pendingKey = null;
-    if (!store.available || key === submittedKey) return;
+    if (!searchTerm || inputKey(getInput(searchTerm)) !== key) return;
+    if (!store.available || (key === submittedKey && store.hasSearched && !store.error)) return;
     submittedKey = key;
     void store.search(input, { preserveQuery: true });
   }
@@ -57,7 +58,7 @@ export function useDebouncedMessageSearch({
 
     const input = getInput(query);
     const key = inputKey(input);
-    if (key === pendingKey || key === submittedKey) return;
+    if (key === pendingKey || (key === submittedKey && store.hasSearched && !store.error)) return;
 
     debounce.cancel();
     pendingKey = key;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -19,7 +19,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
     type MessageSearchStore
   } from '$lib/state/server/messageSearch.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
-  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
+  import { useDebouncedMessageSearch } from '$lib/hooks/useDebouncedMessageSearch.svelte';
   import { EmptyState, Hint, ScrollFader } from '$lib/ui';
   import { Button, TextInput } from '$lib/ui/form';
   import { formatDateTime } from '$lib/utils/formatTime';
@@ -37,32 +37,17 @@ so switching rooms cannot leak a query or plaintext results into another room.
 
   const userSettings = getUserSettings();
   const activeLocale = $derived(getLocale());
-  const searchTerm = $derived(store.query.trim());
-  const searchDebounce = useDebounce();
-  let pendingSearchTerm: string | null = null;
-  let submittedSearchTerm: string | null = initialSubmittedSearchTerm();
-
-  function initialSubmittedSearchTerm(): string | null {
-    return store.hasSearched ? store.query.trim() : null;
-  }
+  const search = useDebouncedMessageSearch({
+    getStore: () => store,
+    getInput: (query) => ({ query, roomId, order: MessageSearchOrder.RELEVANCE })
+  });
 
   $effect(() => {
     void store.ensureStatus();
   });
 
   function searchNow(): void {
-    searchDebounce.cancel();
-    pendingSearchTerm = null;
-    if (!searchTerm || searchTerm === submittedSearchTerm || !store.available) return;
-    submittedSearchTerm = searchTerm;
-    void store.search(
-      {
-        query: searchTerm,
-        roomId,
-        order: MessageSearchOrder.RELEVANCE
-      },
-      { preserveQuery: true }
-    );
+    search.submitNow();
   }
 
   function submit(event: SubmitEvent): void {
@@ -78,24 +63,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
   };
 
   function scheduleSearch(event: Event): void {
-    store.query = (event.currentTarget as HTMLInputElement).value;
-    if (!searchTerm) {
-      searchDebounce.cancel();
-      pendingSearchTerm = null;
-      submittedSearchTerm = null;
-      store.clearResults();
-      return;
-    }
-    if (
-      searchTerm === pendingSearchTerm ||
-      (store.hasSearched && searchTerm === submittedSearchTerm)
-    ) {
-      return;
-    }
-    searchDebounce.cancel();
-    pendingSearchTerm = searchTerm;
-    store.prepareQueryChange();
-    searchDebounce.run(searchNow, 300);
+    search.schedule((event.currentTarget as HTMLInputElement).value);
   }
 
   function resultActor(result: MessageSearchResult): UserAvatarUserView | null {

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -21,6 +21,7 @@ in the active server store so browser Back can restore the current search.
   import { hour12ForTimeFormat } from '$lib/state/userSettings.svelte';
   import { MessageSearchOrder, MessageSearchState } from '$lib/state/server/messageSearch.svelte';
   import { getLocale } from '$lib/i18n/runtime';
+  import { useDebouncedMessageSearch } from '$lib/hooks/useDebouncedMessageSearch.svelte';
   import { formatDateTime } from '$lib/utils/formatTime';
   import {
     EmptyState,
@@ -50,28 +51,27 @@ in the active server store so browser Back can restore the current search.
     { value: MessageSearchOrder.RELEVANCE, label: m['search.order.relevance']() },
     { value: MessageSearchOrder.NEWEST, label: m['search.order.newest']() }
   ]);
+  const search = useDebouncedMessageSearch({
+    getStore: () => store,
+    getInput: (query) => ({ query, order: store.order })
+  });
   $effect(() => {
     void store.ensureStatus();
   });
 
   function submit(event: SubmitEvent): void {
     event.preventDefault();
-    const trimmed = store.query.trim();
-    if (!trimmed || !store.available) return;
-    void store.search({ query: trimmed, order: store.order });
+    search.submitNow();
+  }
 
-    const queryInput = (event.currentTarget as HTMLFormElement).querySelector<HTMLInputElement>(
-      'input[type="text"]'
-    );
-    queryInput?.focus({ preventScroll: true });
-    queryInput?.select();
+  function scheduleSearch(event: Event): void {
+    search.schedule((event.currentTarget as HTMLInputElement).value);
   }
 
   function setOrder(nextOrder: MessageSearchOrder): void {
+    search.sync();
     store.order = nextOrder;
-    if (store.hasSearched && store.query.trim()) {
-      void store.search({ query: store.query.trim(), order: store.order });
-    }
+    if (store.hasSearched && store.query.trim()) search.submitNow();
   }
 
   function resultActor(result: MessageSearchResult): UserAvatarUserView | null {
@@ -204,11 +204,9 @@ in the active server store so browser Back can restore the current search.
                 leadingIcon="uil--search"
                 autocomplete="off"
                 autofocus
+                oninput={scheduleSearch}
               />
             </div>
-            <Button type="submit" disabled={!store.query.trim()}>
-              {m['search.action']()}
-            </Button>
             <SegmentedControl
               label={m['search.order.label']()}
               options={orderOptions}

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -71,7 +71,7 @@ in the active server store so browser Back can restore the current search.
   function setOrder(nextOrder: MessageSearchOrder): void {
     search.sync();
     store.order = nextOrder;
-    if (store.hasSearched && store.query.trim()) search.submitNow();
+    if (store.query.trim()) search.submitNow();
   }
 
   function resultActor(result: MessageSearchResult): UserAvatarUserView | null {

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -246,6 +246,23 @@ describe('message search page', () => {
     );
   });
 
+  it('allows Enter to refresh a completed search', async () => {
+    const { container } = render(SearchPageTestHarness);
+    const input = container.querySelector('input') as HTMLInputElement;
+    const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
+
+    await userEvent.type(input, 'refresh me');
+    await waitForSearchDebounce();
+    store.messageSearch.hasSearched = true;
+    await userEvent.keyboard('{Enter}');
+
+    expect(mocks.search).toHaveBeenCalledTimes(2);
+    expect(mocks.search).toHaveBeenLastCalledWith(
+      { query: 'refresh me', order: MessageSearchOrder.RELEVANCE },
+      { preserveQuery: true }
+    );
+  });
+
   it('continues pagination when a filtered page has no visible results', async () => {
     let intersectionCallback: ((entries: IntersectionObserverEntry[]) => void) | undefined;
     vi.stubGlobal(

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -11,6 +11,8 @@ const { mocks } = vi.hoisted(() => ({
   mocks: {
     ensureStatus: vi.fn(),
     search: vi.fn(),
+    clearResults: vi.fn(),
+    prepareQueryChange: vi.fn(),
     loadMore: vi.fn(),
     goto: vi.fn(),
     activeServer: vi.fn(),
@@ -70,6 +72,8 @@ function serverStore(
     ensureStatus: mocks.ensureStatus,
     refreshStatus: vi.fn(),
     search: mocks.search,
+    clearResults: mocks.clearResults,
+    prepareQueryChange: mocks.prepareQueryChange,
     loadMore: mocks.loadMore
   });
   return {
@@ -79,6 +83,8 @@ function serverStore(
 }
 
 describe('message search page', () => {
+  const waitForSearchDebounce = () => new Promise((resolve) => setTimeout(resolve, 350));
+
   beforeEach(() => {
     vi.clearAllMocks();
     activeServerId = 'origin';
@@ -86,40 +92,63 @@ describe('message search page', () => {
     mocks.serverStores = { origin: serverStore(), remote: serverStore() };
   });
 
-  it('mounts as a server page and submits an unscoped search', async () => {
+  it('mounts as a server page and debounces unscoped searches without a button', async () => {
     const { container } = render(SearchPageTestHarness);
 
     const input = container.querySelector('input') as HTMLInputElement;
     await userEvent.type(input, 'motherfucking search');
-    await userEvent.click(
-      [...container.querySelectorAll('button')].find(
-        (button) => button.textContent?.trim() === 'Search'
-      )!
-    );
+    await waitForSearchDebounce();
 
     expect(container.textContent).toContain('Search messages');
     expect(
       [...container.querySelectorAll('h2')].map((heading) => heading.textContent?.trim())
     ).toEqual(['Search query', 'Results']);
     expect(container.textContent).not.toContain('All rooms');
+    expect(
+      [...container.querySelectorAll('button')].some(
+        (button) => button.textContent?.trim() === 'Search'
+      )
+    ).toBe(false);
     expect(mocks.ensureStatus).toHaveBeenCalledOnce();
-    expect(mocks.search).toHaveBeenCalledWith({
-      query: 'motherfucking search',
-      order: MessageSearchOrder.RELEVANCE
-    });
+    expect(mocks.search).toHaveBeenCalledWith(
+      {
+        query: 'motherfucking search',
+        order: MessageSearchOrder.RELEVANCE
+      },
+      { preserveQuery: true }
+    );
     expect(document.activeElement).toBe(input);
-    expect(input.selectionStart).toBe(0);
-    expect(input.selectionEnd).toBe(input.value.length);
 
+    await userEvent.clear(input);
     await userEvent.type(input, 'replacement query');
     await userEvent.keyboard('{Enter}');
 
-    expect(mocks.search).toHaveBeenLastCalledWith({
-      query: 'replacement query',
-      order: MessageSearchOrder.RELEVANCE
-    });
-    expect(input.selectionStart).toBe(0);
-    expect(input.selectionEnd).toBe(input.value.length);
+    expect(mocks.search).toHaveBeenLastCalledWith(
+      {
+        query: 'replacement query',
+        order: MessageSearchOrder.RELEVANCE
+      },
+      { preserveQuery: true }
+    );
+    await waitForSearchDebounce();
+    expect(mocks.search).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not repeat a completed search for trailing whitespace', async () => {
+    const { container } = render(SearchPageTestHarness);
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    await userEvent.type(input, 'foo');
+    await waitForSearchDebounce();
+    await userEvent.type(input, ' ');
+    await waitForSearchDebounce();
+
+    expect(input.value).toBe('foo ');
+    expect(mocks.search).toHaveBeenCalledOnce();
+    expect(mocks.search).toHaveBeenCalledWith(
+      { query: 'foo', order: MessageSearchOrder.RELEVANCE },
+      { preserveQuery: true }
+    );
   });
 
   it('switches form state when SvelteKit reuses the page for another server', async () => {
@@ -135,15 +164,30 @@ describe('message search page', () => {
     await tick();
 
     expect(input.value).toBe('remote query');
+    await userEvent.keyboard('{Enter}');
+    expect(mocks.search).toHaveBeenCalledWith(
+      { query: 'remote query', order: MessageSearchOrder.RELEVANCE },
+      { preserveQuery: true }
+    );
+  });
+
+  it('reruns a completed search immediately when its order changes', async () => {
+    mocks.serverStores = {
+      origin: serverStore('needle', MessageSearchOrder.RELEVANCE, { hasSearched: true }),
+      remote: serverStore()
+    };
+    const { container } = render(SearchPageTestHarness);
+
     await userEvent.click(
-      [...container.querySelectorAll('button')].find(
-        (button) => button.textContent?.trim() === 'Search'
+      [...container.querySelectorAll('label')].find(
+        (label) => label.textContent?.trim() === 'Newest'
       )!
     );
-    expect(mocks.search).toHaveBeenCalledWith({
-      query: 'remote query',
-      order: MessageSearchOrder.RELEVANCE
-    });
+
+    expect(mocks.search).toHaveBeenCalledWith(
+      { query: 'needle', order: MessageSearchOrder.NEWEST },
+      { preserveQuery: true }
+    );
   });
 
   it('continues pagination when a filtered page has no visible results', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -138,9 +138,11 @@ describe('message search page', () => {
   it('does not repeat a completed search for trailing whitespace', async () => {
     const { container } = render(SearchPageTestHarness);
     const input = container.querySelector('input') as HTMLInputElement;
+    const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
 
     await userEvent.type(input, 'foo');
     await waitForSearchDebounce();
+    store.messageSearch.hasSearched = true;
     await userEvent.type(input, ' ');
     await waitForSearchDebounce();
 
@@ -187,6 +189,59 @@ describe('message search page', () => {
 
     expect(mocks.search).toHaveBeenCalledWith(
       { query: 'needle', order: MessageSearchOrder.NEWEST },
+      { preserveQuery: true }
+    );
+  });
+
+  it('uses a new order immediately when a search is still pending', async () => {
+    const { container } = render(SearchPageTestHarness);
+    const input = container.querySelector('input') as HTMLInputElement;
+
+    await userEvent.type(input, 'needle');
+    await userEvent.click(
+      [...container.querySelectorAll('label')].find(
+        (label) => label.textContent?.trim() === 'Newest'
+      )!
+    );
+
+    expect(mocks.search).toHaveBeenCalledOnce();
+    expect(mocks.search).toHaveBeenCalledWith(
+      { query: 'needle', order: MessageSearchOrder.NEWEST },
+      { preserveQuery: true }
+    );
+    await waitForSearchDebounce();
+    expect(mocks.search).toHaveBeenCalledOnce();
+  });
+
+  it('discards a pending search when the store is externally cleared', async () => {
+    const { container } = render(SearchPageTestHarness);
+    const input = container.querySelector('input') as HTMLInputElement;
+    const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
+
+    await userEvent.type(input, 'private query');
+    store.messageSearch.query = '';
+    store.messageSearch.hasSearched = false;
+    await tick();
+    await waitForSearchDebounce();
+
+    expect(input.value).toBe('');
+    expect(mocks.search).not.toHaveBeenCalled();
+  });
+
+  it('allows Enter to retry a failed search', async () => {
+    const { container } = render(SearchPageTestHarness);
+    const input = container.querySelector('input') as HTMLInputElement;
+    const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
+
+    await userEvent.type(input, 'retry me');
+    await waitForSearchDebounce();
+    store.messageSearch.hasSearched = true;
+    store.messageSearch.error = true;
+    await userEvent.keyboard('{Enter}');
+
+    expect(mocks.search).toHaveBeenCalledTimes(2);
+    expect(mocks.search).toHaveBeenLastCalledWith(
+      { query: 'retry me', order: MessageSearchOrder.RELEVANCE },
       { preserveQuery: true }
     );
   });

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -97,6 +97,7 @@ describe('message search page', () => {
 
     const input = container.querySelector('input') as HTMLInputElement;
     await userEvent.type(input, 'motherfucking search');
+    expect(mocks.search).not.toHaveBeenCalled();
     await waitForSearchDebounce();
 
     expect(container.textContent).toContain('Search messages');

--- a/docs/fdr/FDR-033-message-search.md
+++ b/docs/fdr/FDR-033-message-search.md
@@ -29,6 +29,10 @@ provider supplies results.
 - Search is available as a server-level page reached from the server sidebar
   between Overview and My Threads, and as a room-sidebar tab that searches only
   the current room or direct-message conversation.
+- Both entry points search automatically after a short typing pause, while
+  Enter submits immediately. Leading or trailing whitespace is ignored for
+  search requests without replacing the text in the field or repeating an
+  otherwise identical search.
 - Each registered server retains its own transient server-wide query, ordering,
   and result state. Recently used rooms also retain separate transient sidebar
   search state. Switching servers or rooms never carries plaintext results into
@@ -118,11 +122,16 @@ features such as stemming and typo tolerance are implementation details.
 ### 7. Server-wide Search has a dedicated page
 
 **Decision:** Search across rooms lives in the server sidebar and opens as a full
-page rather than a modal or part of the quick switcher.
+page rather than a modal or part of the quick switcher. Like room-scoped Search,
+it submits after a short typing pause without requiring an action button.
 **Why:** Searching message history is an extended reading task whose query,
 results, filters, and future conversation context need durable screen space.
+Debounced submission keeps the interaction immediate without issuing a request
+for every keystroke.
 **Tradeoff:** Opening a result leaves the Search page; each server's transient
-search is retained in memory so browser Back can restore it.
+search is retained in memory so browser Back can restore it. Pausing while
+typing can submit an intermediate query, while Enter remains available for an
+immediate search.
 
 ### 8. Providers return relevance scores
 


### PR DESCRIPTION
## Why

Server-wide Search still required an explicit button even though room-scoped
Search already responds naturally to typing. Aligning the two reduces friction
and prevents their normalized-query behavior from drifting.

## What changed

- debounce server-wide message searches while preserving immediate Enter submission
- remove the explicit Search button and share the trimmed, derived scheduling path with room search
- submit sort changes immediately and fence pending work across store clears and server switches
- allow failed searches to be retried with Enter
- document the automatic-search interaction in FDR-033 and the operator guide

This is a bundled-client interaction change only. It does not change public
APIs, persistence, permissions, rollout requirements, or operator configuration.

## Test plan

- [x] `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/search/search.page.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'` (49 Chromium tests passed)
- [x] `mise x -- pnpm --dir apps/frontend check` (0 errors and 0 warnings)
- [x] `mise x -- pnpm --dir apps/frontend lint`
- [x] `mise test-frontend`
- [x] `mise x -- pnpm --dir apps/frontend exec playwright test e2e/search.test.ts` (2 tests passed)
- [x] Svelte autofixer reported no issues in the new shared hook or changed components
- [x] GitHub CI (all attached checks passed)

## Documentation

- [FDR-033: Message Search](docs/fdr/FDR-033-message-search.md)
- Search operations guide
