### PR TITLE
fix(frontend): backport adaptive ordered list markers

### DIFF
--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -403,6 +403,35 @@ describe('MessageContent component', () => {
     await expect.element(wrapper).toBeInTheDocument();
   });
 
+  it('sizes each ordered-list marker column to its widest marker', async () => {
+    const shortList = '1. Short item 1\n2. Short item 2';
+    const longList = Array.from(
+      { length: 12 },
+      (_, index) => `${index + 1}. Long item ${index + 1}`
+    ).join('\n');
+    const startedList = '9. Started item 9\n10. Started item 10';
+    const body = `${shortList}\n\nBetween lists\n\n${longList}\n\nAnother break\n\n${startedList}`;
+    const { container } = renderMessage(body);
+
+    await expect.poll(() => container.querySelectorAll('ol').length).toBe(3);
+    const [short, long, started] = Array.from(container.querySelectorAll('ol'));
+    const longItems = Array.from(long!.querySelectorAll(':scope > li'));
+    const startedItems = Array.from(started!.querySelectorAll(':scope > li'));
+
+    const textLeft = (element: Element) => {
+      const text = Array.from(element.childNodes).find((node) => node.nodeType === Node.TEXT_NODE);
+      if (!text) throw new Error('Expected a direct text node in the list item');
+      const range = document.createRange();
+      range.selectNodeContents(text);
+      return range.getBoundingClientRect().left;
+    };
+
+    expect(textLeft(longItems[0]!)).toBeCloseTo(textLeft(longItems[9]!), 0);
+    expect(textLeft(longItems[0]!)).toBeGreaterThan(textLeft(short!.querySelector('li')!));
+    expect(textLeft(startedItems[0]!)).toBeCloseTo(textLeft(startedItems[1]!), 0);
+    expect(textLeft(startedItems[0]!)).toBeGreaterThan(textLeft(short!.querySelector('li')!));
+  });
+
   it('styles blockquotes as distinct quote blocks', async () => {
     const { container } = renderMessage('> quoted text\n>\n> second line');
 

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -1419,7 +1419,28 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
   }
 
   :global(.tiptap-editor .ProseMirror ol) {
-    list-style-type: decimal;
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    column-gap: 0.4em;
+    padding-left: 0;
+    list-style: none;
+  }
+
+  :global(.tiptap-editor .ProseMirror ol > li) {
+    counter-increment: list-item;
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+  }
+
+  :global(.tiptap-editor .ProseMirror ol > li::before) {
+    content: counter(list-item) '.';
+    grid-column: 1;
+    text-align: right;
+  }
+
+  :global(.tiptap-editor .ProseMirror ol > li > *) {
+    grid-column: 2;
   }
 
   :global(.tiptap-editor .ProseMirror blockquote) {

--- a/apps/frontend/src/prose.css
+++ b/apps/frontend/src/prose.css
@@ -69,7 +69,28 @@
   }
 
   & ol {
-    list-style-type: decimal;
+    display: grid;
+    grid-template-columns: max-content minmax(0, 1fr);
+    column-gap: 0.4em;
+    padding-left: 0;
+    list-style: none;
+  }
+
+  & ol > li {
+    counter-increment: list-item;
+    display: grid;
+    grid-column: 1 / -1;
+    grid-template-columns: subgrid;
+  }
+
+  & ol > li::before {
+    content: counter(list-item) '.';
+    grid-column: 1;
+    text-align: right;
+  }
+
+  & ol > li > * {
+    grid-column: 2;
   }
 
   & li {


### PR DESCRIPTION
## Why

Backport #1911 so ordered-list markers with two or more digits are not clipped in the 0.4 client, without over-indenting short lists.

## What changed

- Size each ordered list's marker column intrinsically with CSS Grid/subgrid and the standard `list-item` counter.
- Apply the same adaptive alignment in rendered markdown and the message composer, with browser regression coverage.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.
Newer client → older server: Not applicable.
Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise lint-frontend` — passed (Svelte diagnostics and ESLint).
- MessageContent and TipTapEditor browser component suites — 66 tests passed.
- Svelte autofixer — no issues introduced in the edited component.
