### PR TITLE
perf(frontend): stabilise room member presence grouping

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -8,10 +8,14 @@ calls, and similar room-specific panels can plug into the same shell. See the
 -->
 <script module lang="ts">
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+
+  export const PRESENCE_GROUPING_DEBOUNCE_MS = 1_000;
   export type RoomSidebarPanel = 'members' | 'search' | 'files' | 'call';
 </script>
 
 <script lang="ts">
+  import { untrack } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
   import * as m from '$lib/i18n/messages';
   import { startDMWith } from '$lib/dm/startDM';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
@@ -112,7 +116,12 @@ calls, and similar room-specific panels can plug into the same shell. See the
   let banDialogMember = $state<RoomMember | null>(null);
   let banError = $state<string | null>(null);
   const memberSearchDebounce = useDebounce();
+  const presenceGroupingDebounce = useDebounce();
   let memberSearchInput = $state<HTMLInputElement | null>(null);
+  let groupedPresence = $state.raw(new Map<string, PresenceStatus>());
+  let observedLivePresence = new Map<string, PresenceStatus>();
+  let groupedMembersSnapshot: RoomMember[] | null = null;
+  let observedPresenceVersion = -1;
 
   function togglePopover(memberId: string, e: MouseEvent) {
     if (popoverMemberId === memberId) {
@@ -152,14 +161,67 @@ calls, and similar room-specific panels can plug into the same shell. See the
   }
 
   const sortedMembers = $derived(sortByName(members));
+
+  function readPresenceSnapshot(list: RoomMember[]): Map<string, PresenceStatus> {
+    return new Map(list.map((member) => [member.id, getPresence(member)]));
+  }
+
+  function presenceSnapshotsEqual(
+    left: ReadonlyMap<string, PresenceStatus>,
+    right: ReadonlyMap<string, PresenceStatus>
+  ): boolean {
+    if (left.size !== right.size) return false;
+    for (const [userId, status] of left) {
+      if (right.get(userId) !== status) return false;
+    }
+    return true;
+  }
+
+  // Membership and search changes stay immediate. Presence-only changes settle after a short quiet
+  // period so busy rooms do not continuously move rows between the Online and Offline groups.
+  const syncPresenceGrouping: Attachment = () => {
+    const currentMembers = members;
+    const presenceVersion = presenceCache.version;
+    const viewerId = currentUserId;
+    untrack(() => {
+      if (currentMembers !== groupedMembersSnapshot) {
+        groupedMembersSnapshot = currentMembers;
+        observedPresenceVersion = presenceVersion;
+        presenceGroupingDebounce.cancel();
+        observedLivePresence = readPresenceSnapshot(currentMembers);
+        groupedPresence = observedLivePresence;
+        return;
+      }
+      if (presenceVersion === observedPresenceVersion) return;
+      observedPresenceVersion = presenceVersion;
+      const nextPresence = readPresenceSnapshot(currentMembers);
+      if (presenceSnapshotsEqual(nextPresence, observedLivePresence)) return;
+      observedLivePresence = nextPresence;
+
+      const currentMember = viewerId
+        ? currentMembers.find((member) => member.id === viewerId)
+        : undefined;
+      if (
+        currentMember &&
+        groupedPresence.get(currentMember.id) !== nextPresence.get(currentMember.id)
+      ) {
+        presenceGroupingDebounce.cancel();
+        groupedPresence = nextPresence;
+        return;
+      }
+
+      presenceGroupingDebounce.run(() => {
+        groupedPresence = nextPresence;
+      }, PRESENCE_GROUPING_DEBOUNCE_MS);
+    });
+  };
+
   const groupedMembers = $derived.by(() => {
-    // Explicit versions include value-only presence transitions such as OFFLINE→ONLINE.
-    void presenceCache.version;
-    void membersStore.presenceVersion;
     const online: RoomMember[] = [];
     const offline: RoomMember[] = [];
     for (const member of sortedMembers) {
-      (isOnlineStatus(getPresence(member)) ? online : offline).push(member);
+      const groupedStatus = groupedPresence.get(member.id) ?? member.presenceStatus;
+      (isOnlineStatus(groupedStatus) ? online : offline).push(member);
     }
     return { online, offline };
   });
@@ -244,6 +306,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
 
 <aside
   bind:this={sidebarElement}
+  {@attach syncPresenceGrouping}
   class={[
     'relative flex min-h-0 flex-col bg-background',
     presentation === 'desktop'

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -118,8 +118,8 @@ calls, and similar room-specific panels can plug into the same shell. See the
   const memberSearchDebounce = useDebounce();
   const presenceGroupingDebounce = useDebounce();
   let memberSearchInput = $state<HTMLInputElement | null>(null);
-  let groupedPresence = $state.raw(new Map<string, PresenceStatus>());
-  let observedLivePresence = new Map<string, PresenceStatus>();
+  let groupedOnlineState = $state.raw(new Map<string, boolean>());
+  let observedLiveOnlineState = new Map<string, boolean>();
   let groupedMembersSnapshot: RoomMember[] | null = null;
   let observedPresenceVersion = -1;
 
@@ -162,13 +162,13 @@ calls, and similar room-specific panels can plug into the same shell. See the
 
   const sortedMembers = $derived(sortByName(members));
 
-  function readPresenceSnapshot(list: RoomMember[]): Map<string, PresenceStatus> {
-    return new Map(list.map((member) => [member.id, getPresence(member)]));
+  function readOnlineState(list: RoomMember[]): Map<string, boolean> {
+    return new Map(list.map((member) => [member.id, isOnlineStatus(getPresence(member))]));
   }
 
-  function presenceSnapshotsEqual(
-    left: ReadonlyMap<string, PresenceStatus>,
-    right: ReadonlyMap<string, PresenceStatus>
+  function onlineStatesEqual(
+    left: ReadonlyMap<string, boolean>,
+    right: ReadonlyMap<string, boolean>
   ): boolean {
     if (left.size !== right.size) return false;
     for (const [userId, status] of left) {
@@ -188,30 +188,35 @@ calls, and similar room-specific panels can plug into the same shell. See the
         groupedMembersSnapshot = currentMembers;
         observedPresenceVersion = presenceVersion;
         presenceGroupingDebounce.cancel();
-        observedLivePresence = readPresenceSnapshot(currentMembers);
-        groupedPresence = observedLivePresence;
+        observedLiveOnlineState = readOnlineState(currentMembers);
+        groupedOnlineState = observedLiveOnlineState;
         return;
       }
       if (presenceVersion === observedPresenceVersion) return;
       observedPresenceVersion = presenceVersion;
-      const nextPresence = readPresenceSnapshot(currentMembers);
-      if (presenceSnapshotsEqual(nextPresence, observedLivePresence)) return;
-      observedLivePresence = nextPresence;
+      const nextOnlineState = readOnlineState(currentMembers);
+      if (onlineStatesEqual(nextOnlineState, observedLiveOnlineState)) return;
+      observedLiveOnlineState = nextOnlineState;
 
       const currentMember = viewerId
         ? currentMembers.find((member) => member.id === viewerId)
         : undefined;
       if (
         currentMember &&
-        groupedPresence.get(currentMember.id) !== nextPresence.get(currentMember.id)
+        groupedOnlineState.get(currentMember.id) !== nextOnlineState.get(currentMember.id)
       ) {
-        presenceGroupingDebounce.cancel();
-        groupedPresence = nextPresence;
-        return;
+        groupedOnlineState = new Map([
+          ...groupedOnlineState,
+          [currentMember.id, nextOnlineState.get(currentMember.id) ?? false]
+        ]);
       }
 
+      if (onlineStatesEqual(groupedOnlineState, nextOnlineState)) {
+        presenceGroupingDebounce.cancel();
+        return;
+      }
       presenceGroupingDebounce.run(() => {
-        groupedPresence = nextPresence;
+        groupedOnlineState = nextOnlineState;
       }, PRESENCE_GROUPING_DEBOUNCE_MS);
     });
   };
@@ -220,8 +225,9 @@ calls, and similar room-specific panels can plug into the same shell. See the
     const online: RoomMember[] = [];
     const offline: RoomMember[] = [];
     for (const member of sortedMembers) {
-      const groupedStatus = groupedPresence.get(member.id) ?? member.presenceStatus;
-      (isOnlineStatus(groupedStatus) ? online : offline).push(member);
+      const groupedOnline =
+        groupedOnlineState.get(member.id) ?? isOnlineStatus(member.presenceStatus);
+      (groupedOnline ? online : offline).push(member);
     }
     return { online, offline };
   });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -1592,10 +1592,11 @@ describe('RoomSidebar', () => {
     expect(buttonByText(container, 'Offline (2)')).toBeTruthy();
   });
 
-  it('moves the current user between presence groups immediately', async () => {
+  it('moves only the current user between presence groups immediately', async () => {
     let presenceCache: PresenceCache | null = null;
     const current = member(1);
-    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([current]));
+    const other = member(2);
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([current, other]));
 
     const { container } = render(RoomSidebarTestHarness, {
       props: {
@@ -1609,16 +1610,64 @@ describe('RoomSidebar', () => {
 
     await vi.waitFor(() => {
       expect(presenceCache).toBeTruthy();
-      expect(buttonByText(container, 'Online (1)')).toBeTruthy();
+      expect(buttonByText(container, 'Online (2)')).toBeTruthy();
     });
 
+    presenceCache!.update(
+      { serverId: 'test-server', userId: other.id },
+      PresenceStatus.OFFLINE
+    );
+    await tick();
     presenceCache!.update(
       { serverId: 'test-server', userId: current.id },
       PresenceStatus.OFFLINE
     );
     await tick();
 
+    expect(buttonByText(container, 'Offline (1)')).toBeTruthy();
+    expect(buttonByText(container, 'Online (1)')).toBeTruthy();
+
+    await waitForPresenceGrouping();
     expect(buttonByText(container, 'Online (1)')).toBeFalsy();
+    expect(buttonByText(container, 'Offline (2)')).toBeTruthy();
+  });
+
+  it('does not postpone group movement for online-like status churn', async () => {
+    let presenceCache: PresenceCache | null = null;
+    const first = member(1);
+    const second = member(2);
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([first, second]));
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        currentUserId: second.id,
+        onPresenceCacheReady: (cache: PresenceCache) => {
+          presenceCache = cache;
+        }
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(presenceCache).toBeTruthy();
+      expect(buttonByText(container, 'Online (2)')).toBeTruthy();
+    });
+
+    presenceCache!.update(
+      { serverId: 'test-server', userId: first.id },
+      PresenceStatus.OFFLINE
+    );
+    await tick();
+    await waitForPresenceGrouping(PRESENCE_GROUPING_DEBOUNCE_MS - 100);
+
+    presenceCache!.update(
+      { serverId: 'test-server', userId: second.id },
+      PresenceStatus.AWAY
+    );
+    await tick();
+    await waitForPresenceGrouping(200);
+
+    expect(buttonByText(container, 'Online (1)')).toBeTruthy();
     expect(buttonByText(container, 'Offline (1)')).toBeTruthy();
   });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '$lib/state/server/messageSearch.svelte';
 
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
+import { PRESENCE_GROUPING_DEBOUNCE_MS } from './RoomSidebar.svelte';
 import RoomSidebarTestHarness from './RoomSidebarTestHarness.svelte';
 
 const queryMock = vi.hoisted(() => vi.fn());
@@ -246,6 +247,11 @@ async function waitForMemberSearchDebounce(): Promise<void> {
 
 async function waitForRoomSearchDebounce(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 350));
+  await tick();
+}
+
+async function waitForPresenceGrouping(delay = PRESENCE_GROUPING_DEBOUNCE_MS + 100): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delay));
   await tick();
 }
 
@@ -1500,6 +1506,120 @@ describe('RoomSidebar', () => {
 
     expect(presenceBadge(container, 'Online')).toBeTruthy();
     expect(buttonByText(container, 'Online (1)')).toBeTruthy();
+  });
+
+  it('shows presence immediately while debouncing member group movement', async () => {
+    let presenceCache: PresenceCache | null = null;
+    const first = member(1);
+    const second = member(2);
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([first, second]));
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        onPresenceCacheReady: (cache: PresenceCache) => {
+          presenceCache = cache;
+        }
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(presenceCache).toBeTruthy();
+      expect(buttonByText(container, 'Online (2)')).toBeTruthy();
+    });
+
+    presenceCache!.update(
+      { serverId: 'test-server', userId: first.id },
+      PresenceStatus.OFFLINE
+    );
+    await tick();
+
+    expect(presenceBadge(container, 'Offline')).toBeTruthy();
+    expect(buttonByText(container, 'Online (2)')).toBeTruthy();
+    expect(buttonByText(container, 'Offline (1)')).toBeFalsy();
+
+    await waitForPresenceGrouping(PRESENCE_GROUPING_DEBOUNCE_MS - 100);
+    presenceCache!.update(
+      { serverId: 'another-server', userId: first.id },
+      PresenceStatus.ONLINE
+    );
+    await tick();
+    await waitForPresenceGrouping(200);
+
+    expect(buttonByText(container, 'Online (1)')).toBeTruthy();
+    expect(buttonByText(container, 'Offline (1)')).toBeTruthy();
+  });
+
+  it('coalesces a burst of presence-driven member group movement', async () => {
+    let presenceCache: PresenceCache | null = null;
+    const first = member(1);
+    const second = member(2);
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([first, second]));
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        onPresenceCacheReady: (cache: PresenceCache) => {
+          presenceCache = cache;
+        }
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(presenceCache).toBeTruthy();
+      expect(buttonByText(container, 'Online (2)')).toBeTruthy();
+    });
+
+    presenceCache!.update(
+      { serverId: 'test-server', userId: first.id },
+      PresenceStatus.OFFLINE
+    );
+    await tick();
+    await waitForPresenceGrouping(PRESENCE_GROUPING_DEBOUNCE_MS - 100);
+
+    presenceCache!.update(
+      { serverId: 'test-server', userId: second.id },
+      PresenceStatus.OFFLINE
+    );
+    await tick();
+    await waitForPresenceGrouping(200);
+
+    expect(buttonByText(container, 'Online (2)')).toBeTruthy();
+    expect(buttonByText(container, 'Offline (2)')).toBeFalsy();
+
+    await waitForPresenceGrouping(PRESENCE_GROUPING_DEBOUNCE_MS);
+    expect(buttonByText(container, 'Online (2)')).toBeFalsy();
+    expect(buttonByText(container, 'Offline (2)')).toBeTruthy();
+  });
+
+  it('moves the current user between presence groups immediately', async () => {
+    let presenceCache: PresenceCache | null = null;
+    const current = member(1);
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(memberPage([current]));
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false),
+        currentUserId: current.id,
+        onPresenceCacheReady: (cache: PresenceCache) => {
+          presenceCache = cache;
+        }
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(presenceCache).toBeTruthy();
+      expect(buttonByText(container, 'Online (1)')).toBeTruthy();
+    });
+
+    presenceCache!.update(
+      { serverId: 'test-server', userId: current.id },
+      PresenceStatus.OFFLINE
+    );
+    await tick();
+
+    expect(buttonByText(container, 'Online (1)')).toBeFalsy();
+    expect(buttonByText(container, 'Offline (1)')).toBeTruthy();
   });
 
   it('calls onClose when the room extras close button is clicked', async () => {

--- a/docs/fdr/FDR-011-user-presence.md
+++ b/docs/fdr/FDR-011-user-presence.md
@@ -1,7 +1,7 @@
 # FDR-011: User Presence
 
 **Status:** Active
-**Last reviewed:** 2026-07-18
+**Last reviewed:** 2026-08-03
 
 ## Overview
 
@@ -19,6 +19,7 @@ Every user has a presence status visible to others as a colored dot on their ava
 - Users can choose "Look offline" locally. The client does not report an Offline status; it stops reporting presence so the existing presence record expires normally while messages and other realtime updates continue working.
 - Disconnecting (closing the tab, network drop) does not send an active Offline signal. After 60 seconds without a heartbeat refresh, the presence entry expires and the user appears Offline.
 - The presence dot updates across the UI as other users' statuses change, in real time.
+- Room member sidebars update presence dots immediately but wait for a short quiet period before moving other users between the Online and Offline groups. Membership changes and the current user's own group movement remain immediate.
 - If a live connection falls behind presence updates, it reconnects and recovers current presence instead of remaining silently stale.
 
 ## Design Decisions
@@ -70,6 +71,12 @@ Every user has a presence status visible to others as a colored dot on their ava
 **Decision:** A connection that cannot keep up with presence transitions is closed and reconnects rather than silently dropping transitions while remaining live.
 **Why:** Presence is latest-value state. Every realtime subscription includes a complete `presences_replace` reconciliation before `caught_up`, so reconnect repairs a missed transition through the same projection stream without a separate user read. Keeping an incomplete stream open would leave a presence dot stale indefinitely. See ADR-049 and ADR-051.
 **Tradeoff:** A sufficiently large presence burst can reconnect a slow client, but only that lagging connection is affected and normal reconnect catch-up already handles the gap.
+
+### 9. Presence display is immediate while member-list grouping settles
+
+**Decision:** Presence indicators show the latest status immediately. Room member sidebars debounce presence-driven movement between their Online and Offline groups, while membership changes and the current user's own movement bypass that delay.
+**Why:** Presence is useful as a current status signal, but repeatedly moving rows during a burst makes a busy member list difficult to scan and causes avoidable repeated work. Delaying only the grouping preserves freshness without making membership or the user's own action feel stale.
+**Tradeoff:** Another user's row can briefly remain in its previous group while its presence dot already shows the new status. Continuous churn postpones regrouping until the updates settle.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -20,7 +20,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-07-20 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-15 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
-| [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-07-18 |
+| [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-08-03 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-07-20 |
 | [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-20 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |


### PR DESCRIPTION
## Summary

- keep member presence badges immediate while applying Online/Offline group movements after a one-second trailing debounce
- keep membership, search, and the current member's own group movement immediate, without flushing queued movements for other members
- isolate grouping updates to the active room and track only Online/Offline classification so same-group presence churn cannot postpone a real regroup
- document the behaviour in [FDR-011](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-011-user-presence.md)

## Why

Rapid realtime presence changes could repeatedly reorder large room member lists even though the individual presence indicators were already cheap to update. Settling only the group allocation reduces visible and computational churn while preserving immediate presence feedback and privacy-sensitive membership changes.

## Verification

- `mise lint-frontend`
- `mise x -- pnpm --dir apps/frontend exec vitest run 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts'` (43 tests)
- Svelte analyzer/autofixer: no relevant issues
- two-pass adversarial code review

Closes #1653.
