### PR TITLE
fix(dev): clean up Compose stack on archive

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -26,6 +26,7 @@ url = "https://docs-website.$CONDUCTOR_WORKSPACE_NAME.orb.local"
 
 [scripts]
 setup = "mise trust && mise setup"
+archive = "docker compose down -v"
 run_mode = "concurrent"
 
 [scripts.run.compose]


### PR DESCRIPTION
## Why

Archived Conductor workspaces currently leave their Docker Compose containers and volumes behind, consuming resources until they are cleaned up manually.

## What changed

Added a Conductor archive hook that runs `docker compose down -v` from the workspace directory.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `docker compose config --quiet`
- TOML parse validation
- `git diff --check origin/main...HEAD`
