### PR TITLE
fix(realtime): use valid fatal close code

### DIFF
--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -333,6 +333,29 @@ describe('eventBusManager realtime transport', () => {
     expect(sockets).toHaveLength(2);
   });
 
+  it('uses a browser-valid application close code for fatal realtime errors', async () => {
+    vi.useFakeTimers();
+    const { socket } = await startAndSubscribe();
+
+    await socket.receive(
+      serverFrame({
+        case: 'error',
+        value: new RealtimeError({
+          code: 'temporarily_unavailable',
+          message: 'realtime service is temporarily unavailable',
+          fatal: true
+        })
+      })
+    );
+
+    expect(socket.closeCalls.at(-1)).toEqual({
+      code: 4000,
+      reason: 'fatal realtime error'
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(sockets).toHaveLength(2);
+  });
+
   it('does not reconnect when the realtime stream reports authentication required', async () => {
     vi.useFakeTimers();
     const { fake, socket } = await startAndSubscribe();

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -32,6 +32,7 @@ const MISSED_HEARTBEATS_BEFORE_STALL = 3;
 const HEARTBEAT_WATCHDOG_MS = 15_000;
 const CATCH_UP_RETRY_MS = 2_500;
 const RECONNECT_WAIT_MS = 5_000;
+const FATAL_REALTIME_CLOSE_CODE = 4000;
 
 type RealtimeMessageEvent = { data: ArrayBuffer | Blob | Uint8Array };
 type RealtimeCloseEvent = { code?: number; reason?: string };
@@ -270,7 +271,7 @@ class EventBusManager {
                 return;
               }
               if (frame.frame.value.fatal) {
-                nextSocket.close(1011, frame.frame.value.code || 'fatal realtime error');
+                nextSocket.close(FATAL_REALTIME_CLOSE_CODE, 'fatal realtime error');
               }
               return;
             case 'close':


### PR DESCRIPTION
## Why

Backport the client-side portion of #1894 so a fatal realtime frame cannot throw `InvalidAccessError` while closing the browser WebSocket on the 0.4 release line.

## What changed

- Close fatal realtime sockets with browser-valid application code `4000` and a bounded fixed reason.
- Verify fatal errors close cleanly and enter the existing reconnect path.
- Omit the main-branch server replay fix because protocol v1 is live-only and has no resume cursor or replay planner.

## API compatibility

- Behavioural change; compatible bug fix to the bundled protocol-v1 client.
- Older client → newer server: unchanged; older 0.4 clients retain the close exception until updated.
- Newer client → older server: fatal teardown uses a valid close code and reconnects through the existing path.
- Capability discovery or minimum client/server version: none required.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/state/server/eventBus.svelte.spec.ts` — 17 passed.
- `mise lint-frontend` — Svelte check reported 0 errors and 0 warnings; ESLint passed.
- Svelte autofixer — no issues or suggestions.
