### PR TITLE
fix(dev): build Lingua during workspace setup

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -24,6 +24,7 @@ run = [
     { task = "setup-natsruntime" },
     { task = "setup-frontend" },
     { task = "build-api-types" },
+    { task = "build-lingua" },
 ]
 
 # =============================================================================


### PR DESCRIPTION
## Why

Fresh agent workspaces install `@chatto/lingua` but leave its exported `dist` files unbuilt, causing frontend tests and other direct package consumers to fail before doing useful work.

## What changed

- Add the existing `build-lingua` task to the repository-wide `mise setup` workflow, alongside `build-api-types`.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise setup` — passed from a workspace where `packages/lingua/dist` was absent and generated the package successfully.
- `mise test-frontend` — passed all server, client, and Storybook test projects.
- `git diff --check` — passed.
