### PR TITLE
docs(operations): explain cross-server origin setup

### DIFF
--- a/apps/docs-website/astro.config.mjs
+++ b/apps/docs-website/astro.config.mjs
@@ -74,6 +74,7 @@ export default defineConfig({
             "guides/operations/identity-login",
             "guides/operations/permissions",
             "guides/operations/notifications-web-push",
+            "guides/operations/cross-server-connections",
             "guides/operations/security",
             "guides/operations/privacy-erasure",
             "guides/operations/server-operations",

--- a/apps/docs-website/src/content/docs/guides/operations/cross-server-connections.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/cross-server-connections.mdx
@@ -1,0 +1,47 @@
+---
+title: Allow Connections From Any Chatto Frontend
+description: Configure a Chatto server so users can add it from a frontend hosted by any other Chatto server.
+---
+
+import { Aside, Tabs, TabItem } from "@astrojs/starlight/components";
+
+To let users add your server from a frontend hosted by **any other Chatto server**, set both the OAuth redirect origins and the CORS origins to `*`.
+
+Chatto calls the callback setting `oauth_redirect_origins`. It belongs to Chatto's own cross-server OAuth flow and is separate from any external OIDC login provider you configure under `auth.providers`.
+
+<Tabs>
+  <TabItem label="chatto.toml">
+    ```toml
+    [webserver]
+    allowed_origins = ["*"]
+    oauth_redirect_origins = ["*"]
+    ```
+  </TabItem>
+  <TabItem label="Environment variables">
+    ```bash
+    CHATTO_WEBSERVER_ALLOWED_ORIGINS=*
+    CHATTO_WEBSERVER_OAUTH_REDIRECT_ORIGINS=*
+    ```
+  </TabItem>
+</Tabs>
+
+Restart Chatto after changing the configuration. Users can then open another Chatto server's frontend, choose **Add server**, and enter your server's URL.
+
+<Aside type="caution" title="This guidance is for Chatto 0.4">
+  The server-connection and origin model is changing in Chatto 0.5, which is not released yet. Review the Chatto 0.5 release notes and updated documentation before carrying this configuration forward to 0.5.
+</Aside>
+
+## Why Both Settings Are Required
+
+The two settings allow different parts of the connection flow:
+
+- `oauth_redirect_origins = ["*"]` lets any valid HTTPS frontend origin receive the OAuth authorization callback.
+- `allowed_origins = ["*"]` lets any frontend origin call your server's API and open its realtime WebSocket connection. Cross-origin clients authenticate with bearer tokens, not cookies.
+
+Setting only one wildcard is not enough. In particular, wildcard CORS does not authorize OAuth redirect callbacks.
+
+## Security Tradeoff
+
+This configuration deliberately trusts any website origin to start a connection flow and make cross-origin requests to your server. Chatto uses PKCE and asks the user for consent before issuing access, but a malicious site can still ask a logged-in user to approve it.
+
+If only specific frontends should be able to add your server, list their exact HTTPS origins instead of `*`. See [Security & Privacy](/guides/operations/security/#chatto-frontend-oauth-redirects) for details.

--- a/apps/docs-website/src/content/docs/guides/operations/security.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/security.mdx
@@ -53,25 +53,15 @@ Reset tokens have a 1-hour TTL and expire automatically via NATS KV TTL — no s
 
 When a Chatto frontend connects to another Chatto server, it opens that server's `/oauth/authorize` page in a separate browser window and uses PKCE to mint a bearer token. Passwords, passkeys, and external-provider sign-in stay on the remote server's own pages. After sign-in, the remote server redirects a short-lived authorization code to the trusted frontend origin; the main client exchanges the code and stores the resulting token.
 
-For a known hosted frontend, list the exact callback origin:
+For a known hosted frontend, list its exact callback origin in `webserver.oauth_redirect_origins`. To make your server addable from a frontend hosted by any other Chatto server, you must allow both wildcard OAuth redirects and wildcard CORS:
 
-```toml
-[webserver]
-oauth_redirect_origins = ["https://app.example.com"]
-```
+<LinkCard
+  title="Allow Connections From Any Chatto Frontend"
+  href="/guides/operations/cross-server-connections/"
+  description="Configure both allowlists, understand the security tradeoff, and read the Chatto 0.5 compatibility note."
+/>
 
-You can also allow any valid HTTPS Chatto frontend to connect:
-
-```toml
-[webserver]
-oauth_redirect_origins = ["*"]
-```
-
-Use `*` only when you intentionally want open connectivity. It allows any HTTPS origin to start a Chatto OAuth authorization request. PKCE prevents passive interception of the code, and Chatto still shows the user a consent screen for each redirect origin, but a malicious site can initiate its own flow and ask a logged-in user to approve it. If the user approves, that site receives an authorization code it can exchange for a bearer token.
-
-<Aside type="caution">
-  `webserver.allowed_origins = ["*"]` is different. That wildcard only affects CORS and WebSocket access; it does not trust OAuth redirect callbacks. Use `webserver.oauth_redirect_origins` for OAuth callback trust.
-</Aside>
+Wildcard redirect trust allows any HTTPS origin to start a Chatto OAuth authorization request. PKCE prevents passive interception of the code, and Chatto still shows the user a consent screen for each redirect origin, but a malicious site can initiate its own flow and ask a logged-in user to approve it. If the user approves, that site receives an authorization code it can exchange for a bearer token.
 
 ## Authorization
 
@@ -185,7 +175,7 @@ There is **no per-IP or per-user rate limiting** at the application layer. If yo
 
 ### CORS and WebSockets
 
-CORS allows the configured `webserver.url`, the local listen port (for development), and any explicit entries in `webserver.allowed_origins`. Credentials (cookies) are only attached for explicit origins; wildcard mode omits credentials, forcing token-based auth in that case.
+CORS allows the configured `webserver.url`, the local listen port (for development), and any explicit entries in `webserver.allowed_origins`. Credentials (cookies) are only attached for explicit origins; wildcard mode omits credentials, forcing token-based auth in that case. See [Allow Connections From Any Chatto Frontend](/guides/operations/cross-server-connections/) when configuring cross-server access.
 
 Realtime WebSocket connections perform the same origin check before the upgrade is accepted.
 

--- a/apps/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/apps/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -52,11 +52,11 @@ Every `chatto.toml` setting can be overridden with an environment variable. The 
 </EnvVar>
 
 <EnvVar name="CHATTO_WEBSERVER_ALLOWED_ORIGINS" toml="webserver.allowed_origins">
-  Comma-separated list of origins allowed for cross-origin requests (CORS and WebSocket). The server's own origin (from `webserver.url`) and `localhost` at the listen port are always allowed. Defaults to `*` (wildcard) when not set, allowing any origin for multi-server support — cross-origin clients authenticate via Bearer tokens, not cookies. Set explicitly to restrict which origins can access the API. Wildcard CORS does not trust OAuth redirect callbacks.
+  Comma-separated list of origins allowed for cross-origin requests (CORS and WebSocket). The server's own origin (from `webserver.url`) and `localhost` at the listen port are always allowed. Defaults to `*` when not set; cross-origin clients authenticate with bearer tokens, not cookies. Wildcard CORS does not trust OAuth redirect callbacks. See [Allow Connections From Any Chatto Frontend](/guides/operations/cross-server-connections/) for the complete setup.
 </EnvVar>
 
 <EnvVar name="CHATTO_WEBSERVER_OAUTH_REDIRECT_ORIGINS" toml="webserver.oauth_redirect_origins">
-  Comma-separated list of origins allowed for Chatto OAuth redirect callbacks when another Chatto frontend connects to this server. Use exact HTTPS origins, such as `https://app.example.com`, when you operate a known frontend. Set to `*` if you intentionally want any valid HTTPS Chatto frontend to connect. This is convenient for open federation-style alpha deployments, but it lets any HTTPS site start an authorization request and ask the user to approve sending an authorization code back to that site. See the [Security guide](/guides/operations/security/#chatto-frontend-oauth-redirects) for the risk tradeoff.
+  Comma-separated list of origins allowed for Chatto OAuth redirect callbacks when another Chatto frontend connects to this server. This setting is separate from external OIDC login providers. Use exact HTTPS origins when you operate known frontends, or follow [Allow Connections From Any Chatto Frontend](/guides/operations/cross-server-connections/) to enable open connectivity.
 </EnvVar>
 
 <EnvVar name="CHATTO_WEBSERVER_TRUSTED_PROXIES" toml="webserver.trusted_proxies">


### PR DESCRIPTION
## Why

Server operators need clear Chatto 0.4 guidance for making their server addable from frontends hosted by any other Chatto server.

## What changed

- Adds a dedicated operations guide covering both wildcard OAuth redirect and CORS settings, while distinguishing Chatto's OAuth flow from external OIDC providers.
- Adds the guide to navigation, consolidates repeated security and environment-reference guidance, and calls out the wildcard security tradeoff plus the unreleased 0.5 change.

## Test plan

- `mise x -- pnpm --dir apps/docs-website build` — passed.
