### PR TITLE
fix(api): omit deleted users from room member reads

### DIFF
--- a/cli/internal/core/room_member_read_authorization_test.go
+++ b/cli/internal/core/room_member_read_authorization_test.go
@@ -65,6 +65,49 @@ func TestRoomMemberReadOperationsRequireMembership(t *testing.T) {
 	}
 }
 
+func TestListRoomMemberReferencesOmitsDeletedUsers(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	viewer, err := core.CreateUser(ctx, SystemActorID, "room-read-viewer", "Room Read Viewer", "password")
+	if err != nil {
+		t.Fatalf("CreateUser viewer: %v", err)
+	}
+	deleted, err := core.CreateUser(ctx, SystemActorID, "room-read-deleted", "Room Read Deleted", "password")
+	if err != nil {
+		t.Fatalf("CreateUser deleted: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "room-read-deleted-user", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	for _, userID := range []string{viewer.Id, deleted.Id} {
+		if _, err := core.JoinRoom(ctx, userID, KindChannel, userID, room.Id); err != nil {
+			t.Fatalf("JoinRoom %s: %v", userID, err)
+		}
+	}
+
+	// Publish only the user tombstone to reproduce the convergence window before
+	// account-deletion cleanup publishes the room membership leave event.
+	deletedEvent := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_UserAccountDeleted{
+		UserAccountDeleted: &corev1.UserAccountDeletedEvent{UserId: deleted.Id},
+	}})
+	if _, err := core.appendUserEvent(ctx, deleted.Id, deletedEvent, "", nil); err != nil {
+		t.Fatalf("append delete event: %v", err)
+	}
+	if !core.RoomMembership.IsMember(room.Id, deleted.Id) {
+		t.Fatal("raw room membership should remain available for account-deletion cleanup")
+	}
+
+	members, err := core.ListRoomMemberReferences(ctx, viewer.Id, room.Id)
+	if err != nil {
+		t.Fatalf("ListRoomMemberReferences: %v", err)
+	}
+	if len(members) != 1 || members[0].GetId() != viewer.Id {
+		t.Fatalf("room member references = %+v, want only active viewer %s", members, viewer.Id)
+	}
+}
+
 func userRefsContain(users []*corev1.User, userID string) bool {
 	for _, user := range users {
 		if user.GetId() == userID {

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -705,13 +705,14 @@ func (c *ChattoCore) ListRoomMemberReferences(ctx context.Context, actorID, room
 		userIDs[i] = membership.GetUserId()
 	}
 	users := make([]*corev1.User, 0, len(memberships))
-	for i, user := range c.Users.GetReferences(userIDs) {
-		if user == nil {
-			user = DeletedUserReference(userIDs[i])
+	for _, user := range c.Users.GetReferences(userIDs) {
+		// User deletion and room-membership cleanup are separate event-sourced
+		// transitions. Omit deleted or unknown references while those projections
+		// converge, and for legacy histories that retain orphan memberships.
+		if user == nil || user.GetDeleted() {
+			continue
 		}
-		if user != nil {
-			users = append(users, user)
-		}
+		users = append(users, user)
 	}
 	return users, nil
 }


### PR DESCRIPTION
## Summary

Omit deleted and unknown user references from room member read responses while preserving raw membership facts for account-deletion cleanup.
The bug occurred because stale membership IDs were converted into deleted-user tombstones and exposed as renderable members.
This keeps `ListMembers`, `GetMember`, and `BatchGetMembers` consistent and hides legacy orphan memberships without changing persisted events or public API shapes.

## Tests

- `mise x -- go test ./internal/core -run 'Test(RoomMemberReadOperationsRequireMembership|ListRoomMemberReferencesOmitsDeletedUsers|ChattoCore_DeleteUser_RoomMembershipIntegrity|ChattoCore_ResolveMentions|ChattoCore_ResolveRoomMentions|DMRoomParticipants)$' -count=1 -timeout 60s`
- `mise x -- go test ./internal/connectapi -run 'Test(RoomServiceListMembersRequiresMembership|MemberDirectoryPaginationDefaultsAndClamps)$' -count=1 -timeout 60s`