### PR TITLE
fix(core): fence message lifecycle mutations

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/server-operations.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/server-operations.mdx
@@ -131,6 +131,14 @@ Use it for tasks such as:
 
 ## Upgrade Practice
 
+<Aside type="caution" title="Upgrading from 0.4 to 0.5">
+  Stop every 0.4 Chatto server replica before starting 0.5. Do not use a rolling
+  server deployment across these releases: their message lifecycle projections
+  make different decisions when an edit races a deletion. Upgrade the bundled
+  frontend with the server replicas because realtime protocol 2 is also a
+  coordinated compatibility boundary.
+</Aside>
+
 1. Read the release notes before upgrading.
 2. Make a fresh backup before changing versions.
 3. For larger servers, restore a copy into a scratch environment and boot the new version against it.

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -97,6 +97,11 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   replica and the bundled frontend together; a 0.5 client treats 0.4 servers as incompatible,
   and a 0.5 server no longer accepts protocol 1. Integrations that use `/api/realtime` must
   migrate to the stable protocol 2 reference.
+- Upgrade every Chatto server replica from 0.4 to 0.5 together rather than using a rolling
+  server deployment. A 0.4 replica can accept a late message edit after another replica has
+  deleted that message and can temporarily render its body again. Once every replica runs
+  0.5, message edits and deletions share one room lifecycle boundary and deletion tombstones
+  remain authoritative during replay.
 - Server discovery no longer publishes `compatibility.protocol_capabilities`, which appeared
   only in unreleased 0.5 development snapshots. The containing `compatibility` message is
   also gone: clients own their minimum supported server release instead of the server

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -171,8 +171,8 @@ authorization, live events, backup/restore, and backend tests.
   contract-scoped generation, while an old binary retains its own schema and
   namespace. Bump the manual token when `Apply`, replay, cutoff, or restore
   semantics change without a schema change.
-- Most current snapshot contracts use semantic token `v1`; Assets, Room
-  Timeline, and user profile use `v2`. Keep password
+- Most current snapshot contracts use semantic token `v1`; Assets and user
+  profile use `v2`, while Room Timeline uses `v3`. Keep password
   verifiers, auth generations, external identity subjects, and OAuth consent in
   the independently cold-replayed `UserAuthProjection`; never add them to a
   profile snapshot schema or codec.

--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -359,6 +359,9 @@ func (s *MessageModel) UpdateMessage(ctx context.Context, input MessageUpdateInp
 	}
 
 	var editOptions []EditMessageOption
+	if input.Body == nil {
+		editOptions = append(editOptions, withPreservedMessageBody())
+	}
 	if input.AlsoSendToChannel != nil {
 		if body.AuthorId != input.ActorID {
 			return nil, kind, ErrNotMessageAuthor

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -1204,7 +1204,7 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 	}
 
 	agg := evtstream.RoomAggregate(roomID)
-	committed, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
+	committedPlaintext, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
 		if updated.GetAuthorId() == "" {
 			return "", fmt.Errorf("cannot edit: message body author is empty")
 		}
@@ -1224,9 +1224,8 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 	// Fan out to echoes (and to the original if this IS an echo) so
 	// the legacy "edit one, both update" semantic is preserved.
 	for _, linkedID := range c.roomModel.linkedEventIDs(eventID) {
-		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(_ context.Context, linkedBody *corev1.MessageBody) (string, error) {
-			copyEditableMessageMetadata(linkedBody, committed.body)
-			return committed.plaintext, nil
+		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(_ context.Context, _ *corev1.MessageBody) (string, error) {
+			return committedPlaintext, nil
 		}); err != nil {
 			c.logger.Warn("Failed to propagate edit to linked message",
 				"source_event_id", eventID, "linked_event_id", linkedID, "error", err)
@@ -1365,20 +1364,15 @@ func (c *ChattoCore) publishMessageRetract(ctx context.Context, actorID string, 
 // EditMessage / editEmbeddedBody can fan the same payload to linked messages.
 type messageEditMutation func(context.Context, *corev1.MessageBody) (plaintext string, err error)
 
-type committedMessageEdit struct {
-	body      *corev1.MessageBody
-	plaintext string
-}
-
 func (c *ChattoCore) publishMessageEdit(
 	ctx context.Context,
 	actorID string,
 	agg evtstream.Aggregate,
 	roomID, eventID string,
 	mutate messageEditMutation,
-) (*committedMessageEdit, error) {
+) (string, error) {
 	if mutate == nil {
-		return nil, fmt.Errorf("message edit mutation is nil")
+		return "", fmt.Errorf("message edit mutation is nil")
 	}
 	bodySubject := agg.Subject(evtstream.EventMessageBody)
 	editSubject := agg.Subject(evtstream.EventMessageEdited)
@@ -1387,30 +1381,30 @@ func (c *ChattoCore) publishMessageEdit(
 	for attempt := 1; attempt <= maxThreadCreateAppendAttempts; attempt++ {
 		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, roomFilter)
 		if err != nil {
-			return nil, fmt.Errorf("read message lifecycle OCC tail: %w", err)
+			return "", fmt.Errorf("read message lifecycle OCC tail: %w", err)
 		}
 		if expectedSeq > 0 {
 			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(roomFilter, expectedSeq)); err != nil {
-				return nil, err
+				return "", err
 			}
 		}
 		entry, ok := c.roomModel.timelineEntry(eventID)
 		if !ok || entry.Event == nil || entry.Event.GetMessagePosted() == nil || roomIDOfEvent(entry.Event) != roomID {
-			return nil, ErrMessageNotFound
+			return "", ErrMessageNotFound
 		}
 		current, retracted, _ := c.roomModel.latestBody(eventID)
 		if retracted || current == nil {
-			return nil, ErrMessageNotFound
+			return "", ErrMessageNotFound
 		}
 		updated := proto.Clone(current).(*corev1.MessageBody)
 		plaintext, err := mutate(ctx, updated)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		updated.UpdatedAt = timestamppb.Now()
 		bodyEventID := NewEventID()
 		if err := c.encryptMessageBody(ctx, updated, roomID, eventID, bodyEventID, plaintext); err != nil {
-			return nil, err
+			return "", err
 		}
 		bodyEvent := newEvent(actorID, &corev1.Event{
 			Id: bodyEventID,
@@ -1445,37 +1439,27 @@ func (c *ChattoCore) publishMessageEdit(
 		})
 		if err == nil {
 			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(editSubject, seqs[len(seqs)-1])); err != nil {
-				return nil, err
+				return "", err
 			}
 			if err := c.waitForMessageBodyAssets(ctx, bodySubject, seqs[0]); err != nil {
-				return nil, err
+				return "", err
 			}
-			return &committedMessageEdit{body: updated, plaintext: plaintext}, nil
+			return plaintext, nil
 		}
 		if !errors.Is(err, events.ErrConflict) {
-			return nil, fmt.Errorf("publish MessageEditedEvent: %w", err)
+			return "", fmt.Errorf("publish MessageEditedEvent: %w", err)
 		}
 		lastErr = err
 		select {
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return "", ctx.Err()
 		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
 		}
 	}
 	if lastErr != nil {
-		return nil, fmt.Errorf("publish MessageEditedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
+		return "", fmt.Errorf("publish MessageEditedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
 	}
-	return nil, fmt.Errorf("publish MessageEditedEvent: retry loop exited unexpectedly")
-}
-
-func copyEditableMessageMetadata(target, source *corev1.MessageBody) {
-	if target == nil || source == nil {
-		return
-	}
-	metadata := proto.Clone(source).(*corev1.MessageBody)
-	target.AssetIds = metadata.AssetIds
-	target.Attachments = metadata.Attachments
-	target.LinkPreview = metadata.LinkPreview
+	return "", fmt.Errorf("publish MessageEditedEvent: retry loop exited unexpectedly")
 }
 
 func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
@@ -1628,7 +1612,7 @@ func (c *ChattoCore) editEmbeddedBody(
 		return ErrMessageNotFound
 	}
 	agg := evtstream.RoomAggregate(roomID)
-	committed, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
+	_, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
 		if updated.GetAuthorId() != actorID {
 			return "", ErrNotMessageAuthor
 		}
@@ -1646,9 +1630,15 @@ func (c *ChattoCore) editEmbeddedBody(
 	}
 	c.secureDeleteObsoleteMessageBodyEvents(ctx, eventID)
 	for _, linkedID := range c.roomModel.linkedEventIDs(eventID) {
-		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(_ context.Context, linkedBody *corev1.MessageBody) (string, error) {
-			copyEditableMessageMetadata(linkedBody, committed.body)
-			return committed.plaintext, nil
+		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(ctx context.Context, linkedBody *corev1.MessageBody) (string, error) {
+			plaintext, err := c.decryptMessageBody(ctx, linkedID, roomID, linkedBody)
+			if err != nil {
+				return "", fmt.Errorf("decrypt linked message body for edit: %w", err)
+			}
+			if err := mutate(linkedBody); err != nil {
+				return "", err
+			}
+			return string(plaintext), nil
 		}); err != nil {
 			c.logger.Warn("Failed to propagate partial edit to linked message",
 				"source_event_id", eventID, "linked_event_id", linkedID, "error", err)

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -26,7 +26,8 @@ type postMessageOptions struct {
 }
 
 type editMessageOptions struct {
-	channelEcho *bool
+	channelEcho  *bool
+	preserveBody bool
 }
 
 // PostMessageOption customizes side effects owned by the message-post command.
@@ -72,6 +73,15 @@ func withPostMessageCommitAuthorization(authorize func(context.Context, string) 
 func WithMessageChannelEcho(enabled bool) EditMessageOption {
 	return func(options *editMessageOptions) {
 		options.channelEcho = &enabled
+	}
+}
+
+// withPreservedMessageBody keeps the latest committed plaintext while applying
+// other edit-time state such as channel-echo reconciliation. It is private so
+// transports must express intent through MessageModel's optional body field.
+func withPreservedMessageBody() EditMessageOption {
+	return func(options *editMessageOptions) {
+		options.preserveBody = true
 	}
 }
 
@@ -1193,44 +1203,31 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		}
 	}
 
-	// Fold in current body so attachments/link preview/timestamps
-	// survive the edit. We then overwrite ciphertext + nonce with the
-	// new content.
-	current, retracted, _ := c.roomModel.latestBody(eventID)
-	if retracted {
-		return ErrMessageNotFound
-	}
-	if current == nil {
-		// Imported legacy event with no body — nothing to edit.
-		return ErrMessageNotFound
-	}
-
-	updated := proto.Clone(current).(*corev1.MessageBody)
-	updated.UpdatedAt = timestamppb.Now()
-	bodyEventID := NewEventID()
-	if err := c.encryptMessageBody(ctx, updated, roomID, eventID, bodyEventID, newBody); err != nil {
-		if updated.GetAuthorId() == "" {
-			return fmt.Errorf("cannot edit: message body author is empty")
-		}
-		return err
-	}
-
 	agg := evtstream.RoomAggregate(roomID)
-	if err := c.publishMessageEdit(ctx, actorID, kind, agg, roomID, eventID, updated); err != nil {
+	committed, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
+		if updated.GetAuthorId() == "" {
+			return "", fmt.Errorf("cannot edit: message body author is empty")
+		}
+		if options.preserveBody {
+			plaintext, err := c.decryptMessageBody(ctx, eventID, roomID, updated)
+			if err != nil {
+				return "", fmt.Errorf("decrypt message body for edit: %w", err)
+			}
+			return string(plaintext), nil
+		}
+		return newBody, nil
+	})
+	if err != nil {
 		return err
 	}
 	c.secureDeleteObsoleteMessageBodyEvents(ctx, eventID)
 	// Fan out to echoes (and to the original if this IS an echo) so
 	// the legacy "edit one, both update" semantic is preserved.
 	for _, linkedID := range c.roomModel.linkedEventIDs(eventID) {
-		linkedBody := proto.Clone(updated).(*corev1.MessageBody)
-		linkedBodyEventID := NewEventID()
-		if err := c.encryptMessageBody(ctx, linkedBody, roomID, linkedID, linkedBodyEventID, newBody); err != nil {
-			c.logger.Warn("Failed to encrypt linked message edit",
-				"source_event_id", eventID, "linked_event_id", linkedID, "error", err)
-			continue
-		}
-		if err := c.publishMessageEdit(ctx, actorID, kind, agg, roomID, linkedID, linkedBody); err != nil {
+		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(_ context.Context, linkedBody *corev1.MessageBody) (string, error) {
+			copyEditableMessageMetadata(linkedBody, committed.body)
+			return committed.plaintext, nil
+		}); err != nil {
 			c.logger.Warn("Failed to propagate edit to linked message",
 				"source_event_id", eventID, "linked_event_id", linkedID, "error", err)
 			continue
@@ -1321,56 +1318,124 @@ func (c *ChattoCore) publishMessageRetract(ctx context.Context, actorID string, 
 			},
 		},
 	})
-	if _, err := c.roomModel.appendTimelineEventually(ctx, c.EventPublisher, agg, event); err != nil {
-		return fmt.Errorf("publish MessageRetractedEvent: %w", err)
-	}
+	retractSubject := agg.SubjectFor(event)
+	roomFilter := agg.AllEventsFilter()
+	var lastErr error
+	for attempt := 1; attempt <= maxThreadCreateAppendAttempts; attempt++ {
+		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, roomFilter)
+		if err != nil {
+			return fmt.Errorf("read message lifecycle OCC tail: %w", err)
+		}
+		if expectedSeq > 0 {
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(roomFilter, expectedSeq)); err != nil {
+				return err
+			}
+		}
+		entry, ok := c.roomModel.timelineEntry(eventID)
+		if !ok || entry.Event == nil || entry.Event.GetMessagePosted() == nil || roomIDOfEvent(entry.Event) != roomID {
+			return ErrMessageNotFound
+		}
+		_, retracted, _ := c.roomModel.latestBody(eventID)
+		if retracted {
+			return nil
+		}
 
-	return nil
+		seq, err := c.EventPublisher.AppendAtFilter(ctx, retractSubject, event, roomFilter, expectedSeq)
+		if err == nil {
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(retractSubject, seq)); err != nil {
+				return err
+			}
+			return nil
+		}
+		if !errors.Is(err, events.ErrConflict) {
+			return fmt.Errorf("publish MessageRetractedEvent: %w", err)
+		}
+		lastErr = err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
+		}
+	}
+	return fmt.Errorf("publish MessageRetractedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
 }
 
 // publishMessageEdit emits a MessageEditedEvent on EVT. StreamMyEvents
 // receives the canonical live.evt.> republish directly. Factored out so
 // EditMessage / editEmbeddedBody can fan the same payload to linked messages.
-func (c *ChattoCore) publishMessageEdit(ctx context.Context, actorID string, kind RoomKind, agg evtstream.Aggregate, roomID, eventID string, body *corev1.MessageBody) error {
-	if body == nil {
-		return fmt.Errorf("message edit body is nil")
+type messageEditMutation func(context.Context, *corev1.MessageBody) (plaintext string, err error)
+
+type committedMessageEdit struct {
+	body      *corev1.MessageBody
+	plaintext string
+}
+
+func (c *ChattoCore) publishMessageEdit(
+	ctx context.Context,
+	actorID string,
+	agg evtstream.Aggregate,
+	roomID, eventID string,
+	mutate messageEditMutation,
+) (*committedMessageEdit, error) {
+	if mutate == nil {
+		return nil, fmt.Errorf("message edit mutation is nil")
 	}
-	bodyEventID := body.GetBodyEventId()
-	if bodyEventID == "" {
-		return fmt.Errorf("message edit body event ID is empty")
-	}
-	bodyEvent := newEvent(actorID, &corev1.Event{
-		Id: bodyEventID,
-		Event: &corev1.Event_MessageBody{
-			MessageBody: &corev1.MessageBodyEvent{
-				RoomId:  roomID,
-				EventId: eventID,
-				Body:    body,
-			},
-		},
-	})
-	event := newEvent(actorID, &corev1.Event{
-		Event: &corev1.Event_MessageEdited{
-			MessageEdited: &corev1.MessageEditedEvent{
-				RoomId:  roomID,
-				EventId: eventID,
-			},
-		},
-	})
-	bodySubject := agg.SubjectFor(bodyEvent)
-	editSubject := agg.SubjectFor(event)
+	bodySubject := agg.Subject(evtstream.EventMessageBody)
+	editSubject := agg.Subject(evtstream.EventMessageEdited)
+	roomFilter := agg.AllEventsFilter()
 	var lastErr error
 	for attempt := 1; attempt <= maxThreadCreateAppendAttempts; attempt++ {
-		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, editSubject)
+		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, roomFilter)
 		if err != nil {
-			return fmt.Errorf("read edit OCC tail: %w", err)
+			return nil, fmt.Errorf("read message lifecycle OCC tail: %w", err)
 		}
+		if expectedSeq > 0 {
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(roomFilter, expectedSeq)); err != nil {
+				return nil, err
+			}
+		}
+		entry, ok := c.roomModel.timelineEntry(eventID)
+		if !ok || entry.Event == nil || entry.Event.GetMessagePosted() == nil || roomIDOfEvent(entry.Event) != roomID {
+			return nil, ErrMessageNotFound
+		}
+		current, retracted, _ := c.roomModel.latestBody(eventID)
+		if retracted || current == nil {
+			return nil, ErrMessageNotFound
+		}
+		updated := proto.Clone(current).(*corev1.MessageBody)
+		plaintext, err := mutate(ctx, updated)
+		if err != nil {
+			return nil, err
+		}
+		updated.UpdatedAt = timestamppb.Now()
+		bodyEventID := NewEventID()
+		if err := c.encryptMessageBody(ctx, updated, roomID, eventID, bodyEventID, plaintext); err != nil {
+			return nil, err
+		}
+		bodyEvent := newEvent(actorID, &corev1.Event{
+			Id: bodyEventID,
+			Event: &corev1.Event_MessageBody{
+				MessageBody: &corev1.MessageBodyEvent{
+					RoomId:  roomID,
+					EventId: eventID,
+					Body:    updated,
+				},
+			},
+		})
+		event := newEvent(actorID, &corev1.Event{
+			Event: &corev1.Event_MessageEdited{
+				MessageEdited: &corev1.MessageEditedEvent{
+					RoomId:  roomID,
+					EventId: eventID,
+				},
+			},
+		})
 		seqs, err := c.EventPublisher.AppendBatch(ctx, []evtstream.BatchEntry{
 			{
 				Subject:       bodySubject,
 				Event:         bodyEvent,
 				ExpectedSeq:   expectedSeq,
-				FilterSubject: editSubject,
+				FilterSubject: roomFilter,
 				HasOCC:        true,
 			},
 			{
@@ -1380,27 +1445,37 @@ func (c *ChattoCore) publishMessageEdit(ctx context.Context, actorID string, kin
 		})
 		if err == nil {
 			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(editSubject, seqs[len(seqs)-1])); err != nil {
-				return err
+				return nil, err
 			}
 			if err := c.waitForMessageBodyAssets(ctx, bodySubject, seqs[0]); err != nil {
-				return err
+				return nil, err
 			}
-			return nil
+			return &committedMessageEdit{body: updated, plaintext: plaintext}, nil
 		}
 		if !errors.Is(err, events.ErrConflict) {
-			return fmt.Errorf("publish MessageEditedEvent: %w", err)
+			return nil, fmt.Errorf("publish MessageEditedEvent: %w", err)
 		}
 		lastErr = err
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return nil, ctx.Err()
 		case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
 		}
 	}
 	if lastErr != nil {
-		return fmt.Errorf("publish MessageEditedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
+		return nil, fmt.Errorf("publish MessageEditedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
 	}
-	return fmt.Errorf("publish MessageEditedEvent: retry loop exited unexpectedly")
+	return nil, fmt.Errorf("publish MessageEditedEvent: retry loop exited unexpectedly")
+}
+
+func copyEditableMessageMetadata(target, source *corev1.MessageBody) {
+	if target == nil || source == nil {
+		return
+	}
+	metadata := proto.Clone(source).(*corev1.MessageBody)
+	target.AssetIds = metadata.AssetIds
+	target.Attachments = metadata.Attachments
+	target.LinkPreview = metadata.LinkPreview
 }
 
 func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
@@ -1552,57 +1627,29 @@ func (c *ChattoCore) editEmbeddedBody(
 	if eventID == "" {
 		return ErrMessageNotFound
 	}
-	entry, ok := c.roomModel.timelineEntry(eventID)
-	if !ok {
-		return ErrMessageNotFound
-	}
-	if entry.Event.GetMessagePosted() == nil {
-		return ErrMessageNotFound
-	}
-	current, retracted, _ := c.roomModel.latestBody(eventID)
-	if retracted || current == nil {
-		return ErrMessageNotFound
-	}
-	if current.GetAuthorId() != actorID {
-		return ErrNotMessageAuthor
-	}
-	plaintext, err := c.decryptMessageBody(ctx, eventID, roomID, current)
-	if err != nil {
-		return fmt.Errorf("decrypt message body for edit: %w", err)
-	}
-	updated := proto.Clone(current).(*corev1.MessageBody)
-	if err := mutate(updated); err != nil {
-		return err
-	}
-	updated.UpdatedAt = timestamppb.Now()
-	bodyEventID := NewEventID()
-	if err := c.encryptMessageBody(ctx, updated, roomID, eventID, bodyEventID, string(plaintext)); err != nil {
-		return err
-	}
-
 	agg := evtstream.RoomAggregate(roomID)
-	if err := c.publishMessageEdit(ctx, actorID, kind, agg, roomID, eventID, updated); err != nil {
+	committed, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
+		if updated.GetAuthorId() != actorID {
+			return "", ErrNotMessageAuthor
+		}
+		plaintext, err := c.decryptMessageBody(ctx, eventID, roomID, updated)
+		if err != nil {
+			return "", fmt.Errorf("decrypt message body for edit: %w", err)
+		}
+		if err := mutate(updated); err != nil {
+			return "", err
+		}
+		return string(plaintext), nil
+	})
+	if err != nil {
 		return err
 	}
 	c.secureDeleteObsoleteMessageBodyEvents(ctx, eventID)
 	for _, linkedID := range c.roomModel.linkedEventIDs(eventID) {
-		linkedCurrent, linkedRetracted, _ := c.roomModel.latestBody(linkedID)
-		if linkedRetracted || linkedCurrent == nil {
-			continue
-		}
-		linkedBody := proto.Clone(linkedCurrent).(*corev1.MessageBody)
-		metadata := proto.Clone(updated).(*corev1.MessageBody)
-		linkedBody.AssetIds = append([]string(nil), metadata.GetAssetIds()...)
-		linkedBody.Attachments = metadata.GetAttachments()
-		linkedBody.LinkPreview = metadata.GetLinkPreview()
-		linkedBody.UpdatedAt = metadata.GetUpdatedAt()
-		linkedBodyEventID := NewEventID()
-		if err := c.encryptMessageBody(ctx, linkedBody, roomID, linkedID, linkedBodyEventID, string(plaintext)); err != nil {
-			c.logger.Warn("Failed to encrypt linked message partial edit",
-				"source_event_id", eventID, "linked_event_id", linkedID, "error", err)
-			continue
-		}
-		if err := c.publishMessageEdit(ctx, actorID, kind, agg, roomID, linkedID, linkedBody); err != nil {
+		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(_ context.Context, linkedBody *corev1.MessageBody) (string, error) {
+			copyEditableMessageMetadata(linkedBody, committed.body)
+			return committed.plaintext, nil
+		}); err != nil {
 			c.logger.Warn("Failed to propagate partial edit to linked message",
 				"source_event_id", eventID, "linked_event_id", linkedID, "error", err)
 			continue

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -1224,7 +1224,14 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 	// Fan out to echoes (and to the original if this IS an echo) so
 	// the legacy "edit one, both update" semantic is preserved.
 	for _, linkedID := range c.roomModel.linkedEventIDs(eventID) {
-		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(_ context.Context, _ *corev1.MessageBody) (string, error) {
+		if _, err := c.publishMessageEdit(ctx, actorID, agg, roomID, linkedID, func(ctx context.Context, linked *corev1.MessageBody) (string, error) {
+			if options.preserveBody {
+				plaintext, err := c.decryptMessageBody(ctx, linkedID, roomID, linked)
+				if err != nil {
+					return "", fmt.Errorf("decrypt linked message body for edit: %w", err)
+				}
+				return string(plaintext), nil
+			}
 			return committedPlaintext, nil
 		}); err != nil {
 			c.logger.Warn("Failed to propagate edit to linked message",

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -389,6 +389,16 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	if gotEchoID, ok := core.roomModel.channelEchoEventID(reply.Id); !ok || gotEchoID != echoID {
 		t.Fatalf("nil echo option should preserve echo; got id=%q ok=%v", gotEchoID, ok)
 	}
+	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "stale preflight text", withPreservedMessageBody()); err != nil {
+		t.Fatalf("EditMessage preserve current body: %v", err)
+	}
+	preservedText, err := core.GetMessageBody(ctx, reply.Id)
+	if err != nil {
+		t.Fatalf("Get preserved reply body: %v", err)
+	}
+	if preservedText != "reply edited again" {
+		t.Fatalf("preserved reply body = %q, want latest committed text", preservedText)
+	}
 
 	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "reply without echo", WithMessageChannelEcho(false)); err != nil {
 		t.Fatalf("EditMessage remove echo: %v", err)
@@ -446,6 +456,72 @@ func TestChattoCore_EditMessageRejectsInvalidEchoStateTargets(t *testing.T) {
 	if body, err := core.GetMessageBody(ctx, reply.Id); err != nil || body != "reply" {
 		t.Fatalf("invalid echo-state edit should not change body; body=%q err=%v", body, err)
 	}
+}
+
+func TestPublishMessageEditRejectsRetractionCommittedDuringAttempt(t *testing.T) {
+	chattoCore, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := chattoCore.CreateUser(ctx, SystemActorID, "edit-retract-race-user", "Edit Retract Race User", "password123")
+	require.NoError(t, err)
+	room, err := chattoCore.CreateRoom(ctx, user.Id, KindChannel, "", "edit-retract-race", "")
+	require.NoError(t, err)
+	_, err = chattoCore.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	require.NoError(t, err)
+	posted, err := chattoCore.PostMessage(ctx, KindChannel, room.Id, user.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	agg := evtstream.RoomAggregate(room.Id)
+	attempts := 0
+	_, err = chattoCore.publishMessageEdit(ctx, user.Id, agg, room.Id, posted.Id, func(_ context.Context, _ *corev1.MessageBody) (string, error) {
+		attempts++
+		if attempts == 1 {
+			require.NoError(t, chattoCore.publishMessageRetract(ctx, user.Id, KindChannel, agg, room.Id, posted.Id))
+		}
+		return "late edit", nil
+	})
+	require.ErrorIs(t, err, ErrMessageNotFound)
+	require.Equal(t, 1, attempts, "the retry must observe the tombstone before rebuilding a body")
+
+	body, retracted, ok := chattoCore.roomModel.latestBody(posted.Id)
+	require.True(t, ok)
+	require.True(t, retracted)
+	require.Nil(t, body)
+	edits, _, err := chattoCore.EventPublisher.SubjectEvents(ctx, agg.Subject(evtstream.EventMessageEdited))
+	require.NoError(t, err)
+	require.Empty(t, edits, "the edit batch must be rejected when retraction advances the room lifecycle")
+}
+
+func TestPublishMessageEditRebuildsBodyAfterOCCConflict(t *testing.T) {
+	chattoCore, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := chattoCore.CreateUser(ctx, SystemActorID, "edit-recompose-user", "Edit Recompose User", "password123")
+	require.NoError(t, err)
+	room, err := chattoCore.CreateRoom(ctx, user.Id, KindChannel, "", "edit-recompose", "")
+	require.NoError(t, err)
+	_, err = chattoCore.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	require.NoError(t, err)
+	preview := &corev1.LinkPreview{Url: "https://example.com/original"}
+	posted, err := chattoCore.PostMessage(ctx, KindChannel, room.Id, user.Id, "original", nil, "", "", preview, false)
+	require.NoError(t, err)
+
+	agg := evtstream.RoomAggregate(room.Id)
+	attempts := 0
+	_, err = chattoCore.publishMessageEdit(ctx, user.Id, agg, room.Id, posted.Id, func(_ context.Context, _ *corev1.MessageBody) (string, error) {
+		attempts++
+		if attempts == 1 {
+			require.NoError(t, chattoCore.DeleteLinkPreviewFromMessage(ctx, user.Id, KindChannel, room.Id, posted.Id, preview.GetUrl()))
+		}
+		return "edited after conflict", nil
+	})
+	require.NoError(t, err)
+	require.Equal(t, 2, attempts)
+
+	body, err := chattoCore.GetFullMessageBody(ctx, posted.Id)
+	require.NoError(t, err)
+	require.Equal(t, "edited after conflict", body.Body)
+	require.Nil(t, body.LinkPreview, "the retry must not restore metadata removed by the conflicting edit")
 }
 
 func TestChattoCore_PostMessageSchedulesVideoProcessing(t *testing.T) {

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -524,6 +524,71 @@ func TestPublishMessageEditRebuildsBodyAfterOCCConflict(t *testing.T) {
 	require.Nil(t, body.LinkPreview, "the retry must not restore metadata removed by the conflicting edit")
 }
 
+func TestPartialEditPropagationAppliesDeltaToLatestLinkedBody(t *testing.T) {
+	chattoCore, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := chattoCore.CreateUser(ctx, SystemActorID, "linked-partial-edit-user", "Linked Partial Edit User", "password123")
+	require.NoError(t, err)
+	room, err := chattoCore.CreateRoom(ctx, user.Id, KindChannel, "", "linked-partial-edit", "")
+	require.NoError(t, err)
+	_, err = chattoCore.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	require.NoError(t, err)
+	attachmentA, err := chattoCore.UploadAttachment(ctx, user.Id, room.Id, "a.png", "image/png", bytes.NewReader(createTestPNG(20, 20)))
+	require.NoError(t, err)
+	attachmentB, err := chattoCore.UploadAttachment(ctx, user.Id, room.Id, "b.png", "image/png", bytes.NewReader(createTestPNG(20, 20)))
+	require.NoError(t, err)
+	root, err := chattoCore.PostMessage(ctx, KindChannel, room.Id, user.Id, "root", nil, "", "", nil, false)
+	require.NoError(t, err)
+	reply, err := chattoCore.PostMessage(ctx, KindChannel, room.Id, user.Id, "reply", []string{attachmentA.Id, attachmentB.Id}, root.Id, "", nil, true)
+	require.NoError(t, err)
+	echoID, ok := chattoCore.roomModel.channelEchoEventID(reply.Id)
+	require.True(t, ok)
+
+	removeAsset := func(body *corev1.MessageBody, assetID string) {
+		ids := body.AssetIds[:0]
+		for _, id := range body.GetAssetIds() {
+			if id != assetID {
+				ids = append(ids, id)
+			}
+		}
+		body.AssetIds = ids
+		attachments := body.Attachments[:0]
+		for _, attachment := range body.GetAttachments() {
+			if attachment.GetId() != assetID {
+				attachments = append(attachments, attachment)
+			}
+		}
+		body.Attachments = attachments
+	}
+
+	agg := evtstream.RoomAggregate(room.Id)
+	_, err = chattoCore.publishMessageEdit(ctx, user.Id, agg, room.Id, echoID, func(ctx context.Context, body *corev1.MessageBody) (string, error) {
+		plaintext, err := chattoCore.decryptMessageBody(ctx, echoID, room.Id, body)
+		if err != nil {
+			return "", err
+		}
+		removeAsset(body, attachmentB.Id)
+		return string(plaintext), nil
+	})
+	require.NoError(t, err)
+
+	err = chattoCore.editEmbeddedBody(ctx, user.Id, KindChannel, room.Id, reply.Id, func(body *corev1.MessageBody) error {
+		removeAsset(body, attachmentA.Id)
+		return nil
+	})
+	require.NoError(t, err)
+
+	originalBody, retracted, ok := chattoCore.roomModel.latestBody(reply.Id)
+	require.True(t, ok)
+	require.False(t, retracted)
+	require.Equal(t, []string{attachmentB.Id}, originalBody.GetAssetIds())
+	echoBody, retracted, ok := chattoCore.roomModel.latestBody(echoID)
+	require.True(t, ok)
+	require.False(t, retracted)
+	require.Empty(t, echoBody.GetAssetIds(), "propagation must not restore the independently removed attachment")
+}
+
 func TestChattoCore_PostMessageSchedulesVideoProcessing(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -389,6 +389,12 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	if gotEchoID, ok := core.roomModel.channelEchoEventID(reply.Id); !ok || gotEchoID != echoID {
 		t.Fatalf("nil echo option should preserve echo; got id=%q ok=%v", gotEchoID, ok)
 	}
+	agg := evtstream.RoomAggregate(room.Id)
+	if _, err := core.publishMessageEdit(ctx, user.Id, agg, room.Id, echoID, func(_ context.Context, _ *corev1.MessageBody) (string, error) {
+		return "independently edited echo", nil
+	}); err != nil {
+		t.Fatalf("Diverge linked echo body: %v", err)
+	}
 	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "stale preflight text", withPreservedMessageBody()); err != nil {
 		t.Fatalf("EditMessage preserve current body: %v", err)
 	}
@@ -398,6 +404,13 @@ func TestChattoCore_EditMessageReconcilesThreadReplyEcho(t *testing.T) {
 	}
 	if preservedText != "reply edited again" {
 		t.Fatalf("preserved reply body = %q, want latest committed text", preservedText)
+	}
+	preservedEchoText, err := core.GetMessageBody(ctx, echoID)
+	if err != nil {
+		t.Fatalf("Get preserved echo body: %v", err)
+	}
+	if preservedEchoText != "independently edited echo" {
+		t.Fatalf("preserved echo body = %q, want its independently committed text", preservedEchoText)
 	}
 
 	if err := core.EditMessage(ctx, user.Id, KindChannel, room.Id, reply.Id, "reply without echo", WithMessageChannelEcho(false)); err != nil {

--- a/cli/internal/core/projection_snapshots_test.go
+++ b/cli/internal/core/projection_snapshots_test.go
@@ -64,7 +64,7 @@ func TestProjectionSnapshotContractsIncludeCurrentSchema(t *testing.T) {
 		{reactionSnapshotContractID, "v1", &corev1.ReactionProjectionSnapshot{}},
 		{roomDirectorySnapshotContractID, "v1", &corev1.RoomDirectoryProjectionSnapshot{}},
 		{roomGroupLayoutSnapshotContractID, "v1", &corev1.RoomGroupLayoutProjectionSnapshot{}},
-		{roomTimelineSnapshotContractID, "v2", &corev1.RoomTimelineProjectionSnapshot{}},
+		{roomTimelineSnapshotContractID, "v3", &corev1.RoomTimelineProjectionSnapshot{}},
 		{threadSnapshotContractID, "v1", &corev1.ThreadProjectionSnapshot{}},
 		{userSnapshotContractID, "v2", &corev1.UserProfileProjectionSnapshot{}},
 	}
@@ -246,7 +246,7 @@ func TestProjectionSnapshotsRoundTripTransactionally(t *testing.T) {
 
 	expectedContractPrefix := map[string]string{
 		"room_directory": "v1-", "server_config": "v1-", "room_group_layout": "v1-",
-		"room_timeline": "v2-", "call_state": "v1-", "assets": "v2-", "reactions": "v1-",
+		"room_timeline": "v3-", "call_state": "v1-", "assets": "v2-", "reactions": "v1-",
 		"content_keys": "v1-", "rbac": "v1-", "mentionables": "v1-", "users": "v2-",
 	}
 	for _, tt := range tests {

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -193,6 +193,7 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 					// replay can present a late body after the tombstone; retain its
 					// sequence for secure deletion without making it visible again.
 					if _, retracted := p.retractedFlags[targetID]; retracted {
+						p.clearBodyLocked(targetID)
 						p.removeAttachmentMessageLocked(targetID)
 					} else {
 						p.refreshAttachmentMessageLocked(roomID, targetID, body)

--- a/cli/internal/core/room_timeline_projection.go
+++ b/cli/internal/core/room_timeline_projection.go
@@ -189,8 +189,14 @@ func (p *RoomTimelineProjection) Apply(event *corev1.Event, seq uint64) error {
 						body.BodyEventId = event.GetId()
 					}
 					p.setCurrentBodyLocked(targetID, body, seq)
-					delete(p.retractedFlags, targetID)
-					p.refreshAttachmentMessageLocked(roomID, targetID, body)
+					// Retractions are monotonic. Mixed-version replicas or historical
+					// replay can present a late body after the tombstone; retain its
+					// sequence for secure deletion without making it visible again.
+					if _, retracted := p.retractedFlags[targetID]; retracted {
+						p.removeAttachmentMessageLocked(targetID)
+					} else {
+						p.refreshAttachmentMessageLocked(roomID, targetID, body)
+					}
 				}
 			}
 		}

--- a/cli/internal/core/room_timeline_projection_snapshot.go
+++ b/cli/internal/core/room_timeline_projection_snapshot.go
@@ -10,7 +10,7 @@ import (
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
-var roomTimelineSnapshotContractID = snapshotContractID("v2", &corev1.RoomTimelineProjectionSnapshot{})
+var roomTimelineSnapshotContractID = snapshotContractID("v3", &corev1.RoomTimelineProjectionSnapshot{})
 
 func (*RoomTimelineProjection) SnapshotContractID() string {
 	return roomTimelineSnapshotContractID

--- a/cli/internal/core/room_timeline_projection_snapshot.go
+++ b/cli/internal/core/room_timeline_projection_snapshot.go
@@ -160,6 +160,12 @@ func (p *RoomTimelineProjection) Restore(data []byte) error {
 		return fmt.Errorf("room timeline shredded users: %w", err)
 	}
 	for messageID, state := range restored.bodyStates {
+		if _, retracted := restored.retractedFlags[messageID]; retracted {
+			continue
+		}
+		if _, hidden := restored.hiddenEchoes[messageID]; hidden {
+			continue
+		}
 		entry, ok := restored.entryByEventIDLocked(messageID)
 		if !ok || entry.Event == nil || state.body == nil {
 			continue

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -539,6 +539,19 @@ func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
 	if got := p.ObsoleteBodyEventSeqs("ENV-M1"); !slices.Equal(got, []uint64{1, 3}) {
 		t.Fatalf("ObsoleteBodyEventSeqs retracted = %v, want [1 3]", got)
 	}
+
+	if err := p.Apply(bodyEvent("ENV-BODY-LATE", "ENV-M1", "R1", "U1", "late", 5), 5); err != nil {
+		t.Fatalf("Apply late body after retraction: %v", err)
+	}
+	if body, retracted, ok := p.LatestBody("ENV-M1"); body != nil || !retracted || !ok {
+		t.Fatalf("LatestBody after late body = (%v, %v, %v), want retracted", body, retracted, ok)
+	}
+	if got := p.ObsoleteBodyEventSeqs("ENV-M1"); !slices.Equal(got, []uint64{1, 3, 5}) {
+		t.Fatalf("ObsoleteBodyEventSeqs after late body = %v, want [1 3 5]", got)
+	}
+	if got := p.AllObsoleteBodyEventSeqs(); !slices.Equal(got, []uint64{1, 3, 5}) {
+		t.Fatalf("AllObsoleteBodyEventSeqs after late body = %v, want [1 3 5]", got)
+	}
 }
 
 func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
@@ -548,6 +561,7 @@ func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
 		bodylessPostedEvent("ENV-M1", "R1", "U1", 2),
 		bodyEvent("ENV-BODY-2", "ENV-M1", "R1", "U1", "two", 3),
 		retractedEvent("ENV-RETRACT-M1", "ENV-M1", "R1", "U1", "", 4),
+		bodyEvent("ENV-BODY-LATE", "ENV-M1", "R1", "U1", "late", 5),
 	})
 
 	payload, err := p.Snapshot()
@@ -560,11 +574,11 @@ func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
 	}
 
 	seqs, current, ok := restored.BodyEventSeqs("ENV-M1")
-	if !ok || current != 3 || !slices.Equal(seqs, []uint64{1, 3}) {
-		t.Fatalf("BodyEventSeqs after restore = (%v, %d, %v), want ([1 3], 3, true)", seqs, current, ok)
+	if !ok || current != 5 || !slices.Equal(seqs, []uint64{1, 3, 5}) {
+		t.Fatalf("BodyEventSeqs after restore = (%v, %d, %v), want ([1 3 5], 5, true)", seqs, current, ok)
 	}
-	if got := restored.ObsoleteBodyEventSeqs("ENV-M1"); !slices.Equal(got, []uint64{1, 3}) {
-		t.Fatalf("ObsoleteBodyEventSeqs after restore = %v, want [1 3]", got)
+	if got := restored.ObsoleteBodyEventSeqs("ENV-M1"); !slices.Equal(got, []uint64{1, 3, 5}) {
+		t.Fatalf("ObsoleteBodyEventSeqs after restore = %v, want [1 3 5]", got)
 	}
 	if body, retracted, ok := restored.LatestBody("ENV-M1"); body != nil || !retracted || !ok {
 		t.Fatalf("LatestBody after restore = (%v, %v, %v), want retracted", body, retracted, ok)

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -554,6 +554,9 @@ func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
 	if got := p.AllObsoleteBodyEventSeqs(); !slices.Equal(got, []uint64{1, 3, 5}) {
 		t.Fatalf("AllObsoleteBodyEventSeqs after late body = %v, want [1 3 5]", got)
 	}
+	if got := p.bodyStates["ENV-M1"].body; got != nil {
+		t.Fatal("late body ciphertext remained projected after retraction")
+	}
 	if got := p.CurrentRoomAttachmentMessages("R1"); len(got) != 0 {
 		t.Fatalf("CurrentRoomAttachmentMessages after late body = %v, want empty", got)
 	}
@@ -589,6 +592,9 @@ func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
 	}
 	if body, retracted, ok := restored.LatestBody("ENV-M1"); body != nil || !retracted || !ok {
 		t.Fatalf("LatestBody after restore = (%v, %v, %v), want retracted", body, retracted, ok)
+	}
+	if got := restored.bodyStates["ENV-M1"].body; got != nil {
+		t.Fatal("restored snapshot retained late body ciphertext after retraction")
 	}
 	if got := restored.CurrentRoomAttachmentMessages("R1"); len(got) != 0 {
 		t.Fatalf("CurrentRoomAttachmentMessages after restore = %v, want empty", got)

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -482,7 +482,7 @@ func TestRoomTimeline_ApplyDoesNotMutateMessageBodyEvent(t *testing.T) {
 	}
 }
 
-func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
+func TestRoomTimeline_MessageBodyLifecycleRejectsLegacyLateBody(t *testing.T) {
 	p := NewRoomTimelineProjection()
 
 	if err := p.Apply(bodyEvent("ENV-BODY-1", "ENV-M1", "R1", "U1", "one", 1), 1); err != nil {

--- a/cli/internal/core/room_timeline_projection_test.go
+++ b/cli/internal/core/room_timeline_projection_test.go
@@ -540,7 +540,9 @@ func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
 		t.Fatalf("ObsoleteBodyEventSeqs retracted = %v, want [1 3]", got)
 	}
 
-	if err := p.Apply(bodyEvent("ENV-BODY-LATE", "ENV-M1", "R1", "U1", "late", 5), 5); err != nil {
+	lateBody := bodyEvent("ENV-BODY-LATE", "ENV-M1", "R1", "U1", "late", 5)
+	lateBody.GetMessageBody().GetBody().AssetIds = []string{"A-LATE"}
+	if err := p.Apply(lateBody, 5); err != nil {
 		t.Fatalf("Apply late body after retraction: %v", err)
 	}
 	if body, retracted, ok := p.LatestBody("ENV-M1"); body != nil || !retracted || !ok {
@@ -552,16 +554,21 @@ func TestRoomTimeline_MessageBodyEventIsPrivateCurrentState(t *testing.T) {
 	if got := p.AllObsoleteBodyEventSeqs(); !slices.Equal(got, []uint64{1, 3, 5}) {
 		t.Fatalf("AllObsoleteBodyEventSeqs after late body = %v, want [1 3 5]", got)
 	}
+	if got := p.CurrentRoomAttachmentMessages("R1"); len(got) != 0 {
+		t.Fatalf("CurrentRoomAttachmentMessages after late body = %v, want empty", got)
+	}
 }
 
 func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
 	p := NewRoomTimelineProjection()
+	lateBody := bodyEvent("ENV-BODY-LATE", "ENV-M1", "R1", "U1", "late", 5)
+	lateBody.GetMessageBody().GetBody().AssetIds = []string{"A-LATE"}
 	applyAll(t, p, []*corev1.Event{
 		bodyEvent("ENV-BODY-1", "ENV-M1", "R1", "U1", "one", 1),
 		bodylessPostedEvent("ENV-M1", "R1", "U1", 2),
 		bodyEvent("ENV-BODY-2", "ENV-M1", "R1", "U1", "two", 3),
 		retractedEvent("ENV-RETRACT-M1", "ENV-M1", "R1", "U1", "", 4),
-		bodyEvent("ENV-BODY-LATE", "ENV-M1", "R1", "U1", "late", 5),
+		lateBody,
 	})
 
 	payload, err := p.Snapshot()
@@ -582,6 +589,9 @@ func TestRoomTimeline_SnapshotPreservesBodyLifecycle(t *testing.T) {
 	}
 	if body, retracted, ok := restored.LatestBody("ENV-M1"); body != nil || !retracted || !ok {
 		t.Fatalf("LatestBody after restore = (%v, %v, %v), want retracted", body, retracted, ok)
+	}
+	if got := restored.CurrentRoomAttachmentMessages("R1"); len(got) != 0 {
+		t.Fatalf("CurrentRoomAttachmentMessages after restore = %v, want empty", got)
 	}
 }
 

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -151,6 +151,12 @@ change automatically starts a new contract namespace. Most contracts use
 semantic token `v1`; Assets and user profile use `v2`, and Room Timeline uses
 `v3`.
 
+Room Timeline `v3` keeps retraction tombstones authoritative when a legacy
+writer appends a later body payload and retains that payload's sequence for
+secure deletion. Version 0.4 replicas use the earlier projection behavior, so
+the 0.4-to-0.5 release upgrade requires coordinated replacement of every Chatto
+server replica rather than a rolling server deployment.
+
 Snapshot loads and replay frontiers are projection-local. A successful restore
 starts that projection's ordered consumer at one greater than its cutoff. A
 missing, invalid, or unavailable snapshot cold-replays only its owning

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -148,7 +148,8 @@ generation prefix. The contract covers serialized state, replay semantics,
 consumed event families, and cutoff meaning. Each ID combines a manual semantic
 token with a fingerprint of the codec's reachable protobuf schema, so a schema
 change automatically starts a new contract namespace. Most contracts use
-semantic token `v1`; Assets, Room Timeline, and user profile use `v2`.
+semantic token `v1`; Assets and user profile use `v2`, and Room Timeline uses
+`v3`.
 
 Snapshot loads and replay frontiers are projection-local. A successful restore
 starts that projection's ordered consumer at one greater than its cutoff. A
@@ -218,7 +219,8 @@ reconstruction. Legacy cohort paths remain outside application S3 expiry.
 | Projection | Contract | Payload store | Pointer store | Publication |
 | ---------- | -------- | ------------- | ------------- | ----------- |
 | Threads, Room Directory, Server Config, Room Group Layout, Call State, Reactions, Content Keys, RBAC, Mentionables | `v1` per projection | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Elected publisher checks hourly; cold/delta replay publishes immediately and unchanged state refreshes at 23 hours |
-| Room Timeline, Assets | `v2` per projection | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; `v1` snapshots remain independently addressable during rollout and rollback |
+| Room Timeline | `v3` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; tombstones remain authoritative over late body facts during replay |
+| Assets | `v2` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher; `v1` snapshots remain independently addressable during rollout and rollback |
 | Users (profile state only) | `v2` | `PROJECTION_SNAPSHOTS` or configured S3 | Encrypted per-projection `RUNTIME_STATE` pointer with KV revision OCC | Same elected age-aware publisher |
 
 ## Registered projections

--- a/docs/fdr/FDR-004-message-editing-and-deletion.md
+++ b/docs/fdr/FDR-004-message-editing-and-deletion.md
@@ -1,7 +1,7 @@
 # FDR-004: Message Editing & Deletion
 
 **Status:** Active
-**Last reviewed:** 2026-07-10
+**Last reviewed:** 2026-08-06
 
 ## Overview
 
@@ -17,6 +17,8 @@ Authors can edit and delete their own messages; users with `message.manage` can 
 - Being a reply, a message inside a thread, or a channel echo does not by itself keep a deleted-message placeholder visible.
 - Deleting an already-deleted message is a no-op.
 - Editing a message does not re-resolve mentions. Mentions and mention notifications remain tied to the original posted message.
+- A racing deletion always wins over an edit; a deleted message cannot be made visible again by a late edit retry.
+- An edit retried after another message mutation keeps the latest attachments and preview metadata instead of restoring an older body snapshot.
 - Editing or deleting a thread reply that was echoed to the channel propagates to both visible artifacts automatically through the echo's `echoOfEventId` link.
 - Deleting the echo artifact itself hides only the room-timeline echo. The original thread reply remains readable inside the thread.
 - Individual attachments and link previews can be removed from a message by the author without deleting the whole message.
@@ -38,9 +40,9 @@ Authors can edit and delete their own messages; users with `message.manage` can 
 
 ### 3. Optimistic concurrency for edits
 
-**Decision:** Edit mutations carry a revision token and fail if two edits race. The client must retry.
-**Why:** A non-OCC update would risk silently overwriting concurrent edits — particularly bad when a moderator and the author both edit a message at once. See ADR-016.
-**Tradeoff:** Clients need retry logic. In practice, conflicts are rare enough that a single retry almost always succeeds.
+**Decision:** Edit and delete mutations use optimistic concurrency over the room's ordered facts. Every server-side edit retry rebuilds from the latest committed body before applying the requested text or metadata change. A concurrent deletion tombstones the message and prevents the edit from committing.
+**Why:** Reusing a body prepared before an OCC conflict could restore an attachment or preview removed by another mutation, while guarding edit and delete facts independently could let a late body resurrect a deleted message. See ADR-016.
+**Tradeoff:** Same-room activity can force internal retries. The public API does not currently expose a client revision token, so concurrent full-text replacements resolve in commit order; the later successful edit supplies the visible text while retaining independently committed metadata changes.
 
 ### 4. Edits don't re-resolve mentions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -13,7 +13,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-07-19 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-08-06 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
-| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-07-10 |
+| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-06 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-08-05 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-15 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-07-22 |


### PR DESCRIPTION
## Why

Message edits and retractions previously fenced only their own event subjects. A concurrent lifecycle or body mutation could therefore pass OCC independently, allowing a late edit to recreate projected content after retraction or allowing a retry to restore stale body metadata.

This change makes the room aggregate the concurrency boundary for message lifecycle mutations and ensures every retry rebuilds its write from the latest projected state.

## What changed

- Guard message edit and retraction attempts against the complete room aggregate tail, wait for the room timeline through that tail, and retry conflicts from freshly projected state.
- Recompose encrypted message bodies inside each edit attempt so concurrent attachment, preview, and text changes are preserved instead of overwritten.
- Apply partial-edit deltas to each linked original/echo body independently, and preserve each linked body's own text for bodyless echo-state updates.
- Keep retraction tombstones when legacy late body events are replayed, discard their ciphertext, and retain enough sequence metadata for secure deletion.
- Bump the disposable room-timeline snapshot semantics token to v3 and rebuild its attachment index without retracted or hidden messages.
- Update FDR-004, the runtime architecture inventory, 0.5 release notes, and operator guidance to describe the OCC behavior and coordinated upgrade requirement.

## Compatibility and rollout

- No public API or persisted protobuf schema changes.
- Room-timeline projection snapshots use contract v3; older snapshots safely cold-replay from EVT.
- Operators upgrading a replicated deployment from 0.4 to 0.5 must stop every 0.4 server replica before starting 0.5. An already-running 0.4 writer cannot observe the new room-wide OCC boundary and its projection can clear a retraction tombstone.
- The v3 projection safely suppresses historical late body events that already exist in EVT.

## Test plan

- `mise test-cli` — passed
- `mise lint` — passed
- `mise license-check` — passed
- `mise x -- pnpm --dir apps/docs-website build` — passed (64 pages built)
- Targeted lifecycle, OCC retry, linked-edit, tombstone, and snapshot tests — passed, including three consecutive independent-review runs
- `git diff --check origin/main...HEAD` — passed
- Extended `mise test` — shared modules, CLI, desktop, and workspace tests passed; the 648-test E2E sweep degraded after repeated local server-start failures (570 passed, 73 flaky, 5 final failures). A fresh single-worker rerun cleared four failures; the unrelated video-player controls assertion remains reproducibly red on this tree.
- GitHub Actions CI — passed after rebasing onto current `main`, including all four E2E shards and the codegen-proto-drift job
