### PR TITLE
fix(realtime): avoid duplicate viewer state on reset

### DIFF
--- a/cli/internal/connectapi/realtime_projection.go
+++ b/cli/internal/connectapi/realtime_projection.go
@@ -30,6 +30,9 @@ type RealtimeProjectionSnapshot struct {
 	Timelines     []*RealtimeProjectionRoomTimeline
 	Notifications *RealtimeProjectionNotifications
 	ActiveCalls   []*apiv1.ActiveCall
+	// RoomMarkerFence fences room read-marker changes concurrent with
+	// compacted snapshot assembly. It is internal transport metadata.
+	RoomMarkerFence uint64
 }
 
 // RealtimeProjectionServerState is authenticated server state carried by the
@@ -185,6 +188,10 @@ func (a *API) BuildRealtimeProjectionSnapshot(ctx context.Context, userID string
 	if err != nil {
 		return nil, fmt.Errorf("assemble realtime users: %w", err)
 	}
+	roomMarkerFence, err := a.core.ReadState().RoomMarkerFence(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("capture realtime room-marker fence: %w", err)
+	}
 	rooms, err := a.core.RoomDirectoryReads().ListRooms(ctx, userID, core.RoomDirectoryListOptions{
 		IncludeChannels: true,
 		IncludeDMs:      true,
@@ -247,15 +254,16 @@ func (a *API) BuildRealtimeProjectionSnapshot(ctx context.Context, userID string
 	}
 
 	return &RealtimeProjectionSnapshot{
-		Server:        server,
-		ServerState:   serverState,
-		Viewer:        viewer,
-		Users:         users,
-		Rooms:         apiRooms,
-		RoomGroups:    apiGroups,
-		Timelines:     timelines,
-		Notifications: notifications,
-		ActiveCalls:   activeCalls,
+		Server:          server,
+		ServerState:     serverState,
+		Viewer:          viewer,
+		Users:           users,
+		Rooms:           apiRooms,
+		RoomGroups:      apiGroups,
+		Timelines:       timelines,
+		Notifications:   notifications,
+		ActiveCalls:     activeCalls,
+		RoomMarkerFence: roomMarkerFence,
 	}, nil
 }
 

--- a/cli/internal/connectapi/realtime_projection.go
+++ b/cli/internal/connectapi/realtime_projection.go
@@ -65,7 +65,8 @@ type RealtimeProjectionNotifications struct {
 }
 
 // RealtimeProjectionRoomViewerState is one latest-value room read/permission
-// row reconciled on every subscription.
+// row reconciled after incremental replay. Compacted snapshots carry the same
+// state in their exhaustive room upserts.
 type RealtimeProjectionRoomViewerState struct {
 	RoomID      string
 	ViewerState *apiv1.RoomViewerState

--- a/cli/internal/core/read_state_index.go
+++ b/cli/internal/core/read_state_index.go
@@ -3,6 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -14,7 +15,14 @@ import (
 const (
 	roomReadMarkerFilter   = "read.room.>"
 	threadReadMarkerFilter = "read.thread.>"
+	roomMarkerChangeLimit  = 4096
 )
+
+type roomMarkerChange struct {
+	generation uint64
+	userID     string
+	roomID     string
+}
 
 type threadReadMarkerKey struct {
 	roomID            string
@@ -42,13 +50,16 @@ type ReadStateIndex struct {
 	kv     jetstream.KeyValue
 	logger *log.Logger
 
-	mu             sync.RWMutex
-	roomMarkers    map[string]map[string]readStateIndexEntry
-	threadMarkers  map[string]map[threadReadMarkerKey]readStateIndexEntry
-	changed        chan struct{}
-	ready          chan struct{}
-	readyOnce      sync.Once
-	resyncRequests chan chan error
+	mu                   sync.RWMutex
+	roomMarkers          map[string]map[string]readStateIndexEntry
+	threadMarkers        map[string]map[threadReadMarkerKey]readStateIndexEntry
+	roomChangeGeneration uint64
+	roomChangeFloor      uint64
+	roomChanges          []roomMarkerChange
+	changed              chan struct{}
+	ready                chan struct{}
+	readyOnce            sync.Once
+	resyncRequests       chan chan error
 }
 
 // NewReadStateIndex creates an empty index. Run must be started before reads.
@@ -142,8 +153,45 @@ func (i *ReadStateIndex) resetSnapshot() {
 	defer i.mu.Unlock()
 	i.roomMarkers = make(map[string]map[string]readStateIndexEntry)
 	i.threadMarkers = make(map[string]map[threadReadMarkerKey]readStateIndexEntry)
+	i.roomChangeGeneration++
+	i.roomChangeFloor = i.roomChangeGeneration
+	i.roomChanges = nil
 	close(i.changed)
 	i.changed = make(chan struct{})
+}
+
+func (i *ReadStateIndex) roomMarkerFence(ctx context.Context) (uint64, error) {
+	if err := i.WaitReady(ctx); err != nil {
+		return 0, err
+	}
+	i.mu.RLock()
+	generation := i.roomChangeGeneration
+	i.mu.RUnlock()
+	return generation, nil
+}
+
+func (i *ReadStateIndex) roomMarkerIDsChangedAfter(ctx context.Context, userID string, fence uint64) ([]string, error) {
+	if err := i.WaitReady(ctx); err != nil {
+		return nil, err
+	}
+	i.mu.RLock()
+	if fence < i.roomChangeFloor {
+		i.mu.RUnlock()
+		return nil, fmt.Errorf("room marker change fence %d precedes retained generation %d", fence, i.roomChangeFloor)
+	}
+	changed := make(map[string]struct{})
+	for _, change := range i.roomChanges {
+		if change.generation > fence && change.userID == userID {
+			changed[change.roomID] = struct{}{}
+		}
+	}
+	i.mu.RUnlock()
+	roomIDs := make([]string, 0, len(changed))
+	for roomID := range changed {
+		roomIDs = append(roomIDs, roomID)
+	}
+	slices.Sort(roomIDs)
+	return roomIDs, nil
 }
 
 // Resync replaces the watcher and waits for its latest-value snapshot.
@@ -300,6 +348,16 @@ func (i *ReadStateIndex) apply(entry jetstream.KeyValueEntry) {
 			value:    append([]byte(nil), entry.Value()...),
 			revision: revision,
 			deleted:  deleted,
+		}
+		i.roomChangeGeneration++
+		i.roomChanges = append(i.roomChanges, roomMarkerChange{
+			generation: i.roomChangeGeneration,
+			userID:     roomUserID,
+			roomID:     roomID,
+		})
+		if len(i.roomChanges) > roomMarkerChangeLimit {
+			i.roomChangeFloor = i.roomChanges[0].generation
+			i.roomChanges = i.roomChanges[1:]
 		}
 	case isThread:
 		if i.threadMarkers[threadUserID] == nil {

--- a/cli/internal/core/read_state_index_test.go
+++ b/cli/internal/core/read_state_index_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -342,6 +343,41 @@ func TestParseReadMarkerKeys(t *testing.T) {
 	}
 	if _, _, ok := parseThreadReadMarkerKey("read.thread.U123.R456"); ok {
 		t.Fatal("short thread marker key parsed successfully")
+	}
+}
+
+func TestReadStateIndexTracksBoundedRoomMarkerChangesAfterFence(t *testing.T) {
+	index := NewReadStateIndex(nil, nil)
+	index.readyOnce.Do(func() { close(index.ready) })
+	fence, err := index.roomMarkerFence(context.Background())
+	if err != nil {
+		t.Fatalf("roomMarkerFence: %v", err)
+	}
+	for revision, key := range []string{
+		"read.room.U1.R2",
+		"read.room.U2.R3",
+		"read.room.U1.R1",
+		"read.room.U1.R2",
+	} {
+		index.apply(benchmarkKVEntry{key: key, value: []byte("Echanged"), revision: uint64(revision + 1)})
+	}
+	roomIDs, err := index.roomMarkerIDsChangedAfter(context.Background(), "U1", fence)
+	if err != nil {
+		t.Fatalf("roomMarkerIDsChangedAfter: %v", err)
+	}
+	if want := []string{"R1", "R2"}; !slices.Equal(roomIDs, want) {
+		t.Fatalf("changed room IDs = %v, want %v", roomIDs, want)
+	}
+
+	for revision := 0; revision <= roomMarkerChangeLimit; revision++ {
+		index.apply(benchmarkKVEntry{
+			key:      fmt.Sprintf("read.room.U1.overflow-%d", revision),
+			value:    []byte("Eoverflow"),
+			revision: uint64(revision + 100),
+		})
+	}
+	if _, err := index.roomMarkerIDsChangedAfter(context.Background(), "U1", fence); err == nil {
+		t.Fatal("expired room-marker fence was accepted")
 	}
 }
 

--- a/cli/internal/core/read_state_model.go
+++ b/cli/internal/core/read_state_model.go
@@ -51,6 +51,19 @@ func (s *ReadStateModel) Resync(ctx context.Context) error {
 	return s.index.Resync(ctx)
 }
 
+// RoomMarkerFence captures the latest room-marker change generation visible
+// through the process-wide read-state index.
+func (s *ReadStateModel) RoomMarkerFence(ctx context.Context) (uint64, error) {
+	return s.index.roomMarkerFence(ctx)
+}
+
+// RoomMarkerIDsChangedAfter returns one user's room marker keys changed after
+// fence. It supports bounded realtime reset repair without rebuilding every
+// visible room's permissions and read state.
+func (s *ReadStateModel) RoomMarkerIDsChangedAfter(ctx context.Context, userID string, fence uint64) ([]string, error) {
+	return s.index.roomMarkerIDsChangedAfter(ctx, userID, fence)
+}
+
 func (s *ReadStateModel) MarkRoomAsRead(ctx context.Context, actorID, roomID, upToEventID string) (*MarkRoomAsReadResult, error) {
 	room, kind, err := s.core.requireRoomMember(ctx, actorID, roomID)
 	if err != nil {

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -340,7 +340,7 @@ func (s *HTTPServer) serveRealtimeWebSocket(parent context.Context, conn *websoc
 			return
 		}
 	}
-	reconciliation, err := s.realtimeProjectionReconciliationFrame(catchUpCtx, user.Id)
+	reconciliation, err := s.realtimeProjectionReconciliationFrame(catchUpCtx, user.Id, !replayPlan.Reset)
 	if err != nil {
 		failCatchUp("Realtime latest-value reconciliation failed", err)
 		return

--- a/cli/internal/http_server/realtime.go
+++ b/cli/internal/http_server/realtime.go
@@ -313,16 +313,19 @@ func (s *HTTPServer) serveRealtimeWebSocket(parent context.Context, conn *websoc
 
 	hydrateRooms := make(chan string, 16)
 	go s.readRealtimeControlFrames(ctx, cancel, conn, writeFrame, hydrateRooms)
+	var roomMarkerFence *uint64
 	if replayPlan.Reset {
 		retainedRoomIDs := make([]string, 0, len(retainedRooms))
 		for roomID := range retainedRooms {
 			retainedRoomIDs = append(retainedRoomIDs, roomID)
 		}
 		slices.Sort(retainedRoomIDs)
-		if err := s.writeRealtimeProjectionSnapshot(catchUpCtx, user.Id, retainedRoomIDs, writeCatchUpFrame); err != nil {
+		revision, err := s.writeRealtimeProjectionSnapshot(catchUpCtx, user.Id, retainedRoomIDs, writeCatchUpFrame)
+		if err != nil {
 			failCatchUp("Realtime compacted projection replay failed", err)
 			return
 		}
+		roomMarkerFence = &revision
 	}
 	for _, event := range replayPlan.Events {
 		frame, handled, err := s.realtimeProjectionFrameForEventWithRooms(catchUpCtx, user.Id, event, retainedRooms)
@@ -340,7 +343,7 @@ func (s *HTTPServer) serveRealtimeWebSocket(parent context.Context, conn *websoc
 			return
 		}
 	}
-	reconciliation, err := s.realtimeProjectionReconciliationFrame(catchUpCtx, user.Id, !replayPlan.Reset)
+	reconciliation, err := s.realtimeProjectionReconciliationFrame(catchUpCtx, user.Id, roomMarkerFence)
 	if err != nil {
 		failCatchUp("Realtime latest-value reconciliation failed", err)
 		return

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -15,7 +15,7 @@ import (
 
 func (s *HTTPServer) realtimeProjectionSnapshotFrames(ctx context.Context, userID string, timelineRoomIDs []string) ([]*realtimev1.RealtimeServerFrame, error) {
 	frames := make([]*realtimev1.RealtimeServerFrame, 0)
-	err := s.writeRealtimeProjectionSnapshot(ctx, userID, timelineRoomIDs, func(frame *realtimev1.RealtimeServerFrame) error {
+	_, err := s.writeRealtimeProjectionSnapshot(ctx, userID, timelineRoomIDs, func(frame *realtimev1.RealtimeServerFrame) error {
 		frames = append(frames, frame)
 		return nil
 	})
@@ -25,13 +25,13 @@ func (s *HTTPServer) realtimeProjectionSnapshotFrames(ctx context.Context, userI
 // writeRealtimeProjectionSnapshot emits the compacted prefix incrementally so
 // the transport does not retain a second frame graph for every decrypted room
 // timeline while a reset is in flight.
-func (s *HTTPServer) writeRealtimeProjectionSnapshot(ctx context.Context, userID string, timelineRoomIDs []string, writeFrame func(*realtimev1.RealtimeServerFrame) error) error {
+func (s *HTTPServer) writeRealtimeProjectionSnapshot(ctx context.Context, userID string, timelineRoomIDs []string, writeFrame func(*realtimev1.RealtimeServerFrame) error) (uint64, error) {
 	if s.connectAPI == nil {
-		return errors.New("Connect API is unavailable")
+		return 0, errors.New("Connect API is unavailable")
 	}
 	snapshot, err := s.connectAPI.BuildRealtimeProjectionSnapshot(ctx, userID, timelineRoomIDs)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	var writeErr error
@@ -77,7 +77,7 @@ func (s *HTTPServer) writeRealtimeProjectionSnapshot(ctx context.Context, userID
 			RoomTimelineReplace: &realtimev1.RealtimeProjectionRoomTimelineReplace{RoomId: timeline.RoomID, Page: timeline.Page, EventCursors: timeline.EventCursors},
 		}})
 	}
-	return writeErr
+	return snapshot.RoomMarkerFence, writeErr
 }
 
 func realtimeProjectionServerFrame(event *realtimev1.RealtimeProjectionEvent) *realtimev1.RealtimeServerFrame {
@@ -114,18 +114,35 @@ func (s *HTTPServer) realtimeProjectionRoomTimelineFrame(ctx context.Context, vi
 // that is not fully represented by an EVT gap: room/thread read markers,
 // pending notifications, and presence. Viewer config is included as a cheap
 // authoritative replacement so all self-only fields converge together.
-// Room viewer state is needed after incremental replay, but a compacted reset
-// already supplied it exhaustively in the snapshot's room upserts.
-func (s *HTTPServer) realtimeProjectionReconciliationFrame(ctx context.Context, userID string, includeRoomViewerStates bool) (*realtimev1.RealtimeServerFrame, error) {
+// Room viewer state is needed after incremental replay. A compacted reset
+// supplies it in snapshot room upserts and repairs only markers that changed
+// while that snapshot was assembled.
+func (s *HTTPServer) realtimeProjectionReconciliationFrame(ctx context.Context, userID string, roomMarkerFence *uint64) (*realtimev1.RealtimeServerFrame, error) {
 	viewer, err := s.connectAPI.BuildRealtimeProjectionViewer(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("assemble viewer reconciliation: %w", err)
 	}
 	var roomStates []*connectapi.RealtimeProjectionRoomViewerState
-	if includeRoomViewerStates {
+	if roomMarkerFence == nil {
 		roomStates, err = s.connectAPI.BuildRealtimeProjectionRoomViewerStates(ctx, userID)
 		if err != nil {
 			return nil, fmt.Errorf("assemble room viewer-state reconciliation: %w", err)
+		}
+	} else {
+		roomIDs, changedErr := s.core.ReadState().RoomMarkerIDsChangedAfter(ctx, userID, *roomMarkerFence)
+		if changedErr != nil {
+			return nil, fmt.Errorf("identify concurrent room viewer-state changes: %w", changedErr)
+		}
+		roomStates = make([]*connectapi.RealtimeProjectionRoomViewerState, 0, len(roomIDs))
+		for _, roomID := range roomIDs {
+			viewerState, stateErr := s.connectAPI.BuildRealtimeProjectionRoomViewerState(ctx, userID, roomID)
+			if stateErr != nil {
+				if errors.Is(stateErr, core.ErrNotFound) || errors.Is(stateErr, core.ErrPermissionDenied) || errors.Is(stateErr, core.ErrNotRoomMember) {
+					continue
+				}
+				return nil, fmt.Errorf("assemble changed room %q viewer-state reconciliation: %w", roomID, stateErr)
+			}
+			roomStates = append(roomStates, &connectapi.RealtimeProjectionRoomViewerState{RoomID: roomID, ViewerState: viewerState})
 		}
 	}
 	threadStates, err := s.connectAPI.BuildRealtimeProjectionThreadViewerStates(ctx, userID)

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -114,14 +114,19 @@ func (s *HTTPServer) realtimeProjectionRoomTimelineFrame(ctx context.Context, vi
 // that is not fully represented by an EVT gap: room/thread read markers,
 // pending notifications, and presence. Viewer config is included as a cheap
 // authoritative replacement so all self-only fields converge together.
-func (s *HTTPServer) realtimeProjectionReconciliationFrame(ctx context.Context, userID string) (*realtimev1.RealtimeServerFrame, error) {
+// Room viewer state is needed after incremental replay, but a compacted reset
+// already supplied it exhaustively in the snapshot's room upserts.
+func (s *HTTPServer) realtimeProjectionReconciliationFrame(ctx context.Context, userID string, includeRoomViewerStates bool) (*realtimev1.RealtimeServerFrame, error) {
 	viewer, err := s.connectAPI.BuildRealtimeProjectionViewer(ctx, userID)
 	if err != nil {
 		return nil, fmt.Errorf("assemble viewer reconciliation: %w", err)
 	}
-	roomStates, err := s.connectAPI.BuildRealtimeProjectionRoomViewerStates(ctx, userID)
-	if err != nil {
-		return nil, fmt.Errorf("assemble room viewer-state reconciliation: %w", err)
+	var roomStates []*connectapi.RealtimeProjectionRoomViewerState
+	if includeRoomViewerStates {
+		roomStates, err = s.connectAPI.BuildRealtimeProjectionRoomViewerStates(ctx, userID)
+		if err != nil {
+			return nil, fmt.Errorf("assemble room viewer-state reconciliation: %w", err)
+		}
 	}
 	threadStates, err := s.connectAPI.BuildRealtimeProjectionThreadViewerStates(ctx, userID)
 	if err != nil {

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -2371,6 +2371,23 @@ func TestRealtimeWebSocketExpiredCursorFallsBackToCompactedReset(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
+	room, err := env.core.CreateRoom(env.ctx, user.Id, core.KindChannel, "", "rt-expired-resume-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, user.Id, core.KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	message, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, user.Id, "retained reset thread", nil, "", "", nil, false)
+	if err != nil {
+		t.Fatalf("PostMessage: %v", err)
+	}
+	if err := env.core.FollowThread(env.ctx, core.KindChannel, user.Id, room.Id, message.Id); err != nil {
+		t.Fatalf("FollowThread: %v", err)
+	}
+	if _, err := env.core.ReadState().MarkRoomAsRead(env.ctx, user.Id, room.Id, message.Id); err != nil {
+		t.Fatalf("MarkRoomAsRead: %v", err)
+	}
 	token, err := env.core.CreateAuthToken(env.ctx, user.Id)
 	if err != nil {
 		t.Fatalf("CreateAuthToken: %v", err)
@@ -2428,7 +2445,7 @@ func TestRealtimeWebSocketExpiredCursorFallsBackToCompactedReset(t *testing.T) {
 		t.Fatal("did not receive resumed hello")
 	}
 	sendRealtimeClientFrame(t, resumed, &realtimev1.RealtimeClientFrame{Frame: &realtimev1.RealtimeClientFrame_SubscribeEvents{
-		SubscribeEvents: &realtimev1.RealtimeSubscribeEvents{ResumeCursor: &expiredCursor},
+		SubscribeEvents: &realtimev1.RealtimeSubscribeEvents{ResumeCursor: &expiredCursor, RetainedRoomIds: []string{room.Id}},
 	}})
 	subscribed, ok := readRealtimeServerFrame(t, resumed, 5*time.Second)
 	if !ok || subscribed.GetSubscribed() == nil {
@@ -2448,8 +2465,56 @@ func TestRealtimeWebSocketExpiredCursorFallsBackToCompactedReset(t *testing.T) {
 	if firstProjection.GetProjectionEvent().GetResumeCursor() != "" {
 		t.Fatal("expired resume reset exposed a cursor before the replacement snapshot completed")
 	}
-	if caughtUp := readRealtimeCaughtUp(t, resumed); caughtUp.GetCursor() == "" {
-		t.Fatal("expired resume reset did not reach a new caught_up cursor")
+
+	var foundRoom, foundTimeline, foundThreadStates, foundNotifications, foundViewer, foundPresence bool
+	for {
+		frame, ok := readRealtimeServerFrame(t, resumed, 5*time.Second)
+		if !ok {
+			t.Fatal("timed out waiting for expired-resume caught_up")
+		}
+		if caughtUp := frame.GetCaughtUp(); caughtUp != nil {
+			if caughtUp.GetCursor() == "" {
+				t.Fatal("expired resume reset did not reach a new caught_up cursor")
+			}
+			break
+		}
+		projection := frame.GetProjectionEvent()
+		if projection == nil {
+			t.Fatalf("expired-resume frame = %T, want projection_event or caught_up", frame.GetFrame())
+		}
+		var frameHasThreadStates, frameHasNotifications, frameHasViewer bool
+		var framePresences *realtimev1.RealtimeProjectionPresencesReplace
+		for _, operation := range projection.GetOperations() {
+			if replacement := operation.GetRoomViewerStateReplace(); replacement != nil {
+				t.Fatalf("compacted reset repeated room viewer state for %q", replacement.GetRoomId())
+			}
+			if upsert := operation.GetRoomUpsert(); upsert.GetRoom().GetRoom().GetId() == room.Id {
+				viewerState := upsert.GetRoom().GetViewerState()
+				foundRoom = viewerState.GetIsMember() && !viewerState.GetHasUnread() && len(viewerState.GetPermissions()) > 0 && slices.Contains(upsert.GetMemberUserIds(), user.Id)
+			}
+			if timeline := operation.GetRoomTimelineReplace(); timeline.GetRoomId() == room.Id {
+				foundTimeline = timeline.GetEventCursors()[message.Id] != ""
+			}
+			if threads := operation.GetThreadViewerStatesReplace(); threads != nil {
+				for _, state := range threads.GetStates() {
+					frameHasThreadStates = frameHasThreadStates || state.GetRoomId() == room.Id && state.GetThreadRootEventId() == message.Id && state.GetViewerState().GetIsFollowing()
+				}
+			}
+			frameHasNotifications = frameHasNotifications || operation.GetNotificationsReplace() != nil
+			frameHasViewer = frameHasViewer || operation.GetViewerUpsert() != nil
+			if presences := operation.GetPresencesReplace(); presences != nil {
+				framePresences = presences
+			}
+		}
+		if framePresences != nil {
+			_, foundPresence = framePresences.GetStatuses()[user.Id]
+			foundThreadStates = frameHasThreadStates
+			foundNotifications = frameHasNotifications
+			foundViewer = frameHasViewer
+		}
+	}
+	if !foundRoom || !foundTimeline || !foundThreadStates || !foundNotifications || !foundViewer || !foundPresence {
+		t.Fatalf("compacted reset coverage: room=%v timeline=%v thread_states=%v notifications=%v viewer=%v presence=%v", foundRoom, foundTimeline, foundThreadStates, foundNotifications, foundViewer, foundPresence)
 	}
 }
 

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -801,6 +801,60 @@ func TestRealtimeProjectionSnapshotFramesKeepTimelinesAndChannelMembershipLazy(t
 	}
 }
 
+func TestRealtimeProjectionCompactedReconciliationRepairsOnlyRoomMarkersChangedDuringSnapshot(t *testing.T) {
+	env := setupWebSocketTestServer(t)
+	viewer, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-reset-marker-fence", "RT Reset Marker Fence", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	author, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-reset-marker-author", "RT Reset Marker Author", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser author: %v", err)
+	}
+	rooms := make([]*corev1.Room, 0, 2)
+	messages := make([]*corev1.Event, 0, 2)
+	for i := range 2 {
+		room, err := env.core.CreateRoom(env.ctx, viewer.Id, core.KindChannel, "", fmt.Sprintf("rt-reset-marker-fence-%d", i), "")
+		if err != nil {
+			t.Fatalf("CreateRoom %d: %v", i, err)
+		}
+		if _, err := env.core.JoinRoom(env.ctx, viewer.Id, core.KindChannel, viewer.Id, room.Id); err != nil {
+			t.Fatalf("JoinRoom %d: %v", i, err)
+		}
+		if _, err := env.core.JoinRoom(env.ctx, viewer.Id, core.KindChannel, author.Id, room.Id); err != nil {
+			t.Fatalf("JoinRoom author %d: %v", i, err)
+		}
+		message, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, author.Id, fmt.Sprintf("marker fence %d", i), nil, "", "", nil, false)
+		if err != nil {
+			t.Fatalf("PostMessage %d: %v", i, err)
+		}
+		rooms = append(rooms, room)
+		messages = append(messages, message)
+	}
+
+	snapshot, err := env.httpServer.connectAPI.BuildRealtimeProjectionSnapshot(env.ctx, viewer.Id, nil)
+	if err != nil {
+		t.Fatalf("BuildRealtimeProjectionSnapshot: %v", err)
+	}
+	if _, err := env.core.ReadState().MarkRoomAsRead(env.ctx, viewer.Id, rooms[0].Id, messages[0].Id); err != nil {
+		t.Fatalf("MarkRoomAsRead: %v", err)
+	}
+
+	frame, err := env.httpServer.realtimeProjectionReconciliationFrame(env.ctx, viewer.Id, &snapshot.RoomMarkerFence)
+	if err != nil {
+		t.Fatalf("realtimeProjectionReconciliationFrame: %v", err)
+	}
+	var replacements []*realtimev1.RealtimeProjectionRoomViewerStateReplace
+	for _, operation := range frame.GetProjectionEvent().GetOperations() {
+		if replacement := operation.GetRoomViewerStateReplace(); replacement != nil {
+			replacements = append(replacements, replacement)
+		}
+	}
+	if len(replacements) != 1 || replacements[0].GetRoomId() != rooms[0].Id || replacements[0].GetViewerState().GetHasUnread() {
+		t.Fatalf("changed room replacements = %+v, want only current state for %q", replacements, rooms[0].Id)
+	}
+}
+
 func TestRealtimeRetainedRoomSetIsBoundedAndValidated(t *testing.T) {
 	rooms, err := realtimeRetainedRoomSet([]string{"R1", "R1", " R2 "})
 	if err != nil {

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -213,11 +213,22 @@ compacted reset emits frames incrementally and materialises at most 64 retained
 windows (3,200 recent rows), bounding decryption and transient response memory.
 
 Every subscription emits one finite latest-value reconciliation before
-`caught_up`. It replaces the viewer resource; every visible room's read and
-permission state; the complete followed-thread viewer-state set, including
-RUNTIME_STATE unread markers; pending notifications and room counts; and the
-server directory's current presence. Missing followed-thread entries
-authoritatively clear follow/unread state on retained thread roots.
+`caught_up`. It replaces the viewer resource; the complete followed-thread
+viewer-state set, including RUNTIME_STATE unread markers; pending notifications
+and room counts; and the server directory's current presence. Missing
+followed-thread entries authoritatively clear follow/unread state on retained
+thread roots.
+
+For incremental replay, reconciliation also replaces every visible room's
+latest read and permission state because an EVT gap cannot reconstruct
+RUNTIME_STATE read markers. A compacted reset instead owns those rows in its
+incremental `room_upsert` snapshot frames, so its reconciliation neither
+rebuilds nor repeats the complete room viewer-state collection. The bounded
+snapshot phase owns server and directory resources, room summaries, membership,
+permissions, room read state, room groups, active calls, and retained timelines.
+It also seeds viewer data and notifications. Reconciliation authoritatively
+refreshes viewer data, followed-thread/read state, notifications and counts, and
+presence after either replay-plan branch.
 
 Buffered live signals cover mutations concurrent with this reconciliation. Thread
 follow/unfollow and read-marker advances publish the same user-scoped

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -228,7 +228,11 @@ snapshot phase owns server and directory resources, room summaries, membership,
 permissions, room read state, room groups, active calls, and retained timelines.
 It also seeds viewer data and notifications. Reconciliation authoritatively
 refreshes viewer data, followed-thread/read state, notifications and counts, and
-presence after either replay-plan branch.
+presence after either replay-plan branch. A reset captures the read-state
+index's bounded room-change fence before snapshot assembly and reconciles only
+room markers changed after that fence. This delta repairs concurrent or lost
+best-effort room-read invalidations with work proportional to concurrent
+changes; catch-up retries if the bounded change history is exceeded.
 
 Buffered live signals cover mutations concurrent with this reconciliation. Thread
 follow/unfollow and read-marker advances publish the same user-scoped


### PR DESCRIPTION
## Why

A compacted realtime reset already sends authoritative room snapshots in
incremental frames, but the final latest-value reconciliation rebuilt and sent
every visible room's viewer state a second time. That duplicated CPU, memory,
and encoded output in proportion to the viewer's complete visible-room graph.

Simply removing the second pass would leave a race: room read markers can
change while the snapshot is assembled, and their live invalidation is
best-effort. The reset must repair those concurrent changes without returning
to a full-room reconciliation.

Closes #1957.

## What changed

- Keep the complete room viewer-state replacement for incremental replay.
- Let compacted reset room snapshots own their authoritative membership,
  permission, and read state.
- Capture a process-wide read-marker change fence before snapshot room
  assembly and reconcile only room IDs changed after that fence.
- Retain at most 4,096 room-marker changes; if a catch-up fence is overrun or
  invalidated by index resync, fail catch-up safely so the client retries.
- Continue reconciling viewer data, followed-thread/read state,
  notifications/counts, and presence for both replay-plan branches.
- Document phase ownership in the realtime architecture inventory.

## Compatibility and operations

- Classification: behavioural, wire-compatible realtime optimization.
- No protobuf, frame, cursor, capability, or protocol-version changes.
- Older clients against the newer server continue to apply the existing
  reset/snapshot/reconciliation sequence and converge normally.
- Newer clients require no new behavior and remain compatible with older
  servers, which may still send the redundant room viewer-state replacements.
- No migration, rollout coordination, generated artifacts, or release-note
  guidance is required.
- Change-history overflow fails closed as a reconnectable catch-up failure
  rather than publishing stale state or performing unbounded work.

## Test plan

- `mise test-cli` — passed.
- Focused realtime WebSocket tests for compacted reset and incremental replay —
  passed.
- Focused room-marker fence, delta, and overflow tests — passed.
- `git diff --check` — passed.
- Two adversarial review passes completed; the second reported no findings.
