### PR TITLE
fix(desktop): make release verification reliable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,14 @@ on:
       - "chatto-desktop/v*"
   workflow_dispatch:
     inputs:
+      target:
+        description: "Artifact to build"
+        required: true
+        default: image
+        type: choice
+        options:
+          - image
+          - desktop
       ref:
         description: "Git ref or SHA to build. Defaults to the selected workflow ref."
         required: false
@@ -44,7 +52,7 @@ jobs:
           target-branch: ${{ env.TARGET_BRANCH }}
 
   build-image:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.target == 'image' }}
     # runs-on: ubicloud-standard-4
     runs-on: ubuntu-latest
     permissions:
@@ -150,7 +158,7 @@ jobs:
             org.opencontainers.image.licenses=AGPL-3.0-or-later
 
   build-desktop-release:
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chatto-desktop/v') }}
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chatto-desktop/v')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'desktop') }}
     name: build-desktop-release (${{ matrix.platform }})
     timeout-minutes: 45
     strategy:
@@ -169,6 +177,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -192,7 +202,19 @@ jobs:
       - name: Resolve desktop version
         id: version
         shell: bash
-        run: echo "version=${GITHUB_REF_NAME#chatto-desktop/v}" >> "$GITHUB_OUTPUT"
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            version="${GITHUB_REF_NAME#chatto-desktop/v}"
+          else
+            version="$(jq -r '.version' apps/desktop/deno.json)"
+          fi
+
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "::error::Could not determine the Chatto Desktop version."
+            exit 1
+          fi
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Package macOS release
         if: runner.os == 'macOS'
@@ -235,8 +257,8 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  publish-desktop-release:
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chatto-desktop/v') }}
+  assemble-desktop-release:
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chatto-desktop/v')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'desktop') }}
     needs: build-desktop-release
     runs-on: ubuntu-latest
     permissions:
@@ -255,7 +277,17 @@ jobs:
           cd .context/desktop-release
           sha256sum chatto-desktop_* > chatto-desktop_checksums.txt
 
+      - name: Upload desktop release verification
+        if: github.event_name == 'workflow_dispatch'
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-release-verification-${{ github.run_id }}
+          path: .context/desktop-release
+          if-no-files-found: error
+          retention-days: 1
+
       - name: Upload and publish desktop release
+        if: github.event_name == 'push'
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/desktop/deno.json
+++ b/apps/desktop/deno.json
@@ -5,6 +5,9 @@
   "imports": {
     "@std/http/file-server": "jsr:@std/http@1.1.3/file-server"
   },
+  "fmt": {
+    "include": ["*.ts", "scripts/**/*.ts", "deno.json"]
+  },
   "tasks": {
     "build": "deno desktop --allow-net=127.0.0.1,localhost --allow-read=../frontend/build --include=../frontend/build main.ts && deno run --allow-read=deno.json,legal,../../NOTICE,../../LICENSES,dist --allow-run=codesign,plutil --allow-write=dist scripts/finalize_build.ts",
     "check": "deno fmt --check && deno lint && deno check --desktop main.ts scripts/**/*.ts && deno test --allow-read --allow-write",

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -69,6 +69,13 @@ different questions. The desktop version identifies packaging and runtime
 changes; client-server compatibility continues to use the official frontend
 version embedded by the tagged commit.
 
+Before publishing a tag, the release workflow can verify the complete desktop
+packaging path without creating a release or building a Chatto server image.
+Run the `release` workflow manually, select the `desktop` target, and optionally
+provide a branch, tag, or commit in the `ref` input. The workflow builds and
+packages all three platforms, generates the same checksum file used by a tagged
+release, and uploads the assembled files as a one-day verification artifact.
+
 ## Create a stable release branch
 
 Create `release-x.y` from the commit intended for the stable release. On that


### PR DESCRIPTION
## Why

Release Please generates the desktop changelog in a Markdown style that Deno reformats, causing every platform build for the first desktop alpha release to fail before producing artifacts.

## What changed

- Scope Deno formatting to desktop TypeScript sources and `deno.json`, leaving generated and hand-written Markdown outside the format check.
- Add mutually exclusive `image` and `desktop` manual release targets; desktop verification builds and packages every platform, generates release checksums, and uploads the assembled files without publishing a release or server image.
- Document the manual desktop verification workflow for maintainers.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise test-desktop` — passed; 6 tests passed and formatting checked 11 code/config files.
- `mise desktop-build` — passed; frontend bundle built and the macOS desktop bundle signature verified.
- `mise x -- actionlint .github/workflows/*.yml` — passed.
- Manual `release` workflow with target `desktop` — passed on Linux, macOS, and Windows; assembled archives and checksums without running server release jobs.
- `git diff --check` — passed.
