### PR TITLE
fix(realtime): recover after deleting processing videos

### DIFF
--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -620,6 +620,7 @@ describe('eventBusManager realtime transport', () => {
     const { socket } = await startAndSubscribe();
 
     await socket.receive(projectionFrame('cursor-must-not-persist'));
+    expect(socket.closeCalls.at(-1)?.code).toBe(4000);
     expect(socket.closeCalls.at(-1)?.reason).toBe('projection reducer failed');
     expect(consoleError).toHaveBeenCalledWith(
       `[eventBus:${TEST_SERVER}] projection reducer failed`,
@@ -731,6 +732,29 @@ describe('eventBusManager realtime transport', () => {
     socket.serverClose();
 
     expect(fake.status).toBe('disconnected');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sockets).toHaveLength(2);
+  });
+
+  it('uses a browser-valid application close code for fatal realtime errors', async () => {
+    vi.useFakeTimers();
+    const { socket } = await startAndSubscribe();
+
+    await socket.receive(
+      serverFrame({
+        case: 'error',
+        value: new RealtimeError({
+          code: 'replay_unavailable',
+          message: 'realtime replay is temporarily unavailable',
+          fatal: true
+        })
+      })
+    );
+
+    expect(socket.closeCalls.at(-1)).toEqual({
+      code: 4000,
+      reason: 'fatal realtime error'
+    });
     await vi.advanceTimersByTimeAsync(0);
     expect(sockets).toHaveLength(2);
   });

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -33,6 +33,7 @@ const INACTIVE_POLL_INTERVAL_MS = 60_000;
 const INACTIVE_POLL_JITTER_MS = 10_000;
 const INACTIVE_POLL_TIMEOUT_MS = 30_000;
 const HYDRATION_RETRY_FALLBACK_MS = 1_000;
+const FATAL_REALTIME_CLOSE_CODE = 4000;
 
 type RealtimeMessageEvent = { data: ArrayBuffer | Blob | Uint8Array };
 type RealtimeCloseEvent = { code?: number; reason?: string };
@@ -399,7 +400,7 @@ class EventBusManager {
                 dispatchProjectionEvent(frame.frame.value);
               } catch (error) {
                 console.error(`[eventBus:${serverId}] projection reducer failed`, error);
-                nextSocket.close(1011, 'projection reducer failed');
+                nextSocket.close(FATAL_REALTIME_CLOSE_CODE, 'projection reducer failed');
                 return;
               }
               sync.acceptProjectionEvent(
@@ -458,7 +459,7 @@ class EventBusManager {
                 return;
               }
               if (frame.frame.value.fatal) {
-                nextSocket.close(1011, frame.frame.value.code || 'fatal realtime error');
+                nextSocket.close(FATAL_REALTIME_CLOSE_CODE, 'fatal realtime error');
               }
               return;
             case 'close':

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -578,7 +578,10 @@ func (s *HTTPServer) realtimeProjectionFrameForEventWithRooms(ctx context.Contex
 		*corev1.Event_AssetDeleted:
 		roomID, messageEventID, ok := s.core.AssetEventTimelineTarget(evt)
 		if !ok {
-			return nil, false, nil
+			// The owning message may already have removed this asset. Its
+			// MessageEdited event is then the authoritative timeline update, but
+			// this durable lifecycle fact must still advance the replay cursor.
+			break
 		}
 		if err := appendTimeline(roomID, messageEventID, nil); err != nil {
 			return nil, false, err

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -2188,6 +2188,82 @@ func TestRealtimeProjectionReplayMapsAssetLifecycleToCurrentMessage(t *testing.T
 	}
 }
 
+func TestRealtimeProjectionReplayAdvancesPastDeletedAttachmentAssetLifecycle(t *testing.T) {
+	env := setupWebSocketTestServer(t)
+	user, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-deleted-asset-replay", "Deleted Asset Replay", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, core.KindChannel, "", "rt-deleted-asset-replay", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, core.KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	attachment, err := env.core.UploadAttachment(env.ctx, user.Id, room.Id, "delete-during-processing.mp4", "video/mp4", strings.NewReader("video"))
+	if err != nil {
+		t.Fatalf("UploadAttachment: %v", err)
+	}
+	message, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, user.Id, "delete during processing", []string{attachment.Id}, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	if err := env.core.RecordAssetProcessingStarted(env.ctx, core.SystemActorID, room.Id, message.Id, attachment.Id); err != nil {
+		t.Fatalf("RecordAssetProcessingStarted: %v", err)
+	}
+	partialDerivative, err := env.core.UploadDerivativeAttachment(
+		env.ctx,
+		attachment.Id,
+		corev1.AssetDerivativeRole_ASSET_DERIVATIVE_ROLE_HLS_MEDIA_SEGMENT,
+		room.Id,
+		"partial-segment.ts",
+		"video/mp2t",
+		strings.NewReader("segment"),
+	)
+	if err != nil {
+		t.Fatalf("UploadDerivativeAttachment: %v", err)
+	}
+	before, err := env.core.PlanRealtimeReplay(env.ctx, user.Id, "")
+	if err != nil {
+		t.Fatalf("initial PlanRealtimeReplay: %v", err)
+	}
+	if err := env.core.DeleteAttachmentFromMessage(env.ctx, user.Id, core.KindChannel, room.Id, message.Id, attachment.Id); err != nil {
+		t.Fatalf("DeleteAttachmentFromMessage: %v", err)
+	}
+	if err := env.core.RecordAssetDeleted(env.ctx, core.SystemActorID, room.Id, partialDerivative.Id); err != nil {
+		t.Fatalf("RecordAssetDeleted partial derivative: %v", err)
+	}
+
+	replay, err := env.core.PlanRealtimeReplay(env.ctx, user.Id, before.BoundaryCursor)
+	if err != nil {
+		t.Fatalf("PlanRealtimeReplay: %v", err)
+	}
+	foundDeletion := false
+	for _, event := range replay.Events {
+		if event.EVTEvent().GetAssetDeleted().GetAssetId() != partialDerivative.Id {
+			continue
+		}
+		foundDeletion = true
+		frame, handled, err := env.httpServer.realtimeProjectionFrameForEvent(env.ctx, user.Id, event)
+		if err != nil {
+			t.Fatalf("map asset deletion event: %v", err)
+		}
+		if !handled || frame.GetProjectionEvent() == nil {
+			t.Fatal("asset deletion was not projected")
+		}
+		if len(frame.GetProjectionEvent().GetOperations()) != 0 {
+			t.Fatalf("asset deletion operations = %+v, want cursor-only projection", frame.GetProjectionEvent().GetOperations())
+		}
+		if frame.GetProjectionEvent().GetResumeCursor() == "" {
+			t.Fatal("asset deletion projection has no resume cursor")
+		}
+	}
+	if !foundDeletion {
+		t.Fatal("replay did not contain asset deletion")
+	}
+}
+
 func TestRealtimeWebSocketReplaysReactionAfterDisconnect(t *testing.T) {
 	env := setupWebSocketTestServer(t)
 	user, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-replay-member", "RT Replay Member", "password123")


### PR DESCRIPTION
## Why

Deleting a video attachment while processing could leave a partial derivative deletion without a timeline owner, trapping realtime replay on that durable event and breaking the client reconnect loop.

## What changed

- Advance replay with a cursor-only projection when an asset lifecycle fact no longer has a timeline target.
- Close fatal browser WebSockets with valid application code `4000` and a bounded reason.
- Cover partial derivative cleanup and fatal client teardown with focused regressions.

## API compatibility

- Behavioural change; compatible bug fix to `chatto.realtime.v1` replay and reconnect handling.
- Older client → newer server: affected replay cursors now advance normally.
- Newer client → older server: fatal teardown no longer throws in the browser, but the older server can still reject the affected replay until upgraded.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise lint-frontend`
- `mise build-frontend`
- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/state/server/eventBus.svelte.spec.ts` — 34 passed.
- `mise x -- go test ./internal/http_server -count=1`
