### PR TITLE
feat(frontend): show user ID in account settings

### DIFF
--- a/apps/frontend/e2e/pages/AccountPage.ts
+++ b/apps/frontend/e2e/pages/AccountPage.ts
@@ -27,7 +27,7 @@ export class AccountPage {
 
   /** The username display */
   get usernameDisplay(): Locator {
-    return this.page.locator('dd.font-mono');
+    return this.page.getByText('Username', { exact: true }).locator('..').locator('dd');
   }
 
   // --- Locators: Delete Account ---

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -32,6 +32,10 @@
   <FormSection title={m('settings.account.info_title')} maxWidth="max-w-md">
     <dl class="flex flex-col gap-3 text-sm">
       <div class="flex items-center justify-between">
+        <dt class="text-muted">{m('admin.members.user_id')}</dt>
+        <dd class="font-mono">{currentUser.user?.id}</dd>
+      </div>
+      <div class="flex items-center justify-between">
         <dt class="text-muted">{m('settings.account.username')}</dt>
         <dd class="font-mono">{currentUser.user?.login}</dd>
       </div>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/account.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/account.page.svelte.spec.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+import AccountPage from './+page.svelte';
+
+const mocks = vi.hoisted(() => ({
+  listExternalIdentities: vi.fn(),
+  currentUser: {
+    user: {
+      id: 'U123abcetc.',
+      login: 'alice',
+      displayName: 'Alice',
+      hasPassword: true,
+      viewerCanDeleteAccount: false
+    },
+    loading: false,
+    load: vi.fn()
+  }
+}));
+
+const connection = {
+  queryScope: 'account-settings-test',
+  getAPI: () => ({
+    list: mocks.listExternalIdentities
+  })
+};
+
+vi.mock('$lib/state/server/scope.svelte', () => ({
+  useServerScope: () => ({
+    serverId: 'origin',
+    store: { currentUser: mocks.currentUser },
+    connection,
+    isCurrent: () => true
+  })
+}));
+
+async function settle(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  flushSync();
+}
+
+describe('Account settings page', () => {
+  beforeEach(() => {
+    mocks.listExternalIdentities.mockReset();
+    mocks.listExternalIdentities.mockResolvedValue({ providers: [], linkedIdentities: [] });
+  });
+
+  it('shows the current user ID in account information', async () => {
+    const { getByText } = render(AccountPage);
+    await settle();
+
+    await expect.element(getByText('User ID')).toBeVisible();
+    await expect.element(getByText('U123abcetc.')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Why

Users need to see their stable user ID without asking an administrator or looking it up elsewhere.

## What changed

- Show the current viewer's monospaced user ID in Account Information.
- Add a focused browser-component regression test for the label and ID value.
- Scope the account E2E username locator to its labelled row so other monospaced fields do not make it ambiguous.

## API compatibility

- No public API or protocol behaviour changed; the frontend uses the existing viewer response.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm run check:frontend` — passed.
- Focused account settings Vitest browser test — passed.
- Focused account settings Playwright E2E test — passed.
- `mise test-frontend` — passed (1,089 server, 1,543 Chromium, and 177 Storybook tests).
- Manual in-app browser verification was unavailable because no browser instance was connected.
