### PR TITLE
fix(api): omit deleted users from room member reads

### DIFF
--- a/cli/internal/core/room_member_read_authorization_test.go
+++ b/cli/internal/core/room_member_read_authorization_test.go
@@ -143,6 +143,65 @@ func TestRoomMemberReadOperationsRequireMembership(t *testing.T) {
 	}
 }
 
+func TestRoomMemberReferenceReadsOmitDeletedUsers(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	viewer, err := core.CreateUser(ctx, SystemActorID, "room-read-viewer", "Room Read Viewer", "password")
+	if err != nil {
+		t.Fatalf("CreateUser viewer: %v", err)
+	}
+	deleted, err := core.CreateUser(ctx, SystemActorID, "room-read-deleted", "Room Read Deleted", "password")
+	if err != nil {
+		t.Fatalf("CreateUser deleted: %v", err)
+	}
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "room-read-deleted-user", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	for _, userID := range []string{viewer.Id, deleted.Id} {
+		if _, err := core.JoinRoom(ctx, userID, KindChannel, userID, room.Id); err != nil {
+			t.Fatalf("JoinRoom %s: %v", userID, err)
+		}
+	}
+
+	// Publish only the user tombstone to reproduce the convergence window before
+	// account-deletion cleanup publishes the room membership leave event.
+	deletedEvent := newEvent(SystemActorID, &corev1.Event{Event: &corev1.Event_UserAccountDeleted{
+		UserAccountDeleted: &corev1.UserAccountDeletedEvent{UserId: deleted.Id},
+	}})
+	if _, err := core.appendUserEvent(ctx, deleted.Id, deletedEvent, "", nil); err != nil {
+		t.Fatalf("append delete event: %v", err)
+	}
+	if !core.roomModel.hasExplicitRoomMembership(room.Id, deleted.Id) {
+		t.Fatal("raw room membership should remain available for account-deletion cleanup")
+	}
+
+	reads := []struct {
+		name string
+		read func() ([]*corev1.User, error)
+	}{
+		{"member", func() ([]*corev1.User, error) {
+			return core.ListRoomMemberReferences(ctx, viewer.Id, room.Id)
+		}},
+		{"list", func() ([]*corev1.User, error) {
+			return core.ListRoomMemberReferencesForList(ctx, viewer.Id, room.Id)
+		}},
+		{"lookup", func() ([]*corev1.User, error) {
+			return core.ListRoomMemberReferencesForLookup(ctx, viewer.Id, room.Id)
+		}},
+	}
+	for _, tc := range reads {
+		members, err := tc.read()
+		if err != nil {
+			t.Fatalf("%s room member references: %v", tc.name, err)
+		}
+		if len(members) != 1 || members[0].GetId() != viewer.Id {
+			t.Fatalf("%s room member references = %+v, want only active viewer %s", tc.name, members, viewer.Id)
+		}
+	}
+}
+
 func userRefsContain(users []*corev1.User, userID string) bool {
 	for _, user := range users {
 		if user.GetId() == userID {

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -765,13 +765,14 @@ func (c *ChattoCore) roomMemberReferences(ctx context.Context, kind RoomKind, ro
 	if err != nil {
 		return nil, err
 	}
-	for i, user := range references {
-		if user == nil {
-			user = DeletedUserReference(userIDs[i])
+	for _, user := range references {
+		// User deletion and room-membership cleanup are separate event-sourced
+		// transitions. Omit deleted or unknown references while those projections
+		// converge, and for legacy histories that retain orphan memberships.
+		if user == nil || user.GetDeleted() {
+			continue
 		}
-		if user != nil {
-			users = append(users, user)
-		}
+		users = append(users, user)
 	}
 	return users, nil
 }


### PR DESCRIPTION
## Summary

Port #1963's fix to main's refactored room-member read path.
Deleted and unknown user references were converted into renderable deleted-user tombstones, causing stale memberships to appear in room member lists.
The shared member/list/lookup helper now omits those references while preserving raw membership facts for account-deletion cleanup.

## Tests

- `mise x -- go test ./internal/core -run 'Test(RoomMemberReadOperationsRequireMembership|RoomMemberReferenceReadsOmitDeletedUsers|ChattoCore_DeleteUser_RoomMembershipIntegrity|ChattoCore_ResolveMentions|ChattoCore_ResolveRoomMentions|DMRoomParticipants)$' -count=1 -timeout 60s`
- `mise x -- go test ./internal/connectapi -run 'Test(RoomServiceListMembersRequiresMembership|MemberDirectoryPaginationDefaultsAndClamps)$' -count=1 -timeout 60s`