### PR TITLE
feat(search): support filter-only queries

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/search.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/search.mdx
@@ -59,6 +59,8 @@ search is also available in direct-message conversations.
 
 Search runs automatically after a short pause while you type, or immediately
 when you press Enter. Leading and trailing spaces do not repeat the same search.
+Filters such as `from:alice`, `in:general`, `after:2026-01-01`, and
+`has:attachment` work on their own; you do not need to add a search word.
 
 The server-wide page and recently used rooms keep independent, transient query
 and result state. Selecting a result opens that message in its room or thread

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/message-search.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/message-search.mdx
@@ -70,7 +70,7 @@ Request to search current message bodies visible to the authenticated user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `query` | `string` | Required query text. Words are required terms, quoted text is an exact phrase, and `AND` may separate terms. The query also accepts `in:`, `from:`, `before:`, `after:`, and `has:attachment` filters. |
+| `query` | `string` | Required query expression. Words are required terms, quoted text is an exact phrase, and `AND` may separate terms. The query also accepts `in:`, `from:`, `before:`, `after:`, and `has:attachment` filters; a recognized filter may be used without a word or phrase. |
 | `room_id` | `optional string` | Optional room-ID scope. The server intersects this room with rooms the current user may read and with any `in:` filters in query. |
 | `author_id` | `optional string` | Optional author-ID scope. The server intersects this author with any `from:` filters in query. |
 | `created_after` | `google.protobuf.Timestamp` | Exclusive lower bound on message creation time. The stricter bound wins when query also contains `after:`. |

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -15,7 +15,7 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 <ReleaseFeatureGrid>
   <ReleaseFeatureCard title="Search across your server" size="large">
-    Find messages across every room you can access, with filters for rooms and authors.
+    Find messages across every room you can access, with standalone filters for rooms and authors.
     Language-aware matching handles common word forms, CJK text, exact phrases, and
     conservative typos. Press Cmd-K (or Ctrl-K) and prefix a query with `?` to merge the
     best-ranked matches from all your registered servers into one quick result list.

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1034,7 +1034,7 @@ Request to search current message bodies visible to the authenticated user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `query` | `string` | Required query text. Words are required terms, quoted text is an exact phrase, and `AND` may separate terms. The query also accepts `in:`, `from:`, `before:`, `after:`, and `has:attachment` filters. |
+| `query` | `string` | Required query expression. Words are required terms, quoted text is an exact phrase, and `AND` may separate terms. The query also accepts `in:`, `from:`, `before:`, `after:`, and `has:attachment` filters; a recognized filter may be used without a word or phrase. |
 | `room_id` | `optional string` | Optional room-ID scope. The server intersects this room with rooms the current user may read and with any `in:` filters in query. |
 | `author_id` | `optional string` | Optional author-ID scope. The server intersects this author with any `from:` filters in query. |
 | `created_after` | `google.protobuf.Timestamp` | Exclusive lower bound on message creation time. The stricter bound wins when query also contains `after:`. |

--- a/apps/frontend/e2e/search.test.ts
+++ b/apps/frontend/e2e/search.test.ts
@@ -64,7 +64,7 @@ test.describe('message search', () => {
     chatPage,
     roomPage
   }) => {
-    await createAndLoginTestUser(page);
+    const user = await createAndLoginTestUser(page);
     await chatPage.goto();
     await chatPage.enterRoom('general');
     const generalRoomPath = new URL(page.url()).pathname;
@@ -81,6 +81,9 @@ test.describe('message search', () => {
 
     await test.step('find a newly indexed message through the sidebar and follow its result', async () => {
       await openSearch(page);
+
+      const authorResult = await expectSearchResult(page, `from:${user.login}`, originalBody);
+      await expect(authorResult).toBeVisible();
 
       // "run" exercises the configured English analyzer: the body contains
       // only inflected forms, while the unique term keeps this result isolated.

--- a/cli/internal/connectapi/message_search_test.go
+++ b/cli/internal/connectapi/message_search_test.go
@@ -118,6 +118,33 @@ func TestProviderSearchRequestIncludesCompleteAuthorizedRoomScope(t *testing.T) 
 	require.NoError(t, searchsvc.ValidateQueryRequest(request))
 }
 
+func TestMessageSearchAcceptsAuthorFilterWithoutBodyTerms(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	env.api.config.Search.Enabled = true
+	ctx := withCaller(env.ctx, env.viewer)
+	room, err := env.core.CreateRoom(ctx, core.SystemActorID, core.KindChannel, "", "filter-only-search", "")
+	require.NoError(t, err)
+	_, err = env.core.JoinRoom(ctx, env.viewer.Id, core.KindChannel, env.viewer.Id, room.Id)
+	require.NoError(t, err)
+
+	provider := &fakeMessageSearchProvider{}
+	env.api.searchProvider = provider
+	service := &messageSearchService{api: env.api}
+	response, err := service.SearchMessages(ctx, connect.NewRequest(&apiv1.SearchMessagesRequest{
+		Query: "from:" + env.viewer.Login,
+		Order: apiv1.MessageSearchOrder_MESSAGE_SEARCH_ORDER_NEWEST,
+	}))
+	require.NoError(t, err)
+	require.Empty(t, response.Msg.GetResults())
+
+	queries := provider.capturedQueries()
+	require.Len(t, queries, 1)
+	require.Empty(t, queries[0].GetRequiredTerms())
+	require.Empty(t, queries[0].GetRequiredPhrases())
+	require.Equal(t, []string{env.viewer.Id}, queries[0].GetAuthorIds())
+	require.Contains(t, queries[0].GetRoomIds(), room.Id)
+}
+
 func TestMessageSearchAuthorizesHydratesAndSealsProviderCursor(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	env.api.config.Search.Enabled = true

--- a/cli/internal/pb/chatto/api/v1/message_search.pb.go
+++ b/cli/internal/pb/chatto/api/v1/message_search.pb.go
@@ -149,9 +149,10 @@ func (MessageSearchState) EnumDescriptor() ([]byte, []int) {
 // Request to search current message bodies visible to the authenticated user.
 type SearchMessagesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Required query text. Words are required terms, quoted text is an exact
-	// phrase, and `AND` may separate terms. The query also accepts `in:`,
-	// `from:`, `before:`, `after:`, and `has:attachment` filters.
+	// Required query expression. Words are required terms, quoted text is an
+	// exact phrase, and `AND` may separate terms. The query also accepts `in:`,
+	// `from:`, `before:`, `after:`, and `has:attachment` filters; a recognized
+	// filter may be used without a word or phrase.
 	Query string `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
 	// Optional room-ID scope. The server intersects this room with rooms the
 	// current user may read and with any `in:` filters in query.

--- a/cli/internal/pb/chatto/search/v1/search.pb.go
+++ b/cli/internal/pb/chatto/search/v1/search.pb.go
@@ -141,8 +141,9 @@ func (ProviderState) EnumDescriptor() ([]byte, []int) {
 	return file_chatto_search_v1_search_proto_rawDescGZIP(), []int{1}
 }
 
-// QueryRequest is a parsed, provider-neutral message search. Every term and
-// phrase is required; providers must not reinterpret these fields as an OR.
+// QueryRequest is a parsed, provider-neutral message search. Every supplied
+// term and phrase is required; providers must not reinterpret these fields as
+// an OR. Terms and phrases may both be empty when another filter is present.
 type QueryRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Normalized individual terms that every result must contain.

--- a/cli/internal/search/bleve/projection_test.go
+++ b/cli/internal/search/bleve/projection_test.go
@@ -433,15 +433,15 @@ func TestProjectionFiltersByAuthorDateAndAttachments(t *testing.T) {
 		{
 			name: "author",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, AuthorIds: []string{"U2"},
-				Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
+				AuthorIds: []string{"U2"},
+				Order:     searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M2"},
 		},
 		{
 			name: "creation window",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, CreatedAfter: timestamppb.New(time.Unix(150, 0)),
+				CreatedAfter:  timestamppb.New(time.Unix(150, 0)),
 				CreatedBefore: timestamppb.New(time.Unix(250, 0)), Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M2"},
@@ -449,40 +449,40 @@ func TestProjectionFiltersByAuthorDateAndAttachments(t *testing.T) {
 		{
 			name: "attachments",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, HasAttachments: true,
-				Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
+				HasAttachments: true,
+				Order:          searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M3", "M1"},
 		},
 		{
 			name: "multiple rooms are alternatives",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, RoomIds: []string{"R1", "R2"},
-				Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
+				RoomIds: []string{"R1", "R2"},
+				Order:   searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M3", "M2", "M1"},
 		},
 		{
 			name: "multiple authors are alternatives",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, AuthorIds: []string{"U1", "U2"},
-				Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
+				AuthorIds: []string{"U1", "U2"},
+				Order:     searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M3", "M2", "M1"},
 		},
 		{
 			name: "after excludes exact boundary",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, CreatedAfter: timestamppb.New(time.Unix(200, 0)),
-				Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
+				CreatedAfter: timestamppb.New(time.Unix(200, 0)),
+				Order:        searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M3"},
 		},
 		{
 			name: "before excludes exact boundary",
 			request: &searchv1.QueryRequest{
-				RequiredTerms: []string{"filter"}, CreatedBefore: timestamppb.New(time.Unix(200, 0)),
-				Order: searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
+				CreatedBefore: timestamppb.New(time.Unix(200, 0)),
+				Order:         searchv1.SearchOrder_SEARCH_ORDER_NEWEST, PageSize: 10,
 			},
 			want: []string{"M1"},
 		},

--- a/cli/internal/search/contract_test.go
+++ b/cli/internal/search/contract_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/nats-io/nats.go"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	searchv1 "hmans.de/chatto/internal/pb/chatto/search/v1"
 	"hmans.de/chatto/internal/testutil"
@@ -118,6 +119,25 @@ func TestClientAndServiceRoundTrip(t *testing.T) {
 	slices.Sort(subjects)
 	if !slices.Equal(subjects, []string{QuerySubject, StatusSubject}) {
 		t.Fatalf("endpoint subjects = %v", subjects)
+	}
+}
+
+func TestValidateQueryRequestAcceptsFilterOnlyQueries(t *testing.T) {
+	tests := map[string]*searchv1.QueryRequest{
+		"room":           {RoomIds: []string{"rm_one"}},
+		"author":         {AuthorIds: []string{"usr_one"}},
+		"created after":  {CreatedAfter: timestamppb.New(time.Unix(100, 0))},
+		"created before": {CreatedBefore: timestamppb.New(time.Unix(200, 0))},
+		"attachments":    {HasAttachments: true},
+	}
+	for name, query := range tests {
+		t.Run(name, func(t *testing.T) {
+			query.Order = searchv1.SearchOrder_SEARCH_ORDER_NEWEST
+			query.PageSize = 20
+			if err := ValidateQueryRequest(query); err != nil {
+				t.Fatalf("ValidateQueryRequest() = %v", err)
+			}
+		})
 	}
 }
 

--- a/cli/internal/search/query_parser.go
+++ b/cli/internal/search/query_parser.go
@@ -131,13 +131,23 @@ func ParseQuery(input string) (ParsedQuery, error) {
 			return ParsedQuery{}, fmt.Errorf("search query exceeds %d terms and phrases", maxQueryParts)
 		}
 	}
-	if len(parsed.RequiredTerms) == 0 && len(parsed.RequiredPhrases) == 0 {
-		return ParsedQuery{}, fmt.Errorf("search query requires a term or quoted phrase")
+	if !parsed.hasCriterion() {
+		return ParsedQuery{}, fmt.Errorf("search query requires a term, phrase, or filter")
 	}
 	if parsed.CreatedAfter != nil && parsed.CreatedBefore != nil && !parsed.CreatedAfter.Before(*parsed.CreatedBefore) {
 		return ParsedQuery{}, fmt.Errorf("after filter must precede before filter")
 	}
 	return parsed, nil
+}
+
+func (q ParsedQuery) hasCriterion() bool {
+	return len(q.RequiredTerms) > 0 ||
+		len(q.RequiredPhrases) > 0 ||
+		len(q.RoomSelectors) > 0 ||
+		len(q.AuthorSelectors) > 0 ||
+		q.CreatedAfter != nil ||
+		q.CreatedBefore != nil ||
+		q.HasAttachments
 }
 
 func containsSearchableRune(value string) bool {

--- a/cli/internal/search/query_parser_test.go
+++ b/cli/internal/search/query_parser_test.go
@@ -28,14 +28,32 @@ func TestParseQueryUsesStrictestRepeatedDateBounds(t *testing.T) {
 	require.Equal(t, time.Date(2025, 1, 20, 0, 0, 0, 0, time.UTC), *parsed.CreatedBefore)
 }
 
+func TestParseQueryAcceptsFilterOnlyQueries(t *testing.T) {
+	tests := []string{
+		"in:general",
+		"from:alice",
+		"after:2025-01-01",
+		"before:2025-02-01",
+		"has:attachment",
+		"in:general from:alice after:2025-01-01 before:2025-02-01 has:attachments",
+	}
+	for _, input := range tests {
+		t.Run(input, func(t *testing.T) {
+			parsed, err := ParseQuery(input)
+			require.NoError(t, err)
+			require.Empty(t, parsed.RequiredTerms)
+			require.Empty(t, parsed.RequiredPhrases)
+		})
+	}
+}
+
 func TestParseQueryRejectsInvalidSyntax(t *testing.T) {
 	tests := []string{
+		``,
+		`AND`,
 		`"unterminated`,
 		`"!!!"`,
 		`!!!`,
-		`has:attachment`,
-		`in:general`,
-		"in:room has:attachments",
 		"search in:",
 		"search after:not-a-date",
 		"search after:2025-02-01 before:2025-01-01",

--- a/cli/internal/search/validation.go
+++ b/cli/internal/search/validation.go
@@ -28,8 +28,8 @@ func validateQueryRequest(request *searchv1.QueryRequest) error {
 	if request == nil {
 		return fmt.Errorf("request is required")
 	}
-	if len(request.GetRequiredTerms()) == 0 && len(request.GetRequiredPhrases()) == 0 {
-		return fmt.Errorf("at least one term or phrase is required")
+	if !queryRequestHasCriterion(request) {
+		return fmt.Errorf("at least one term, phrase, or filter is required")
 	}
 	if err := validateStrings("required terms", request.GetRequiredTerms(), maxQueryParts, maxQueryPartBytes); err != nil {
 		return err
@@ -70,6 +70,16 @@ func validateQueryRequest(request *searchv1.QueryRequest) error {
 		return fmt.Errorf("created after must precede created before")
 	}
 	return nil
+}
+
+func queryRequestHasCriterion(request *searchv1.QueryRequest) bool {
+	return len(request.GetRequiredTerms()) > 0 ||
+		len(request.GetRequiredPhrases()) > 0 ||
+		len(request.GetRoomIds()) > 0 ||
+		len(request.GetAuthorIds()) > 0 ||
+		request.GetCreatedAfter() != nil ||
+		request.GetCreatedBefore() != nil ||
+		request.GetHasAttachments()
 }
 
 func validateStrings(name string, values []string, maxItems, maxBytes int) error {

--- a/docs/fdr/FDR-033-message-search.md
+++ b/docs/fdr/FDR-033-message-search.md
@@ -25,7 +25,8 @@ provider supplies results.
   analyzer is selected, and conservative one-character spelling mistakes in
   longer words. The bundled provider enables all analyzers by default.
 - Structured filters support a room (`in:`), author (`from:`), messages before
-  or after a date, and messages with attachments.
+  or after a date, and messages with attachments. Any recognized filter can be
+  used on its own without an additional word or phrase.
 - Search is available as a server-level page reached from the server sidebar
   between Overview and My Threads, and as a room-sidebar tab that searches only
   the current room or direct-message conversation.
@@ -112,12 +113,15 @@ requires operators to protect the provider volume.
 ### 6. One canonical query language fronts every provider
 
 **Decision:** Chatto defines and parses the user-facing query syntax before
-issuing normalized provider requests.
+issuing normalized provider requests. A recognized structured filter is a
+complete query even when no message-body term accompanies it.
 **Why:** Query syntax, required-term semantics, and filters should remain stable
 when an operator replaces Bleve with another provider, and third-party clients
 should not need to emit a backend-specific query language.
 **Tradeoff:** Recall and ranking may still vary by provider because analysis
 features such as stemming and typo tolerance are implementation details.
+Filter-only relevance has no body-text signal, so deterministic recency and ID
+tie-breakers decide otherwise equal results.
 
 ### 7. Server-wide Search has a dedicated page
 

--- a/packages/api-types/src/chatto/api/v1/message_search_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/message_search_pb.ts
@@ -114,9 +114,10 @@ proto3.util.setEnumType(MessageSearchState, "chatto.api.v1.MessageSearchState", 
  */
 export class SearchMessagesRequest extends Message<SearchMessagesRequest> {
   /**
-   * Required query text. Words are required terms, quoted text is an exact
-   * phrase, and `AND` may separate terms. The query also accepts `in:`,
-   * `from:`, `before:`, `after:`, and `has:attachment` filters.
+   * Required query expression. Words are required terms, quoted text is an
+   * exact phrase, and `AND` may separate terms. The query also accepts `in:`,
+   * `from:`, `before:`, `after:`, and `has:attachment` filters; a recognized
+   * filter may be used without a word or phrase.
    *
    * @generated from field: string query = 1;
    */

--- a/proto/chatto/api/v1/message_search.proto
+++ b/proto/chatto/api/v1/message_search.proto
@@ -37,9 +37,10 @@ enum MessageSearchState {
 
 // Request to search current message bodies visible to the authenticated user.
 message SearchMessagesRequest {
-  // Required query text. Words are required terms, quoted text is an exact
-  // phrase, and `AND` may separate terms. The query also accepts `in:`,
-  // `from:`, `before:`, `after:`, and `has:attachment` filters.
+  // Required query expression. Words are required terms, quoted text is an
+  // exact phrase, and `AND` may separate terms. The query also accepts `in:`,
+  // `from:`, `before:`, `after:`, and `has:attachment` filters; a recognized
+  // filter may be used without a word or phrase.
   string query = 1 [(buf.validate.field).string = {
     min_len: 1
     max_bytes: 1024

--- a/proto/chatto/search/v1/search.proto
+++ b/proto/chatto/search/v1/search.proto
@@ -33,8 +33,9 @@ enum ProviderState {
   PROVIDER_STATE_UNAVAILABLE = 5;
 }
 
-// QueryRequest is a parsed, provider-neutral message search. Every term and
-// phrase is required; providers must not reinterpret these fields as an OR.
+// QueryRequest is a parsed, provider-neutral message search. Every supplied
+// term and phrase is required; providers must not reinterpret these fields as
+// an OR. Terms and phrases may both be empty when another filter is present.
 message QueryRequest {
   // Normalized individual terms that every result must contain.
   repeated string required_terms = 1;


### PR DESCRIPTION
## Why

People should be able to ask for all messages from a user, in a room, during a date range, or with attachments without inventing an unrelated body-text term. Queries such as `from:alice` should therefore be complete searches on their own.

## What changed

- recognises any supported room, author, date, or attachment filter as a complete query without requiring a body term or phrase
- carries filter-only queries through the public API, provider contract, and bundled Bleve provider while preserving authorised room scoping
- documents the behaviour and covers author, room, date, and attachment filters across parser, contract, provider, API, and browser tests

## Compatibility

- Classification: additive behavioural expansion for the unreleased Chatto 0.5 search API; protobuf wire shapes are unchanged.
- Older client → newer server: existing queries continue to behave as before.
- Newer client → older server: a filter-only query is rejected with `INVALID_ARGUMENT`; because search is new in the unreleased 0.5 line, no capability split or data migration is required.
- External 0.5 search providers should update to accept requests with no terms or phrases when another query criterion is present.
- Authorisation, visibility, cursor sealing, storage, and deployment behaviour are unchanged.

## Test plan

- `mise test-cli` — passed
- `mise lint` — passed with zero Svelte errors or warnings
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/search.test.ts` — 2 passed
- `mise codegen-proto` — passed
- `mise license-check` — passed
- GitHub Actions CI — passed; the frontend unit job passed on a targeted rerun after one timing-sensitive assertion in unchanged code failed under full-suite load

## Documentation

- Updates FDR-033, the operator search guide, 0.5 release notes, and generated ConnectRPC reference comments.
