### PR TITLE
perf(frontend): skip dev-only production work

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -94,6 +94,9 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
   the canonical guide for choosing components, semantic utilities, tokens, and
   Storybook coverage.
 - Use Tailwind 4 utilities and established components; avoid one-off CSS.
+- Keep `src/app.css` scoped to Tailwind's `source('./')` detection root. Production
+  CSS must not scan frontend E2E tests, scripts, or build configuration outside
+  `src`; co-located unit tests and stories remain inside the application boundary.
 - Use Iconify's dynamic utilities, for example `icon-[uil--check]`. Keep its Tailwind
   plugin in dynamic mode; configuring `prefixes` eagerly expands complete icon
   collections and materially increases production-build memory.

--- a/apps/frontend/scripts/check-design-system.mjs
+++ b/apps/frontend/scripts/check-design-system.mjs
@@ -80,6 +80,12 @@ async function sourceFiles(directory) {
 const failures = [];
 const appCss = await readFile(appCssPath, 'utf8');
 
+if (!/@import\s+['"]tailwindcss['"]\s+source\(['"]\.\/['"]\)/.test(appCss)) {
+  failures.push(
+    "src/app.css: scope Tailwind source detection to source('./') so production ignores sources outside src"
+  );
+}
+
 if (/\bprefixes\s*:/.test(appCss)) {
   failures.push(
     'src/app.css: Iconify prefixes eagerly expand complete icon collections; use dynamic utilities such as icon-[uil--check]'

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -2,7 +2,7 @@
 @import '@fontsource-variable/ibm-plex-sans/wght-italic.css';
 @import '@fontsource/ibm-plex-mono/400.css';
 @import '@fontsource/ibm-plex-mono/500.css';
-@import 'tailwindcss';
+@import 'tailwindcss' source('./');
 @import './prose.css';
 /* @plugin '@tailwindcss/forms'; */
 /* Dynamic utilities load only referenced candidates such as icon-[uil--check].

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,11 +3,9 @@ import { execFile } from 'node:child_process';
 import { readdirSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
-import devtoolsJson from 'vite-plugin-devtools-json';
 import tailwindcss from '@tailwindcss/vite';
-import { paraglideVitePlugin } from '@inlang/paraglide-js';
 import { sveltekit } from '@sveltejs/kit/vite';
-import { defineConfig, type Plugin, type UserConfig } from 'vite';
+import { defineConfig, type Plugin, type PluginOption, type UserConfig } from 'vite';
 
 // Backend target for dev proxy. Set CHATTO_BACKEND_URL to proxy to a remote
 // backend (e.g. "https://dev.chatto.run") instead of a local one.
@@ -197,95 +195,111 @@ async function createTestConfig(): Promise<NonNullable<UserConfig['test']>> {
 
 const testConfig = process.env.VITEST ? await createTestConfig() : undefined;
 
-export default defineConfig(({ command }) => ({
-  clearScreen: false,
-  plugins: [
-    tailwindcss(),
-    highlightLanguageMetadata(),
-    // Production compiles messages in the package build script so Paraglide's
-    // compiler process can exit before Vite constructs the application graph.
-    // Dev and Vitest retain the plugin for live catalogue updates.
-    command === 'serve'
-      ? paraglideVitePlugin({
-          project: './project.inlang',
-          outdir: './src/lib/paraglide',
-          strategy: ['localStorage', 'preferredLanguage', 'baseLocale'],
-          emitTsDeclarations: false,
-          outputStructure: 'locale-modules'
-        })
-      : null,
-    command === 'serve' ? i18nFacade() : null,
-    sveltekit(),
-    devtoolsJson()
-  ],
-  build: {
-    reportCompressedSize: false
-  },
-  resolve: {
-    alias: {
-      // The lowlight package root re-exports `all`, which imports every
-      // highlight.js grammar. We only need createLowlight, so point bundling
-      // at the implementation module to keep language grammars lazy.
-      lowlight: fileURLToPath(new URL('./node_modules/lowlight/lib/index.js', import.meta.url))
-    }
-  },
-  ssr: {
-    // TipTap is browser-only but imported in Svelte components that are
-    // compiled for SSR. Bundle them into the SSR output to avoid
-    // "could not be resolved" warnings (the code paths are guarded by
-    // $effect which doesn't run during SSR).
-    noExternal: [
-      '@tiptap/core',
-      '@tiptap/extension-code-block-lowlight',
-      '@tiptap/extension-placeholder',
-      '@tiptap/markdown',
-      '@tiptap/starter-kit'
-    ]
-  },
-  optimizeDeps: {
-    include: [...tiptapDeps]
-  },
-  server: {
-    // Proxy some URL routes to the Go backend process in development.
-    port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : undefined,
-    host: true,
-    allowedHosts: ['fatso.fritz.box', '.orb.local'],
-    // Bind-mount inotify on macOS (Docker Desktop / OrbStack) drops events
-    // during bursty changes. Polling is reliable; cost is negligible at this
-    // tree size.
-    watch: {
-      usePolling: true,
-      interval: 300
+async function createServePlugins(): Promise<{
+  paraglide: PluginOption;
+  devtoolsJson: PluginOption;
+}> {
+  const [{ paraglideVitePlugin }, { default: devtoolsJson }] = await Promise.all([
+    import('@inlang/paraglide-js'),
+    import('vite-plugin-devtools-json')
+  ]);
+
+  return {
+    paraglide: paraglideVitePlugin({
+      project: './project.inlang',
+      outdir: './src/lib/paraglide',
+      strategy: ['localStorage', 'preferredLanguage', 'baseLocale'],
+      emitTsDeclarations: false,
+      outputStructure: 'locale-modules'
+    }),
+    devtoolsJson: devtoolsJson()
+  };
+}
+
+export default defineConfig(async ({ command }) => {
+  // Production compiles Paraglide before Vite starts. Keep the compiler and
+  // devtools modules out of that process entirely.
+  const servePlugins = command === 'serve' ? await createServePlugins() : null;
+
+  return {
+    clearScreen: false,
+    plugins: [
+      tailwindcss(),
+      highlightLanguageMetadata(),
+      servePlugins?.paraglide,
+      servePlugins ? i18nFacade() : null,
+      sveltekit(),
+      servePlugins?.devtoolsJson
+    ],
+    build: {
+      reportCompressedSize: false
     },
-    proxy: {
-      '/api': {
-        target: backendTarget,
-        ws: true,
-        changeOrigin: true,
-        secure: false,
-        cookieDomainRewrite: { '*': '' },
-        // Rewrite the Origin header on WebSocket upgrades so the
-        // backend's CheckOrigin accepts the connection.
-        rewriteWsOrigin: true
-      },
-      '/auth': {
-        target: backendTarget,
-        changeOrigin: true,
-        cookieDomainRewrite: { '*': '' }
-      },
-      '/assets': {
-        target: backendTarget,
-        changeOrigin: true
-      },
-      '/.well-known/chatto/shields': {
-        target: backendTarget,
-        changeOrigin: true
-      },
-      '/webhooks': {
-        target: backendTarget,
-        changeOrigin: true
+    resolve: {
+      alias: {
+        // The lowlight package root re-exports `all`, which imports every
+        // highlight.js grammar. We only need createLowlight, so point bundling
+        // at the implementation module to keep language grammars lazy.
+        lowlight: fileURLToPath(new URL('./node_modules/lowlight/lib/index.js', import.meta.url))
       }
-    }
-  },
-  test: testConfig
-}));
+    },
+    ssr: {
+      // TipTap is browser-only but imported in Svelte components that are
+      // compiled for SSR. Bundle them into the SSR output to avoid
+      // "could not be resolved" warnings (the code paths are guarded by
+      // $effect which doesn't run during SSR).
+      noExternal: [
+        '@tiptap/core',
+        '@tiptap/extension-code-block-lowlight',
+        '@tiptap/extension-placeholder',
+        '@tiptap/markdown',
+        '@tiptap/starter-kit'
+      ]
+    },
+    optimizeDeps: {
+      include: [...tiptapDeps]
+    },
+    server: {
+      // Proxy some URL routes to the Go backend process in development.
+      port: process.env.VITE_PORT ? parseInt(process.env.VITE_PORT) : undefined,
+      host: true,
+      allowedHosts: ['fatso.fritz.box', '.orb.local'],
+      // Bind-mount inotify on macOS (Docker Desktop / OrbStack) drops events
+      // during bursty changes. Polling is reliable; cost is negligible at this
+      // tree size.
+      watch: {
+        usePolling: true,
+        interval: 300
+      },
+      proxy: {
+        '/api': {
+          target: backendTarget,
+          ws: true,
+          changeOrigin: true,
+          secure: false,
+          cookieDomainRewrite: { '*': '' },
+          // Rewrite the Origin header on WebSocket upgrades so the
+          // backend's CheckOrigin accepts the connection.
+          rewriteWsOrigin: true
+        },
+        '/auth': {
+          target: backendTarget,
+          changeOrigin: true,
+          cookieDomainRewrite: { '*': '' }
+        },
+        '/assets': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/.well-known/chatto/shields': {
+          target: backendTarget,
+          changeOrigin: true
+        },
+        '/webhooks': {
+          target: backendTarget,
+          changeOrigin: true
+        }
+      }
+    },
+    test: testConfig
+  };
+});


### PR DESCRIPTION
## Why

After moving the frontend to Vite 8/Rolldown, production builds still peak near 1.5 GiB RSS. Vite was loading plugins used only by development, and Tailwind was discovering candidates outside application source. This removes those two avoidable costs without introducing a separate production code-generation path.

## What changed

- keep Paraglide and devtools Vite plugins out of production processes by loading them only for serve-mode workflows
- scope Tailwind candidate discovery to the frontend `src` tree instead of the package root
- guard and document the Tailwind source boundary

## Evidence

Using the same local production build command with a 1 GiB V8 heap cap:

```sh
/usr/bin/time -lp env NODE_OPTIONS=--max-old-space-size=1024 mise x -- pnpm --dir apps/frontend build
```

- baseline peak RSS: 1,558,085,632 bytes
- optimized peak RSS: 1,511,260,160 bytes
- reduction: 46,825,472 bytes (about 44.7 MiB / 3.0%)

All 26 non-base locales remain lazy client chunks, and the production build still succeeds under the 1 GiB heap cap. Paraglide generation remains identical across production, development, type-check, and test workflows.

There are no public API, persistence, runtime compatibility, rollout, or migration changes.

## Test plan

- `env NODE_OPTIONS=--max-old-space-size=1024 mise build-frontend`
- `mise lint-frontend`
- targeted rerun of the two flaky media specs (2 files, 28 tests)
- `env NODE_OPTIONS=--max-old-space-size=1024 mise desktop-build`
- `mise test-desktop`
- `docker compose build chatto storybook`
- `mise license-check`
- independent adversarial diff review
- complete GitHub CI matrix, including frontend unit, all E2E shards, and desktop builds on macOS, Linux, and Windows
