### PR TITLE
fix(frontend): prevent premature attachment URL refreshes

### DIFF
--- a/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.test.ts
@@ -193,6 +193,15 @@ describe('asset URL expiry helpers', () => {
     );
     expect(withAssetUrlRetryParam('/assets/files/A', 'again')).toBe('/assets/files/A?retry=again');
   });
+
+  it('leaves non-network asset URLs unchanged', () => {
+    expect(withAssetUrlRetryParam('data:image/gif;base64,R0lGODlhAQABAAAAACw=', 123)).toBe(
+      'data:image/gif;base64,R0lGODlhAQABAAAAACw='
+    );
+    expect(withAssetUrlRetryParam('blob:https://chat.example.test/asset-id', 123)).toBe(
+      'blob:https://chat.example.test/asset-id'
+    );
+  });
 });
 
 describe('createAssetUrlRetainer', () => {

--- a/apps/frontend/src/lib/attachments/attachmentUrls.ts
+++ b/apps/frontend/src/lib/attachments/attachmentUrls.ts
@@ -118,6 +118,8 @@ export function mergeRefreshedAttachmentUrls(
 }
 
 export function withAssetUrlRetryParam(url: string, retry: string | number): string {
+  if (url.startsWith('data:') || url.startsWith('blob:')) return url;
+
   const hashStart = url.indexOf('#');
   const base = hashStart === -1 ? url : url.slice(0, hashStart);
   const hash = hashStart === -1 ? '' : url.slice(hashStart);

--- a/apps/frontend/src/lib/attachments/useExpiringAssetUrlRefresh.svelte.ts
+++ b/apps/frontend/src/lib/attachments/useExpiringAssetUrlRefresh.svelte.ts
@@ -1,5 +1,7 @@
 import { onMount, untrack } from 'svelte';
 
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+
 type ExpiringAssetUrlRefreshOptions = {
 	getRefreshAt: () => number | null;
 	hasStaleUrl: () => boolean;
@@ -36,17 +38,23 @@ export function useExpiringAssetUrlRefresh({
 
 	$effect(() => {
 		const refreshAt = getRefreshAt();
-		const hasStale = hasStaleUrl();
 		if (refreshAt === null) return;
+		let timeout: number | undefined;
 
-		const delay = refreshAt - Date.now();
-		if (delay <= 0 && hasStale) {
-			untrack(() => void runRefresh());
-			return;
-		}
+		const schedule = () => {
+			const delay = refreshAt - Date.now();
+			if (delay <= 0) {
+				if (hasStaleUrl()) untrack(() => void runRefresh());
+				return;
+			}
 
-		const timeout = window.setTimeout(() => void runRefresh(), delay);
-		return () => window.clearTimeout(timeout);
+			timeout = window.setTimeout(schedule, Math.min(delay, MAX_TIMEOUT_DELAY_MS));
+		};
+
+		schedule();
+		return () => {
+			if (timeout !== undefined) window.clearTimeout(timeout);
+		};
 	});
 
 	onMount(() => {


### PR DESCRIPTION
## Why

Distant attachment expiry dates overflowed the browser's maximum timer delay, triggering immediate duplicate refreshes and intermittently failing `MessageAttachments.svelte.spec.ts` in CI.

## What changed

- Schedule distant expiry deadlines in safe timer-sized chunks and re-check staleness at the deadline.
- Preserve `data:` and `blob:` asset URLs when adding network retry cache-busters, with regression coverage.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: N/A

Newer client → older server: N/A

Capability discovery or minimum client/server version: N/A

## Test plan

- `mise lint-frontend` — passed with zero Svelte diagnostics and ESLint errors.
- `mise test-frontend` — passed: 123 server files, 153 browser files, and 60 Storybook files.
