### PR TITLE
fix(push): prioritize visible notifications

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/notifications-web-push.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/notifications-web-push.mdx
@@ -89,7 +89,7 @@ Each browser or installed PWA creates its own subscription. A user can have mult
 
 When a user reopens Chatto, the app refreshes the server's stored subscription for that browser. Expired subscriptions are cleaned up automatically when push providers report them as gone.
 
-Chatto sends regular notifications in a declarative-compatible Web Push format, with browser-managed display and app-badge updates where supported. Its service worker preserves notification display and click compatibility and updates a closed app's badge after cross-device dismissals. Operators do not need to change VAPID keys or push configuration for this behavior.
+Chatto sends regular notifications in a declarative-compatible Web Push format, with browser-managed display and app-badge updates where supported. User-visible pushes request high-urgency delivery so mobile push services can wake sleeping devices promptly; silent cross-device dismissal updates remain normal urgency. Its service worker preserves notification display and click compatibility and updates a closed app's badge after cross-device dismissals. Operators do not need to change VAPID keys or push configuration for this behavior.
 
 On iOS and iPadOS, Web Push works only for supported Home Screen web apps. Safari tabs that are not installed as an app may not receive native push.
 

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -63,7 +63,8 @@ type Payload struct {
 	NotificationID string `json:"notificationId,omitempty"`
 	URL            string `json:"url,omitempty"`
 	AppBadge       string `json:"-"`
-	// Action is used for special payloads like "dismiss" to close notifications on other devices
+	// Action is empty for regular user-visible notifications. Control pushes set
+	// it to a command such as "dismiss" and do not display a new notification.
 	Action string `json:"action,omitempty"`
 }
 
@@ -132,6 +133,19 @@ func (p Payload) MarshalJSON() ([]byte, error) {
 
 func (p Payload) declarativeNotificationEligible() bool {
 	return p.Action == "" && p.Title != "" && p.URL != ""
+}
+
+func (p Payload) isUserVisibleNotification() bool {
+	return p.Action == ""
+}
+
+// deliveryUrgency keeps visible notifications prompt on sleeping mobile
+// devices without using high-priority delivery for silent control pushes.
+func (p Payload) deliveryUrgency() webpush.Urgency {
+	if p.isUserVisibleNotification() {
+		return webpush.UrgencyHigh
+	}
+	return webpush.UrgencyNormal
 }
 
 // PayloadContext provides optional context for building push payloads.
@@ -211,6 +225,7 @@ func (s *Sender) Send(ctx context.Context, sub *corev1.PushSubscription, payload
 		VAPIDPublicKey:  s.config.VAPIDPublicKey,
 		VAPIDPrivateKey: s.config.VAPIDPrivateKey,
 		TTL:             86400, // 24 hours
+		Urgency:         payload.deliveryUrgency(),
 		RecordSize:      pushRecordSize,
 		HTTPClient:      s.httpClient,
 	})

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -768,6 +768,7 @@ func TestSend(t *testing.T) {
 		var bodyLen int
 		var contentEncoding string
 		var ttl string
+		var urgency string
 		var readErr error
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -780,6 +781,7 @@ func TestSend(t *testing.T) {
 			bodyLen = len(body)
 			contentEncoding = r.Header.Get("Content-Encoding")
 			ttl = r.Header.Get("TTL")
+			urgency = r.Header.Get("Urgency")
 			w.WriteHeader(http.StatusCreated)
 		}))
 		defer server.Close()
@@ -810,6 +812,31 @@ func TestSend(t *testing.T) {
 		}
 		if ttl != "86400" {
 			t.Fatalf("TTL = %q, want 86400", ttl)
+		}
+		if urgency != "high" {
+			t.Fatalf("Urgency = %q, want high", urgency)
+		}
+	})
+
+	t.Run("uses normal urgency for silent dismiss pushes", func(t *testing.T) {
+		var urgency string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			urgency = r.Header.Get("Urgency")
+			w.WriteHeader(http.StatusCreated)
+		}))
+		defer server.Close()
+
+		sender := newTestSender(t, server.Client())
+		result := sender.Send(context.Background(), newTestPushSubscription(t, server.URL), &Payload{
+			Action: "dismiss",
+			Tag:    "notification-1",
+		})
+
+		if result.Error != nil {
+			t.Fatalf("Send error: %v", result.Error)
+		}
+		if urgency != "normal" {
+			t.Fatalf("Urgency = %q, want normal", urgency)
 		}
 	})
 

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -1,7 +1,7 @@
 # FDR-013: Web Push Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-07-20
+**Last reviewed:** 2026-08-08
 
 ## Overview
 
@@ -19,6 +19,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 - Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
 - Push payloads include a mutable declarative-compatible notification envelope with a title, a truncated message preview (max 100 chars, broken at word boundaries), a navigation URL, and the pending app badge count when available. The legacy root fields remain present so older Chatto service workers can display the same notification during upgrades.
+- User-visible notification pushes request high-urgency delivery so mobile push services can wake sleeping devices promptly. Silent cross-device dismissal pushes use normal urgency.
 - Clicking a push notification navigates to the relevant room, thread, or DM.
 - Dismissing a notification in one place sends a "dismiss" action push to other devices, closing the system notification there too.
 - Immediately before a regular push is sent, Chatto confirms that the notification is still pending and the exact prepared subscription is still active. This prevents slower asynchronous creation delivery from overtaking a dismissal or subscription rotation.
@@ -89,6 +90,12 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 **Decision:** Regular push delivery revalidates both the pending notification and exact active subscription immediately before sending. While the app is visible, direct synchronization uses a numeric badge only for an exact aggregate DM count and a flag for other or incompletely loaded notifications. After a regular push, the worker sends visible pages a value-free refresh signal so they replay that intent. Declarative push handles regular closed or suspended-app updates with the origin server's numeric total; dismiss pushes carry the remaining origin-server total and the worker applies it whenever no visible app window owns the badge.
 **Why:** Notification creation and dismissal callbacks run asynchronously, so a slower creation path can otherwise finish after dismissal and restore a stale native notification. The open page must remain authoritative for its aggregate multi-server intent, including when a browser applies a later origin-only declarative badge without changing page state. The narrow refresh signal does not duplicate badge values or ownership state, while the dismiss fallback prevents cross-device dismissals from leaving a closed installed app stale. This needs no persisted badge state.
 **Tradeoff:** The server check cannot revoke a request after the final validation has already passed and the push provider has accepted it. Web Push does not provide strict cross-message ordering, so concurrent badge-bearing pushes remain last-delivery-wins until another push or the visible app refreshes the aggregate. A closed app may temporarily show an all-notification number instead of the visible app's DM-count-or-flag meaning; that count also covers only the app's origin server. Browsers without declarative or worker Badging API support restore the authoritative aggregate when the app next opens.
+
+### 11. High urgency only for user-visible pushes
+
+**Decision:** Regular notification pushes request high-urgency delivery, while silent dismissal pushes use normal urgency.
+**Why:** Mobile operating systems may defer normal-urgency Web Push while a device is sleeping. Messages, mentions, and replies are user-visible and time-sensitive, so they should wake the device promptly. Dismissal pushes only reconcile an existing notification and do not justify waking a sleeping device.
+**Tradeoff:** Prompt delivery uses more battery than batched delivery. Restricting high urgency to pushes that display a notification keeps that cost aligned with visible user attention and avoids training push services to downgrade silent traffic.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -22,7 +22,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-08-03 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-07-20 |
-| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-20 |
+| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-08-08 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |


### PR DESCRIPTION
## Why

Android may defer normal-urgency Web Push while a device is sleeping, causing user-visible chat notifications to arrive tens of minutes late.

## What changed

- Send regular, user-visible notification pushes with high urgency.
- Keep silent cross-device dismissal pushes at normal urgency to avoid unnecessary wake-ups and provider downgrading.
- Cover both emitted urgency headers and document the delivery policy in FDR-013 and the operator guide.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Existing clients receive the same notification payload with more prompt provider delivery.

Newer client → older server: Unchanged; older servers continue to use the Web Push default urgency.

Capability discovery or minimum client/server version: None required.

## Test plan

- `mise lint` — passed.
- `mise test-cli` — passed, including the production frontend build and complete CLI Go suite.
- `mise x -- go test ./internal/push -timeout 30s` — passed.
- `git diff --check origin/main...` — passed.
- Physical Android Doze-mode verification remains outstanding.
