### PR TITLE
refactor(frontend): deduplicate message search helpers

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -202,6 +202,9 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
 - Pure functions/classes can use Node Vitest. Mounted Svelte components,
   DOM/CSS/localStorage/drag behavior, context, and `$effect` runtime behavior
   need browser/component tests.
+- Keep debounce assertions independent of browser-suite scheduling: use fake
+  timers or dispatch the complete input value synchronously instead of timing
+  multi-keystroke `userEvent.type` calls against the production delay.
 - E2E is for real backend/NATS/WebSocket/multi-user/cross-route behavior.
 - When changing multi-server authentication or shared chat providers, cover an
   authenticated remote server with an anonymous origin server.

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -11,6 +11,7 @@
   import { getAvatarInitials } from '$lib/utils/initials';
   import { getGradientForName } from '$lib/utils/gradients';
   import { buildDirectMessagePresentation } from '$lib/render/users';
+  import { buildMessageLinkPath } from '$lib/messageLinks';
   import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
   import { quickSwitcher } from '$lib/state/globals.svelte';
   import { useDebounce } from '$lib/hooks/useDebounce.svelte';
@@ -512,19 +513,12 @@
       });
     }
     if (item.kind === 'message' && item.message) {
-      if (item.message.threadRootEventId) {
-        return resolve('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', {
-          serverId: serverIdToSegment(item.serverId),
-          roomId: item.message.roomId,
-          threadId: item.message.threadRootEventId,
-          messageId: item.message.id
-        });
-      }
-      return resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-        serverId: serverIdToSegment(item.serverId),
-        roomId: item.message.roomId,
-        messageId: item.message.id
-      });
+      return buildMessageLinkPath(
+        item.serverId,
+        item.message.roomId,
+        item.message.id,
+        item.message.threadRootEventId
+      );
     }
     return undefined;
   }
@@ -565,37 +559,8 @@
     if (!url) return;
     if (item.kind !== 'message') recentQuickSwitcher.record(url);
 
-    if (item.kind === 'destination') {
-      goto(resolve('/chat/notifications'));
-    } else if (item.kind === 'server') {
-      goto(resolve('/chat/[serverId]/overview', { serverId: serverIdToSegment(item.serverId) }));
-    } else if (item.kind === 'dm' || item.kind === 'room') {
-      goto(
-        resolve('/chat/[serverId]/[roomId]', {
-          serverId: serverIdToSegment(item.serverId),
-          roomId: item.id
-        })
-      );
-    } else if (item.kind === 'message' && item.message) {
-      if (item.message.threadRootEventId) {
-        goto(
-          resolve('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', {
-            serverId: serverIdToSegment(item.serverId),
-            roomId: item.message.roomId,
-            threadId: item.message.threadRootEventId,
-            messageId: item.message.id
-          })
-        );
-      } else {
-        goto(
-          resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-            serverId: serverIdToSegment(item.serverId),
-            roomId: item.message.roomId,
-            messageId: item.message.id
-          })
-        );
-      }
-    }
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- itemUrl() returns resolved app routes
+    goto(url);
   }
 
   // --- Keyboard ---

--- a/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.spec.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useLoadMoreWhenVisible } from './useLoadMoreWhenVisible.svelte';
+
+let intersectionCallback: IntersectionObserverCallback;
+const disconnectObserver = vi.fn();
+
+beforeEach(() => {
+  disconnectObserver.mockReset();
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+      }
+      observe = vi.fn();
+      disconnect = disconnectObserver;
+    }
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  document.body.replaceChildren();
+});
+
+describe('useLoadMoreWhenVisible', () => {
+  it('loads successive pages while the sentinel remains near the viewport', async () => {
+    let cursor: string | null = 'first';
+    const loadMore = vi.fn(async () => {
+      cursor = cursor === 'first' ? 'second' : null;
+    });
+    const attachment = useLoadMoreWhenVisible({
+      getCursor: () => cursor,
+      loadMore,
+      hasError: () => false
+    });
+    const sentinel = document.createElement('div');
+    document.body.append(sentinel);
+    const cleanup = attachment(sentinel);
+
+    intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as never);
+
+    await vi.waitFor(() => expect(loadMore).toHaveBeenCalledTimes(2));
+    if (typeof cleanup === 'function') cleanup();
+    expect(disconnectObserver).toHaveBeenCalledOnce();
+  });
+
+  it('stops when loading does not advance the cursor', async () => {
+    const loadMore = vi.fn(async () => {});
+    const attachment = useLoadMoreWhenVisible({
+      getCursor: () => 'unchanged',
+      loadMore,
+      hasError: () => false
+    });
+    const sentinel = document.createElement('div');
+    document.body.append(sentinel);
+    attachment(sentinel);
+
+    intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as never);
+
+    await vi.waitFor(() => expect(loadMore).toHaveBeenCalledOnce());
+  });
+});

--- a/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.ts
@@ -1,0 +1,46 @@
+import { tick } from 'svelte';
+import type { Attachment } from 'svelte/attachments';
+
+type LoadMoreWhenVisibleOptions = {
+  getCursor: () => string | null;
+  loadMore: () => Promise<void>;
+  hasError: () => boolean;
+};
+
+/** Load successive pages while a trailing sentinel remains near the viewport. */
+export function useLoadMoreWhenVisible({
+  getCursor,
+  loadMore,
+  hasError
+}: LoadMoreWhenVisibleOptions): Attachment<HTMLElement> {
+  return (node) => {
+    if (typeof IntersectionObserver === 'undefined') return;
+    let loadingVisiblePages = false;
+
+    const loadVisiblePages = async (): Promise<void> => {
+      if (loadingVisiblePages) return;
+      loadingVisiblePages = true;
+      try {
+        do {
+          const cursor = getCursor();
+          await loadMore();
+          await tick();
+          if (hasError() || getCursor() === cursor) break;
+          const bounds = node.getBoundingClientRect();
+          if (bounds.top > window.innerHeight + 160 || bounds.bottom < -160) break;
+        } while (getCursor() && node.isConnected);
+      } finally {
+        loadingVisiblePages = false;
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) void loadVisiblePages();
+      },
+      { rootMargin: '160px 0px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -6,7 +6,6 @@ so switching rooms cannot leak a query or plaintext results into another room.
 -->
 <script lang="ts">
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-  import { tick } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
   import type { MessageSearchResult } from '$lib/api-client/messageSearch';
   import MessageView from '$lib/components/messages/MessageView.svelte';
@@ -20,6 +19,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
   } from '$lib/state/server/messageSearch.svelte';
   import { getUserSettings } from '$lib/state/userSettings.svelte';
   import { useDebouncedMessageSearch } from '$lib/hooks/useDebouncedMessageSearch.svelte';
+  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
   import { EmptyState, Hint, ScrollFader } from '$lib/ui';
   import { Button, TextInput } from '$lib/ui/form';
   import { formatDateTime } from '$lib/utils/formatTime';
@@ -40,6 +40,11 @@ so switching rooms cannot leak a query or plaintext results into another room.
   const search = useDebouncedMessageSearch({
     getStore: () => store,
     getInput: (query) => ({ query, roomId, order: MessageSearchOrder.RELEVANCE })
+  });
+  const loadMoreWhenVisible = useLoadMoreWhenVisible({
+    getCursor: () => store.nextCursor,
+    loadMore: () => store.loadMore(),
+    hasError: () => store.error
   });
 
   $effect(() => {
@@ -84,35 +89,6 @@ so switching rooms cannot leak a query or plaintext results into another room.
     if (event.target !== event.currentTarget || event.key !== 'Enter') return;
     event.preventDefault();
     onOpenResult?.(result.id, result.threadRootEventId);
-  }
-
-  function loadMoreWhenVisible(node: HTMLElement): ReturnType<Attachment> {
-    if (typeof IntersectionObserver === 'undefined') return;
-    let loadingVisiblePages = false;
-    const loadVisiblePages = async (): Promise<void> => {
-      if (loadingVisiblePages) return;
-      loadingVisiblePages = true;
-      try {
-        do {
-          const cursor = store.nextCursor;
-          await store.loadMore();
-          await tick();
-          if (store.error || store.nextCursor === cursor) break;
-          const bounds = node.getBoundingClientRect();
-          if (bounds.top > window.innerHeight + 160 || bounds.bottom < -160) break;
-        } while (store.nextCursor && node.isConnected);
-      } finally {
-        loadingVisiblePages = false;
-      }
-    };
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) void loadVisiblePages();
-      },
-      { rootMargin: '160px 0px' }
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
   }
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -6,8 +6,6 @@ in the active server store so browser Back can restore the current search.
 -->
 <script lang="ts">
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-  import type { Attachment } from 'svelte/attachments';
-  import { tick } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { Panel } from '$lib/components/admin';
@@ -22,6 +20,8 @@ in the active server store so browser Back can restore the current search.
   import { MessageSearchOrder, MessageSearchState } from '$lib/state/server/messageSearch.svelte';
   import { getLocale } from '$lib/i18n/runtime';
   import { useDebouncedMessageSearch } from '$lib/hooks/useDebouncedMessageSearch.svelte';
+  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
+  import { buildMessageLinkPath } from '$lib/messageLinks';
   import { formatDateTime } from '$lib/utils/formatTime';
   import {
     EmptyState,
@@ -55,6 +55,11 @@ in the active server store so browser Back can restore the current search.
     getStore: () => store,
     getInput: (query) => ({ query, order: store.order })
   });
+  const loadMoreWhenVisible = useLoadMoreWhenVisible({
+    getCursor: () => store.nextCursor,
+    loadMore: () => store.loadMore(),
+    hasError: () => store.error
+  });
   $effect(() => {
     void store.ensureStatus();
   });
@@ -82,58 +87,13 @@ in the active server store so browser Back can restore the current search.
     };
   }
 
-  function loadMoreWhenVisible(node: HTMLElement): ReturnType<Attachment> {
-    if (typeof IntersectionObserver === 'undefined') return;
-    let loadingVisiblePages = false;
-    const loadVisiblePages = async (): Promise<void> => {
-      if (loadingVisiblePages) return;
-      loadingVisiblePages = true;
-      try {
-        do {
-          const cursor = store.nextCursor;
-          await store.loadMore();
-          await tick();
-          if (store.error || store.nextCursor === cursor) break;
-          const bounds = node.getBoundingClientRect();
-          if (bounds.top > window.innerHeight + 160 || bounds.bottom < -160) break;
-        } while (store.nextCursor && node.isConnected);
-      } finally {
-        loadingVisiblePages = false;
-      }
-    };
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) void loadVisiblePages();
-      },
-      { rootMargin: '160px 0px' }
-    );
-    observer.observe(node);
-    return () => observer.disconnect();
-  }
-
   function formatTimestamp(value: string): string {
     return value ? formatDateTime(value, timeFormatSettings, activeLocale) : '';
   }
 
   function navigateToResult(result: MessageSearchResult): void {
-    if (result.threadRootEventId) {
-      void goto(
-        resolve('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', {
-          serverId: serverIdToSegment(serverId),
-          roomId: result.roomId,
-          threadId: result.threadRootEventId,
-          messageId: result.id
-        })
-      );
-      return;
-    }
-    void goto(
-      resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-        serverId: serverIdToSegment(serverId),
-        roomId: result.roomId,
-        messageId: result.id
-      })
-    );
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route
+    void goto(buildMessageLinkPath(serverId, result.roomId, result.id, result.threadRootEventId));
   }
 
   function openResult(event: MouseEvent, result: MessageSearchResult): void {
@@ -275,25 +235,21 @@ in the active server store so browser Back can restore the current search.
                             </a>
                             {#if result.createdAt}
                               <span class="text-xs text-muted" aria-hidden="true">·</span>
+                              <!-- eslint-disable svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route -->
                               <a
                                 class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
-                                href={result.threadRootEventId
-                                  ? resolve('/chat/[serverId]/[roomId]/[threadId]/m/[messageId]', {
-                                      serverId: serverIdToSegment(serverId),
-                                      roomId: result.roomId,
-                                      threadId: result.threadRootEventId,
-                                      messageId: result.id
-                                    })
-                                  : resolve('/chat/[serverId]/[roomId]/m/[messageId]', {
-                                      serverId: serverIdToSegment(serverId),
-                                      roomId: result.roomId,
-                                      messageId: result.id
-                                    })}
+                                href={buildMessageLinkPath(
+                                  serverId,
+                                  result.roomId,
+                                  result.id,
+                                  result.threadRootEventId
+                                )}
                               >
                                 <time datetime={result.createdAt}
                                   >{formatTimestamp(result.createdAt)}</time
                                 >
                               </a>
+                              <!-- eslint-enable svelte/no-navigation-without-resolve -->
                             {/if}
                           {/snippet}
 

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -96,7 +96,8 @@ describe('message search page', () => {
     const { container } = render(SearchPageTestHarness);
 
     const input = container.querySelector('input') as HTMLInputElement;
-    await userEvent.type(input, 'motherfucking search');
+    input.value = 'motherfucking search';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
     expect(mocks.search).not.toHaveBeenCalled();
     await waitForSearchDebounce();
 
@@ -120,9 +121,10 @@ describe('message search page', () => {
     );
     expect(document.activeElement).toBe(input);
 
-    await userEvent.clear(input);
-    await userEvent.type(input, 'replacement query');
-    await userEvent.keyboard('{Enter}');
+    input.value = 'replacement query';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.form!.requestSubmit();
+    await tick();
 
     expect(mocks.search).toHaveBeenLastCalledWith(
       {
@@ -140,10 +142,10 @@ describe('message search page', () => {
     const input = container.querySelector('input') as HTMLInputElement;
     const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
 
-    await userEvent.type(input, 'foo');
+    await userEvent.fill(input, 'foo');
     await waitForSearchDebounce();
     store.messageSearch.hasSearched = true;
-    await userEvent.type(input, ' ');
+    await userEvent.fill(input, 'foo ');
     await waitForSearchDebounce();
 
     expect(input.value).toBe('foo ');
@@ -197,12 +199,12 @@ describe('message search page', () => {
     const { container } = render(SearchPageTestHarness);
     const input = container.querySelector('input') as HTMLInputElement;
 
-    await userEvent.type(input, 'needle');
-    await userEvent.click(
-      [...container.querySelectorAll('label')].find(
-        (label) => label.textContent?.trim() === 'Newest'
-      )!
-    );
+    input.value = 'needle';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    [...container.querySelectorAll('label')]
+      .find((label) => label.textContent?.trim() === 'Newest')!
+      .click();
+    await tick();
 
     expect(mocks.search).toHaveBeenCalledOnce();
     expect(mocks.search).toHaveBeenCalledWith(
@@ -218,7 +220,7 @@ describe('message search page', () => {
     const input = container.querySelector('input') as HTMLInputElement;
     const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
 
-    await userEvent.type(input, 'private query');
+    await userEvent.fill(input, 'private query');
     store.messageSearch.query = '';
     store.messageSearch.hasSearched = false;
     await tick();
@@ -233,7 +235,7 @@ describe('message search page', () => {
     const input = container.querySelector('input') as HTMLInputElement;
     const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
 
-    await userEvent.type(input, 'retry me');
+    await userEvent.fill(input, 'retry me');
     await waitForSearchDebounce();
     store.messageSearch.hasSearched = true;
     store.messageSearch.error = true;
@@ -251,7 +253,7 @@ describe('message search page', () => {
     const input = container.querySelector('input') as HTMLInputElement;
     const store = mocks.serverStores.origin as ReturnType<typeof serverStore>;
 
-    await userEvent.type(input, 'refresh me');
+    await userEvent.fill(input, 'refresh me');
     await waitForSearchDebounce();
     store.messageSearch.hasSearched = true;
     await userEvent.keyboard('{Enter}');


### PR DESCRIPTION
## Why

The newly added room, server, and cross-server message-search surfaces had begun
to duplicate message-route construction and automatic pagination behavior. This
refactor gives those shared concerns one implementation while preserving each
surface's distinct search semantics.

## What changed

- Reuse the canonical message-link builder for server search results and
  cross-server Quick Switcher results.
- Navigate Quick Switcher selections through the URL it already computes
  instead of reconstructing each route.
- Share the automatic visible-sentinel pagination attachment between room and
  server search, with focused coverage for multi-page loading and stalled
  cursors.
- Make debounce integration tests independent of browser-suite scheduling
  delays and document that testing convention for future frontend work.

This is an internal frontend refactor. It has no public API, compatibility,
migration, security, rollout, or operational impact.

## Test plan

- `mise test-frontend` — 310 files and 2,622 tests passed.
- `mise lint` — passed with zero Svelte errors or warnings.
- `mise x -- npx @sveltejs/mcp svelte-autofixer` — passed for every changed
  Svelte component and module.
- Independent code review — no actionable findings.
