### PR TITLE
refactor(frontend): query notification settings

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -177,6 +177,10 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
   owning per-server stores; see ADR-062.
 - Use event-driven updates from the per-server event bus and explicit projected
   refetches rather than assuming a normalized client cache.
+- When a snapshot query also reconciles a realtime-owned store, do not replay a
+  cached mount snapshot into that store; wait for a successful fresh response.
+  If a mutation cancels an in-flight refresh, serialize related mutations and
+  resume authoritative reconciliation after both success and failure.
 - For paginated caches reconciled from realtime snapshots, queue relevant
   updates during first hydration instead of restarting it, fence and retry
   stale append reads, and version per-resource async refreshes so older

--- a/apps/frontend/src/lib/api-client-tests/memberDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/memberDirectory.spec.ts
@@ -82,7 +82,8 @@ describe('createMemberDirectoryAPI', () => {
       bearerToken: 'token'
     });
 
-    await expect(api.listUsers('ali', 10, 20)).resolves.toEqual({
+    const signal = new AbortController().signal;
+    await expect(api.listUsers('ali', 10, 20, { signal })).resolves.toEqual({
       members: [
         {
           id: 'U1',
@@ -110,7 +111,7 @@ describe('createMemberDirectoryAPI', () => {
     });
     expect(mocks.listUsers).toHaveBeenCalledWith(
       { search: 'ali', page: { limit: 10, offset: 20 } },
-      { headers: { Authorization: 'Bearer token' } }
+      { headers: { Authorization: 'Bearer token' }, signal }
     );
   });
 

--- a/apps/frontend/src/lib/api-client-tests/notificationPreferences.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/notificationPreferences.spec.ts
@@ -66,8 +66,9 @@ describe('notificationPreferences API', () => {
       baseUrl: 'https://remote.example.test/api/connect',
       bearerToken: 'remote-token'
     };
+    const signal = new AbortController().signal;
 
-    await expect(getServerNotificationPreference(config)).resolves.toEqual({
+    await expect(getServerNotificationPreference(config, { signal })).resolves.toEqual({
       level: NotificationLevel.NORMAL,
       effectiveLevel: NotificationLevel.NORMAL
     });
@@ -85,7 +86,8 @@ describe('notificationPreferences API', () => {
     expect(mocks.getServerNotificationPreference).toHaveBeenCalledWith(
       {},
       {
-        headers: { Authorization: 'Bearer remote-token' }
+        headers: { Authorization: 'Bearer remote-token' },
+        signal
       }
     );
     expect(mocks.updateServerNotificationPreference).toHaveBeenCalledWith(

--- a/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
@@ -107,7 +107,8 @@ describe('createRoomDirectoryAPI', () => {
       baseUrl: 'https://remote.example.com/api/connect',
       bearerToken: 'token'
     });
-    const rooms = await api.listRooms(RoomDirectoryScope.DMS);
+    const signal = new AbortController().signal;
+    const rooms = await api.listRooms(RoomDirectoryScope.DMS, { signal });
 
     expect(mocks.createConnectTransport).toHaveBeenCalledWith({
       baseUrl: 'https://remote.example.com/api/connect',
@@ -115,7 +116,7 @@ describe('createRoomDirectoryAPI', () => {
     });
     expect(mocks.listRooms).toHaveBeenCalledWith(
       { scope: RoomDirectoryScope.DMS },
-      { headers: { Authorization: 'Bearer token' } }
+      { headers: { Authorization: 'Bearer token' }, signal }
     );
     expect(rooms).toEqual([
       {

--- a/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/viewer.spec.ts
@@ -173,10 +173,19 @@ describe('getCurrentUserViaConnect', () => {
       ]
     });
 
-    const viewer = await getViewerStateViaConnect({
-      baseUrl: '/api/connect',
-      bearerToken: 'token'
-    });
+    const signal = new AbortController().signal;
+    const viewer = await getViewerStateViaConnect(
+      {
+        baseUrl: '/api/connect',
+        bearerToken: 'token'
+      },
+      { signal }
+    );
+
+    expect(mocks.getViewer).toHaveBeenCalledWith(
+      {},
+      { headers: { Authorization: 'Bearer token' }, signal }
+    );
 
     expect(viewer).toEqual(
       expect.objectContaining({

--- a/apps/frontend/src/lib/api-client/memberDirectory.ts
+++ b/apps/frontend/src/lib/api-client/memberDirectory.ts
@@ -47,10 +47,14 @@ export function createMemberDirectoryAPI(config: MemberDirectoryAPIConfig) {
       search = "",
       limit = 20,
       offset = 0,
+      options: { signal?: AbortSignal } = {},
     ): Promise<MemberDirectoryPage> {
       const response = await users.listUsers(
         { search, page: { limit, offset } },
-        { headers: headers() },
+        {
+          headers: headers(),
+          ...(options.signal ? { signal: options.signal } : {}),
+        },
       );
       return {
         members: response.users.map(mapDirectoryMember),

--- a/apps/frontend/src/lib/api-client/notificationPreferences.ts
+++ b/apps/frontend/src/lib/api-client/notificationPreferences.ts
@@ -20,7 +20,8 @@ export type NotificationPreference = {
 };
 
 export async function getServerNotificationPreference(
-  config: ConnectAPIConfig
+  config: ConnectAPIConfig,
+  options: { signal?: AbortSignal } = {}
 ): Promise<NotificationPreference> {
   const client = createNotificationPreferencesClient(config);
   let response;
@@ -28,7 +29,8 @@ export async function getServerNotificationPreference(
     response = await client.getServerNotificationPreference(
       {},
       {
-        headers: connectHeaders(config)
+        headers: connectHeaders(config),
+        ...(options.signal ? { signal: options.signal } : {})
       }
     );
   } catch (err) {

--- a/apps/frontend/src/lib/api-client/roomDirectory.ts
+++ b/apps/frontend/src/lib/api-client/roomDirectory.ts
@@ -91,9 +91,15 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
   const headers = () => authHeaders(config);
 
   return {
-    async listRooms(scope: RoomDirectoryScope): Promise<DirectoryRoomSummary[]> {
+    async listRooms(
+      scope: RoomDirectoryScope,
+      options: { signal?: AbortSignal } = {}
+    ): Promise<DirectoryRoomSummary[]> {
       try {
-        const response = await directory.listRooms({ scope }, { headers: headers() });
+        const response = await directory.listRooms(
+          { scope },
+          { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) }
+        );
         return response.rooms.flatMap((entry) => mapDirectoryRoom(entry) ?? []);
       } catch (err) {
         return handleAuthError(config, err);

--- a/apps/frontend/src/lib/api-client/viewer.ts
+++ b/apps/frontend/src/lib/api-client/viewer.ts
@@ -77,12 +77,16 @@ const capabilityKeys = {
   manageUserPermissions: 'user.manage-permissions'
 } as const;
 
-export async function getViewerStateViaConnect(config: ViewerAPIConfig): Promise<ViewerState> {
+export async function getViewerStateViaConnect(
+  config: ViewerAPIConfig,
+  options: { signal?: AbortSignal } = {}
+): Promise<ViewerState> {
   const client = createChattoClient(ViewerService, config);
   const response = await client.getViewer(
     {},
     {
-      headers: authHeaders(config)
+      headers: authHeaders(config),
+      ...(options.signal ? { signal: options.signal } : {})
     }
   );
   return viewerResponseToState(response);

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -182,7 +182,7 @@ These preferences are server-side and sync across devices.
         queryClient.cancelQueries({ queryKey, exact: true }),
       mutationFn: ({ serverId, connection, level }: ServerPreferenceVariables) =>
         updateServerNotificationPreference({ ...connection.apiConfig, serverId }, level),
-      onSuccess: async (preference, variables) => {
+      onSuccess: (preference, variables) => {
         if (!isCurrentSession(variables)) return;
         const mapped = notificationPreferenceFromAPI(preference);
         notificationLevelStore.setServerPreference(mapped.level, mapped.effectiveLevel);
@@ -208,8 +208,6 @@ These preferences are server-side and sync across devices.
               }
             : current
         );
-        await queryClient.invalidateQueries({ queryKey: variables.queryKey, exact: true });
-        if (!isCurrentSession(variables)) return;
         toast.success(m['settings.notifications.levels.server_updated']());
       },
       onError: (mutationError, variables) => {
@@ -220,8 +218,14 @@ These preferences are server-side and sync across devices.
             : m['settings.notifications.levels.update_failed']()
         );
       },
-      onSettled: () => {
-        if (componentActive) preferenceMutationLocked = false;
+      onSettled: async (_data, _error, variables) => {
+        try {
+          if (isCurrentSession(variables)) {
+            await queryClient.invalidateQueries({ queryKey: variables.queryKey, exact: true });
+          }
+        } finally {
+          if (componentActive) preferenceMutationLocked = false;
+        }
       }
     }),
     () => queryClient

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -4,6 +4,10 @@
 Server-wide and per-room notification level settings for the current user.
 These preferences are server-side and sync across devices.
 -->
+<script module lang="ts">
+  let nextNotificationSettingsSnapshotVersion = 0;
+</script>
+
 <script lang="ts">
   import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
   import { createMutation, createQuery } from '@tanstack/svelte-query';
@@ -47,6 +51,7 @@ These preferences are server-side and sync across devices.
   };
   type NotificationSettingsRoom = NotificationPreference & { id: string; name: string };
   type NotificationSettingsSnapshot = {
+    version: number;
     serverPreference: NotificationPreference;
     rooms: NotificationSettingsRoom[];
   };
@@ -74,7 +79,7 @@ These preferences are server-side and sync across devices.
     },
     () => queryClient
   );
-  const mountDataUpdatedAt = untrack(() => preferencesQuery.dataUpdatedAt);
+  let synchronizedSnapshotVersion = untrack(() => preferencesQuery.data?.version ?? 0);
 
   const snapshot = $derived(preferencesQuery.data ?? null);
   const serverLevel = $derived(
@@ -103,10 +108,11 @@ These preferences are server-side and sync across devices.
     if (
       !current ||
       preferencesQuery.isError ||
-      preferencesQuery.dataUpdatedAt <= mountDataUpdatedAt
+      current.version === synchronizedSnapshotVersion
     ) {
       return;
     }
+    synchronizedSnapshotVersion = current.version;
     notificationLevelStore.setServerPreference(
       current.serverPreference.level,
       current.serverPreference.effectiveLevel
@@ -132,6 +138,7 @@ These preferences are server-side and sync across devices.
       viewer.roomNotificationPreferences.map((preference) => [preference.roomId, preference])
     );
     return {
+      version: ++nextNotificationSettingsSnapshotVersion,
       serverPreference: mappedServerPreference,
       rooms: channelRooms.map((room) => {
         const preference = roomPreferences.get(room.id);
@@ -171,6 +178,8 @@ These preferences are server-side and sync across devices.
 
   const serverPreferenceMutation = createMutation(
     () => ({
+      onMutate: ({ queryKey }: ServerPreferenceVariables) =>
+        queryClient.cancelQueries({ queryKey, exact: true }),
       mutationFn: ({ serverId, connection, level }: ServerPreferenceVariables) =>
         updateServerNotificationPreference({ ...connection.apiConfig, serverId }, level),
       onSuccess: async (preference, variables) => {
@@ -220,6 +229,8 @@ These preferences are server-side and sync across devices.
 
   const roomPreferenceMutation = createMutation(
     () => ({
+      onMutate: ({ queryKey }: RoomPreferenceVariables) =>
+        queryClient.cancelQueries({ queryKey, exact: true }),
       mutationFn: ({ serverId, connection, roomId, level }: RoomPreferenceVariables) =>
         updateRoomNotificationPreference({ ...connection.apiConfig, serverId }, roomId, level),
       onSuccess: (preference, variables) => {
@@ -250,8 +261,14 @@ These preferences are server-side and sync across devices.
             : m['settings.notifications.levels.update_failed']()
         );
       },
-      onSettled: () => {
-        if (componentActive) preferenceMutationLocked = false;
+      onSettled: async (_data, _error, variables) => {
+        try {
+          if (isCurrentSession(variables)) {
+            await queryClient.invalidateQueries({ queryKey: variables.queryKey, exact: true });
+          }
+        } finally {
+          if (componentActive) preferenceMutationLocked = false;
+        }
       }
     }),
     () => queryClient

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -6,9 +6,11 @@ These preferences are server-side and sync across devices.
 -->
 <script lang="ts">
   import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
+  import { createMutation, createQuery } from '@tanstack/svelte-query';
   import { notificationLevelOrDefault } from '$lib/api-client/enumDefaults';
-  import { onMount } from 'svelte';
+  import { onDestroy } from 'svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
+  import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
 
   import { ChoiceRow, FormSection } from '$lib/ui';
   import { FormError } from '$lib/ui/form';
@@ -21,132 +23,225 @@ These preferences are server-side and sync across devices.
   } from '$lib/api-client/notificationPreferences';
   import { createRoomDirectoryAPI, RoomDirectoryScope } from '$lib/api-client/roomDirectory';
   import { getViewerStateViaConnect } from '$lib/api-client/viewer';
+  import { registerServerQueryCacheRemovalListener } from '$lib/query/cacheRegistry';
+  import { queryClient } from '$lib/query/client';
+  import { settingsQueryKeys } from '$lib/query/settings';
 
   const serverScope = useServerScope();
-  const serverId = serverScope.serverId;
-  const connection = serverScope.connection;
-  const notificationLevelStore = serverScope.store.notificationLevels;
+  const notificationLevelStore = $derived(serverScope.store.notificationLevels);
+  let componentActive = true;
+  let privacyGeneration = 0;
+  const removeCacheRemovalListener = registerServerQueryCacheRemovalListener((serverId) => {
+    if (serverId === serverScope.serverId) privacyGeneration += 1;
+  });
 
-  let serverLevel = $state<NotificationLevel>(NotificationLevel.DEFAULT);
-  let serverEffectiveLevel = $state<NotificationLevel>(NotificationLevel.NORMAL);
-
-  let rooms = $state<
-    Array<{
-      id: string;
-      name: string;
-      level: NotificationLevel;
-      effectiveLevel: NotificationLevel;
-    }>
-  >([]);
-
-  let loading = $state(true);
-  let error = $state('');
-  let savingServerLevel = $state(false);
-  let savingRoomId = $state<string | null>(null);
+  onDestroy(() => {
+    componentActive = false;
+    privacyGeneration += 1;
+    removeCacheRemovalListener();
+  });
 
   type NotificationPreference = {
     level: NotificationLevel;
     effectiveLevel: NotificationLevel;
   };
+  type NotificationSettingsRoom = NotificationPreference & { id: string; name: string };
+  type NotificationSettingsSnapshot = {
+    serverPreference: NotificationPreference;
+    rooms: NotificationSettingsRoom[];
+  };
+  type NotificationMutationScope = {
+    serverId: string;
+    connection: ServerConnection;
+    queryKey: ReturnType<typeof settingsQueryKeys.notificationPreferences>;
+    privacyGeneration: number;
+  };
+  type ServerPreferenceVariables = NotificationMutationScope & { level: NotificationLevel };
+  type RoomPreferenceVariables = NotificationMutationScope & {
+    roomId: string;
+    level: NotificationLevel;
+  };
 
-  onMount(() => {
-    void loadPreferences();
+  const preferencesQuery = createQuery(
+    () => {
+      const serverId = serverScope.serverId;
+      const connection = serverScope.connection;
+      return {
+        queryKey: settingsQueryKeys.notificationPreferences(serverId, connection),
+        queryFn: ({ signal }) => loadNotificationSettings(serverId, connection, signal),
+        refetchOnMount: 'always' as const
+      };
+    },
+    () => queryClient
+  );
+
+  const snapshot = $derived(preferencesQuery.data ?? null);
+  const serverLevel = $derived(
+    snapshot?.serverPreference.level === NotificationLevel.DEFAULT
+      ? NotificationLevel.NORMAL
+      : (snapshot?.serverPreference.level ?? NotificationLevel.NORMAL)
+  );
+  const serverEffectiveLevel = $derived(
+    snapshot?.serverPreference.effectiveLevel ?? NotificationLevel.NORMAL
+  );
+  const rooms = $derived(snapshot?.rooms ?? []);
+  const loading = $derived(preferencesQuery.isPending && snapshot === null);
+  const error = $derived.by(() => {
+    const queryError = preferencesQuery.error;
+    if (!queryError) return '';
+    return queryError instanceof Error
+      ? queryError.message
+      : m['settings.notifications.levels.load_failed']();
   });
 
-  async function loadPreferences() {
-    loading = true;
-    error = '';
+  // The query owns the bounded settings snapshot; the realtime store remains the shared
+  // rendering owner and is synchronized from every authoritative snapshot replacement.
+  $effect(() => {
+    const current = snapshot;
+    if (!current) return;
+    notificationLevelStore.setServerPreference(
+      current.serverPreference.level,
+      current.serverPreference.effectiveLevel
+    );
+    for (const room of current.rooms) {
+      notificationLevelStore.setRoomPreference(room.id, room.level, room.effectiveLevel);
+    }
+  });
 
-    try {
-      const config = preferenceConfig();
-      const [serverPref, viewer, channelRooms] = await Promise.all([
-        getServerNotificationPreference(config),
-        getViewerStateViaConnect(config),
-        connection.getAPI(createRoomDirectoryAPI).listRooms(RoomDirectoryScope.CHANNELS)
-      ]);
-      if (!serverScope.isCurrent()) return;
-
-      const mappedServerPref = notificationPreferenceFromAPI(serverPref);
-      serverLevel =
-        mappedServerPref.level === NotificationLevel.DEFAULT
-          ? NotificationLevel.NORMAL
-          : mappedServerPref.level;
-      serverEffectiveLevel = mappedServerPref.effectiveLevel;
-      notificationLevelStore.setServerPreference(
-        mappedServerPref.level,
-        mappedServerPref.effectiveLevel
-      );
-
-      const roomPreferences = new Map(
-        viewer.roomNotificationPreferences.map((pref) => [pref.roomId, pref])
-      );
-      rooms = channelRooms.map((room) => {
-        const pref = roomPreferences.get(room.id);
+  async function loadNotificationSettings(
+    serverId: string,
+    connection: ServerConnection,
+    signal: AbortSignal
+  ): Promise<NotificationSettingsSnapshot> {
+    const config = { ...connection.apiConfig, serverId };
+    const [serverPreference, viewer, channelRooms] = await Promise.all([
+      getServerNotificationPreference(config, { signal }),
+      getViewerStateViaConnect(config, { signal }),
+      connection.getAPI(createRoomDirectoryAPI).listRooms(RoomDirectoryScope.CHANNELS, { signal })
+    ]);
+    const mappedServerPreference = notificationPreferenceFromAPI(serverPreference);
+    const roomPreferences = new Map(
+      viewer.roomNotificationPreferences.map((preference) => [preference.roomId, preference])
+    );
+    return {
+      serverPreference: mappedServerPreference,
+      rooms: channelRooms.map((room) => {
+        const preference = roomPreferences.get(room.id);
         return {
           id: room.id,
           name: room.name,
-          level: pref?.level ?? NotificationLevel.DEFAULT,
-          effectiveLevel: pref?.effectiveLevel ?? NotificationLevel.NORMAL
+          level: preference?.level ?? NotificationLevel.DEFAULT,
+          effectiveLevel: preference?.effectiveLevel ?? NotificationLevel.NORMAL
         };
-      });
-
-      for (const room of rooms) {
-        notificationLevelStore.setRoomPreference(room.id, room.level, room.effectiveLevel);
-      }
-    } catch (e) {
-      if (!serverScope.isCurrent()) return;
-      error = e instanceof Error ? e.message : m['settings.notifications.levels.load_failed']();
-    } finally {
-      if (serverScope.isCurrent()) loading = false;
-    }
+      })
+    };
   }
 
-  async function handleServerLevelChange(newLevel: NotificationLevel) {
-    savingServerLevel = true;
-
-    try {
-      const pref = notificationPreferenceFromAPI(
-        await updateServerNotificationPreference(preferenceConfig(), newLevel)
-      );
-      if (!serverScope.isCurrent()) return;
-      serverLevel = pref.level;
-      serverEffectiveLevel = pref.effectiveLevel;
-      notificationLevelStore.setServerPreference(pref.level, pref.effectiveLevel);
-
-      await loadPreferences();
-      if (!serverScope.isCurrent()) return;
-      toast.success(m['settings.notifications.levels.server_updated']());
-    } catch (e) {
-      if (!serverScope.isCurrent()) return;
-      toast.error(
-        e instanceof Error ? e.message : m['settings.notifications.levels.update_failed']()
-      );
-    } finally {
-      if (serverScope.isCurrent()) savingServerLevel = false;
-    }
+  function mutationScope(): NotificationMutationScope {
+    const serverId = serverScope.serverId;
+    const connection = serverScope.connection;
+    return {
+      serverId,
+      connection,
+      queryKey: settingsQueryKeys.notificationPreferences(serverId, connection),
+      privacyGeneration
+    };
   }
 
-  async function handleRoomLevelChange(roomId: string, newLevel: NotificationLevel) {
-    savingRoomId = roomId;
+  function isCurrentSession(
+    variables: NotificationMutationScope | undefined
+  ): variables is NotificationMutationScope {
+    return (
+      variables !== undefined &&
+      componentActive &&
+      serverScope.isCurrent() &&
+      variables.serverId === serverScope.serverId &&
+      variables.connection.queryScope === serverScope.connection.queryScope &&
+      variables.privacyGeneration === privacyGeneration
+    );
+  }
 
-    try {
-      const pref = await setRoomLevel(roomId, newLevel);
-      if (!serverScope.isCurrent()) return;
-      const idx = rooms.findIndex((r) => r.id === roomId);
-      if (idx !== -1) {
-        rooms[idx] = { ...rooms[idx], level: pref.level, effectiveLevel: pref.effectiveLevel };
+  const serverPreferenceMutation = createMutation(
+    () => ({
+      mutationFn: ({ serverId, connection, level }: ServerPreferenceVariables) =>
+        updateServerNotificationPreference({ ...connection.apiConfig, serverId }, level),
+      onSuccess: (preference, variables) => {
+        if (!isCurrentSession(variables)) return;
+        const mapped = notificationPreferenceFromAPI(preference);
+        queryClient.setQueryData<NotificationSettingsSnapshot>(variables.queryKey, (current) =>
+          current
+            ? {
+                ...current,
+                serverPreference: mapped,
+                rooms: current.rooms.map((room) =>
+                  room.level === NotificationLevel.DEFAULT
+                    ? { ...room, effectiveLevel: mapped.effectiveLevel }
+                    : room
+                )
+              }
+            : current
+        );
+        void queryClient.invalidateQueries({ queryKey: variables.queryKey, exact: true });
+        toast.success(m['settings.notifications.levels.server_updated']());
+      },
+      onError: (mutationError, variables) => {
+        if (!isCurrentSession(variables)) return;
+        toast.error(
+          mutationError instanceof Error
+            ? mutationError.message
+            : m['settings.notifications.levels.update_failed']()
+        );
       }
+    }),
+    () => queryClient
+  );
 
-      notificationLevelStore.setRoomPreference(roomId, pref.level, pref.effectiveLevel);
-      toast.success(m['settings.notifications.levels.room_updated']());
-    } catch (e) {
-      if (!serverScope.isCurrent()) return;
-      toast.error(
-        e instanceof Error ? e.message : m['settings.notifications.levels.update_failed']()
-      );
-    } finally {
-      if (serverScope.isCurrent()) savingRoomId = null;
-    }
+  const roomPreferenceMutation = createMutation(
+    () => ({
+      mutationFn: ({ serverId, connection, roomId, level }: RoomPreferenceVariables) =>
+        updateRoomNotificationPreference({ ...connection.apiConfig, serverId }, roomId, level),
+      onSuccess: (preference, variables) => {
+        if (!isCurrentSession(variables)) return;
+        const mapped = notificationPreferenceFromAPI(preference);
+        queryClient.setQueryData<NotificationSettingsSnapshot>(variables.queryKey, (current) =>
+          current
+            ? {
+                ...current,
+                rooms: current.rooms.map((room) =>
+                  room.id === variables.roomId ? { ...room, ...mapped } : room
+                )
+              }
+            : current
+        );
+        toast.success(m['settings.notifications.levels.room_updated']());
+      },
+      onError: (mutationError, variables) => {
+        if (!isCurrentSession(variables)) return;
+        toast.error(
+          mutationError instanceof Error
+            ? mutationError.message
+            : m['settings.notifications.levels.update_failed']()
+        );
+      }
+    }),
+    () => queryClient
+  );
+
+  const savingServerLevel = $derived(serverPreferenceMutation.isPending);
+  const savingRoomId = $derived(
+    roomPreferenceMutation.isPending && isCurrentSession(roomPreferenceMutation.variables)
+      ? roomPreferenceMutation.variables.roomId
+      : null
+  );
+
+  function handleServerLevelChange(newLevel: NotificationLevel) {
+    if (serverPreferenceMutation.isPending || newLevel === serverLevel) return;
+    serverPreferenceMutation.mutate({ ...mutationScope(), level: newLevel });
+  }
+
+  function handleRoomLevelChange(roomId: string, newLevel: NotificationLevel) {
+    if (roomPreferenceMutation.isPending) return;
+    roomPreferenceMutation.mutate({ ...mutationScope(), roomId, level: newLevel });
   }
 
   const levelOptions = $derived<
@@ -173,18 +268,6 @@ These preferences are server-side and sync across devices.
       description: m['settings.notifications.levels.all_messages.description']()
     }
   ]);
-
-  async function setRoomLevel(
-    roomId: string,
-    newLevel: NotificationLevel
-  ): Promise<NotificationPreference> {
-    const pref = await updateRoomNotificationPreference(preferenceConfig(), roomId, newLevel);
-    return notificationPreferenceFromAPI(pref);
-  }
-
-  function preferenceConfig() {
-    return { ...connection.apiConfig, serverId };
-  }
 
   function notificationPreferenceFromAPI(pref: {
     level: NotificationLevel;

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -95,10 +95,11 @@ These preferences are server-side and sync across devices.
   });
 
   // The query owns the bounded settings snapshot; the realtime store remains the shared
-  // rendering owner and is synchronized from every authoritative snapshot replacement.
+  // rendering owner. Never regress it from a cached mount snapshot: synchronize only after
+  // this observer has received an authoritative response or mutation update.
   $effect(() => {
     const current = snapshot;
-    if (!current) return;
+    if (!current || !preferencesQuery.isFetchedAfterMount) return;
     notificationLevelStore.setServerPreference(
       current.serverPreference.level,
       current.serverPreference.effectiveLevel
@@ -168,6 +169,16 @@ These preferences are server-side and sync across devices.
       onSuccess: (preference, variables) => {
         if (!isCurrentSession(variables)) return;
         const mapped = notificationPreferenceFromAPI(preference);
+        notificationLevelStore.setServerPreference(mapped.level, mapped.effectiveLevel);
+        for (const room of snapshot?.rooms ?? []) {
+          if (room.level === NotificationLevel.DEFAULT) {
+            notificationLevelStore.setRoomPreference(
+              room.id,
+              room.level,
+              mapped.effectiveLevel
+            );
+          }
+        }
         queryClient.setQueryData<NotificationSettingsSnapshot>(variables.queryKey, (current) =>
           current
             ? {
@@ -203,6 +214,11 @@ These preferences are server-side and sync across devices.
       onSuccess: (preference, variables) => {
         if (!isCurrentSession(variables)) return;
         const mapped = notificationPreferenceFromAPI(preference);
+        notificationLevelStore.setRoomPreference(
+          variables.roomId,
+          mapped.level,
+          mapped.effectiveLevel
+        );
         queryClient.setQueryData<NotificationSettingsSnapshot>(variables.queryKey, (current) =>
           current
             ? {

--- a/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationLevelSettings.svelte
@@ -8,7 +8,7 @@ These preferences are server-side and sync across devices.
   import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
   import { createMutation, createQuery } from '@tanstack/svelte-query';
   import { notificationLevelOrDefault } from '$lib/api-client/enumDefaults';
-  import { onDestroy } from 'svelte';
+  import { onDestroy, untrack } from 'svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
 
@@ -74,6 +74,7 @@ These preferences are server-side and sync across devices.
     },
     () => queryClient
   );
+  const mountDataUpdatedAt = untrack(() => preferencesQuery.dataUpdatedAt);
 
   const snapshot = $derived(preferencesQuery.data ?? null);
   const serverLevel = $derived(
@@ -99,7 +100,13 @@ These preferences are server-side and sync across devices.
   // this observer has received an authoritative response or mutation update.
   $effect(() => {
     const current = snapshot;
-    if (!current || !preferencesQuery.isFetchedAfterMount) return;
+    if (
+      !current ||
+      preferencesQuery.isError ||
+      preferencesQuery.dataUpdatedAt <= mountDataUpdatedAt
+    ) {
+      return;
+    }
     notificationLevelStore.setServerPreference(
       current.serverPreference.level,
       current.serverPreference.effectiveLevel
@@ -166,7 +173,7 @@ These preferences are server-side and sync across devices.
     () => ({
       mutationFn: ({ serverId, connection, level }: ServerPreferenceVariables) =>
         updateServerNotificationPreference({ ...connection.apiConfig, serverId }, level),
-      onSuccess: (preference, variables) => {
+      onSuccess: async (preference, variables) => {
         if (!isCurrentSession(variables)) return;
         const mapped = notificationPreferenceFromAPI(preference);
         notificationLevelStore.setServerPreference(mapped.level, mapped.effectiveLevel);
@@ -192,7 +199,8 @@ These preferences are server-side and sync across devices.
               }
             : current
         );
-        void queryClient.invalidateQueries({ queryKey: variables.queryKey, exact: true });
+        await queryClient.invalidateQueries({ queryKey: variables.queryKey, exact: true });
+        if (!isCurrentSession(variables)) return;
         toast.success(m['settings.notifications.levels.server_updated']());
       },
       onError: (mutationError, variables) => {
@@ -202,6 +210,9 @@ These preferences are server-side and sync across devices.
             ? mutationError.message
             : m['settings.notifications.levels.update_failed']()
         );
+      },
+      onSettled: () => {
+        if (componentActive) preferenceMutationLocked = false;
       }
     }),
     () => queryClient
@@ -238,12 +249,20 @@ These preferences are server-side and sync across devices.
             ? mutationError.message
             : m['settings.notifications.levels.update_failed']()
         );
+      },
+      onSettled: () => {
+        if (componentActive) preferenceMutationLocked = false;
       }
     }),
     () => queryClient
   );
 
-  const savingServerLevel = $derived(serverPreferenceMutation.isPending);
+  let preferenceMutationLocked = $state(false);
+  const savingPreference = $derived(
+    preferenceMutationLocked ||
+      serverPreferenceMutation.isPending ||
+      roomPreferenceMutation.isPending
+  );
   const savingRoomId = $derived(
     roomPreferenceMutation.isPending && isCurrentSession(roomPreferenceMutation.variables)
       ? roomPreferenceMutation.variables.roomId
@@ -251,12 +270,14 @@ These preferences are server-side and sync across devices.
   );
 
   function handleServerLevelChange(newLevel: NotificationLevel) {
-    if (serverPreferenceMutation.isPending || newLevel === serverLevel) return;
+    if (preferenceMutationLocked || newLevel === serverLevel) return;
+    preferenceMutationLocked = true;
     serverPreferenceMutation.mutate({ ...mutationScope(), level: newLevel });
   }
 
   function handleRoomLevelChange(roomId: string, newLevel: NotificationLevel) {
-    if (roomPreferenceMutation.isPending) return;
+    if (preferenceMutationLocked) return;
+    preferenceMutationLocked = true;
     roomPreferenceMutation.mutate({ ...mutationScope(), roomId, level: newLevel });
   }
 
@@ -327,7 +348,7 @@ These preferences are server-side and sync across devices.
           label={option.label}
           description={option.description}
           selected={isSelected}
-          disabled={savingServerLevel}
+          disabled={savingPreference}
           onclick={() => handleServerLevelChange(option.value)}
         />
       {/each}
@@ -372,7 +393,7 @@ These preferences are server-side and sync across devices.
             <select
               aria-label={m['settings.notifications.levels.room_level_label']({ room: room.name })}
               value={String(room.level)}
-              disabled={isSaving}
+              disabled={savingPreference}
               onchange={(e) =>
                 handleRoomLevelChange(
                   room.id,

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
+  import { createQuery } from '@tanstack/svelte-query';
   import { createMemberDirectoryAPI, type DirectoryMember } from '$lib/api-client/memberDirectory';
   import { useDebounce } from '$lib/hooks/useDebounce.svelte';
+  import { queryClient } from '$lib/query/client';
+  import { directoryQueryKeys } from '$lib/query/directory';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { Combobox } from '$lib/ui/form';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
@@ -25,10 +28,28 @@
 
   const serverScope = useServerScope();
 
-  let users = $state.raw<User[]>([]);
-  let loading = $state(false);
-  let requestId = 0;
+  const SEARCH_LIMIT = 10;
+  let activeSearch = $state('');
+  let debouncePending = $state(false);
   const searchDebounce = useDebounce();
+  const usersQuery = createQuery(
+    () => {
+      const serverId = serverScope.serverId;
+      const connection = serverScope.connection;
+      const search = activeSearch;
+      return {
+        queryKey: directoryQueryKeys.users(serverId, connection, search, SEARCH_LIMIT),
+        queryFn: ({ signal }) =>
+          connection
+            .getAPI(createMemberDirectoryAPI)
+            .listUsers(search, SEARCH_LIMIT, 0, { signal }),
+        enabled: search.length > 0
+      };
+    },
+    () => queryClient
+  );
+  const users = $derived<User[]>(activeSearch ? (usersQuery.data?.members ?? []) : []);
+  const loading = $derived(debouncePending || (!!activeSearch && usersQuery.isFetching));
 
   function userLabel(user: User): string {
     const handle = user.login ? `@${user.login}` : user.id;
@@ -38,35 +59,18 @@
   function scheduleSearch(query: string) {
     searchDebounce.cancel();
     const search = query.trim();
-    const currentRequest = ++requestId;
 
     if (!search) {
-      users = [];
-      loading = false;
+      activeSearch = '';
+      debouncePending = false;
       return;
     }
 
-    loading = true;
+    debouncePending = true;
     searchDebounce.run(() => {
-      void searchUsers(search, currentRequest);
+      activeSearch = search;
+      debouncePending = false;
     }, 200);
-  }
-
-  async function searchUsers(search: string, currentRequest: number) {
-    try {
-      const api = serverScope.connection.getAPI(createMemberDirectoryAPI);
-      const result = await api.listUsers(search, 10, 0);
-      if (currentRequest !== requestId) return;
-      users = result.members;
-    } catch {
-      if (currentRequest === requestId) {
-        users = [];
-      }
-    } finally {
-      if (currentRequest === requestId) {
-        loading = false;
-      }
-    }
   }
 </script>
 

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte
@@ -48,7 +48,9 @@
     },
     () => queryClient
   );
-  const users = $derived<User[]>(activeSearch ? (usersQuery.data?.members ?? []) : []);
+  const users = $derived<User[]>(
+    activeSearch && !debouncePending ? (usersQuery.data?.members ?? []) : []
+  );
   const loading = $derived(debouncePending || (!!activeSearch && usersQuery.isFetching));
 
   function userLabel(user: User): string {

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
+import { queryClient } from '$lib/query/client';
 import UserCombobox from './UserCombobox.svelte';
 
 const mocks = vi.hoisted(() => ({
@@ -12,6 +13,7 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
     serverId: 'origin',
     store: {},
     connection: {
+      queryScope: 'origin-session',
       connectBaseUrl: 'http://localhost/api/connect',
       bearerToken: null,
       getAPI: (factory: (config: never) => unknown) => factory({} as never)
@@ -31,9 +33,24 @@ async function settle() {
   flushSync();
 }
 
+function enterSearch(container: Element, search: string) {
+  const input = container.querySelector('input') as HTMLInputElement;
+  input.value = search;
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('UserCombobox', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    queryClient.clear();
     mocks.listUsers.mockReset();
     mocks.listUsers.mockResolvedValue({
       members: [
@@ -55,6 +72,7 @@ describe('UserCombobox', () => {
   });
 
   afterEach(() => {
+    queryClient.clear();
     vi.useRealTimers();
   });
 
@@ -66,18 +84,53 @@ describe('UserCombobox', () => {
       }
     });
 
-    const input = container.querySelector('input') as HTMLInputElement;
-    input.value = 'alice';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    enterSearch(container, 'alice');
     await vi.advanceTimersByTimeAsync(220);
     await settle();
 
-    expect(mocks.listUsers).toHaveBeenCalledWith('alice', 10, 0);
+    expect(mocks.listUsers).toHaveBeenCalledWith('alice', 10, 0, {
+      signal: expect.any(AbortSignal)
+    });
 
-    input.value = 'bob';
-    input.dispatchEvent(new Event('input', { bubbles: true }));
+    enterSearch(container, 'bob');
     unmount();
     await vi.advanceTimersByTimeAsync(220);
     expect(mocks.listUsers).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses a fresh cached search after remounting', async () => {
+    const first = render(UserCombobox, {
+      props: { id: 'actor', label: 'Actor' }
+    });
+    enterSearch(first.container, 'alice');
+    await vi.advanceTimersByTimeAsync(220);
+    await settle();
+    first.unmount();
+
+    const second = render(UserCombobox, {
+      props: { id: 'actor', label: 'Actor' }
+    });
+    enterSearch(second.container, 'alice');
+    await vi.advanceTimersByTimeAsync(220);
+    await settle();
+
+    expect(mocks.listUsers).toHaveBeenCalledOnce();
+    expect(second.container.textContent).toContain('Alice Admin');
+  });
+
+  it('cancels an in-flight search when unmounted', async () => {
+    const pending = deferred<never>();
+    mocks.listUsers.mockReturnValue(pending.promise);
+    const view = render(UserCombobox, {
+      props: { id: 'actor', label: 'Actor' }
+    });
+    enterSearch(view.container, 'alice');
+    await vi.advanceTimersByTimeAsync(220);
+    await settle();
+    const options = mocks.listUsers.mock.calls[0]?.[3] as { signal: AbortSignal };
+
+    view.unmount();
+
+    expect(options.signal.aborted).toBe(true);
   });
 });

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
@@ -133,4 +133,57 @@ describe('UserCombobox', () => {
 
     expect(options.signal.aborted).toBe(true);
   });
+
+  it('hides a superseded search result while the next term is debouncing', async () => {
+    const alice = deferred<Awaited<ReturnType<typeof mocks.listUsers>>>();
+    mocks.listUsers.mockReturnValueOnce(alice.promise).mockResolvedValue({
+      members: [
+        {
+          id: 'user-2',
+          login: 'bob',
+          displayName: 'Bob Builder',
+          deleted: false,
+          avatarUrl: null,
+          presenceStatus: 'ONLINE',
+          customStatus: null,
+          roles: [],
+          createdAt: null
+        }
+      ],
+      totalCount: 1,
+      hasMore: false
+    });
+    const view = render(UserCombobox, {
+      props: { id: 'actor', label: 'Actor' }
+    });
+    enterSearch(view.container, 'alice');
+    await vi.advanceTimersByTimeAsync(220);
+    await settle();
+
+    enterSearch(view.container, 'bob');
+    alice.resolve({
+      members: [
+        {
+          id: 'user-1',
+          login: 'alice',
+          displayName: 'Alice Admin',
+          deleted: false,
+          avatarUrl: null,
+          presenceStatus: 'ONLINE',
+          customStatus: null,
+          roles: [],
+          createdAt: null
+        }
+      ],
+      totalCount: 1,
+      hasMore: false
+    });
+    await settle();
+
+    expect(view.container.textContent).not.toContain('Alice Admin');
+
+    await vi.advanceTimersByTimeAsync(220);
+    await settle();
+    expect(view.container.textContent).toContain('Bob Builder');
+  });
 });

--- a/apps/frontend/src/lib/query/directory.ts
+++ b/apps/frontend/src/lib/query/directory.ts
@@ -1,0 +1,14 @@
+import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+
+type DirectoryQueryConnection = Pick<ServerConnection, 'queryScope'>;
+
+function directoryRoot(serverId: string, connection: DirectoryQueryConnection) {
+  return ['server', serverId, 'session', connection.queryScope, 'directory'] as const;
+}
+
+export const directoryQueryKeys = {
+  root: directoryRoot,
+  users(serverId: string, connection: DirectoryQueryConnection, search: string, limit: number) {
+    return [...directoryRoot(serverId, connection), 'users', { search, limit }] as const;
+  }
+};

--- a/apps/frontend/src/lib/query/settings.ts
+++ b/apps/frontend/src/lib/query/settings.ts
@@ -10,5 +10,8 @@ export const settingsQueryKeys = {
   root: settingsRoot,
   externalIdentities(serverId: string, connection: SettingsQueryConnection) {
     return [...settingsRoot(serverId, connection), 'external-identities'] as const;
+  },
+  notificationPreferences(serverId: string, connection: SettingsQueryConnection) {
+    return [...settingsRoot(serverId, connection), 'notification-preferences'] as const;
   }
 };

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -1,5 +1,5 @@
 import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import NotificationsPage from './+page.svelte';
@@ -9,6 +9,8 @@ import { RoomDirectoryScope } from '@chatto/api-types/api/v1/room_directory_pb';
 import { q } from '$lib/test-utils';
 import { userPreferences } from '$lib/state/userPreferences.svelte';
 import { defaultNotificationSoundFilters } from '$lib/audio/notificationSounds';
+import { removeRegisteredServerQueries } from '$lib/query/cacheRegistry';
+import { queryClient } from '$lib/query/client';
 
 const mocks = vi.hoisted(() => ({
   query: vi.fn(),
@@ -93,6 +95,7 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
       notificationLevels: mocks.notificationLevels
     },
     connection: {
+      queryScope: 'origin-session',
       isConnected: true,
       showConnectionLostBanner: false,
       client: {
@@ -120,6 +123,14 @@ async function settle() {
   flushSync();
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 function setRangeValue(input: HTMLInputElement, value: string) {
   input.value = value;
   input.dispatchEvent(new Event('input', { bubbles: true }));
@@ -144,6 +155,7 @@ function buttonWithText(container: Element, text: string): HTMLButtonElement {
 
 describe('Notification settings page', () => {
   beforeEach(() => {
+    queryClient.clear();
     localStorage.clear();
     userPreferences.notificationSound = 'chime-up';
     userPreferences.resetNotificationSoundFilters();
@@ -199,6 +211,8 @@ describe('Notification settings page', () => {
     mocks.listRooms.mockResolvedValue([{ id: 'room-1', name: 'general', hasUnread: false }]);
   });
 
+  afterEach(() => queryClient.clear());
+
   it('renders notification levels and sound choices from mocked state', async () => {
     const { container } = render(NotificationsPage);
     await settle();
@@ -208,17 +222,25 @@ describe('Notification settings page', () => {
       .element(q(container, '[data-testid="room-notification-general"]'))
       .toBeInTheDocument();
     expect(mocks.query).not.toHaveBeenCalled();
-    expect(mocks.getServerNotificationPreference).toHaveBeenCalledWith({
-      serverId: 'origin',
-      baseUrl: 'https://origin.test/api/connect',
-      bearerToken: 'origin-token'
+    expect(mocks.getServerNotificationPreference).toHaveBeenCalledWith(
+      {
+        serverId: 'origin',
+        baseUrl: 'https://origin.test/api/connect',
+        bearerToken: 'origin-token'
+      },
+      { signal: expect.any(AbortSignal) }
+    );
+    expect(mocks.getViewerStateViaConnect).toHaveBeenCalledWith(
+      {
+        serverId: 'origin',
+        baseUrl: 'https://origin.test/api/connect',
+        bearerToken: 'origin-token'
+      },
+      { signal: expect.any(AbortSignal) }
+    );
+    expect(mocks.listRooms).toHaveBeenCalledWith(RoomDirectoryScope.CHANNELS, {
+      signal: expect.any(AbortSignal)
     });
-    expect(mocks.getViewerStateViaConnect).toHaveBeenCalledWith({
-      serverId: 'origin',
-      baseUrl: 'https://origin.test/api/connect',
-      bearerToken: 'origin-token'
-    });
-    expect(mocks.listRooms).toHaveBeenCalledWith(RoomDirectoryScope.CHANNELS);
     expect(container.textContent).toContain('Notification Sound');
     expect(container.textContent).toContain('Silent');
     expect(container.textContent).toContain('Simple');
@@ -240,6 +262,34 @@ describe('Notification settings page', () => {
     expect(container.querySelector('.uil--redo')).not.toBeNull();
     expect(container.querySelector('.uil--cloud')).not.toBeNull();
     expect(container.querySelector('.uil--fire')).not.toBeNull();
+  });
+
+  it('revalidates the cached notification snapshot on remount', async () => {
+    const first = render(NotificationsPage);
+    await settle();
+    first.unmount();
+
+    render(NotificationsPage);
+    await settle();
+
+    expect(mocks.getServerNotificationPreference).toHaveBeenCalledTimes(2);
+    expect(mocks.getViewerStateViaConnect).toHaveBeenCalledTimes(2);
+    expect(mocks.listRooms).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancels the notification snapshot when its observer unmounts', async () => {
+    const pending = deferred<never>();
+    mocks.getServerNotificationPreference.mockReturnValue(pending.promise);
+
+    const view = render(NotificationsPage);
+    await settle();
+    const options = mocks.getServerNotificationPreference.mock.calls[0]?.[1] as {
+      signal: AbortSignal;
+    };
+
+    view.unmount();
+
+    expect(options.signal.aborted).toBe(true);
   });
 
   it('selects and persists a non-silent notification sound', async () => {
@@ -301,6 +351,35 @@ describe('Notification settings page', () => {
       NotificationLevel.MUTED,
       NotificationLevel.MUTED
     );
+  });
+
+  it('fences a late room update after the server session is removed', async () => {
+    const pending = deferred<{
+      level: NotificationLevel;
+      effectiveLevel: NotificationLevel;
+    }>();
+    mocks.updateRoomNotificationPreference.mockReturnValue(pending.promise);
+    const view = render(NotificationsPage);
+    await settle();
+    mocks.notificationLevels.setRoomPreference.mockClear();
+
+    const select = q(
+      view.container,
+      '[data-testid="room-notification-general"] select'
+    ) as HTMLSelectElement;
+    select.value = String(NotificationLevel.MUTED);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await settle();
+
+    removeRegisteredServerQueries('origin');
+    view.unmount();
+    pending.resolve({
+      level: NotificationLevel.MUTED,
+      effectiveLevel: NotificationLevel.MUTED
+    });
+    await settle();
+
+    expect(mocks.notificationLevels.setRoomPreference).not.toHaveBeenCalled();
   });
 
   it('updates server notification level through ConnectRPC', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -277,6 +277,26 @@ describe('Notification settings page', () => {
     expect(mocks.listRooms).toHaveBeenCalledTimes(2);
   });
 
+  it('does not regress the shared store from a cached remount snapshot', async () => {
+    const first = render(NotificationsPage);
+    await settle();
+    first.unmount();
+    mocks.notificationLevels.setServerPreference.mockClear();
+    mocks.notificationLevels.setRoomPreference.mockClear();
+    const pending = deferred<never>();
+    mocks.getServerNotificationPreference.mockReturnValue(pending.promise);
+
+    const second = render(NotificationsPage);
+    await settle();
+
+    await expect
+      .element(q(second.container, '[data-testid="room-notification-general"]'))
+      .toBeInTheDocument();
+    expect(mocks.notificationLevels.setServerPreference).not.toHaveBeenCalled();
+    expect(mocks.notificationLevels.setRoomPreference).not.toHaveBeenCalled();
+    second.unmount();
+  });
+
   it('cancels the notification snapshot when its observer unmounts', async () => {
     const pending = deferred<never>();
     mocks.getServerNotificationPreference.mockReturnValue(pending.promise);

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -523,6 +523,36 @@ describe('Notification settings page', () => {
     });
   });
 
+  it('resumes remount revalidation after a failed server preference update', async () => {
+    const first = render(NotificationsPage);
+    await settle();
+    first.unmount();
+    const pending = deferred<never>();
+    mocks.getServerNotificationPreference.mockReturnValueOnce(pending.promise);
+    mocks.updateServerNotificationPreference.mockRejectedValue(
+      new ConnectError('server update denied', Code.PermissionDenied)
+    );
+
+    const second = render(NotificationsPage);
+    await settle();
+    const signal = (
+      mocks.getServerNotificationPreference.mock.calls[1]?.[1] as { signal: AbortSignal }
+    ).signal;
+    const allMessages = buttonWithText(second.container, 'All Messages');
+    allMessages.click();
+    await settle();
+
+    expect(signal.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(mocks.getServerNotificationPreference).toHaveBeenCalledTimes(3);
+    });
+    await vi.waitFor(() => {
+      flushSync();
+      expect(allMessages.disabled).toBe(false);
+    });
+    second.unmount();
+  });
+
   it('serializes room changes through server preference reconciliation', async () => {
     const pending = deferred<{
       level: NotificationLevel;

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -1,4 +1,5 @@
 import { NotificationLevel } from '@chatto/api-types/api/v1/notification_preferences_pb';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
@@ -297,6 +298,26 @@ describe('Notification settings page', () => {
     second.unmount();
   });
 
+  it('does not regress the shared store when cached remount revalidation fails', async () => {
+    const first = render(NotificationsPage);
+    await settle();
+    first.unmount();
+    mocks.notificationLevels.setServerPreference.mockClear();
+    mocks.notificationLevels.setRoomPreference.mockClear();
+    mocks.getServerNotificationPreference.mockRejectedValue(
+      new ConnectError('preferences denied', Code.PermissionDenied)
+    );
+
+    const second = render(NotificationsPage);
+    await settle();
+    await settle();
+
+    expect(second.container.textContent).toContain('preferences denied');
+    expect(mocks.notificationLevels.setServerPreference).not.toHaveBeenCalled();
+    expect(mocks.notificationLevels.setRoomPreference).not.toHaveBeenCalled();
+    second.unmount();
+  });
+
   it('cancels the notification snapshot when its observer unmounts', async () => {
     const pending = deferred<never>();
     mocks.getServerNotificationPreference.mockReturnValue(pending.promise);
@@ -422,6 +443,42 @@ describe('Notification settings page', () => {
       NotificationLevel.ALL_MESSAGES,
       NotificationLevel.ALL_MESSAGES
     );
+  });
+
+  it('serializes room changes through server preference reconciliation', async () => {
+    const pending = deferred<{
+      level: NotificationLevel;
+      effectiveLevel: NotificationLevel;
+    }>();
+    mocks.updateServerNotificationPreference.mockReturnValue(pending.promise);
+    const { container } = render(NotificationsPage);
+    await settle();
+
+    buttonWithText(container, 'All Messages').click();
+    flushSync();
+    const select = q(
+      container,
+      '[data-testid="room-notification-general"] select'
+    ) as HTMLSelectElement;
+    expect(select.disabled).toBe(true);
+    select.value = String(NotificationLevel.DEFAULT);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await settle();
+
+    expect(mocks.updateRoomNotificationPreference).not.toHaveBeenCalled();
+
+    pending.resolve({
+      level: NotificationLevel.ALL_MESSAGES,
+      effectiveLevel: NotificationLevel.ALL_MESSAGES
+    });
+    await settle();
+    await settle();
+
+    expect(select.disabled).toBe(false);
+    select.value = String(NotificationLevel.MUTED);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await settle();
+    expect(mocks.updateRoomNotificationPreference).toHaveBeenCalledOnce();
   });
 
   it('shows the push enable path when configured and not subscribed', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -366,6 +366,15 @@ describe('Notification settings page', () => {
   });
 
   it('updates room notification overrides through ConnectRPC', async () => {
+    mocks.getViewerStateViaConnect.mockResolvedValue({
+      roomNotificationPreferences: [
+        {
+          roomId: 'room-1',
+          level: NotificationLevel.MUTED,
+          effectiveLevel: NotificationLevel.MUTED
+        }
+      ]
+    });
     const { container } = render(NotificationsPage);
     await settle();
 
@@ -423,9 +432,76 @@ describe('Notification settings page', () => {
     expect(mocks.notificationLevels.setRoomPreference).not.toHaveBeenCalled();
   });
 
+  it('cancels stale remount revalidation before updating a room preference', async () => {
+    const first = render(NotificationsPage);
+    await settle();
+    first.unmount();
+    const pending = deferred<never>();
+    mocks.getServerNotificationPreference.mockReturnValueOnce(pending.promise);
+
+    const second = render(NotificationsPage);
+    await settle();
+    const signal = (
+      mocks.getServerNotificationPreference.mock.calls[1]?.[1] as { signal: AbortSignal }
+    ).signal;
+    const select = q(
+      second.container,
+      '[data-testid="room-notification-general"] select'
+    ) as HTMLSelectElement;
+    select.value = String(NotificationLevel.MUTED);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await settle();
+
+    expect(signal.aborted).toBe(true);
+    expect(mocks.updateRoomNotificationPreference).toHaveBeenCalledOnce();
+    await vi.waitFor(() => {
+      expect(mocks.getServerNotificationPreference).toHaveBeenCalledTimes(3);
+    });
+    second.unmount();
+  });
+
+  it('resumes remount revalidation after a failed room preference update', async () => {
+    const first = render(NotificationsPage);
+    await settle();
+    first.unmount();
+    const pending = deferred<never>();
+    mocks.getServerNotificationPreference.mockReturnValueOnce(pending.promise);
+    mocks.updateRoomNotificationPreference.mockRejectedValue(
+      new ConnectError('update denied', Code.PermissionDenied)
+    );
+
+    const second = render(NotificationsPage);
+    await settle();
+    const signal = (
+      mocks.getServerNotificationPreference.mock.calls[1]?.[1] as { signal: AbortSignal }
+    ).signal;
+    const select = q(
+      second.container,
+      '[data-testid="room-notification-general"] select'
+    ) as HTMLSelectElement;
+    select.value = String(NotificationLevel.MUTED);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await settle();
+    await settle();
+
+    expect(signal.aborted).toBe(true);
+    await vi.waitFor(() => {
+      expect(mocks.getServerNotificationPreference).toHaveBeenCalledTimes(3);
+    });
+    await vi.waitFor(() => {
+      flushSync();
+      expect(select.disabled).toBe(false);
+    });
+    second.unmount();
+  });
+
   it('updates server notification level through ConnectRPC', async () => {
     const { container } = render(NotificationsPage);
     await settle();
+    mocks.getServerNotificationPreference.mockResolvedValue({
+      level: ApiNotificationLevel.ALL_MESSAGES,
+      effectiveLevel: ApiNotificationLevel.ALL_MESSAGES
+    });
 
     buttonWithText(container, 'All Messages').click();
     await settle();
@@ -439,10 +515,12 @@ describe('Notification settings page', () => {
       ApiNotificationLevel.ALL_MESSAGES
     );
     expect(mocks.mutation).not.toHaveBeenCalled();
-    expect(mocks.notificationLevels.setServerPreference).toHaveBeenCalledWith(
-      NotificationLevel.ALL_MESSAGES,
-      NotificationLevel.ALL_MESSAGES
-    );
+    await vi.waitFor(() => {
+      expect(mocks.notificationLevels.setServerPreference).toHaveBeenCalledWith(
+        NotificationLevel.ALL_MESSAGES,
+        NotificationLevel.ALL_MESSAGES
+      );
+    });
   });
 
   it('serializes room changes through server preference reconciliation', async () => {
@@ -470,6 +548,10 @@ describe('Notification settings page', () => {
     pending.resolve({
       level: NotificationLevel.ALL_MESSAGES,
       effectiveLevel: NotificationLevel.ALL_MESSAGES
+    });
+    mocks.getServerNotificationPreference.mockResolvedValue({
+      level: ApiNotificationLevel.ALL_MESSAGES,
+      effectiveLevel: ApiNotificationLevel.ALL_MESSAGES
     });
     await settle();
     await settle();


### PR DESCRIPTION
## Why

Notification-level settings and the reusable user combobox still managed snapshot request lifecycles by hand. Moving them onto the existing TanStack Query boundary gives these reads consistent cancellation, session scoping, short-lived reuse, and mutation reconciliation without moving realtime notification ownership into the query cache.

## What changed

- Replaced the notification settings component's mount-time loader with one session-scoped composite query for server preferences, viewer room preferences, and channel rooms.
- Converted server- and room-level preference updates to serialized mutations that cancel stale reads, update the exact cache, fence late results at session disposal, and resume authoritative reconciliation after both success and failure.
- Kept the shared realtime notification store authoritative: cached remount data renders immediately but only a successful fresh snapshot may synchronize into that store.
- Replaced manual user-search request IDs with a debounced, cancellable directory query keyed by server session and search term; fresh results are reused and superseded results stay hidden.
- Added AbortSignal support and coverage to the four API reads used by these queries.
- Documented the cache/realtime reconciliation invariant in the frontend agent guidance.

This is an internal frontend lifecycle refactor governed by ADR-062. It changes no public API, persisted data, permissions, user-visible copy, rollout, or migration requirements.

## Test plan

- `mise test-frontend` — 323 files / 2,715 tests passed.
- Focused component/API run — 6 files / 55 tests passed.
- `mise lint-frontend` — passed; Svelte reported 0 errors and 0 warnings, and ESLint passed.
- `mise x -- pnpm exec playwright test e2e/notification-level.test.ts --retries=0` from `apps/frontend` — all 7 real-backend tests passed.
- Production build — passed; bundle budgets: login 266.9/290 KiB, overview 292.6/325 KiB, room 464.9/510 KiB.
- `mise license-check` — passed for 2,638/2,638 files.
- Svelte autofixer — no issues in either changed component; the notification advisory is the intentional external query-to-realtime-store synchronization effect.
- Four adversarial review passes — all findings addressed; final pass found no significant actionable issues.
