### PR TITLE
fix: harden realtime and message consistency

### DIFF
--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -622,6 +622,8 @@ describe('eventBusManager realtime transport', () => {
     sync.markCaughtUp('cursor-before-reset');
     const fake = new FakeServerConnection();
     eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection, true, sync);
+    const purgeProjection = vi.fn();
+    eventBusManager.getBus(TEST_SERVER)!.projectionHandlers.add(purgeProjection);
     const socket = sockets[0];
     socket.open();
     await socket.receive(helloFrame());
@@ -640,6 +642,10 @@ describe('eventBusManager realtime transport', () => {
 
     expect(sync.resumeCursor).toBeNull();
     expect(sync.desiredRoomIds).toEqual(['room-still-open']);
+    expect(purgeProjection).toHaveBeenCalledOnce();
+    const reset = purgeProjection.mock.calls[0]?.[0] as RealtimeProjectionEvent;
+    expect(reset.operations).toHaveLength(1);
+    expect(reset.operations[0]?.operation.case).toBe('reset');
     await vi.advanceTimersByTimeAsync(0);
     const resumed = sockets.at(-1)!;
     resumed.open();

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -622,7 +622,11 @@ describe('eventBusManager realtime transport', () => {
     sync.markCaughtUp('cursor-before-reset');
     const fake = new FakeServerConnection();
     eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection, true, sync);
+    const brokenProjectionConsumer = vi.fn(() => {
+      throw new Error('reset consumer failed');
+    });
     const purgeProjection = vi.fn();
+    eventBusManager.getBus(TEST_SERVER)!.projectionHandlers.add(brokenProjectionConsumer);
     eventBusManager.getBus(TEST_SERVER)!.projectionHandlers.add(purgeProjection);
     const socket = sockets[0];
     socket.open();
@@ -642,10 +646,15 @@ describe('eventBusManager realtime transport', () => {
 
     expect(sync.resumeCursor).toBeNull();
     expect(sync.desiredRoomIds).toEqual(['room-still-open']);
+    expect(brokenProjectionConsumer).toHaveBeenCalledOnce();
     expect(purgeProjection).toHaveBeenCalledOnce();
     const reset = purgeProjection.mock.calls[0]?.[0] as RealtimeProjectionEvent;
     expect(reset.operations).toHaveLength(1);
     expect(reset.operations[0]?.operation.case).toBe('reset');
+    expect(consoleError).toHaveBeenCalledWith(
+      `[eventBus:${TEST_SERVER}] projection reset handler threw`,
+      expect.any(Error)
+    );
     await vi.advanceTimersByTimeAsync(0);
     const resumed = sockets.at(-1)!;
     resumed.open();

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.spec.ts
@@ -615,6 +615,47 @@ describe('eventBusManager realtime transport', () => {
     expect(sync.retainedRoomIds).toEqual(['room-retained']);
   });
 
+  it('drops an unusable cursor before a requested compacted reset', async () => {
+    vi.useFakeTimers();
+    const sync = new RealtimeProjectionSyncState();
+    sync.retainRoom('room-still-open');
+    sync.markCaughtUp('cursor-before-reset');
+    const fake = new FakeServerConnection();
+    eventBusManager.startBus(TEST_SERVER, fake as unknown as ServerConnection, true, sync);
+    const socket = sockets[0];
+    socket.open();
+    await socket.receive(helloFrame());
+    await socket.receive(subscribedFrame());
+
+    await socket.receive(
+      serverFrame({
+        case: 'close',
+        value: new RealtimeClose({
+          code: 'projection_reset_required',
+          message: 'authorization changed',
+          reconnect: true
+        })
+      })
+    );
+
+    expect(sync.resumeCursor).toBeNull();
+    expect(sync.desiredRoomIds).toEqual(['room-still-open']);
+    await vi.advanceTimersByTimeAsync(0);
+    const resumed = sockets.at(-1)!;
+    resumed.open();
+    await resumed.receive(helloFrame());
+    const subscribe = RealtimeClientFrame.fromBinary(resumed.sent[1]);
+    expect(subscribe.frame.case).toBe('subscribeEvents');
+    if (subscribe.frame.case !== 'subscribeEvents') throw new Error('expected subscribe frame');
+    expect(subscribe.frame.value.resumeCursor).toBeUndefined();
+    expect(subscribe.frame.value.retainedRoomIds).toEqual([]);
+    await resumed.receive(subscribedFrame());
+    const hydration = RealtimeClientFrame.fromBinary(resumed.sent[2]);
+    expect(hydration.frame.case).toBe('hydrateRoom');
+    if (hydration.frame.case !== 'hydrateRoom') throw new Error('expected hydrate room frame');
+    expect(hydration.frame.value.roomId).toBe('room-still-open');
+  });
+
   it('does not advance the cursor when no projection reducer is registered', async () => {
     vi.useFakeTimers();
     const { socket } = await startAndSubscribe();

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -17,9 +17,11 @@ import {
   RealtimeClientFrame,
   RealtimeClientHello,
   RealtimeHydrateRoom,
+  RealtimeProjectionEvent,
+  RealtimeProjectionOperation,
+  RealtimeProjectionReset,
   RealtimeServerFrame,
-  RealtimeSubscribeEvents,
-  type RealtimeProjectionEvent
+  RealtimeSubscribeEvents
 } from '@chatto/api-types/realtime/v1/realtime_pb';
 import type { ConnectionStatus, ServerConnection } from './serverConnection.svelte';
 import { RealtimeProjectionSyncState } from './realtimeSync.svelte';
@@ -326,6 +328,25 @@ class EventBusManager {
       for (const handler of projectionHandlers) handler(event);
     };
 
+    const dispatchProjectionReset = () => {
+      const reset = new RealtimeProjectionEvent({
+        operations: [
+          new RealtimeProjectionOperation({
+            operation: { case: 'reset', value: new RealtimeProjectionReset() }
+          })
+        ]
+      });
+      for (const handler of projectionHandlers) {
+        try {
+          handler(reset);
+        } catch (error) {
+          // A broken optional consumer must not stop the owning store (or
+          // another mirror) from purging authorization-sensitive state.
+          console.error(`[eventBus:${serverId}] projection reset handler threw`, error);
+        }
+      }
+    };
+
     const connect = (reason: string) => {
       if (stopped || !projectionSupported || mode === 'dormant' || socket) return;
       clearReconnectTimer();
@@ -468,6 +489,7 @@ class EventBusManager {
                 return;
               }
               if (frame.frame.value.code === 'projection_reset_required') {
+                dispatchProjectionReset();
                 sync.requireCompactedReset();
               }
               nextSocket.onclose = null;

--- a/apps/frontend/src/lib/state/server/eventBus.svelte.ts
+++ b/apps/frontend/src/lib/state/server/eventBus.svelte.ts
@@ -467,6 +467,9 @@ class EventBusManager {
                 stopForAuthenticationRequired(nextSocket, 'close frame');
                 return;
               }
+              if (frame.frame.value.code === 'projection_reset_required') {
+                sync.requireCompactedReset();
+              }
               nextSocket.onclose = null;
               if (socket === nextSocket) socket = null;
               // The close frame bypasses the socket's normal onclose handler.

--- a/apps/frontend/src/lib/state/server/realtimeSync.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/realtimeSync.svelte.spec.ts
@@ -67,6 +67,20 @@ describe('RealtimeProjectionSyncState', () => {
     expect(sync.retainedRoomIds).toEqual([]);
   });
 
+  it('requires a compacted reset without forgetting desired rooms', () => {
+    const state = new RealtimeProjectionSyncState();
+    state.retainRoom('room-1');
+    state.confirmRoom('room-1');
+    state.markCaughtUp('cursor-1');
+
+    state.requireCompactedReset();
+
+    expect(state.phase).toBe('empty');
+    expect(state.resumeCursor).toBeNull();
+    expect(state.desiredRoomIds).toEqual(['room-1']);
+    expect(state.retainedRoomIds).toEqual([]);
+  });
+
   it('clears cursor and readiness only when the owning projection is discarded', () => {
     const state = new RealtimeProjectionSyncState();
     state.markCaughtUp('cursor');

--- a/apps/frontend/src/lib/state/server/realtimeSync.svelte.ts
+++ b/apps/frontend/src/lib/state/server/realtimeSync.svelte.ts
@@ -92,6 +92,15 @@ export class RealtimeProjectionSyncState {
     if (this.phase === 'ready') this.phase = 'stale';
   }
 
+  /** Discard an unusable cursor while retaining the rooms the UI still wants. */
+  requireCompactedReset(): void {
+    this.phase = 'empty';
+    this.lastCaughtUpAt = null;
+    this.#resumeCursor = null;
+    this.#materializedRoomIds.clear();
+    this.#pendingTransportEvictions = [];
+  }
+
   reset(): void {
     this.phase = 'empty';
     this.lastCaughtUpAt = null;

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
@@ -35,12 +35,14 @@
   const serverScope = useServerScope();
   const serverSegment = $derived(serverIdToSegment(serverScope.serverId));
   const roleName = $derived(page.params.name!);
+  let disposed = false;
   let privacyGeneration = 0;
   const removeCacheRemovalListener = registerQueryCacheRemovalListener((serverId) => {
     if (serverId === serverScope.serverId) privacyGeneration += 1;
   });
 
   onDestroy(() => {
+    disposed = true;
     privacyGeneration += 1;
     removeCacheRemovalListener();
   });
@@ -81,16 +83,22 @@
   let deleteConfirmRoleName = $state<string | null>(null);
   let metadataRevision = $state(0);
 
-  function isCurrentSession(
+  function isCurrentConnection(
     variables: RoleMutationScope | undefined
   ): variables is RoleMutationScope {
     return (
       variables !== undefined &&
+      !disposed &&
       serverScope.isCurrent() &&
       variables.serverId === serverScope.serverId &&
-      variables.connection.queryScope === serverScope.connection.queryScope &&
-      variables.privacyGeneration === privacyGeneration
+      variables.connection.queryScope === serverScope.connection.queryScope
     );
+  }
+
+  function isCurrentSession(
+    variables: RoleMutationScope | undefined
+  ): variables is RoleMutationScope {
+    return isCurrentConnection(variables) && variables.privacyGeneration === privacyGeneration;
   }
 
   function isCurrentRole(variables: RoleMutationScope | undefined): variables is RoleMutationScope {
@@ -134,9 +142,14 @@
       mutationFn: ({ api, roleName: targetRoleName }: RoleMutationScope) =>
         api.deleteRole(targetRoleName),
       onSuccess: (_deleted, variables) => {
-        if (!isCurrentSession(variables)) return;
-        removeDeletedRoleQueries(variables.serverId, variables.connection, variables.roleName);
-        if (isCurrentRole(variables)) {
+        if (!isCurrentConnection(variables)) return;
+        if (isCurrentSession(variables)) {
+          removeDeletedRoleQueries(variables.serverId, variables.connection, variables.roleName);
+        }
+        // A reset may already have purged every admin query and invalidated
+        // the mutation generation. Leaving a now-deleted route is still safe;
+        // the list destination reauthorizes and reloads from scratch.
+        if (variables.roleName === roleName) {
           goto(resolve('/chat/[serverId]/manage/server/permissions', { serverId: serverSegment }));
         }
       },

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/role.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/role.page.svelte.spec.ts
@@ -4,6 +4,7 @@ import { render } from 'vitest-browser-svelte';
 import type { RoleDetails, ServerRole } from '$lib/api-client/roles';
 import { adminQueryKeys } from '$lib/query/admin';
 import { queryClient } from '$lib/query/client';
+import { removeRegisteredAdminQueries } from '$lib/query/cacheRegistry';
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
@@ -280,5 +281,50 @@ describe('role management page identity', () => {
     expect(queryClient.getQueryData(roleDetailsKey)).toBeUndefined();
     expect(queryClient.getQueryState(tierKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(userKey)?.isInvalidated).toBe(true);
+  });
+
+  it('leaves a deleted role route after an RBAC reset purges admin caches', async () => {
+    const deletion = deferred<boolean>();
+    mocks.getRole.mockResolvedValue(details('role-a', 'Role A', 'Description'));
+    mocks.deleteRole.mockReturnValue(deletion.promise);
+    const { container } = render(RolePage);
+    await vi.waitFor(() => expect(container.querySelector('#displayName')).not.toBeNull());
+
+    const openDelete = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Delete Role'
+    )!;
+    openDelete.click();
+    flushSync();
+    (container.querySelector('[data-testid="confirm-role-delete"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.deleteRole).toHaveBeenCalledWith('role-a'));
+    removeRegisteredAdminQueries('origin');
+    deletion.resolve(true);
+
+    await vi.waitFor(() =>
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/origin/manage/server/permissions')
+    );
+  });
+
+  it('does not navigate after the deleted-role page is destroyed', async () => {
+    const deletion = deferred<boolean>();
+    mocks.getRole.mockResolvedValue(details('role-a', 'Role A', 'Description'));
+    mocks.deleteRole.mockReturnValue(deletion.promise);
+    const view = render(RolePage);
+    await vi.waitFor(() => expect(view.container.querySelector('#displayName')).not.toBeNull());
+
+    const openDelete = [...view.container.querySelectorAll('button')].find(
+      (button) => button.textContent?.trim() === 'Delete Role'
+    )!;
+    openDelete.click();
+    flushSync();
+    (
+      view.container.querySelector('[data-testid="confirm-role-delete"]') as HTMLButtonElement
+    ).click();
+    await vi.waitFor(() => expect(mocks.deleteRole).toHaveBeenCalledWith('role-a'));
+    view.unmount();
+    deletion.resolve(true);
+    await Promise.resolve();
+
+    expect(mocks.goto).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/new/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/new/+page.svelte
@@ -20,12 +20,14 @@
   import { m } from '$lib/i18n/messages';
 
   const serverScope = useServerScope();
+  let disposed = false;
   let privacyGeneration = 0;
   const removeCacheRemovalListener = registerQueryCacheRemovalListener((serverId) => {
     if (serverId === serverScope.serverId) privacyGeneration += 1;
   });
 
   onDestroy(() => {
+    disposed = true;
     privacyGeneration += 1;
     removeCacheRemovalListener();
   });
@@ -55,28 +57,38 @@
     () => queryClient
   );
 
-  function isCurrentSession(
+  function isCurrentConnection(
     variables: CreateRoleVariables | undefined
   ): variables is CreateRoleVariables {
     return (
       variables !== undefined &&
+      !disposed &&
       serverScope.isCurrent() &&
       variables.serverId === serverScope.serverId &&
-      variables.connection.queryScope === serverScope.connection.queryScope &&
-      variables.privacyGeneration === privacyGeneration
+      variables.connection.queryScope === serverScope.connection.queryScope
     );
+  }
+
+  function isCurrentSession(
+    variables: CreateRoleVariables | undefined
+  ): variables is CreateRoleVariables {
+    return isCurrentConnection(variables) && variables.privacyGeneration === privacyGeneration;
   }
 
   const createRoleMutation = createMutation(
     () => ({
       mutationFn: ({ api, input }: CreateRoleVariables) => api.createRole(input),
-      onSuccess: (createdRole, variables) => {
-        if (!isCurrentSession(variables)) return;
+      onSuccess: (_createdRole, variables) => {
+        if (!isCurrentConnection(variables)) return;
         invalidatePermissionTiers(variables.serverId, variables.connection);
+        // An RBAC write deliberately purges admin caches before its Connect
+        // response can settle. Navigation remains safe because it uses the
+        // submitted slug, while the destination performs a fresh authorized
+        // read; returned admin data stays privacy-generation gated.
         goto(
           resolve('/chat/[serverId]/manage/server/permissions/[name]', {
             serverId: serverIdToSegment(variables.serverId),
-            name: createdRole.name
+            name: variables.input.name
           })
         );
       }

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/new/role-create.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/new/role-create.page.svelte.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { adminQueryKeys } from '$lib/query/admin';
 import { queryClient } from '$lib/query/client';
+import { removeRegisteredAdminQueries } from '$lib/query/cacheRegistry';
 
 const mocks = vi.hoisted(() => ({
   listAdminRoles: vi.fn(),
@@ -51,6 +52,14 @@ vi.mock('$lib/ui/PageTitle.svelte', async () => ({
 
 import RoleCreatePage from './+page.svelte';
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe('role creation query invalidation', () => {
   beforeEach(() => {
     queryClient.clear();
@@ -89,5 +98,40 @@ describe('role creation query invalidation', () => {
     );
 
     expect(mocks.listAdminRoles).not.toHaveBeenCalled();
+  });
+
+  it('navigates using the submitted slug after an RBAC reset purges admin caches', async () => {
+    const create = deferred<{ name: string }>();
+    mocks.createRole.mockReturnValue(create.promise);
+    const { container } = render(RoleCreatePage);
+    await vi.waitFor(() =>
+      expect(container.querySelector('[data-testid="create-role"]')).not.toBeNull()
+    );
+
+    (container.querySelector('[data-testid="create-role"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.createRole).toHaveBeenCalledOnce());
+    removeRegisteredAdminQueries('origin');
+    create.resolve({ name: 'untrusted-response-name' });
+
+    await vi.waitFor(() =>
+      expect(mocks.goto).toHaveBeenCalledWith('/chat/origin/manage/server/permissions/moderator')
+    );
+  });
+
+  it('does not navigate after the create page is destroyed', async () => {
+    const create = deferred<{ name: string }>();
+    mocks.createRole.mockReturnValue(create.promise);
+    const view = render(RoleCreatePage);
+    await vi.waitFor(() =>
+      expect(view.container.querySelector('[data-testid="create-role"]')).not.toBeNull()
+    );
+
+    (view.container.querySelector('[data-testid="create-role"]') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.createRole).toHaveBeenCalledOnce());
+    view.unmount();
+    create.resolve({ name: 'moderator' });
+    await Promise.resolve();
+
+    expect(mocks.goto).not.toHaveBeenCalled();
   });
 });

--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -384,6 +384,29 @@ func (s *MessageModel) UpdateMessage(ctx context.Context, input MessageUpdateInp
 		}
 		editOptions = append(editOptions, WithMessageChannelEcho(*input.AlsoSendToChannel))
 	}
+	editOptions = append(editOptions, withEditMessageCommitAuthorization(func(attemptCtx context.Context) error {
+		if err := s.core.authorizeMessageEdit(attemptCtx, input.ActorID, kind, room.Id, input.EventID, input.AlsoSendToChannel != nil); err != nil {
+			return err
+		}
+		if input.AlsoSendToChannel == nil || !*input.AlsoSendToChannel {
+			return nil
+		}
+		can, err := s.core.CanEchoMessage(attemptCtx, input.ActorID, kind, room.Id)
+		if err != nil {
+			return err
+		}
+		if !can {
+			return ErrPermissionDenied
+		}
+		can, err = s.core.CanPostMessage(attemptCtx, input.ActorID, kind, room.Id)
+		if err != nil {
+			return err
+		}
+		if !can {
+			return ErrPermissionDenied
+		}
+		return nil
+	}))
 
 	newBody := body.Body
 	if input.Body != nil {

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -26,8 +26,9 @@ type postMessageOptions struct {
 }
 
 type editMessageOptions struct {
-	channelEcho  *bool
-	preserveBody bool
+	channelEcho     *bool
+	preserveBody    bool
+	commitAuthorize func(context.Context) error
 }
 
 // PostMessageOption customizes side effects owned by the message-post command.
@@ -82,6 +83,15 @@ func WithMessageChannelEcho(enabled bool) EditMessageOption {
 func withPreservedMessageBody() EditMessageOption {
 	return func(options *editMessageOptions) {
 		options.preserveBody = true
+	}
+}
+
+// withEditMessageCommitAuthorization installs an additional authorization
+// check run inside every OCC attempt. It stays package-private because public
+// transports must go through MessageModel, which owns user-facing policy.
+func withEditMessageCommitAuthorization(authorize func(context.Context) error) EditMessageOption {
+	return func(options *editMessageOptions) {
+		options.commitAuthorize = authorize
 	}
 }
 
@@ -204,10 +214,10 @@ func (c *ChattoCore) waitForAssetProcessingBatch(
 	return nil
 }
 
-// prepareMessageAppendAttempt captures every event-log boundary used by the
-// message-post authorization decision, waits for the serving projections, and
-// reruns the authoritative check. The returned sequences must be attached to
-// the same atomic batch; otherwise the projection reads are not fenced.
+// prepareMessageAppendAttempt captures every event-log boundary used by a
+// message-mutation authorization decision, waits for the serving projections,
+// and reruns the authoritative check. The returned sequences must be attached
+// to the same atomic batch; otherwise the projection reads are not fenced.
 func (c *ChattoCore) prepareMessageAppendAttempt(
 	ctx context.Context,
 	agg evtstream.Aggregate,
@@ -251,8 +261,8 @@ func (c *ChattoCore) prepareMessageAppendAttempt(
 	}
 
 	if attempt.roomSeq > 0 {
-		if err := c.roomModel.waitForDirectory(ctx, events.SubjectPosition(attempt.roomFilter, attempt.roomSeq)); err != nil {
-			return messageAppendAttempt{}, fmt.Errorf("wait for room authorization projection: %w", err)
+		if err := c.roomModel.waitForDirectoryAndTimeline(ctx, events.SubjectPosition(attempt.roomFilter, attempt.roomSeq)); err != nil {
+			return messageAppendAttempt{}, fmt.Errorf("wait for room and message authorization projections: %w", err)
 		}
 	}
 	if err := c.roomModel.waitForGroupLayout(ctx, groupPosition); err != nil {
@@ -410,6 +420,8 @@ func (c *ChattoCore) appendThreadReplyEcho(
 	originalPost *corev1.MessagePostedEvent,
 	body *corev1.MessageBody,
 	plaintext string,
+	authorize func(context.Context) error,
+	validateCommit func() error,
 ) (string, bool, error) {
 	if originalEvent == nil || originalPost == nil || body == nil {
 		return "", false, ErrMessageNotFound
@@ -421,12 +433,12 @@ func (c *ChattoCore) appendThreadReplyEcho(
 	var lastErr error
 
 	for attempt := 1; attempt <= maxThreadCreateAppendAttempts; attempt++ {
-		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, messageSubject)
+		guard, err := c.prepareMessageAppendAttempt(ctx, agg, actorID, authorize)
 		if err != nil {
-			return "", false, fmt.Errorf("read echo OCC tail: %w", err)
+			return "", false, err
 		}
-		if expectedSeq > 0 {
-			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(messageSubject, expectedSeq)); err != nil {
+		if authorize == nil && guard.roomSeq > 0 {
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(guard.roomFilter, guard.roomSeq)); err != nil {
 				return "", false, err
 			}
 		}
@@ -465,24 +477,32 @@ func (c *ChattoCore) appendThreadReplyEcho(
 			},
 		})
 
-		seqs, err := c.EventPublisher.AppendBatch(ctx, []evtstream.BatchEntry{
+		entries := []evtstream.BatchEntry{
 			{
 				Subject:       bodySubject,
 				Event:         echoBodyEvent,
-				ExpectedSeq:   expectedSeq,
-				FilterSubject: messageSubject,
+				ExpectedSeq:   guard.roomSeq,
+				FilterSubject: guard.roomFilter,
 				HasOCC:        true,
 			},
 			{
-				Subject:       messageSubject,
-				Event:         echoEvent,
-				ExpectedSeq:   expectedSeq,
-				FilterSubject: messageSubject,
-				HasOCC:        true,
+				Subject: messageSubject,
+				Event:   echoEvent,
 			},
-		})
+		}
+		if validateCommit != nil {
+			if err := validateCommit(); err != nil {
+				return "", false, err
+			}
+		}
+		if authorize != nil {
+			entries[len(entries)-1].HasOCC = true
+			entries[len(entries)-1].ExpectedSeq = guard.authorizationSeq
+			entries[len(entries)-1].FilterSubject = guard.authorizationFilter
+		}
+		seqs, err := c.EventPublisher.AppendBatch(ctx, entries)
 		if err == nil {
-			echoSeq := seqs[len(seqs)-1]
+			echoSeq := seqs[len(entries)-1]
 			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(messageSubject, echoSeq)); err != nil {
 				return echoID, true, err
 			}
@@ -508,17 +528,23 @@ func (c *ChattoCore) appendThreadReplyEcho(
 	return "", false, fmt.Errorf("publish thread reply echo after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
 }
 
-func (c *ChattoCore) hideChannelEchoForReply(ctx context.Context, actorID string, kind RoomKind, agg evtstream.Aggregate, roomID, originalEventID string) error {
+func (c *ChattoCore) hideChannelEchoForReply(
+	ctx context.Context,
+	actorID string,
+	kind RoomKind,
+	agg evtstream.Aggregate,
+	roomID, originalEventID string,
+) error {
 	retractSubject := agg.Subject(evtstream.EventMessageRetracted)
 	var lastErr error
 
 	for attempt := 1; attempt <= maxThreadCreateAppendAttempts; attempt++ {
-		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, retractSubject)
+		guard, err := c.prepareMessageAppendAttempt(ctx, agg, actorID, nil)
 		if err != nil {
-			return fmt.Errorf("read echo retract OCC tail: %w", err)
+			return err
 		}
-		if expectedSeq > 0 {
-			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(retractSubject, expectedSeq)); err != nil {
+		if guard.roomSeq > 0 {
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(guard.roomFilter, guard.roomSeq)); err != nil {
 				return err
 			}
 		}
@@ -535,9 +561,16 @@ func (c *ChattoCore) hideChannelEchoForReply(ctx context.Context, actorID string
 				},
 			},
 		})
-		seq, err := c.EventPublisher.AppendAt(ctx, retractSubject, event, expectedSeq)
+		entries := []evtstream.BatchEntry{{
+			Subject:       retractSubject,
+			Event:         event,
+			ExpectedSeq:   guard.roomSeq,
+			FilterSubject: guard.roomFilter,
+			HasOCC:        true,
+		}}
+		seqs, err := c.EventPublisher.AppendBatch(ctx, entries)
 		if err == nil {
-			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(retractSubject, seq)); err != nil {
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(retractSubject, seqs[0])); err != nil {
 				return err
 			}
 			c.logger.Debug("Message echo hidden", "kind", kind, "room_id", roomID, "event_id", echoID, "actor_id", actorID)
@@ -1063,7 +1096,7 @@ func (c *ChattoCore) PostMessage(ctx context.Context, kind RoomKind, room_id, us
 	// it back to the underlying body. The body is encrypted again for the
 	// echo event ID because v2 encryption authenticates the event context.
 	if inThread != "" && alsoSendToChannel {
-		echoID, created, err := c.appendThreadReplyEcho(ctx, user_id, kind, agg, event, event.GetMessagePosted(), messageBody, body)
+		echoID, created, err := c.appendThreadReplyEcho(ctx, user_id, kind, agg, event, event.GetMessagePosted(), messageBody, body, nil, nil)
 		if err != nil {
 			c.logger.Warn("Failed to publish thread reply echo", "error", err, "thread_reply_event_id", event.Id)
 		} else if created {
@@ -1265,6 +1298,7 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 			return ErrEditWindowExpired
 		}
 	}
+	channelEchoRetractionTargetID := ""
 	if options.channelEcho != nil {
 		echoTargetEvent := originalEntry.Event
 		echoTargetPost := origPost
@@ -1288,10 +1322,13 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		if time.Since(echoTargetEvent.GetCreatedAt().AsTime()) > MessageEditWindow {
 			return ErrEditWindowExpired
 		}
+		if !*options.channelEcho && options.commitAuthorize != nil {
+			channelEchoRetractionTargetID = echoTargetEvent.GetId()
+		}
 	}
 
 	agg := evtstream.RoomAggregate(roomID)
-	committedPlaintext, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
+	mutate := func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
 		if updated.GetAuthorId() == "" {
 			return "", fmt.Errorf("cannot edit: message body author is empty")
 		}
@@ -1303,7 +1340,16 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 			return string(plaintext), nil
 		}
 		return newBody, nil
-	})
+	}
+	var committedPlaintext string
+	if options.commitAuthorize != nil {
+		validateCommit := func() error {
+			return c.validateMessageEditIdentityAndWindow(actorID, roomID, eventID, options.channelEcho != nil, time.Now())
+		}
+		committedPlaintext, err = c.publishAuthorizedMessageEdit(ctx, actorID, agg, roomID, eventID, options.commitAuthorize, validateCommit, channelEchoRetractionTargetID, mutate)
+	} else {
+		committedPlaintext, err = c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, mutate)
+	}
 	if err != nil {
 		return err
 	}
@@ -1330,14 +1376,34 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 
 	c.logger.Debug("Message edited", "kind", kind, "room_id", roomID, "event_id", eventID, "actor_id", actorID)
 	if options.channelEcho != nil {
-		if err := c.reconcileEditedMessageChannelEcho(ctx, actorID, kind, roomID, eventID, *options.channelEcho); err != nil {
+		// User-facing echo removal is part of the authorized edit batch above,
+		// where the body and edit facts provide independent room and
+		// authorization OCC guards without advancing the authorization lane.
+		if options.commitAuthorize != nil && !*options.channelEcho {
+			return nil
+		}
+		var validateCommit func() error
+		if options.commitAuthorize != nil {
+			validateCommit = func() error {
+				return c.validateMessageEditIdentityAndWindow(actorID, roomID, eventID, true, time.Now())
+			}
+		}
+		if err := c.reconcileEditedMessageChannelEcho(ctx, actorID, kind, roomID, eventID, *options.channelEcho, options.commitAuthorize, validateCommit); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, actorID string, kind RoomKind, roomID, eventID string, enabled bool) error {
+func (c *ChattoCore) reconcileEditedMessageChannelEcho(
+	ctx context.Context,
+	actorID string,
+	kind RoomKind,
+	roomID, eventID string,
+	enabled bool,
+	authorize func(context.Context) error,
+	validateCommit func() error,
+) error {
 	entry, ok := c.roomModel.timelineEntry(eventID)
 	if !ok || entry.Event == nil {
 		return ErrMessageNotFound
@@ -1384,7 +1450,7 @@ func (c *ChattoCore) reconcileEditedMessageChannelEcho(ctx context.Context, acto
 	if err != nil {
 		return fmt.Errorf("decrypt message body for echo: %w", err)
 	}
-	echoID, created, err := c.appendThreadReplyEcho(ctx, actorID, kind, agg, originalEvent, originalPost, current, string(plaintext))
+	echoID, created, err := c.appendThreadReplyEcho(ctx, actorID, kind, agg, originalEvent, originalPost, current, string(plaintext), authorize, validateCommit)
 	if err != nil {
 		return err
 	}
@@ -1465,6 +1531,35 @@ func (c *ChattoCore) publishMessageEdit(
 	roomID, eventID string,
 	mutate messageEditMutation,
 ) (string, error) {
+	return c.publishMessageEditWithAuthorization(ctx, actorID, agg, roomID, eventID, nil, nil, "", mutate)
+}
+
+func (c *ChattoCore) publishAuthorizedMessageEdit(
+	ctx context.Context,
+	actorID string,
+	agg evtstream.Aggregate,
+	roomID, eventID string,
+	authorize func(context.Context) error,
+	validateCommit func() error,
+	channelEchoRetractionTargetID string,
+	mutate messageEditMutation,
+) (string, error) {
+	if authorize == nil || validateCommit == nil {
+		return "", fmt.Errorf("message edit commit authorization is incomplete")
+	}
+	return c.publishMessageEditWithAuthorization(ctx, actorID, agg, roomID, eventID, authorize, validateCommit, channelEchoRetractionTargetID, mutate)
+}
+
+func (c *ChattoCore) publishMessageEditWithAuthorization(
+	ctx context.Context,
+	actorID string,
+	agg evtstream.Aggregate,
+	roomID, eventID string,
+	authorize func(context.Context) error,
+	validateCommit func() error,
+	channelEchoRetractionTargetID string,
+	mutate messageEditMutation,
+) (string, error) {
 	if mutate == nil {
 		return "", fmt.Errorf("message edit mutation is nil")
 	}
@@ -1473,11 +1568,12 @@ func (c *ChattoCore) publishMessageEdit(
 	roomFilter := agg.AllEventsFilter()
 	var lastErr error
 	for attempt := 1; attempt <= maxThreadCreateAppendAttempts; attempt++ {
-		expectedSeq, err := c.EventPublisher.LastSubjectSeq(ctx, roomFilter)
+		guard, err := c.prepareMessageAppendAttempt(ctx, agg, actorID, authorize)
 		if err != nil {
-			return "", fmt.Errorf("read message lifecycle OCC tail: %w", err)
+			return "", err
 		}
-		if expectedSeq > 0 {
+		expectedSeq := guard.roomSeq
+		if authorize == nil && expectedSeq > 0 {
 			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(roomFilter, expectedSeq)); err != nil {
 				return "", err
 			}
@@ -1518,7 +1614,7 @@ func (c *ChattoCore) publishMessageEdit(
 				},
 			},
 		})
-		seqs, err := c.EventPublisher.AppendBatch(ctx, []evtstream.BatchEntry{
+		entries := []evtstream.BatchEntry{
 			{
 				Subject:       bodySubject,
 				Event:         bodyEvent,
@@ -1530,9 +1626,37 @@ func (c *ChattoCore) publishMessageEdit(
 				Subject: editSubject,
 				Event:   event,
 			},
-		})
+		}
+		if channelEchoRetractionTargetID != "" {
+			if echoID, ok := c.roomModel.channelEchoEventID(channelEchoRetractionTargetID); ok {
+				retraction := newEvent(actorID, &corev1.Event{
+					Event: &corev1.Event_MessageRetracted{
+						MessageRetracted: &corev1.MessageRetractedEvent{
+							RoomId:  roomID,
+							EventId: echoID,
+						},
+					},
+				})
+				entries = append(entries, evtstream.BatchEntry{
+					Subject: agg.Subject(evtstream.EventMessageRetracted),
+					Event:   retraction,
+				})
+			}
+		}
+		if validateCommit != nil {
+			if err := validateCommit(); err != nil {
+				return "", err
+			}
+		}
+		if authorize != nil {
+			entries[1].HasOCC = true
+			entries[1].ExpectedSeq = guard.authorizationSeq
+			entries[1].FilterSubject = guard.authorizationFilter
+		}
+		seqs, err := c.EventPublisher.AppendBatch(ctx, entries)
 		if err == nil {
-			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(editSubject, seqs[len(seqs)-1])); err != nil {
+			lastIndex := len(entries) - 1
+			if err := c.roomModel.waitForTimeline(ctx, events.SubjectPosition(entries[lastIndex].Subject, seqs[lastIndex])); err != nil {
 				return "", err
 			}
 			if err := c.waitForMessageBodyAssets(ctx, bodySubject, seqs[0]); err != nil {
@@ -1554,6 +1678,57 @@ func (c *ChattoCore) publishMessageEdit(
 		return "", fmt.Errorf("publish MessageEditedEvent after %d attempts: %w", maxThreadCreateAppendAttempts, lastErr)
 	}
 	return "", fmt.Errorf("publish MessageEditedEvent: retry loop exited unexpectedly")
+}
+
+// authorizeMessageEdit resolves every mutable input to edit authorization at
+// the same room and authorization boundaries used by the committing OCC batch.
+func (c *ChattoCore) authorizeMessageEdit(ctx context.Context, actorID string, kind RoomKind, roomID, eventID string, authorOnly bool) error {
+	room, err := c.GetRoom(ctx, kind, roomID)
+	if err != nil {
+		return err
+	}
+	if room.GetArchived() {
+		return ErrRoomArchived
+	}
+	member, err := c.RoomMembershipExists(ctx, kind, actorID, roomID)
+	if err != nil {
+		return err
+	}
+	if !member {
+		return ErrNotRoomMember
+	}
+	if err := c.validateMessageEditIdentityAndWindow(actorID, roomID, eventID, authorOnly, time.Now()); err != nil {
+		return err
+	}
+	entry, _ := c.roomModel.timelineEntry(eventID)
+	if entry.Event.GetActorId() == actorID {
+		return nil
+	}
+	canManage, err := c.CanManageOthersMessage(ctx, actorID, kind, roomID)
+	if err != nil {
+		return err
+	}
+	if !canManage {
+		return ErrPermissionDenied
+	}
+	return nil
+}
+
+func (c *ChattoCore) validateMessageEditIdentityAndWindow(actorID, roomID, eventID string, authorOnly bool, now time.Time) error {
+	entry, ok := c.roomModel.timelineEntry(eventID)
+	if !ok || entry.Event == nil || entry.Event.GetMessagePosted() == nil || roomIDOfEvent(entry.Event) != roomID {
+		return ErrMessageNotFound
+	}
+	if entry.Event.GetActorId() == actorID {
+		if now.Sub(entry.Event.GetCreatedAt().AsTime()) > MessageEditWindow {
+			return ErrEditWindowExpired
+		}
+		return nil
+	}
+	if authorOnly {
+		return ErrNotMessageAuthor
+	}
+	return nil
 }
 
 func validateLinkPreview(linkPreview *corev1.LinkPreview) error {
@@ -1706,7 +1881,13 @@ func (c *ChattoCore) editEmbeddedBody(
 		return ErrMessageNotFound
 	}
 	agg := evtstream.RoomAggregate(roomID)
-	_, err := c.publishMessageEdit(ctx, actorID, agg, roomID, eventID, func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
+	authorize := func(attemptCtx context.Context) error {
+		return c.authorizeMessageEdit(attemptCtx, actorID, kind, roomID, eventID, true)
+	}
+	validateCommit := func() error {
+		return c.validateMessageEditIdentityAndWindow(actorID, roomID, eventID, true, time.Now())
+	}
+	_, err := c.publishAuthorizedMessageEdit(ctx, actorID, agg, roomID, eventID, authorize, validateCommit, "", func(ctx context.Context, updated *corev1.MessageBody) (string, error) {
 		if updated.GetAuthorId() != actorID {
 			return "", ErrNotMessageAuthor
 		}

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 	"github.com/stretchr/testify/require"
@@ -916,6 +917,89 @@ func TestMessageModel_PostMessageDoesNotAdvanceAuthorizationFence(t *testing.T) 
 	require.Equal(t, before, after, "ordinary message posts must only check the authorization fence")
 }
 
+func TestMessageModel_UpdateMessageDoesNotAdvanceAuthorizationFence(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "edit-fence-user", "Edit Fence User", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-fence-room", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	require.NoError(t, err)
+	message, err := core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID: user.Id,
+		RoomID:  room.Id,
+		Body:    "before edit",
+	})
+	require.NoError(t, err)
+
+	before, err := core.authorizationFenceSeq(ctx)
+	require.NoError(t, err)
+	updatedBody := "after edit"
+	_, _, err = core.Messages().UpdateMessage(ctx, MessageUpdateInput{
+		ActorID: user.Id,
+		RoomID:  room.Id,
+		EventID: message.Event.Id,
+		Body:    &updatedBody,
+	})
+	require.NoError(t, err)
+	after, err := core.authorizationFenceSeq(ctx)
+	require.NoError(t, err)
+	require.Equal(t, before, after, "ordinary message edits must only check the authorization fence")
+}
+
+func TestMessageModel_UpdateMessageEchoChangesDoNotAdvanceAuthorizationFence(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	user, err := core.CreateUser(ctx, SystemActorID, "edit-echo-fence-user", "Edit Echo Fence User", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-echo-fence-room", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id)
+	require.NoError(t, err)
+	root, err := core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID: user.Id,
+		RoomID:  room.Id,
+		Body:    "root",
+	})
+	require.NoError(t, err)
+	reply, err := core.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		Body:              "reply",
+		ThreadRootEventID: root.Event.Id,
+	})
+	require.NoError(t, err)
+
+	before, err := core.authorizationFenceSeq(ctx)
+	require.NoError(t, err)
+	enabled := true
+	_, _, err = core.Messages().UpdateMessage(ctx, MessageUpdateInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		EventID:           reply.Event.Id,
+		AlsoSendToChannel: &enabled,
+	})
+	require.NoError(t, err)
+	afterEnable, err := core.authorizationFenceSeq(ctx)
+	require.NoError(t, err)
+	require.Equal(t, before, afterEnable, "echo creation must only check the authorization fence")
+
+	enabled = false
+	_, _, err = core.Messages().UpdateMessage(ctx, MessageUpdateInput{
+		ActorID:           user.Id,
+		RoomID:            room.Id,
+		EventID:           reply.Event.Id,
+		AlsoSendToChannel: &enabled,
+	})
+	require.NoError(t, err)
+	afterDisable, err := core.authorizationFenceSeq(ctx)
+	require.NoError(t, err)
+	require.Equal(t, before, afterDisable, "echo removal must only check the authorization fence")
+}
+
 func TestMessageModel_PostMessageCommitAuthorizationUsesInferredThread(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
@@ -1173,6 +1257,191 @@ func TestChattoCore_PostMessageCommitAuthorizationRetriesAfterRoomGroupChange(t 
 	threadCreated, _, err := core.EventPublisher.SubjectEvents(ctx, evtstream.RoomAggregate(room.Id).Subject(evtstream.EventThreadCreated))
 	require.NoError(t, err)
 	require.Empty(t, threadCreated, "the rejected reply must not leave a ThreadCreatedEvent")
+}
+
+func TestChattoCore_EditMessageCommitAuthorizationRetriesAfterMemberRemoval(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-remove-race", "Edit Remove Race", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-remove-race", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	checks := 0
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, message.Id, "must not land",
+		withEditMessageCommitAuthorization(func(attemptCtx context.Context) error {
+			if err := core.authorizeMessageEdit(attemptCtx, author.Id, KindChannel, room.Id, message.Id, false); err != nil {
+				return err
+			}
+			checks++
+			if checks != 1 {
+				return nil
+			}
+			removed, err := core.RemoveMember(attemptCtx, SystemActorID, KindChannel, room.Id, author.Id)
+			if err != nil {
+				return err
+			}
+			if !removed {
+				return errors.New("member was not removed")
+			}
+			return nil
+		}),
+	)
+	require.ErrorIs(t, err, ErrNotRoomMember)
+	require.Equal(t, 1, checks, "the retry must fail its built-in authorization before the test hook runs again")
+
+	edits, _, err := core.EventPublisher.SubjectEvents(ctx, evtstream.RoomAggregate(room.Id).Subject(evtstream.EventMessageEdited))
+	require.NoError(t, err)
+	require.Empty(t, edits, "the rejected edit must not leave a MessageEditedEvent")
+}
+
+func TestChattoCore_EditMessageCommitAuthorizationRetriesAfterArchive(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-archive-race", "Edit Archive Race", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-archive-race", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	checks := 0
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, message.Id, "must not land",
+		withEditMessageCommitAuthorization(func(attemptCtx context.Context) error {
+			if err := core.authorizeMessageEdit(attemptCtx, author.Id, KindChannel, room.Id, message.Id, false); err != nil {
+				return err
+			}
+			checks++
+			if checks == 1 {
+				_, err := core.ArchiveRoom(attemptCtx, SystemActorID, KindChannel, room.Id)
+				return err
+			}
+			return nil
+		}),
+	)
+	require.ErrorIs(t, err, ErrRoomArchived)
+	require.Equal(t, 1, checks, "the retry must fail its built-in authorization before the test hook runs again")
+
+	edits, _, err := core.EventPublisher.SubjectEvents(ctx, evtstream.RoomAggregate(room.Id).Subject(evtstream.EventMessageEdited))
+	require.NoError(t, err)
+	require.Empty(t, edits, "the rejected edit must not leave a MessageEditedEvent")
+}
+
+func TestChattoCore_EditMessageCommitAuthorizationRetriesAfterManageRevocation(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-manage-author", "Edit Manage Author", "password123")
+	require.NoError(t, err)
+	manager, err := core.CreateUser(ctx, SystemActorID, "edit-manage-race", "Edit Manage Race", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-manage-race", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, manager.Id, KindChannel, manager.Id, room.Id)
+	require.NoError(t, err)
+	require.NoError(t, core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, manager.Id, PermMessageManage))
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	checks := 0
+	err = core.EditMessage(ctx, manager.Id, KindChannel, room.Id, message.Id, "must not land",
+		withEditMessageCommitAuthorization(func(attemptCtx context.Context) error {
+			if err := core.authorizeMessageEdit(attemptCtx, manager.Id, KindChannel, room.Id, message.Id, false); err != nil {
+				return err
+			}
+			checks++
+			if checks == 1 {
+				return core.DenyUserRoomPermission(attemptCtx, SystemActorID, room.Id, manager.Id, PermMessageManage)
+			}
+			return nil
+		}),
+	)
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	require.Equal(t, 1, checks, "the retry must fail its built-in authorization before the test hook runs again")
+
+	edits, _, err := core.EventPublisher.SubjectEvents(ctx, evtstream.RoomAggregate(room.Id).Subject(evtstream.EventMessageEdited))
+	require.NoError(t, err)
+	require.Empty(t, edits, "the rejected edit must not leave a MessageEditedEvent")
+}
+
+func TestChattoCore_EditMessageChannelEchoRetriesAfterPermissionRevocation(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-echo-race", "Edit Echo Race", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-echo-race", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "root", nil, "", "", nil, false)
+	require.NoError(t, err)
+	reply, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "reply", nil, root.Id, "", nil, false)
+	require.NoError(t, err)
+
+	checks := 0
+	authorize := func(attemptCtx context.Context) error {
+		checks++
+		if err := core.authorizeMessageEdit(attemptCtx, author.Id, KindChannel, room.Id, reply.Id, true); err != nil {
+			return err
+		}
+		canEcho, err := core.CanEchoMessage(attemptCtx, author.Id, KindChannel, room.Id)
+		if err != nil {
+			return err
+		}
+		canPost, err := core.CanPostMessage(attemptCtx, author.Id, KindChannel, room.Id)
+		if err != nil {
+			return err
+		}
+		if !canEcho || !canPost {
+			return ErrPermissionDenied
+		}
+		if checks == 2 {
+			return core.DenyUserRoomPermission(attemptCtx, SystemActorID, room.Id, author.Id, PermMessageEcho)
+		}
+		return nil
+	}
+
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, reply.Id, "edited reply",
+		WithMessageChannelEcho(true),
+		withEditMessageCommitAuthorization(authorize),
+	)
+	require.ErrorIs(t, err, ErrPermissionDenied)
+	require.GreaterOrEqual(t, checks, 3, "authorization should rerun for the echo after the OCC conflict")
+	_, exists := core.roomModel.channelEchoEventID(reply.Id)
+	require.False(t, exists, "the revoked echo must not become visible")
+
+	posted, _, err := core.EventPublisher.SubjectEvents(ctx, evtstream.RoomAggregate(room.Id).Subject(evtstream.EventMessagePosted))
+	require.NoError(t, err)
+	require.Len(t, posted, 2, "the rejected echo must not leave a MessagePostedEvent")
+}
+
+func TestValidateMessageEditIdentityAndWindowUsesCommitTime(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-window-boundary", "Edit Window Boundary", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-window-boundary", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	expiresAt := message.GetCreatedAt().AsTime().Add(MessageEditWindow)
+	require.NoError(t, core.validateMessageEditIdentityAndWindow(author.Id, room.Id, message.Id, false, expiresAt))
+	require.ErrorIs(t, core.validateMessageEditIdentityAndWindow(author.Id, room.Id, message.Id, false, expiresAt.Add(time.Nanosecond)), ErrEditWindowExpired)
 }
 
 func TestChattoCore_PostMessage_InvalidRoom(t *testing.T) {

--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -539,7 +539,6 @@ func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, autho
 		seqs, err := c.appendAuthorizationFencedBatch(ctx, actorID, entries, authorizationSeq)
 		if err == nil {
 			c.logger.Info("Moved room to group", "room_id", roomID, "group_id", targetGroupID, "actor_id", actorID)
-			c.notifyRoomLayoutChanged(ctx, actorID, "move_room")
 
 			// Wait on the final seq — the projector applies in stream order
 			// so reaching the last batch entry's seq implies every earlier
@@ -549,6 +548,7 @@ func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, autho
 			if err := c.roomModel.waitForGroupLayout(ctx, events.SubjectPosition(lastSubject, seqs[lastDomainIndex])); err != nil {
 				return fmt.Errorf("wait for room group layout projection: %w", err)
 			}
+			c.notifyRoomLayoutChanged(ctx, actorID, "move_room")
 			return nil
 		}
 		if !errors.Is(err, events.ErrConflict) {

--- a/cli/internal/core/room_groups_test.go
+++ b/cli/internal/core/room_groups_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"sync"
@@ -379,6 +380,77 @@ func TestMoveRoomToSet_FromSourceRejectsChangedSourceAfterOCCRetry(t *testing.T)
 	}
 	if len(target.RoomIds) != 0 {
 		t.Fatalf("target room IDs = %v, want empty", target.RoomIds)
+	}
+}
+
+func TestMoveRoomToGroupPublishesLayoutUpdateAfterProjectionCatchUp(t *testing.T) {
+	harness := newTestEventHarness(t)
+	ctx := testContext(t)
+
+	groupLayout := NewRoomGroupLayoutProjection()
+	groupLayoutProjector := harness.projector(groupLayout)
+	core := &ChattoCore{
+		nc:             harness.nc,
+		logger:         testCoreLogger(),
+		EventPublisher: harness.publisher,
+	}
+	core.roomModel = newTestRoomModel(t, nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+	waitEntered := make(chan struct{})
+	releaseWait := make(chan struct{})
+	core.roomModel.waitForGroupLayoutOverride = func(waitCtx context.Context, pos events.StreamPosition) error {
+		close(waitEntered)
+		select {
+		case <-releaseWait:
+		case <-waitCtx.Done():
+			return waitCtx.Err()
+		}
+		return waitForPositionAll(waitCtx, pos, waitForProjection("room group layout", groupLayoutProjector))
+	}
+
+	for index, event := range []*corev1.Event{
+		newEvent("actor", groupCreatedEvent("G-source", "Source", "")),
+		newEvent("actor", groupCreatedEvent("G-target", "Target", "")),
+		newEvent("actor", roomAddedToGroupEvent("G-source", "R1")),
+	} {
+		subject := evtstream.GroupAggregate(groupIDOfTestGroupEvent(t, event)).SubjectFor(event)
+		seq, err := harness.publisher.AppendEventually(ctx, subject, event)
+		if err != nil {
+			t.Fatalf("append setup event %d: %v", index, err)
+		}
+		if err := groupLayout.Apply(event, seq); err != nil {
+			t.Fatalf("apply setup event %d: %v", index, err)
+		}
+	}
+
+	updates, cleanup := subscribeRoomGroupsUpdated(t, harness.nc)
+	defer cleanup()
+	drainExisting(updates)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- core.MoveRoomToGroup(ctx, "actor", "R1", "G-target")
+	}()
+	<-waitEntered
+	if err := harness.nc.Flush(); err != nil {
+		t.Fatalf("flush notification subscription: %v", err)
+	}
+
+	select {
+	case msg := <-updates:
+		t.Fatalf("layout update arrived before projection catch-up: %+v", msg)
+	case err := <-errCh:
+		t.Fatalf("MoveRoomToGroup returned before projection catch-up: %v", err)
+	default:
+	}
+
+	startTestProjector(t, groupLayoutProjector)
+	close(releaseWait)
+	if err := <-errCh; err != nil {
+		t.Fatalf("MoveRoomToGroup after projection catch-up: %v", err)
+	}
+	expectRoomGroupsUpdated(t, updates, "actor")
+	if got := core.roomModel.roomGroupForRoom("R1"); got != "G-target" {
+		t.Fatalf("group projection at live delivery = %q, want G-target", got)
 	}
 }
 

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -16,11 +16,12 @@ import (
 // individual projector fields. That keeps the "which projections must catch
 // up?" knowledge with the room read models.
 type RoomModel struct {
-	directory   events.ProjectionHandle[*RoomDirectoryProjection]
-	groupLayout events.ProjectionHandle[*RoomGroupLayoutProjection]
-	timeline    events.ProjectionHandle[*RoomTimelineProjection]
-	threads     events.ProjectionHandle[*ThreadProjection]
-	reactions   events.ProjectionHandle[*ReactionProjection]
+	directory                  events.ProjectionHandle[*RoomDirectoryProjection]
+	groupLayout                events.ProjectionHandle[*RoomGroupLayoutProjection]
+	timeline                   events.ProjectionHandle[*RoomTimelineProjection]
+	threads                    events.ProjectionHandle[*ThreadProjection]
+	reactions                  events.ProjectionHandle[*ReactionProjection]
+	waitForGroupLayoutOverride func(context.Context, events.StreamPosition) error
 }
 
 func newRoomModel(
@@ -44,6 +45,9 @@ func (m *RoomModel) waitForDirectory(ctx context.Context, pos events.StreamPosit
 }
 
 func (m *RoomModel) waitForGroupLayout(ctx context.Context, pos events.StreamPosition) error {
+	if m.waitForGroupLayoutOverride != nil {
+		return m.waitForGroupLayoutOverride(ctx, pos)
+	}
 	return waitForPositionAll(ctx, pos, waitForProjection("room group layout", m.groupLayout.Projector()))
 }
 

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -340,7 +340,7 @@ func (s *HTTPServer) serveRealtimeWebSocket(parent context.Context, conn *websoc
 			return
 		}
 	}
-	reconciliation, err := s.realtimeProjectionReconciliationFrame(catchUpCtx, user.Id)
+	reconciliation, err := s.realtimeProjectionReconciliationFrame(catchUpCtx, user.Id, !replayPlan.Reset)
 	if err != nil {
 		failCatchUp("Realtime latest-value reconciliation failed", err)
 		return

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -114,14 +114,22 @@ func (s *HTTPServer) realtimeProjectionRoomTimelineFrame(ctx context.Context, vi
 // that is not fully represented by an EVT gap: room/thread read markers,
 // pending notifications, and presence. Viewer config is included as a cheap
 // authoritative replacement so all self-only fields converge together.
-func (s *HTTPServer) realtimeProjectionReconciliationFrame(ctx context.Context, userID string) (*realtimev1.RealtimeServerFrame, error) {
+//
+// A compacted reset has already emitted every room with its authoritative
+// viewer state in separately framed snapshot operations. Omitting room states
+// from that reset's reconciliation avoids rebuilding the complete room graph
+// into one duplicate, unbounded follow-up frame.
+func (s *HTTPServer) realtimeProjectionReconciliationFrame(ctx context.Context, userID string, includeRoomStates bool) (*realtimev1.RealtimeServerFrame, error) {
 	viewer, err := s.connectAPI.BuildRealtimeProjectionViewer(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("assemble viewer reconciliation: %w", err)
 	}
-	roomStates, err := s.connectAPI.BuildRealtimeProjectionRoomViewerStates(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("assemble room viewer-state reconciliation: %w", err)
+	roomStates := []*connectapi.RealtimeProjectionRoomViewerState(nil)
+	if includeRoomStates {
+		roomStates, err = s.connectAPI.BuildRealtimeProjectionRoomViewerStates(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("assemble room viewer-state reconciliation: %w", err)
+		}
 	}
 	threadStates, err := s.connectAPI.BuildRealtimeProjectionThreadViewerStates(ctx, userID)
 	if err != nil {

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -768,6 +768,43 @@ func TestRealtimeProjectionSnapshotFramesBeginWithResetAndContainCanonicalResour
 	}
 }
 
+func TestRealtimeProjectionResetReconciliationOmitsRoomViewerStates(t *testing.T) {
+	env := setupWebSocketTestServer(t)
+	viewer, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-reset-reconciliation", "RT Reset Reconciliation", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, viewer.Id, core.KindChannel, "", "rt-reset-reconciliation-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, viewer.Id, core.KindChannel, viewer.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+
+	regular, err := env.httpServer.realtimeProjectionReconciliationFrame(env.ctx, viewer.Id, true)
+	if err != nil {
+		t.Fatalf("regular reconciliation: %v", err)
+	}
+	foundRoomState := false
+	for _, operation := range regular.GetProjectionEvent().GetOperations() {
+		foundRoomState = foundRoomState || operation.GetRoomViewerStateReplace().GetRoomId() == room.Id
+	}
+	if !foundRoomState {
+		t.Fatal("regular reconciliation omitted room viewer state")
+	}
+
+	reset, err := env.httpServer.realtimeProjectionReconciliationFrame(env.ctx, viewer.Id, false)
+	if err != nil {
+		t.Fatalf("reset reconciliation: %v", err)
+	}
+	for _, operation := range reset.GetProjectionEvent().GetOperations() {
+		if operation.GetRoomViewerStateReplace() != nil {
+			t.Fatalf("reset reconciliation repeated room viewer state: %+v", operation)
+		}
+	}
+}
+
 func TestRealtimeProjectionSnapshotFramesKeepTimelinesAndChannelMembershipLazy(t *testing.T) {
 	env := setupWebSocketTestServer(t)
 	viewer, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-lazy-snapshot", "RT Lazy Snapshot", "password123")

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -213,11 +213,14 @@ compacted reset emits frames incrementally and materialises at most 64 retained
 windows (3,200 recent rows), bounding decryption and transient response memory.
 
 Every subscription emits one finite latest-value reconciliation before
-`caught_up`. It replaces the viewer resource; every visible room's read and
-permission state; the complete followed-thread viewer-state set, including
-RUNTIME_STATE unread markers; pending notifications and room counts; and the
-server directory's current presence. Missing followed-thread entries
-authoritatively clear follow/unread state on retained thread roots.
+`caught_up`. It replaces the viewer resource; the complete followed-thread
+viewer-state set, including RUNTIME_STATE unread markers; pending notifications
+and room counts; and the server directory's current presence. Incremental
+subscriptions additionally replace every visible room's read and permission
+state. A compacted reset omits those room replacements from reconciliation
+because its incrementally framed room snapshot already supplied the same
+authoritative viewer state. Missing followed-thread entries authoritatively
+clear follow/unread state on retained thread roots.
 
 Buffered live signals cover mutations concurrent with this reconciliation. Thread
 follow/unfollow and read-marker advances publish the same user-scoped
@@ -273,8 +276,10 @@ echo emits `room_timeline_event_remove`; ordinary deleted messages remain
 renderable tombstone upserts.
 
 RBAC facts are fanned through the shared hub. The mapper responds with a
-reconnecting `projection_reset_required` close so the next subscription starts
-from current authorization.
+reconnecting `projection_reset_required` close. The browser discards the
+rejected cursor and materialized room set while retaining non-plaintext desired
+room IDs, so the next subscription receives a compacted reset and rehydrates
+rooms still wanted by the UI.
 
 ## Process-wide live ingress
 

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -276,10 +276,12 @@ echo emits `room_timeline_event_remove`; ordinary deleted messages remain
 renderable tombstone upserts.
 
 RBAC facts are fanned through the shared hub. The mapper responds with a
-reconnecting `projection_reset_required` close. The browser discards the
-rejected cursor and materialized room set while retaining non-plaintext desired
-room IDs, so the next subscription receives a compacted reset and rehydrates
-rooms still wanted by the UI.
+reconnecting `projection_reset_required` close. On receipt, the browser first
+applies the canonical projection reset locally, immediately purging projected
+state and every registered room, thread, query, permission, notification, and
+search mirror. It then discards the rejected cursor and materialized room set
+while retaining non-plaintext desired room IDs, so the next subscription
+receives a compacted reset and rehydrates rooms still wanted by the UI.
 
 ## Process-wide live ingress
 

--- a/docs/fdr/FDR-004-message-editing-and-deletion.md
+++ b/docs/fdr/FDR-004-message-editing-and-deletion.md
@@ -1,7 +1,7 @@
 # FDR-004: Message Editing & Deletion
 
 **Status:** Active
-**Last reviewed:** 2026-08-06
+**Last reviewed:** 2026-08-10
 
 ## Overview
 
@@ -40,9 +40,9 @@ Authors can edit and delete their own messages; users with `message.manage` can 
 
 ### 3. Optimistic concurrency for edits
 
-**Decision:** Edit and delete mutations use optimistic concurrency over the room's ordered facts. Every server-side edit retry rebuilds from the latest committed body before applying the requested text or metadata change. A concurrent deletion tombstones the message and prevents the edit from committing.
-**Why:** Reusing a body prepared before an OCC conflict could restore an attachment or preview removed by another mutation, while guarding edit and delete facts independently could let a late body resurrect a deleted message. See ADR-016.
-**Tradeoff:** Same-room activity can force internal retries. The public API does not currently expose a client revision token, so concurrent full-text replacements resolve in commit order; the later successful edit supplies the visible text while retaining independently committed metadata changes.
+**Decision:** Edit and delete mutations use optimistic concurrency over the room's ordered facts. Every server-side edit retry rebuilds from the latest committed body before applying the requested text or metadata change. An edit also rechecks membership, room archive state, authorship and the edit window, and `message.manage` authority as part of the commit attempt. A concurrent deletion tombstones the message and prevents the edit from committing.
+**Why:** Reusing a body prepared before an OCC conflict could restore an attachment or preview removed by another mutation, while guarding edit and delete facts independently could let a late body resurrect a deleted message. Commit-time authorization prevents a membership or permission revocation from racing a previously authorized edit. See ADR-016.
+**Tradeoff:** Same-room activity or authorization changes can force internal retries. The public API does not currently expose a client revision token, so concurrent full-text replacements resolve in commit order; the later successful edit supplies the visible text while retaining independently committed metadata changes.
 
 ### 4. Edits don't re-resolve mentions
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -13,7 +13,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-07-19 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-08-08 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
-| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-06 |
+| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-10 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-08-05 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-06-15 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-07-22 |


### PR DESCRIPTION
## Why

PR #1933 explored a general runtime configuration system, but that system was premature. This replacement keeps only three independent correctness and scalability fixes that are valuable without configuration infrastructure.

## What changed

- Publish room-layout invalidation only after the room-group projection has applied a committed move, preventing clients from rebuilding against stale layout state.
- Avoid duplicating every room's viewer state in compacted realtime reset reconciliation; on a required reset, immediately purge authorization-sensitive client mirrors before discarding the rejected cursor and reconnecting while retaining desired room IDs.
- Re-authorize message edits inside each OCC commit attempt against current membership, archive state, authorship/edit-window rules, and `message.manage`; echo creation and removal receive equivalent commit-time protection without advancing the global authorization-write lane.
- Add deterministic projection-ordering, reset/reconnect, authorization-race, edit-window boundary, and authorization-fence regression coverage.
- Update the realtime architecture inventory and message-editing FDR.

## Compatibility

This is a behavioural, non-breaking hardening change. It adds no protobufs, RPCs, frame variants, persisted schema, configuration aggregates, or generated API changes. A new client safely handles the existing `projection_reset_required` close from an older server; the server-side compacted-reset change uses the existing snapshot and reconciliation operations.

## Verification

- `mise test-cli` — passed.
- `mise lint-frontend` — passed with zero errors or warnings.
- `mise test-frontend` — passed all server, client, and Storybook suites.
- Svelte autofixer on both changed Svelte modules — passed with no findings.
- `mise codegen-proto` — passed with no generated drift.
- Independent code review — clean after the review/fix loop and final full-diff audit.
- GitHub CI — the original head passed every required check; the current review-fix head is running the same matrix.

Outstanding: GitHub CI on the current head.
