### PR TITLE
fix(frontend): improve thread badge interaction

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -584,6 +584,16 @@ describe('MessageComposer', () => {
       await vi.waitFor(() => expect(secondReady).toHaveBeenCalledOnce());
     });
 
+    it('fulfils an API focus request made before the editor is ready', async () => {
+      const { container } = renderMessageComposer({
+        roomId: 'room-focus-on-ready',
+        autoFocus: false,
+        onReady: (api) => api.focus()
+      });
+
+      await expect.element(await findEditor(container)).toHaveFocus();
+    });
+
     it('editor is editable initially', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
 

--- a/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
+++ b/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
@@ -124,6 +124,7 @@ export class MessageComposerState {
   #editSeededForEvent = '';
   #autocompleteRoomId = '';
   #insertedQuoteRequestId = 0;
+  #focusRequested = false;
 
   constructor(dependencies: MessageComposerDependencies) {
     this.#dependencies = dependencies;
@@ -249,7 +250,16 @@ export class MessageComposerState {
   }
 
   focus(): void {
-    tick().then(() => this.editorApi?.focus());
+    const api = this.editorApi;
+    if (!api) {
+      this.#focusRequested = true;
+      return;
+    }
+
+    this.#focusRequested = false;
+    tick().then(() => {
+      if (this.editorApi === api) api.focus();
+    });
   }
 
   insertQuote(text: QuoteInsertionContent): void {
@@ -318,6 +328,7 @@ export class MessageComposerState {
   handleEditorReady(api: TipTapEditorApi): void {
     this.editorApi = api;
     if (this.message) api.setContent(this.message);
+    if (this.#focusRequested) this.focus();
   }
 
   #synchronizeMentionSearch(): void {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -141,7 +141,7 @@ local to the footer.
         roomId,
         threadId: threadRootEventId
       })}
-      class="{baseButtonClass} gap-2 border-transparent px-2 text-xs"
+      class="{baseButtonClass} gap-2 border-transparent px-2 text-xs whitespace-nowrap"
       onclick={openThreadFromLink}
       {@attach threadLinkGestureBoundary}
     >
@@ -158,7 +158,7 @@ local to the footer.
         roomId,
         threadId: threadRootEventId
       })}
-      class="{baseButtonClass} gap-2 border-transparent px-2 text-xs"
+      class="{baseButtonClass} gap-2 border-transparent px-2 text-xs whitespace-nowrap"
       onclick={openThreadFromLink}
       {@attach threadLinkGestureBoundary}
     >

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte.spec.ts
@@ -115,6 +115,7 @@ describe('MessageMetaBar', () => {
 
     await expect.element(link).toBeInTheDocument();
     expect(link.textContent?.replace(/\s+/g, ' ').trim()).toContain('2 replies');
+    expect(link.classList).toContain('whitespace-nowrap');
   });
 
   it('renders an explicitly created empty thread', async () => {
@@ -144,6 +145,7 @@ describe('MessageMetaBar', () => {
 
     await expect.element(link).toBeInTheDocument();
     expect(link.textContent).toContain('Thread');
+    expect(link.classList).toContain('whitespace-nowrap');
     const icon = link.querySelector('.iconify');
     expect(icon?.classList).toContain('icon-[uil--corner-up-right]');
     expect(icon?.classList).toContain('rtl:-scale-x-100');


### PR DESCRIPTION
## Why

Thread badges could wrap onto multiple lines, and opening a thread could leave keyboard focus behind instead of placing it in the reply composer.

## What changed

- Keep reply-count and echoed-thread badges on one line.
- Queue composer focus requests made before the lazy TipTap editor is ready, then focus only the current editor instance.
- Add regression coverage for both badge variants and early composer focus.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `MessageMetaBar.svelte.spec.ts`: 12 tests passed.
- `MessageComposer.svelte.spec.ts`: 131 tests passed.
- ESLint, Svelte autofixer, Prettier, design-system guardrails, and `git diff --check` passed.
- Manual browser verification remains outstanding because no browser instance was available.
