### PR TITLE
refactor(frontend): unify message action state

### DIFF
--- a/apps/frontend/src/lib/hooks/index.ts
+++ b/apps/frontend/src/lib/hooks/index.ts
@@ -7,7 +7,7 @@ export {
 
 // Message actions
 export { useMessageActions, useReactionActions } from './useMessageActions.svelte';
-export type { MessageActionParams } from './useMessageActions.svelte';
+export type { MessageActionParams, MessageActions } from './useMessageActions.svelte';
 
 // Data hooks
 export { useRoomData } from './useRoomData.svelte';

--- a/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useMessageActions.svelte.ts
@@ -151,3 +151,5 @@ export function useMessageActions() {
     copyMessageLink
   };
 }
+
+export type MessageActions = ReturnType<typeof useMessageActions>;

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte
@@ -8,125 +8,58 @@ surface-specific sizing and menu semantics.
 <script lang="ts">
   import type { Snippet } from 'svelte';
 
-  import { useMessageActions, type MessageActionParams } from '$lib/hooks';
   import * as m from '$lib/i18n/messages';
-  import type { MessagesStore } from '$lib/state/room';
   import { getRecentEmojis } from '$lib/state/recentEmojis.svelte';
-  import { getEmojiByName } from '$lib/emoji';
+  import type { MessageActionModel } from './messageActionModel';
 
   let {
     presentation = 'menu',
-    serverId,
-    roomId,
-    messageEventId,
-    eventId,
-    deleteEventId = eventId,
-    messageBody,
-    permalinkThreadRootEventId = null,
-    threadRootEventId = null,
-    channelEchoEventId = null,
-    canAddChannelEcho = false,
-    messageStore = null,
-    reactions = [],
-    canReact = false,
-    canEdit = false,
-    canDelete = false,
-    replyInRoomLabel,
-    replyThreadLabel,
-    onReplyInRoom,
-    onReply,
+    action,
     onOpenEmojiPicker,
     onClose
   }: {
     presentation?: 'menu' | 'sheet';
-    serverId: string;
-    roomId: string;
-    messageEventId: string;
-    eventId: string;
-    deleteEventId?: string;
-    messageBody: string;
-    permalinkThreadRootEventId?: string | null;
-    threadRootEventId?: string | null;
-    channelEchoEventId?: string | null;
-    canAddChannelEcho?: boolean;
-    messageStore?: MessagesStore | null;
-    reactions?: { emoji: string; hasReacted: boolean }[];
-    canReact?: boolean;
-    canEdit?: boolean;
-    canDelete?: boolean;
-    replyInRoomLabel?: string;
-    replyThreadLabel?: string;
-    onReplyInRoom?: () => void;
-    onReply?: () => void;
+    action: MessageActionModel;
     onOpenEmojiPicker?: () => void;
     onClose: () => void;
   } = $props();
 
   const isSheet = $derived(presentation === 'sheet');
-  const recentEmojis = $derived(getRecentEmojis(serverId));
+  const recentEmojis = $derived(getRecentEmojis(action.serverId));
   const quickReactions = $derived(recentEmojis.quickReactions);
 
-  const actions = useMessageActions();
-  const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());
-  const replyThreadActionLabel = $derived(
-    replyThreadLabel ?? m['room.message.actions.reply_thread']()
-  );
-
-  const params: MessageActionParams = $derived({
-    serverId,
-    roomId,
-    messageEventId,
-    eventId,
-    deleteEventId,
-    messageBody,
-    permalinkThreadRootEventId,
-    threadRootEventId,
-    channelEchoEventId,
-    canAddChannelEcho,
-    messageStore
-  });
-
-  /** Set of Unicode emojis the current user has already reacted with (API returns shortcodes). */
-  const myReactions = $derived(
-    new Set(reactions.filter((r) => r.hasReacted).map((r) => getEmojiByName(r.emoji) ?? r.emoji))
-  );
-
-  function hasReacted(emoji: string): boolean {
-    return myReactions.has(emoji);
-  }
-
   async function handleReaction(emoji: string) {
-    await actions.toggleReaction(params, emoji, hasReacted(emoji));
+    await action.toggleReaction(emoji);
     onClose();
   }
 
   function handleReplyInRoom() {
-    onReplyInRoom?.();
+    action.replyInRoom?.();
     onClose();
   }
 
   function handleReply() {
-    onReply?.();
+    action.replyThread?.();
     onClose();
   }
 
   function handleEdit() {
-    actions.startEdit(params);
+    action.edit();
     onClose();
   }
 
   async function handleCopyText() {
-    await actions.copyMessageText(params);
+    await action.copyText();
     onClose();
   }
 
   async function handleCopyLink() {
-    await actions.copyMessageLink(params);
+    await action.copyLink();
     onClose();
   }
 
   function handleDelete() {
-    actions.openDeleteConfirmation(params);
+    action.delete();
     onClose();
   }
 </script>
@@ -196,7 +129,7 @@ surface-specific sizing and menu semantics.
 {/snippet}
 
 {#snippet menuContent()}
-  {#if canReact}
+  {#if action.canReact}
     {#if isSheet}
       <div class="flex justify-between menu-section px-2 py-1.5">
         {@render reactionButtons()}
@@ -210,34 +143,36 @@ surface-specific sizing and menu semantics.
     {/if}
   {/if}
 
-  {#if onReplyInRoom || onReply || canEdit}
+  {#if action.replyInRoom || action.replyThread || action.canEdit}
     {@render actionGroup(primaryActions)}
   {/if}
 
   {@render actionGroup(copyActions)}
 
-  {#if canDelete}
+  {#if action.canDelete}
     {@render actionGroup(deleteAction)}
   {/if}
 {/snippet}
 
 {#snippet primaryActions()}
-  {#if onReplyInRoom}
-    {@render
-      actionButton(replyInRoomActionLabel, 'uil--corner-up-left', handleReplyInRoom)}
+  {#if action.replyInRoom}
+    {@render actionButton(action.replyInRoomLabel, 'uil--corner-up-left', handleReplyInRoom)}
   {/if}
-  {#if onReply}
-    {@render actionButton(replyThreadActionLabel, 'uil--comment-alt-lines', handleReply)}
+  {#if action.replyThread}
+    {@render actionButton(action.replyThreadLabel, 'uil--comment-alt-lines', handleReply)}
   {/if}
-  {#if canEdit}
+  {#if action.canEdit}
     {@render actionButton(m['room.message.actions.edit_short'](), 'uil--pen', handleEdit)}
   {/if}
 {/snippet}
 
 {#snippet copyActions()}
-  {#if messageBody}
-    {@render
-      actionButton(m['room.message.actions.copy_text'](), 'uil--clipboard-notes', handleCopyText)}
+  {#if action.messageBody}
+    {@render actionButton(
+      m['room.message.actions.copy_text'](),
+      'uil--clipboard-notes',
+      handleCopyText
+    )}
   {/if}
   {@render actionButton(m['room.message.actions.copy_link'](), 'uil--link', handleCopyLink)}
 {/snippet}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte.spec.ts
@@ -4,19 +4,18 @@ import { q } from '$lib/test-utils';
 import MessageActionMenu from './MessageActionMenu.svelte';
 import MessageEventActionOverlays from './MessageEventActionOverlays.svelte';
 import { MessageEventInteractionState } from './messageEventInteractions.svelte';
+import { buildMessageActionModel } from './messageActionModel';
 
 const mocks = vi.hoisted(() => ({
   actions: {
     toggleReaction: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
     startEdit: vi.fn(),
     openDeleteConfirmation: vi.fn(),
     copyMessageText: vi.fn(),
     copyMessageLink: vi.fn()
   }
-}));
-
-vi.mock('$lib/hooks', () => ({
-  useMessageActions: () => mocks.actions
 }));
 
 vi.mock('$lib/state/recentEmojis.svelte', () => ({
@@ -26,20 +25,64 @@ vi.mock('$lib/state/recentEmojis.svelte', () => ({
   })
 }));
 
-const baseProps = {
+const baseParams = {
   serverId: 'server-1',
   roomId: 'room-1',
   messageEventId: 'message-event-1',
   eventId: 'event-1',
-  messageBody: 'Hello',
+  messageBody: 'Hello'
+};
+
+const baseProps = {
   onClose: vi.fn()
 };
 
-function renderMenu(props: Record<string, unknown> = {}) {
+type ActionOverrides = {
+  messageBody?: string;
+  permalinkThreadRootEventId?: string | null;
+  reactions?: { emoji: string; hasReacted: boolean }[];
+  canReact?: boolean;
+  canEdit?: boolean;
+  canDelete?: boolean;
+  replyInRoomLabel?: string;
+  replyThreadLabel?: string;
+  onReplyInRoom?: () => void;
+  onReply?: () => void;
+};
+
+function buildAction(overrides: ActionOverrides = {}) {
+  return buildMessageActionModel({
+    actions: mocks.actions,
+    params: {
+      ...baseParams,
+      messageBody: overrides.messageBody ?? baseParams.messageBody,
+      permalinkThreadRootEventId: overrides.permalinkThreadRootEventId
+    },
+    reactions: overrides.reactions ?? [],
+    canReact: overrides.canReact ?? false,
+    canEdit: overrides.canEdit ?? false,
+    canDelete: overrides.canDelete ?? false,
+    replyInRoomLabel: overrides.replyInRoomLabel ?? 'Reply',
+    replyThreadLabel: overrides.replyThreadLabel ?? 'Reply in thread',
+    replyInRoom: overrides.onReplyInRoom,
+    replyThread: overrides.onReply
+  });
+}
+
+function renderMenu({
+  presentation,
+  onOpenEmojiPicker,
+  ...overrides
+}: ActionOverrides & {
+  presentation?: 'menu' | 'sheet';
+  onOpenEmojiPicker?: () => void;
+} = {}) {
   return render(MessageActionMenu, {
     props: {
-      ...baseProps,
-      ...props
+      action: buildAction(overrides),
+      presentation,
+      onOpenEmojiPicker,
+      onClose: baseProps.onClose
     }
   });
 }
@@ -84,11 +127,7 @@ describe('MessageActionMenu', () => {
           button.textContent?.trim()
         )
       )
-    ).toEqual([
-      ['Reply', 'Reply in thread', 'Edit'],
-      ['Copy text', 'Copy link'],
-      ['Delete']
-    ]);
+    ).toEqual([['Reply', 'Reply in thread', 'Edit'], ['Copy text', 'Copy link'], ['Delete']]);
   });
 
   it('uses custom reply action labels when provided', () => {
@@ -257,15 +296,9 @@ describe('MessageActionMenu', () => {
       ]);
       expect(
         Array.from(container.querySelectorAll('nav')).map((section) =>
-          Array.from(section.querySelectorAll('button')).map((button) =>
-            button.textContent?.trim()
-          )
+          Array.from(section.querySelectorAll('button')).map((button) => button.textContent?.trim())
         )
-      ).toEqual([
-        ['Reply', 'Reply in thread', 'Edit'],
-        ['Copy text', 'Copy link'],
-        ['Delete']
-      ]);
+      ).toEqual([['Reply', 'Reply in thread', 'Edit'], ['Copy text', 'Copy link'], ['Delete']]);
       expect(container.querySelector('[role="menuitem"]')).toBeNull();
       expect(container.querySelector('nav button')).toHaveClass('min-h-11');
       expect(q(container, '[aria-label="React with 👍"]')).toHaveClass('rounded-full', 'text-xl');
@@ -298,13 +331,7 @@ describe('MessageActionMenu', () => {
       const { container } = render(MessageEventActionOverlays, {
         props: {
           interactions,
-          serverId: 'server-1',
-          roomId: 'room-1',
-          messageEventId: 'message-event-1',
-          eventId: 'event-1',
-          deleteEventId: 'event-1',
-          messageBody: 'Hello',
-          onEmojiSelect: vi.fn(),
+          action: buildAction(),
           onClose
         }
       });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -27,7 +27,6 @@
   import { formatMessageTime, timeFormatSettingsFor } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
   import { useMessageActions } from '$lib/hooks';
-  import { emojiToName } from '$lib/emoji';
   import { toast } from '$lib/ui/toast';
   import { copyMessageLinkToClipboard } from '$lib/messageLinks';
   import { serverIdToSegment } from '$lib/navigation';
@@ -51,6 +50,7 @@
     resolveMessageEventReferences
   } from './messageEventModel';
   import { ThreadFollowState } from './threadFollowState.svelte';
+  import { buildMessageActionModel } from './messageActionModel';
 
   let {
     event,
@@ -122,23 +122,7 @@
   let messageBodySelectionRoot = $state<HTMLElement>();
   let selectedReplyQuoteSnapshot = $state<QuoteInsertionContent | null>(null);
 
-  const emojiActions = useMessageActions();
-
-  async function handleEmojiSelect(emoji: string) {
-    if (!msg) return;
-
-    const params = {
-      serverId: activeServerId,
-      roomId,
-      messageEventId: event.id,
-      eventId: isEcho ? messageEvent!.echoOfEventId! : event.id,
-      messageBody: msg.body ?? '',
-      messageStore
-    };
-    const name = emojiToName(emoji);
-    const alreadyReacted = msg.reactions.some((r) => r.emoji === name && r.hasReacted);
-    await emojiActions.toggleReaction(params, emoji, alreadyReacted);
-  }
+  const messageActions = useMessageActions();
 
   // Touch handlers for mobile
   function handleTouchStart() {
@@ -262,6 +246,32 @@
     isEcho
       ? !!onOpenThread && !!messageEvent?.echoFromThreadRootEventId
       : roomPermissions.canPostInThread && !!onOpenThread
+  );
+  const actionModel = $derived(
+    buildMessageActionModel({
+      actions: messageActions,
+      params: {
+        serverId: activeServerId,
+        roomId,
+        messageEventId: event.id,
+        eventId: editEventId,
+        deleteEventId: event.id,
+        messageBody: msg?.body ?? '',
+        permalinkThreadRootEventId,
+        threadRootEventId: editThreadRootEventId,
+        channelEchoEventId: editChannelEchoEventId,
+        canAddChannelEcho: canReconcileChannelEcho,
+        messageStore
+      },
+      reactions: msg?.reactions ?? [],
+      canReact: roomPermissions.canReact,
+      canEdit,
+      canDelete,
+      replyInRoomLabel: replyInRoomActionLabel,
+      replyThreadLabel: replyThreadActionLabel,
+      replyInRoom: canUseReplyAction ? handleReplyInRoom : undefined,
+      replyThread: canUseThreadAction ? handleOpenThread : undefined
+    })
   );
 
   const threadFollow = new ThreadFollowState({
@@ -573,15 +583,13 @@
       {#if hasMessageFooter}
         <MessageMetaBar
           {roomId}
-          messageEventId={event.id}
           serverSegment={serverIdToSegment(activeServerId)}
           {threadRootEventId}
           reactions={msg?.reactions ?? []}
+          action={actionModel}
           replyCount={messageEvent?.replyCount}
           threadParticipants={messageEvent?.threadParticipants}
           {hasThreadNotification}
-          canReact={roomPermissions.canReact}
-          {messageStore}
           isFollowingThread={threadFollow.following}
           isThreadFollowPending={threadFollow.pending}
           onToggleThreadFollow={hasReplies ? toggleThreadFollow : undefined}
@@ -597,24 +605,8 @@
     {#snippet actions()}
       {#if !isDeleted && canUseHoverActions}
         <MessageHoverBar
-          serverId={activeServerId}
-          {roomId}
-          messageEventId={event.id}
-          eventId={editEventId}
-          deleteEventId={event.id}
-          messageBody={msg.body ?? ''}
-          threadRootEventId={editThreadRootEventId}
-          channelEchoEventId={editChannelEchoEventId}
-          canAddChannelEcho={canReconcileChannelEcho}
-          {messageStore}
-          reactions={msg?.reactions ?? []}
-          canReact={roomPermissions.canReact}
-          {canEdit}
+          action={actionModel}
           forceVisible={interactions.forceHoverActionsVisible}
-          replyInRoomLabel={replyInRoomActionLabel}
-          replyThreadLabel={replyThreadActionLabel}
-          onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
-          onReply={canUseThreadAction ? handleOpenThread : undefined}
           onOpenEmojiPicker={roomPermissions.canReact
             ? (event) => interactions.openEmojiPickerFromToolbar(event)
             : undefined}
@@ -636,26 +628,7 @@
   {#if !isDeleted}
     <MessageEventActionOverlays
       {interactions}
-      serverId={activeServerId}
-      {roomId}
-      messageEventId={event.id}
-      eventId={editEventId}
-      deleteEventId={event.id}
-      messageBody={msg.body ?? ''}
-      {permalinkThreadRootEventId}
-      threadRootEventId={editThreadRootEventId}
-      channelEchoEventId={editChannelEchoEventId}
-      canAddChannelEcho={canReconcileChannelEcho}
-      {messageStore}
-      reactions={msg.reactions}
-      canReact={roomPermissions.canReact}
-      {canEdit}
-      {canDelete}
-      replyInRoomLabel={replyInRoomActionLabel}
-      replyThreadLabel={replyThreadActionLabel}
-      onReplyInRoom={canUseReplyAction ? handleReplyInRoom : undefined}
-      onReply={canUseThreadAction ? handleOpenThread : undefined}
-      onEmojiSelect={handleEmojiSelect}
+      action={actionModel}
       onClose={discardSelectedReplyQuote}
     />
   {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte.spec.ts
@@ -1,0 +1,295 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync, tick } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { TimelineEventKind, type TimelineEventView } from '$lib/render/timelineEvents';
+import { q } from '$lib/test-utils';
+import MessageEventTestHarness from './MessageEventTestHarness.svelte';
+
+const mocks = vi.hoisted(() => ({
+  actions: {
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    startEdit: vi.fn(),
+    openDeleteConfirmation: vi.fn(),
+    copyMessageText: vi.fn(),
+    copyMessageLink: vi.fn()
+  }
+}));
+
+vi.mock('$lib/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/hooks')>();
+  return { ...actual, useMessageActions: () => mocks.actions };
+});
+
+vi.mock('$lib/components/messages/MessageView.svelte', async () => {
+  const { default: MessageViewActionTestSurface } =
+    await import('./MessageViewActionTestSurface.svelte');
+  return { default: MessageViewActionTestSurface };
+});
+
+vi.mock('$lib/utils/inputCapabilities', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('$lib/utils/inputCapabilities')>();
+  return {
+    ...actual,
+    prefersTouchActions: () => false,
+    supportsHoverActions: () => true
+  };
+});
+
+vi.mock('$app/paths', () => ({
+  assets: '',
+  base: '',
+  resolve: (path: string, params?: Record<string, string>) =>
+    path
+      .replace('[serverId]', params?.serverId ?? '')
+      .replace('[roomId]', params?.roomId ?? '')
+      .replace('[threadId]', params?.threadId ?? '')
+      .replace('[messageId]', params?.messageId ?? '')
+}));
+
+type MessageOverrides = Partial<{
+  id: string;
+  actorId: string;
+  body: string;
+  threadRootEventId: string | null;
+  echoOfEventId: string | null;
+  echoFromThreadRootEventId: string | null;
+  channelEchoEventId: string | null;
+}>;
+
+function messageEvent(overrides: MessageOverrides = {}): TimelineEventView {
+  const actorId = overrides.actorId ?? 'viewer';
+  return {
+    id: overrides.id ?? 'regular-message',
+    actorId,
+    actor: {
+      id: actorId,
+      login: actorId,
+      displayName: actorId,
+      deleted: false,
+      avatarUrl: null,
+      presenceStatus: PresenceStatus.OFFLINE
+    },
+    createdAt: new Date().toISOString(),
+    event: {
+      kind: TimelineEventKind.MessagePosted,
+      roomId: 'room-1',
+      body: overrides.body ?? 'Hello from this message',
+      attachments: [],
+      linkPreview: null,
+      reactions: [
+        {
+          emoji: 'thumbsup',
+          count: 1,
+          hasReacted: true,
+          users: [{ id: 'viewer', displayName: 'viewer' }]
+        }
+      ],
+      updatedAt: null,
+      inReplyTo: null,
+      threadRootEventId: overrides.threadRootEventId ?? null,
+      echoOfEventId: overrides.echoOfEventId ?? null,
+      echoFromThreadRootEventId: overrides.echoFromThreadRootEventId ?? null,
+      channelEchoEventId: overrides.channelEchoEventId ?? null,
+      replyCount: 0,
+      lastReplyAt: null,
+      threadParticipants: [],
+      viewerIsFollowingThread: false
+    }
+  } as TimelineEventView;
+}
+
+function menuButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent?.trim() === label
+  );
+}
+
+function actionSheetButton(container: HTMLElement, label: string): HTMLButtonElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('dialog[open] button')).find(
+    (button) => button.textContent?.trim() === label
+  );
+}
+
+async function openContextMenu(container: HTMLElement): Promise<void> {
+  q(container, '[data-testid="message-row"]')!.dispatchEvent(
+    new MouseEvent('contextmenu', {
+      bubbles: true,
+      cancelable: true,
+      clientX: 80,
+      clientY: 120
+    })
+  );
+  await vi.waitFor(() => expect(menuButton(container, 'Copy link')).toBeTruthy());
+}
+
+async function selectPickerEmoji(
+  container: HTMLElement,
+  query: string,
+  title: string
+): Promise<void> {
+  const input = q(container, 'input[placeholder="Search emojis..."]') as HTMLInputElement;
+  input.value = query;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+  flushSync();
+  await tick();
+  (q(container, `button[title="${title}"]`) as HTMLButtonElement).click();
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  for (const action of Object.values(mocks.actions)) action.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  window.getSelection()?.removeAllRanges();
+});
+
+describe('MessageEvent action model integration', () => {
+  it('rebinds every action surface when a virtualized row changes message shape', async () => {
+    const regular = messageEvent();
+    const rendered = render(MessageEventTestHarness, { props: { event: regular } });
+
+    (
+      q(rendered.container, 'button[aria-label="Remove 👍 reaction (1)"]') as HTMLButtonElement
+    ).click();
+    await vi.waitFor(() =>
+      expect(mocks.actions.toggleReaction).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          serverId: 'remote-server',
+          roomId: 'room-1',
+          messageEventId: 'regular-message',
+          eventId: 'regular-message',
+          deleteEventId: 'regular-message'
+        }),
+        'thumbsup',
+        true
+      )
+    );
+
+    const threadReply = messageEvent({
+      id: 'thread-reply',
+      body: 'Thread reply',
+      threadRootEventId: 'thread-root'
+    });
+    await rendered.rerender({
+      event: threadReply,
+      permalinkThreadRootEventId: 'thread-root'
+    });
+    (q(rendered.container, 'button[aria-label="Edit message"]') as HTMLButtonElement).click();
+    expect(mocks.actions.startEdit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messageEventId: 'thread-reply',
+        eventId: 'thread-reply',
+        deleteEventId: 'thread-reply',
+        permalinkThreadRootEventId: 'thread-root',
+        threadRootEventId: 'thread-root'
+      })
+    );
+
+    await openContextMenu(rendered.container);
+    menuButton(rendered.container, 'Copy link')!.click();
+    await vi.waitFor(() =>
+      expect(mocks.actions.copyMessageLink).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          messageEventId: 'thread-reply',
+          permalinkThreadRootEventId: 'thread-root'
+        })
+      )
+    );
+
+    const echo = messageEvent({
+      id: 'echo-wrapper',
+      body: 'Channel echo',
+      echoOfEventId: 'original-thread-message',
+      echoFromThreadRootEventId: 'thread-root'
+    });
+    await rendered.rerender({ event: echo, permalinkThreadRootEventId: null });
+    (q(rendered.container, 'button[aria-label="Edit message"]') as HTMLButtonElement).click();
+    expect(mocks.actions.startEdit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messageEventId: 'echo-wrapper',
+        eventId: 'original-thread-message',
+        deleteEventId: 'echo-wrapper',
+        threadRootEventId: 'thread-root',
+        channelEchoEventId: 'echo-wrapper',
+        canAddChannelEcho: true
+      })
+    );
+
+    await openContextMenu(rendered.container);
+    menuButton(rendered.container, 'Delete')!.click();
+    expect(mocks.actions.openDeleteConfirmation).toHaveBeenLastCalledWith(
+      expect.objectContaining({ eventId: 'original-thread-message', deleteEventId: 'echo-wrapper' })
+    );
+
+    (q(rendered.container, 'button[aria-label="Add reaction"]') as HTMLButtonElement).click();
+    await vi.waitFor(() =>
+      expect(q(rendered.container, 'input[placeholder="Search emojis..."]')).toBeTruthy()
+    );
+    await selectPickerEmoji(rendered.container, 'check', 'white_check_mark');
+    await vi.waitFor(() =>
+      expect(mocks.actions.toggleReaction).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          messageEventId: 'echo-wrapper',
+          eventId: 'original-thread-message'
+        }),
+        '✅',
+        false
+      )
+    );
+  });
+
+  it('keeps selected-text replies current and updates permissions in the touch surface', async () => {
+    const onOpenThread = vi.fn();
+    const echo = messageEvent({
+      id: 'echo-wrapper',
+      body: 'Quote this selection',
+      echoOfEventId: 'original-thread-message',
+      echoFromThreadRootEventId: 'thread-root'
+    });
+    const rendered = render(MessageEventTestHarness, { props: { event: echo, onOpenThread } });
+    const body = q(rendered.container, '[data-testid="message-body"]')!;
+    const range = document.createRange();
+    range.selectNodeContents(body);
+    window.getSelection()!.addRange(range);
+
+    q(rendered.container, '[data-testid="message-row"]')!.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true, cancelable: true, button: 2 })
+    );
+    await openContextMenu(rendered.container);
+    menuButton(rendered.container, 'Reply in thread')!.click();
+    expect(onOpenThread).toHaveBeenCalledWith(
+      'thread-root',
+      expect.objectContaining({
+        highlightEventId: 'original-thread-message',
+        quoteText: 'Quote this selection',
+        reply: expect.objectContaining({ eventId: 'original-thread-message' })
+      })
+    );
+
+    const otherUsersMessage = messageEvent({ id: 'other-message', actorId: 'other-user' });
+    await rendered.rerender({ event: otherUsersMessage, canReact: false, onOpenThread });
+
+    expect(q(rendered.container, 'button[aria-label="Edit message"]')).toBeNull();
+    expect(
+      (q(rendered.container, 'button[aria-label="Remove 👍 reaction (1)"]') as HTMLButtonElement)
+        .disabled
+    ).toBe(true);
+
+    vi.useFakeTimers();
+    q(rendered.container, '[data-testid="message-row"]')!.dispatchEvent(
+      new Event('touchstart', { bubbles: true, cancelable: true })
+    );
+    vi.advanceTimersByTime(500);
+    flushSync();
+    vi.useRealTimers();
+    await vi.waitFor(() => expect(actionSheetButton(rendered.container, 'Copy link')).toBeTruthy());
+    expect(actionSheetButton(rendered.container, 'Edit')).toBeUndefined();
+    expect(actionSheetButton(rendered.container, 'Delete')).toBeUndefined();
+    expect(q(rendered.container, 'dialog[open] button[aria-label="React with 👍"]')).toBeNull();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
@@ -2,8 +2,7 @@
   import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
   import * as m from '$lib/i18n/messages';
-  import type { ReactionSummaryView } from '$lib/render/reactions';
-  import type { MessagesStore } from '$lib/state/room';
+  import type { MessageActionModel } from './messageActionModel';
   import type { MessageEventInteractionState } from './messageEventInteractions.svelte';
 
   let messageActionMenuModule: Promise<typeof import('./MessageActionMenu.svelte')> | null = null;
@@ -29,49 +28,11 @@
 
   let {
     interactions,
-    serverId,
-    roomId,
-    messageEventId,
-    eventId,
-    deleteEventId,
-    messageBody,
-    permalinkThreadRootEventId = null,
-    threadRootEventId = null,
-    channelEchoEventId = null,
-    canAddChannelEcho = false,
-    messageStore = null,
-    reactions = [],
-    canReact = false,
-    canEdit = false,
-    canDelete = false,
-    replyInRoomLabel,
-    replyThreadLabel,
-    onReplyInRoom,
-    onReply,
-    onEmojiSelect,
+    action,
     onClose
   }: {
     interactions: MessageEventInteractionState;
-    serverId: string;
-    roomId: string;
-    messageEventId: string;
-    eventId: string;
-    deleteEventId: string;
-    messageBody: string;
-    permalinkThreadRootEventId?: string | null;
-    threadRootEventId?: string | null;
-    channelEchoEventId?: string | null;
-    canAddChannelEcho?: boolean;
-    messageStore?: MessagesStore | null;
-    reactions?: ReactionSummaryView[];
-    canReact?: boolean;
-    canEdit?: boolean;
-    canDelete?: boolean;
-    replyInRoomLabel?: string;
-    replyThreadLabel?: string;
-    onReplyInRoom?: () => void;
-    onReply?: () => void;
-    onEmojiSelect: (emoji: string) => void | Promise<void>;
+    action: MessageActionModel;
     onClose?: () => void;
   } = $props();
 
@@ -96,7 +57,7 @@
 
   async function handleEmojiSelect(emoji: string): Promise<void> {
     closeEmojiPicker();
-    await onEmojiSelect(emoji);
+    await action.toggleReaction(emoji);
   }
 </script>
 
@@ -115,26 +76,8 @@
   {:then { default: MessageActionMenu }}
     <MessageActionMenu
       presentation={presentation === 'sheet' ? 'sheet' : undefined}
-      {serverId}
-      {roomId}
-      {messageEventId}
-      {eventId}
-      {deleteEventId}
-      {messageBody}
-      {permalinkThreadRootEventId}
-      {threadRootEventId}
-      {channelEchoEventId}
-      {canAddChannelEcho}
-      {messageStore}
-      {reactions}
-      {canReact}
-      {canEdit}
-      {canDelete}
-      {replyInRoomLabel}
-      {replyThreadLabel}
-      {onReplyInRoom}
-      {onReply}
-      onOpenEmojiPicker={canReact
+      {action}
+      onOpenEmojiPicker={action.canReact
         ? presentation === 'sheet'
           ? openSheetEmojiPicker
           : () => interactions.openEmojiPicker()
@@ -166,7 +109,11 @@
     {#await loadEmojiPicker(emojiPickerLoadAttempt)}
       <p class="p-4 text-center text-sm text-muted" aria-busy="true">{m['common.loading']()}</p>
     {:then { default: EmojiPicker }}
-      <EmojiPicker {serverId} onSelect={handleEmojiSelect} onClose={closeEmojiPicker} />
+      <EmojiPicker
+        serverId={action.serverId}
+        onSelect={handleEmojiSelect}
+        onClose={closeEmojiPicker}
+      />
     {:catch}
       {@render loadError(() => (emojiPickerLoadAttempt += 1))}
     {/await}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventTestHarness.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+  import { provideServerScope } from '$lib/state/server/scope.svelte';
+  import type { ServerStateStore } from '$lib/state/server/store.svelte';
+  import type { TimelineEventView } from '$lib/render/timelineEvents';
+  import {
+    createComposerContext,
+    createMentionRoles,
+    createRoomMembers,
+    createRoomPermissions,
+    DEFAULT_ROOM_PERMISSIONS
+  } from '$lib/state/room';
+  import { createPresenceCache } from '$lib/state/presenceCache.svelte';
+  import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
+  import MessageEvent from './MessageEvent.svelte';
+  import type { OpenThreadHandler } from './threadOpenOptions';
+
+  let {
+    event,
+    roomId = 'room-1',
+    serverId = 'remote-server',
+    permalinkThreadRootEventId = null,
+    canReact = true,
+    canManageOthersMessage = false,
+    onOpenThread
+  }: {
+    event: TimelineEventView;
+    roomId?: string;
+    serverId?: string;
+    permalinkThreadRootEventId?: string | null;
+    canReact?: boolean;
+    canManageOthersMessage?: boolean;
+    onOpenThread?: OpenThreadHandler;
+  } = $props();
+
+  const connection = {} as ServerConnection;
+  const store = {
+    notifications: { hasThreadNotification: () => false },
+    serverInfo: { messageEditWindowSeconds: 31_536_000 },
+    activeCallRooms: { getParticipantCallPresence: () => null },
+    currentUser: {
+      user: { id: 'viewer', login: 'viewer', settings: undefined }
+    },
+    permissions: { canStartDMs: false }
+  } as unknown as ServerStateStore;
+
+  provideServerScope({
+    get serverId() {
+      return serverId;
+    },
+    connection,
+    store,
+    isCurrent: () => true
+  });
+  createComposerContext({ scroll: true });
+  createMentionRoles();
+  createRoomMembers();
+  createRoomPermissions(() => ({
+    ...DEFAULT_ROOM_PERMISSIONS,
+    canPostMessage: true,
+    canPostInThread: true,
+    canReact,
+    canManageOthersMessage,
+    canEchoMessage: true
+  }));
+  createPresenceCache();
+  createUserProfileCache();
+
+  const messageStore = {
+    ensureEvent: () => undefined,
+    getEventById: () => undefined,
+    beginOptimisticThreadFollow: () => undefined,
+    setThreadRootFollowState: () => undefined
+  };
+</script>
+
+<MessageEvent
+  {event}
+  {roomId}
+  {permalinkThreadRootEventId}
+  messageStore={messageStore as never}
+  {onOpenThread}
+/>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.recentReactions.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.recentReactions.svelte.spec.ts
@@ -6,31 +6,42 @@ import { PINNED_REACTIONS } from '$lib/emoji';
 import { __resetRecentEmojisForTests, getRecentEmojis } from '$lib/state/recentEmojis.svelte';
 import { serverStorageKey } from '$lib/storage/serverStorage';
 import MessageHoverBar from './MessageHoverBar.svelte';
+import { buildMessageActionModel } from './messageActionModel';
 
 const SERVER_ID = 'recent-reactions-server';
 
 const mocks = vi.hoisted(() => ({
   actions: {
     toggleReaction: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
     startEdit: vi.fn(),
-    openDeleteConfirmation: vi.fn()
+    openDeleteConfirmation: vi.fn(),
+    copyMessageText: vi.fn(),
+    copyMessageLink: vi.fn()
   }
 }));
 
-vi.mock('$lib/hooks', () => ({
-  useMessageActions: () => mocks.actions
-}));
-
 function renderBar() {
-  return render(MessageHoverBar, {
-    props: {
+  const action = buildMessageActionModel({
+    actions: mocks.actions,
+    params: {
       serverId: SERVER_ID,
       roomId: 'room-1',
       messageEventId: 'message-event-1',
       eventId: 'event-1',
-      messageBody: 'Hello',
-      canReact: true
-    }
+      messageBody: 'Hello'
+    },
+    reactions: [],
+    canReact: true,
+    canEdit: false,
+    canDelete: false,
+    replyInRoomLabel: 'Reply',
+    replyThreadLabel: 'Reply in thread'
+  });
+
+  return render(MessageHoverBar, {
+    props: { action }
   });
 }
 
@@ -73,7 +84,9 @@ describe('MessageHoverBar recent reactions integration', () => {
       }
     });
     await searchEmoji(picker.container, 'check');
-    (picker.container.querySelector('button[title="white_check_mark"]') as HTMLButtonElement).click();
+    (
+      picker.container.querySelector('button[title="white_check_mark"]') as HTMLButtonElement
+    ).click();
     flushSync();
     await tick();
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte
@@ -5,123 +5,32 @@ Quick actions toolbar that appears on hover at the upper-right of a message.
 Shows quick reaction emoji and action icons (reply, edit, more menu) inline.
 Hover-capable input only; pure touch devices use the long-press action sheet instead.
 
-**Props:**
-- `serverId` - Server ID (scopes the recent-emoji slots per server)
-- `roomId` - Room ID
-- `messageEventId` - Event ID of the message
-- `eventId` - Event ID for edit operations
-- `deleteEventId` - Event ID for delete operations (defaults to `eventId`)
-- `messageBody` - Current message body text
-- `reactions` - Current reactions on the message (for toggle behavior)
-- `canReact` - Whether the user can add reactions
-- `canEdit` - Whether the user can edit this message
-- `forceVisible` - Keep toolbar visible (e.g. while emoji picker is open)
-- `onReplyInRoom` - Callback to reply in room (attribution only, no thread)
-- `onReply` - Callback to open the thread pane
-- `replyInRoomLabel` - Accessible label for the reply-in-room action
-- `replyThreadLabel` - Accessible label for the thread action
-- `onOpenEmojiPicker` - Callback to open the full emoji picker
-- `onOpenMenu` - Callback to open the full context menu
+Receives the same bound message-action model as the context menu and touch
+sheet, plus toolbar-only controls for opening those surfaces.
 -->
 <script lang="ts">
-  import { useMessageActions, type MessageActionParams } from '$lib/hooks';
   import * as m from '$lib/i18n/messages';
-  import type { MessagesStore } from '$lib/state/room';
   import { getRecentEmojis } from '$lib/state/recentEmojis.svelte';
-  import { getEmojiByName } from '$lib/emoji';
+  import type { MessageActionModel } from './messageActionModel';
 
   let {
-    serverId,
-    roomId,
-    messageEventId,
-    eventId,
-    deleteEventId = eventId,
-    messageBody,
-    threadRootEventId = null,
-    channelEchoEventId = null,
-    canAddChannelEcho = false,
-    messageStore = null,
-    reactions = [],
-    canReact = false,
-    canEdit = false,
+    action,
     forceVisible = false,
-    replyInRoomLabel,
-    replyThreadLabel,
-    onReplyInRoom,
-    onReply,
     onOpenEmojiPicker,
     onOpenMenu
   }: {
-    serverId: string;
-    roomId: string;
-    messageEventId: string;
-    eventId: string;
-    deleteEventId?: string;
-    messageBody: string;
-    threadRootEventId?: string | null;
-    channelEchoEventId?: string | null;
-    canAddChannelEcho?: boolean;
-    messageStore?: MessagesStore | null;
-    reactions?: { emoji: string; hasReacted: boolean }[];
-    canReact?: boolean;
-    canEdit?: boolean;
+    action: MessageActionModel;
     forceVisible?: boolean;
-    replyInRoomLabel?: string;
-    replyThreadLabel?: string;
-    onReplyInRoom?: () => void;
-    onReply?: () => void;
     onOpenEmojiPicker?: (e: MouseEvent) => void;
     onOpenMenu?: (e: MouseEvent) => void;
   } = $props();
 
-  const recentEmojis = $derived(getRecentEmojis(serverId));
+  const recentEmojis = $derived(getRecentEmojis(action.serverId));
   const quickReactions = $derived(recentEmojis.quickReactions);
 
-  const actions = useMessageActions();
-  const replyInRoomActionLabel = $derived(replyInRoomLabel ?? m['room.message.actions.reply']());
-  const replyThreadActionLabel = $derived(
-    replyThreadLabel ?? m['room.message.actions.reply_thread']()
+  const hasActions = $derived(
+    !!action.replyInRoom || !!action.replyThread || action.canEdit || !!onOpenMenu
   );
-
-  const params: MessageActionParams = $derived({
-    serverId,
-    roomId,
-    messageEventId,
-    eventId,
-    deleteEventId,
-    messageBody,
-    threadRootEventId,
-    channelEchoEventId,
-    canAddChannelEcho,
-    messageStore
-  });
-
-  const hasActions = $derived(!!onReplyInRoom || !!onReply || canEdit || !!onOpenMenu);
-
-  /** Set of Unicode emojis the current user has already reacted with (API returns shortcodes) */
-  const myReactions = $derived(
-    new Set(reactions.filter((r) => r.hasReacted).map((r) => getEmojiByName(r.emoji) ?? r.emoji))
-  );
-
-  function hasReacted(emoji: string): boolean {
-    return myReactions.has(emoji);
-  }
-
-  async function handleReaction(emoji: string) {
-    await actions.toggleReaction(params, emoji, hasReacted(emoji));
-  }
-
-  function handleReplyInRoom() {
-    onReplyInRoom?.();
-  }
-
-  function handleReply() {
-    onReply?.();
-  }
-
-  function handleEdit() {
-    actions.startEdit(params);
-  }
 </script>
 
 <div
@@ -138,13 +47,13 @@ Hover-capable input only; pure touch devices use the long-press action sheet ins
     e.stopPropagation();
   }}
 >
-  {#if canReact}
+  {#if action.canReact}
     <div class="flex items-center menu-section-sm">
       {#each quickReactions as emoji (emoji)}
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-base transition-[background-color,scale] hover:bg-surface active:scale-[0.96]"
-          onclick={() => handleReaction(emoji)}
-          aria-label={hasReacted(emoji)
+          onclick={() => action.toggleReaction(emoji)}
+          aria-label={action.hasReacted(emoji)
             ? m['room.message.actions.remove_reaction']({ emoji })
             : m['room.message.actions.react_with']({ emoji })}
         >
@@ -165,30 +74,30 @@ Hover-capable input only; pure touch devices use the long-press action sheet ins
 
   {#if hasActions}
     <div class="flex items-center menu-section-sm">
-      {#if onReplyInRoom}
+      {#if action.replyInRoom}
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface hover:text-text active:scale-[0.96]"
-          onclick={handleReplyInRoom}
-          aria-label={replyInRoomActionLabel}
+          onclick={action.replyInRoom}
+          aria-label={action.replyInRoomLabel}
         >
           <span class="iconify text-base uil--corner-up-left"></span>
         </button>
       {/if}
 
-      {#if onReply}
+      {#if action.replyThread}
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface hover:text-text active:scale-[0.96]"
-          onclick={handleReply}
-          aria-label={replyThreadActionLabel}
+          onclick={action.replyThread}
+          aria-label={action.replyThreadLabel}
         >
           <span class="iconify text-base uil--comment-alt-lines"></span>
         </button>
       {/if}
 
-      {#if canEdit}
+      {#if action.canEdit}
         <button
           class="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] hover:bg-surface hover:text-text active:scale-[0.96]"
-          onclick={handleEdit}
+          onclick={action.edit}
           aria-label={m['room.message.actions.edit']()}
         >
           <span class="iconify text-base uil--pen"></span>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageHoverBar.svelte.spec.ts
@@ -2,17 +2,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import MessageHoverBar from './MessageHoverBar.svelte';
+import { buildMessageActionModel } from './messageActionModel';
 
 const mocks = vi.hoisted(() => ({
   actions: {
     toggleReaction: vi.fn(),
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
     startEdit: vi.fn(),
-    openDeleteConfirmation: vi.fn()
+    openDeleteConfirmation: vi.fn(),
+    copyMessageText: vi.fn(),
+    copyMessageLink: vi.fn()
   }
-}));
-
-vi.mock('$lib/hooks', () => ({
-  useMessageActions: () => mocks.actions
 }));
 
 vi.mock('$lib/state/recentEmojis.svelte', () => ({
@@ -21,7 +22,7 @@ vi.mock('$lib/state/recentEmojis.svelte', () => ({
   })
 }));
 
-const baseProps = {
+const baseParams = {
   serverId: 'server-1',
   roomId: 'room-1',
   messageEventId: 'message-event-1',
@@ -29,34 +30,44 @@ const baseProps = {
   messageBody: 'Hello'
 };
 
-type MessageHoverBarProps = {
-  serverId: string;
-  roomId: string;
-  messageEventId: string;
-  eventId: string;
-  deleteEventId?: string;
-  messageBody: string;
-  threadRootEventId?: string | null;
-  channelEchoEventId?: string | null;
-  canAddChannelEcho?: boolean;
+type ActionOverrides = {
   reactions?: { emoji: string; hasReacted: boolean }[];
   canReact?: boolean;
   canEdit?: boolean;
-  forceVisible?: boolean;
+  canDelete?: boolean;
   replyInRoomLabel?: string;
   replyThreadLabel?: string;
   onReplyInRoom?: () => void;
   onReply?: () => void;
+};
+
+type MessageHoverBarProps = ActionOverrides & {
+  forceVisible?: boolean;
   onOpenEmojiPicker?: (e: MouseEvent) => void;
   onOpenMenu?: (e: MouseEvent) => void;
 };
 
-function renderBar(props: Partial<MessageHoverBarProps> = {}) {
+function renderBar({
+  forceVisible,
+  onOpenEmojiPicker,
+  onOpenMenu,
+  ...overrides
+}: Partial<MessageHoverBarProps> = {}) {
+  const action = buildMessageActionModel({
+    actions: mocks.actions,
+    params: baseParams,
+    reactions: overrides.reactions ?? [],
+    canReact: overrides.canReact ?? false,
+    canEdit: overrides.canEdit ?? false,
+    canDelete: overrides.canDelete ?? false,
+    replyInRoomLabel: overrides.replyInRoomLabel ?? 'Reply',
+    replyThreadLabel: overrides.replyThreadLabel ?? 'Reply in thread',
+    replyInRoom: overrides.onReplyInRoom,
+    replyThread: overrides.onReply
+  });
+
   return render(MessageHoverBar, {
-    props: {
-      ...baseProps,
-      ...props
-    }
+    props: { action, forceVisible, onOpenEmojiPicker, onOpenMenu }
   });
 }
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -4,21 +4,9 @@
 Meta bar shown beneath a message when it has thread replies or reactions.
 Contains the thread reply button, reaction pills, and an add-reaction button.
 
-**Props:**
-- `spaceId` - Space ID
-- `roomId` - Room ID
-- `messageEventId` - Event ID of the message
-- `serverSegment` - URL segment for the active server
-- `threadRootEventId` - Root event ID for the linked thread
-- `reactions` - Array of reaction summaries
-- `replyCount` - Number of thread replies
-- `threadParticipants` - Thread participant user fragments (for avatars)
-- `hasThreadNotification` - Whether there's an unread thread notification
-- `canReact` - Whether the user can add reactions
-- `isFollowingThread` - Whether the viewer is following this thread
-- `onToggleThreadFollow` - Callback to toggle thread follow state
-- `onOpenThread` - Callback to open the thread pane
-- `onOpenEmojiPicker` - Callback to open the emoji picker
+Reaction mutations use the same bound message-action model as the hover,
+context-menu, and touch surfaces. Thread navigation and tooltip state remain
+local to the footer.
 -->
 <script lang="ts">
   import { resolve } from '$app/paths';
@@ -26,11 +14,10 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   import type { MessagePostedPayload } from '$lib/render/timelineEvents';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
-  import { useReactionActions, type MessageActionParams } from '$lib/hooks';
-  import type { MessagesStore } from '$lib/state/room';
   import FloatingPopover from '$lib/ui/FloatingPopover.svelte';
   import { getEmojiByName, getEmojiDisplayName } from '$lib/emoji';
   import * as m from '$lib/i18n/messages';
+  import type { MessageActionModel } from './messageActionModel';
 
   // Extract the MessagePostedEvent type from the union
   type ReactionSummary = MessagePostedPayload['reactions'][number];
@@ -42,15 +29,13 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
 
   let {
     roomId,
-    messageEventId,
     serverSegment,
     threadRootEventId,
     reactions,
+    action,
     replyCount = 0,
     threadParticipants,
     hasThreadNotification = false,
-    canReact = false,
-    messageStore = null,
     isFollowingThread = false,
     isThreadFollowPending = false,
     onToggleThreadFollow,
@@ -59,15 +44,13 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     isEchoEvent = false
   }: {
     roomId: string;
-    messageEventId: string;
     serverSegment: string;
     threadRootEventId?: string | null;
     reactions: ReactionSummary[];
+    action: MessageActionModel;
     replyCount?: number;
     threadParticipants?: MessagePostedPayload['threadParticipants'];
     hasThreadNotification?: boolean;
-    canReact?: boolean;
-    messageStore?: MessagesStore | null;
     isFollowingThread?: boolean;
     isThreadFollowPending?: boolean;
     onToggleThreadFollow?: (e: MouseEvent) => void;
@@ -76,7 +59,6 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     isEchoEvent?: boolean;
   } = $props();
 
-  const reactionActions = useReactionActions();
   const replyCountLabel = $derived(
     replyCount === 1
       ? m['room.message.meta.reply_count_one']()
@@ -89,16 +71,6 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
     tooltipReactionEmoji ? (reactions.find((r) => r.emoji === tooltipReactionEmoji) ?? null) : null
   );
   const REACTION_TOOLTIP_USER_LIMIT = 5;
-  const reactionParams: MessageActionParams = $derived({
-    serverId: serverSegment,
-    roomId,
-    messageEventId,
-    eventId: messageEventId,
-    messageBody: '',
-    threadRootEventId,
-    messageStore
-  });
-
   function reactionTooltipUsers(reaction: ReactionSummary): {
     names: string[];
     remaining: number;
@@ -127,7 +99,7 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
   }
 
   async function toggleReaction(reaction: ReactionSummary) {
-    await reactionActions.toggleReaction(reactionParams, reaction.emoji, reaction.hasReacted);
+    await action.toggleReaction(reaction.emoji);
   }
 
   function openThreadFromLink(e: MouseEvent) {
@@ -236,13 +208,13 @@ Contains the thread reply button, reaction pills, and an add-reaction button.
         class={[
           baseButtonClass,
           'gap-1 px-2 text-sm',
-          canReact ? '' : '!cursor-default opacity-60',
+          action.canReact ? '' : '!cursor-default opacity-60',
           reaction.hasReacted ? 'border-action/50' : 'border-transparent'
         ]}
-        onclick={() => canReact && toggleReaction(reaction)}
+        onclick={() => action.canReact && toggleReaction(reaction)}
         onfocus={(e) => showReactionTooltip(e, reaction)}
         onblur={hideReactionTooltip}
-        disabled={!canReact}
+        disabled={!action.canReact}
         aria-describedby={tooltipReactionEmoji === reaction.emoji ? reactionTooltipId : undefined}
         aria-label={reaction.hasReacted
           ? m['room.message.meta.remove_reaction_label']({

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -3,15 +3,18 @@ import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
 import MessageMetaBar from './MessageMetaBar.svelte';
+import { buildMessageActionModel } from './messageActionModel';
 
 const mocks = vi.hoisted(() => ({
-  reactionActions: {
-    toggleReaction: vi.fn()
+  actions: {
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    startEdit: vi.fn(),
+    openDeleteConfirmation: vi.fn(),
+    copyMessageText: vi.fn(),
+    copyMessageLink: vi.fn()
   }
-}));
-
-vi.mock('$lib/hooks', () => ({
-  useReactionActions: () => mocks.reactionActions
 }));
 
 vi.mock('$app/paths', () => ({
@@ -39,12 +42,41 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
 
 const baseProps = {
   roomId: 'room-1',
-  messageEventId: 'thread-1',
   serverSegment: '-',
   threadRootEventId: 'thread-1',
   reactions: [],
+  action: buildAction(),
   onOpenThread: vi.fn()
 };
+
+function buildAction({
+  canReact = false,
+  reactions = [],
+  messageStore
+}: {
+  canReact?: boolean;
+  reactions?: { emoji: string; hasReacted: boolean }[];
+  messageStore?: never;
+} = {}) {
+  return buildMessageActionModel({
+    actions: mocks.actions,
+    params: {
+      serverId: 'server-1',
+      roomId: 'room-1',
+      messageEventId: 'thread-1',
+      eventId: 'thread-1',
+      messageBody: '',
+      threadRootEventId: 'thread-1',
+      messageStore
+    },
+    reactions,
+    canReact,
+    canEdit: false,
+    canDelete: false,
+    replyInRoomLabel: 'Reply',
+    replyThreadLabel: 'Reply in thread'
+  });
+}
 
 function reaction(
   overrides: Partial<{
@@ -294,7 +326,7 @@ describe('MessageMetaBar', () => {
         reactions: [
           reaction({ emoji: 'heart', count: 1, users: [{ id: 'user-1', displayName: 'Alice' }] })
         ],
-        canReact: false
+        action: buildAction()
       }
     });
 
@@ -317,15 +349,18 @@ describe('MessageMetaBar', () => {
       props: {
         ...baseProps,
         reactions: [reaction({ hasReacted: true })],
-        canReact: true,
-        messageStore: messageStore as never
+        action: buildAction({
+          canReact: true,
+          reactions: [reaction({ hasReacted: true })],
+          messageStore: messageStore as never
+        })
       }
     });
 
     (q(container, 'button[aria-label="Remove 👍 reaction (2)"]') as HTMLButtonElement).click();
 
     await vi.waitFor(() => {
-      expect(mocks.reactionActions.toggleReaction).toHaveBeenCalledWith(
+      expect(mocks.actions.toggleReaction).toHaveBeenCalledWith(
         expect.objectContaining({
           roomId: 'room-1',
           messageEventId: 'thread-1',

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBarStoryFrame.svelte
@@ -8,6 +8,7 @@
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
   import type { ReactionSummaryView } from '$lib/render/reactions';
   import type { UserAvatarUserView } from '$lib/render/users';
+  import type { MessageActionModel } from './messageActionModel';
   type Variant =
     | 'reactions'
     | 'replies-and-reactions'
@@ -35,7 +36,6 @@
   createUserProfileCache();
 
   const roomId = 'room-design';
-  const messageEventId = 'evt-root';
   const serverSegment = '-';
   const threadRootEventId = 'evt-root';
 
@@ -106,29 +106,44 @@
   };
 
   function noop() {}
+  async function noopAsync() {}
+  const action: MessageActionModel = {
+    serverId: 'storybook',
+    messageBody: '',
+    canReact: true,
+    canEdit: false,
+    canDelete: false,
+    replyInRoomLabel: 'Reply',
+    replyThreadLabel: 'Reply in thread',
+    hasReacted: () => false,
+    toggleReaction: noopAsync,
+    edit: noop,
+    copyText: noopAsync,
+    copyLink: noopAsync,
+    delete: noop
+  };
+  const readOnlyAction: MessageActionModel = { ...action, canReact: false };
 </script>
 
 <div class="group/badges inline-flex rounded-md bg-background p-4 text-text">
   {#if variant === 'reactions'}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       {reactions}
-      canReact
+      {action}
       onOpenEmojiPicker={noop}
     />
   {:else if variant === 'replies-and-reactions'}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       {reactions}
+      {action}
       replyCount={2}
       threadParticipants={[alice, jordan, mika]}
-      canReact
       isFollowingThread
       onToggleThreadFollow={noop}
       onOpenThread={noop}
@@ -137,14 +152,13 @@
   {:else if variant === 'unread-followed-thread'}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       reactions={[]}
+      {action}
       replyCount={5}
       threadParticipants={[alice, jordan, mika]}
       hasThreadNotification
-      canReact
       isFollowingThread
       onToggleThreadFollow={noop}
       onOpenThread={noop}
@@ -153,11 +167,10 @@
   {:else if variant === 'thread-echo'}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       reactions={reactions.slice(0, 1)}
-      canReact
+      {action}
       isEchoEvent
       onOpenThread={noop}
       onOpenEmojiPicker={noop}
@@ -165,29 +178,26 @@
   {:else if variant === 'read-only-reactions'}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       {reactions}
-      canReact={false}
+      action={readOnlyAction}
     />
   {:else if variant === 'short-reaction-popover'}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       reactions={[shortReaction]}
-      canReact={false}
+      action={readOnlyAction}
     />
   {:else}
     <MessageMetaBar
       {roomId}
-      {messageEventId}
       {serverSegment}
       {threadRootEventId}
       reactions={[highCountReaction]}
-      canReact={false}
+      action={readOnlyAction}
     />
   {/if}
 </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageRowStoryFrame.svelte
@@ -9,6 +9,7 @@
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
   import type { ReactionSummaryView } from '$lib/render/reactions';
   import type { UserAvatarUserView } from '$lib/render/users';
+  import type { MessageActionModel } from './messageActionModel';
   type Variant =
     | 'plain'
     | 'with-meta-bar'
@@ -35,7 +36,6 @@
   createUserProfileCache();
 
   const roomId = 'room-design';
-  const messageEventId = 'evt-root';
   const serverSegment = '-';
   const threadRootEventId = 'evt-root';
 
@@ -86,18 +86,33 @@
   ];
 
   function noop() {}
+  async function noopAsync() {}
+  const action: MessageActionModel = {
+    serverId: 'storybook',
+    messageBody: 'Hello!',
+    canReact: true,
+    canEdit: false,
+    canDelete: false,
+    replyInRoomLabel: 'Reply',
+    replyThreadLabel: 'Reply in thread',
+    hasReacted: () => false,
+    toggleReaction: noopAsync,
+    edit: noop,
+    copyText: noopAsync,
+    copyLink: noopAsync,
+    delete: noop
+  };
 </script>
 
 {#snippet metaBar(replyCount = 2)}
   <MessageMetaBar
     {roomId}
-    {messageEventId}
     {serverSegment}
     {threadRootEventId}
     {reactions}
+    {action}
     {replyCount}
     {threadParticipants}
-    canReact
     isFollowingThread
     onToggleThreadFollow={noop}
     onOpenThread={noop}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageViewActionTestSurface.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageViewActionTestSurface.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let {
+    eventId,
+    body,
+    oncontextmenu,
+    onmousedown,
+    onmouseup,
+    onmouseleave,
+    ontouchstart,
+    ontouchend,
+    ontouchmove,
+    ontouchcancel,
+    bodyElement = $bindable(),
+    afterBody,
+    actions
+  }: {
+    eventId: string;
+    body?: string | null;
+    oncontextmenu?: (event: MouseEvent) => void;
+    onmousedown?: (event: MouseEvent) => void;
+    onmouseup?: (event: MouseEvent) => void;
+    onmouseleave?: (event: MouseEvent) => void;
+    ontouchstart?: (event: TouchEvent) => void;
+    ontouchend?: (event: TouchEvent) => void;
+    ontouchmove?: (event: TouchEvent) => void;
+    ontouchcancel?: (event: TouchEvent) => void;
+    bodyElement?: HTMLElement;
+    afterBody?: Snippet;
+    actions?: Snippet;
+  } = $props();
+</script>
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+  class="message-row"
+  data-testid="message-row"
+  data-event-id={eventId}
+  {oncontextmenu}
+  {onmousedown}
+  {onmouseup}
+  {onmouseleave}
+  {ontouchstart}
+  {ontouchend}
+  {ontouchmove}
+  {ontouchcancel}
+>
+  <span data-testid="message-body" bind:this={bodyElement}>{body}</span>
+  {@render afterBody?.()}
+  {@render actions?.()}
+</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageActionModel.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageActionModel.spec.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { MessageActionParams, MessageActions } from '$lib/hooks';
+import { buildMessageActionModel } from './messageActionModel';
+
+function createActions(): MessageActions {
+  return {
+    addReaction: vi.fn(),
+    removeReaction: vi.fn(),
+    toggleReaction: vi.fn(),
+    startEdit: vi.fn(),
+    openDeleteConfirmation: vi.fn(),
+    copyMessageText: vi.fn(),
+    copyMessageLink: vi.fn()
+  };
+}
+
+const params: MessageActionParams = {
+  serverId: 'remote-server',
+  roomId: 'room-1',
+  messageEventId: 'message-1',
+  eventId: 'original-thread-message',
+  deleteEventId: 'channel-echo',
+  messageBody: 'Hello',
+  permalinkThreadRootEventId: 'thread-root',
+  threadRootEventId: 'thread-root',
+  channelEchoEventId: 'channel-echo',
+  canAddChannelEcho: true
+};
+
+function buildModel(actions = createActions()) {
+  return {
+    actions,
+    model: buildMessageActionModel({
+      actions,
+      params,
+      reactions: [
+        { emoji: 'thumbsup', hasReacted: true },
+        { emoji: 'heart', hasReacted: false }
+      ],
+      canReact: true,
+      canEdit: true,
+      canDelete: true,
+      replyInRoomLabel: 'Reply in thread',
+      replyThreadLabel: 'Open thread'
+    })
+  };
+}
+
+describe('buildMessageActionModel', () => {
+  it('binds all action surfaces to the same server-scoped message target', async () => {
+    const { actions, model } = buildModel();
+
+    model.edit();
+    await model.copyText();
+    await model.copyLink();
+    model.delete();
+
+    expect(actions.startEdit).toHaveBeenCalledWith(params);
+    expect(actions.copyMessageText).toHaveBeenCalledWith(params);
+    expect(actions.copyMessageLink).toHaveBeenCalledWith(params);
+    expect(actions.openDeleteConfirmation).toHaveBeenCalledWith(params);
+    expect(model.serverId).toBe('remote-server');
+    expect(model.messageBody).toBe('Hello');
+  });
+
+  it('normalizes API reaction names before toggling picker and quick reactions', async () => {
+    const { actions, model } = buildModel();
+
+    expect(model.hasReacted('👍')).toBe(true);
+    expect(model.hasReacted('thumbsup')).toBe(true);
+    expect(model.hasReacted('❤️')).toBe(false);
+
+    await model.toggleReaction('👍');
+    await model.toggleReaction('❤️');
+
+    expect(actions.toggleReaction).toHaveBeenNthCalledWith(1, params, '👍', true);
+    expect(actions.toggleReaction).toHaveBeenNthCalledWith(2, params, '❤️', false);
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageActionModel.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/messageActionModel.ts
@@ -1,0 +1,75 @@
+import { getEmojiByName } from '$lib/emoji';
+import type { MessageActionParams, MessageActions } from '$lib/hooks';
+
+type ReactionState = {
+  emoji: string;
+  hasReacted: boolean;
+};
+
+export type MessageActionModel = {
+  serverId: string;
+  messageBody: string;
+  canReact: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  replyInRoomLabel: string;
+  replyThreadLabel: string;
+  replyInRoom?: () => void;
+  replyThread?: () => void;
+  hasReacted: (emoji: string) => boolean;
+  toggleReaction: (emoji: string) => Promise<void>;
+  edit: () => void;
+  copyText: () => Promise<void>;
+  copyLink: () => Promise<void>;
+  delete: () => void;
+};
+
+/** Binds one message target to the behavior shared by every message-action surface. */
+export function buildMessageActionModel({
+  actions,
+  params,
+  reactions,
+  canReact,
+  canEdit,
+  canDelete,
+  replyInRoomLabel,
+  replyThreadLabel,
+  replyInRoom,
+  replyThread
+}: {
+  actions: MessageActions;
+  params: MessageActionParams;
+  reactions: ReactionState[];
+  canReact: boolean;
+  canEdit: boolean;
+  canDelete: boolean;
+  replyInRoomLabel: string;
+  replyThreadLabel: string;
+  replyInRoom?: () => void;
+  replyThread?: () => void;
+}): MessageActionModel {
+  const viewerReactions = new Set(
+    reactions
+      .filter((reaction) => reaction.hasReacted)
+      .map((reaction) => getEmojiByName(reaction.emoji) ?? reaction.emoji)
+  );
+  const hasReacted = (emoji: string) => viewerReactions.has(getEmojiByName(emoji) ?? emoji);
+
+  return {
+    serverId: params.serverId,
+    messageBody: params.messageBody,
+    canReact,
+    canEdit,
+    canDelete,
+    replyInRoomLabel,
+    replyThreadLabel,
+    replyInRoom,
+    replyThread,
+    hasReacted,
+    toggleReaction: (emoji) => actions.toggleReaction(params, emoji, hasReacted(emoji)),
+    edit: () => actions.startEdit(params),
+    copyText: () => actions.copyMessageText(params),
+    copyLink: () => actions.copyMessageLink(params),
+    delete: () => actions.openDeleteConfirmation(params)
+  };
+}


### PR DESCRIPTION
## Why

Message actions were assembled independently by the message footer, hover toolbar, context menu, touch sheet, and emoji picker. That duplicated action parameters, permissions, reaction normalization, labels, and callbacks, making thread replies and channel echoes especially easy to wire inconsistently.

## What changed

- Build one reactive message action model in `MessageEvent` and pass it to every action surface.
- Keep hover, right-click, touch, lazy-loaded menu/picker, selected-text reply, thread, channel-echo, and server-scoping behavior intact.
- Make the presentation components consume the shared model instead of reconstructing action state.
- Add model tests and a mounted rerender integration test covering regular messages, thread replies, channel echoes, permission changes, and every action surface.

The production implementation is 187 lines smaller.

## Verification

- `mise test-frontend` — 321 files, 2,671 tests passed
- `mise lint-frontend` — design-system checks, Paraglide, Svelte check (0 errors and 0 warnings), and ESLint passed
- `mise build-frontend` — production build and route bundle budgets passed
- `mise license-check` — REUSE compliance passed
- Svelte autofixer — no issues in changed Svelte files
- Independent code review — no actionable findings after the mounted integration coverage was added

## Compatibility and documentation

Frontend-only internal refactor. There are no public API, persistence, migration, rollout, copy, configuration, or user-visible behavior changes, so no product or architecture documentation updates are needed.
