### PR TITLE
perf(build): shrink bundled Chatto binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Build frontend for production image
         env:
           CHATTO_BUILD_VERSION: ${{ steps.image-version.outputs.version }}
+          CHATTO_FRONTEND_PRECOMPRESS: "1"
         run: mise build-frontend
 
       - name: Verify frontend build version
@@ -84,7 +85,9 @@ jobs:
             cp NOTICE "$context/NOTICE"
             (
               cd cli
+              # Chatto does not expose Gin's MessagePack binding; omit its large codec.
               CGO_ENABLED=0 GOOS=linux GOARCH="$arch" go build -trimpath \
+                -tags=nomsgpack \
                 -ldflags="-s -w -X main.Version=${VERSION}" \
                 -o "../$context/chatto" .
             )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,9 @@ jobs:
 
           (
             cd cli
+            # Chatto does not expose Gin's MessagePack binding; omit its large codec.
             CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -trimpath \
+              -tags=nomsgpack \
               -ldflags="-s -w -X main.Version=${VERSION}" \
               -o "$context/chatto" .
           )

--- a/cli/internal/http_server/frontend.go
+++ b/cli/internal/http_server/frontend.go
@@ -1,17 +1,20 @@
 package http_server
 
 import (
+	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"embed"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"mime"
 	"net/http"
 	"net/url"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -214,26 +217,88 @@ func dynamicPWAManifest(staticManifest []byte, serverName string, icons *pwaServ
 // clientAcceptsEncoding checks if the client accepts a specific encoding.
 // It parses the Accept-Encoding header and looks for the encoding name.
 func clientAcceptsEncoding(acceptEncoding, encoding string) bool {
-	// Simple check - look for the encoding in the header
-	// This handles common cases like "gzip, deflate, br" or "br"
+	encoding = strings.ToLower(encoding)
+	wildcardQuality := -1.0
 	for _, part := range strings.Split(acceptEncoding, ",") {
-		part = strings.TrimSpace(part)
-		// Strip quality value if present (e.g., "gzip;q=0.8")
-		if idx := strings.Index(part, ";"); idx != -1 {
-			part = part[:idx]
+		fields := strings.Split(part, ";")
+		name := strings.ToLower(strings.TrimSpace(fields[0]))
+		quality := 1.0
+		valid := name != ""
+		for _, parameter := range fields[1:] {
+			key, value, found := strings.Cut(parameter, "=")
+			if !found || !strings.EqualFold(strings.TrimSpace(key), "q") {
+				continue
+			}
+			parsed, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+			if err != nil || parsed < 0 || parsed > 1 {
+				valid = false
+				break
+			}
+			quality = parsed
 		}
-		if part == encoding {
-			return true
+		if !valid {
+			continue
+		}
+		if name == encoding {
+			return quality > 0
+		}
+		if name == "*" {
+			wildcardQuality = quality
 		}
 	}
-	return false
+	return wildcardQuality > 0
+}
+
+// readFrontendIdentityFile returns the uncompressed representation of an
+// embedded frontend file. Release builds omit raw files when SvelteKit emitted
+// a gzip sibling, so clients without compression support are served by
+// inflating that trusted embedded fallback on demand.
+func readFrontendIdentityFile(clientFS fs.FS, filePath string) ([]byte, error) {
+	content, rawErr := fs.ReadFile(clientFS, filePath)
+	if rawErr == nil {
+		return content, nil
+	}
+
+	compressed, err := clientFS.Open(filePath + ".gz")
+	if err != nil {
+		return nil, rawErr
+	}
+	defer compressed.Close()
+
+	reader, err := gzip.NewReader(compressed)
+	if err != nil {
+		return nil, fmt.Errorf("open embedded gzip fallback for %q: %w", filePath, err)
+	}
+	defer reader.Close()
+
+	content, err = io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("decompress embedded gzip fallback for %q: %w", filePath, err)
+	}
+	return content, nil
+}
+
+func frontendFileExists(clientFS fs.FS, filePath string) bool {
+	if _, err := fs.Stat(clientFS, filePath); err == nil {
+		return true
+	}
+	_, err := fs.Stat(clientFS, filePath+".gz")
+	return err == nil
+}
+
+func frontendContentType(filePath string) string {
+	contentType := mime.TypeByExtension(filepath.Ext(filePath))
+	if contentType == "" {
+		return "application/octet-stream"
+	}
+	return contentType
 }
 
 // serveSPAFallback serves the 200.html file as a fallback for SPA routing.
 // It injects OpenGraph meta tags based on the URL path.
 // Returns true if the fallback was served successfully, false if an error occurred.
 func (s *HTTPServer) serveSPAFallback(c *gin.Context, clientFS fs.FS) bool {
-	content, err := fs.ReadFile(clientFS, "200.html")
+	content, err := readFrontendIdentityFile(clientFS, "200.html")
 	if err != nil {
 		log.Error("Failed to read 200.html for SPA fallback", "error", err)
 		c.String(http.StatusInternalServerError, "Failed to load application")
@@ -259,7 +324,7 @@ func (s *HTTPServer) redirectBrowserIcon(c *gin.Context, size int, fallbackURL s
 }
 
 func (s *HTTPServer) servePWAWebManifest(c *gin.Context, clientFS fs.FS) {
-	content, err := fs.ReadFile(clientFS, "manifest.webmanifest")
+	content, err := readFrontendIdentityFile(clientFS, "manifest.webmanifest")
 	if err != nil {
 		c.Status(http.StatusInternalServerError)
 		return
@@ -306,11 +371,7 @@ func servePrecompressedFile(c *gin.Context, clientFS fs.FS, filePath string) boo
 			continue // Compressed file doesn't exist, try next
 		}
 
-		// Determine content type from the original file extension
-		contentType := mime.TypeByExtension(filepath.Ext(filePath))
-		if contentType == "" {
-			contentType = "application/octet-stream"
-		}
+		contentType := frontendContentType(filePath)
 
 		c.Header("Content-Encoding", enc.name)
 		c.Header("Content-Type", contentType)
@@ -321,6 +382,23 @@ func servePrecompressedFile(c *gin.Context, clientFS fs.FS, filePath string) boo
 	}
 
 	return false
+}
+
+func serveFrontendFile(c *gin.Context, clientFS fs.FS, filePath string) error {
+	// Identity and encoded representations share this URL.
+	c.Header("Vary", "Accept-Encoding")
+	if servePrecompressedFile(c, clientFS, filePath) {
+		return nil
+	}
+
+	// Development builds retain the raw file. Release builds instead inflate
+	// the embedded gzip fallback for clients that do not accept compression.
+	content, err := readFrontendIdentityFile(clientFS, filePath)
+	if err != nil {
+		return err
+	}
+	c.Data(http.StatusOK, frontendContentType(filePath), content)
+	return nil
 }
 
 func isReservedNonFrontendPath(urlPath string) bool {
@@ -384,9 +462,8 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 		// Refresh session for all SPA routes to prevent cookie expiration
 		refreshSessionIfAuthenticated(c)
 
-		// Check if file exists
-		_, err := fs.Stat(clientFS, filePath)
-		if err != nil {
+		// Release builds may retain only compressed representations.
+		if !frontendFileExists(clientFS, filePath) {
 			// File not found, serve 200.html for SPA routing
 			s.serveSPAFallback(c, clientFS)
 			return
@@ -399,7 +476,7 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 		}
 
 		if filePath == "service-worker.js" {
-			content, err := fs.ReadFile(clientFS, filePath)
+			content, err := readFrontendIdentityFile(clientFS, filePath)
 			if err != nil {
 				c.Status(http.StatusInternalServerError)
 				return
@@ -414,23 +491,9 @@ func (s *HTTPServer) setupFrontendRoutes() error {
 			return
 		}
 
-		// Try to serve precompressed version first
-		if servePrecompressedFile(c, clientFS, filePath) {
-			return
-		}
-
-		// Serve the original file
-		content, err := fs.ReadFile(clientFS, filePath)
-		if err != nil {
+		if err := serveFrontendFile(c, clientFS, filePath); err != nil {
 			c.Status(http.StatusInternalServerError)
-			return
 		}
-
-		contentType := mime.TypeByExtension(filepath.Ext(filePath))
-		if contentType == "" {
-			contentType = "application/octet-stream"
-		}
-		c.Data(http.StatusOK, contentType, content)
 	}
 
 	// Handle root path explicitly to avoid directory listing

--- a/cli/internal/http_server/frontend_test.go
+++ b/cli/internal/http_server/frontend_test.go
@@ -1,6 +1,8 @@
 package http_server
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -334,12 +336,147 @@ func TestClientAcceptsEncoding(t *testing.T) {
 			expected:       true,
 			encoding:       "br",
 		},
+		{
+			name:           "zero quality rejects encoding",
+			acceptEncoding: "gzip, br;q=0",
+			expected:       false,
+			encoding:       "br",
+		},
+		{
+			name:           "wildcard accepts encoding",
+			acceptEncoding: "*;q=0.5",
+			expected:       true,
+			encoding:       "br",
+		},
+		{
+			name:           "specific rejection overrides wildcard",
+			acceptEncoding: "*;q=1, br;q=0",
+			expected:       false,
+			encoding:       "br",
+		},
+		{
+			name:           "encoding names are case insensitive",
+			acceptEncoding: "GZip",
+			expected:       true,
+			encoding:       "gzip",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := clientAcceptsEncoding(tt.acceptEncoding, tt.encoding)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func gzipFrontendTestData(t *testing.T, content []byte) []byte {
+	t.Helper()
+	var compressed bytes.Buffer
+	writer := gzip.NewWriter(&compressed)
+	if _, err := writer.Write(content); err != nil {
+		t.Fatalf("write gzip test data: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close gzip test data: %v", err)
+	}
+	return compressed.Bytes()
+}
+
+func TestReadFrontendIdentityFile(t *testing.T) {
+	original := []byte("console.log('embedded');")
+	compressed := gzipFrontendTestData(t, original)
+
+	t.Run("prefers raw file when present", func(t *testing.T) {
+		clientFS := fstest.MapFS{
+			"app.js":    &fstest.MapFile{Data: original},
+			"app.js.gz": &fstest.MapFile{Data: []byte("not gzip")},
+		}
+		content, err := readFrontendIdentityFile(clientFS, "app.js")
+		assert.NoError(t, err)
+		assert.Equal(t, original, content)
+	})
+
+	t.Run("inflates gzip when raw file was omitted", func(t *testing.T) {
+		clientFS := fstest.MapFS{
+			"app.js.gz": &fstest.MapFile{Data: compressed},
+		}
+		content, err := readFrontendIdentityFile(clientFS, "app.js")
+		assert.NoError(t, err)
+		assert.Equal(t, original, content)
+		assert.True(t, frontendFileExists(clientFS, "app.js"))
+	})
+
+	t.Run("rejects corrupt gzip fallback", func(t *testing.T) {
+		clientFS := fstest.MapFS{
+			"app.js.gz": &fstest.MapFile{Data: []byte("not gzip")},
+		}
+		_, err := readFrontendIdentityFile(clientFS, "app.js")
+		assert.Error(t, err)
+	})
+
+	t.Run("reports missing file", func(t *testing.T) {
+		clientFS := fstest.MapFS{}
+		_, err := readFrontendIdentityFile(clientFS, "app.js")
+		assert.Error(t, err)
+		assert.False(t, frontendFileExists(clientFS, "app.js"))
+	})
+}
+
+func TestServeFrontendFile(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	original := []byte("console.log('embedded');")
+	brotli := []byte("brotli representation")
+	compressed := gzipFrontendTestData(t, original)
+	clientFS := fstest.MapFS{
+		"app.js.br": &fstest.MapFile{Data: brotli},
+		"app.js.gz": &fstest.MapFile{Data: compressed},
+	}
+
+	tests := []struct {
+		name           string
+		acceptEncoding string
+		wantBody       []byte
+		wantEncoding   string
+	}{
+		{
+			name:           "serves Brotli when accepted",
+			acceptEncoding: "gzip, br",
+			wantBody:       brotli,
+			wantEncoding:   "br",
+		},
+		{
+			name:           "serves gzip when accepted",
+			acceptEncoding: "gzip",
+			wantBody:       compressed,
+			wantEncoding:   "gzip",
+		},
+		{
+			name:     "inflates gzip for identity client",
+			wantBody: original,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := gin.New()
+			router.GET("/app.js", func(c *gin.Context) {
+				if err := serveFrontendFile(c, clientFS, "app.js"); err != nil {
+					c.Status(http.StatusInternalServerError)
+				}
+			})
+			req := httptest.NewRequest(http.MethodGet, "/app.js", nil)
+			if tt.acceptEncoding != "" {
+				req.Header.Set("Accept-Encoding", tt.acceptEncoding)
+			}
+			response := httptest.NewRecorder()
+			router.ServeHTTP(response, req)
+
+			assert.Equal(t, http.StatusOK, response.Code)
+			assert.Equal(t, tt.wantBody, response.Body.Bytes())
+			assert.Equal(t, tt.wantEncoding, response.Header().Get("Content-Encoding"))
+			assert.Equal(t, "Accept-Encoding", response.Header().Get("Vary"))
+			assert.Contains(t, response.Header().Get("Content-Type"), "javascript")
 		})
 	}
 }

--- a/docker/Dockerfile.compose
+++ b/docker/Dockerfile.compose
@@ -11,7 +11,8 @@ RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
 
 COPY apps/frontend apps/frontend
 COPY packages/api-types packages/api-types
-RUN pnpm --filter @chatto/api-types build && pnpm --filter chatto-frontend build
+RUN pnpm --filter @chatto/api-types build \
+    && CHATTO_FRONTEND_PRECOMPRESS=1 pnpm --filter chatto-frontend build
 
 FROM golang:1.26.2-bookworm AS builder
 
@@ -20,11 +21,15 @@ COPY go.work go.work.sum ./
 COPY authling/go.mod authling/go.sum authling/
 COPY cli cli
 COPY pkg pkg
-COPY --from=frontend /src/apps/frontend/build cli/internal/http_server/.client
+COPY tools/prepare-embedded-frontend.sh tools/prepare-embedded-frontend.sh
+COPY --from=frontend /src/apps/frontend/build apps/frontend/build
 
+# Chatto does not expose Gin's MessagePack binding; omit its large codec.
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
-    cd cli && CGO_ENABLED=0 go build -trimpath -tags bootstrap \
+    tools/prepare-embedded-frontend.sh \
+      apps/frontend/build cli/internal/http_server/.client \
+    && cd cli && CGO_ENABLED=0 go build -trimpath -tags 'bootstrap nomsgpack' \
       -ldflags "-s -w -X main.Version=0.5.0-dev" -o /out/chatto .
 
 FROM alpine:3.22

--- a/docker/Dockerfile.compose.dockerignore
+++ b/docker/Dockerfile.compose.dockerignore
@@ -27,3 +27,5 @@ cli/data/
 cli/internal/http_server/.client/
 !pkg/
 !pkg/**
+!tools/
+!tools/prepare-embedded-frontend.sh

--- a/mise.toml
+++ b/mise.toml
@@ -132,6 +132,9 @@ run = { task = "codegen-*" }
 # Build
 # =============================================================================
 
+# Chatto does not expose Gin's MessagePack binding. Keep the nomsgpack tag on
+# every Chatto binary build so the large, unused ugorji codec is not linked.
+
 [tasks.sync-cli-legal]
 description = "Copy root legal files into the CLI module for go:embed"
 run = [
@@ -163,9 +166,7 @@ run = [
     "pnpm svelte-kit sync",
     "pnpm build",
     "touch build/.mise-build-stamp",
-    "rm -rf ../../cli/internal/http_server/.client",
-    "cp -r build ../../cli/internal/http_server/.client",
-    "printf '\\n' > ../../cli/internal/http_server/.client/.gitkeep",
+    "../../tools/prepare-embedded-frontend.sh build ../../cli/internal/http_server/.client",
 ]
 sources = [
     "../../.npmrc",
@@ -178,6 +179,7 @@ sources = [
     "project.inlang/**/*",
     "scripts/check-bundle-size.mjs",
     "scripts/generate-i18n-facade.mjs",
+    "../../tools/prepare-embedded-frontend.sh",
     "src/**/*",
     "!src/**/*.spec.*",
     "!src/**/*.test.*",
@@ -194,7 +196,7 @@ outputs = ["build/.mise-build-stamp", "../../cli/internal/http_server/.client/.g
 description = "Build the development CLI application for the current architecture"
 depends = ["setup-cli", "build-frontend"]
 dir = "cli"
-run = "go build -trimpath -tags bootstrap -ldflags \"-X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o bin/chatto ."
+run = "go build -trimpath -tags 'bootstrap nomsgpack' -ldflags \"-X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o bin/chatto ."
 sources = [
     "go.mod",
     "go.sum",
@@ -215,7 +217,7 @@ dir = "cli"
 # test-only HTTP endpoints (e.g. /auth/test/create-user) used by per-test
 # fixtures. Deliberately scoped — the e2e binary should NOT pull in any
 # future broader dev-only code that might land under a separate tag.
-run = "CGO_ENABLED=0 go build -trimpath -tags 'bootstrap test_endpoints' -ldflags \"-s -w -X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o ../apps/frontend/e2e/fixtures/bin/chatto ."
+run = "CGO_ENABLED=0 go build -trimpath -tags 'bootstrap nomsgpack test_endpoints' -ldflags \"-s -w -X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o ../apps/frontend/e2e/fixtures/bin/chatto ."
 sources = [
     "**/*.go",
     "cmd/embedded/LICENSE",
@@ -228,7 +230,7 @@ outputs = ["../apps/frontend/e2e/fixtures/bin/chatto"]
 description = "Build the production Chatto binary used as the current side of compatibility tests"
 depends = ["setup-cli", "build-frontend"]
 dir = "cli"
-run = "CGO_ENABLED=0 go build -trimpath -ldflags \"-s -w -X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o ../apps/frontend/e2e/fixtures/bin/chatto-current ."
+run = "CGO_ENABLED=0 go build -trimpath -tags nomsgpack -ldflags \"-s -w -X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o ../apps/frontend/e2e/fixtures/bin/chatto-current ."
 sources = [
     "**/*.go",
     "cmd/embedded/LICENSE",
@@ -250,7 +252,7 @@ run = "exec pnpm exec storybook dev --host 127.0.0.1 --port \"$CHATTO_STORYBOOK_
 description = "Build and run the local development backend"
 depends = ["setup-cli"]
 dir = "cli"
-run = "mkdir -p internal/http_server/.client && touch internal/http_server/.client/.gitkeep && go build -trimpath -tags bootstrap -ldflags \"-X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o bin/chatto-dev . && exec ./bin/chatto-dev start"
+run = "mkdir -p internal/http_server/.client && touch internal/http_server/.client/.gitkeep && go build -trimpath -tags 'bootstrap nomsgpack' -ldflags \"-X main.Version=$CHATTO_DEVELOPMENT_VERSION\" -o bin/chatto-dev . && exec ./bin/chatto-dev start"
 
 [tasks.dev-frontend]
 description = "Run the local development frontend"

--- a/tools/prepare-embedded-frontend.sh
+++ b/tools/prepare-embedded-frontend.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 ChattoCorp GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+if [[ "$#" -ne 2 ]]; then
+	echo "usage: $0 <frontend-build-directory> <target-.client-directory>" >&2
+	exit 2
+fi
+
+source_directory="$(cd "$1" && pwd -P)"
+target_parent="$(cd "$(dirname "$2")" && pwd -P)"
+target_directory="$target_parent/$(basename "$2")"
+
+if [[ "$(basename "$target_directory")" != ".client" ]]; then
+	echo "refusing to replace non-.client target: $target_directory" >&2
+	exit 2
+fi
+if [[ ! -f "$source_directory/200.html" && ! -f "$source_directory/200.html.gz" ]]; then
+	echo "frontend build is missing 200.html or 200.html.gz: $source_directory" >&2
+	exit 2
+fi
+if [[ "$source_directory" == "$target_directory" ]]; then
+	echo "frontend source and target directories must differ" >&2
+	exit 2
+fi
+
+rm -rf "$target_directory"
+cp -R "$source_directory" "$target_directory"
+
+# SvelteKit's precompress option emits raw, Brotli, and gzip representations.
+# Keep both encoded forms for direct negotiation, but use gzip as the canonical
+# identity fallback so the Go binary does not embed the large raw copy too.
+while IFS= read -r -d '' gzip_file; do
+	raw_file="${gzip_file%.gz}"
+	if [[ -f "$raw_file" ]]; then
+		rm "$raw_file"
+	fi
+done < <(find "$target_directory" -type f -name '*.gz' -print0)
+
+printf '\n' > "$target_directory/.gitkeep"


### PR DESCRIPTION
## Why

The release-shaped Chatto binary had grown to 94.97 MB because Gin linked unused MessagePack support and the embedded frontend carried raw, Brotli, and gzip copies of the same assets.

## What changed

- Build every Chatto binary with Gin's `nomsgpack` tag and compact only the Go-embedded frontend copy by retaining Brotli/gzip representations while inflating gzip for identity clients.
- Preserve the complete frontend build for nginx, enable precompression in main and Compose builds, tighten `Accept-Encoding` handling, and cover raw, encoded, corrupt, missing, and identity representations; the release-shaped binary now measures 79.75 MB (15.22 MB / 16% smaller).

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged; normal HTTP content negotiation continues to serve Brotli, gzip, or identity representations.
- Newer client → older server: unchanged.
- Capability discovery or minimum client/server version: unchanged.

## Test plan

- `CHATTO_FRONTEND_PRECOMPRESS=1 mise run --force build-frontend` (bundle budgets passed).
- `mise x -- go test -trimpath -tags nomsgpack ./internal/http_server`.
- Linux/amd64 release-shaped build and dependency inspection (79,745,186 bytes; `ugorji/go/codec` absent).
- `docker buildx build --check --file docker/Dockerfile.compose .`; `mise license-check`; `bash -n tools/prepare-embedded-frontend.sh`; `git diff --check`.
