### PR TITLE
test(frontend): backport message preview test stabilization

### DIFF
--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -15,7 +15,17 @@ const { getRoomEventsAroundMock, timelineResults, refreshAssetUrlsMock } = vi.ho
 );
 
 function testImageUrl(label: string): string {
-  return `/icons/favicon.png?label=${label}`;
+  return `data:image/svg+xml,${encodeURIComponent(
+    `<svg xmlns="http://www.w3.org/2000/svg"><title>${label}</title></svg>`
+  )}`;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
 }
 
 vi.mock('$lib/api-client/roomTimeline', () => ({
@@ -262,7 +272,8 @@ describe('MessagePreviewCard', () => {
 
   it('clears stale preview thumbnail asset URLs when refresh returns null', async () => {
     timelineResults.push(previewResult(testImageUrl('old-image')));
-    refreshAssetUrlsMock.mockResolvedValueOnce(clearedRefreshResult('att_1'));
+    const refresh = deferred<Map<string, RefreshedAttachmentUrls>>();
+    refreshAssetUrlsMock.mockReturnValueOnce(refresh.promise);
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
@@ -275,8 +286,12 @@ describe('MessagePreviewCard', () => {
     });
     img.dispatchEvent(new Event('error'));
 
+    expect(refreshAssetUrlsMock).toHaveBeenCalled();
+    expect(container.querySelector('img[alt="photo.jpg"]')).toBe(img);
+
+    refresh.resolve(clearedRefreshResult('att_1'));
+
     await vi.waitFor(() => {
-      expect(refreshAssetUrlsMock).toHaveBeenCalled();
       expect(container.querySelector('img[alt="photo.jpg"]')).toBeNull();
     });
     expect(container.textContent).toContain('Image');
@@ -322,7 +337,8 @@ describe('MessagePreviewCard', () => {
 
   it('clears stale preview video thumbnail asset URLs when refresh returns null', async () => {
     timelineResults.push(videoPreviewResult(testImageUrl('old-video')));
-    refreshAssetUrlsMock.mockResolvedValueOnce(clearedRefreshResult('att_video'));
+    const refresh = deferred<Map<string, RefreshedAttachmentUrls>>();
+    refreshAssetUrlsMock.mockReturnValueOnce(refresh.promise);
 
     const { container } = render(MessagePreviewCard, {
       props: { link: link(), showDismiss: false }
@@ -335,8 +351,12 @@ describe('MessagePreviewCard', () => {
     });
     img.dispatchEvent(new Event('error'));
 
+    expect(refreshAssetUrlsMock).toHaveBeenCalled();
+    expect(container.querySelector('img[alt="clip.mp4"]')).toBe(img);
+
+    refresh.resolve(clearedRefreshResult('att_video'));
+
     await vi.waitFor(() => {
-      expect(refreshAssetUrlsMock).toHaveBeenCalled();
       expect(container.querySelector('img[alt="clip.mp4"]')).toBeNull();
     });
     expect(container.querySelector('.uil--play')).not.toBeNull();


### PR DESCRIPTION
## Why

Backport #1909 so the `release-0.4` frontend suite does not depend on a static image request racing its assertions.

## What changed

- Use inline SVG data URLs for message-preview image fixtures.
- Wait for asset refresh to start before resolving deferred results, eliminating the thumbnail-refresh race.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.
Newer client → older server: Not applicable.
Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/components/MessagePreviewCard.svelte.spec.ts` — 8 tests passed.
- `mise lint-frontend` — passed (Svelte diagnostics and ESLint).
