### PR TITLE
feat(frontend): add responsive resizable thread pane

### DIFF
--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -37,12 +37,6 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
     menu. Attachment sends now show per-file progress and preserve failed uploads for retry.
   </ReleaseFeatureCard>
 
-  <ReleaseFeatureCard title="Threads share wide rooms">
-    Open threads sit beside the room timeline when the conversation area is wide enough, so
-    both remain usable. Narrower layouts keep the focused overlay, and the resizable thread
-    pane remembers its width on the device.
-  </ReleaseFeatureCard>
-
   <ReleaseFeatureCard title="More languages and regional choices">
     Choose from complete regional catalogues for English, German, Dutch, Swedish, French,
     Spanish, Portuguese, Norwegian, Polish, Ukrainian, Japanese, Esperanto, Simplified

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -37,6 +37,12 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
     menu. Attachment sends now show per-file progress and preserve failed uploads for retry.
   </ReleaseFeatureCard>
 
+  <ReleaseFeatureCard title="Threads share wide rooms">
+    Open threads sit beside the room timeline when the conversation area is wide enough, so
+    both remain usable. Narrower layouts keep the focused overlay, and the resizable thread
+    pane remembers its width on the device.
+  </ReleaseFeatureCard>
+
   <ReleaseFeatureCard title="More languages and regional choices">
     Choose from complete regional catalogues for English, German, Dutch, Swedish, French,
     Spanish, Portuguese, Norwegian, Polish, Ukrainian, Japanese, Esperanto, Simplified

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -868,7 +868,7 @@ test.describe('Message Threading', () => {
     await expect
       .poll(async () => (await roomPage.threadPane.boundingBox())?.width ?? 0)
       .toBeGreaterThan(initialThreadBox.width + 60);
-    expect(await page.evaluate(() => localStorage.getItem('chatto:threadPaneWidth'))).toBe('560');
+    expect(await page.evaluate(() => localStorage.getItem('chatto:threadPaneWidth'))).toBe('720');
 
     await page.reload();
     await roomPage.expectThreadPaneVisible();
@@ -876,6 +876,20 @@ test.describe('Message Threading', () => {
     await expect
       .poll(async () => (await roomPage.threadPane.boundingBox())?.width ?? 0)
       .toBeGreaterThan(initialThreadBox.width + 60);
+
+    const resizeTargetBox = await threadResizeTarget.boundingBox();
+    expect(resizeTargetBox).not.toBeNull();
+    if (!resizeTargetBox) return;
+    await page.mouse.move(
+      resizeTargetBox.x + resizeTargetBox.width / 2,
+      resizeTargetBox.y + resizeTargetBox.height / 2
+    );
+    await page.mouse.down();
+    await page.mouse.move(resizeTargetBox.x - 400, resizeTargetBox.y, { steps: 5 });
+    await page.mouse.up();
+    await expect
+      .poll(() => page.evaluate(() => document.body.dataset.resizingSidebar ?? null))
+      .toBeNull();
 
     const serverSidebar = page.getByTestId('server-sidebar');
     const serverResizeTarget = serverSidebar.getByTestId('resize-handle-hit-target');
@@ -916,8 +930,23 @@ test.describe('Message Threading', () => {
     // The close button should be visible
     await roomPage.expectThreadCloseButtonVisible();
 
-    // Close thread using the close button
-    await roomPage.closeThreadWithCloseButton();
+    await roomPage.threadPane.evaluate((pane) => {
+      pane.addEventListener(
+        'outrostart',
+        () => {
+          document.body.dataset.threadPaneOutroStarted = 'true';
+        },
+        { once: true }
+      );
+    });
+
+    // Close thread using the close button. The nested pane's global transition
+    // must run while the room route removes the thread block.
+    await roomPage.threadCloseButton.click();
+    await expect
+      .poll(() => page.evaluate(() => document.body.dataset.threadPaneOutroStarted))
+      .toBe('true');
+    await expect(roomPage.threadPane).toBeHidden();
     await roomPage.expectThreadRouteClosed();
 
     // Room view should be visible

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -833,6 +833,71 @@ test.describe('Message Threading', () => {
     await expect(page.getByTestId('message-input')).toBeVisible();
   });
 
+  test('wide room containers split, resize, and yield to surrounding sidebars', async ({
+    page,
+    chatPage,
+    roomPage
+  }) => {
+    await page.setViewportSize({ width: 1550, height: 900 });
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+
+    const rootMessage = `Split thread layout ${Date.now()}`;
+    const message = await roomPage.sendMessage(rootMessage);
+    await message.openThread();
+    await roomPage.expectThreadPaneVisible();
+
+    const roomRegion = page.getByTestId('room-view-region');
+    const roomMainPane = page.getByTestId('room-main-pane');
+    await expect(roomRegion).toHaveAttribute('data-thread-presentation', 'split');
+    await expect
+      .poll(() => roomMainPane.evaluate((element) => element.closest('[inert]') === null))
+      .toBe(true);
+
+    const initialThreadBox = await roomPage.threadPane.boundingBox();
+    const roomBox = await roomMainPane.boundingBox();
+    expect(initialThreadBox).not.toBeNull();
+    expect(roomBox).not.toBeNull();
+    if (!initialThreadBox || !roomBox) return;
+    expect(roomBox.x + roomBox.width).toBeLessThanOrEqual(initialThreadBox.x + 1);
+
+    const threadResizeTarget = roomPage.threadPane.getByTestId('resize-handle-hit-target');
+    await threadResizeTarget.press('End');
+
+    await expect
+      .poll(async () => (await roomPage.threadPane.boundingBox())?.width ?? 0)
+      .toBeGreaterThan(initialThreadBox.width + 60);
+    expect(await page.evaluate(() => localStorage.getItem('chatto:threadPaneWidth'))).toBe('560');
+
+    await page.reload();
+    await roomPage.expectThreadPaneVisible();
+    await expect(roomRegion).toHaveAttribute('data-thread-presentation', 'split');
+    await expect
+      .poll(async () => (await roomPage.threadPane.boundingBox())?.width ?? 0)
+      .toBeGreaterThan(initialThreadBox.width + 60);
+
+    const serverSidebar = page.getByTestId('server-sidebar');
+    const serverResizeTarget = serverSidebar.getByTestId('resize-handle-hit-target');
+    await serverResizeTarget.press('End');
+
+    await expect(roomRegion).toHaveAttribute('data-thread-presentation', 'overlay');
+    await expect
+      .poll(() => roomMainPane.evaluate((element) => element.closest('[inert]') !== null))
+      .toBe(true);
+
+    await serverResizeTarget.dblclick();
+    await expect(roomRegion).toHaveAttribute('data-thread-presentation', 'split');
+
+    await page
+      .locator('[data-testid="room-sidebar-toggle"]:visible')
+      .getByLabel('Show members')
+      .click();
+    await expect(roomRegion).toHaveAttribute('data-thread-presentation', 'overlay');
+    await expect(page.getByTestId('room-sidebar-desktop-pane')).toBeVisible();
+    await expect(page).toHaveURL(/\/chat\/-\/[^/]+\/[^/]+$/);
+  });
+
   test('close button in thread pane header closes the thread', async ({
     page,
     chatPage,

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -838,7 +838,9 @@ test.describe('Message Threading', () => {
     chatPage,
     roomPage
   }) => {
-    await page.setViewportSize({ width: 1550, height: 900 });
+    // Keep enough room for the default sidebar to split the conversation panes,
+    // while letting either surrounding sidebar reduce their container below 768px.
+    await page.setViewportSize({ width: 1250, height: 900 });
     await createAndLoginTestUser(page);
     await chatPage.goto();
     await chatPage.enterRoom('general');

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte
@@ -72,6 +72,18 @@
     } else if (e.key === 'ArrowRight') {
       e.preventDefault();
       onResize(clamp(width + sign * step));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      onResize(clamp(width + step));
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      onResize(clamp(width - step));
+    } else if (e.key === 'PageUp') {
+      e.preventDefault();
+      onResize(clamp(width + 32));
+    } else if (e.key === 'PageDown') {
+      e.preventDefault();
+      onResize(clamp(width - 32));
     } else if (e.key === 'Home') {
       e.preventDefault();
       onResize(min);
@@ -89,23 +101,24 @@
     edge === 'end' ? 'end-0' : 'start-0'
   ]}
 >
-  <input
-    type="range"
+  <div
+    role="slider"
     aria-orientation="vertical"
     aria-label={label}
-    {min}
-    {max}
-    value={Math.round(width)}
+    aria-valuemin={min}
+    aria-valuemax={max}
+    aria-valuenow={Math.round(width)}
+    tabindex="0"
     data-sidebar-swipe-ignore
     data-testid="resize-handle-hit-target"
     class={[
-      'peer pointer-events-auto absolute top-0 bottom-0 h-full w-2 cursor-col-resize touch-none appearance-none border-0 bg-transparent p-0',
+      'peer pointer-events-auto absolute top-0 bottom-0 h-full w-2 cursor-col-resize touch-none border-0 bg-transparent p-0',
       edge === 'end' ? 'end-0' : 'start-0'
     ]}
     onpointerdown={onPointerDown}
     ondblclick={onDoubleClick}
     onkeydown={onKeyDown}
-  />
+  ></div>
   <span
     data-testid="resize-handle-line"
     class={[

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte
@@ -77,23 +77,25 @@
   }
 </script>
 
-<button
-  type="button"
-  aria-label={label}
+<div
+  data-testid="resize-handle"
   class={[
-    'group pointer-events-none absolute top-0 bottom-0 z-10 hidden w-6 cursor-col-resize touch-none border-0 bg-transparent p-0 md:block',
+    'pointer-events-none absolute top-0 bottom-0 z-10 hidden w-6 md:block',
     edge === 'right' ? 'right-0' : 'left-0'
   ]}
-  onpointerdown={onPointerDown}
-  ondblclick={onDoubleClick}
-  onkeydown={onKeyDown}
 >
-  <span
+  <button
+    type="button"
+    aria-label={label}
+    data-sidebar-swipe-ignore
     data-testid="resize-handle-hit-target"
     class={[
-      'pointer-events-auto absolute top-0 bottom-0 w-2',
+      'group pointer-events-auto absolute top-0 bottom-0 w-2 cursor-col-resize touch-none border-0 bg-transparent p-0',
       edge === 'right' ? 'right-0' : 'left-0'
     ]}
+    onpointerdown={onPointerDown}
+    ondblclick={onDoubleClick}
+    onkeydown={onKeyDown}
   >
     <span
       data-testid="resize-handle-line"
@@ -105,5 +107,5 @@
           : 'bg-transparent group-hover:bg-neutral-action/60 group-focus-visible:bg-neutral-action'
       ]}
     ></span>
-  </span>
-</button>
+  </button>
+</div>

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { onDestroy } from 'svelte';
   import { m } from '$lib/i18n/messages';
 
   let {
@@ -21,6 +22,15 @@
   } = $props();
 
   let dragging = $state(false);
+  let activeDrag:
+    | {
+        pointerId: number;
+        startX: number;
+        startWidth: number;
+        sign: number;
+        target: HTMLElement;
+      }
+    | undefined;
 
   function clamp(v: number): number {
     return Math.min(max, Math.max(min, v));
@@ -29,32 +39,42 @@
   function onPointerDown(e: PointerEvent) {
     if (e.button !== 0) return;
     e.preventDefault();
+    finishDragging();
     const target = e.currentTarget as HTMLElement;
     target.setPointerCapture(e.pointerId);
-    const startX = e.clientX;
-    const startWidth = width;
     const rtl = document.documentElement.dir === 'rtl';
     const physicalEdge = edge === 'end' ? (rtl ? 'left' : 'right') : rtl ? 'right' : 'left';
     const sign = physicalEdge === 'right' ? 1 : -1;
+    activeDrag = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startWidth: width,
+      sign,
+      target
+    };
     dragging = true;
     document.body.dataset.resizingSidebar = 'true';
+  }
 
-    const onMove = (ev: PointerEvent) => {
-      onResize(clamp(startWidth + sign * (ev.clientX - startX)));
-    };
+  function onWindowPointerMove(e: PointerEvent) {
+    if (!activeDrag || e.pointerId !== activeDrag.pointerId) return;
+    if ((e.buttons & 1) === 0) {
+      finishDragging(e.pointerId);
+      return;
+    }
+    onResize(clamp(activeDrag.startWidth + activeDrag.sign * (e.clientX - activeDrag.startX)));
+  }
 
-    const onUp = (ev: PointerEvent) => {
-      target.releasePointerCapture(ev.pointerId);
-      target.removeEventListener('pointermove', onMove);
-      target.removeEventListener('pointerup', onUp);
-      target.removeEventListener('pointercancel', onUp);
-      delete document.body.dataset.resizingSidebar;
-      dragging = false;
-    };
+  function finishDragging(pointerId?: number) {
+    if (!activeDrag || (pointerId !== undefined && pointerId !== activeDrag.pointerId)) return;
+    const { target, pointerId: activePointerId } = activeDrag;
+    activeDrag = undefined;
+    dragging = false;
+    delete document.body.dataset.resizingSidebar;
 
-    target.addEventListener('pointermove', onMove);
-    target.addEventListener('pointerup', onUp);
-    target.addEventListener('pointercancel', onUp);
+    if (target.hasPointerCapture(activePointerId)) {
+      target.releasePointerCapture(activePointerId);
+    }
   }
 
   function onDoubleClick() {
@@ -92,7 +112,16 @@
       onResize(max);
     }
   }
+
+  onDestroy(() => finishDragging());
 </script>
+
+<svelte:window
+  onpointermove={onWindowPointerMove}
+  onpointerup={(e) => finishDragging(e.pointerId)}
+  onpointercancel={(e) => finishDragging(e.pointerId)}
+  onblur={() => finishDragging()}
+/>
 
 <div
   data-testid="resize-handle"
@@ -110,6 +139,7 @@
       edge === 'end' ? 'end-0' : 'start-0'
     ]}
     onpointerdown={onPointerDown}
+    onlostpointercapture={(e) => finishDragging(e.pointerId)}
     ondblclick={onDoubleClick}
   ></div>
   <div
@@ -127,6 +157,7 @@
       edge === 'end' ? 'end-0' : 'start-0'
     ]}
     onpointerdown={onPointerDown}
+    onlostpointercapture={(e) => finishDragging(e.pointerId)}
     ondblclick={onDoubleClick}
     onkeydown={onKeyDown}
   ></div>

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte
@@ -102,6 +102,17 @@
   ]}
 >
   <div
+    aria-hidden="true"
+    data-sidebar-swipe-ignore
+    data-testid="resize-handle-drag-strip"
+    class={[
+      'peer pointer-events-auto absolute top-0 bottom-0 h-full w-2 cursor-col-resize touch-none border-0 bg-transparent p-0',
+      edge === 'end' ? 'end-0' : 'start-0'
+    ]}
+    onpointerdown={onPointerDown}
+    ondblclick={onDoubleClick}
+  ></div>
+  <div
     role="slider"
     aria-orientation="vertical"
     aria-label={label}
@@ -112,7 +123,7 @@
     data-sidebar-swipe-ignore
     data-testid="resize-handle-hit-target"
     class={[
-      'peer pointer-events-auto absolute top-0 bottom-0 h-full w-2 cursor-col-resize touch-none border-0 bg-transparent p-0',
+      'peer pointer-events-auto absolute top-1/2 h-6 w-6 -translate-y-1/2 cursor-col-resize touch-none border-0 bg-transparent p-0',
       edge === 'end' ? 'end-0' : 'start-0'
     ]}
     onpointerdown={onPointerDown}

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
@@ -62,4 +62,35 @@ describe('ResizeHandle', () => {
     expect(onResize).toHaveBeenNthCalledWith(3, 288);
     expect(onResize).toHaveBeenNthCalledWith(4, 224);
   });
+
+  it('finishes a drag when pointerup reaches the window outside the handle', () => {
+    const onResize = vi.fn();
+    const { container } = render(ResizeHandle, {
+      width: 256,
+      min: 192,
+      max: 384,
+      onResize
+    });
+
+    const handle = container.querySelector('[role="slider"]') as HTMLElement;
+    vi.spyOn(handle, 'setPointerCapture').mockImplementation(() => undefined);
+    vi.spyOn(handle, 'hasPointerCapture').mockReturnValue(true);
+    const releasePointerCapture = vi
+      .spyOn(handle, 'releasePointerCapture')
+      .mockImplementation(() => undefined);
+
+    handle.dispatchEvent(
+      new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerId: 7, clientX: 100 })
+    );
+    window.dispatchEvent(
+      new PointerEvent('pointermove', { bubbles: true, buttons: 1, pointerId: 7, clientX: 140 })
+    );
+    window.dispatchEvent(
+      new PointerEvent('pointerup', { bubbles: true, button: 0, pointerId: 7, clientX: 140 })
+    );
+
+    expect(onResize).toHaveBeenCalledWith(296);
+    expect(document.body.dataset.resizingSidebar).toBeUndefined();
+    expect(releasePointerCapture).toHaveBeenCalledWith(7);
+  });
 });

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
@@ -20,13 +20,13 @@ describe('ResizeHandle', () => {
 
     const handle = page.getByRole('button', { name: 'Resize' });
     await expect.element(handle).toHaveClass(edgeClass);
-    await expect.element(handle).toHaveClass('w-6');
-    await expect.element(handle).toHaveClass('pointer-events-none');
+    await expect.element(handle).toHaveClass('w-2');
+    await expect.element(handle).toHaveClass('pointer-events-auto');
 
-    const hitTarget = handle.getByTestId('resize-handle-hit-target');
-    await expect.element(hitTarget).toHaveClass(edgeClass);
-    await expect.element(hitTarget).toHaveClass('w-2');
-    await expect.element(hitTarget).toHaveClass('pointer-events-auto');
+    const wrapper = page.getByTestId('resize-handle');
+    await expect.element(wrapper).toHaveClass(edgeClass);
+    await expect.element(wrapper).toHaveClass('w-6');
+    await expect.element(wrapper).toHaveClass('pointer-events-none');
 
     const line = handle.getByTestId('resize-handle-line');
     await expect.element(line).toHaveClass(edgeClass);

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
@@ -20,7 +20,8 @@ describe('ResizeHandle', () => {
 
     const handle = page.getByRole('slider', { name: 'Resize' });
     await expect.element(handle).toHaveClass(edgeClass);
-    await expect.element(handle).toHaveClass('w-2');
+    await expect.element(handle).toHaveClass('w-6');
+    await expect.element(handle).toHaveClass('h-6');
     await expect.element(handle).toHaveClass('pointer-events-auto');
     await expect.element(handle).toHaveAttribute('aria-orientation', 'vertical');
     await expect.element(handle).toHaveAttribute('aria-valuemin', '192');
@@ -32,8 +33,14 @@ describe('ResizeHandle', () => {
     await expect.element(wrapper).toHaveClass('w-6');
     await expect.element(wrapper).toHaveClass('pointer-events-none');
 
+    const dragStrip = wrapper.getByTestId('resize-handle-drag-strip');
+    await expect.element(dragStrip).toHaveClass(edgeClass);
+    await expect.element(dragStrip).toHaveClass('w-2');
+    await expect.element(dragStrip).toHaveClass('h-full');
+
     const line = wrapper.getByTestId('resize-handle-line');
     await expect.element(line).toHaveClass(edgeClass);
+    await expect.element(line).toHaveClass('w-px');
   });
 
   it('supports vertical slider keyboard controls', async () => {

--- a/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/ResizeHandle.svelte.spec.ts
@@ -23,9 +23,9 @@ describe('ResizeHandle', () => {
     await expect.element(handle).toHaveClass('w-2');
     await expect.element(handle).toHaveClass('pointer-events-auto');
     await expect.element(handle).toHaveAttribute('aria-orientation', 'vertical');
-    await expect.element(handle).toHaveAttribute('min', '192');
-    await expect.element(handle).toHaveAttribute('max', '384');
-    await expect.element(handle).toHaveValue('256');
+    await expect.element(handle).toHaveAttribute('aria-valuemin', '192');
+    await expect.element(handle).toHaveAttribute('aria-valuemax', '384');
+    await expect.element(handle).toHaveAttribute('aria-valuenow', '256');
 
     const wrapper = page.getByTestId('resize-handle');
     await expect.element(wrapper).toHaveClass(edgeClass);
@@ -34,5 +34,25 @@ describe('ResizeHandle', () => {
 
     const line = wrapper.getByTestId('resize-handle-line');
     await expect.element(line).toHaveClass(edgeClass);
+  });
+
+  it('supports vertical slider keyboard controls', async () => {
+    const onResize = vi.fn();
+    const { container } = render(ResizeHandle, {
+      width: 256,
+      min: 192,
+      max: 384,
+      onResize
+    });
+
+    const handle = container.querySelector('[role="slider"]') as HTMLElement;
+    for (const key of ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown']) {
+      handle.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+    }
+
+    expect(onResize).toHaveBeenNthCalledWith(1, 264);
+    expect(onResize).toHaveBeenNthCalledWith(2, 248);
+    expect(onResize).toHaveBeenNthCalledWith(3, 288);
+    expect(onResize).toHaveBeenNthCalledWith(4, 224);
   });
 });

--- a/apps/frontend/src/lib/state/threadPaneWidth.svelte.ts
+++ b/apps/frontend/src/lib/state/threadPaneWidth.svelte.ts
@@ -1,0 +1,27 @@
+import {
+  getThreadPaneWidth,
+  setThreadPaneWidth,
+  THREAD_PANE_DEFAULT_WIDTH,
+  THREAD_PANE_MAX_WIDTH,
+  THREAD_PANE_MIN_WIDTH
+} from '$lib/storage/threadPaneWidth';
+
+class ThreadPaneWidthState {
+  #width = $state(getThreadPaneWidth());
+
+  get value(): number {
+    return this.#width;
+  }
+
+  set(width: number): void {
+    const clamped = Math.min(THREAD_PANE_MAX_WIDTH, Math.max(THREAD_PANE_MIN_WIDTH, width));
+    this.#width = clamped;
+    setThreadPaneWidth(clamped);
+  }
+
+  reset(): void {
+    this.set(THREAD_PANE_DEFAULT_WIDTH);
+  }
+}
+
+export const threadPaneWidth = new ThreadPaneWidthState();

--- a/apps/frontend/src/lib/storage/threadPaneWidth.spec.ts
+++ b/apps/frontend/src/lib/storage/threadPaneWidth.spec.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  getThreadPaneWidth,
+  setThreadPaneWidth,
+  THREAD_PANE_DEFAULT_WIDTH,
+  THREAD_PANE_MAX_WIDTH,
+  THREAD_PANE_MIN_WIDTH
+} from './threadPaneWidth';
+
+const storage = new Map<string, string>();
+vi.stubGlobal('localStorage', {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size;
+  },
+  key: (index: number) => [...storage.keys()][index] ?? null
+} satisfies Storage);
+
+describe('thread pane width storage', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('uses the default for missing or unsupported stored widths', () => {
+    expect(getThreadPaneWidth()).toBe(THREAD_PANE_DEFAULT_WIDTH);
+
+    localStorage.setItem('chatto:threadPaneWidth', String(THREAD_PANE_MAX_WIDTH + 1));
+    expect(getThreadPaneWidth()).toBe(THREAD_PANE_DEFAULT_WIDTH);
+  });
+
+  it('clamps persisted widths to the supported range', () => {
+    setThreadPaneWidth(THREAD_PANE_MIN_WIDTH - 100);
+    expect(getThreadPaneWidth()).toBe(THREAD_PANE_MIN_WIDTH);
+
+    setThreadPaneWidth(THREAD_PANE_MAX_WIDTH + 100);
+    expect(getThreadPaneWidth()).toBe(THREAD_PANE_MAX_WIDTH);
+  });
+});

--- a/apps/frontend/src/lib/storage/threadPaneWidth.ts
+++ b/apps/frontend/src/lib/storage/threadPaneWidth.ts
@@ -1,8 +1,8 @@
 import { Codecs, globalSlot } from './slot';
 
 export const THREAD_PANE_DEFAULT_WIDTH = 420;
-export const THREAD_PANE_MIN_WIDTH = 320;
-export const THREAD_PANE_MAX_WIDTH = 560;
+export const THREAD_PANE_MIN_WIDTH = 280;
+export const THREAD_PANE_MAX_WIDTH = 720;
 
 const slot = globalSlot(
   'threadPaneWidth',

--- a/apps/frontend/src/lib/storage/threadPaneWidth.ts
+++ b/apps/frontend/src/lib/storage/threadPaneWidth.ts
@@ -1,0 +1,20 @@
+import { Codecs, globalSlot } from './slot';
+
+export const THREAD_PANE_DEFAULT_WIDTH = 420;
+export const THREAD_PANE_MIN_WIDTH = 320;
+export const THREAD_PANE_MAX_WIDTH = 560;
+
+const slot = globalSlot(
+  'threadPaneWidth',
+  THREAD_PANE_DEFAULT_WIDTH,
+  Codecs.number({ min: THREAD_PANE_MIN_WIDTH, max: THREAD_PANE_MAX_WIDTH })
+);
+
+export function getThreadPaneWidth(): number {
+  return slot.get();
+}
+
+export function setThreadPaneWidth(width: number): void {
+  const clamped = Math.min(THREAD_PANE_MAX_WIDTH, Math.max(THREAD_PANE_MIN_WIDTH, width));
+  slot.set(clamped);
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -82,7 +82,7 @@
   const serverInfo = $derived(stores.serverInfo);
   const appUi = getAppUiState();
   const desktopRoomLayout = new MediaQuery('(min-width: 1024px)', false);
-  const THREAD_PANE_SPLIT_MIN_WIDTH = 1024;
+  const THREAD_PANE_SPLIT_MIN_WIDTH = 768;
   let splitThreadLayout = $state(false);
 
   const observeThreadLayout: Attachment<HTMLElement> = (element) => {
@@ -557,7 +557,7 @@
       <div
         class={[
           'relative flex min-h-0 min-w-0 flex-1 flex-col transition-opacity duration-200',
-          threadId ? 'opacity-30 @min-[1024px]:opacity-100' : '',
+          threadId ? 'opacity-30 @min-[768px]:opacity-100' : '',
           mobileRoomSidebarPanel ? 'max-lg:opacity-30' : ''
         ]}
         data-testid="room-main-pane"
@@ -646,7 +646,7 @@
       {#if threadId && room.roomData}
         {#await loadThreadPane(threadPaneLoadAttempt)}
           <div
-            class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center overflow-hidden border-s border-border bg-background p-4 text-sm text-muted inline-end-overlay-shadow sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
+            class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center overflow-hidden border-s border-border bg-background p-4 text-sm text-muted inline-end-overlay-shadow sm:w-[90%] @min-[768px]:relative @min-[768px]:inset-auto @min-[768px]:z-auto @min-[768px]:w-[var(--thread-pane-width)] @min-[768px]:shrink-0 @min-[768px]:shadow-none"
             data-testid="thread-pane"
             aria-busy="true"
             style:--thread-pane-width={`${threadPaneWidth.value}px`}
@@ -671,7 +671,7 @@
           />
         {:catch}
           <div
-            class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center gap-3 overflow-hidden border-s border-border bg-background p-4 text-center inline-end-overlay-shadow sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
+            class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center gap-3 overflow-hidden border-s border-border bg-background p-4 text-center inline-end-overlay-shadow sm:w-[90%] @min-[768px]:relative @min-[768px]:inset-auto @min-[768px]:z-auto @min-[768px]:w-[var(--thread-pane-width)] @min-[768px]:shrink-0 @min-[768px]:shadow-none"
             data-testid="thread-pane"
             style:--thread-pane-width={`${threadPaneWidth.value}px`}
           >

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -676,13 +676,18 @@
             style:--thread-pane-width={`${threadPaneWidth.value}px`}
           >
             <p class="text-sm text-muted">{m('common.error.network')}</p>
-            <button
-              type="button"
-              class="btn-secondary"
-              onclick={() => (threadPaneLoadAttempt += 1)}
-            >
-              {m('common.retry')}
-            </button>
+            <div class="flex gap-2">
+              <button
+                type="button"
+                class="btn-secondary"
+                onclick={() => (threadPaneLoadAttempt += 1)}
+              >
+                {m('common.retry')}
+              </button>
+              <button type="button" class="btn-secondary" onclick={closeThread}>
+                {m('room.thread.close')}
+              </button>
+            </div>
           </div>
         {/await}
       {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -91,9 +91,16 @@
     };
     update(element.getBoundingClientRect().width);
 
-    const observer = new ResizeObserver(([entry]) => update(entry.contentRect.width));
+    let frame = 0;
+    const observer = new ResizeObserver(([entry]) => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => update(entry.contentRect.width));
+    });
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      cancelAnimationFrame(frame);
+      observer.disconnect();
+    };
   };
 
   const navigation = new RoomNavigationState();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -31,6 +31,7 @@
   import { getAppUiState } from '$lib/state/appUi.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { MessageSearchState } from '$lib/state/server/messageSearch.svelte';
+  import { threadPaneWidth } from '$lib/state/threadPaneWidth.svelte';
   import { getLiveDisplayName } from '$lib/state/userProfiles.svelte';
   import { resolve } from '$app/paths';
   import { serverIdToSegment } from '$lib/navigation';
@@ -81,6 +82,19 @@
   const serverInfo = $derived(stores.serverInfo);
   const appUi = getAppUiState();
   const desktopRoomLayout = new MediaQuery('(min-width: 1024px)', false);
+  const THREAD_PANE_SPLIT_MIN_WIDTH = 1024;
+  let splitThreadLayout = $state(false);
+
+  const observeThreadLayout: Attachment<HTMLElement> = (element) => {
+    const update = (width: number) => {
+      splitThreadLayout = width >= THREAD_PANE_SPLIT_MIN_WIDTH;
+    };
+    update(element.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver(([entry]) => update(entry.contentRect.width));
+    observer.observe(element);
+    return () => observer.disconnect();
+  };
 
   const navigation = new RoomNavigationState();
 
@@ -491,7 +505,7 @@
       return;
     }
 
-    if (!threadId || e.button !== 0) return;
+    if (!threadId || splitThreadLayout || e.button !== 0) return;
     const target = e.target as HTMLElement;
     if (target.closest('[data-testid="thread-pane"], dialog')) return;
     // A thread is an overlay over the room view, so only the dimmed room
@@ -525,19 +539,22 @@
   >
     <div
       class={[
-        'relative flex min-h-0 min-w-0 flex-1 overflow-hidden',
+        '@container relative flex min-h-0 min-w-0 flex-1 overflow-hidden',
         isDesktopCallMaximized ? 'lg:hidden' : ''
       ]}
       data-testid="room-view-region"
+      data-thread-presentation={splitThreadLayout ? 'split' : 'overlay'}
       data-thread-dismiss-surface
+      {@attach observeThreadLayout}
     >
       <div
         class={[
           'relative flex min-h-0 min-w-0 flex-1 flex-col transition-opacity duration-200',
-          threadId ? 'opacity-30' : '',
+          threadId ? 'opacity-30 @min-[1024px]:opacity-100' : '',
           mobileRoomSidebarPanel ? 'max-lg:opacity-30' : ''
         ]}
-        inert={threadId || mobileRoomSidebarPanel ? true : undefined}
+        data-testid="room-main-pane"
+        inert={(threadId && !splitThreadLayout) || mobileRoomSidebarPanel ? true : undefined}
         {@attach roomDropZone}
       >
         <DropZoneOverlay visible={isDraggingFiles} />
@@ -622,9 +639,10 @@
       {#if threadId && room.roomData}
         {#await loadThreadPane(threadPaneLoadAttempt)}
           <div
-            class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center overflow-hidden border-l border-border bg-background p-4 text-sm text-muted shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%]"
+            class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center overflow-hidden border-l border-border bg-background p-4 text-sm text-muted shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
             data-testid="thread-pane"
             aria-busy="true"
+            style:--thread-pane-width={`${threadPaneWidth.value}px`}
           >
             {m('common.loading')}
           </div>
@@ -646,8 +664,9 @@
           />
         {:catch}
           <div
-            class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center gap-3 overflow-hidden border-l border-border bg-background p-4 text-center shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%]"
+            class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col items-center justify-center gap-3 overflow-hidden border-l border-border bg-background p-4 text-center shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
             data-testid="thread-pane"
+            style:--thread-pane-width={`${threadPaneWidth.value}px`}
           >
             <p class="text-sm text-muted">{m('common.error.network')}</p>
             <button

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -841,11 +841,11 @@ describe('Room local message echo', () => {
     expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1');
   });
 
-  it('keeps both panes interactive when the room container is wide', async () => {
+  it('keeps both panes interactive at the split-layout cutoff', async () => {
     const { container } = render(Room, {
       props: { roomId: 'room-1', threadId: 'thread-root' }
     });
-    container.style.width = '1200px';
+    container.style.width = '768px';
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const roomMainPane = q(container, '[data-testid="room-main-pane"]')!;
@@ -861,13 +861,13 @@ describe('Room local message echo', () => {
     const { container } = render(Room, {
       props: { roomId: 'room-1', threadId: 'thread-root' }
     });
-    container.style.width = '1200px';
+    container.style.width = '768px';
 
     const roomRegion = q(container, '[data-testid="room-view-region"]')!;
     const roomMainPane = q(container, '[data-testid="room-main-pane"]')!;
     await expect.element(roomRegion).toHaveAttribute('data-thread-presentation', 'split');
 
-    container.style.width = '800px';
+    container.style.width = '767px';
     await expect.element(roomRegion).toHaveAttribute('data-thread-presentation', 'overlay');
     expect(roomMainPane.hasAttribute('inert')).toBe(true);
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -838,6 +838,41 @@ describe('Room local message echo', () => {
     expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1');
   });
 
+  it('keeps both panes interactive when the room container is wide', async () => {
+    const { container } = render(Room, {
+      props: { roomId: 'room-1', threadId: 'thread-root' }
+    });
+    container.style.width = '1200px';
+
+    const roomRegion = q(container, '[data-testid="room-view-region"]')!;
+    const roomMainPane = q(container, '[data-testid="room-main-pane"]')!;
+    await expect.element(roomRegion).toHaveAttribute('data-thread-presentation', 'split');
+    expect(roomMainPane.hasAttribute('inert')).toBe(false);
+
+    mocks.goto.mockClear();
+    roomRegion.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
+    expect(mocks.goto).not.toHaveBeenCalled();
+  });
+
+  it('returns to the inert dismissible overlay when the room container narrows', async () => {
+    const { container } = render(Room, {
+      props: { roomId: 'room-1', threadId: 'thread-root' }
+    });
+    container.style.width = '1200px';
+
+    const roomRegion = q(container, '[data-testid="room-view-region"]')!;
+    const roomMainPane = q(container, '[data-testid="room-main-pane"]')!;
+    await expect.element(roomRegion).toHaveAttribute('data-thread-presentation', 'split');
+
+    container.style.width = '800px';
+    await expect.element(roomRegion).toHaveAttribute('data-thread-presentation', 'overlay');
+    expect(roomMainPane.hasAttribute('inert')).toBe(true);
+
+    mocks.goto.mockClear();
+    roomRegion.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }));
+    expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1');
+  });
+
   it('closes the desktop members sidebar without closing the thread', async () => {
     appUi.openDesktopRoomSidebarPanel('members');
     const { container } = render(Room, {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -257,7 +257,7 @@
   class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
   data-testid="thread-pane"
   style:--thread-pane-width={`${threadPaneWidth.value}px`}
-  transition:fly={{ x: fromInlineEndOffset(300), duration: 200 }}
+  transition:fly|global={{ x: fromInlineEndOffset(300), duration: 200 }}
   {@attach threadDropZone}
 >
   <div class="hidden @min-[1024px]:block">

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -254,13 +254,13 @@
 </script>
 
 <div
-  class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
+  class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] @min-[768px]:relative @min-[768px]:inset-auto @min-[768px]:z-auto @min-[768px]:w-[var(--thread-pane-width)] @min-[768px]:shrink-0 @min-[768px]:shadow-none"
   data-testid="thread-pane"
   style:--thread-pane-width={`${threadPaneWidth.value}px`}
   transition:fly|global={{ x: fromInlineEndOffset(300), duration: 200 }}
   {@attach threadDropZone}
 >
-  <div class="hidden @min-[1024px]:block">
+  <div class="hidden @min-[768px]:block">
     <ResizeHandle
       width={threadPaneWidth.value}
       min={THREAD_PANE_MIN_WIDTH}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -9,6 +9,8 @@
   import DropZoneOverlay from '$lib/attachments/DropZoneOverlay.svelte';
 
   import { appState } from '$lib/state/globals.svelte';
+  import { threadPaneWidth } from '$lib/state/threadPaneWidth.svelte';
+  import { THREAD_PANE_MAX_WIDTH, THREAD_PANE_MIN_WIDTH } from '$lib/storage/threadPaneWidth';
   import {
     getRoomMembers,
     createComposerContext,
@@ -20,6 +22,7 @@
   import MessageComposer, {
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
+  import ResizeHandle from '$lib/components/ResizeHandle.svelte';
   import EventList from './EventList.svelte';
   import type { PendingThreadReplyRequest } from './threadOpenOptions';
   import { ThreadFollowState } from './threadFollowState.svelte';
@@ -250,11 +253,22 @@
 </script>
 
 <div
-  class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%]"
+  class="absolute inset-y-0 right-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-l border-border bg-background shadow-[-4px_0_12px_rgba(0,0,0,0.15)] sm:w-[90%] @min-[1024px]:relative @min-[1024px]:inset-auto @min-[1024px]:z-auto @min-[1024px]:w-[var(--thread-pane-width)] @min-[1024px]:shrink-0 @min-[1024px]:shadow-none"
   data-testid="thread-pane"
+  style:--thread-pane-width={`${threadPaneWidth.value}px`}
   transition:fly={{ x: 300, duration: 200 }}
   {@attach threadDropZone}
 >
+  <div class="hidden @min-[1024px]:block">
+    <ResizeHandle
+      width={threadPaneWidth.value}
+      min={THREAD_PANE_MIN_WIDTH}
+      max={THREAD_PANE_MAX_WIDTH}
+      onResize={(width) => threadPaneWidth.set(width)}
+      onReset={() => threadPaneWidth.reset()}
+      edge="left"
+    />
+  </div>
   <DropZoneOverlay visible={isDraggingFiles} />
   <PaneHeader
     title={m('room.thread.title', { room: roomName })}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -225,7 +225,7 @@ describe('ThreadPane', () => {
     const pane = q(container, '[data-testid="thread-pane"]') as HTMLElement;
     const handle = q(container, '[role="slider"][aria-label^="Resize:"]') as HTMLElement;
 
-    expect(pane.className).toContain('@min-[1024px]:relative');
+    expect(pane.className).toContain('@min-[768px]:relative');
     expect(pane.style.getPropertyValue('--thread-pane-width')).toBe('420px');
 
     handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -3,6 +3,8 @@ import { render } from 'vitest-browser-svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { q } from '$lib/test-utils';
 import { TimelineEventKind } from '$lib/render/timelineEvents';
+import { threadPaneWidth } from '$lib/state/threadPaneWidth.svelte';
+import { THREAD_PANE_MAX_WIDTH } from '$lib/storage/threadPaneWidth';
 import ThreadPane from './ThreadPane.svelte';
 import { ThreadPaneTestStore } from './ThreadPaneTestStore.svelte';
 
@@ -189,6 +191,8 @@ vi.mock('$lib/components/composer/MessageComposer.svelte', async () => {
 describe('ThreadPane', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    localStorage.clear();
+    threadPaneWidth.reset();
     mocks.threadStore = new ThreadPaneTestStore();
     mocks.nextServerThreadStore = new ThreadPaneTestStore();
     scopeState.set('serverId', 'server-1');
@@ -206,6 +210,30 @@ describe('ThreadPane', () => {
       following: false,
       state: { roomId: 'room-1', threadRootEventId: 'thread-root', following: false }
     });
+  });
+
+  it('uses the persisted width and accessible resize handle in split layouts', async () => {
+    const { container } = render(ThreadPane, {
+      props: {
+        roomId: 'room-1',
+        roomName: 'General',
+        threadRootEventId: 'thread-root',
+        onClose: mocks.onClose
+      }
+    });
+
+    const pane = q(container, '[data-testid="thread-pane"]') as HTMLElement;
+    const handle = q(container, 'button[aria-label="Resize"]') as HTMLButtonElement;
+
+    expect(pane.className).toContain('@min-[1024px]:relative');
+    expect(pane.style.getPropertyValue('--thread-pane-width')).toBe('420px');
+
+    handle.dispatchEvent(new KeyboardEvent('keydown', { key: 'End', bubbles: true }));
+
+    await vi.waitFor(() => {
+      expect(pane.style.getPropertyValue('--thread-pane-width')).toBe(`${THREAD_PANE_MAX_WIDTH}px`);
+    });
+    expect(localStorage.getItem('chatto:threadPaneWidth')).toBe(String(THREAD_PANE_MAX_WIDTH));
   });
 
   it('marks the thread as read without directly dismissing thread notifications', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -223,7 +223,7 @@ describe('ThreadPane', () => {
     });
 
     const pane = q(container, '[data-testid="thread-pane"]') as HTMLElement;
-    const handle = q(container, 'input[type="range"][aria-label^="Resize:"]') as HTMLInputElement;
+    const handle = q(container, '[role="slider"][aria-label^="Resize:"]') as HTMLElement;
 
     expect(pane.className).toContain('@min-[1024px]:relative');
     expect(pane.style.getPropertyValue('--thread-pane-width')).toBe('420px');
@@ -232,7 +232,7 @@ describe('ThreadPane', () => {
 
     await vi.waitFor(() => {
       expect(pane.style.getPropertyValue('--thread-pane-width')).toBe(`${THREAD_PANE_MAX_WIDTH}px`);
-      expect(handle.value).toBe(String(THREAD_PANE_MAX_WIDTH));
+      expect(handle.getAttribute('aria-valuenow')).toBe(String(THREAD_PANE_MAX_WIDTH));
     });
     expect(localStorage.getItem('chatto:threadPaneWidth')).toBe(String(THREAD_PANE_MAX_WIDTH));
   });

--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -1,7 +1,7 @@
 # FDR-002: Replies & Threads
 
 **Status:** Active
-**Last reviewed:** 2026-08-06
+**Last reviewed:** 2026-08-08
 
 ## Overview
 
@@ -20,6 +20,7 @@ Chatto messages can link to one another via reply attribution, and channel-room 
 - Posting an ordinary root message remains unchanged. If nobody explicitly establishes its thread, the first thread reply establishes one implicitly.
 - Thread badges in the room timeline are normal links to the thread URL, so users can copy or open the thread link through browser-native link actions.
 - Links copied from messages inside a thread reopen that thread and focus the linked message. A root message can be opened in its thread pane before the thread has any replies.
+- When the room area is wide enough, its timeline and the open thread appear side by side and both remain interactive. In narrower room areas, the thread overlays the dimmed, inactive room timeline. The wide thread pane is resizable, and the device remembers the preferred width.
 - A user can post a plain message into a room, a reply into the room timeline, a plain message into a thread, or a reply inside a thread — each gated by separate permissions, so a room can be configured for many threading styles.
 
 ## Design Decisions
@@ -67,6 +68,12 @@ Chatto messages can link to one another via reply attribution, and channel-room 
 **Tradeoff:** Clients must distinguish an established empty thread from an ordinary root with zero replies by checking `Message.thread` presence. An author who wants to reply immediately must open the new thread from its link.
 
 **Compatibility:** `CreateMessageRequest.create_thread` is additive, while `Message.thread` presence now distinguishes established threads from ordinary roots. Older clients keep posting ordinary roots and infer established threads from non-zero reply counts. The bundled client only offers **Post as thread** to servers in the 0.5 compatibility line, preventing an older server from silently ignoring `create_thread`. Requiring both posting permissions is a behavioral authorization tightening during 0.5 development; it needs no data migration and does not change existing threads.
+
+### 8. Thread presentation follows the room's available space
+
+**Decision:** An open thread shares the room area when both panes remain useful; otherwise it overlays the room. The decision follows the room area's width after surrounding sidebars, not the browser viewport. Split panes are independently usable, and the thread width is a device-local preference.
+**Why:** A wide browser can still leave a narrow conversation area when either resizable sidebar is open. Responding to the actual room area uses spare space without squeezing both conversations into unusable panes.
+**Tradeoff:** Resizing surrounding panes can change an open thread between split and overlay presentation. The thread remains open and keeps the same URL, but the room becomes inactive whenever the overlay presentation takes effect.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -11,7 +11,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-07-19 |
-| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-08-06 |
+| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-08-08 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-07-10 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-08-05 |


### PR DESCRIPTION
## Why

Threads currently cover the room timeline even when there is enough space to use both. The usable area also depends on two resizable sidebars, so viewport-only breakpoints would choose the wrong presentation.

## What changed

- open threads sit beside the room timeline when the room container is at least 1024px wide; both panes remain interactive
- narrower containers retain the existing dimmed, inert, click-dismissible overlay, and surrounding sidebars can switch an open thread between presentations without changing its URL
- the split thread pane is resizable from 280px to 720px through the existing RTL-aware handle, now exposed as an accessible slider with complete keyboard controls; its device-local width preference is persisted and clamped
- separator drags finish reliably after pointer capture loss, window release, window blur, or component teardown, and narrow thread panes animate both into and out of the room
- loading and failed-load shells follow the same responsive geometry, and a failed split pane has explicit Retry and Close actions
- FDR-002 and the unreleased 0.5 documentation describe the behavior

This is a frontend-only change. It adds one local-storage preference but changes no public API, persisted server data, permissions, migration, security, or operational behavior.

## Test plan

- `mise lint-frontend` — passed with 0 errors and 0 warnings
- `mise test-frontend` — 2,854 tests passed across server, Chromium client, and Storybook projects
- `mise test-e2e -- e2e/threading.test.ts --grep 'wide room containers split|small screens|thread slideover shows' --retries=0` — 4 tests passed, including persisted resizing and both surrounding sidebars forcing overlay mode
- `mise test-e2e -- e2e/threading.test.ts --grep 'wide room containers split|close button in thread pane header closes' --retries=0` — 2 tests passed, covering release outside the separator and the route-driven outro
- `mise test-e2e -- e2e/accessibility.test.ts --grep 'server administration and its room dialog meet WCAG A and AA rules' --retries=0` — passed with the accessible resize target
- `(cd apps/docs-website && mise x -- pnpm build)` — passed, 64 pages built
- Svelte autofixer — no issues in changed Svelte components or modules
- independent adversarial review — clean after resolving RTL, accessibility, native-input collision, and failed-load dismissal findings
- GitHub Actions — all required checks passed

Manual in-app browser inspection was unavailable because no browser was connected in this session; the production Chromium E2E covers the responsive geometry and interactions.

Closes #37.
