### PR TITLE
test(realtime): stabilise hydration admission test

### DIFF
--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -854,9 +854,22 @@ func TestRealtimeWebSocketHydrationRejectionIdentifiesRoomAndRetryDelay(t *testi
 	}
 	readRealtimeCaughtUp(t, conn)
 
-	release, admissionErr := env.httpServer.realtimeCatchUps.acquireHydration(viewer.Id)
-	if admissionErr != nil {
-		t.Fatalf("reserve hydration admission: %v", admissionErr)
+	// The server releases bootstrap admission immediately after writing
+	// caught_up, but the client can receive that frame before the serving
+	// goroutine gets scheduled to perform the release. Wait for that handoff
+	// before reserving the hydration slot this test needs to hold.
+	var release func()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var admissionErr *realtimeCatchUpAdmissionError
+		release, admissionErr = env.httpServer.realtimeCatchUps.acquireHydration(viewer.Id)
+		if admissionErr == nil {
+			break
+		}
+		if admissionErr.code != "room_hydration_in_progress" || time.Now().After(deadline) {
+			t.Fatalf("reserve hydration admission: %+v", admissionErr)
+		}
+		time.Sleep(time.Millisecond)
 	}
 	t.Cleanup(release)
 	sendRealtimeClientFrame(t, conn, &realtimev1.RealtimeClientFrame{Frame: &realtimev1.RealtimeClientFrame_HydrateRoom{


### PR DESCRIPTION
## Why

`TestRealtimeWebSocketHydrationRejectionIdentifiesRoomAndRetryDelay` could race the server goroutine that releases bootstrap admission immediately after writing `caught_up`, causing intermittent `room_hydration_in_progress` setup failures in `test-cli` CI.

## What changed

- Wait for the expected bootstrap admission handoff before reserving the hydration slot that the test deliberately holds.
- Preserve production behavior and keep unexpected admission errors or a stuck handoff fatal.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- go test ./internal/http_server -run '^(TestRealtimeWebSocketHydrationRejectionIdentifiesRoomAndRetryDelay|TestRealtime.*Admission.*)$' -count=250` — passed.
- `git diff --check` — passed.
- `mise x -- go test ./internal/http_server` — unrelated frontend fallback tests remain blocked locally because the embedded test filesystem has no `200.html` asset.
