### PR TITLE
refactor(frontend): separate quick switcher state

### DIFF
--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte
@@ -1,428 +1,14 @@
 <script lang="ts">
-  import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
-  import { goto } from '$app/navigation';
-  import { resolve } from '$app/paths';
   import { untrack } from 'svelte';
-  import { scoreItem } from './quickSwitcherSearch';
-  import { serverIdToSegment } from '$lib/navigation';
-  import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
+  import * as m from '$lib/i18n/messages';
+  import { quickSwitcher } from '$lib/state/globals.svelte';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
   import { getAvatarInitials } from '$lib/utils/initials';
   import { getGradientForName } from '$lib/utils/gradients';
-  import { buildDirectMessagePresentation } from '$lib/render/users';
-  import { buildMessageLinkPath } from '$lib/messageLinks';
-  import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
-  import { quickSwitcher } from '$lib/state/globals.svelte';
-  import { useDebounce } from '$lib/hooks/useDebounce.svelte';
+  import { QuickSwitcherModel, type QuickSwitcherAvatarUser } from './quickSwitcherModel.svelte';
 
-  import { isNavigationVisibleRoom } from '$lib/state/server/rooms.svelte';
-  import * as m from '$lib/i18n/messages';
-  import { toast } from '$lib/ui/toast';
-  import { createRoomCommandAPI } from '$lib/api-client/rooms';
-  import { createMemberDirectoryAPI, type DirectoryMember } from '$lib/api-client/memberDirectory';
-  import {
-    createMessageSearchAPI,
-    MessageSearchOrder,
-    type MessageSearchResult
-  } from '$lib/api-client/messageSearch';
-
-  type ServerLogo = { name: string; logoUrl?: string | null };
-  type AvatarUser = Pick<DirectoryMember, 'id' | 'login' | 'displayName' | 'deleted'> & {
-    avatarUrl?: string | null;
-  };
-
-  type ResultItem = {
-    kind: 'room' | 'dm' | 'destination' | 'server' | 'user' | 'message';
-    id: string;
-    label: string;
-    detail: string;
-    serverId: string;
-    serverName: string;
-    serverLogo?: ServerLogo;
-    participants?: AvatarUser[];
-    currentUserId?: string;
-    targetUserId?: string;
-    href?: string;
-    icon?: string;
-    message?: MessageSearchResult;
-    score: number;
-  };
-
-  const MESSAGE_SEARCH_SERVER_TIMEOUT_MS = 3_000;
-
-  let query = $state('');
-  let selectedIndex = $state(0);
-  let userSearchLoading = $state(false);
-  let messageSearchLoading = $state(false);
-  let allItems = $state.raw<ResultItem[]>([]);
-  let userItems = $state.raw<ResultItem[]>([]);
-  let messageItems = $state.raw<ResultItem[]>([]);
+  const model = new QuickSwitcherModel();
   let dialogEl: HTMLDialogElement | undefined;
-  let inputEl: HTMLInputElement | undefined;
-  const userSearchDebounce = useDebounce();
-  const messageSearchDebounce = useDebounce();
-  let userSearchRequestId = 0;
-  let messageSearchRequestId = 0;
-  let messageSearchServerKey = '';
-
-  // --- Data loading ---
-
-  function loadAll() {
-    const instances = serverRegistry.servers;
-    const multiInstance = instances.length > 1;
-    const items: ResultItem[] = [];
-
-    for (const instance of instances) {
-      const store = serverRegistry.tryGetStore(instance.id);
-      const serverName = store?.serverInfo.name || instance.name || getHostname(instance.url);
-      const serverLabel = multiInstance ? serverName : '';
-      const currentUserId = store?.currentUser.user?.id ?? undefined;
-      const logo: ServerLogo = {
-        name: serverName,
-        logoUrl: store?.serverInfo.iconUrl ?? null
-      };
-
-      items.push({
-        kind: 'server',
-        id: `server-${instance.id}`,
-        label: logo.name,
-        detail: '',
-        serverId: instance.id,
-        serverName: logo.name,
-        serverLogo: logo,
-        href: resolve('/chat/[serverId]/overview', { serverId: serverIdToSegment(instance.id) }),
-        score: 0
-      });
-
-      for (const room of store?.navigation.rooms ?? []) {
-        if (room.type === RoomKind.DM) {
-          if (!isNavigationVisibleRoom(room)) continue;
-          const participants = room.members.map(avatarUser);
-          const presentation = buildDirectMessagePresentation(
-            participants,
-            currentUserId,
-            m['common.you']()
-          );
-          items.push({
-            kind: 'dm',
-            id: room.id,
-            label: presentation.label,
-            detail: serverLabel,
-            serverId: instance.id,
-            serverName,
-            participants: presentation.visibleParticipants.slice(0, 2),
-            score: 0
-          });
-          continue;
-        }
-
-        if (!room.viewerIsMember) continue;
-        items.push({
-          kind: 'room',
-          id: room.id,
-          label: room.name,
-          detail: serverLabel || logo.name,
-          serverId: instance.id,
-          serverName,
-          serverLogo: logo,
-          score: 0
-        });
-      }
-    }
-
-    items.push({
-      kind: 'destination',
-      id: 'notifications',
-      label: m['ui.notifications'](),
-      detail: '',
-      serverId: '',
-      serverName: '',
-      href: resolve('/chat/notifications'),
-      icon: 'uil--bell',
-      score: 0
-    });
-
-    allItems = items;
-    selectedIndex = 0;
-  }
-
-  function scheduleUserSearch(raw: string) {
-    userSearchDebounce.cancel();
-
-    const search = raw.trim();
-    const requestId = ++userSearchRequestId;
-
-    if (!quickSwitcher.visible || !search || search.startsWith('#') || search.startsWith('?')) {
-      userItems = [];
-      userSearchLoading = false;
-      return;
-    }
-
-    userSearchLoading = true;
-    userSearchDebounce.run(() => {
-      void loadUserResults(search, requestId);
-    }, 200);
-  }
-
-  function scheduleMessageSearch(raw: string) {
-    messageSearchDebounce.cancel();
-
-    const trimmed = raw.trim();
-    const search = trimmed.startsWith('?') ? trimmed.slice(1).trim() : '';
-    const requestId = ++messageSearchRequestId;
-
-    if (!quickSwitcher.visible || !search) {
-      messageItems = [];
-      messageSearchLoading = false;
-      return;
-    }
-
-    messageSearchLoading = true;
-    messageSearchDebounce.run(() => {
-      void loadMessageResults(search, requestId);
-    }, 200);
-  }
-
-  function handleQueryInput(e: Event) {
-    const value = (e.currentTarget as HTMLInputElement).value;
-    query = value;
-    selectedIndex = 0;
-    scheduleUserSearch(value);
-    scheduleMessageSearch(value);
-  }
-
-  async function loadUserResults(search: string, requestId: number) {
-    const instances = serverRegistry.servers;
-    const multiInstance = instances.length > 1;
-    const items: ResultItem[] = [];
-
-    await Promise.allSettled(
-      instances.map(async (instance) => {
-        const serverConnection = serverConnectionManager.getClient(instance.id);
-        const store = serverRegistry.tryGetStore(instance.id);
-        const serverName = store?.serverInfo.name || instance.name || getHostname(instance.url);
-        const serverLabel = multiInstance ? serverName : '';
-
-        if (!store?.permissions.canStartDMs) return;
-
-        const currentUserId = store.currentUser.user?.id ?? undefined;
-        const api = serverConnection.getAPI(createMemberDirectoryAPI);
-        const result = await api.listUsers(search, 20, 0);
-        for (const member of result.members) {
-          const user = avatarUser(member);
-          items.push({
-            kind: 'user',
-            id: user.id,
-            label: user.displayName || user.login,
-            detail: [user.login ? `@${user.login}` : '', serverLabel].filter(Boolean).join(' · '),
-            serverId: instance.id,
-            serverName,
-            participants: [user],
-            currentUserId,
-            targetUserId: user.id,
-            score: 0
-          });
-        }
-      })
-    );
-
-    if (requestId !== userSearchRequestId) return;
-    userItems = items;
-    selectedIndex = 0;
-    userSearchLoading = false;
-  }
-
-  async function loadMessageResults(search: string, requestId: number) {
-    const instances = [...serverRegistry.servers];
-    const resultsByServer: Record<string, ResultItem[]> = {};
-
-    function publish(serverId: string, items: ResultItem[]) {
-      if (requestId !== messageSearchRequestId) return;
-      if (!serverRegistry.servers.some((instance) => instance.id === serverId)) return;
-      const selected = messageItems[selectedIndex];
-      resultsByServer[serverId] = items;
-      const accumulated = Object.values(resultsByServer)
-        .flat()
-        .sort(
-          (a, b) =>
-            b.score - a.score ||
-            (b.message?.createdAt ?? '').localeCompare(a.message?.createdAt ?? '') ||
-            a.id.localeCompare(b.id)
-        );
-      messageItems = accumulated;
-      const preservedIndex = selected
-        ? accumulated.findIndex(
-            (item) => item.serverId === selected.serverId && item.id === selected.id
-          )
-        : -1;
-      selectedIndex = preservedIndex >= 0 ? preservedIndex : 0;
-    }
-
-    const searches = instances.map(async (instance): Promise<ResultItem[]> => {
-      const store = serverRegistry.tryGetStore(instance.id);
-      if (!store?.serverInfo.supportsFeature('messageSearch')) return [];
-
-      await store.messageSearch.ensureStatus();
-      if (!store.messageSearch.available) return [];
-
-      const serverName = store.serverInfo.name || instance.name || getHostname(instance.url);
-      const api = serverConnectionManager.getClient(instance.id).getAPI(createMessageSearchAPI);
-      try {
-        const page = await api.searchMessages({
-          query: search,
-          order: MessageSearchOrder.RELEVANCE,
-          pageSize: 10
-        });
-        return page.results.map((message) => ({
-          kind: 'message',
-          id: message.id,
-          label: message.body,
-          detail: [
-            message.actor?.displayName || message.actor?.login,
-            message.roomName ? `#${message.roomName}` : null,
-            serverName
-          ]
-            .filter(Boolean)
-            .join(' · '),
-          serverId: instance.id,
-          serverName,
-          message,
-          score: message.relevanceScore
-        }));
-      } catch {
-        return [];
-      }
-    });
-    const boundedSearches = searches.map((searchPromise) =>
-      resolveWithin(searchPromise, MESSAGE_SEARCH_SERVER_TIMEOUT_MS, [])
-    );
-
-    boundedSearches.forEach((searchPromise, index) => {
-      const serverId = instances[index]!.id;
-      void searchPromise.then(
-        (items) => publish(serverId, items),
-        () => publish(serverId, [])
-      );
-    });
-
-    await Promise.all(boundedSearches);
-
-    if (requestId !== messageSearchRequestId) return;
-    messageSearchLoading = false;
-  }
-
-  function resolveWithin<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
-    return new Promise((resolve) => {
-      let settled = false;
-      const timeout = setTimeout(() => {
-        settled = true;
-        resolve(fallback);
-      }, timeoutMs);
-      void promise.then(
-        (value) => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          resolve(value);
-        },
-        () => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timeout);
-          resolve(fallback);
-        }
-      );
-    });
-  }
-
-  function getHostname(url: string): string {
-    try {
-      return new URL(url).hostname;
-    } catch {
-      return url;
-    }
-  }
-
-  // --- Filtering ---
-
-  let filtered = $derived.by(() => {
-    const raw = query.trim();
-    const recentUrls = recentQuickSwitcher.urls;
-    const recentSet = new Set(recentUrls);
-    const searchableItems = [...allItems.filter((item) => item.kind !== 'dm'), ...userItems];
-
-    if (raw.startsWith('?')) return messageItems;
-
-    if (!raw) {
-      // Split into recent and non-recent groups
-      const recent: ResultItem[] = [];
-      const rest: ResultItem[] = [];
-
-      for (const item of allItems) {
-        const url = itemUrl(item);
-        if (url && recentSet.has(url)) {
-          recent.push(item);
-        } else {
-          rest.push(item);
-        }
-      }
-
-      // Sort recents by their recency order
-      recent.sort((a, b) => {
-        const ai = recentUrls.indexOf(itemUrl(a)!);
-        const bi = recentUrls.indexOf(itemUrl(b)!);
-        return ai - bi;
-      });
-
-      // Sort rest by kind then alphabetically
-      const kindOrder: Record<ResultItem['kind'], number> = {
-        destination: 0,
-        server: 1,
-        room: 2,
-        dm: 3,
-        user: 4,
-        message: 5
-      };
-      rest.sort((a, b) => kindOrder[a.kind] - kindOrder[b.kind] || a.label.localeCompare(b.label));
-
-      return [...recent, ...rest];
-    }
-
-    const isChannelFilter = raw.startsWith('#');
-    const q = isChannelFilter ? raw.slice(1) : raw;
-    const pool = isChannelFilter
-      ? allItems.filter((item) => item.kind === 'room')
-      : searchableItems;
-
-    if (isChannelFilter && !q) {
-      return [...pool].sort((a, b) => a.label.localeCompare(b.label));
-    }
-
-    // Multi-token fuzzy match across label, detail, and server name.
-    const scored: ResultItem[] = [];
-    for (const item of pool) {
-      const matchScore = scoreItem(q, item);
-      if (matchScore === null) continue;
-
-      let best = matchScore;
-      // Boost recent destinations
-      const url = itemUrl(item);
-      if (url) {
-        const recentIndex = recentUrls.indexOf(url);
-        if (recentIndex !== -1) {
-          best += 300 - recentIndex * 20;
-        }
-      }
-      scored.push({ ...item, score: best });
-    }
-
-    scored.sort((a, b) => b.score - a.score);
-
-    return scored;
-  });
-
-  // --- Visibility ---
 
   function syncQuickSwitcherDialog(node: HTMLDialogElement) {
     dialogEl = node;
@@ -430,212 +16,44 @@
 
     untrack(() => {
       if (visible) {
-        query = '';
-        selectedIndex = 0;
-        allItems = [];
-        userItems = [];
-        messageItems = [];
-        scheduleUserSearch('');
-        scheduleMessageSearch('');
+        model.activate();
         if (!node.open) node.showModal();
       } else {
-        userSearchDebounce.cancel();
-        messageSearchDebounce.cancel();
-        userItems = [];
-        messageItems = [];
-        userSearchLoading = false;
-        messageSearchLoading = false;
-        userSearchRequestId++;
-        messageSearchRequestId++;
+        model.deactivate();
         if (node.open) node.close();
       }
     });
   }
 
-  // Rebuild from the canonical per-server room stores when the switcher opens or a store refreshes.
-  $effect(() => {
-    if (!quickSwitcher.visible) return;
-    void serverRegistry.servers;
-    for (const instance of serverRegistry.servers) {
-      const store = serverRegistry.tryGetStore(instance.id);
-      void store?.navigation.rooms;
-      void store?.navigation.isInitialLoading;
-    }
-    untrack(loadAll);
-  });
-
-  // Purge and fence the palette's transient plaintext through the same
-  // realtime privacy invalidations as each server's dedicated Search state.
-  $effect(() => {
-    if (!quickSwitcher.visible) return;
-    const instances = serverRegistry.servers;
-    const serverKey = instances.map((instance) => instance.id).join('\0');
-    const stores = instances.flatMap((instance) => {
-      const store = serverRegistry.tryGetStore(instance.id);
-      return store ? [{ serverId: instance.id, store }] : [];
-    });
-    const unsubscribes = untrack(() => {
-      if (messageSearchServerKey && messageSearchServerKey !== serverKey) {
-        messageItems = [];
-        scheduleMessageSearch(query);
-      }
-      messageSearchServerKey = serverKey;
-      return stores.map(({ serverId, store }) =>
-        store.messageSearch.subscribePrivacyInvalidation((matches, force) => {
-          if (!quickSwitcher.visible) return;
-          const affected = messageItems.some(
-            (item) => item.serverId === serverId && item.message && matches(item.message)
-          );
-          if (force || affected) messageItems = [];
-          scheduleMessageSearch(query);
-        })
-      );
-    });
-    return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
-  });
+  // Rebuild from the canonical per-server room stores while the switcher is open.
+  $effect(() => model.syncCatalog());
+  // Fence transient message plaintext at every server's search privacy boundary.
+  $effect(() => model.syncPrivacy());
 
   function registerInput(node: HTMLInputElement) {
-    inputEl = node;
     queueMicrotask(() => node.focus());
-    return () => {
-      if (inputEl === node) inputEl = undefined;
-    };
   }
 
-  // --- Navigation ---
-
-  function itemUrl(item: ResultItem): string | undefined {
-    if ((item.kind === 'destination' || item.kind === 'server') && item.href) return item.href;
-    if (item.kind === 'dm' || item.kind === 'room') {
-      return resolve('/chat/[serverId]/[roomId]', {
-        serverId: serverIdToSegment(item.serverId),
-        roomId: item.id
-      });
-    }
-    if (item.kind === 'message' && item.message) {
-      return buildMessageLinkPath(
-        item.serverId,
-        item.message.roomId,
-        item.message.id,
-        item.message.threadRootEventId
-      );
-    }
-    return undefined;
-  }
-
-  async function startDMFromUser(item: ResultItem) {
-    if (!item.targetUserId) throw new Error('Missing DM target');
-
-    const conn = serverConnectionManager.getClient(item.serverId);
-    const room = await conn
-      .getAPI(createRoomCommandAPI)
-      .startDM(item.targetUserId === item.currentUserId ? [] : [item.targetUserId]);
-
-    const roomId = room?.id;
-    if (!roomId) throw new Error('Failed to start DM');
-
-    return roomId;
-  }
-
-  async function select(item: ResultItem) {
-    quickSwitcher.close();
-
-    if (item.kind === 'user') {
-      try {
-        const roomId = await startDMFromUser(item);
-        const url = resolve('/chat/[serverId]/[roomId]', {
-          serverId: serverIdToSegment(item.serverId),
-          roomId
-        });
-        recentQuickSwitcher.record(url);
-        goto(url);
-      } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Failed to start DM');
-      }
-      return;
-    }
-
-    const url = itemUrl(item);
-    if (!url) return;
-    if (item.kind !== 'message') recentQuickSwitcher.record(url);
-
-    // eslint-disable-next-line svelte/no-navigation-without-resolve -- itemUrl() returns resolved app routes
-    goto(url);
-  }
-
-  // --- Keyboard ---
-
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault();
-      selectedIndex = Math.min(selectedIndex + 1, filtered.length - 1);
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      model.moveSelection(event.key === 'ArrowDown' ? 1 : -1);
       scrollSelectedIntoView();
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault();
-      selectedIndex = Math.max(selectedIndex - 1, 0);
-      scrollSelectedIntoView();
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      const item = filtered[selectedIndex];
-      if (item) select(item);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      model.selectCurrent();
     }
   }
 
   function scrollSelectedIntoView() {
     requestAnimationFrame(() => {
-      const el = dialogEl?.querySelector(`[data-index="${selectedIndex}"]`);
-      el?.scrollIntoView({ block: 'nearest' });
+      const selected = dialogEl?.querySelector(`[data-index="${model.selectedIndex}"]`);
+      selected?.scrollIntoView({ block: 'nearest' });
     });
-  }
-
-  // --- Kind labels ---
-
-  const kindLabels = $derived<Record<ResultItem['kind'], string>>({
-    destination: m['quick_switcher.kind.destination'](),
-    server: m['quick_switcher.kind.server'](),
-    room: m['quick_switcher.kind.room'](),
-    dm: m['quick_switcher.kind.dm'](),
-    user: m['quick_switcher.kind.user'](),
-    message: m['quick_switcher.kind.message']()
-  });
-
-  function isRecent(item: ResultItem): boolean {
-    const url = itemUrl(item);
-    return url !== undefined && recentQuickSwitcher.urls.includes(url);
-  }
-
-  function showGroupHeader(index: number): string | null {
-    if (query.trim()) return null;
-    const item = filtered[index];
-    if (!item) return null;
-    const prev = index > 0 ? filtered[index - 1] : null;
-    const itemIsRecent = isRecent(item);
-    const prevIsRecent = prev ? isRecent(prev) : false;
-
-    // Transition from recent to non-recent section
-    if (!itemIsRecent && (index === 0 || prevIsRecent)) return kindLabels[item.kind];
-    // First item or kind change within non-recent section
-    if (itemIsRecent && (index === 0 || !prevIsRecent)) return m['quick_switcher.recent']();
-    if (!itemIsRecent && prev && prev.kind !== item.kind) return kindLabels[item.kind];
-    return null;
-  }
-
-  function userAvatarParticipant(item: ResultItem): AvatarUser | null {
-    return item.participants?.[0] ?? null;
-  }
-
-  function avatarUser(user: AvatarUser): AvatarUser {
-    return {
-      id: user.id,
-      login: user.login,
-      displayName: user.displayName,
-      deleted: user.deleted,
-      avatarUrl: user.avatarUrl ?? null
-    };
   }
 </script>
 
-{#snippet avatar(user: AvatarUser)}
+{#snippet avatar(user: QuickSwitcherAvatarUser)}
   {#if user.avatarUrl}
     <SkeletonImg
       loading="lazy"
@@ -657,15 +75,15 @@
 <dialog
   {@attach syncQuickSwitcherDialog}
   onclose={() => quickSwitcher.close()}
-  onkeydown={(e) => {
-    if (e.key === 'Escape') e.stopPropagation();
+  onkeydown={(event) => {
+    if (event.key === 'Escape') event.stopPropagation();
   }}
-  oncancel={(e) => {
-    e.preventDefault();
+  oncancel={(event) => {
+    event.preventDefault();
     quickSwitcher.close();
   }}
-  onclick={(e) => {
-    if (e.target === dialogEl) quickSwitcher.close();
+  onclick={(event) => {
+    if (event.target === dialogEl) quickSwitcher.close();
   }}
   class="quick-switcher m-auto mt-[15vh] max-h-none max-w-none overflow-visible border-none bg-transparent p-0 text-inherit backdrop:bg-black/50"
 >
@@ -673,40 +91,38 @@
     <div
       class="flex w-140 max-w-[90vw] flex-col gap-1 rounded-lg border border-text/10 bg-surface p-1 text-sm shadow-xl"
     >
-      <!-- Search section -->
       <div class="menu-section">
         <div class="flex items-center gap-2 px-3 py-1.5">
           <span class="sidebar-icon iconify text-muted uil--search"></span>
           <input
             {@attach registerInput}
-            bind:value={query}
-            oninput={handleQueryInput}
+            value={model.query}
+            oninput={(event) => model.setQuery(event.currentTarget.value)}
             onkeydown={handleKeydown}
             type="text"
             placeholder={m['quick_switcher.placeholder']()}
             class="flex-1 bg-transparent text-text outline-none placeholder:text-muted"
           />
-          {#if userSearchLoading || messageSearchLoading}
+          {#if model.loading}
             <span class="sidebar-icon iconify animate-spin text-muted uil--spinner-alt"></span>
           {/if}
           <kbd class="rounded border border-text/10 px-1.5 py-0.5 text-xs text-muted">Esc</kbd>
         </div>
       </div>
 
-      <!-- Results section -->
       <div class="max-h-80 overflow-y-auto menu-section">
         <nav class="sidebar-nav">
-          {#if filtered.length === 0 && !userSearchLoading && !messageSearchLoading}
+          {#if model.filtered.length === 0 && !model.loading}
             <p class="px-3 py-6 text-center text-muted">
-              {query.trim() === '?'
+              {model.query.trim() === '?'
                 ? m['quick_switcher.message_search.prompt']()
-                : query.trim().startsWith('?')
+                : model.query.trim().startsWith('?')
                   ? m['quick_switcher.message_search.no_results']()
                   : m['quick_switcher.no_results']()}
             </p>
           {:else}
-            {#each filtered as item, i (`${item.serverId}:${item.kind}:${item.id}`)}
-              {@const header = showGroupHeader(i)}
+            {#each model.filtered as item, index (`${item.serverId}:${item.kind}:${item.id}`)}
+              {@const header = model.groupHeader(index)}
 
               {#if header}
                 <div class="px-3 pt-2 pb-0.5 text-xs font-medium text-muted uppercase">
@@ -715,15 +131,15 @@
               {/if}
 
               <button
-                data-index={i}
+                data-index={index}
                 type="button"
                 class={[
                   'sidebar-item text-left',
                   item.kind === 'message' ? 'items-start px-2 py-2' : '',
-                  i === selectedIndex ? 'bg-surface' : ''
+                  index === model.selectedIndex ? 'bg-surface' : ''
                 ]}
-                onclick={() => select(item)}
-                onpointerenter={() => (selectedIndex = i)}
+                onclick={() => model.select(item)}
+                onpointerenter={() => model.selectIndex(index)}
               >
                 {#if item.kind === 'message'}
                   <span
@@ -732,7 +148,7 @@
                 {:else if item.kind === 'destination' && item.icon}
                   <span class="sidebar-icon iconify text-muted {item.icon}"></span>
                 {:else if item.kind === 'user'}
-                  {@const user = userAvatarParticipant(item)}
+                  {@const user = item.participants?.[0] ?? null}
                   <span class="sidebar-icon">
                     {#if user}
                       {@render avatar(user)}
@@ -742,11 +158,11 @@
                   </span>
                 {:else if item.kind === 'dm' && item.participants}
                   <span class="sidebar-icon">
-                    <div class="flex -space-x-2">
+                    <span class="flex -space-x-2">
                       {#each item.participants as participant (participant.id)}
                         {@render avatar(participant)}
                       {/each}
-                    </div>
+                    </span>
                   </span>
                 {:else if item.serverLogo}
                   {@const logo = item.serverLogo}
@@ -789,8 +205,8 @@
                   </span>
                 {/if}
 
-                {#if !query.trim()}
-                  <span class="shrink-0 text-xs text-muted">{kindLabels[item.kind]}</span>
+                {#if !model.query.trim()}
+                  <span class="shrink-0 text-xs text-muted">{model.kindLabels[item.kind]}</span>
                 {/if}
               </button>
             {/each}

--- a/apps/frontend/src/lib/components/quickSwitcherModel.svelte.ts
+++ b/apps/frontend/src/lib/components/quickSwitcherModel.svelte.ts
@@ -1,0 +1,578 @@
+import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { goto } from '$app/navigation';
+import { resolve } from '$app/paths';
+import { untrack } from 'svelte';
+import { SvelteSet } from 'svelte/reactivity';
+import { createMemberDirectoryAPI, type DirectoryMember } from '$lib/api-client/memberDirectory';
+import {
+  createMessageSearchAPI,
+  MessageSearchOrder,
+  type MessageSearchResult
+} from '$lib/api-client/messageSearch';
+import { createRoomCommandAPI } from '$lib/api-client/rooms';
+import { useDebounce } from '$lib/hooks/useDebounce.svelte';
+import * as m from '$lib/i18n/messages';
+import { buildMessageLinkPath } from '$lib/messageLinks';
+import { serverIdToSegment } from '$lib/navigation';
+import { buildDirectMessagePresentation } from '$lib/render/users';
+import { quickSwitcher } from '$lib/state/globals.svelte';
+import { recentQuickSwitcher } from '$lib/state/recentQuickSwitcher.svelte';
+import { serverRegistry } from '$lib/state/server/registry.svelte';
+import { isNavigationVisibleRoom } from '$lib/state/server/rooms.svelte';
+import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
+import { toast } from '$lib/ui/toast';
+import { scoreItem } from './quickSwitcherSearch';
+
+export type QuickSwitcherAvatarUser = Pick<
+  DirectoryMember,
+  'id' | 'login' | 'displayName' | 'deleted'
+> & {
+  avatarUrl?: string | null;
+};
+
+type ServerLogo = { name: string; logoUrl?: string | null };
+
+export type QuickSwitcherItem = {
+  kind: 'room' | 'dm' | 'destination' | 'server' | 'user' | 'message';
+  id: string;
+  label: string;
+  detail: string;
+  serverId: string;
+  serverName: string;
+  serverLogo?: ServerLogo;
+  participants?: QuickSwitcherAvatarUser[];
+  currentUserId?: string;
+  targetUserId?: string;
+  href?: string;
+  icon?: string;
+  message?: MessageSearchResult;
+  score: number;
+};
+
+const SEARCH_DEBOUNCE_MS = 200;
+const MESSAGE_SEARCH_SERVER_TIMEOUT_MS = 3_000;
+
+class SearchChannel<T> {
+  items = $state.raw<T[]>([]);
+  loading = $state(false);
+
+  #requestId = 0;
+  #debounce = useDebounce();
+
+  schedule(query: string | null, load: (query: string, requestId: number) => void): void {
+    this.#debounce.cancel();
+    const requestId = ++this.#requestId;
+    if (!query) {
+      this.items = [];
+      this.loading = false;
+      return;
+    }
+
+    this.loading = true;
+    this.#debounce.run(() => load(query, requestId), SEARCH_DEBOUNCE_MS);
+  }
+
+  replace(requestId: number, items: T[]): boolean {
+    if (!this.isCurrent(requestId)) return false;
+    this.items = items;
+    return true;
+  }
+
+  finish(requestId: number): void {
+    if (this.isCurrent(requestId)) this.loading = false;
+  }
+
+  isCurrent(requestId: number): boolean {
+    return requestId === this.#requestId;
+  }
+
+  fence(): void {
+    this.#debounce.cancel();
+    this.#requestId++;
+    this.items = [];
+    this.loading = false;
+  }
+}
+
+/**
+ * Owns the Quick Switcher's per-mount catalog, search, privacy, selection, and
+ * navigation lifecycle. DOM focus and dialog behavior remain in the component.
+ */
+export class QuickSwitcherModel {
+  query = $state('');
+  selectedIndex = $state(0);
+
+  #allItems = $state.raw<QuickSwitcherItem[]>([]);
+  #userSearch = new SearchChannel<QuickSwitcherItem>();
+  #messageSearch = new SearchChannel<QuickSwitcherItem>();
+  #messageSearchServerKey = '';
+
+  kindLabels = $derived<Record<QuickSwitcherItem['kind'], string>>({
+    destination: m['quick_switcher.kind.destination'](),
+    server: m['quick_switcher.kind.server'](),
+    room: m['quick_switcher.kind.room'](),
+    dm: m['quick_switcher.kind.dm'](),
+    user: m['quick_switcher.kind.user'](),
+    message: m['quick_switcher.kind.message']()
+  });
+
+  filtered = $derived.by(() => {
+    const raw = this.query.trim();
+    const recentUrls = recentQuickSwitcher.urls;
+    const recentSet = new SvelteSet(recentUrls);
+    const searchableItems = [
+      ...this.#allItems.filter((item) => item.kind !== 'dm'),
+      ...this.#userSearch.items
+    ];
+
+    if (raw.startsWith('?')) return this.#messageSearch.items;
+
+    if (!raw) {
+      const recent: QuickSwitcherItem[] = [];
+      const rest: QuickSwitcherItem[] = [];
+      for (const item of this.#allItems) {
+        const url = this.#itemUrl(item);
+        (url && recentSet.has(url) ? recent : rest).push(item);
+      }
+      recent.sort(
+        (a, b) => recentUrls.indexOf(this.#itemUrl(a)!) - recentUrls.indexOf(this.#itemUrl(b)!)
+      );
+      const kindOrder: Record<QuickSwitcherItem['kind'], number> = {
+        destination: 0,
+        server: 1,
+        room: 2,
+        dm: 3,
+        user: 4,
+        message: 5
+      };
+      rest.sort((a, b) => kindOrder[a.kind] - kindOrder[b.kind] || a.label.localeCompare(b.label));
+      return [...recent, ...rest];
+    }
+
+    const isChannelFilter = raw.startsWith('#');
+    const query = isChannelFilter ? raw.slice(1) : raw;
+    const pool = isChannelFilter
+      ? this.#allItems.filter((item) => item.kind === 'room')
+      : searchableItems;
+    if (isChannelFilter && !query) {
+      return [...pool].sort((a, b) => a.label.localeCompare(b.label));
+    }
+
+    const scored: QuickSwitcherItem[] = [];
+    for (const item of pool) {
+      const matchScore = scoreItem(query, item);
+      if (matchScore === null) continue;
+      const recentIndex = recentUrls.indexOf(this.#itemUrl(item) ?? '');
+      scored.push({
+        ...item,
+        score: matchScore + (recentIndex === -1 ? 0 : 300 - recentIndex * 20)
+      });
+    }
+    return scored.sort((a, b) => b.score - a.score);
+  });
+
+  get loading(): boolean {
+    return this.#userSearch.loading || this.#messageSearch.loading;
+  }
+
+  activate(): void {
+    this.query = '';
+    this.selectedIndex = 0;
+    this.#allItems = [];
+    this.#userSearch.fence();
+    this.#messageSearch.fence();
+  }
+
+  deactivate(): void {
+    this.#userSearch.fence();
+    this.#messageSearch.fence();
+  }
+
+  setQuery(raw: string): void {
+    this.query = raw;
+    this.selectedIndex = 0;
+
+    const userQuery = raw.trim();
+    this.#userSearch.schedule(
+      quickSwitcher.visible && userQuery && !userQuery.startsWith('#') && !userQuery.startsWith('?')
+        ? userQuery
+        : null,
+      (query, requestId) => void this.#loadUserResults(query, requestId)
+    );
+
+    this.#scheduleMessageSearch(raw);
+  }
+
+  moveSelection(delta: number): void {
+    this.selectedIndex = Math.max(
+      0,
+      Math.min(this.selectedIndex + delta, this.filtered.length - 1)
+    );
+  }
+
+  selectIndex(index: number): void {
+    this.selectedIndex = index;
+  }
+
+  selectCurrent(): void {
+    const item = this.filtered[this.selectedIndex];
+    if (item) void this.select(item);
+  }
+
+  async select(item: QuickSwitcherItem): Promise<void> {
+    quickSwitcher.close();
+
+    if (item.kind === 'user') {
+      try {
+        const roomId = await this.#startDMFromUser(item);
+        const url = resolve('/chat/[serverId]/[roomId]', {
+          serverId: serverIdToSegment(item.serverId),
+          roomId
+        });
+        recentQuickSwitcher.record(url);
+        await goto(url);
+      } catch (error) {
+        toast.error(error instanceof Error ? error.message : 'Failed to start DM');
+      }
+      return;
+    }
+
+    const url = this.#itemUrl(item);
+    if (!url) return;
+    if (item.kind !== 'message') recentQuickSwitcher.record(url);
+    // eslint-disable-next-line svelte/no-navigation-without-resolve -- itemUrl returns paths from resolve() or buildMessageLinkPath()
+    await goto(url);
+  }
+
+  groupHeader(index: number): string | null {
+    if (this.query.trim()) return null;
+    const item = this.filtered[index];
+    if (!item) return null;
+    const previous = index > 0 ? this.filtered[index - 1] : null;
+    const recent = this.#isRecent(item);
+    const previousRecent = previous ? this.#isRecent(previous) : false;
+
+    if (!recent && (index === 0 || previousRecent)) return this.kindLabels[item.kind];
+    if (recent && (index === 0 || !previousRecent)) return m['quick_switcher.recent']();
+    if (!recent && previous && previous.kind !== item.kind) return this.kindLabels[item.kind];
+    return null;
+  }
+
+  /** Track the canonical cross-server navigation inputs and rebuild the local catalog. */
+  syncCatalog(): void {
+    if (!quickSwitcher.visible) return;
+    void serverRegistry.servers;
+    for (const instance of serverRegistry.servers) {
+      const store = serverRegistry.tryGetStore(instance.id);
+      void store?.navigation.rooms;
+      void store?.navigation.isInitialLoading;
+    }
+    untrack(() => this.#loadCatalog());
+  }
+
+  /** Subscribe to each server's message-search privacy boundary for this open palette. */
+  syncPrivacy(): (() => void) | undefined {
+    if (!quickSwitcher.visible) return;
+    const instances = serverRegistry.servers;
+    const serverKey = instances.map((instance) => instance.id).join('\0');
+    const stores = instances.flatMap((instance) => {
+      const store = serverRegistry.tryGetStore(instance.id);
+      return store ? [{ serverId: instance.id, store }] : [];
+    });
+
+    return untrack(() => {
+      if (this.#messageSearchServerKey && this.#messageSearchServerKey !== serverKey) {
+        this.#restartMessageSearch(true);
+      }
+      this.#messageSearchServerKey = serverKey;
+      const unsubscribes = stores.map(({ serverId, store }) =>
+        store.messageSearch.subscribePrivacyInvalidation((matches, force) => {
+          if (!quickSwitcher.visible) return;
+          const affected = this.#messageSearch.items.some(
+            (item) => item.serverId === serverId && item.message && matches(item.message)
+          );
+          this.#restartMessageSearch(force || affected);
+        })
+      );
+      return () => unsubscribes.forEach((unsubscribe) => unsubscribe());
+    });
+  }
+
+  #restartMessageSearch(clearResults: boolean): void {
+    if (clearResults) this.#messageSearch.fence();
+    this.#scheduleMessageSearch(this.query);
+  }
+
+  #scheduleMessageSearch(raw: string): void {
+    const trimmed = raw.trim();
+    const query = trimmed.startsWith('?') ? trimmed.slice(1).trim() : '';
+    this.#messageSearch.schedule(
+      quickSwitcher.visible && query ? query : null,
+      (search, requestId) => void this.#loadMessageResults(search, requestId)
+    );
+  }
+
+  #loadCatalog(): void {
+    const instances = serverRegistry.servers;
+    const multiInstance = instances.length > 1;
+    const items: QuickSwitcherItem[] = [];
+
+    for (const instance of instances) {
+      const store = serverRegistry.tryGetStore(instance.id);
+      const serverName = store?.serverInfo.name || instance.name || getHostname(instance.url);
+      const serverLabel = multiInstance ? serverName : '';
+      const currentUserId = store?.currentUser.user?.id ?? undefined;
+      const logo: ServerLogo = { name: serverName, logoUrl: store?.serverInfo.iconUrl ?? null };
+
+      items.push({
+        kind: 'server',
+        id: `server-${instance.id}`,
+        label: logo.name,
+        detail: '',
+        serverId: instance.id,
+        serverName: logo.name,
+        serverLogo: logo,
+        href: resolve('/chat/[serverId]/overview', { serverId: serverIdToSegment(instance.id) }),
+        score: 0
+      });
+
+      for (const room of store?.navigation.rooms ?? []) {
+        if (room.type === RoomKind.DM) {
+          if (!isNavigationVisibleRoom(room)) continue;
+          const participants = room.members.map(avatarUser);
+          const presentation = buildDirectMessagePresentation(
+            participants,
+            currentUserId,
+            m['common.you']()
+          );
+          items.push({
+            kind: 'dm',
+            id: room.id,
+            label: presentation.label,
+            detail: serverLabel,
+            serverId: instance.id,
+            serverName,
+            participants: presentation.visibleParticipants.slice(0, 2),
+            score: 0
+          });
+          continue;
+        }
+
+        if (!room.viewerIsMember) continue;
+        items.push({
+          kind: 'room',
+          id: room.id,
+          label: room.name,
+          detail: serverLabel || logo.name,
+          serverId: instance.id,
+          serverName,
+          serverLogo: logo,
+          score: 0
+        });
+      }
+    }
+
+    items.push({
+      kind: 'destination',
+      id: 'notifications',
+      label: m['ui.notifications'](),
+      detail: '',
+      serverId: '',
+      serverName: '',
+      href: resolve('/chat/notifications'),
+      icon: 'uil--bell',
+      score: 0
+    });
+    this.#allItems = items;
+    this.selectedIndex = 0;
+  }
+
+  async #loadUserResults(search: string, requestId: number): Promise<void> {
+    const instances = serverRegistry.servers;
+    const multiInstance = instances.length > 1;
+    const items: QuickSwitcherItem[] = [];
+
+    await Promise.allSettled(
+      instances.map(async (instance) => {
+        const store = serverRegistry.tryGetStore(instance.id);
+        if (!store?.permissions.canStartDMs) return;
+
+        const serverName = store.serverInfo.name || instance.name || getHostname(instance.url);
+        const result = await serverConnectionManager
+          .getClient(instance.id)
+          .getAPI(createMemberDirectoryAPI)
+          .listUsers(search, 20, 0);
+        for (const member of result.members) {
+          const user = avatarUser(member);
+          items.push({
+            kind: 'user',
+            id: user.id,
+            label: user.displayName || user.login,
+            detail: [user.login ? `@${user.login}` : '', multiInstance ? serverName : '']
+              .filter(Boolean)
+              .join(' · '),
+            serverId: instance.id,
+            serverName,
+            participants: [user],
+            currentUserId: store.currentUser.user?.id ?? undefined,
+            targetUserId: user.id,
+            score: 0
+          });
+        }
+      })
+    );
+
+    if (this.#userSearch.replace(requestId, items)) this.selectedIndex = 0;
+    this.#userSearch.finish(requestId);
+  }
+
+  async #loadMessageResults(search: string, requestId: number): Promise<void> {
+    const instances = [...serverRegistry.servers];
+    const resultsByServer: Record<string, QuickSwitcherItem[]> = {};
+    const publish = (serverId: string, items: QuickSwitcherItem[]) => {
+      if (!this.#messageSearch.isCurrent(requestId)) return;
+      if (!serverRegistry.servers.some((instance) => instance.id === serverId)) return;
+      const selected = this.#messageSearch.items[this.selectedIndex];
+      resultsByServer[serverId] = items;
+      const accumulated = Object.values(resultsByServer)
+        .flat()
+        .sort(
+          (a, b) =>
+            b.score - a.score ||
+            (b.message?.createdAt ?? '').localeCompare(a.message?.createdAt ?? '') ||
+            a.id.localeCompare(b.id)
+        );
+      if (!this.#messageSearch.replace(requestId, accumulated)) return;
+      const preservedIndex = selected
+        ? accumulated.findIndex(
+            (item) => item.serverId === selected.serverId && item.id === selected.id
+          )
+        : -1;
+      this.selectedIndex = preservedIndex >= 0 ? preservedIndex : 0;
+    };
+
+    const searches = instances.map(async (instance): Promise<QuickSwitcherItem[]> => {
+      const store = serverRegistry.tryGetStore(instance.id);
+      if (!store?.serverInfo.supportsFeature('messageSearch')) return [];
+      await store.messageSearch.ensureStatus();
+      if (!store.messageSearch.available) return [];
+
+      const serverName = store.serverInfo.name || instance.name || getHostname(instance.url);
+      try {
+        const page = await serverConnectionManager
+          .getClient(instance.id)
+          .getAPI(createMessageSearchAPI)
+          .searchMessages({
+            query: search,
+            order: MessageSearchOrder.RELEVANCE,
+            pageSize: 10
+          });
+        return page.results.map((message) => ({
+          kind: 'message',
+          id: message.id,
+          label: message.body,
+          detail: [
+            message.actor?.displayName || message.actor?.login,
+            message.roomName ? `#${message.roomName}` : null,
+            serverName
+          ]
+            .filter(Boolean)
+            .join(' · '),
+          serverId: instance.id,
+          serverName,
+          message,
+          score: message.relevanceScore
+        }));
+      } catch {
+        return [];
+      }
+    });
+    const boundedSearches = searches.map((promise) =>
+      resolveWithin(promise, MESSAGE_SEARCH_SERVER_TIMEOUT_MS, [])
+    );
+    boundedSearches.forEach((promise, index) => {
+      const serverId = instances[index]!.id;
+      void promise.then(
+        (items) => publish(serverId, items),
+        () => publish(serverId, [])
+      );
+    });
+    await Promise.all(boundedSearches);
+    this.#messageSearch.finish(requestId);
+  }
+
+  #itemUrl(item: QuickSwitcherItem): string | undefined {
+    if ((item.kind === 'destination' || item.kind === 'server') && item.href) return item.href;
+    if (item.kind === 'dm' || item.kind === 'room') {
+      return resolve('/chat/[serverId]/[roomId]', {
+        serverId: serverIdToSegment(item.serverId),
+        roomId: item.id
+      });
+    }
+    if (item.kind === 'message' && item.message) {
+      return buildMessageLinkPath(
+        item.serverId,
+        item.message.roomId,
+        item.message.id,
+        item.message.threadRootEventId
+      );
+    }
+  }
+
+  #isRecent(item: QuickSwitcherItem): boolean {
+    const url = this.#itemUrl(item);
+    return url !== undefined && recentQuickSwitcher.urls.includes(url);
+  }
+
+  async #startDMFromUser(item: QuickSwitcherItem): Promise<string> {
+    if (!item.targetUserId) throw new Error('Missing DM target');
+    const room = await serverConnectionManager
+      .getClient(item.serverId)
+      .getAPI(createRoomCommandAPI)
+      .startDM(item.targetUserId === item.currentUserId ? [] : [item.targetUserId]);
+    if (!room?.id) throw new Error('Failed to start DM');
+    return room.id;
+  }
+}
+
+function avatarUser(user: QuickSwitcherAvatarUser): QuickSwitcherAvatarUser {
+  return {
+    id: user.id,
+    login: user.login,
+    displayName: user.displayName,
+    deleted: user.deleted,
+    avatarUrl: user.avatarUrl ?? null
+  };
+}
+
+function getHostname(url: string): string {
+  try {
+    return new URL(url).hostname;
+  } catch {
+    return url;
+  }
+}
+
+function resolveWithin<T>(promise: Promise<T>, timeoutMs: number, fallback: T): Promise<T> {
+  return new Promise((resolve) => {
+    let settled = false;
+    const timeout = setTimeout(() => {
+      settled = true;
+      resolve(fallback);
+    }, timeoutMs);
+    void promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(value);
+      },
+      () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve(fallback);
+      }
+    );
+  });
+}


### PR DESCRIPTION
## Why

The global Quick Switcher had grown to 802 lines and mixed dialog rendering with cross-server catalog construction, two asynchronous search pipelines, request fencing, privacy invalidation, ranking, selection, DM creation, and navigation. That made its most sensitive multi-server and plaintext-lifecycle behavior difficult to reason about in one component.

## What changed

- Added one per-mounted-palette `QuickSwitcherModel` for catalog, search, privacy, selection, and navigation state.
- Consolidated duplicated debounce, request-generation, cancellation, loading, result, and stale-response mechanics in a small internal search channel.
- Reduced `QuickSwitcher.svelte` from 802 to 218 lines, leaving it responsible for native-dialog/focus/keyboard DOM behavior and rendering.
- Preserved partial cross-server message results, per-server timeouts, selection stability as slower servers respond, privacy purging and in-flight fencing, member search, DM creation, recents, and every existing destination.

Component plus model is six production lines smaller overall.

## Test plan

- `mise x -- pnpm --dir=apps/frontend exec vitest run src/lib/components/QuickSwitcher.svelte.spec.ts src/lib/components/quickSwitcherSearch.test.ts` — 2 files, 21 tests passed on the final rebased tip
- `mise test-frontend` — 322 files, 2,687 tests passed
- `mise lint-frontend` — design-system checks, Paraglide, Svelte check (0 errors and 0 warnings), and ESLint passed
- `mise build-frontend` — production build and all route bundle budgets passed
- `mise license-check` — REUSE compliance passed
- `mise knip` — no new unused surface identified
- Svelte autofixer — no issues in changed Svelte files
- Independent code review — no actionable findings

## Compatibility and documentation

Frontend-only internal refactor with no user-visible, public API, persistence, migration, rollout, security, configuration, or operational changes. No product or architecture documentation updates are needed.
