### PR TITLE
chore(desktop): upgrade Deno to 2.9.5

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -4,7 +4,7 @@ This directory packages the official Chatto SvelteKit frontend as an
 experimental desktop app. It uses
 [Deno Desktop](https://docs.deno.com/runtime/desktop/) with the Chromium
 Embedded Framework (CEF) backend, so WebRTC and rendering use a bundled Chromium
-engine on every supported platform. The toolchain is pinned to Deno 2.9.4, the
+engine on every supported platform. The toolchain is pinned to Deno 2.9.5, the
 current stable release; Deno Desktop remains explicitly experimental in that
 release.
 
@@ -37,7 +37,7 @@ The app opens Chatto's normal server registration screen. Servers and delegated
 access tokens use the same browser storage as the standalone web frontend.
 
 On macOS, the development task first builds `Chatto Desktop.app` and then makes
-an APFS copy-on-write clone for Deno's private HMR host. Deno 2.9.4 otherwise
+an APFS copy-on-write clone for Deno's private HMR host. Deno 2.9.5 otherwise
 launches its generic cached `laufey.app`, whose `Info.plist` lacks the privacy
 descriptions required by macOS. Requesting a microphone or camera from that
 generic host makes macOS terminate the process instead of showing a permission
@@ -67,7 +67,7 @@ Deno Desktop's automatic SvelteKit detection does not support
 artifacts with the existing `200.html` SPA fallback, while `main.ts` owns the
 native window bindings. Neither contains application UI.
 
-Deno 2.9.4 writes a configured macOS icon after its internal ad-hoc signing
+Deno 2.9.5 writes a configured macOS icon after its internal ad-hoc signing
 pass. The build task therefore applies and verifies one final ad-hoc signature
 on macOS. Remove that workaround when upgrading to a Deno release that seals the
 icon itself, and replace it with the release signing/notarisation workflow
@@ -97,7 +97,7 @@ app-specific path. On macOS the directory is:
 
 It contains Chromium-managed state such as cookies, registered servers, and
 delegated access tokens; the shell writes no separate settings file. Deno
-Desktop 2.9.4 does not expose a profile-path setting, so a release should wait
+Desktop 2.9.5 does not expose a profile-path setting, so a release should wait
 for that support or add an upstream-compatible isolation mechanism.
 
 ## Prototype boundaries

--- a/apps/desktop/scripts/finalize_build.ts
+++ b/apps/desktop/scripts/finalize_build.ts
@@ -35,7 +35,7 @@ if (import.meta.main && Deno.build.os === "darwin") {
     `${bundle}/Contents/Info.plist`,
   ]);
 
-  // Deno 2.9.4 adds a configured AppIcon.icns after its internal signing pass.
+  // Deno 2.9.5 adds a configured AppIcon.icns after its internal signing pass.
   // A previously launched build may also contain Laufey's runtime marker.
   // Return the output to its pre-launch state, then seal all bundled resources.
   await Deno.remove(updateMarker).catch((error) => {

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -24,7 +24,7 @@ custom startup blocks.
 ## Client runtimes
 
 The experimental Deno desktop shell is a Chatto client runtime using Deno
-Desktop 2.9.4 and its CEF backend. It embeds the official static SvelteKit build
+Desktop 2.9.5 and its CEF backend. It embeds the official static SvelteKit build
 and serves it from Deno Desktop's private loopback origin; the existing
 standalone frontend owns server registration, authentication, and routing. The
 shell adopts the startup `BrowserWindow` and exposes per-window bindings that

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 actionlint = "latest"
 buf = "latest"
-deno = "2.9.4"
+deno = "2.9.5"
 go = "1.26.2"
 goreleaser = "latest"
 node = "22"


### PR DESCRIPTION
## Why

Deno 2.9.5 includes desktop-specific HMR, page-load, and signed-update verification fixes that Chatto Desktop should consume.

## What changed

- Pin the repository Deno toolchain to 2.9.5.
- Keep the desktop README, macOS signing workaround comment, and runtime architecture inventory aligned with the pinned release.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: No change.

## Test plan

- `mise test-desktop` — passed; formatting, linting, type checking, and all 6 tests succeeded.
- `mise desktop-build` — passed on macOS; the bundle built and its ad-hoc signature verified.
- `deno check --desktop --frozen main.ts scripts/**/*.ts` — passed with the committed lockfile unchanged.
