### PR TITLE
refactor(frontend): query room management snapshots

### DIFF
--- a/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
@@ -224,6 +224,28 @@ describe('createAdminRoomLayoutAPI', () => {
     );
   });
 
+  it('forwards cancellation signals for room detail snapshots', async () => {
+    mocks.getRoom.mockResolvedValue({ room: undefined });
+    mocks.getRoomGroup.mockResolvedValue({ group: undefined });
+    const api = createAdminRoomLayoutAPI({
+      baseUrl: 'https://remote.example.test/api/connect',
+      bearerToken: 'token'
+    });
+    const signal = new AbortController().signal;
+
+    await api.getRoom('r1', { signal });
+    await api.getRoomGroup('g1', { signal });
+
+    expect(mocks.getRoom).toHaveBeenCalledWith(
+      { roomId: 'r1' },
+      expect.objectContaining({ signal })
+    );
+    expect(mocks.getRoomGroup).toHaveBeenCalledWith(
+      { groupId: 'g1' },
+      expect.objectContaining({ signal })
+    );
+  });
+
   it('routes unauthenticated errors through the server registry', async () => {
     const err = new ConnectError('authentication required', Code.Unauthenticated);
     mocks.createRoomGroup.mockRejectedValue(err);

--- a/apps/frontend/src/lib/api-client/adminRoomLayout.ts
+++ b/apps/frontend/src/lib/api-client/adminRoomLayout.ts
@@ -70,9 +70,15 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
   const layout = createChattoClient(AdminRoomLayoutService, config);
   const headers = () => authHeaders(config);
   return {
-    async getRoom(roomId: string): Promise<AdminManagedRoom | null> {
+    async getRoom(
+      roomId: string,
+      options: { signal?: AbortSignal } = {}
+    ): Promise<AdminManagedRoom | null> {
       try {
-        const response = await layout.getRoom({ roomId }, { headers: headers() });
+        const response = await layout.getRoom(
+          { roomId },
+          { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) }
+        );
         return response.room
           ? {
               ...mapAdminRoom(response.room),
@@ -85,9 +91,15 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
       }
     },
 
-    async getRoomGroup(groupId: string): Promise<AdminManagedRoomGroup | null> {
+    async getRoomGroup(
+      groupId: string,
+      options: { signal?: AbortSignal } = {}
+    ): Promise<AdminManagedRoomGroup | null> {
       try {
-        const response = await layout.getRoomGroup({ groupId }, { headers: headers() });
+        const response = await layout.getRoomGroup(
+          { groupId },
+          { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) }
+        );
         return response.group
           ? {
               group: mapAdminRoomLayoutGroup(response.group),

--- a/apps/frontend/src/lib/query/admin.ts
+++ b/apps/frontend/src/lib/query/admin.ts
@@ -78,5 +78,11 @@ export const adminQueryKeys = {
   },
   securityConfig(serverId: string, connection: AdminQueryConnection) {
     return [...adminRoot(serverId, connection), 'security-config'] as const;
+  },
+  room(serverId: string, connection: AdminQueryConnection, roomId: string) {
+    return [...adminRoot(serverId, connection), 'room', roomId] as const;
+  },
+  roomGroup(serverId: string, connection: AdminQueryConnection, groupId: string) {
+    return [...adminRoot(serverId, connection), 'room-group', groupId] as const;
   }
 };

--- a/apps/frontend/src/lib/query/adminInvalidation.spec.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.spec.ts
@@ -1,8 +1,11 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { adminQueryKeys } from './admin';
 import {
+  invalidateAdminRoomLayoutQueries,
   invalidatePermissionTiers,
   invalidateRolePermissionDependents,
+  purgeAdminRoomGroupQuery,
+  purgeAdminRoomQuery,
   removeDeletedRoleQueries
 } from './adminInvalidation';
 import { queryClient } from './client';
@@ -14,6 +17,8 @@ const catalogKey = adminQueryKeys.roleCatalog(serverId, connection);
 const roleKey = adminQueryKeys.rolePermissions(serverId, connection, 'moderator');
 const roleDetailsKey = adminQueryKeys.role(serverId, connection, 'moderator');
 const userKey = adminQueryKeys.userPermissions(serverId, connection, 'user-1');
+const roomKey = adminQueryKeys.room(serverId, connection, 'room-1');
+const groupKey = adminQueryKeys.roomGroup(serverId, connection, 'group-1');
 
 beforeEach(() => {
   queryClient.clear();
@@ -22,6 +27,28 @@ beforeEach(() => {
   queryClient.setQueryData(roleKey, { roleName: 'moderator' });
   queryClient.setQueryData(roleDetailsKey, { role: { name: 'moderator' } });
   queryClient.setQueryData(userKey, { userId: 'user-1' });
+  queryClient.setQueryData(roomKey, { id: 'room-1', name: 'general' });
+  queryClient.setQueryData(groupKey, { group: { id: 'group-1', name: 'Lobby' } });
+});
+
+describe('admin room-layout query invalidation', () => {
+  it('invalidates only the named room and group snapshots', () => {
+    invalidateAdminRoomLayoutQueries(serverId, connection, 'room-1', 'group-1');
+
+    expect(queryClient.getQueryState(roomKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(groupKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(tierKey)?.isInvalidated).toBe(false);
+  });
+
+  it('synchronously purges removed room and group snapshots', () => {
+    purgeAdminRoomQuery(serverId, connection, 'room-1');
+    purgeAdminRoomGroupQuery(serverId, connection, 'group-1');
+
+    expect(queryClient.getQueryData(roomKey)).toBeNull();
+    expect(queryClient.getQueryData(groupKey)).toBeNull();
+    expect(queryClient.getQueryState(roomKey)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(groupKey)?.isInvalidated).toBe(true);
+  });
 });
 
 describe('admin role query invalidation', () => {

--- a/apps/frontend/src/lib/query/adminInvalidation.spec.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.spec.ts
@@ -19,6 +19,8 @@ const roleDetailsKey = adminQueryKeys.role(serverId, connection, 'moderator');
 const userKey = adminQueryKeys.userPermissions(serverId, connection, 'user-1');
 const roomKey = adminQueryKeys.room(serverId, connection, 'room-1');
 const groupKey = adminQueryKeys.roomGroup(serverId, connection, 'group-1');
+const roomPermissionsKey = adminQueryKeys.permissionTier(serverId, connection, 'room-1', null);
+const groupPermissionsKey = adminQueryKeys.permissionTier(serverId, connection, null, 'group-1');
 
 beforeEach(() => {
   queryClient.clear();
@@ -29,6 +31,8 @@ beforeEach(() => {
   queryClient.setQueryData(userKey, { userId: 'user-1' });
   queryClient.setQueryData(roomKey, { id: 'room-1', name: 'general' });
   queryClient.setQueryData(groupKey, { group: { id: 'group-1', name: 'Lobby' } });
+  queryClient.setQueryData(roomPermissionsKey, { roles: ['private-room-role'] });
+  queryClient.setQueryData(groupPermissionsKey, { roles: ['private-group-role'] });
 });
 
 describe('admin room-layout query invalidation', () => {
@@ -46,6 +50,8 @@ describe('admin room-layout query invalidation', () => {
 
     expect(queryClient.getQueryData(roomKey)).toBeNull();
     expect(queryClient.getQueryData(groupKey)).toBeNull();
+    expect(queryClient.getQueryData(roomPermissionsKey)).toBeUndefined();
+    expect(queryClient.getQueryData(groupPermissionsKey)).toBeUndefined();
     expect(queryClient.getQueryState(roomKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(groupKey)?.isInvalidated).toBe(true);
   });

--- a/apps/frontend/src/lib/query/adminInvalidation.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.ts
@@ -54,3 +54,48 @@ export function removeDeletedRoleQueries(
   queryClient.removeQueries({ queryKey: roleDetailsKey, exact: true });
   invalidateRolePermissionDependents(serverId, connection, roleName);
 }
+
+/** Refresh the room and room-group snapshots affected by a layout projection. */
+export function invalidateAdminRoomLayoutQueries(
+  serverId: string,
+  connection: AdminQueryConnection,
+  roomId?: string,
+  groupId?: string
+): void {
+  if (roomId) {
+    void queryClient.invalidateQueries({
+      queryKey: adminQueryKeys.room(serverId, connection, roomId),
+      exact: true
+    });
+  }
+  if (groupId) {
+    void queryClient.invalidateQueries({
+      queryKey: adminQueryKeys.roomGroup(serverId, connection, groupId),
+      exact: true
+    });
+  }
+}
+
+/** Purge a room snapshot before attempting any projected re-authorization read. */
+export function purgeAdminRoomQuery(
+  serverId: string,
+  connection: AdminQueryConnection,
+  roomId: string
+): void {
+  const queryKey = adminQueryKeys.room(serverId, connection, roomId);
+  void queryClient.cancelQueries({ queryKey, exact: true });
+  queryClient.setQueryData(queryKey, null);
+  void queryClient.invalidateQueries({ queryKey, exact: true });
+}
+
+/** Purge a room-group snapshot before attempting any projected re-authorization read. */
+export function purgeAdminRoomGroupQuery(
+  serverId: string,
+  connection: AdminQueryConnection,
+  groupId: string
+): void {
+  const queryKey = adminQueryKeys.roomGroup(serverId, connection, groupId);
+  void queryClient.cancelQueries({ queryKey, exact: true });
+  queryClient.setQueryData(queryKey, null);
+  void queryClient.invalidateQueries({ queryKey, exact: true });
+}

--- a/apps/frontend/src/lib/query/adminInvalidation.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.ts
@@ -83,8 +83,12 @@ export function purgeAdminRoomQuery(
   roomId: string
 ): void {
   const queryKey = adminQueryKeys.room(serverId, connection, roomId);
+  const permissionsKey = adminQueryKeys.permissionTier(serverId, connection, roomId, null);
   void queryClient.cancelQueries({ queryKey, exact: true });
+  void queryClient.cancelQueries({ queryKey: permissionsKey, exact: true });
   queryClient.setQueryData(queryKey, null);
+  queryClient.setQueryData(permissionsKey, null);
+  queryClient.removeQueries({ queryKey: permissionsKey, exact: true });
   void queryClient.invalidateQueries({ queryKey, exact: true });
 }
 
@@ -95,7 +99,11 @@ export function purgeAdminRoomGroupQuery(
   groupId: string
 ): void {
   const queryKey = adminQueryKeys.roomGroup(serverId, connection, groupId);
+  const permissionsKey = adminQueryKeys.permissionTier(serverId, connection, null, groupId);
   void queryClient.cancelQueries({ queryKey, exact: true });
+  void queryClient.cancelQueries({ queryKey: permissionsKey, exact: true });
   queryClient.setQueryData(queryKey, null);
+  queryClient.setQueryData(permissionsKey, null);
+  queryClient.removeQueries({ queryKey: permissionsKey, exact: true });
   void queryClient.invalidateQueries({ queryKey, exact: true });
 }

--- a/apps/frontend/src/lib/query/cacheRegistry.ts
+++ b/apps/frontend/src/lib/query/cacheRegistry.ts
@@ -2,10 +2,14 @@ type ServerCacheRemover = (serverId: string) => void;
 type AdminUserCacheRemover = (serverId: string, userId: string) => void;
 type AdminUserRemovalListener = (serverId: string, userId: string) => void;
 type QueryCacheRemovalListener = (serverId: string) => void;
+type AdminRoomQueryReconciler = (serverId: string, roomId: string, removed: boolean) => void;
+type AdminRoomGroupQueryReconciler = (serverId: string, visibleGroupIds: readonly string[]) => void;
 
 let removeServerCache: ServerCacheRemover | undefined;
 let removeAdminCache: ServerCacheRemover | undefined;
 let removeAdminUserCache: AdminUserCacheRemover | undefined;
+let reconcileAdminRoomCache: AdminRoomQueryReconciler | undefined;
+let reconcileAdminRoomGroupCache: AdminRoomGroupQueryReconciler | undefined;
 const adminUserRemovalListeners = new Set<AdminUserRemovalListener>();
 const queryCacheRemovalListeners = new Set<QueryCacheRemovalListener>();
 
@@ -14,10 +18,14 @@ export function registerServerQueryCache(removers: {
   server: ServerCacheRemover;
   admin: ServerCacheRemover;
   adminUser: AdminUserCacheRemover;
+  adminRoom: AdminRoomQueryReconciler;
+  adminRoomGroups: AdminRoomGroupQueryReconciler;
 }): void {
   removeServerCache = removers.server;
   removeAdminCache = removers.admin;
   removeAdminUserCache = removers.adminUser;
+  reconcileAdminRoomCache = removers.adminRoom;
+  reconcileAdminRoomGroupCache = removers.adminRoomGroups;
 }
 
 /** Purge cached private reads when a server session is disposed. */
@@ -36,6 +44,23 @@ export function removeRegisteredAdminQueries(serverId: string): void {
 export function removeRegisteredAdminUserQueries(serverId: string, userId: string): void {
   for (const listener of adminUserRemovalListeners) listener(serverId, userId);
   removeAdminUserCache?.(serverId, userId);
+}
+
+/** Reconcile cached room-management snapshots from the process-wide projection owner. */
+export function reconcileRegisteredAdminRoomQueries(
+  serverId: string,
+  roomId: string,
+  removed = false
+): void {
+  reconcileAdminRoomCache?.(serverId, roomId, removed);
+}
+
+/** Reconcile cached room-group snapshots from the authoritative visible group replacement. */
+export function reconcileRegisteredAdminRoomGroupQueries(
+  serverId: string,
+  visibleGroupIds: readonly string[]
+): void {
+  reconcileAdminRoomGroupCache?.(serverId, visibleGroupIds);
 }
 
 /** Observe privacy-driven admin-user removal while a detail owner is mounted. */

--- a/apps/frontend/src/lib/query/client.spec.ts
+++ b/apps/frontend/src/lib/query/client.spec.ts
@@ -1,6 +1,8 @@
 import { Code, ConnectError } from '@connectrpc/connect';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  reconcileRegisteredAdminRoomGroupQueries,
+  reconcileRegisteredAdminRoomQueries,
   removeRegisteredAdminQueries,
   removeRegisteredAdminUserQueries,
   removeRegisteredServerQueries,
@@ -174,6 +176,83 @@ describe('server query cache', () => {
         'moderator'
       ])?.users
     ).toEqual([{ id: 'retained', login: 'retained', displayName: 'Retained User' }]);
+  });
+
+  it('invalidates room details across sessions and purges removed permission snapshots', () => {
+    const roomOne = ['server', 'one', 'session', 'scope-a', 'admin', 'room', 'R1'] as const;
+    const roomTwo = ['server', 'one', 'session', 'scope-b', 'admin', 'room', 'R1'] as const;
+    const permissions = [
+      'server',
+      'one',
+      'session',
+      'scope-a',
+      'admin',
+      'permission-tier',
+      { roomId: 'R1', groupId: null }
+    ] as const;
+    queryClient.setQueryData(roomOne, 'private-room-a');
+    queryClient.setQueryData(roomTwo, 'private-room-b');
+    queryClient.setQueryData(permissions, 'private-permissions');
+
+    reconcileRegisteredAdminRoomQueries('one', 'R1');
+    expect(queryClient.getQueryState(roomOne)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(roomTwo)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryData(permissions)).toBe('private-permissions');
+
+    reconcileRegisteredAdminRoomQueries('one', 'R1', true);
+    expect(queryClient.getQueryData(roomOne)).toBeNull();
+    expect(queryClient.getQueryData(roomTwo)).toBeNull();
+    expect(queryClient.getQueryData(permissions)).toBeUndefined();
+  });
+
+  it('invalidates visible groups and purges groups omitted from a replacement', () => {
+    const visibleGroup = [
+      'server',
+      'one',
+      'session',
+      'scope',
+      'admin',
+      'room-group',
+      'G1'
+    ] as const;
+    const removedGroup = [
+      'server',
+      'one',
+      'session',
+      'scope',
+      'admin',
+      'room-group',
+      'G2'
+    ] as const;
+    const removedPermissions = [
+      'server',
+      'one',
+      'session',
+      'scope',
+      'admin',
+      'permission-tier',
+      { roomId: null, groupId: 'G2' }
+    ] as const;
+    const orphanedPermissions = [
+      'server',
+      'one',
+      'session',
+      'scope',
+      'admin',
+      'permission-tier',
+      { roomId: null, groupId: 'G3' }
+    ] as const;
+    queryClient.setQueryData(visibleGroup, 'visible-group');
+    queryClient.setQueryData(removedGroup, 'removed-group');
+    queryClient.setQueryData(removedPermissions, 'private-permissions');
+    queryClient.setQueryData(orphanedPermissions, 'orphaned-private-permissions');
+
+    reconcileRegisteredAdminRoomGroupQueries('one', ['G1']);
+
+    expect(queryClient.getQueryState(visibleGroup)?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryData(removedGroup)).toBeNull();
+    expect(queryClient.getQueryData(removedPermissions)).toBeUndefined();
+    expect(queryClient.getQueryData(orphanedPermissions)).toBeUndefined();
   });
 
   it('does not retry authentication or permission failures', async () => {

--- a/apps/frontend/src/lib/query/client.ts
+++ b/apps/frontend/src/lib/query/client.ts
@@ -121,9 +121,7 @@ export function removeAdminUserQueries(serverId: string, userId: string): void {
       }
     },
     (details) =>
-      details
-        ? { ...details, users: details.users.filter((user) => user.id !== userId) }
-        : details
+      details ? { ...details, users: details.users.filter((user) => user.id !== userId) } : details
   );
   queryClient.setQueriesData(
     {
@@ -141,8 +139,85 @@ export function removeAdminUserQueries(serverId: string, userId: string): void {
   });
 }
 
+function isAdminQueryForServer(key: QueryKey, serverId: string): boolean {
+  return key[0] === 'server' && key[1] === serverId && key[4] === 'admin';
+}
+
+function permissionTierScope(key: QueryKey): { roomId?: unknown; groupId?: unknown } | null {
+  if (key[5] !== 'permission-tier') return null;
+  const scope = key[6];
+  return scope && typeof scope === 'object' ? scope : null;
+}
+
+/** Keep every cached session's room detail coherent even when its route is not mounted. */
+export function reconcileAdminRoomQueries(
+  serverId: string,
+  roomId: string,
+  removed: boolean
+): void {
+  const isRoomDetail = (key: QueryKey): boolean =>
+    isAdminQueryForServer(key, serverId) && key[5] === 'room' && key[6] === roomId;
+  const isRoomPermissions = (key: QueryKey): boolean =>
+    isAdminQueryForServer(key, serverId) && permissionTierScope(key)?.roomId === roomId;
+
+  if (removed) {
+    void queryClient.cancelQueries({ predicate: (query) => isRoomDetail(query.queryKey) });
+    void queryClient.cancelQueries({ predicate: (query) => isRoomPermissions(query.queryKey) });
+    queryClient.setQueriesData({ predicate: (query) => isRoomDetail(query.queryKey) }, null);
+    queryClient.setQueriesData({ predicate: (query) => isRoomPermissions(query.queryKey) }, null);
+    queryClient.removeQueries({ predicate: (query) => isRoomPermissions(query.queryKey) });
+  }
+  void queryClient.invalidateQueries({ predicate: (query) => isRoomDetail(query.queryKey) });
+}
+
+/** Invalidate visible groups and purge snapshots no longer present in the viewer projection. */
+export function reconcileAdminRoomGroupQueries(
+  serverId: string,
+  visibleGroupIds: readonly string[]
+): void {
+  const visible = new Set(visibleGroupIds);
+  const isRemovedGroupPermissions = (key: QueryKey): boolean => {
+    if (!isAdminQueryForServer(key, serverId)) return false;
+    const groupId = permissionTierScope(key)?.groupId;
+    return typeof groupId === 'string' && !visible.has(groupId);
+  };
+  const groupQueries = queryClient.getQueryCache().findAll({
+    predicate: (query) => {
+      const key = query.queryKey;
+      return isAdminQueryForServer(key, serverId) && key[5] === 'room-group';
+    }
+  });
+
+  for (const query of groupQueries) {
+    const groupId = query.queryKey[6];
+    if (typeof groupId !== 'string') continue;
+    if (visible.has(groupId)) {
+      void queryClient.invalidateQueries({ queryKey: query.queryKey, exact: true });
+      continue;
+    }
+
+    void queryClient.cancelQueries({ queryKey: query.queryKey, exact: true });
+    queryClient.setQueryData(query.queryKey, null);
+    void queryClient.invalidateQueries({ queryKey: query.queryKey, exact: true });
+  }
+
+  // Permission matrices can outlive their detail query, so scrub them independently.
+  void queryClient.cancelQueries({
+    predicate: (query) => isRemovedGroupPermissions(query.queryKey)
+  });
+  queryClient.setQueriesData(
+    { predicate: (query) => isRemovedGroupPermissions(query.queryKey) },
+    null
+  );
+  queryClient.removeQueries({
+    predicate: (query) => isRemovedGroupPermissions(query.queryKey)
+  });
+}
+
 registerServerQueryCache({
   server: removeServerQueries,
   admin: removeAdminQueries,
-  adminUser: removeAdminUserQueries
+  adminUser: removeAdminUserQueries,
+  adminRoom: reconcileAdminRoomQueries,
+  adminRoomGroups: reconcileAdminRoomGroupQueries
 });

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -35,6 +35,8 @@ import {
   RealtimeProjectionServerState,
   RealtimeProjectionReset,
   RealtimeProjectionRoom,
+  RealtimeProjectionRoomGroupsReplace,
+  RealtimeProjectionRoomRemove,
   RealtimeProjectionUserRemove
 } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { MAX_RETAINED_ROOM_TIMELINES } from './realtimeSync.svelte';
@@ -44,6 +46,8 @@ const { soundMocks, apiMocks, cacheMocks } = vi.hoisted(() => ({
     playCallSound: vi.fn(() => Promise.resolve())
   },
   cacheMocks: {
+    reconcileRegisteredAdminRoomGroupQueries: vi.fn(),
+    reconcileRegisteredAdminRoomQueries: vi.fn(),
     removeRegisteredAdminQueries: vi.fn(),
     removeRegisteredAdminUserQueries: vi.fn(),
     removeRegisteredServerQueries: vi.fn()
@@ -389,8 +393,12 @@ beforeEach(() => {
   registerServerQueryCache({
     server: cacheMocks.removeRegisteredServerQueries,
     admin: cacheMocks.removeRegisteredAdminQueries,
-    adminUser: cacheMocks.removeRegisteredAdminUserQueries
+    adminUser: cacheMocks.removeRegisteredAdminUserQueries,
+    adminRoom: cacheMocks.reconcileRegisteredAdminRoomQueries,
+    adminRoomGroups: cacheMocks.reconcileRegisteredAdminRoomGroupQueries
   });
+  cacheMocks.reconcileRegisteredAdminRoomQueries.mockClear();
+  cacheMocks.reconcileRegisteredAdminRoomGroupQueries.mockClear();
   cacheMocks.removeRegisteredServerQueries.mockClear();
   cacheMocks.removeRegisteredAdminQueries.mockClear();
   cacheMocks.removeRegisteredAdminUserQueries.mockClear();
@@ -808,6 +816,65 @@ describe('ServerStateStore live server updates', () => {
     expect(store.navigation.rooms[0]?.members).toEqual([]);
     expect(messages.events[0]).toMatchObject({ actorId: 'U2', actor: null });
     expect(cacheMocks.removeRegisteredAdminUserQueries).toHaveBeenCalledWith(registered.id, 'U2');
+  });
+
+  it('reconciles query-backed room snapshots from process-wide projection events', () => {
+    const fake = new FakeServerConnection([]);
+    makeStore(fake);
+    eventBusManager.startBus(registered.id, fake as unknown as ServerConnection);
+    flushSync();
+    const bus = eventBusManager.getBus(registered.id)!;
+    const dispatch = (operation: RealtimeProjectionOperation) => {
+      for (const handler of bus.projectionHandlers) {
+        handler(new RealtimeProjectionEvent({ operations: [operation] }));
+      }
+    };
+
+    dispatch(
+      new RealtimeProjectionOperation({
+        operation: {
+          case: 'roomUpsert',
+          value: new RealtimeProjectionRoom({
+            room: new RoomWithViewerState({ room: new Room({ id: 'R1' }) })
+          })
+        }
+      })
+    );
+    dispatch(
+      new RealtimeProjectionOperation({
+        operation: {
+          case: 'roomRemove',
+          value: new RealtimeProjectionRoomRemove({ roomId: 'R2' })
+        }
+      })
+    );
+    dispatch(
+      new RealtimeProjectionOperation({
+        operation: {
+          case: 'roomGroupsReplace',
+          value: new RealtimeProjectionRoomGroupsReplace({
+            groups: [new RoomGroup({ id: 'G1' })]
+          })
+        }
+      })
+    );
+
+    expect(cacheMocks.reconcileRegisteredAdminRoomQueries).toHaveBeenNthCalledWith(
+      1,
+      registered.id,
+      'R1',
+      false
+    );
+    expect(cacheMocks.reconcileRegisteredAdminRoomQueries).toHaveBeenNthCalledWith(
+      2,
+      registered.id,
+      'R2',
+      true
+    );
+    expect(cacheMocks.reconcileRegisteredAdminRoomGroupQueries).toHaveBeenCalledWith(
+      registered.id,
+      ['G1']
+    );
   });
 
   it('keeps a first-view room timeline loading while requesting it from realtime', () => {

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -48,6 +48,8 @@ import type { ActiveCall } from '@chatto/api-types/api/v1/voice_calls_pb';
 import { MessageSearchStore } from './messageSearch.svelte';
 import { MentionRolesStore } from './mentionRoles.svelte';
 import {
+  reconcileRegisteredAdminRoomGroupQueries,
+  reconcileRegisteredAdminRoomQueries,
   removeRegisteredAdminQueries,
   removeRegisteredAdminUserQueries,
   removeRegisteredServerQueries
@@ -383,6 +385,7 @@ export class ServerStateStore {
           adminRoomLayoutChanged = true;
           const roomId = operation.operation.value.room?.room?.id;
           if (!roomId) break;
+          reconcileRegisteredAdminRoomQueries(this.serverId, roomId);
           const viewerState = operation.operation.value.room?.viewerState;
           this.roomDirectory.acknowledgeMembership(roomId, viewerState?.isMember);
           this.roomUnread.acknowledgeRoomProjection(roomId, viewerState?.hasUnread);
@@ -397,6 +400,7 @@ export class ServerStateStore {
         case 'roomRemove': {
           adminRoomLayoutChanged = true;
           const roomId = operation.operation.value.roomId;
+          reconcileRegisteredAdminRoomQueries(this.serverId, roomId, true);
           this.roomDirectory.removeMembershipProjection(roomId);
           this.roomUnread.removeRoomProjection(roomId);
           this.forRoomMessageSearch(roomId, (store) => store.revokeRoom(roomId));
@@ -405,6 +409,10 @@ export class ServerStateStore {
         }
         case 'roomGroupsReplace': {
           adminRoomLayoutChanged = true;
+          reconcileRegisteredAdminRoomGroupQueries(
+            this.serverId,
+            operation.operation.value.groups.map((group) => group.id)
+          );
           break;
         }
         case 'roomTimelineReplace': {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/+page.svelte
@@ -1,21 +1,34 @@
 <script lang="ts">
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
+  import { createMutation, createQuery } from '@tanstack/svelte-query';
+  import { onDestroy } from 'svelte';
   import { serverIdToSegment } from '$lib/navigation';
-  import { createAdminRoomLayoutAPI, type AdminRoomGroup } from '$lib/api-client/adminRoomLayout';
+  import {
+    createAdminRoomLayoutAPI,
+    type AdminManagedRoomGroup
+  } from '$lib/api-client/adminRoomLayout';
+  import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { Panel } from '$lib/components/admin';
-  import { Button, TextArea, TextInput } from '$lib/ui/form';
+  import { Button } from '$lib/ui/form';
   import AccessDenied from '$lib/ui/AccessDenied.svelte';
   import { EmptyState } from '$lib/ui';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import Hint from '$lib/ui/Hint.svelte';
   import PermissionMatrix from '$lib/components/rbac/PermissionMatrix.svelte';
+  import { useProjectionEvent } from '$lib/hooks';
   import { toast } from '$lib/ui/toast';
-  import { isCurrentResourceOperation } from '$lib/utils/resourceOperationFence';
   import { classifyManagementLoadError } from '$lib/utils/managementLoadError';
-  import { buildRoomGroupSettingsUpdate } from './roomGroupSettings';
+  import { adminQueryKeys } from '$lib/query/admin';
+  import { queryClient } from '$lib/query/client';
+  import {
+    invalidateAdminRoomLayoutQueries,
+    purgeAdminRoomGroupQuery
+  } from '$lib/query/adminInvalidation';
+  import { registerQueryCacheRemovalListener } from '$lib/query/cacheRegistry';
+  import RoomGroupGeneralSettingsPanel from './RoomGroupGeneralSettingsPanel.svelte';
+  import type { buildRoomGroupSettingsUpdate } from './roomGroupSettings';
   import * as m from '$lib/i18n/messages';
 
   const serverScope = useServerScope();
@@ -24,115 +37,149 @@
   const serverSegment = $derived(serverIdToSegment(activeServerId));
   const backHref = $derived(resolve('/chat/[serverId]/manage/rooms', { serverId: serverSegment }));
 
-  let group = $state<AdminRoomGroup | null>(null);
-  let loading = $state(true);
-  let accessDenied = $state(false);
-  let loadFailure = $state<string | null>(null);
-  let saving = $state(false);
-  let name = $state('');
-  let description = $state('');
-  let originalName = $state('');
-  let originalDescription = $state('');
-  let canManageGroup = $state(false);
-  let canManagePermissions = $state(false);
-  let loadId = 0;
-  const changed = $derived(
-    name.trim() !== originalName || description.trim() !== originalDescription
-  );
-
-  function applyGroup(nextGroup: AdminRoomGroup): void {
-    group = nextGroup;
-    name = nextGroup.name;
-    description = nextGroup.description ?? '';
-    originalName = nextGroup.name;
-    originalDescription = nextGroup.description ?? '';
-  }
-
-  async function loadGroup(targetServerId: string, targetGroupId: string) {
-    if (targetServerId !== serverScope.serverId) return;
-    const targetStore = serverScope.store;
-    const targetConnection = serverScope.connection;
-    const thisId = ++loadId;
-    loading = true;
-    saving = false;
-    group = null;
-    accessDenied = false;
-    loadFailure = null;
-    canManageGroup = false;
-    canManagePermissions = false;
-    try {
-      const info = targetStore.serverInfo;
-      if (!info?.supportsFeature('adminApi')) {
-        accessDenied = true;
-        return;
-      }
-      const details = await targetConnection
-        .getAPI(createAdminRoomLayoutAPI)
-        .getRoomGroup(targetGroupId);
-      if (!serverScope.isCurrent() || thisId !== loadId || targetServerId !== activeServerId)
-        return;
-      if (details) {
-        canManageGroup = details.canManageGroup;
-        canManagePermissions = details.canManagePermissions;
-        applyGroup(details.group);
-      } else {
-        accessDenied = true;
-      }
-    } catch (error) {
-      if (!serverScope.isCurrent() || thisId !== loadId || targetServerId !== activeServerId)
-        return;
-      const classified = classifyManagementLoadError(error);
-      if (classified.kind === 'access-denied') {
-        accessDenied = true;
-      } else {
-        loadFailure = classified.message;
-      }
-    } finally {
-      if (serverScope.isCurrent() && thisId === loadId && targetServerId === activeServerId) {
-        loading = false;
-      }
-    }
-  }
-
-  $effect(() => {
-    void loadGroup(activeServerId, groupId);
+  const supportsAdminAPI = $derived(serverScope.store.serverInfo.supportsFeature('adminApi'));
+  let privacyGeneration = 0;
+  let snapshotGeneration = 0;
+  let formRevision = $state(0);
+  const removeCacheRemovalListener = registerQueryCacheRemovalListener((serverId) => {
+    if (serverId === serverScope.serverId) privacyGeneration += 1;
   });
 
-  async function saveGeneralSettings(event: SubmitEvent): Promise<void> {
-    event.preventDefault();
-    if (!canManageGroup || saving || !name.trim() || !changed) return;
+  onDestroy(() => {
+    privacyGeneration += 1;
+    snapshotGeneration += 1;
+    removeCacheRemovalListener();
+  });
 
-    const target = { resourceId: groupId, generation: loadId };
-    const targetConnection = serverScope.connection;
-    const targetRoomLayout = serverScope.store.adminRoomLayout;
-    const update = buildRoomGroupSettingsUpdate(
-      target.resourceId,
-      { name, description },
-      { name: originalName, description: originalDescription }
+  type GroupMutationScope = {
+    serverId: string;
+    connection: ServerConnection;
+    groupId: string;
+    queryKey: ReturnType<typeof adminQueryKeys.roomGroup>;
+    api: ReturnType<typeof createAdminRoomLayoutAPI>;
+    privacyGeneration: number;
+    snapshotGeneration: number;
+    input: ReturnType<typeof buildRoomGroupSettingsUpdate>;
+  };
+
+  const groupQuery = createQuery(
+    () => {
+      const serverId = activeServerId;
+      const connection = serverScope.connection;
+      const targetGroupId = groupId;
+      return {
+        queryKey: adminQueryKeys.roomGroup(serverId, connection, targetGroupId),
+        queryFn: ({ signal }) =>
+          connection.getAPI(createAdminRoomLayoutAPI).getRoomGroup(targetGroupId, { signal }),
+        enabled: supportsAdminAPI
+      };
+    },
+    () => queryClient
+  );
+
+  const groupDetails = $derived(groupQuery.data ?? null);
+  const group = $derived(groupDetails?.group ?? null);
+  const canManageGroup = $derived(groupDetails?.canManageGroup ?? false);
+  const canManagePermissions = $derived(groupDetails?.canManagePermissions ?? false);
+  const loading = $derived(supportsAdminAPI && groupQuery.isPending);
+  const classifiedLoadError = $derived(
+    groupQuery.error ? classifyManagementLoadError(groupQuery.error) : null
+  );
+  const accessDenied = $derived(
+    !supportsAdminAPI || classifiedLoadError?.kind === 'access-denied' || (!loading && !group)
+  );
+  const loadFailure = $derived(
+    classifiedLoadError?.kind === 'failure' ? classifiedLoadError.message : null
+  );
+
+  function isCurrentGroup(variables: GroupMutationScope | undefined): boolean {
+    return (
+      variables !== undefined &&
+      serverScope.isCurrent() &&
+      variables.serverId === activeServerId &&
+      variables.connection.queryScope === serverScope.connection.queryScope &&
+      variables.groupId === groupId &&
+      variables.privacyGeneration === privacyGeneration
     );
-    saving = true;
-    try {
-      const api = targetConnection.getAPI(createAdminRoomLayoutAPI);
-      const updated = await api.updateRoomGroup(update);
-      if (!serverScope.isCurrent() || !isCurrentResourceOperation(target, groupId, loadId)) return;
-      if (!updated) throw new Error('Room group update returned no group');
-
-      applyGroup(updated);
-      void targetRoomLayout.refresh();
-      toast.success(m['admin.rooms_admin.group_renamed']());
-    } catch (error) {
-      if (!serverScope.isCurrent() || !isCurrentResourceOperation(target, groupId, loadId)) return;
-      toast.error(
-        m['admin.rooms_admin.rename_group_failed']({
-          error: error instanceof Error ? error.message : String(error)
-        })
-      );
-    } finally {
-      if (serverScope.isCurrent() && isCurrentResourceOperation(target, groupId, loadId)) {
-        saving = false;
-      }
-    }
   }
+
+  function canApplyGroupSnapshot(variables: GroupMutationScope): boolean {
+    return isCurrentGroup(variables) && variables.snapshotGeneration === snapshotGeneration;
+  }
+
+  const updateGroupMutation = createMutation(
+    () => ({
+      mutationFn: async ({ api, input }: GroupMutationScope) => {
+        const updated = await api.updateRoomGroup(input);
+        if (!updated) throw new Error('Room group update returned no group');
+        return updated;
+      },
+      onSuccess: (updated, variables) => {
+        if (!isCurrentGroup(variables)) return;
+        if (canApplyGroupSnapshot(variables)) {
+          queryClient.setQueryData<AdminManagedRoomGroup | null>(variables.queryKey, (current) =>
+            current ? { ...current, group: updated } : current
+          );
+        }
+        invalidateAdminRoomLayoutQueries(
+          variables.serverId,
+          variables.connection,
+          undefined,
+          variables.groupId
+        );
+        void serverScope.store.adminRoomLayout.refresh();
+        formRevision += 1;
+        toast.success(m['admin.rooms_admin.group_renamed']());
+      },
+      onError: (error, variables) => {
+        if (!isCurrentGroup(variables)) return;
+        toast.error(
+          m['admin.rooms_admin.rename_group_failed']({
+            error: error instanceof Error ? error.message : String(error)
+          })
+        );
+      }
+    }),
+    () => queryClient
+  );
+
+  function saveGeneralSettings(input: ReturnType<typeof buildRoomGroupSettingsUpdate>): void {
+    if (!canManageGroup || updateGroupMutation.isPending) return;
+    const connection = serverScope.connection;
+    updateGroupMutation.mutate({
+      serverId: activeServerId,
+      connection,
+      groupId,
+      queryKey: adminQueryKeys.roomGroup(activeServerId, connection, groupId),
+      api: connection.getAPI(createAdminRoomLayoutAPI),
+      privacyGeneration,
+      snapshotGeneration,
+      input
+    });
+  }
+
+  useProjectionEvent((event) => {
+    for (const operation of event.operations) {
+      if (operation.operation.case !== 'roomGroupsReplace') continue;
+      snapshotGeneration += 1;
+      if (operation.operation.value.groups.some((candidate) => candidate.id === groupId)) {
+        invalidateAdminRoomLayoutQueries(
+          activeServerId,
+          serverScope.connection,
+          undefined,
+          groupId
+        );
+      } else {
+        privacyGeneration += 1;
+        purgeAdminRoomGroupQuery(activeServerId, serverScope.connection, groupId);
+      }
+      return;
+    }
+  });
+
+  const saving = $derived(
+    updateGroupMutation.isPending && isCurrentGroup(updateGroupMutation.variables)
+  );
 
   const pageTitle = $derived(
     group
@@ -149,7 +196,7 @@
   <EmptyState icon="uil--exclamation-triangle" title={m['common.error.generic']()}>
     <div class="flex flex-col items-center gap-4">
       <p>{loadFailure}</p>
-      <Button variant="secondary" onclick={() => void loadGroup(activeServerId, groupId)}>
+      <Button variant="secondary" onclick={() => void groupQuery.refetch()}>
         {m['common.retry']()}
       </Button>
     </div>
@@ -172,31 +219,9 @@
 
     <div class="flex flex-col gap-6 overflow-y-auto p-6">
       {#if canManageGroup}
-        <Panel title={m['admin.nav.general']()} icon="iconify uil--setting">
-          <form class="flex max-w-2xl flex-col gap-4" onsubmit={saveGeneralSettings}>
-            <TextInput
-              id="room-group-settings-name"
-              label={m['admin.rooms_admin.group_name']()}
-              bind:value={name}
-              required
-              maxlength={80}
-              disabled={saving}
-            />
-            <TextArea
-              id="room-group-settings-description"
-              label={m['rbac.role_form.description']()}
-              bind:value={description}
-              rows={3}
-              maxlength={500}
-              disabled={saving}
-            />
-            <div class="flex justify-end">
-              <Button type="submit" loading={saving} disabled={!name.trim() || !changed}>
-                {m['admin.permissions.save_changes']()}
-              </Button>
-            </div>
-          </form>
-        </Panel>
+        {#key `${activeServerId}:${serverScope.connection.queryScope}:${group.id}:${formRevision}`}
+          <RoomGroupGeneralSettingsPanel {group} {saving} onSave={saveGeneralSettings} />
+        {/key}
       {/if}
 
       <div class="flex flex-col gap-4">

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/+page.svelte
@@ -71,7 +71,8 @@
         queryKey: adminQueryKeys.roomGroup(serverId, connection, targetGroupId),
         queryFn: ({ signal }) =>
           connection.getAPI(createAdminRoomLayoutAPI).getRoomGroup(targetGroupId, { signal }),
-        enabled: supportsAdminAPI
+        enabled: supportsAdminAPI,
+        refetchOnMount: 'always' as const
       };
     },
     () => queryClient
@@ -120,6 +121,7 @@
           queryClient.setQueryData<AdminManagedRoomGroup | null>(variables.queryKey, (current) =>
             current ? { ...current, group: updated } : current
           );
+          formRevision += 1;
         }
         invalidateAdminRoomLayoutQueries(
           variables.serverId,
@@ -128,7 +130,6 @@
           variables.groupId
         );
         void serverScope.store.adminRoomLayout.refresh();
-        formRevision += 1;
         toast.success(m['admin.rooms_admin.group_renamed']());
       },
       onError: (error, variables) => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupGeneralSettingsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupGeneralSettingsPanel.svelte
@@ -17,10 +17,25 @@
   } = $props();
 
   // The parent keys this editor by group identity and successful save revision.
-  const originalName = untrack(() => group.name);
-  const originalDescription = untrack(() => group.description ?? '');
-  let name = $state(originalName);
-  let description = $state(originalDescription);
+  let originalName = $state(untrack(() => group.name));
+  let originalDescription = $state(untrack(() => group.description ?? ''));
+  let name = $state(untrack(() => group.name));
+  let description = $state(untrack(() => group.description ?? ''));
+
+  // Query snapshots may refresh while this editor is mounted. Adopt each remote
+  // field only when that field is pristine, preserving unrelated local edits.
+  $effect(() => {
+    const nextName = group.name;
+    const nextDescription = group.description ?? '';
+    untrack(() => {
+      const nameWasPristine = name === originalName;
+      const descriptionWasPristine = description === originalDescription;
+      originalName = nextName;
+      originalDescription = nextDescription;
+      if (nameWasPristine) name = nextName;
+      if (descriptionWasPristine) description = nextDescription;
+    });
+  });
   const changed = $derived(
     name.trim() !== originalName || description.trim() !== originalDescription
   );

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupGeneralSettingsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupGeneralSettingsPanel.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { AdminRoomGroup } from '$lib/api-client/adminRoomLayout';
+  import { Panel } from '$lib/components/admin';
+  import { Button, TextArea, TextInput } from '$lib/ui/form';
+  import { buildRoomGroupSettingsUpdate } from './roomGroupSettings';
+  import * as m from '$lib/i18n/messages';
+
+  let {
+    group,
+    saving,
+    onSave
+  }: {
+    group: AdminRoomGroup;
+    saving: boolean;
+    onSave: (update: ReturnType<typeof buildRoomGroupSettingsUpdate>) => void;
+  } = $props();
+
+  // The parent keys this editor by group identity and successful save revision.
+  const originalName = untrack(() => group.name);
+  const originalDescription = untrack(() => group.description ?? '');
+  let name = $state(originalName);
+  let description = $state(originalDescription);
+  const changed = $derived(
+    name.trim() !== originalName || description.trim() !== originalDescription
+  );
+
+  function save(event: SubmitEvent): void {
+    event.preventDefault();
+    if (saving || !name.trim() || !changed) return;
+    onSave(
+      buildRoomGroupSettingsUpdate(
+        group.id,
+        { name, description },
+        { name: originalName, description: originalDescription }
+      )
+    );
+  }
+</script>
+
+<Panel title={m['admin.nav.general']()} icon="iconify uil--setting">
+  <form class="flex max-w-2xl flex-col gap-4" onsubmit={save}>
+    <TextInput
+      id="room-group-settings-name"
+      label={m['admin.rooms_admin.group_name']()}
+      bind:value={name}
+      required
+      maxlength={80}
+      disabled={saving}
+    />
+    <TextArea
+      id="room-group-settings-description"
+      label={m['rbac.role_form.description']()}
+      bind:value={description}
+      rows={3}
+      maxlength={500}
+      disabled={saving}
+    />
+    <div class="flex justify-end">
+      <Button type="submit" loading={saving} disabled={!name.trim() || !changed}>
+        {m['admin.permissions.save_changes']()}
+      </Button>
+    </div>
+  </form>
+</Panel>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupPageTestState.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupPageTestState.svelte.ts
@@ -1,0 +1,20 @@
+class RoomGroupPageTestState {
+  serverId = $state('server-a');
+  groupId = $state('group-a');
+
+  reset(): void {
+    this.serverId = 'server-a';
+    this.groupId = 'group-a';
+  }
+}
+
+export const roomGroupPageTestState = new RoomGroupPageTestState();
+
+export const roomGroupTestPage = {
+  get params() {
+    return {
+      serverId: roomGroupPageTestState.serverId,
+      groupId: roomGroupPageTestState.groupId
+    };
+  }
+};

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/room-group.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/room-group.page.svelte.spec.ts
@@ -1,0 +1,272 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import { RoomGroup } from '@chatto/api-types/api/v1/room_directory_pb';
+import {
+  RealtimeProjectionEvent,
+  RealtimeProjectionOperation,
+  RealtimeProjectionRoomGroupsReplace
+} from '@chatto/api-types/realtime/v1/realtime_pb';
+import { loadLocaleMessages } from '$lib/i18n/messages';
+import { setReactiveLocale } from '$lib/i18n/state.svelte';
+import { queryClient } from '$lib/query/client';
+import { roomGroupPageTestState, roomGroupTestPage } from './RoomGroupPageTestState.svelte';
+
+const mocks = vi.hoisted(() => ({
+  getRoomGroup: vi.fn(),
+  updateRoomGroup: vi.fn(),
+  refreshLayout: vi.fn(),
+  projectionHandlers: [] as Array<(event: RealtimeProjectionEvent) => void>,
+  success: vi.fn(),
+  error: vi.fn()
+}));
+
+vi.mock('$app/state', () => ({ page: roomGroupTestPage }));
+
+vi.mock('$lib/hooks', () => ({
+  useProjectionEvent: (handler: (event: RealtimeProjectionEvent) => void) => {
+    mocks.projectionHandlers.push(handler);
+  }
+}));
+
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({
+    get serverId() {
+      return roomGroupPageTestState.serverId;
+    },
+    get connection() {
+      const serverId = roomGroupPageTestState.serverId;
+      return {
+        queryScope: `${serverId}-query-scope`,
+        getAPI: (factory: (config: never) => unknown) =>
+          factory({
+            serverId,
+            baseUrl: `https://${serverId}.example.test/api/connect`,
+            bearerToken: `${serverId}-token`
+          } as never)
+      };
+    },
+    get store() {
+      return {
+        serverInfo: { supportsFeature: () => true },
+        adminRoomLayout: { refresh: mocks.refreshLayout }
+      };
+    },
+    isCurrent: () => true
+  })
+}));
+
+vi.mock('$lib/api-client/adminRoomLayout', () => ({
+  createAdminRoomLayoutAPI: ({ serverId }: { serverId: string }) => ({
+    getRoomGroup: (groupId: string, options?: { signal?: AbortSignal }) =>
+      mocks.getRoomGroup(serverId, groupId, options),
+    updateRoomGroup: (input: unknown) => mocks.updateRoomGroup(serverId, input)
+  })
+}));
+
+vi.mock('$lib/components/rbac/PermissionMatrix.svelte', async () => ({
+  default: (await import('../../rooms/[roomId]/RoomManagementPagePermissionMatrixMock.svelte'))
+    .default
+}));
+
+vi.mock('$lib/ui/toast', () => ({
+  toast: { success: mocks.success, error: mocks.error }
+}));
+
+import RoomGroupPage from './+page.svelte';
+
+function managedGroup(name: string, groupId = roomGroupPageTestState.groupId) {
+  return {
+    group: {
+      id: groupId,
+      name,
+      description: 'Description',
+      canCreateRoom: true,
+      rooms: [],
+      items: []
+    },
+    canManageGroup: true,
+    canManagePermissions: true
+  };
+}
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+function dispatchGroups(groupIds: string[]): void {
+  const event = new RealtimeProjectionEvent({
+    operations: [
+      new RealtimeProjectionOperation({
+        operation: {
+          case: 'roomGroupsReplace',
+          value: new RealtimeProjectionRoomGroupsReplace({
+            groups: groupIds.map((id) => new RoomGroup({ id, name: id }))
+          })
+        }
+      })
+    ]
+  });
+  for (const handler of mocks.projectionHandlers) handler(event);
+}
+
+describe('room-group management query lifecycle', () => {
+  beforeEach(async () => {
+    queryClient.clear();
+    vi.clearAllMocks();
+    mocks.projectionHandlers = [];
+    roomGroupPageTestState.reset();
+    mocks.getRoomGroup.mockResolvedValue(managedGroup('Lobby'));
+    mocks.updateRoomGroup.mockResolvedValue(managedGroup('Projects').group);
+    mocks.refreshLayout.mockResolvedValue(undefined);
+    await loadLocaleMessages('en-GB');
+    setReactiveLocale('en-GB');
+  });
+
+  it('passes cancellation through and reuses a fresh cached group snapshot', async () => {
+    const first = render(RoomGroupPage);
+    await settle();
+
+    expect(mocks.getRoomGroup).toHaveBeenCalledWith(
+      'server-a',
+      'group-a',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(first.container.textContent).toContain('Lobby');
+    first.unmount();
+
+    const second = render(RoomGroupPage);
+    await settle();
+    expect(second.container.textContent).toContain('Lobby');
+    expect(mocks.getRoomGroup).toHaveBeenCalledOnce();
+  });
+
+  it('switches query identity when the route group changes', async () => {
+    mocks.getRoomGroup.mockImplementation((_serverId: string, groupId: string) =>
+      Promise.resolve(managedGroup(groupId === 'group-a' ? 'Lobby' : 'Projects', groupId))
+    );
+    const { container } = render(RoomGroupPage);
+    await settle();
+
+    roomGroupPageTestState.groupId = 'group-b';
+    flushSync();
+    await settle();
+
+    expect(container.textContent).toContain('Projects');
+    expect((container.querySelector('#room-group-settings-name') as HTMLInputElement).value).toBe(
+      'Projects'
+    );
+  });
+
+  it('preserves a dirty draft while a group projection refreshes the snapshot', async () => {
+    mocks.getRoomGroup
+      .mockResolvedValueOnce(managedGroup('Lobby'))
+      .mockResolvedValueOnce(managedGroup('Remote name'));
+    const { container } = render(RoomGroupPage);
+    await settle();
+
+    const input = container.querySelector('#room-group-settings-name') as HTMLInputElement;
+    input.value = 'Local draft';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    dispatchGroups(['group-a']);
+    await vi.waitFor(() => expect(mocks.getRoomGroup).toHaveBeenCalledTimes(2));
+    await settle();
+
+    expect((container.querySelector('#room-group-settings-name') as HTMLInputElement).value).toBe(
+      'Local draft'
+    );
+    expect(container.textContent).toContain('Remote name');
+  });
+
+  it('updates the exact snapshot after a settings mutation', async () => {
+    const { container } = render(RoomGroupPage);
+    await settle();
+
+    const input = container.querySelector('#room-group-settings-name') as HTMLInputElement;
+    input.value = 'Projects';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    (container.querySelector('form button[type="submit"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => expect(mocks.updateRoomGroup).toHaveBeenCalledOnce());
+    await settle();
+    expect(mocks.success).toHaveBeenCalledOnce();
+    expect(mocks.refreshLayout).toHaveBeenCalledOnce();
+    expect((container.querySelector('#room-group-settings-name') as HTMLInputElement).value).toBe(
+      'Projects'
+    );
+  });
+
+  it('acknowledges a save without overwriting a newer projected snapshot', async () => {
+    const pendingSave = deferred<ReturnType<typeof managedGroup>['group']>();
+    mocks.updateRoomGroup.mockReturnValueOnce(pendingSave.promise);
+    const { container } = render(RoomGroupPage);
+    await settle();
+
+    const input = container.querySelector('#room-group-settings-name') as HTMLInputElement;
+    input.value = 'Projects';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    (container.querySelector('form button[type="submit"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.updateRoomGroup).toHaveBeenCalledOnce());
+
+    mocks.getRoomGroup.mockResolvedValue(managedGroup('Projected name'));
+    dispatchGroups(['group-a']);
+    await vi.waitFor(() => expect(container.textContent).toContain('Projected name'));
+
+    pendingSave.resolve(managedGroup('Mutation response').group);
+    await vi.waitFor(() => expect(mocks.success).toHaveBeenCalledOnce());
+    await settle();
+
+    expect(container.textContent).toContain('Projected name');
+    expect(container.textContent).not.toContain('Mutation response');
+  });
+
+  it('fences a late save response after projected group removal', async () => {
+    const pendingSave = deferred<ReturnType<typeof managedGroup>['group']>();
+    mocks.updateRoomGroup.mockReturnValueOnce(pendingSave.promise);
+    const { container } = render(RoomGroupPage);
+    await settle();
+
+    const input = container.querySelector('#room-group-settings-name') as HTMLInputElement;
+    input.value = 'Private draft';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    (container.querySelector('form button[type="submit"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.updateRoomGroup).toHaveBeenCalledOnce());
+
+    mocks.getRoomGroup.mockResolvedValue(null);
+    dispatchGroups([]);
+    pendingSave.resolve(managedGroup('Private draft').group);
+    await settle();
+
+    expect(container.textContent).not.toContain('Private draft');
+    expect(mocks.success).not.toHaveBeenCalled();
+  });
+
+  it('purges the visible group immediately when projection access disappears', async () => {
+    const { container } = render(RoomGroupPage);
+    await settle();
+    expect(container.textContent).toContain('Lobby');
+    mocks.getRoomGroup.mockResolvedValueOnce(null);
+
+    dispatchGroups([]);
+    flushSync();
+
+    expect(container.textContent).not.toContain('Lobby');
+    expect(container.querySelector('#room-group-settings-name')).toBeNull();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/room-group.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/room-group.page.svelte.spec.ts
@@ -134,7 +134,7 @@ describe('room-group management query lifecycle', () => {
     setReactiveLocale('en-GB');
   });
 
-  it('passes cancellation through and reuses a fresh cached group snapshot', async () => {
+  it('passes cancellation through and revalidates a cached group snapshot on remount', async () => {
     const first = render(RoomGroupPage);
     await settle();
 
@@ -149,7 +149,7 @@ describe('room-group management query lifecycle', () => {
     const second = render(RoomGroupPage);
     await settle();
     expect(second.container.textContent).toContain('Lobby');
-    expect(mocks.getRoomGroup).toHaveBeenCalledOnce();
+    expect(mocks.getRoomGroup).toHaveBeenCalledTimes(2);
   });
 
   it('switches query identity when the route group changes', async () => {
@@ -191,9 +191,26 @@ describe('room-group management query lifecycle', () => {
     expect(container.textContent).toContain('Remote name');
   });
 
+  it('adopts refreshed group fields while the form is pristine', async () => {
+    mocks.getRoomGroup
+      .mockResolvedValueOnce(managedGroup('Lobby'))
+      .mockResolvedValueOnce(managedGroup('Remote name'));
+    const { container } = render(RoomGroupPage);
+    await settle();
+
+    dispatchGroups(['group-a']);
+    await vi.waitFor(() => expect(mocks.getRoomGroup).toHaveBeenCalledTimes(2));
+    await settle();
+
+    expect((container.querySelector('#room-group-settings-name') as HTMLInputElement).value).toBe(
+      'Remote name'
+    );
+  });
+
   it('updates the exact snapshot after a settings mutation', async () => {
     const { container } = render(RoomGroupPage);
     await settle();
+    mocks.getRoomGroup.mockResolvedValue(managedGroup('Projects'));
 
     const input = container.querySelector('#room-group-settings-name') as HTMLInputElement;
     input.value = 'Projects';

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -88,7 +88,8 @@
         queryKey: adminQueryKeys.room(serverId, connection, targetRoomId),
         queryFn: ({ signal }) =>
           connection.getAPI(createAdminRoomLayoutAPI).getRoom(targetRoomId, { signal }),
-        enabled: supportsAdminAPI
+        enabled: supportsAdminAPI,
+        refetchOnMount: 'always' as const
       };
     },
     () => queryClient
@@ -152,6 +153,7 @@
                 }
               : current
           );
+          formRevision += 1;
         }
         invalidateAdminRoomLayoutQueries(
           variables.serverId,
@@ -159,7 +161,6 @@
           variables.roomId
         );
         void serverScope.store.adminRoomLayout.refresh();
-        formRevision += 1;
         toast.success(m['admin.rooms_admin.room_updated']());
       },
       onError: (error, variables) => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/+page.svelte
@@ -1,22 +1,17 @@
 <script lang="ts">
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { untrack } from 'svelte';
+  import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+  import { onDestroy } from 'svelte';
   import { page } from '$app/state';
   import { resolve } from '$app/paths';
+  import { createMutation, createQuery } from '@tanstack/svelte-query';
   import { serverIdToSegment } from '$lib/navigation';
   import { createAdminRoomLayoutAPI, type AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
   import { createRoomCommandAPI } from '$lib/api-client/rooms';
-  import {
-    hasValidRoomNameCharacters,
-    normalizeRoomName,
-    ROOM_NAME_MAX_LENGTH,
-    roomNameCharacterCount
-  } from '$lib/utils/roomName';
   import { createMemberDirectoryAPI } from '$lib/api-client/memberDirectory';
   import { getChromePermissions } from '$lib/state/server/chromePermissions.svelte';
   import { useProjectionEvent } from '$lib/hooks';
-  import { Panel } from '$lib/components/admin';
-  import { Button, Checkbox, TextArea, TextInput } from '$lib/ui/form';
+  import { Button } from '$lib/ui/form';
   import AccessDenied from '$lib/ui/AccessDenied.svelte';
   import { EmptyState, PaneContent } from '$lib/ui';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
@@ -24,9 +19,16 @@
   import Hint from '$lib/ui/Hint.svelte';
   import PermissionMatrix from '$lib/components/rbac/PermissionMatrix.svelte';
   import { toast } from '$lib/ui/toast';
-  import { UNIVERSAL_ROOM_HELP_TEXT } from '$lib/utils/roomCopy';
   import { classifyManagementLoadError } from '$lib/utils/managementLoadError';
-  import { buildRoomSettingsUpdate } from './roomSettings';
+  import { adminQueryKeys } from '$lib/query/admin';
+  import { queryClient } from '$lib/query/client';
+  import {
+    invalidateAdminRoomLayoutQueries,
+    purgeAdminRoomQuery
+  } from '$lib/query/adminInvalidation';
+  import { registerQueryCacheRemovalListener } from '$lib/query/cacheRegistry';
+  import type { buildRoomSettingsUpdate } from './roomSettings';
+  import RoomGeneralSettingsPanel from './RoomGeneralSettingsPanel.svelte';
   import RoomMembersPanel from './RoomMembersPanel.svelte';
   import { RoomMemberManagementStore } from './RoomMemberManagementStore.svelte';
   import * as m from '$lib/i18n/messages';
@@ -39,20 +41,21 @@
   const getChromePermissionsState = getChromePermissions();
   const chromePermissions = $derived(getChromePermissionsState());
 
-  let room = $state<AdminManagedRoom | null>(null);
-  let loading = $state(true);
-  let accessDenied = $state(false);
-  let loadFailure = $state<string | null>(null);
-  let saving = $state(false);
-  let name = $state('');
-  let description = $state('');
-  let universal = $state(false);
-  let originalName = $state('');
-  let originalDescription = $state('');
-  let originalUniversal = $state(false);
-  let loadId = 0;
-  let identityGeneration = 0;
   let scrollContainer = $state<HTMLDivElement>();
+  let privacyGeneration = 0;
+  let snapshotGeneration = 0;
+  let formRevision = $state(0);
+  const supportsAdminAPI = $derived(serverScope.store.serverInfo.supportsFeature('adminApi'));
+
+  const removeCacheRemovalListener = registerQueryCacheRemovalListener((serverId) => {
+    if (serverId === serverScope.serverId) privacyGeneration += 1;
+  });
+
+  onDestroy(() => {
+    privacyGeneration += 1;
+    snapshotGeneration += 1;
+    removeCacheRemovalListener();
+  });
 
   const memberManagement = new RoomMemberManagementStore(
     () => {
@@ -65,6 +68,33 @@
     () => serverScope.isCurrent()
   );
 
+  type RoomMutationScope = {
+    serverId: string;
+    connection: ServerConnection;
+    roomId: string;
+    queryKey: ReturnType<typeof adminQueryKeys.room>;
+    api: ReturnType<typeof createRoomCommandAPI>;
+    privacyGeneration: number;
+    snapshotGeneration: number;
+    input: ReturnType<typeof buildRoomSettingsUpdate>;
+  };
+
+  const roomQuery = createQuery(
+    () => {
+      const serverId = activeServerId;
+      const connection = serverScope.connection;
+      const targetRoomId = roomId;
+      return {
+        queryKey: adminQueryKeys.room(serverId, connection, targetRoomId),
+        queryFn: ({ signal }) =>
+          connection.getAPI(createAdminRoomLayoutAPI).getRoom(targetRoomId, { signal }),
+        enabled: supportsAdminAPI
+      };
+    },
+    () => queryClient
+  );
+
+  const room = $derived(roomQuery.data ?? null);
   const canManageRoom = $derived(room?.canManageRoom ?? false);
   const canManagePermissions = $derived(room?.canManagePermissions ?? false);
   const supportsMemberManagement = $derived(
@@ -75,125 +105,105 @@
       ? resolve('/chat/[serverId]/manage/rooms', { serverId: serverSegment })
       : resolve('/chat/[serverId]/[roomId]', { serverId: serverSegment, roomId })
   );
-  const normalizedName = $derived(normalizeRoomName(name));
-  const nameError = $derived.by(() => {
-    if (!name) return undefined;
-    if (name.trim() === '') return m['admin.rooms_admin.room_name_empty']();
-    if (name !== name.trim()) return m['admin.rooms_admin.room_name_trim']();
-    if (!hasValidRoomNameCharacters(normalizedName)) {
-      return m['admin.rooms_admin.room_name_charset']();
-    }
-    if (roomNameCharacterCount(normalizedName) > ROOM_NAME_MAX_LENGTH) {
-      return m['admin.rooms_admin.room_name_too_long']();
-    }
-    return undefined;
-  });
-  const changed = $derived(
-    normalizedName !== originalName ||
-      description.trim() !== originalDescription ||
-      universal !== originalUniversal
+  const loading = $derived(supportsAdminAPI && roomQuery.isPending);
+  const classifiedLoadError = $derived(
+    roomQuery.error ? classifyManagementLoadError(roomQuery.error) : null
+  );
+  const accessDenied = $derived(
+    !supportsAdminAPI || classifiedLoadError?.kind === 'access-denied' || (!loading && !room)
+  );
+  const loadFailure = $derived(
+    classifiedLoadError?.kind === 'failure' ? classifiedLoadError.message : null
   );
 
-  function applyRoom(nextRoom: AdminManagedRoom): void {
-    room = nextRoom;
-    name = nextRoom.name;
-    description = nextRoom.description ?? '';
-    universal = nextRoom.isUniversal;
-    originalName = nextRoom.name;
-    originalDescription = nextRoom.description ?? '';
-    originalUniversal = nextRoom.isUniversal;
-  }
-
-  function isCurrentLoad(requestId: number, targetServerId: string, targetRoomId: string): boolean {
+  function isCurrentRoom(variables: RoomMutationScope | undefined): boolean {
     return (
+      variables !== undefined &&
       serverScope.isCurrent() &&
-      requestId === loadId &&
-      targetServerId === activeServerId &&
-      targetRoomId === roomId
+      variables.serverId === activeServerId &&
+      variables.connection.queryScope === serverScope.connection.queryScope &&
+      variables.roomId === roomId &&
+      variables.privacyGeneration === privacyGeneration
     );
   }
 
-  function isCurrentIdentity(target: {
-    serverId: string;
-    roomId: string;
-    identityGeneration: number;
-  }): boolean {
-    return (
-      serverScope.isCurrent() &&
-      target.serverId === activeServerId &&
-      target.roomId === roomId &&
-      target.identityGeneration === identityGeneration
-    );
+  function canApplyRoomSnapshot(variables: RoomMutationScope): boolean {
+    return isCurrentRoom(variables) && variables.snapshotGeneration === snapshotGeneration;
   }
 
-  async function loadRoom(
-    targetServerId: string,
-    targetRoomId: string,
-    preserveRoom = false
-  ): Promise<void> {
-    if (targetServerId !== serverScope.serverId) return;
-    const targetStore = serverScope.store;
-    const targetConnection = serverScope.connection;
-    const thisId = ++loadId;
-    if (!preserveRoom) {
-      loading = true;
-      room = null;
-      saving = false;
-    }
-    accessDenied = false;
-    loadFailure = null;
-    try {
-      const info = targetStore.serverInfo;
-      if (!info?.supportsFeature('adminApi')) {
-        accessDenied = true;
-        return;
+  const updateRoomMutation = createMutation(
+    () => ({
+      mutationFn: async ({ api, input }: RoomMutationScope) => {
+        const updated = await api.updateRoom(input);
+        if (!updated) throw new Error('Room update returned no room');
+        return updated;
+      },
+      onSuccess: (updated, variables) => {
+        if (!isCurrentRoom(variables)) return;
+        if (canApplyRoomSnapshot(variables)) {
+          queryClient.setQueryData<AdminManagedRoom | null>(variables.queryKey, (current) =>
+            current
+              ? {
+                  ...current,
+                  name: updated.name,
+                  description: updated.description || null,
+                  isUniversal: updated.universal,
+                  archived: updated.archived
+                }
+              : current
+          );
+        }
+        invalidateAdminRoomLayoutQueries(
+          variables.serverId,
+          variables.connection,
+          variables.roomId
+        );
+        void serverScope.store.adminRoomLayout.refresh();
+        formRevision += 1;
+        toast.success(m['admin.rooms_admin.room_updated']());
+      },
+      onError: (error, variables) => {
+        if (!isCurrentRoom(variables)) return;
+        toast.error(
+          m['admin.rooms_admin.update_room_failed']({
+            error: error instanceof Error ? error.message : String(error)
+          })
+        );
       }
-      const nextRoom: AdminManagedRoom | null = await targetConnection
-        .getAPI(createAdminRoomLayoutAPI)
-        .getRoom(targetRoomId);
-      if (!isCurrentLoad(thisId, targetServerId, targetRoomId)) return;
-      if (nextRoom) {
-        applyRoom(nextRoom);
-      } else {
-        accessDenied = true;
-      }
-    } catch (error) {
-      if (!isCurrentLoad(thisId, targetServerId, targetRoomId)) return;
-      const classified = classifyManagementLoadError(error);
-      if (classified.kind === 'access-denied') {
-        accessDenied = true;
-      } else {
-        loadFailure = classified.message;
-      }
-    } finally {
-      if (isCurrentLoad(thisId, targetServerId, targetRoomId)) loading = false;
-    }
-  }
+    }),
+    () => queryClient
+  );
 
-  $effect(() => {
-    const targetServerId = activeServerId;
-    const targetRoomId = roomId;
-    untrack(() => {
-      identityGeneration++;
-      saving = false;
-      void loadRoom(targetServerId, targetRoomId);
+  function saveGeneralSettings(input: ReturnType<typeof buildRoomSettingsUpdate>): void {
+    if (!canManageRoom || updateRoomMutation.isPending) return;
+    const connection = serverScope.connection;
+    updateRoomMutation.mutate({
+      serverId: activeServerId,
+      connection,
+      roomId,
+      queryKey: adminQueryKeys.room(activeServerId, connection, roomId),
+      api: connection.getAPI(createRoomCommandAPI),
+      privacyGeneration,
+      snapshotGeneration,
+      input
     });
-  });
+  }
 
   useProjectionEvent((event) => {
     for (const operation of event.operations) {
       switch (operation.operation.case) {
         case 'roomUpsert':
           if (operation.operation.value.room?.room?.id === roomId) {
-            void loadRoom(activeServerId, roomId, true);
+            snapshotGeneration += 1;
+            invalidateAdminRoomLayoutQueries(activeServerId, serverScope.connection, roomId);
             return;
           }
           break;
         case 'roomRemove':
           if (operation.operation.value.roomId === roomId) {
-            identityGeneration++;
-            saving = false;
-            void loadRoom(activeServerId, roomId);
+            snapshotGeneration += 1;
+            privacyGeneration += 1;
+            purgeAdminRoomQuery(activeServerId, serverScope.connection, roomId);
             return;
           }
           break;
@@ -201,53 +211,9 @@
     }
   });
 
-  async function saveGeneralSettings(event: SubmitEvent): Promise<void> {
-    event.preventDefault();
-    if (!canManageRoom || saving || nameError || !name.trim() || !changed) return;
-
-    const target = {
-      serverId: activeServerId,
-      roomId,
-      identityGeneration,
-      loadId
-    };
-    const update = buildRoomSettingsUpdate(
-      target.roomId,
-      { name, description, universal },
-      {
-        name: originalName,
-        description: originalDescription,
-        universal: originalUniversal
-      }
-    );
-    saving = true;
-    try {
-      const api = serverScope.connection.getAPI(createRoomCommandAPI);
-      const updated = await api.updateRoom(update);
-      if (!isCurrentIdentity(target)) return;
-      if (!updated) throw new Error('Room update returned no room');
-
-      if (target.loadId === loadId && room) {
-        applyRoom({
-          ...room,
-          name: updated.name,
-          description: updated.description || null,
-          isUniversal: updated.universal,
-          archived: updated.archived
-        });
-      }
-      toast.success(m['admin.rooms_admin.room_updated']());
-    } catch (error) {
-      if (!isCurrentIdentity(target)) return;
-      toast.error(
-        m['admin.rooms_admin.update_room_failed']({
-          error: error instanceof Error ? error.message : String(error)
-        })
-      );
-    } finally {
-      if (isCurrentIdentity(target)) saving = false;
-    }
-  }
+  const saving = $derived(
+    updateRoomMutation.isPending && isCurrentRoom(updateRoomMutation.variables)
+  );
 
   const pageTitle = $derived(
     room ? `#${room.name} · ${m['room_list.room_settings']()}` : m['room_list.room_settings']()
@@ -262,7 +228,7 @@
   <EmptyState icon="uil--exclamation-triangle" title={m['common.error.generic']()}>
     <div class="flex flex-col items-center gap-4">
       <p>{loadFailure}</p>
-      <Button variant="secondary" onclick={() => void loadRoom(activeServerId, roomId)}>
+      <Button variant="secondary" onclick={() => void roomQuery.refetch()}>
         {m['common.retry']()}
       </Button>
     </div>
@@ -285,42 +251,9 @@
     <PaneContent bind:scrollContainer>
       <div class="flex flex-col gap-6">
         {#if canManageRoom}
-          <Panel title={m['admin.nav.general']()} icon="iconify uil--setting">
-            <form class="flex max-w-2xl flex-col gap-4" onsubmit={saveGeneralSettings}>
-              <TextInput
-                id="room-settings-name"
-                label={m['rbac.role_form.name']()}
-                bind:value={name}
-                required
-                disabled={saving}
-                error={nameError}
-              />
-              <TextArea
-                id="room-settings-description"
-                label={m['rbac.role_form.description']()}
-                bind:value={description}
-                rows={3}
-                disabled={saving}
-                placeholder={m['admin.rooms_admin.room_description_placeholder']()}
-              />
-              <Checkbox
-                id="room-settings-universal"
-                bind:checked={universal}
-                disabled={saving}
-                label={m['admin.rooms_admin.universal_room']()}
-                description={UNIVERSAL_ROOM_HELP_TEXT}
-              />
-              <div class="flex justify-end">
-                <Button
-                  type="submit"
-                  loading={saving}
-                  disabled={!name.trim() || !!nameError || !changed}
-                >
-                  {m['admin.permissions.save_changes']()}
-                </Button>
-              </div>
-            </form>
-          </Panel>
+          {#key `${activeServerId}:${serverScope.connection.queryScope}:${room.id}:${formRevision}`}
+            <RoomGeneralSettingsPanel {room} {saving} onSave={saveGeneralSettings} />
+          {/key}
         {/if}
 
         {#if supportsMemberManagement}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomGeneralSettingsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomGeneralSettingsPanel.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { untrack } from 'svelte';
+  import type { AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
+  import { Panel } from '$lib/components/admin';
+  import { Button, Checkbox, TextArea, TextInput } from '$lib/ui/form';
+  import {
+    hasValidRoomNameCharacters,
+    normalizeRoomName,
+    ROOM_NAME_MAX_LENGTH,
+    roomNameCharacterCount
+  } from '$lib/utils/roomName';
+  import { UNIVERSAL_ROOM_HELP_TEXT } from '$lib/utils/roomCopy';
+  import { buildRoomSettingsUpdate } from './roomSettings';
+  import * as m from '$lib/i18n/messages';
+
+  let {
+    room,
+    saving,
+    onSave
+  }: {
+    room: AdminManagedRoom;
+    saving: boolean;
+    onSave: (update: ReturnType<typeof buildRoomSettingsUpdate>) => void;
+  } = $props();
+
+  // The parent keys this editor by room identity and successful save revision.
+  const originalName = untrack(() => room.name);
+  const originalDescription = untrack(() => room.description ?? '');
+  const originalUniversal = untrack(() => room.isUniversal);
+  let name = $state(originalName);
+  let description = $state(originalDescription);
+  let universal = $state(originalUniversal);
+
+  const normalizedName = $derived(normalizeRoomName(name));
+  const nameError = $derived.by(() => {
+    if (!name) return undefined;
+    if (name.trim() === '') return m['admin.rooms_admin.room_name_empty']();
+    if (name !== name.trim()) return m['admin.rooms_admin.room_name_trim']();
+    if (!hasValidRoomNameCharacters(normalizedName)) {
+      return m['admin.rooms_admin.room_name_charset']();
+    }
+    if (roomNameCharacterCount(normalizedName) > ROOM_NAME_MAX_LENGTH) {
+      return m['admin.rooms_admin.room_name_too_long']();
+    }
+    return undefined;
+  });
+  const changed = $derived(
+    normalizedName !== originalName ||
+      description.trim() !== originalDescription ||
+      universal !== originalUniversal
+  );
+
+  function save(event: SubmitEvent): void {
+    event.preventDefault();
+    if (saving || nameError || !name.trim() || !changed) return;
+    onSave(
+      buildRoomSettingsUpdate(
+        room.id,
+        { name, description, universal },
+        {
+          name: originalName,
+          description: originalDescription,
+          universal: originalUniversal
+        }
+      )
+    );
+  }
+</script>
+
+<Panel title={m['admin.nav.general']()} icon="iconify uil--setting">
+  <form class="flex max-w-2xl flex-col gap-4" onsubmit={save}>
+    <TextInput
+      id="room-settings-name"
+      label={m['rbac.role_form.name']()}
+      bind:value={name}
+      required
+      disabled={saving}
+      error={nameError}
+    />
+    <TextArea
+      id="room-settings-description"
+      label={m['rbac.role_form.description']()}
+      bind:value={description}
+      rows={3}
+      disabled={saving}
+      placeholder={m['admin.rooms_admin.room_description_placeholder']()}
+    />
+    <Checkbox
+      id="room-settings-universal"
+      bind:checked={universal}
+      disabled={saving}
+      label={m['admin.rooms_admin.universal_room']()}
+      description={UNIVERSAL_ROOM_HELP_TEXT}
+    />
+    <div class="flex justify-end">
+      <Button type="submit" loading={saving} disabled={!name.trim() || !!nameError || !changed}>
+        {m['admin.permissions.save_changes']()}
+      </Button>
+    </div>
+  </form>
+</Panel>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomGeneralSettingsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomGeneralSettingsPanel.svelte
@@ -24,12 +24,31 @@
   } = $props();
 
   // The parent keys this editor by room identity and successful save revision.
-  const originalName = untrack(() => room.name);
-  const originalDescription = untrack(() => room.description ?? '');
-  const originalUniversal = untrack(() => room.isUniversal);
-  let name = $state(originalName);
-  let description = $state(originalDescription);
-  let universal = $state(originalUniversal);
+  let originalName = $state(untrack(() => room.name));
+  let originalDescription = $state(untrack(() => room.description ?? ''));
+  let originalUniversal = $state(untrack(() => room.isUniversal));
+  let name = $state(untrack(() => room.name));
+  let description = $state(untrack(() => room.description ?? ''));
+  let universal = $state(untrack(() => room.isUniversal));
+
+  // Query snapshots may refresh while this editor is mounted. Adopt each remote
+  // field only when that field is pristine, preserving unrelated local edits.
+  $effect(() => {
+    const nextName = room.name;
+    const nextDescription = room.description ?? '';
+    const nextUniversal = room.isUniversal;
+    untrack(() => {
+      const nameWasPristine = name === originalName;
+      const descriptionWasPristine = description === originalDescription;
+      const universalWasPristine = universal === originalUniversal;
+      originalName = nextName;
+      originalDescription = nextDescription;
+      originalUniversal = nextUniversal;
+      if (nameWasPristine) name = nextName;
+      if (descriptionWasPristine) description = nextDescription;
+      if (universalWasPristine) universal = nextUniversal;
+    });
+  });
 
   const normalizedName = $derived(normalizeRoomName(name));
   const nameError = $derived.by(() => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -227,10 +227,9 @@ describe('room management page identity and realtime authority', () => {
 
   it('reconciles room rules and permissions after a realtime room update', async () => {
     mocks.getRoom.mockResolvedValueOnce(managedRoom('general')).mockResolvedValueOnce(
-      managedRoom('general', {
+      managedRoom('remote-name', {
         archived: true,
-        isUniversal: true,
-        canManageRoom: false
+        isUniversal: true
       })
     );
     const { container } = render(RoomManagementPage);
@@ -242,6 +241,9 @@ describe('room management page identity and realtime authority', () => {
 
     expect(container.querySelector('#room-member-picker')).toBeNull();
     expect(container.textContent).toContain('Membership is automatic in Universal rooms.');
+    expect((container.querySelector('#room-settings-name') as HTMLInputElement).value).toBe(
+      'remote-name'
+    );
   });
 
   it('reuses a fresh room snapshot and preserves a dirty draft across projection refreshes', async () => {
@@ -268,9 +270,10 @@ describe('room management page identity and realtime authority', () => {
     expect(first.container.textContent).toContain('Membership is automatic in Universal rooms.');
     first.unmount();
 
+    mocks.getRoom.mockResolvedValue(managedRoom('remote-name', { isUniversal: true }));
     const second = render(RoomManagementPage);
     await settle();
-    expect(mocks.getRoom).toHaveBeenCalledTimes(2);
+    expect(mocks.getRoom).toHaveBeenCalledTimes(3);
     expect((second.container.querySelector('#room-settings-name') as HTMLInputElement).value).toBe(
       'remote-name'
     );

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -11,6 +11,10 @@ import { Room } from '@chatto/api-types/api/v1/rooms_pb';
 import { RoomWithViewerState } from '@chatto/api-types/api/v1/room_directory_pb';
 import { loadLocaleMessages } from '$lib/i18n/messages';
 import { setReactiveLocale } from '$lib/i18n/state.svelte';
+import { queryClient } from '$lib/query/client';
+import { adminQueryKeys } from '$lib/query/admin';
+import { removeRegisteredAdminQueries } from '$lib/query/cacheRegistry';
+import type { AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
 import {
   roomManagementPageTestState,
   roomManagementTestPage
@@ -20,6 +24,9 @@ const mocks = vi.hoisted(() => ({
   getRoom: vi.fn(),
   projectionHandlers: [] as Array<(event: RealtimeProjectionEvent) => void>,
   updateRoom: vi.fn(),
+  refreshLayout: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
   serverVersion: '0.5.0'
 }));
 
@@ -59,6 +66,7 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
     get connection() {
       const serverId = roomManagementPageTestState.serverId;
       return {
+        queryScope: `${serverId}-query-scope`,
         getAPI: (factory: (config: never) => unknown) =>
           factory({
             serverId,
@@ -74,7 +82,8 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
             return mocks.serverVersion;
           },
           supportsFeature: () => mocks.serverVersion === '0.5.0'
-        }
+        },
+        adminRoomLayout: { refresh: mocks.refreshLayout }
       };
     },
     isCurrent: () => true
@@ -87,7 +96,8 @@ vi.mock('$lib/state/server/chromePermissions.svelte', () => ({
 
 vi.mock('$lib/api-client/adminRoomLayout', () => ({
   createAdminRoomLayoutAPI: ({ serverId }: { serverId: string }) => ({
-    getRoom: (roomId: string) => mocks.getRoom(serverId, roomId)
+    getRoom: (roomId: string, options?: { signal?: AbortSignal }) =>
+      mocks.getRoom(serverId, roomId, options)
   })
 }));
 
@@ -109,6 +119,10 @@ vi.mock('$lib/api-client/rooms', () => ({
 
 vi.mock('$lib/components/rbac/PermissionMatrix.svelte', async () => ({
   default: (await import('./RoomManagementPagePermissionMatrixMock.svelte')).default
+}));
+
+vi.mock('$lib/ui/toast', () => ({
+  toast: { success: mocks.success, error: mocks.error }
 }));
 
 import RoomManagementPage from './+page.svelte';
@@ -168,9 +182,11 @@ function roomUpsert(): RealtimeProjectionOperation {
 
 describe('room management page identity and realtime authority', () => {
   beforeEach(async () => {
+    queryClient.clear();
     vi.clearAllMocks();
     mocks.projectionHandlers = [];
     mocks.serverVersion = '0.5.0';
+    mocks.refreshLayout.mockResolvedValue(undefined);
     mocks.updateRoom.mockResolvedValue({
       id: 'shared-room',
       name: 'general',
@@ -200,7 +216,11 @@ describe('room management page identity and realtime authority', () => {
     flushSync();
     await settle();
 
-    expect(mocks.getRoom).toHaveBeenCalledWith('server-b', 'shared-room');
+    expect(mocks.getRoom).toHaveBeenCalledWith(
+      'server-b',
+      'shared-room',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
     expect(container.textContent).toContain('#beta');
     expect(container.textContent).not.toContain('#alpha');
   });
@@ -222,6 +242,38 @@ describe('room management page identity and realtime authority', () => {
 
     expect(container.querySelector('#room-member-picker')).toBeNull();
     expect(container.textContent).toContain('Membership is automatic in Universal rooms.');
+  });
+
+  it('reuses a fresh room snapshot and preserves a dirty draft across projection refreshes', async () => {
+    mocks.getRoom.mockResolvedValueOnce(managedRoom('general')).mockResolvedValueOnce(
+      managedRoom('remote-name', {
+        isUniversal: true
+      })
+    );
+    const first = render(RoomManagementPage);
+    await settle();
+
+    const nameInput = first.container.querySelector('#room-settings-name') as HTMLInputElement;
+    nameInput.value = 'local-draft';
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+
+    dispatchProjection(roomUpsert());
+    await vi.waitFor(() => expect(mocks.getRoom).toHaveBeenCalledTimes(2));
+    await settle();
+
+    expect((first.container.querySelector('#room-settings-name') as HTMLInputElement).value).toBe(
+      'local-draft'
+    );
+    expect(first.container.textContent).toContain('Membership is automatic in Universal rooms.');
+    first.unmount();
+
+    const second = render(RoomManagementPage);
+    await settle();
+    expect(mocks.getRoom).toHaveBeenCalledTimes(2);
+    expect((second.container.querySelector('#room-settings-name') as HTMLInputElement).value).toBe(
+      'remote-name'
+    );
   });
 
   it('hides member management on servers that predate the room-management API', async () => {
@@ -331,5 +383,45 @@ describe('room management page identity and realtime authority', () => {
     expect(
       (container.querySelector('form button[type="submit"]') as HTMLButtonElement).disabled
     ).toBe(false);
+  });
+
+  it('does not restore a room snapshot after an admin-cache privacy boundary', async () => {
+    const pendingSave = deferred<{
+      id: string;
+      name: string;
+      description: string;
+      universal: boolean;
+      archived: boolean;
+    }>();
+    mocks.getRoom.mockResolvedValue(managedRoom('general'));
+    mocks.updateRoom.mockReturnValueOnce(pendingSave.promise);
+    const view = render(RoomManagementPage);
+    await settle();
+
+    const input = view.container.querySelector('#room-settings-name') as HTMLInputElement;
+    input.value = 'private-name';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    (view.container.querySelector('form button[type="submit"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.updateRoom).toHaveBeenCalledOnce());
+
+    removeRegisteredAdminQueries('server-a');
+    view.unmount();
+    pendingSave.resolve({
+      id: 'shared-room',
+      name: 'private-name',
+      description: '',
+      universal: false,
+      archived: false
+    });
+    await settle();
+
+    const queryKey = adminQueryKeys.room(
+      'server-a',
+      { queryScope: 'server-a-query-scope' },
+      'shared-room'
+    );
+    expect(queryClient.getQueryData<AdminManagedRoom>(queryKey)?.name).not.toBe('private-name');
+    expect(mocks.success).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Why

Room and room-group management still owned snapshot fetching, refresh, and mutation lifecycle by hand. Moving these high-value admin detail views onto the shared TanStack Query boundary gives them consistent session-scoped caching, cancellation, projection reconciliation, and privacy cleanup while preserving editable drafts.

## What changed

- Added session-scoped query keys and cancellable room/room-group detail API reads.
- Converted both management pages to query-backed snapshots and fenced settings mutations.
- Reconciled realtime projection updates across every registered session cache, including inactive routes.
- Purged room/group detail and permission-tier data when access disappears, including permission caches whose detail query has already expired.
- Kept dirty form fields local while allowing pristine fields to adopt refreshed server values.
- Added mounted page, cache lifecycle, projection-ordering, removal, and AbortSignal coverage.

This is an internal frontend refactor. It changes no public API, persistence contract, user-facing copy, migration, or deployment behavior. ADR-062 already defines the incremental TanStack Query boundary used here.

## Test plan

- `mise test-frontend` — passed after merging latest `main`: 322 files, 2,687 tests.
- `mise lint-frontend` — passed: Svelte check 0 errors/0 warnings and ESLint clean.
- `mise build-frontend` — passed after merging latest `main`; all bundle budgets passed (login 266.7/290 KiB, overview 292.4/325 KiB, room 464.7/510 KiB).
- `mise x -- pnpm exec playwright test e2e/room-layout.test.ts -g 'admin can create, rename, and delete sections' --retries=0` — passed.
- `mise license-check` — passed: 2,620/2,620 files compliant.
- Svelte autofixer — no issues in changed Svelte components/modules; expected cautions only for the deliberate external-snapshot/draft synchronization effects.
- Two adversarial review passes completed; the second found no significant actionable issues.
