### PR TITLE
perf(desktop): prune unused Electron locales

### DIFF
--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -1,9 +1,10 @@
 import { execFileSync } from "node:child_process";
-import { mkdir, rename, rm } from "node:fs/promises";
+import { mkdir, readdir, rename, rm } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { packager } from "@electron/packager";
 import packageJson from "../package.json" with { type: "json" };
+import { pruneElectronLocales } from "./locales.mjs";
 import { macOSVersions, releaseBuildVersion } from "./version.mjs";
 
 const desktopRoot = path.resolve(
@@ -16,6 +17,13 @@ const packagerOut = path.join(distRoot, ".packager");
 const platform = process.platform;
 const macVersions =
   platform === "darwin" ? macOSVersions(packageJson.version) : undefined;
+const supportedLocales = (
+  await readdir(path.resolve(desktopRoot, "../frontend/messages"), {
+    withFileTypes: true,
+  })
+)
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
 
 await rm(distRoot, { recursive: true, force: true });
 await mkdir(packagerOut, { recursive: true });
@@ -25,7 +33,6 @@ const [bundleRoot] = await packager({
   out: packagerOut,
   overwrite: true,
   asar: true,
-  prune: false,
   name: packageJson.productName,
   executableName: platform === "darwin" ? undefined : "chatto-desktop",
   appVersion: macVersions?.shortVersion ?? packageJson.version,
@@ -58,8 +65,20 @@ const [bundleRoot] = await packager({
   ],
 });
 
+const appBundle =
+  platform === "darwin"
+    ? path.join(bundleRoot, `${packageJson.productName}.app`)
+    : bundleRoot;
+const prunedLocales = await pruneElectronLocales(
+  appBundle,
+  platform,
+  supportedLocales,
+);
+console.log(
+  `Removed ${prunedLocales.removedLocales} unused Electron locale resources (${(prunedLocales.removedBytes / 1024 / 1024).toFixed(1)} MiB)`,
+);
+
 if (platform === "darwin") {
-  const appBundle = path.join(bundleRoot, `${packageJson.productName}.app`);
   execFileSync("codesign", ["--force", "--deep", "--sign", "-", appBundle]);
   await rename(
     appBundle,

--- a/apps/desktop/scripts/locales.mjs
+++ b/apps/desktop/scripts/locales.mjs
@@ -1,0 +1,107 @@
+import { readdir, rm, stat } from "node:fs/promises";
+import path from "node:path";
+
+const macOSGenderSuffix = /_(?:FEMININE|MASCULINE|NEUTER)$/;
+
+function normaliseElectronLocale(entryName) {
+  return entryName
+    .replace(/\.(?:lproj|pak)$/, "")
+    .replace(macOSGenderSuffix, "")
+    .replaceAll("_", "-");
+}
+
+/**
+ * Returns whether an Electron locale resource can serve one of the frontend's
+ * locales. Electron uses both language-only names and platform-specific tag
+ * formats, so a base pack such as `de` serves every supported German variant.
+ */
+export function isElectronLocaleSupported(entryName, supportedLocales) {
+  const locale = normaliseElectronLocale(entryName);
+  const language = locale.split("-", 1)[0];
+
+  return supportedLocales.some(
+    (supportedLocale) =>
+      supportedLocale === locale || supportedLocale.startsWith(`${language}-`),
+  );
+}
+
+async function entrySize(entryPath) {
+  const entry = await stat(entryPath);
+  if (!entry.isDirectory()) {
+    return entry.size;
+  }
+
+  const children = await readdir(entryPath);
+  const sizes = await Promise.all(
+    children.map((child) => entrySize(path.join(entryPath, child))),
+  );
+  return sizes.reduce((total, size) => total + size, 0);
+}
+
+async function pruneLocaleDirectory(directory, extension, supportedLocales) {
+  let entries;
+  try {
+    entries = await readdir(directory, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return { removedBytes: 0, removedLocales: 0 };
+    }
+    throw error;
+  }
+
+  const removable = entries.filter(
+    (entry) =>
+      entry.name.endsWith(extension) &&
+      !isElectronLocaleSupported(entry.name, supportedLocales),
+  );
+  const sizes = await Promise.all(
+    removable.map((entry) => entrySize(path.join(directory, entry.name))),
+  );
+  await Promise.all(
+    removable.map((entry) =>
+      rm(path.join(directory, entry.name), { recursive: true, force: true }),
+    ),
+  );
+
+  return {
+    removedBytes: sizes.reduce((total, size) => total + size, 0),
+    removedLocales: removable.length,
+  };
+}
+
+/** Removes packaged native locale resources which the Chatto UI cannot use. */
+export async function pruneElectronLocales(
+  bundleRoot,
+  platform,
+  supportedLocales,
+) {
+  const locations =
+    platform === "darwin"
+      ? [
+          path.join(bundleRoot, "Contents", "Resources"),
+          path.join(
+            bundleRoot,
+            "Contents",
+            "Frameworks",
+            "Electron Framework.framework",
+            "Versions",
+            "A",
+            "Resources",
+          ),
+        ].map((directory) => [directory, ".lproj"])
+      : [[path.join(bundleRoot, "locales"), ".pak"]];
+
+  const results = await Promise.all(
+    locations.map(([directory, extension]) =>
+      pruneLocaleDirectory(directory, extension, supportedLocales),
+    ),
+  );
+
+  return results.reduce(
+    (total, result) => ({
+      removedBytes: total.removedBytes + result.removedBytes,
+      removedLocales: total.removedLocales + result.removedLocales,
+    }),
+    { removedBytes: 0, removedLocales: 0 },
+  );
+}

--- a/apps/desktop/scripts/locales.test.mjs
+++ b/apps/desktop/scripts/locales.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { isElectronLocaleSupported, pruneElectronLocales } from "./locales.mjs";
+
+const supportedLocales = ["de-DE", "en-GB", "en-US", "es-419", "zh-TW"];
+
+test("maps Electron locale names to supported frontend locales", () => {
+  assert.equal(isElectronLocaleSupported("de.lproj", supportedLocales), true);
+  assert.equal(
+    isElectronLocaleSupported("de_FEMININE.lproj", supportedLocales),
+    true,
+  );
+  assert.equal(isElectronLocaleSupported("en-US.pak", supportedLocales), true);
+  assert.equal(
+    isElectronLocaleSupported("es_419.lproj", supportedLocales),
+    true,
+  );
+  assert.equal(
+    isElectronLocaleSupported("zh_TW_NEUTER.lproj", supportedLocales),
+    true,
+  );
+  assert.equal(isElectronLocaleSupported("fr.lproj", supportedLocales), false);
+});
+
+test("prunes unsupported macOS locale bundles", async (t) => {
+  const temporaryRoot = await mkdtemp(
+    path.join(os.tmpdir(), "chatto-desktop-locales-"),
+  );
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+
+  const resources = path.join(
+    temporaryRoot,
+    "Contents",
+    "Frameworks",
+    "Electron Framework.framework",
+    "Versions",
+    "A",
+    "Resources",
+  );
+  await Promise.all(
+    ["de.lproj", "en.lproj", "fr.lproj"].map(async (locale) => {
+      const directory = path.join(resources, locale);
+      await mkdir(directory, { recursive: true });
+      await writeFile(path.join(directory, "locale.pak"), locale);
+    }),
+  );
+
+  const result = await pruneElectronLocales(
+    temporaryRoot,
+    "darwin",
+    supportedLocales,
+  );
+
+  assert.deepEqual(await readdir(resources), ["de.lproj", "en.lproj"]);
+  assert.equal(result.removedLocales, 1);
+  assert.equal(result.removedBytes, Buffer.byteLength("fr.lproj"));
+});
+
+test("prunes unsupported Windows and Linux locale packs", async (t) => {
+  const temporaryRoot = await mkdtemp(
+    path.join(os.tmpdir(), "chatto-desktop-locales-"),
+  );
+  t.after(() => rm(temporaryRoot, { recursive: true, force: true }));
+
+  const locales = path.join(temporaryRoot, "locales");
+  await mkdir(locales, { recursive: true });
+  await Promise.all(
+    ["de.pak", "en-US.pak", "fr.pak"].map((locale) =>
+      writeFile(path.join(locales, locale), locale),
+    ),
+  );
+
+  const result = await pruneElectronLocales(
+    temporaryRoot,
+    "linux",
+    supportedLocales,
+  );
+
+  assert.deepEqual(await readdir(locales), ["de.pak", "en-US.pak"]);
+  assert.equal(result.removedLocales, 1);
+  assert.equal(result.removedBytes, Buffer.byteLength("fr.pak"));
+});


### PR DESCRIPTION
## Why

Electron's complete native locale set adds avoidable weight to every desktop download and installation, including languages the Chatto frontend does not offer.

## What changed

- Derive required native locales from the frontend message catalogs and prune unsupported Electron locale resources before signing or packaging.
- Handle macOS `.lproj` resources and Windows/Linux `.pak` resources, while restoring Electron Packager's normal production-dependency pruning.
- Reduce the measured macOS bundle from 306 MiB to 276 MiB without removing any Chatto-supported language.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise test-desktop`
- `mise desktop-build` — removed 29.7 MiB of unused locale resources; packaged app launched and passed strict code-signature verification.
- `mise license-check`
- Prettier check and `git diff --check`
