### PR TITLE
chore(dev): unify Conductor Compose stack

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,50 +1,38 @@
 "$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
 
 [[preview_urls]]
-name = "Chatto"
-url = "http://localhost:$CONDUCTOR_PORT"
+name = "Compose: Chatto"
+url = "https://chatto.$CONDUCTOR_WORKSPACE_NAME.orb.local"
 
 [[preview_urls]]
-name = "Mailpit"
-url = "http://localhost:$CONDUCTOR_PORT+9"
+name = "Compose: Authling"
+url = "https://authling.$CONDUCTOR_WORKSPACE_NAME.orb.local"
 
 [[preview_urls]]
-name = "Storybook"
-url = "http://localhost:$CONDUCTOR_PORT"
+name = "Compose: Mailpit"
+url = "https://mailpit.$CONDUCTOR_WORKSPACE_NAME.orb.local"
 
 [[preview_urls]]
-name = "Authling"
-url = "http://localhost:$CONDUCTOR_PORT"
+name = "Compose: LiveKit"
+url = "https://livekit.$CONDUCTOR_WORKSPACE_NAME.orb.local"
 
 [[preview_urls]]
-name = "Authling Mailpit"
-url = "http://localhost:$CONDUCTOR_PORT+9"
+name = "Compose: Storybook"
+url = "https://storybook.$CONDUCTOR_WORKSPACE_NAME.orb.local"
+
+[[preview_urls]]
+name = "Compose: Docs website"
+url = "https://docs-website.$CONDUCTOR_WORKSPACE_NAME.orb.local"
 
 [scripts]
 setup = "mise trust && mise setup"
 run_mode = "concurrent"
 
-[scripts.run.chatto]
-command = "exec tools/dev-supervisor.sh mise dev"
-icon = "message-square"
-
-[scripts.run.chatto-compiled]
-command = "exec tools/dev-supervisor.sh mise dev-compiled"
-default = true
-icon = "package"
-
-[scripts.run.docs-website]
-command = "exec mise dev-docs-website"
-icon = "book-open"
-
-[scripts.run.storybook]
-command = "exec mise storybook"
-icon = "palette"
-
-[scripts.run.authling]
-command = "cd authling && exec ../tools/dev-supervisor.sh mise dev"
+[scripts.run.compose]
+command = "exec docker compose up --build"
 available_in = [ "local" ]
-icon = "fingerprint"
+default = true
+icon = "boxes"
 
 [prompts]
 create_pr = "Create a full GitHub pull request for the current branch, not a draft PR."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,17 +24,33 @@ configuration for those.
 
 ## Local Development with Conductor or Paseo
 
-[Conductor](https://conductor.build) and Paseo workspaces run the live local development stack. The default Conductor `chatto` run script in `.conductor/settings.toml` and the Paseo `dev` service in `paseo.json` both delegate to `mise dev`. The mise task uses Conductor's assigned `$CONDUCTOR_PORT`, Paseo's assigned `$PASEO_PORT`, or `4000` outside either tool, then reserves the next ports for bundled services:
+[Conductor](https://conductor.build) runs the complete root
+[`compose.yml`](compose.yml) stack through OrbStack. Its single run script
+builds and starts Chatto, Authling, Mailpit, LiveKit, Storybook, and the docs
+website with workspace-specific `*.orb.local` domains. The default Open URL is
+Chatto, and the remaining service URLs are available from Conductor's Open
+menu.
+
+Paseo's `dev` service in `paseo.json` delegates to `mise dev` for live backend
+and frontend development. The mise task uses Paseo's assigned `$PASEO_PORT`,
+or `4000` outside Paseo, then reserves the next ports for bundled services:
 
 | Port                              | Process                                       |
 | --------------------------------- | --------------------------------------------- |
-| `$CONDUCTOR_PORT` / `$PASEO_PORT` | Vite frontend (user-facing URL)               |
+| `$PASEO_PORT`                     | Vite frontend (user-facing URL)               |
 | `+1`                              | Chatto backend webserver                      |
 | `+2`                              | Embedded NATS                                 |
 | `+3`                              | Prometheus metrics                            |
 | `+4`                              | Deployment-wide exporter metrics              |
 
-The repository-level Conductor settings are shared in `.conductor/settings.toml`, and the repository-level Paseo settings are shared in `paseo.json`. Both wire per-workspace ports before starting the backend and frontend development servers so multiple workspaces can run side by side. Conductor also exposes a `docs-website` run script, and Paseo exposes a separate `dev-docs-website` service; both are backed by `mise dev-docs-website` and reuse the workspace base port for the docs website. Put machine-specific Conductor overrides in `.conductor/settings.local.toml`; that file is gitignored and wins over shared settings on your machine. Conductor also reads `.worktreeinclude` to copy gitignored local environment files, such as `.env` and `.env.*`, into new workspaces.
+The repository-level Conductor settings are shared in
+`.conductor/settings.toml`, and the repository-level Paseo settings are shared
+in `paseo.json`. Both isolate concurrent workspaces. Put machine-specific
+Conductor overrides in `.conductor/settings.local.toml`; that file is
+gitignored and wins over shared settings on your machine. Conductor also reads
+`.worktreeinclude` to copy gitignored local environment files, such as `.env`
+and `.env.*`, into new workspaces. Paseo exposes a separate
+`dev-docs-website` service backed by `mise dev-docs-website`.
 
 ## Developing Outside of Conductor
 
@@ -45,7 +61,7 @@ mise trust
 mise run setup
 ```
 
-To run the same live development stack Conductor and Paseo use:
+To run the live backend and frontend development stack outside Conductor:
 
 ```sh
 mise dev

--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ repository once it no longer needs frequent atomic changes with the shared
 
 ## Complete Local Stack
 
-The root [`compose.yml`](compose.yml) runs Chatto, Authling, Mailpit, and
-LiveKit together on [OrbStack](https://docs.orbstack.dev/docker/domains). It
-builds Chatto and Authling from the current checkout, gives both products
+The root [`compose.yml`](compose.yml) runs Chatto, Authling, Mailpit, LiveKit,
+Storybook, and the Chatto docs website together on
+[OrbStack](https://docs.orbstack.dev/docker/domains). It builds every
+repository-owned service from the current checkout, gives Chatto and Authling
 separate persistent embedded-NATS storage, and configures Chatto to use
 Authling as an OpenID Connect provider through Chatto's public Client ID
 Metadata Document, without preregistering Chatto in Authling. Compose derives
@@ -47,6 +48,8 @@ HTTPS origins:
 - Authling: `https://authling.<project>.orb.local`
 - Mailpit: `https://mailpit.<project>.orb.local`
 - LiveKit signaling: `https://livekit.<project>.orb.local`
+- Storybook: `https://storybook.<project>.orb.local`
+- Docs website: `https://docs-website.<project>.orb.local`
 
 Create an Authling account, read its verification code in Mailpit, then choose
 **Authling** on Chatto's login screen. Chatto asks for a username on the first

--- a/apps/frontend/Dockerfile.storybook
+++ b/apps/frontend/Dockerfile.storybook
@@ -1,0 +1,22 @@
+FROM node:22-alpine AS build
+
+RUN corepack enable
+WORKDIR /src
+
+COPY .npmrc package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/frontend/package.json apps/frontend/package.json
+COPY packages/api-types/package.json packages/api-types/package.json
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store \
+    pnpm install --frozen-lockfile --filter chatto-frontend...
+
+COPY apps/frontend apps/frontend
+COPY packages/api-types packages/api-types
+RUN pnpm --filter chatto-frontend build-storybook
+
+FROM nginxinc/nginx-unprivileged:1.29-alpine
+
+COPY --from=build /src/apps/frontend/storybook-static /usr/share/nginx/html
+COPY LICENSES/Apache-2.0.txt /usr/share/doc/chatto-storybook/LICENSE
+COPY NOTICE /usr/share/doc/chatto-storybook/NOTICE
+
+EXPOSE 8080

--- a/apps/frontend/Dockerfile.storybook.dockerignore
+++ b/apps/frontend/Dockerfile.storybook.dockerignore
@@ -1,0 +1,30 @@
+# Ignore everything by default.
+*
+
+# Storybook builds from the repository root so it can use the pnpm workspace.
+!.npmrc
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!LICENSES/
+!LICENSES/Apache-2.0.txt
+!NOTICE
+!apps/
+!apps/frontend/
+!apps/frontend/**
+!packages/
+!packages/api-types/
+!packages/api-types/**
+
+# Keep local and generated state out of the build context.
+apps/frontend/node_modules
+apps/frontend/.svelte-kit
+apps/frontend/build
+apps/frontend/storybook-static
+apps/frontend/project.inlang/cache
+apps/frontend/.env
+apps/frontend/.env.*
+apps/frontend/.DS_Store
+apps/frontend/**/.DS_Store
+packages/api-types/dist
+packages/api-types/node_modules

--- a/compose.yml
+++ b/compose.yml
@@ -25,6 +25,22 @@ services:
     labels:
       dev.orbstack.http-port: "7880"
 
+  docs-website:
+    build:
+      context: .
+      dockerfile: apps/docs-website/Dockerfile
+      args:
+        CHATTO_DOCS_SITE_URL: https://docs-website.${COMPOSE_PROJECT_NAME}.orb.local
+    labels:
+      dev.orbstack.http-port: "8080"
+
+  storybook:
+    build:
+      context: .
+      dockerfile: apps/frontend/Dockerfile.storybook
+    labels:
+      dev.orbstack.http-port: "8080"
+
   authling:
     build:
       context: .

--- a/mise.toml
+++ b/mise.toml
@@ -518,6 +518,7 @@ docker/nats-wrapper_test.sh
 docker buildx build --check --build-arg TARGETARCH=amd64 -f docker/Dockerfile.dev .
 docker buildx build --check -f docker/Dockerfile.frontend.dev .
 docker buildx build --check -f docker/Dockerfile.frontend.prebuilt .
+docker buildx build --check -f apps/frontend/Dockerfile.storybook .
 
 tmp="$(mktemp -d /tmp/chatto-docker-verify.XXXXXX)"
 trap 'rm -rf "$tmp"' EXIT


### PR DESCRIPTION
## Why

Conductor should provide one workspace-isolated command that starts every local development surface through OrbStack.

## What changed

- Replaced the separate Conductor run scripts and port previews with one default Compose script and service-specific OrbStack URLs.
- Added static Storybook and docs website images to the root Compose stack, including the workspace-specific docs canonical URL.
- Updated contributor documentation and Dockerfile validation for the unified workflow.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `docker compose config --quiet`
- `docker compose build docs-website storybook`
- Served and fetched both images through their OrbStack HTTPS origins.
- `docker buildx build --check -f apps/frontend/Dockerfile.storybook .`
- `mise license-check`
- Parsed and asserted the final Conductor TOML structure and preview URLs.
