### PR TITLE
refactor(frontend): query followed threads

### DIFF
--- a/apps/frontend/src/lib/api-client-tests/threads.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/threads.spec.ts
@@ -91,6 +91,22 @@ describe('createThreadAPI', () => {
     });
   });
 
+  it('passes cancellation through when listing followed threads', async () => {
+    mocks.listFollowedThreads.mockResolvedValue({ threads: [], page: {} });
+    const signal = new AbortController().signal;
+    const api = createThreadAPI({
+      baseUrl: 'https://remote.example.test/api/connect',
+      bearerToken: null
+    });
+
+    await api.listFollowedThreads({ limit: 20, offset: 0 }, { signal });
+
+    expect(mocks.listFollowedThreads).toHaveBeenCalledWith(
+      { page: { limit: 20, offset: 0 } },
+      { headers: undefined, signal }
+    );
+  });
+
   it('follows a thread with bearer auth', async () => {
     mocks.followThread.mockResolvedValue({
       following: true,

--- a/apps/frontend/src/lib/api-client/threads.ts
+++ b/apps/frontend/src/lib/api-client/threads.ts
@@ -40,14 +40,20 @@ export function createThreadAPI(config: ConnectAPIConfig) {
   const client = createChattoClient(ThreadService, config);
   const headers = () => authHeaders(config);
   return {
-    async listFollowedThreads(input: {
-      limit: number;
-      offset: number;
-    }): Promise<FollowedThreadsPage> {
+    async listFollowedThreads(
+      input: {
+        limit: number;
+        offset: number;
+      },
+      options: { signal?: AbortSignal } = {}
+    ): Promise<FollowedThreadsPage> {
       try {
         const response = await client.listFollowedThreads(
           { page: { limit: input.limit, offset: input.offset } },
-          { headers: headers() }
+          {
+            headers: headers(),
+            ...(options.signal ? { signal: options.signal } : {})
+          }
         );
         const users = response.includes?.users ?? {};
         return {

--- a/apps/frontend/src/lib/query/cacheRegistry.ts
+++ b/apps/frontend/src/lib/query/cacheRegistry.ts
@@ -4,12 +4,29 @@ type AdminUserRemovalListener = (serverId: string, userId: string) => void;
 type QueryCacheRemovalListener = (serverId: string) => void;
 type AdminRoomQueryReconciler = (serverId: string, roomId: string, removed: boolean) => void;
 type AdminRoomGroupQueryReconciler = (serverId: string, visibleGroupIds: readonly string[]) => void;
+type FollowedThreadViewerState = { hasUnread?: boolean };
+type FollowedThreadSummary = {
+  roomId: string;
+  threadRootEventId: string;
+  replyCount: number;
+  lastReplyAt: string | null;
+  hasUnread?: boolean;
+};
+type FollowedThreadCache = {
+  reset(serverId: string): void;
+  reconcile(serverId: string, states: ReadonlyMap<string, FollowedThreadViewerState>): void;
+  scrubRoom(serverId: string, roomId: string): void;
+  scrubMessage(serverId: string, roomId: string, eventId: string): void;
+  scrubUser(serverId: string): void;
+  updateSummary(serverId: string, summary: FollowedThreadSummary): void;
+};
 
 let removeServerCache: ServerCacheRemover | undefined;
 let removeAdminCache: ServerCacheRemover | undefined;
 let removeAdminUserCache: AdminUserCacheRemover | undefined;
 let reconcileAdminRoomCache: AdminRoomQueryReconciler | undefined;
 let reconcileAdminRoomGroupCache: AdminRoomGroupQueryReconciler | undefined;
+let followedThreadCache: FollowedThreadCache | undefined;
 const adminUserRemovalListeners = new Set<AdminUserRemovalListener>();
 const queryCacheRemovalListeners = new Set<QueryCacheRemovalListener>();
 const serverQueryCacheRemovalListeners = new Set<QueryCacheRemovalListener>();
@@ -27,6 +44,45 @@ export function registerServerQueryCache(removers: {
   removeAdminUserCache = removers.adminUser;
   reconcileAdminRoomCache = removers.adminRoom;
   reconcileAdminRoomGroupCache = removers.adminRoomGroups;
+}
+
+/** Register the followed-thread snapshot cache without loading it into the server store bundle. */
+export function registerFollowedThreadQueryCache(cache: FollowedThreadCache): void {
+  followedThreadCache = cache;
+}
+
+export function resetRegisteredFollowedThreadQueries(serverId: string): void {
+  followedThreadCache?.reset(serverId);
+}
+
+export function reconcileRegisteredFollowedThreadQueries(
+  serverId: string,
+  states: ReadonlyMap<string, FollowedThreadViewerState>
+): void {
+  followedThreadCache?.reconcile(serverId, states);
+}
+
+export function scrubRegisteredFollowedThreadRoom(serverId: string, roomId: string): void {
+  followedThreadCache?.scrubRoom(serverId, roomId);
+}
+
+export function scrubRegisteredFollowedThreadMessage(
+  serverId: string,
+  roomId: string,
+  eventId: string
+): void {
+  followedThreadCache?.scrubMessage(serverId, roomId, eventId);
+}
+
+export function scrubRegisteredFollowedThreadUser(serverId: string): void {
+  followedThreadCache?.scrubUser(serverId);
+}
+
+export function updateRegisteredFollowedThreadSummary(
+  serverId: string,
+  summary: FollowedThreadSummary
+): void {
+  followedThreadCache?.updateSummary(serverId, summary);
 }
 
 /** Purge cached private reads when a server session is disposed. */

--- a/apps/frontend/src/lib/query/threads.spec.ts
+++ b/apps/frontend/src/lib/query/threads.spec.ts
@@ -25,7 +25,10 @@ function thread(
 }
 
 function data(...pages: FollowedThreadsPage[]): FollowedThreadsData {
-  return { pages, pageParams: pages.map((_, index) => index * 20) };
+  return {
+    pages: pages.map((page, index) => ({ ...page, nextOffset: index * 20 + page.threads.length })),
+    pageParams: pages.map((_, index) => index * 20)
+  };
 }
 
 describe('followed thread query helpers', () => {
@@ -57,7 +60,11 @@ describe('followed thread query helpers', () => {
     expect(flattenFollowedThreads(reconciled.data)).toEqual([
       thread('retained', { hasUnread: true })
     ]);
-    expect(reconciled.data?.pages[0]).toMatchObject({ totalCount: 1, hasMore: false });
+    expect(reconciled.data?.pages[0]).toMatchObject({
+      totalCount: 1,
+      hasMore: false,
+      nextOffset: 2
+    });
     expect(reconciled.hasUnknownThreads).toBe(false);
   });
 

--- a/apps/frontend/src/lib/query/threads.spec.ts
+++ b/apps/frontend/src/lib/query/threads.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from 'vitest';
+import type { FollowedThread, FollowedThreadsPage } from '$lib/api-client/threads';
+import {
+  flattenFollowedThreads,
+  followedThreadKey,
+  reconcileFollowedThreadViewerStates,
+  updateFollowedThreadSummary,
+  type FollowedThreadsData
+} from './threads';
+
+function thread(
+  threadRootEventId: string,
+  overrides: Partial<FollowedThread> = {}
+): FollowedThread {
+  return {
+    roomId: 'room-1',
+    roomName: 'general',
+    threadRootEventId,
+    rootMessage: null,
+    replyCount: 1,
+    lastReplyAt: '2026-08-01T10:00:00.000Z',
+    hasUnread: false,
+    ...overrides
+  };
+}
+
+function data(...pages: FollowedThreadsPage[]): FollowedThreadsData {
+  return { pages, pageParams: pages.map((_, index) => index * 20) };
+}
+
+describe('followed thread query helpers', () => {
+  it('flattens pages without duplicating a thread returned across page boundaries', () => {
+    const first = thread('root-1');
+    const duplicate = thread('root-1', { replyCount: 2 });
+    const second = thread('root-2');
+
+    expect(
+      flattenFollowedThreads(
+        data(
+          { threads: [first], totalCount: 2, hasMore: true },
+          { threads: [duplicate, second], totalCount: 2, hasMore: false }
+        )
+      )
+    ).toEqual([first, second]);
+  });
+
+  it('scrubs unfollowed threads and reconciles unread state from the projection', () => {
+    const current = data({
+      threads: [thread('removed'), thread('retained')],
+      totalCount: 2,
+      hasMore: false
+    });
+    const states = new Map([[followedThreadKey('room-1', 'retained'), { hasUnread: true }]]);
+
+    const reconciled = reconcileFollowedThreadViewerStates(current, states);
+
+    expect(flattenFollowedThreads(reconciled.data)).toEqual([
+      thread('retained', { hasUnread: true })
+    ]);
+    expect(reconciled.data?.pages[0]).toMatchObject({ totalCount: 1, hasMore: false });
+    expect(reconciled.hasUnknownThreads).toBe(false);
+  });
+
+  it('reports projection threads that are missing from the cached snapshot', () => {
+    const current = data({ threads: [thread('root-1')], totalCount: 2, hasMore: false });
+    const states = new Map([
+      [followedThreadKey('room-1', 'root-1'), { hasUnread: false }],
+      [followedThreadKey('room-1', 'root-2'), { hasUnread: true }]
+    ]);
+
+    expect(reconcileFollowedThreadViewerStates(current, states).hasUnknownThreads).toBe(true);
+  });
+
+  it('does not refetch merely because projected threads belong to unloaded pages', () => {
+    const current = data({ threads: [thread('root-1')], totalCount: 2, hasMore: true });
+    const states = new Map([
+      [followedThreadKey('room-1', 'root-1'), { hasUnread: false }],
+      [followedThreadKey('room-1', 'root-2'), { hasUnread: true }]
+    ]);
+
+    expect(reconcileFollowedThreadViewerStates(current, states).hasUnknownThreads).toBe(false);
+  });
+
+  it('updates both the list summary and renderable root message', () => {
+    const current = data({
+      threads: [
+        thread('root-1', {
+          rootMessage: {
+            id: 'root-1',
+            createdAt: '2026-08-01T09:00:00.000Z',
+            event: {
+              kind: 'messagePosted',
+              roomId: 'room-1',
+              body: 'Root message',
+              attachments: [],
+              reactions: [],
+              replyCount: 1,
+              lastReplyAt: '2026-08-01T10:00:00.000Z',
+              threadParticipants: []
+            }
+          }
+        })
+      ],
+      totalCount: 1,
+      hasMore: false
+    });
+
+    const updated = updateFollowedThreadSummary(current, {
+      roomId: 'room-1',
+      threadRootEventId: 'root-1',
+      replyCount: 3,
+      lastReplyAt: '2026-08-02T10:00:00.000Z',
+      hasUnread: true
+    });
+    const result = flattenFollowedThreads(updated)[0];
+
+    expect(result).toMatchObject({ replyCount: 3, hasUnread: true });
+    expect(result?.rootMessage?.event).toMatchObject({
+      kind: 'messagePosted',
+      replyCount: 3,
+      lastReplyAt: '2026-08-02T10:00:00.000Z'
+    });
+  });
+});

--- a/apps/frontend/src/lib/query/threads.spec.ts
+++ b/apps/frontend/src/lib/query/threads.spec.ts
@@ -1,4 +1,5 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { InfiniteQueryObserver } from '@tanstack/svelte-query';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { FollowedThread, FollowedThreadsPage } from '$lib/api-client/threads';
 import {
   reconcileRegisteredFollowedThreadQueries,
@@ -195,6 +196,54 @@ describe('followed thread query helpers', () => {
     expect(flattenFollowedThreads(queryClient.getQueryData(queryKey))).toHaveLength(1);
 
     scrubRegisteredFollowedThreadUser('origin');
-    expect(queryClient.getQueryData(queryKey)).toBeUndefined();
+    expect(flattenFollowedThreads(queryClient.getQueryData(queryKey))).toEqual([]);
+  });
+
+  it('immediately clears mounted data and refetches after a user privacy boundary', async () => {
+    const queryKey = threadQueryKeys.followed('origin', { queryScope: 'session-1' });
+    const queryFn = vi.fn().mockResolvedValue({
+      threads: [thread('replacement')],
+      totalCount: 1,
+      hasMore: false,
+      nextOffset: 1
+    });
+    queryClient.setQueryData(
+      queryKey,
+      data({ threads: [thread('private')], totalCount: 1, hasMore: false })
+    );
+    const observer = new InfiniteQueryObserver(queryClient, {
+      queryKey,
+      queryFn,
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextOffset : undefined)
+    });
+    let observed = observer.getCurrentResult().data;
+    const unsubscribe = observer.subscribe((result) => {
+      observed = result.data;
+    });
+
+    scrubRegisteredFollowedThreadUser('origin');
+
+    expect(flattenFollowedThreads(observed)).toEqual([]);
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalled());
+    await vi.waitFor(() =>
+      expect(flattenFollowedThreads(observer.getCurrentResult().data)[0]?.threadRootEventId).toBe(
+        'replacement'
+      )
+    );
+    unsubscribe();
+  });
+
+  it('does not interrupt a query for an unrelated message deletion', async () => {
+    const queryKey = threadQueryKeys.followed('origin', { queryScope: 'session-1' });
+    queryClient.setQueryData(
+      queryKey,
+      data({ threads: [thread('root-1')], totalCount: 1, hasMore: false })
+    );
+    const cancel = vi.spyOn(queryClient, 'cancelQueries');
+
+    scrubRegisteredFollowedThreadMessage('origin', 'room-2', 'unrelated');
+
+    expect(cancel).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/lib/query/threads.spec.ts
+++ b/apps/frontend/src/lib/query/threads.spec.ts
@@ -246,4 +246,43 @@ describe('followed thread query helpers', () => {
 
     expect(cancel).not.toHaveBeenCalled();
   });
+
+  it('restarts hydration when a message is deleted during an active fetch', async () => {
+    const queryKey = threadQueryKeys.followed('origin', { queryScope: 'session-1' });
+    let firstSignal: AbortSignal | undefined;
+    const queryFn = vi
+      .fn()
+      .mockImplementationOnce(
+        ({ signal }: { signal: AbortSignal }) =>
+          new Promise<never>((_resolve, reject) => {
+            firstSignal = signal;
+            signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+          })
+      )
+      .mockResolvedValue({
+        threads: [thread('safe-root', { rootMessage: null })],
+        totalCount: 1,
+        hasMore: false,
+        nextOffset: 1
+      });
+    const observer = new InfiniteQueryObserver(queryClient, {
+      queryKey,
+      queryFn,
+      initialPageParam: 0,
+      getNextPageParam: (lastPage) => (lastPage.hasMore ? lastPage.nextOffset : undefined)
+    });
+    const unsubscribe = observer.subscribe(() => undefined);
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledTimes(1));
+
+    scrubRegisteredFollowedThreadMessage('origin', 'room-1', 'deleted-root');
+
+    await vi.waitFor(() => expect(firstSignal?.aborted).toBe(true));
+    await vi.waitFor(() => expect(queryFn).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(flattenFollowedThreads(observer.getCurrentResult().data)[0]?.threadRootEventId).toBe(
+        'safe-root'
+      )
+    );
+    unsubscribe();
+  });
 });

--- a/apps/frontend/src/lib/query/threads.spec.ts
+++ b/apps/frontend/src/lib/query/threads.spec.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import type { FollowedThread, FollowedThreadsPage } from '$lib/api-client/threads';
+import {
+  reconcileRegisteredFollowedThreadQueries,
+  scrubRegisteredFollowedThreadMessage,
+  scrubRegisteredFollowedThreadRoom,
+  scrubRegisteredFollowedThreadUser
+} from './cacheRegistry';
+import { queryClient } from './client';
 import {
   flattenFollowedThreads,
   followedThreadKey,
   reconcileFollowedThreadViewerStates,
+  threadQueryKeys,
   updateFollowedThreadSummary,
   type FollowedThreadsData
 } from './threads';
@@ -32,6 +40,8 @@ function data(...pages: FollowedThreadsPage[]): FollowedThreadsData {
 }
 
 describe('followed thread query helpers', () => {
+  afterEach(() => queryClient.clear());
+
   it('flattens pages without duplicating a thread returned across page boundaries', () => {
     const first = thread('root-1');
     const duplicate = thread('root-1', { replyCount: 2 });
@@ -85,7 +95,9 @@ describe('followed thread query helpers', () => {
       [followedThreadKey('room-1', 'root-2'), { hasUnread: true }]
     ]);
 
-    expect(reconcileFollowedThreadViewerStates(current, states).hasUnknownThreads).toBe(false);
+    const reconciled = reconcileFollowedThreadViewerStates(current, states);
+    expect(reconciled.hasUnknownThreads).toBe(false);
+    expect(reconciled.data?.pages[0]?.hasMore).toBe(true);
   });
 
   it('updates both the list summary and renderable root message', () => {
@@ -127,5 +139,62 @@ describe('followed thread query helpers', () => {
       replyCount: 3,
       lastReplyAt: '2026-08-02T10:00:00.000Z'
     });
+  });
+
+  it('reconciles every cached session from the process-wide projection owner', () => {
+    const firstKey = threadQueryKeys.followed('origin', { queryScope: 'session-1' });
+    const secondKey = threadQueryKeys.followed('origin', { queryScope: 'session-2' });
+    const current = data({
+      threads: [thread('removed'), thread('retained')],
+      totalCount: 2,
+      hasMore: false
+    });
+    queryClient.setQueryData(firstKey, current);
+    queryClient.setQueryData(secondKey, current);
+
+    reconcileRegisteredFollowedThreadQueries(
+      'origin',
+      new Map([[followedThreadKey('room-1', 'retained'), { hasUnread: true }]])
+    );
+
+    for (const key of [firstKey, secondKey]) {
+      expect(flattenFollowedThreads(queryClient.getQueryData(key))).toEqual([
+        thread('retained', { hasUnread: true })
+      ]);
+    }
+  });
+
+  it('scrubs room, message, and user privacy boundaries from retained caches', () => {
+    const queryKey = threadQueryKeys.followed('origin', { queryScope: 'session-1' });
+    const rootMessage = {
+      id: 'root-2',
+      createdAt: '2026-08-01T09:00:00.000Z',
+      event: {
+        kind: 'messagePosted' as const,
+        roomId: 'room-2',
+        body: 'Private root',
+        attachments: [],
+        reactions: [],
+        replyCount: 1,
+        threadParticipants: []
+      }
+    };
+    queryClient.setQueryData(
+      queryKey,
+      data({
+        threads: [thread('root-1'), thread('root-2', { roomId: 'room-2', rootMessage })],
+        totalCount: 2,
+        hasMore: false
+      })
+    );
+
+    scrubRegisteredFollowedThreadMessage('origin', 'room-2', 'root-2');
+    expect(flattenFollowedThreads(queryClient.getQueryData(queryKey))[1]?.rootMessage).toBeNull();
+
+    scrubRegisteredFollowedThreadRoom('origin', 'room-1');
+    expect(flattenFollowedThreads(queryClient.getQueryData(queryKey))).toHaveLength(1);
+
+    scrubRegisteredFollowedThreadUser('origin');
+    expect(queryClient.getQueryData(queryKey)).toBeUndefined();
   });
 });

--- a/apps/frontend/src/lib/query/threads.ts
+++ b/apps/frontend/src/lib/query/threads.ts
@@ -5,7 +5,12 @@ import type { ServerConnection } from '$lib/state/server/serverConnection.svelte
 type ThreadQueryConnection = Pick<ServerConnection, 'queryScope'>;
 type ThreadViewerState = { hasUnread?: boolean };
 
-export type FollowedThreadsData = InfiniteData<FollowedThreadsPage, unknown>;
+export type FollowedThreadsQueryPage = FollowedThreadsPage & {
+  /** Next server offset, preserved even when projection reconciliation filters rows. */
+  nextOffset: number;
+};
+
+export type FollowedThreadsData = InfiniteData<FollowedThreadsQueryPage, unknown>;
 
 export type ThreadSummaryUpdate = {
   roomId: string;

--- a/apps/frontend/src/lib/query/threads.ts
+++ b/apps/frontend/src/lib/query/threads.ts
@@ -251,7 +251,12 @@ function scrubFollowedThreadMessage(serverId: string, roomId: string, eventId: s
       }));
       return changed ? { ...current, pages } : current;
     });
-    if (changed) resumeFollowedThreadQuery(query.queryKey);
+    // A pending initial or next-page response may contain the deleted root even
+    // when it is not in the committed pages yet. Fence that response, while
+    // leaving settled queries for unrelated deletions alone.
+    if (changed || query.state.fetchStatus === 'fetching') {
+      resumeFollowedThreadQuery(query.queryKey);
+    }
   }
 }
 

--- a/apps/frontend/src/lib/query/threads.ts
+++ b/apps/frontend/src/lib/query/threads.ts
@@ -1,0 +1,136 @@
+import type { InfiniteData } from '@tanstack/svelte-query';
+import type { FollowedThread, FollowedThreadsPage } from '$lib/api-client/threads';
+import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+
+type ThreadQueryConnection = Pick<ServerConnection, 'queryScope'>;
+type ThreadViewerState = { hasUnread?: boolean };
+
+export type FollowedThreadsData = InfiniteData<FollowedThreadsPage, unknown>;
+
+export type ThreadSummaryUpdate = {
+  roomId: string;
+  threadRootEventId: string;
+  replyCount: number;
+  lastReplyAt: string | null;
+  hasUnread?: boolean;
+};
+
+function threadRoot(serverId: string, connection: ThreadQueryConnection) {
+  return ['server', serverId, 'session', connection.queryScope, 'threads'] as const;
+}
+
+export const threadQueryKeys = {
+  followed(serverId: string, connection: ThreadQueryConnection) {
+    return [...threadRoot(serverId, connection), 'followed'] as const;
+  }
+};
+
+export function followedThreadKey(roomId: string, threadRootEventId: string): string {
+  return `${roomId}\u0000${threadRootEventId}`;
+}
+
+/** Flatten offset pages without rendering a duplicate returned across page boundaries. */
+export function flattenFollowedThreads(data: FollowedThreadsData | undefined): FollowedThread[] {
+  const seen = new Set<string>();
+  return (data?.pages ?? []).flatMap((page) =>
+    page.threads.filter((thread) => {
+      const key = followedThreadKey(thread.roomId, thread.threadRootEventId);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+  );
+}
+
+/** Apply the latest projected root-message summary to every cached page. */
+export function updateFollowedThreadSummary(
+  data: FollowedThreadsData | undefined,
+  update: ThreadSummaryUpdate
+): FollowedThreadsData | undefined {
+  if (!data) return data;
+
+  let changed = false;
+  const pages = data.pages.map((page) => ({
+    ...page,
+    threads: page.threads.map((thread) => {
+      if (
+        thread.roomId !== update.roomId ||
+        thread.threadRootEventId !== update.threadRootEventId ||
+        (thread.replyCount === update.replyCount &&
+          (update.hasUnread === undefined || thread.hasUnread === update.hasUnread))
+      ) {
+        return thread;
+      }
+
+      changed = true;
+      const rootMessage = thread.rootMessage;
+      return {
+        ...thread,
+        rootMessage:
+          rootMessage?.event?.kind === 'messagePosted'
+            ? {
+                ...rootMessage,
+                event: {
+                  ...rootMessage.event,
+                  replyCount: update.replyCount,
+                  lastReplyAt: update.lastReplyAt ?? rootMessage.event.lastReplyAt
+                }
+              }
+            : rootMessage,
+        replyCount: update.replyCount,
+        lastReplyAt: update.lastReplyAt ?? thread.lastReplyAt,
+        hasUnread: update.hasUnread ?? thread.hasUnread
+      };
+    })
+  }));
+
+  return changed ? { ...data, pages } : data;
+}
+
+/**
+ * Scrub threads absent from the authoritative followed-thread projection and
+ * reconcile unread state. The caller should refetch once when the projection
+ * contains a thread that the loaded snapshot does not yet contain.
+ */
+export function reconcileFollowedThreadViewerStates(
+  data: FollowedThreadsData | undefined,
+  states: ReadonlyMap<string, ThreadViewerState>
+): { data: FollowedThreadsData | undefined; hasUnknownThreads: boolean } {
+  if (!data) return { data, hasUnknownThreads: states.size > 0 };
+
+  const cachedTotalCount = data.pages[0]?.totalCount ?? 0;
+  const snapshotComplete = data.pages.length > 0 && !data.pages[data.pages.length - 1]!.hasMore;
+  const knownKeys = new Set<string>();
+  let changed = false;
+  let pages = data.pages.map((page) => {
+    const threads = page.threads.flatMap((thread) => {
+      const key = followedThreadKey(thread.roomId, thread.threadRootEventId);
+      knownKeys.add(key);
+      const state = states.get(key);
+      if (!state) {
+        changed = true;
+        return [];
+      }
+      const hasUnread = state.hasUnread ?? false;
+      if (thread.hasUnread === hasUnread) return [thread];
+      changed = true;
+      return [{ ...thread, hasUnread }];
+    });
+    return threads.length === page.threads.length && !changed ? page : { ...page, threads };
+  });
+  const hasMissingProjectionThreads = [...states.keys()].some((key) => !knownKeys.has(key));
+  const hasUnknownThreads =
+    hasMissingProjectionThreads && (snapshotComplete || states.size !== cachedTotalCount);
+  pages = pages.map((page, index) => {
+    const isLastPage = index === pages.length - 1;
+    const hasMore = isLastPage && !hasUnknownThreads ? false : page.hasMore;
+    if (page.totalCount === states.size && page.hasMore === hasMore) return page;
+    changed = true;
+    return { ...page, totalCount: states.size, hasMore };
+  });
+
+  return {
+    data: changed ? { ...data, pages } : data,
+    hasUnknownThreads
+  };
+}

--- a/apps/frontend/src/lib/query/threads.ts
+++ b/apps/frontend/src/lib/query/threads.ts
@@ -159,17 +159,31 @@ function followedThreadQueries(serverId: string) {
   });
 }
 
-function cancelFollowedThreadQueries(serverId: string): void {
-  void queryClient.cancelQueries({
-    predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId)
-  });
+function resetFollowedThreadQueries(serverId: string): void {
+  const queries = followedThreadQueries(serverId);
+  for (const query of queries) {
+    queryClient.setQueryData<FollowedThreadsData>(query.queryKey, {
+      pages: [],
+      pageParams: []
+    });
+  }
+
+  void queryClient
+    .cancelQueries(
+      { predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId) },
+      { revert: false }
+    )
+    .then(() =>
+      queryClient.resetQueries({
+        predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId)
+      })
+    );
 }
 
-function resetFollowedThreadQueries(serverId: string): void {
-  cancelFollowedThreadQueries(serverId);
-  queryClient.removeQueries({
-    predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId)
-  });
+function resumeFollowedThreadQuery(queryKey: QueryKey): void {
+  void queryClient
+    .cancelQueries({ queryKey, exact: true }, { revert: false })
+    .then(() => queryClient.invalidateQueries({ queryKey, exact: true }));
 }
 
 function reconcileFollowedThreadQueries(
@@ -190,7 +204,6 @@ function reconcileFollowedThreadQueries(
 }
 
 function scrubFollowedThreadRoom(serverId: string, roomId: string): void {
-  cancelFollowedThreadQueries(serverId);
   for (const query of followedThreadQueries(serverId)) {
     queryClient.setQueryData<FollowedThreadsData>(query.queryKey, (current) => {
       if (!current) return current;
@@ -212,15 +225,16 @@ function scrubFollowedThreadRoom(serverId: string, roomId: string): void {
         }))
       };
     });
+    // Access loss is a privacy boundary even while a page is being hydrated.
+    resumeFollowedThreadQuery(query.queryKey);
   }
 }
 
 function scrubFollowedThreadMessage(serverId: string, roomId: string, eventId: string): void {
-  cancelFollowedThreadQueries(serverId);
   for (const query of followedThreadQueries(serverId)) {
+    let changed = false;
     queryClient.setQueryData<FollowedThreadsData>(query.queryKey, (current) => {
       if (!current) return current;
-      let changed = false;
       const pages = current.pages.map((page) => ({
         ...page,
         threads: page.threads.map((thread) => {
@@ -237,6 +251,7 @@ function scrubFollowedThreadMessage(serverId: string, roomId: string, eventId: s
       }));
       return changed ? { ...current, pages } : current;
     });
+    if (changed) resumeFollowedThreadQuery(query.queryKey);
   }
 }
 

--- a/apps/frontend/src/lib/query/threads.ts
+++ b/apps/frontend/src/lib/query/threads.ts
@@ -1,6 +1,9 @@
 import type { InfiniteData } from '@tanstack/svelte-query';
+import type { QueryKey } from '@tanstack/svelte-query';
 import type { FollowedThread, FollowedThreadsPage } from '$lib/api-client/threads';
 import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+import { queryClient } from './client';
+import { registerFollowedThreadQueryCache } from './cacheRegistry';
 
 type ThreadQueryConnection = Pick<ServerConnection, 'queryScope'>;
 type ThreadViewerState = { hasUnread?: boolean };
@@ -128,7 +131,7 @@ export function reconcileFollowedThreadViewerStates(
     hasMissingProjectionThreads && (snapshotComplete || states.size !== cachedTotalCount);
   pages = pages.map((page, index) => {
     const isLastPage = index === pages.length - 1;
-    const hasMore = isLastPage && !hasUnknownThreads ? false : page.hasMore;
+    const hasMore = isLastPage && !hasMissingProjectionThreads ? false : page.hasMore;
     if (page.totalCount === states.size && page.hasMore === hasMore) return page;
     changed = true;
     return { ...page, totalCount: states.size, hasMore };
@@ -139,3 +142,117 @@ export function reconcileFollowedThreadViewerStates(
     hasUnknownThreads
   };
 }
+
+function isFollowedThreadQuery(key: QueryKey, serverId: string): boolean {
+  return (
+    key[0] === 'server' &&
+    key[1] === serverId &&
+    key[2] === 'session' &&
+    key[4] === 'threads' &&
+    key[5] === 'followed'
+  );
+}
+
+function followedThreadQueries(serverId: string) {
+  return queryClient.getQueryCache().findAll({
+    predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId)
+  });
+}
+
+function cancelFollowedThreadQueries(serverId: string): void {
+  void queryClient.cancelQueries({
+    predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId)
+  });
+}
+
+function resetFollowedThreadQueries(serverId: string): void {
+  cancelFollowedThreadQueries(serverId);
+  queryClient.removeQueries({
+    predicate: (query) => isFollowedThreadQuery(query.queryKey, serverId)
+  });
+}
+
+function reconcileFollowedThreadQueries(
+  serverId: string,
+  states: ReadonlyMap<string, ThreadViewerState>
+): void {
+  for (const query of followedThreadQueries(serverId)) {
+    const current = query.state.data as FollowedThreadsData | undefined;
+    const reconciled = reconcileFollowedThreadViewerStates(current, states);
+    if (flattenFollowedThreads(reconciled.data).length < flattenFollowedThreads(current).length) {
+      void queryClient.cancelQueries({ queryKey: query.queryKey, exact: true });
+    }
+    if (reconciled.data !== current) queryClient.setQueryData(query.queryKey, reconciled.data);
+    if (reconciled.hasUnknownThreads) {
+      void queryClient.invalidateQueries({ queryKey: query.queryKey, exact: true });
+    }
+  }
+}
+
+function scrubFollowedThreadRoom(serverId: string, roomId: string): void {
+  cancelFollowedThreadQueries(serverId);
+  for (const query of followedThreadQueries(serverId)) {
+    queryClient.setQueryData<FollowedThreadsData>(query.queryKey, (current) => {
+      if (!current) return current;
+      const removed = new Set<string>();
+      const pages = current.pages.map((page) => ({
+        ...page,
+        threads: page.threads.filter((thread) => {
+          if (thread.roomId !== roomId) return true;
+          removed.add(followedThreadKey(thread.roomId, thread.threadRootEventId));
+          return false;
+        })
+      }));
+      if (removed.size === 0) return current;
+      return {
+        ...current,
+        pages: pages.map((page) => ({
+          ...page,
+          totalCount: Math.max(0, page.totalCount - removed.size)
+        }))
+      };
+    });
+  }
+}
+
+function scrubFollowedThreadMessage(serverId: string, roomId: string, eventId: string): void {
+  cancelFollowedThreadQueries(serverId);
+  for (const query of followedThreadQueries(serverId)) {
+    queryClient.setQueryData<FollowedThreadsData>(query.queryKey, (current) => {
+      if (!current) return current;
+      let changed = false;
+      const pages = current.pages.map((page) => ({
+        ...page,
+        threads: page.threads.map((thread) => {
+          if (
+            thread.roomId !== roomId ||
+            thread.threadRootEventId !== eventId ||
+            !thread.rootMessage
+          ) {
+            return thread;
+          }
+          changed = true;
+          return { ...thread, rootMessage: null };
+        })
+      }));
+      return changed ? { ...current, pages } : current;
+    });
+  }
+}
+
+function updateFollowedThreadQueries(serverId: string, summary: ThreadSummaryUpdate): void {
+  for (const query of followedThreadQueries(serverId)) {
+    queryClient.setQueryData<FollowedThreadsData>(query.queryKey, (current) =>
+      updateFollowedThreadSummary(current, summary)
+    );
+  }
+}
+
+registerFollowedThreadQueryCache({
+  reset: resetFollowedThreadQueries,
+  reconcile: reconcileFollowedThreadQueries,
+  scrubRoom: scrubFollowedThreadRoom,
+  scrubMessage: scrubFollowedThreadMessage,
+  scrubUser: resetFollowedThreadQueries,
+  updateSummary: updateFollowedThreadQueries
+});

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -37,6 +37,7 @@ import {
   RealtimeProjectionRoom,
   RealtimeProjectionRoomGroupsReplace,
   RealtimeProjectionRoomRemove,
+  RealtimeProjectionThreadViewerStatesReplace,
   RealtimeProjectionUserRemove
 } from '@chatto/api-types/realtime/v1/realtime_pb';
 import { MAX_RETAINED_ROOM_TIMELINES } from './realtimeSync.svelte';
@@ -50,7 +51,13 @@ const { soundMocks, apiMocks, cacheMocks } = vi.hoisted(() => ({
     reconcileRegisteredAdminRoomQueries: vi.fn(),
     removeRegisteredAdminQueries: vi.fn(),
     removeRegisteredAdminUserQueries: vi.fn(),
-    removeRegisteredServerQueries: vi.fn()
+    removeRegisteredServerQueries: vi.fn(),
+    resetFollowedThreads: vi.fn(),
+    reconcileFollowedThreads: vi.fn(),
+    scrubFollowedThreadRoom: vi.fn(),
+    scrubFollowedThreadMessage: vi.fn(),
+    scrubFollowedThreadUser: vi.fn(),
+    updateFollowedThreadSummary: vi.fn()
   },
   apiMocks: {
     listRooms: vi.fn(() => Promise.resolve([])),
@@ -256,7 +263,10 @@ vi.mock('$lib/api-client/attachments', async (importActual) => {
 
 import { ServerStateStore } from './store.svelte';
 import { eventBusManager, setRealtimeSocketFactoryForTests } from './eventBus.svelte';
-import { registerServerQueryCache } from '$lib/query/cacheRegistry';
+import {
+  registerFollowedThreadQueryCache,
+  registerServerQueryCache
+} from '$lib/query/cacheRegistry';
 import type { ServerConnection } from './serverConnection.svelte';
 import type { RegisteredServer } from './registry.svelte';
 
@@ -397,6 +407,20 @@ beforeEach(() => {
     adminRoom: cacheMocks.reconcileRegisteredAdminRoomQueries,
     adminRoomGroups: cacheMocks.reconcileRegisteredAdminRoomGroupQueries
   });
+  registerFollowedThreadQueryCache({
+    reset: cacheMocks.resetFollowedThreads,
+    reconcile: cacheMocks.reconcileFollowedThreads,
+    scrubRoom: cacheMocks.scrubFollowedThreadRoom,
+    scrubMessage: cacheMocks.scrubFollowedThreadMessage,
+    scrubUser: cacheMocks.scrubFollowedThreadUser,
+    updateSummary: cacheMocks.updateFollowedThreadSummary
+  });
+  cacheMocks.resetFollowedThreads.mockClear();
+  cacheMocks.reconcileFollowedThreads.mockClear();
+  cacheMocks.scrubFollowedThreadRoom.mockClear();
+  cacheMocks.scrubFollowedThreadMessage.mockClear();
+  cacheMocks.scrubFollowedThreadUser.mockClear();
+  cacheMocks.updateFollowedThreadSummary.mockClear();
   cacheMocks.reconcileRegisteredAdminRoomQueries.mockClear();
   cacheMocks.reconcileRegisteredAdminRoomGroupQueries.mockClear();
   cacheMocks.removeRegisteredServerQueries.mockClear();
@@ -816,6 +840,7 @@ describe('ServerStateStore live server updates', () => {
     expect(store.navigation.rooms[0]?.members).toEqual([]);
     expect(messages.events[0]).toMatchObject({ actorId: 'U2', actor: null });
     expect(cacheMocks.removeRegisteredAdminUserQueries).toHaveBeenCalledWith(registered.id, 'U2');
+    expect(cacheMocks.scrubFollowedThreadUser).toHaveBeenCalledWith(registered.id);
   });
 
   it('reconciles query-backed room snapshots from process-wide projection events', () => {
@@ -837,6 +862,14 @@ describe('ServerStateStore live server updates', () => {
           value: new RealtimeProjectionRoom({
             room: new RoomWithViewerState({ room: new Room({ id: 'R1' }) })
           })
+        }
+      })
+    );
+    dispatch(
+      new RealtimeProjectionOperation({
+        operation: {
+          case: 'threadViewerStatesReplace',
+          value: new RealtimeProjectionThreadViewerStatesReplace()
         }
       })
     );
@@ -874,6 +907,11 @@ describe('ServerStateStore live server updates', () => {
     expect(cacheMocks.reconcileRegisteredAdminRoomGroupQueries).toHaveBeenCalledWith(
       registered.id,
       ['G1']
+    );
+    expect(cacheMocks.scrubFollowedThreadRoom).toHaveBeenCalledWith(registered.id, 'R2');
+    expect(cacheMocks.reconcileFollowedThreads).toHaveBeenCalledWith(
+      registered.id,
+      expect.any(Map)
     );
   });
 
@@ -948,6 +986,7 @@ describe('ServerStateStore live server updates', () => {
     );
     expect(store.projection.timelines.has('R1')).toBe(false);
     expect(messages.events).toEqual([]);
+    expect(cacheMocks.scrubFollowedThreadRoom).toHaveBeenCalledWith(registered.id, 'R1');
     expect(messages.isInitialLoading).toBe(false);
     expect(store.realtimeSync.desiredRoomIds).toEqual(['R1']);
     expect(store.realtimeSync.retainedRoomIds).toEqual(['R1']);
@@ -1291,6 +1330,7 @@ describe('ServerStateStore live server updates', () => {
     }
 
     expect(applyTimelineEvent).not.toHaveBeenCalled();
+    expect(cacheMocks.scrubFollowedThreadMessage).toHaveBeenCalledWith(registered.id, 'R1', 'M1');
     expect(files.items.map((item) => item.attachment.id)).toEqual(['A1']);
     expect(apiMocks.listRoomAttachments).toHaveBeenCalledOnce();
   });

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -50,9 +50,15 @@ import { MentionRolesStore } from './mentionRoles.svelte';
 import {
   reconcileRegisteredAdminRoomGroupQueries,
   reconcileRegisteredAdminRoomQueries,
+  reconcileRegisteredFollowedThreadQueries,
   removeRegisteredAdminQueries,
   removeRegisteredAdminUserQueries,
-  removeRegisteredServerQueries
+  removeRegisteredServerQueries,
+  resetRegisteredFollowedThreadQueries,
+  scrubRegisteredFollowedThreadMessage,
+  scrubRegisteredFollowedThreadRoom,
+  scrubRegisteredFollowedThreadUser,
+  updateRegisteredFollowedThreadSummary
 } from '$lib/query/cacheRegistry';
 
 /**
@@ -256,6 +262,7 @@ export class ServerStateStore {
 
   /** Scrub every plaintext timeline mirror for a room at an authorization boundary. */
   private clearRoomAccess(roomId: string, forgetStores = false): void {
+    scrubRegisteredFollowedThreadRoom(this.serverId, roomId);
     this.voiceCall.handleRoomAccessRevoked(roomId);
     this.activeCallRooms.clearRoom(roomId);
     this.notifications.clearRoom(roomId);
@@ -340,6 +347,7 @@ export class ServerStateStore {
     for (const operation of event.operations) {
       switch (operation.operation.case) {
         case 'reset':
+          resetRegisteredFollowedThreadQueries(this.serverId);
           this.resetProjectionMirrors();
           this.forEachMessageSearch((store) => store.clearResults());
           adminRoomLayoutChanged = true;
@@ -368,6 +376,7 @@ export class ServerStateStore {
         }
         case 'userRemove': {
           const userId = operation.operation.value.userId;
+          scrubRegisteredFollowedThreadUser(this.serverId);
           removeRegisteredAdminUserQueries(this.serverId, userId);
           this.forEachMessageSearch((store) => store.invalidateAuthor(userId));
           removeUserSummaryCacheEntry(this.serverId, userId);
@@ -430,6 +439,26 @@ export class ServerStateStore {
         }
         case 'roomTimelineEventUpsert': {
           const update = operation.operation.value;
+          const projectedMessage =
+            update.event?.event.case === 'messagePosted' ? update.event.event.value.message : null;
+          if (update.event && projectedMessage?.deletedAt) {
+            scrubRegisteredFollowedThreadMessage(this.serverId, update.roomId, update.event.id);
+          }
+          const threadSummary = projectedMessage?.thread;
+          if (
+            update.event &&
+            projectedMessage &&
+            !projectedMessage.threadRootEventId &&
+            threadSummary
+          ) {
+            updateRegisteredFollowedThreadSummary(this.serverId, {
+              roomId: update.roomId,
+              threadRootEventId: update.event.id,
+              replyCount: threadSummary.replyCount,
+              lastReplyAt: threadSummary.lastReplyAt?.toDate().toISOString() ?? null,
+              hasUnread: threadSummary.viewerState?.hasUnread
+            });
+          }
           if (update.event && !update.reactionChange) {
             const eventId = update.event.id;
             this.forRoomMessageSearch(update.roomId, (store) =>
@@ -505,6 +534,10 @@ export class ServerStateStore {
           break;
         }
         case 'threadViewerStatesReplace': {
+          reconcileRegisteredFollowedThreadQueries(
+            this.serverId,
+            this.projection.threadViewerStates
+          );
           for (const [roomId, page] of this.projection.timelines) {
             for (const projectedEvent of page.events) {
               if (
@@ -528,6 +561,7 @@ export class ServerStateStore {
         }
         case 'roomTimelineEventRemove': {
           const removal = operation.operation.value;
+          scrubRegisteredFollowedThreadMessage(this.serverId, removal.roomId, removal.eventId);
           this.forRoomMessageSearch(removal.roomId, (store) =>
             store.invalidateMessage(removal.roomId, removal.eventId, true)
           );

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -62,14 +62,16 @@
           const result = await connection
             .getAPI(createThreadAPI)
             .listFollowedThreads({ limit: PAGE_SIZE, offset: pageParam }, { signal });
-          if (!serverScope.isCurrent() || connection !== serverScope.connection) return result;
-          return reconcilePageWithCurrentProjection(result, pageParam);
+          const pageData = {
+            ...result,
+            nextOffset: pageParam + result.threads.length
+          };
+          if (!serverScope.isCurrent() || connection !== serverScope.connection) return pageData;
+          return reconcilePageWithCurrentProjection(pageData, pageParam);
         },
         initialPageParam: 0,
         getNextPageParam: (lastPage, _pages, lastPageParam) =>
-          lastPage.hasMore && lastPage.threads.length > 0
-            ? lastPageParam + lastPage.threads.length
-            : undefined
+          lastPage.hasMore && lastPage.nextOffset > lastPageParam ? lastPage.nextOffset : undefined
       };
     },
     () => queryClient

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -21,7 +21,6 @@
   import RoomEvent from '../[roomId]/RoomEvent.svelte';
   import { formatDate, timeFormatSettingsFor } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
-  import { useProjectionEvent } from '$lib/hooks/useEvent.svelte';
   import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
   import {
     createRoomPermissions,
@@ -50,7 +49,8 @@
     void serverStore.mentionRoles.refresh();
   });
 
-  let reconcileAfterHydration = false;
+  let reconciledQueryScope: string | null = null;
+  let reconciledMountedSnapshot = false;
 
   const threadsQuery = createInfiniteQuery(
     () => {
@@ -145,10 +145,7 @@
   ) {
     const queryKey = threadQueryKeys.followed(serverScope.serverId, serverScope.connection);
     const current = queryClient.getQueryData<FollowedThreadsData>(queryKey);
-    if (!current) {
-      if (refetchUnknown) reconcileAfterHydration = true;
-      return;
-    }
+    if (!current) return;
 
     const reconciled = reconcileFollowedThreadViewerStates(current, states);
     let next = reconciled.data;
@@ -161,53 +158,20 @@
     }
   }
 
-  // Apply live root-message summaries directly from projection operations.
-  // The canonical store reconciliation below also covers summaries that
-  // arrived before this page mounted.
-  useProjectionEvent((event) => {
-    for (const operation of event.operations) {
-      if (operation.operation.case === 'threadViewerStatesReplace') {
-        const states = new Map(
-          operation.operation.value.states.map((state) => [
-            `${state.roomId}\u0000${state.threadRootEventId}`,
-            state.viewerState ?? {}
-          ])
-        );
-        reconcileCachedProjection(states, true);
-        continue;
-      }
-      if (operation.operation.case !== 'roomTimelineEventUpsert') continue;
-      const update = operation.operation.value;
-      const timelineEvent = update.event;
-      if (timelineEvent?.event.case !== 'messagePosted') continue;
-      const message = timelineEvent.event.value.message;
-      const summary = message?.thread;
-      if (!message || message.threadRootEventId || !summary) continue;
-
-      const queryKey = threadQueryKeys.followed(serverScope.serverId, serverScope.connection);
-      queryClient.setQueryData<FollowedThreadsData>(queryKey, (current) =>
-        updateFollowedThreadSummary(current, {
-          roomId: update.roomId,
-          threadRootEventId: timelineEvent.id,
-          replyCount: summary.replyCount,
-          lastReplyAt: summary.lastReplyAt?.toDate().toISOString() ?? null,
-          hasUnread: summary.viewerState?.hasUnread
-        })
-      );
+  // Reconcile after every query commit so an append cannot restore an older
+  // page snapshot over a projection update that arrived while it was in flight.
+  $effect(() => {
+    const queryScope = serverScope.connection.queryScope;
+    const queryData = threadsQuery.data;
+    if (reconciledQueryScope !== queryScope) {
+      reconciledQueryScope = queryScope;
+      reconciledMountedSnapshot = false;
     }
-  });
 
-  // Reconcile followed-thread summaries from the same canonical room
-  // projection that feeds every room timeline.
-  $effect(() => {
-    if (!serverStore.realtimeSync.hasUsableProjection) return;
-    reconcileCachedProjection(serverStore.projection.threadViewerStates, false);
-  });
-
-  $effect(() => {
-    if (!threadsQuery.data || !reconcileAfterHydration) return;
-    reconcileAfterHydration = false;
-    reconcileCachedProjection(serverStore.projection.threadViewerStates, true);
+    if (!serverStore.realtimeSync.hasUsableProjection || !queryData) return;
+    const refetchUnknown = !reconciledMountedSnapshot;
+    reconciledMountedSnapshot = true;
+    reconcileCachedProjection(serverStore.projection.threadViewerStates, refetchUnknown);
   });
 
   async function loadMore() {

--- a/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/threads/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { createInfiniteQuery } from '@tanstack/svelte-query';
   import { goto, replaceState } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
@@ -6,18 +7,22 @@
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import * as m from '$lib/i18n/messages';
 
-  import type { TimelineEventView } from '$lib/render/timelineEvents';
+  import { createThreadAPI, type FollowedThread } from '$lib/api-client/threads';
+  import { queryClient } from '$lib/query/client';
   import {
-    createThreadAPI,
-    type FollowedThread as APIFollowedThread
-  } from '$lib/api-client/threads';
+    flattenFollowedThreads,
+    reconcileFollowedThreadViewerStates,
+    threadQueryKeys,
+    updateFollowedThreadSummary,
+    type FollowedThreadsData
+  } from '$lib/query/threads';
   import { EmptyState, Hint, PaneHeader, SegmentedControl } from '$lib/ui';
   import PageTitle from '$lib/ui/PageTitle.svelte';
-  import { Button } from '$lib/ui/form';
   import RoomEvent from '../[roomId]/RoomEvent.svelte';
   import { formatDate, timeFormatSettingsFor } from '$lib/utils/formatTime';
   import { getLocale } from '$lib/i18n/runtime';
   import { useProjectionEvent } from '$lib/hooks/useEvent.svelte';
+  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
   import {
     createRoomPermissions,
     DEFAULT_ROOM_PERMISSIONS,
@@ -37,9 +42,7 @@
   createComposerContext();
   createMentionRoles(() => serverStore.mentionRoles.roles);
 
-  const userSettings = $derived(
-    timeFormatSettingsFor(serverStore.currentUser.user?.settings)
-  );
+  const userSettings = $derived(timeFormatSettingsFor(serverStore.currentUser.user?.settings));
   const activeLocale = $derived(getLocale());
   const PAGE_SIZE = 20;
 
@@ -47,35 +50,43 @@
     void serverStore.mentionRoles.refresh();
   });
 
-  type FollowedThreadItem = {
-    roomId: string;
-    roomName: string;
-    threadRootEventId: string;
-    rootMessage: TimelineEventView | null;
-    replyCount: number;
-    lastReplyAt: string | null;
-    hasUnread: boolean;
-  };
+  let reconcileAfterHydration = false;
 
-  function mapThread(t: APIFollowedThread): FollowedThreadItem {
-    return {
-      roomId: t.roomId,
-      roomName: t.roomName,
-      threadRootEventId: t.threadRootEventId,
-      rootMessage: t.rootMessage ?? null,
-      replyCount: t.replyCount,
-      lastReplyAt: t.lastReplyAt,
-      hasUnread: t.hasUnread
-    };
-  }
+  const threadsQuery = createInfiniteQuery(
+    () => {
+      const serverId = serverScope.serverId;
+      const connection = serverScope.connection;
+      return {
+        queryKey: threadQueryKeys.followed(serverId, connection),
+        queryFn: async ({ pageParam, signal }) => {
+          const result = await connection
+            .getAPI(createThreadAPI)
+            .listFollowedThreads({ limit: PAGE_SIZE, offset: pageParam }, { signal });
+          if (!serverScope.isCurrent() || connection !== serverScope.connection) return result;
+          return reconcilePageWithCurrentProjection(result, pageParam);
+        },
+        initialPageParam: 0,
+        getNextPageParam: (lastPage, _pages, lastPageParam) =>
+          lastPage.hasMore && lastPage.threads.length > 0
+            ? lastPageParam + lastPage.threads.length
+            : undefined
+      };
+    },
+    () => queryClient
+  );
 
-  let threads = $state<FollowedThreadItem[]>([]);
-  let loading = $state(true);
-  let loadingMore = $state(false);
-  let error = $state<string | null>(null);
-  let hasMore = $state(false);
-  let totalCount = $state(0);
-  let loadId = 0;
+  const threads = $derived(flattenFollowedThreads(threadsQuery.data));
+  const loading = $derived(threadsQuery.isPending);
+  const loadingMore = $derived(threadsQuery.isFetchingNextPage);
+  const error = $derived(
+    threadsQuery.isError
+      ? threadsQuery.error instanceof Error
+        ? threadsQuery.error.message
+        : 'Failed to load threads'
+      : null
+  );
+  const hasMore = $derived(threadsQuery.hasNextPage);
+  const totalCount = $derived(threadsQuery.data?.pages[0]?.totalCount ?? 0);
 
   const filter = $derived(page.state.threadFilter ?? 'all');
   const filterOptions = $derived([
@@ -91,111 +102,62 @@
     filter === 'unread' ? threads.filter((t) => t.hasUnread) : threads
   );
 
-  async function loadThreads({ append = false }: { append?: boolean } = {}) {
-    const thisId = ++loadId;
-    if (append) {
-      loadingMore = true;
-    } else {
-      loading = true;
+  function reconcilePageWithCurrentProjection(
+    pageData: FollowedThreadsData['pages'][number],
+    pageParam: number
+  ): FollowedThreadsData['pages'][number] {
+    if (!serverStore.realtimeSync.hasUsableProjection) return pageData;
+    let data: FollowedThreadsData | undefined = { pages: [pageData], pageParams: [pageParam] };
+    data = reconcileFollowedThreadViewerStates(
+      data,
+      serverStore.projection.threadViewerStates
+    ).data;
+    for (const thread of data?.pages[0]?.threads ?? []) {
+      data = applyProjectedTimelineSummary(data, thread);
     }
-    error = null;
-
-    try {
-      const result = await serverScope.connection.getAPI(createThreadAPI).listFollowedThreads({
-        limit: PAGE_SIZE,
-        offset: append ? threads.length : 0
-      });
-
-      if (thisId !== loadId) return;
-
-      const nextThreads = result.threads.map(mapThread);
-      threads = append ? mergeThreads(threads, nextThreads) : nextThreads;
-      hasMore = result.hasMore;
-      totalCount = result.totalCount;
-    } catch (e) {
-      if (thisId !== loadId) return;
-      error = e instanceof Error ? e.message : 'Failed to load threads';
-    } finally {
-      if (thisId === loadId) {
-        loading = false;
-        loadingMore = false;
-      }
-    }
+    return data?.pages[0] ?? pageData;
   }
 
-  function mergeThreads(
-    existing: FollowedThreadItem[],
-    next: FollowedThreadItem[]
-  ): FollowedThreadItem[] {
-    const seen = new Set(existing.map((thread) => thread.threadRootEventId));
-    return [...existing, ...next.filter((thread) => !seen.has(thread.threadRootEventId))];
+  function applyProjectedTimelineSummary(
+    data: FollowedThreadsData | undefined,
+    thread: FollowedThread
+  ): FollowedThreadsData | undefined {
+    const event = serverStore.projection.timelines
+      .get(thread.roomId)
+      ?.events.find((candidate) => candidate.id === thread.threadRootEventId);
+    const message = event?.event.case === 'messagePosted' ? event.event.value.message : null;
+    const summary = message?.thread;
+    if (!summary) return data;
+    return updateFollowedThreadSummary(data, {
+      roomId: thread.roomId,
+      threadRootEventId: thread.threadRootEventId,
+      replyCount: summary.replyCount,
+      lastReplyAt: summary.lastReplyAt?.toDate().toISOString() ?? null,
+      hasUnread: summary.viewerState?.hasUnread
+    });
   }
 
-  function applyThreadSummary(
-    roomId: string,
-    threadRootEventId: string,
-    replyCount: number,
-    lastReplyAt: string | null,
-    hasUnread?: boolean
+  function reconcileCachedProjection(
+    states: ReadonlyMap<string, { hasUnread?: boolean }>,
+    refetchUnknown: boolean
   ) {
-    let changed = false;
-    const next = threads.map((thread) => {
-      if (
-        thread.roomId !== roomId ||
-        thread.threadRootEventId !== threadRootEventId ||
-        (thread.replyCount === replyCount &&
-          (hasUnread === undefined || thread.hasUnread === hasUnread))
-      ) {
-        return thread;
-      }
-      changed = true;
-      const rootMessage = thread.rootMessage;
-      return {
-        ...thread,
-        rootMessage:
-          rootMessage?.event?.kind === 'messagePosted'
-            ? {
-                ...rootMessage,
-                event: {
-                  ...rootMessage.event,
-                  replyCount,
-                  lastReplyAt: lastReplyAt ?? rootMessage.event.lastReplyAt
-                }
-              }
-            : rootMessage,
-        replyCount,
-        lastReplyAt: lastReplyAt ?? thread.lastReplyAt,
-        hasUnread: hasUnread ?? thread.hasUnread
-      };
-    });
-    if (changed) threads = next;
-  }
+    const queryKey = threadQueryKeys.followed(serverScope.serverId, serverScope.connection);
+    const current = queryClient.getQueryData<FollowedThreadsData>(queryKey);
+    if (!current) {
+      if (refetchUnknown) reconcileAfterHydration = true;
+      return;
+    }
 
-  function reconcileThreadViewerStates(
-    states: ReadonlyMap<string, { hasUnread?: boolean }>
-  ): boolean {
-    const knownKeys = new Set(
-      threads.map((thread) => `${thread.roomId}\u0000${thread.threadRootEventId}`)
-    );
-    let changed = false;
-    const next = threads.flatMap((thread) => {
-      const key = `${thread.roomId}\u0000${thread.threadRootEventId}`;
-      const state = states.get(key);
-      if (!state) {
-        changed = true;
-        return [];
-      }
-      if (thread.hasUnread === (state.hasUnread ?? false)) return [thread];
-      changed = true;
-      return [{ ...thread, hasUnread: state.hasUnread ?? false }];
-    });
-    if (changed) threads = next;
-    return [...states.keys()].some((key) => !knownKeys.has(key));
+    const reconciled = reconcileFollowedThreadViewerStates(current, states);
+    let next = reconciled.data;
+    for (const thread of flattenFollowedThreads(next)) {
+      next = applyProjectedTimelineSummary(next, thread);
+    }
+    if (next !== current) queryClient.setQueryData(queryKey, next);
+    if (refetchUnknown && reconciled.hasUnknownThreads) {
+      void queryClient.invalidateQueries({ queryKey, exact: true });
+    }
   }
-
-  $effect(() => {
-    loadThreads();
-  });
 
   // Apply live root-message summaries directly from projection operations.
   // The canonical store reconciliation below also covers summaries that
@@ -209,7 +171,7 @@
             state.viewerState ?? {}
           ])
         );
-        if (reconcileThreadViewerStates(states)) void loadThreads();
+        reconcileCachedProjection(states, true);
         continue;
       }
       if (operation.operation.case !== 'roomTimelineEventUpsert') continue;
@@ -220,12 +182,15 @@
       const summary = message?.thread;
       if (!message || message.threadRootEventId || !summary) continue;
 
-      applyThreadSummary(
-        update.roomId,
-        timelineEvent.id,
-        summary.replyCount,
-        summary.lastReplyAt?.toDate().toISOString() ?? null,
-        summary.viewerState?.hasUnread
+      const queryKey = threadQueryKeys.followed(serverScope.serverId, serverScope.connection);
+      queryClient.setQueryData<FollowedThreadsData>(queryKey, (current) =>
+        updateFollowedThreadSummary(current, {
+          roomId: update.roomId,
+          threadRootEventId: timelineEvent.id,
+          replyCount: summary.replyCount,
+          lastReplyAt: summary.lastReplyAt?.toDate().toISOString() ?? null,
+          hasUnread: summary.viewerState?.hasUnread
+        })
       );
     }
   });
@@ -234,28 +199,28 @@
   // projection that feeds every room timeline.
   $effect(() => {
     if (!serverStore.realtimeSync.hasUsableProjection) return;
-    reconcileThreadViewerStates(serverStore.projection.threadViewerStates);
+    reconcileCachedProjection(serverStore.projection.threadViewerStates, false);
   });
 
   $effect(() => {
-    for (const thread of threads) {
-      const event = serverStore.projection.timelines
-        .get(thread.roomId)
-        ?.events.find((candidate) => candidate.id === thread.threadRootEventId);
-      const message = event?.event.case === 'messagePosted' ? event.event.value.message : null;
-      const summary = message?.thread;
-      if (!summary || summary.replyCount === thread.replyCount) continue;
-      applyThreadSummary(
-        thread.roomId,
-        thread.threadRootEventId,
-        summary.replyCount,
-        summary.lastReplyAt?.toDate().toISOString() ?? null,
-        summary.viewerState?.hasUnread
-      );
-    }
+    if (!threadsQuery.data || !reconcileAfterHydration) return;
+    reconcileAfterHydration = false;
+    reconcileCachedProjection(serverStore.projection.threadViewerStates, true);
   });
 
-  function navigateToThread(thread: FollowedThreadItem) {
+  async function loadMore() {
+    if (loading || loadingMore || !hasMore) return;
+    await threadsQuery.fetchNextPage();
+  }
+
+  const loadMoreWhenVisible = useLoadMoreWhenVisible({
+    getCursor: () =>
+      hasMore ? `${threadsQuery.data?.pageParams.at(-1) ?? 0}:${threads.length}` : null,
+    loadMore,
+    hasError: () => error !== null
+  });
+
+  function navigateToThread(thread: FollowedThread) {
     goto(
       resolve('/chat/[serverId]/[roomId]/[threadId]', {
         serverId: serverIdToSegment(serverScope.serverId),
@@ -322,14 +287,9 @@
             <span>
               {m['chat.threads.loaded_count']({ loaded: threads.length, total: totalCount })}
             </span>
-            <Button
-              variant="secondary"
-              size="sm"
-              loading={loadingMore}
-              onclick={() => loadThreads({ append: true })}
-            >
-              {m['chat.threads.load_more']()}
-            </Button>
+            <div class="min-h-8 text-muted" {@attach loadMoreWhenVisible}>
+              {#if loadingMore}{m['common.loading']()}{/if}
+            </div>
           </div>
         {:else}
           {m['chat.threads.no_unread']()}
@@ -375,14 +335,8 @@
           </div>
         {/each}
         {#if hasMore}
-          <div class="flex justify-center p-4">
-            <Button
-              variant="secondary"
-              loading={loadingMore}
-              onclick={() => loadThreads({ append: true })}
-            >
-              {m['chat.threads.load_more']()}
-            </Button>
+          <div class="flex min-h-14 justify-center p-4 text-muted" {@attach loadMoreWhenVisible}>
+            {#if loadingMore}{m['common.loading']()}{/if}
           </div>
         {/if}
       </div>


### PR DESCRIPTION
## Why

The My Threads page still managed snapshot loading, cancellation, pagination, and realtime reconciliation by hand. Moving it onto the frontend's established TanStack Query layer gives followed-thread reads the same session-scoped caching and request lifecycle as the other migrated snapshot screens.

## What changed

- Replace the page-local loader with a session-scoped infinite query and automatic offset pagination.
- Pass TanStack cancellation signals through the thread API client.
- Reconcile cached pages with the process-wide realtime projection for follow/unfollow state, unread state, and thread summaries.
- Scrub retained cache data on session, user, room-access, and message-deletion privacy boundaries, including fencing and restarting in-flight hydration.
- Preserve server offsets independently from projection filtering and deduplicate rows across page boundaries.
- Add focused coverage for query helpers, API cancellation, store/cache integration, mounted observer resets, and in-flight deletion races.

## Test plan

- `mise lint-frontend` — passed (Svelte check: 0 errors and 0 warnings; ESLint passed)
- `mise test-frontend` — passed (325 files, 2,730 tests)
- `mise test-e2e -- e2e/my-threads.test.ts` — passed (14 tests)
- Production frontend build and bundle budgets — passed (login 267.0 KiB, overview 292.6 KiB, room 465.0 KiB)
- `mise license-check` — passed (2,642/2,642 files compliant)
- Svelte autofixer — no issues; retained the deliberate external cache-reconciliation effect

## Compatibility and security

- No public API, protobuf, persistence, configuration, or user-visible behavior changes.
- Query keys remain scoped by server and authenticated connection session, and cached content is synchronously scrubbed at privacy boundaries before active queries refetch.
