### PR TITLE
fix(frontend): expire empty attachment tombstones

### DIFF
--- a/apps/frontend/e2e/messages.test.ts
+++ b/apps/frontend/e2e/messages.test.ts
@@ -476,7 +476,7 @@ test('user can cancel deleting a message', async ({ page, chatPage, roomPage }) 
   await roomPage.expectMessageVisible(testMessage);
 });
 
-test('deleted message disappears for other connected clients in real-time', async ({
+test('streamed attachment deletion tombstone expires for other connected clients', async ({
   page,
   chatPage,
   roomPage,
@@ -489,7 +489,7 @@ test('deleted message disappears for other connected clients in real-time', asyn
   await chatPage.enterRoom('general');
 
   const testMessage = `Real-time delete test ${Date.now()}`;
-  const message1 = await roomPage.sendMessage(testMessage);
+  const message1 = await roomPage.sendAttachment('e2e/fixtures/brighton.jpg', testMessage);
   const eventId = await message1.getEventId();
 
   // User 2: Create user and open the server
@@ -501,6 +501,11 @@ test('deleted message disappears for other connected clients in real-time', asyn
 
       // User 2 should see the message
       await expect(page2.getByText(testMessage)).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
+
+      // Install the receiver's clock before the streamed deletion arrives so
+      // this path also covers the tombstone timer created by the projection
+      // stream reducer.
+      await installTombstoneClock(page2);
 
       // User 1: Delete the message
       await message1.delete();
@@ -521,6 +526,8 @@ test('deleted message disappears for other connected clients in real-time', asyn
         await expect(page2.getByText(testMessage)).not.toBeVisible({
           timeout: TIMEOUTS.UI_STANDARD
         });
+        await advancePastTombstoneGrace(page2);
+        await expect(message2AfterDelete).toHaveCount(0);
       }
     },
     { viewport: { width: 1280, height: 720 } }
@@ -601,12 +608,15 @@ test('removing attachment from attachment-only message hides it', async ({
   await message.expectAttachment();
 
   // Remove the attachment (not delete the whole message)
+  await installTombstoneClock(page);
   await message.deleteAttachment();
 
   // Message with no body and no attachments should show the deleted-tombstone
   if (eventId) {
     const messageAfterRemove = roomPage.getMessageByEventId(eventId);
     await messageAfterRemove.expectDeleted();
+    await advancePastTombstoneGrace(page);
+    await expect(messageAfterRemove.locator).toHaveCount(0);
   }
 });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/tombstoneVisibility.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/tombstoneVisibility.spec.ts
@@ -1,8 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import {
-  TimelineEventKind,
-  type TimelineEventView
-} from '$lib/render/timelineEvents';
+import { TimelineEventKind, type TimelineEventView } from '$lib/render/timelineEvents';
 import type { TimeFormatSettings } from '$lib/utils/formatTime';
 import { computeEventMetadata } from './messageGrouping';
 import { buildVirtualItems } from './virtualItems';
@@ -66,6 +63,18 @@ describe('tombstone visibility', () => {
   it('conservatively keeps unavailable messages without tombstone metadata', () => {
     expect(tombstoneExpiry(message({ deletedAt: null }))).toBeNull();
     expect(tombstoneExpiry(message({ deletedAt: 'invalid' }))).toBeNull();
+  });
+
+  it('expires an attachment-only message from the time its final attachment was removed', () => {
+    const updatedAt = '2026-07-10T10:30:00.000Z';
+    const event = message({ body: '', deletedAt: null, updatedAt });
+    expect(tombstoneExpiry(event)).toBe(Date.parse(updatedAt) + MESSAGE_TOMBSTONE_GRACE_MS);
+  });
+
+  it('does not infer deletion from an edited message whose body is unavailable', () => {
+    expect(
+      tombstoneExpiry(message({ body: null, deletedAt: null, updatedAt: deletedAt }))
+    ).toBeNull();
   });
 
   it.each([

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/tombstoneVisibility.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/tombstoneVisibility.ts
@@ -1,7 +1,4 @@
-import {
-  isMessagePostedEvent,
-  type TimelineEventView
-} from '$lib/render/timelineEvents';
+import { isMessagePostedEvent, type TimelineEventView } from '$lib/render/timelineEvents';
 export const MESSAGE_TOMBSTONE_GRACE_MS = 60 * 60 * 1000;
 
 /**
@@ -11,15 +8,21 @@ export const MESSAGE_TOMBSTONE_GRACE_MS = 60 * 60 * 1000;
  */
 export function tombstoneExpiry(event: TimelineEventView): number | null {
   const message = event.event;
-  if (!isMessagePostedEvent(message) || !message.deletedAt) return null;
-  if (message.body != null) return null;
+  if (!isMessagePostedEvent(message) || message.body) return null;
   if ((message.attachments?.length ?? 0) > 0 || message.linkPreview) return null;
   if ((message.reactions?.length ?? 0) > 0 || message.replyCount > 0) return null;
 
-  const deletedAt = Date.parse(message.deletedAt);
-  if (!Number.isFinite(deletedAt)) return null;
+  // Removing the final attachment from an attachment-only message is a
+  // MessageEditedEvent rather than a retraction. The API preserves its empty
+  // body and edit timestamp, which together mark when the row became a
+  // context-free tombstone. A null body without deletedAt remains an unknown
+  // or corrupt body and is deliberately retained.
+  const tombstonedAt = message.deletedAt ?? (message.body === '' ? message.updatedAt : null);
+  if (!tombstonedAt) return null;
+  const tombstonedAtMs = Date.parse(tombstonedAt);
+  if (!Number.isFinite(tombstonedAtMs)) return null;
 
-  return deletedAt + MESSAGE_TOMBSTONE_GRACE_MS;
+  return tombstonedAtMs + MESSAGE_TOMBSTONE_GRACE_MS;
 }
 
 export function shouldHideTombstone(event: TimelineEventView, nowMs: number): boolean {


### PR DESCRIPTION
## Why

Removing the final attachment from an attachment-only message leaves an empty-body tombstone without `deletedAt`, so the frontend retained it forever instead of applying the documented one-hour expiry.

## What changed

- Treat an empty edited body as absent and use its `updatedAt` timestamp as the tombstone clock while preserving conservative handling for unavailable or corrupt bodies.
- Cover final-attachment removal and streamed attachment-bearing deletions through focused unit and browser tests.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: unchanged; older clients may continue displaying these tombstones.

Newer client → older server: compatible because existing timeline payloads already provide the edit timestamp.

Capability discovery or minimum client/server version: none required.

## Test plan

- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- Focused `tombstoneVisibility.spec.ts` Vitest run — 20 tests passed.
- Focused Playwright runs for final-attachment removal and streamed attachment deletion expiry — 2 tests passed.
- Production frontend build and bundle-size checks completed through the E2E setup — passed.
