### PR TITLE
feat(frontend): smooth sliding pane motion

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -7,9 +7,10 @@
 
 :root {
   --inline-direction: 1;
-  /* Expressive movement settles quickly without an abrupt stop. Keep this in
-     sync with Svelte's `expoOut` easing used by component transitions. */
+  /* CSS approximates Svelte's `expoOut` curve for expressive movement that
+     settles quickly without an abrupt stop. */
   --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --motion-duration-pane: 240ms;
 }
 
 :root[dir='rtl'] {

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -7,6 +7,9 @@
 
 :root {
   --inline-direction: 1;
+  /* Expressive movement settles quickly without an abrupt stop. Keep this in
+     sync with Svelte's `expoOut` easing used by component transitions. */
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 :root[dir='rtl'] {
@@ -689,7 +692,7 @@
 }
 
 .quick-switcher[open] {
-  animation: quick-switcher-enter 100ms ease-out;
+  animation: quick-switcher-enter 120ms var(--ease-out-expo);
 }
 
 .quick-switcher[open]::backdrop {

--- a/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
+++ b/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
@@ -21,7 +21,7 @@
     class={[
       'fixed inset-0 top-11 z-40 touch-none bg-black/50 md:hidden',
       !dragging &&
-        'transition-opacity duration-240 ease-[var(--ease-out-expo)] motion-reduce:duration-0',
+        'transition-opacity duration-[var(--motion-duration-pane)] ease-[var(--ease-out-expo)] motion-reduce:duration-0',
       mobileClosed && 'pointer-events-none'
     ]}
     style:opacity={progress}
@@ -66,21 +66,30 @@
 		visually hidden by transform) once the close animation finishes. This
 		matters for accessibility tooling and Playwright's `toBeVisible()`.
 
-		Open  → transform animates 240ms, visibility flips to `visible` immediately.
-		Close → transform animates 240ms, visibility flips to `hidden` AFTER 240ms.
+		Open  → transform animates, visibility flips to `visible` immediately.
+		Close → visibility flips to `hidden` after the transform finishes.
 	*/
   @media (max-width: 767px) {
     :global(.sidebar-mobile-anim) {
       visibility: visible;
       transition:
-        transform 240ms var(--ease-out-expo),
+        transform var(--motion-duration-pane) var(--ease-out-expo),
         visibility 0s linear 0s;
     }
     :global(.sidebar-mobile-anim.sidebar-mobile-closed) {
       visibility: hidden;
       transition:
-        transform 240ms var(--ease-out-expo),
-        visibility 0s linear 240ms;
+        transform var(--motion-duration-pane) var(--ease-out-expo),
+        visibility 0s linear var(--motion-duration-pane);
+    }
+  }
+
+  @media (max-width: 767px) and (prefers-reduced-motion: reduce) {
+    :global(.sidebar-mobile-anim),
+    :global(.sidebar-mobile-anim.sidebar-mobile-closed) {
+      transition:
+        transform 0s,
+        visibility 0s;
     }
   }
 </style>

--- a/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
+++ b/apps/frontend/src/lib/components/MobileSidebarChrome.svelte
@@ -20,7 +20,8 @@
     data-testid="mobile-sidebar-backdrop"
     class={[
       'fixed inset-0 top-11 z-40 touch-none bg-black/50 md:hidden',
-      !dragging && 'transition-opacity duration-200',
+      !dragging &&
+        'transition-opacity duration-240 ease-[var(--ease-out-expo)] motion-reduce:duration-0',
       mobileClosed && 'pointer-events-none'
     ]}
     style:opacity={progress}
@@ -65,21 +66,21 @@
 		visually hidden by transform) once the close animation finishes. This
 		matters for accessibility tooling and Playwright's `toBeVisible()`.
 
-		Open  → transform animates 200ms, visibility flips to `visible` immediately.
-		Close → transform animates 200ms, visibility flips to `hidden` AFTER 200ms.
+		Open  → transform animates 240ms, visibility flips to `visible` immediately.
+		Close → transform animates 240ms, visibility flips to `hidden` AFTER 240ms.
 	*/
   @media (max-width: 767px) {
     :global(.sidebar-mobile-anim) {
       visibility: visible;
       transition:
-        transform 200ms ease-out,
+        transform 240ms var(--ease-out-expo),
         visibility 0s linear 0s;
     }
     :global(.sidebar-mobile-anim.sidebar-mobile-closed) {
       visibility: hidden;
       transition:
-        transform 200ms ease-out,
-        visibility 0s linear 200ms;
+        transform 240ms var(--ease-out-expo),
+        visibility 0s linear 240ms;
     }
   }
 </style>

--- a/apps/frontend/src/lib/ui/BottomSheet.svelte
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte
@@ -74,7 +74,12 @@
   }
 
   function handleAnimationEnd(event: AnimationEvent) {
-    if (closing && event.target === dialogEl && event.animationName === 'slide-down') {
+    if (
+      closing &&
+      event.target === dialogEl &&
+      !event.pseudoElement &&
+      event.animationName.endsWith('slide-down')
+    ) {
       dialogEl.close();
     }
   }

--- a/apps/frontend/src/lib/ui/BottomSheet.svelte
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte
@@ -71,10 +71,12 @@
   function close() {
     if (!dialogEl?.open || closing) return;
     closing = true;
-    // Wait for exit animation, then close
-    setTimeout(() => {
-      dialogEl?.close();
-    }, 240);
+  }
+
+  function handleAnimationEnd(event: AnimationEvent) {
+    if (closing && event.target === dialogEl && event.animationName === 'slide-down') {
+      dialogEl.close();
+    }
   }
 </script>
 
@@ -91,6 +93,7 @@
   onpointerdown={handlePressStart}
   ontouchstart={handlePressStart}
   onfocusin={() => (editableFocusPending = false)}
+  onanimationend={handleAnimationEnd}
   aria-label={ariaLabel}
   class="bottom-sheet m-0 mt-auto w-full max-w-full bg-transparent p-0 backdrop:bg-black/50"
   class:closing
@@ -162,26 +165,26 @@
     transition is suppressed so the transform follows the finger 1:1.
   */
   dialog.bottom-sheet > div {
-    transition: transform 240ms var(--ease-out-expo);
+    transition: transform var(--motion-duration-pane) var(--ease-out-expo);
   }
   dialog.bottom-sheet > div.dragging {
     transition: none;
   }
 
   dialog.bottom-sheet[open] {
-    animation: slide-up 240ms var(--ease-out-expo);
+    animation: slide-up var(--motion-duration-pane) var(--ease-out-expo);
   }
 
   dialog.bottom-sheet[open]::backdrop {
-    animation: backdrop-fade-in 240ms ease-out;
+    animation: backdrop-fade-in var(--motion-duration-pane) ease-out;
   }
 
   dialog.bottom-sheet[open].closing {
-    animation: slide-down 240ms var(--ease-out-expo) forwards;
+    animation: slide-down var(--motion-duration-pane) var(--ease-out-expo) forwards;
   }
 
   dialog.bottom-sheet[open].closing::backdrop {
-    animation: backdrop-fade-out 240ms ease-in forwards;
+    animation: backdrop-fade-out var(--motion-duration-pane) ease-in forwards;
   }
 
   @keyframes slide-up {
@@ -217,6 +220,19 @@
     }
     to {
       opacity: 0;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    dialog.bottom-sheet > div {
+      transition-duration: 0ms;
+    }
+
+    dialog.bottom-sheet[open],
+    dialog.bottom-sheet[open]::backdrop,
+    dialog.bottom-sheet[open].closing,
+    dialog.bottom-sheet[open].closing::backdrop {
+      animation-duration: 0.01ms;
     }
   }
 </style>

--- a/apps/frontend/src/lib/ui/BottomSheet.svelte
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte
@@ -74,7 +74,7 @@
     // Wait for exit animation, then close
     setTimeout(() => {
       dialogEl?.close();
-    }, 200);
+    }, 240);
   }
 </script>
 
@@ -162,26 +162,26 @@
     transition is suppressed so the transform follows the finger 1:1.
   */
   dialog.bottom-sheet > div {
-    transition: transform 200ms ease-out;
+    transition: transform 240ms var(--ease-out-expo);
   }
   dialog.bottom-sheet > div.dragging {
     transition: none;
   }
 
   dialog.bottom-sheet[open] {
-    animation: slide-up 200ms ease-out;
+    animation: slide-up 240ms var(--ease-out-expo);
   }
 
   dialog.bottom-sheet[open]::backdrop {
-    animation: backdrop-fade-in 200ms ease-out;
+    animation: backdrop-fade-in 240ms ease-out;
   }
 
   dialog.bottom-sheet[open].closing {
-    animation: slide-down 200ms ease-in forwards;
+    animation: slide-down 240ms var(--ease-out-expo) forwards;
   }
 
   dialog.bottom-sheet[open].closing::backdrop {
-    animation: backdrop-fade-out 200ms ease-in forwards;
+    animation: backdrop-fade-out 240ms ease-in forwards;
   }
 
   @keyframes slide-up {

--- a/apps/frontend/src/lib/ui/BottomSheet.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte.spec.ts
@@ -109,4 +109,15 @@ describe('BottomSheet', () => {
 
     expect(dialog).toHaveClass('closing');
   });
+
+  it('closes after its exit animation completes', () => {
+    const { container } = renderSheet();
+    const { dialog } = sheetElements(container);
+
+    dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
+    flushSync();
+    dialog.dispatchEvent(new AnimationEvent('animationend', { animationName: 'slide-down' }));
+
+    expect(dialog).not.toHaveAttribute('open');
+  });
 });

--- a/apps/frontend/src/lib/ui/BottomSheet.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/BottomSheet.svelte.spec.ts
@@ -110,13 +110,15 @@ describe('BottomSheet', () => {
     expect(dialog).toHaveClass('closing');
   });
 
-  it('closes after its exit animation completes', () => {
+  it('closes after its scoped exit animation completes', () => {
     const { container } = renderSheet();
     const { dialog } = sheetElements(container);
 
     dialog.dispatchEvent(new Event('cancel', { cancelable: true }));
     flushSync();
-    dialog.dispatchEvent(new AnimationEvent('animationend', { animationName: 'slide-down' }));
+    dialog.dispatchEvent(
+      new AnimationEvent('animationend', { animationName: 'svelte-test-slide-down' })
+    );
 
     expect(dialog).not.toHaveAttribute('open');
   });

--- a/apps/frontend/src/lib/ui/CollapsibleGroup.svelte
+++ b/apps/frontend/src/lib/ui/CollapsibleGroup.svelte
@@ -36,6 +36,7 @@ offline member groups).
 <script lang="ts" generics="T extends { id: string }">
   import type { Snippet } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
+  import { expoOut } from 'svelte/easing';
   import { slide } from 'svelte/transition';
 
   interface Props {
@@ -96,7 +97,7 @@ offline member groups).
   <div class="sidebar-nav">
     {#each items as it (it.id)}
       {#if !collapsed || keepVisibleWhenCollapsed?.(it)}
-        <div transition:slide={{ duration: 150 }}>
+        <div transition:slide={{ duration: 180, easing: expoOut }}>
           {@render item(it)}
         </div>
       {/if}

--- a/apps/frontend/src/lib/ui/CollapsibleGroup.svelte
+++ b/apps/frontend/src/lib/ui/CollapsibleGroup.svelte
@@ -36,8 +36,8 @@ offline member groups).
 <script lang="ts" generics="T extends { id: string }">
   import type { Snippet } from 'svelte';
   import type { Attachment } from 'svelte/attachments';
-  import { expoOut } from 'svelte/easing';
   import { slide } from 'svelte/transition';
+  import { COMPACT_MOTION_DURATION_MS, expoOutTransition } from './motion';
 
   interface Props {
     label: string;
@@ -97,7 +97,7 @@ offline member groups).
   <div class="sidebar-nav">
     {#each items as it (it.id)}
       {#if !collapsed || keepVisibleWhenCollapsed?.(it)}
-        <div transition:slide={{ duration: 180, easing: expoOut }}>
+        <div transition:slide={expoOutTransition(COMPACT_MOTION_DURATION_MS)}>
           {@render item(it)}
         </div>
       {/if}

--- a/apps/frontend/src/lib/ui/motion.ts
+++ b/apps/frontend/src/lib/ui/motion.ts
@@ -1,0 +1,13 @@
+import { expoOut } from 'svelte/easing';
+import { prefersReducedMotion } from 'svelte/motion';
+
+export const COMPACT_MOTION_DURATION_MS = 180;
+const PANE_MOTION_DURATION_MS = 240;
+
+/** Shared exponential transition timing for spatial UI movement. */
+export function expoOutTransition(duration = PANE_MOTION_DURATION_MS) {
+  return {
+    duration: prefersReducedMotion.current ? 0 : duration,
+    easing: expoOut
+  };
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { ComponentProps } from 'svelte';
   import type RoomSidebar from './RoomSidebar.svelte';
+  import { expoOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
   import { m } from '$lib/i18n/messages';
   import { fromInlineEndOffset } from '$lib/i18n/direction';
@@ -58,7 +59,7 @@
     <div
       class="absolute inset-y-0 end-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] lg:hidden"
       data-testid="room-sidebar-mobile-pane"
-      transition:fly={{ x: fromInlineEndOffset(300), duration: 200 }}
+      transition:fly={{ x: fromInlineEndOffset(300), duration: 240, easing: expoOut }}
     >
       {@render sidebar(sidebarProps)}
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebarPane.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import type { ComponentProps } from 'svelte';
   import type RoomSidebar from './RoomSidebar.svelte';
-  import { expoOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
   import { m } from '$lib/i18n/messages';
   import { fromInlineEndOffset } from '$lib/i18n/direction';
+  import { expoOutTransition } from '$lib/ui/motion';
 
   let roomSidebarModule: Promise<typeof import('./RoomSidebar.svelte')> | null = null;
   let roomSidebarLoadAttempt = $state(0);
@@ -59,7 +59,7 @@
     <div
       class="absolute inset-y-0 end-0 z-20 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] lg:hidden"
       data-testid="room-sidebar-mobile-pane"
-      transition:fly={{ x: fromInlineEndOffset(300), duration: 240, easing: expoOut }}
+      transition:fly={{ x: fromInlineEndOffset(300), ...expoOutTransition() }}
     >
       {@render sidebar(sidebarProps)}
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { expoOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
   import { fromInlineEndOffset } from '$lib/i18n/direction';
   import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
@@ -257,7 +258,7 @@
   class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] @min-[768px]:relative @min-[768px]:inset-auto @min-[768px]:z-auto @min-[768px]:w-[var(--thread-pane-width)] @min-[768px]:shrink-0 @min-[768px]:shadow-none"
   data-testid="thread-pane"
   style:--thread-pane-width={`${threadPaneWidth.value}px`}
-  transition:fly|global={{ x: fromInlineEndOffset(300), duration: 200 }}
+  transition:fly|global={{ x: fromInlineEndOffset(300), duration: 240, easing: expoOut }}
   {@attach threadDropZone}
 >
   <div class="hidden @min-[768px]:block">

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { expoOut } from 'svelte/easing';
   import { fly } from 'svelte/transition';
   import { fromInlineEndOffset } from '$lib/i18n/direction';
   import { createReadStateAPI, type MarkThreadAsReadResult } from '$lib/api-client/readState';
@@ -21,6 +20,7 @@
   import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
+  import { expoOutTransition } from '$lib/ui/motion';
   import MessageComposer, {
     type MessageComposerApi
   } from '$lib/components/composer/MessageComposer.svelte';
@@ -258,7 +258,7 @@
   class="absolute inset-y-0 end-0 z-10 flex min-h-0 w-full min-w-0 flex-col overflow-hidden border-s border-border bg-background inline-end-overlay-shadow sm:w-[90%] @min-[768px]:relative @min-[768px]:inset-auto @min-[768px]:z-auto @min-[768px]:w-[var(--thread-pane-width)] @min-[768px]:shrink-0 @min-[768px]:shadow-none"
   data-testid="thread-pane"
   style:--thread-pane-width={`${threadPaneWidth.value}px`}
-  transition:fly|global={{ x: fromInlineEndOffset(300), duration: 240, easing: expoOut }}
+  transition:fly|global={{ x: fromInlineEndOffset(300), ...expoOutTransition() }}
   {@attach threadDropZone}
 >
   <div class="hidden @min-[768px]:block">


### PR DESCRIPTION
## Why

Sliding panes previously used generic easing, which made navigation feel abrupt and mechanical.

## What changed

- Added a shared exponential ease-out curve for CSS-driven motion and used Svelte's `expoOut` for component transitions.
- Applied the motion treatment to thread and room side panes, the mobile sidebar, bottom sheets, collapsible sidebar groups, and the quick switcher.
- Consolidated primary pane timing at 240ms, kept gesture tracking linear until release, and made automated spatial motion immediate when reduced motion is preferred.
- Closed bottom sheets from their scoped exit-animation completion instead of a duplicated wall-clock timer.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise lint-frontend` — passed, including design-system checks, Svelte diagnostics, TypeScript, and ESLint.
- Focused Vitest browser suites for `MobileSidebarChrome`, `BottomSheet`, `CollapsibleGroup`, and `ThreadPane` — 20 tests passed.
- Svelte autofixer — no relevant issues in the five changed Svelte components.
- Interactive browser review remains outstanding because no connected browser was available in the workspace.
