### PR TITLE
fix(push): prioritize visible notifications

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/notifications-web-push.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/notifications-web-push.mdx
@@ -89,7 +89,7 @@ Each browser or installed PWA creates its own subscription. A user can have mult
 
 When a user reopens Chatto, the app refreshes the server's stored subscription for that browser. Expired subscriptions are cleaned up automatically when push providers report them as gone.
 
-Chatto sends regular notifications in a declarative-compatible Web Push format, with service-worker reconciliation where available and declarative display/badge fallback where supported. Operators do not need to change VAPID keys or push configuration for this behavior.
+Chatto sends regular notifications in a declarative-compatible Web Push format, with service-worker reconciliation where available and declarative display/badge fallback where supported. User-visible pushes request high-urgency delivery so mobile push services can wake sleeping devices promptly; silent cross-device dismissal updates remain normal urgency. Operators do not need to change VAPID keys or push configuration for this behavior.
 
 On iOS and iPadOS, Web Push works only for supported Home Screen web apps. Safari tabs that are not installed as an app may not receive native push.
 

--- a/cli/internal/push/push.go
+++ b/cli/internal/push/push.go
@@ -63,7 +63,8 @@ type Payload struct {
 	NotificationID string `json:"notificationId,omitempty"`
 	URL            string `json:"url,omitempty"`
 	AppBadge       string `json:"-"`
-	// Action is used for special payloads like "dismiss" to close notifications on other devices
+	// Action is empty for regular user-visible notifications. Control pushes set
+	// it to a command such as "dismiss" and do not display a new notification.
 	Action string `json:"action,omitempty"`
 }
 
@@ -130,6 +131,19 @@ func (p Payload) MarshalJSON() ([]byte, error) {
 
 func (p Payload) declarativeNotificationEligible() bool {
 	return p.Action == "" && p.Title != "" && p.URL != ""
+}
+
+func (p Payload) isUserVisibleNotification() bool {
+	return p.Action == ""
+}
+
+// deliveryUrgency keeps visible notifications prompt on sleeping mobile
+// devices without using high-priority delivery for silent control pushes.
+func (p Payload) deliveryUrgency() webpush.Urgency {
+	if p.isUserVisibleNotification() {
+		return webpush.UrgencyHigh
+	}
+	return webpush.UrgencyNormal
 }
 
 // PayloadContext provides optional context for building push payloads.
@@ -209,6 +223,7 @@ func (s *Sender) Send(ctx context.Context, sub *corev1.PushSubscription, payload
 		VAPIDPublicKey:  s.config.VAPIDPublicKey,
 		VAPIDPrivateKey: s.config.VAPIDPrivateKey,
 		TTL:             86400, // 24 hours
+		Urgency:         payload.deliveryUrgency(),
 		RecordSize:      pushRecordSize,
 		HTTPClient:      s.httpClient,
 	})

--- a/cli/internal/push/push_test.go
+++ b/cli/internal/push/push_test.go
@@ -761,6 +761,7 @@ func TestSend(t *testing.T) {
 		var bodyLen int
 		var contentEncoding string
 		var ttl string
+		var urgency string
 		var readErr error
 
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -773,6 +774,7 @@ func TestSend(t *testing.T) {
 			bodyLen = len(body)
 			contentEncoding = r.Header.Get("Content-Encoding")
 			ttl = r.Header.Get("TTL")
+			urgency = r.Header.Get("Urgency")
 			w.WriteHeader(http.StatusCreated)
 		}))
 		defer server.Close()
@@ -803,6 +805,31 @@ func TestSend(t *testing.T) {
 		}
 		if ttl != "86400" {
 			t.Fatalf("TTL = %q, want 86400", ttl)
+		}
+		if urgency != "high" {
+			t.Fatalf("Urgency = %q, want high", urgency)
+		}
+	})
+
+	t.Run("uses normal urgency for silent dismiss pushes", func(t *testing.T) {
+		var urgency string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			urgency = r.Header.Get("Urgency")
+			w.WriteHeader(http.StatusCreated)
+		}))
+		defer server.Close()
+
+		sender := newTestSender(t, server.Client())
+		result := sender.Send(context.Background(), newTestPushSubscription(t, server.URL), &Payload{
+			Action: "dismiss",
+			Tag:    "notification-1",
+		})
+
+		if result.Error != nil {
+			t.Fatalf("Send error: %v", result.Error)
+		}
+		if urgency != "normal" {
+			t.Fatalf("Urgency = %q, want normal", urgency)
 		}
 	})
 

--- a/docs/fdr/FDR-013-web-push-notifications.md
+++ b/docs/fdr/FDR-013-web-push-notifications.md
@@ -1,7 +1,7 @@
 # FDR-013: Web Push Notifications
 
 **Status:** Active
-**Last reviewed:** 2026-07-10
+**Last reviewed:** 2026-08-08
 
 ## Overview
 
@@ -19,6 +19,7 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 - Stored subscription fields are bounded: endpoint 4,096 bytes, public key 256 bytes, auth secret 128 bytes, and user agent 512 bytes.
 - A user can have multiple devices subscribed simultaneously — every device receives every push.
 - Push payloads include a mutable declarative-compatible notification envelope with a title, a truncated message preview (max 100 chars, broken at word boundaries), a navigation URL, and the pending app badge count when available. The legacy root fields remain present so older Chatto service workers can display the same notification during upgrades.
+- User-visible notification pushes request high-urgency delivery so mobile push services can wake sleeping devices promptly. Silent cross-device dismissal pushes use normal urgency.
 - Clicking a push notification navigates to the relevant room, thread, or DM.
 - Dismissing a notification in one place sends a "dismiss" action push to other devices, closing the system notification there too.
 - Immediately before a regular push is sent, Chatto confirms that the notification is still pending and the exact prepared subscription is still active. This prevents slower asynchronous creation delivery from overtaking a dismissal or subscription rotation.
@@ -88,6 +89,12 @@ Users can opt in to receive notifications through the browser's W3C Web Push sys
 **Decision:** Regular push delivery revalidates both the pending notification and exact active subscription immediately before sending. The foreground app also retains its latest authoritative badge intent and replays it to an active or replacement service worker.
 **Why:** Notification creation and dismissal callbacks run asynchronously, so a slower creation path can otherwise finish after dismissal and restore a stale native notification or badge during normal use. Separately, first-page control and service-worker replacement can silently drop a one-shot clear message. Revalidation and replay make the latest durable/in-app state win in both paths.
 **Tradeoff:** The server check cannot revoke a request after the final validation has already passed and the push provider has accepted it. Full ordering would require a durable per-user delivery queue; the late check fixes the common race without introducing that wider architecture.
+
+### 11. High urgency only for user-visible pushes
+
+**Decision:** Regular notification pushes request high-urgency delivery, while silent dismissal pushes use normal urgency.
+**Why:** Mobile operating systems may defer normal-urgency Web Push while a device is sleeping. Messages, mentions, and replies are user-visible and time-sensitive, so they should wake the device promptly. Dismissal pushes only reconcile an existing notification and do not justify waking a sleeping device.
+**Tradeoff:** Prompt delivery uses more battery than batched delivery. Restricting high urgency to pushes that display a notification keeps that cost aligned with visible user attention and avoids training push services to downgrade silent traffic.
 
 ## Permissions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -22,7 +22,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-05-19 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-07-18 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Active | 2026-07-01 |
-| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-07-10 |
+| [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-08-08 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-07-15 |


### PR DESCRIPTION
## Why

Android push services can defer normal-urgency Web Push while a device sleeps, delaying visible chat notifications.

## What changed

- Backports #1928 by requesting high urgency for user-visible notification pushes.
- Keeps silent cross-device dismissal pushes at normal urgency and documents the release-line behaviour.

## API compatibility

- No public API or protocol behaviour changed; older clients receive the same payloads from the updated server, while newer clients connected to an older server retain normal provider urgency, with no capability gate required.

## Test plan

- `mise x -- go test ./internal/push -timeout 30s` (from `cli/`)
- `mise lint`
- `mise test-cli`

All checks pass locally; physical Android Doze delivery remains device-dependent and is not covered by automated tests.
