### PR TITLE
fix(core): publish room layout after projection catch-up

### DIFF
--- a/cli/internal/core/room_groups.go
+++ b/cli/internal/core/room_groups.go
@@ -538,17 +538,18 @@ func (c *ChattoCore) moveRoomToGroup(ctx context.Context, actorID, roomID, autho
 
 		seqs, err := c.appendAuthorizationFencedBatch(ctx, actorID, entries, authorizationSeq)
 		if err == nil {
-			c.logger.Info("Moved room to group", "room_id", roomID, "group_id", targetGroupID, "actor_id", actorID)
-			c.notifyRoomLayoutChanged(ctx, actorID, "move_room")
-
 			// Wait on the final seq — the projector applies in stream order
 			// so reaching the last batch entry's seq implies every earlier
-			// entry's Apply has also landed.
+			// entry's Apply has also landed. Publish the transient invalidation
+			// only after the local read model can serve the committed move.
 			lastDomainIndex := len(entries) - 1
 			lastSubject := entries[lastDomainIndex].Subject
 			if err := c.roomModel.waitForGroupLayout(ctx, events.SubjectPosition(lastSubject, seqs[lastDomainIndex])); err != nil {
 				return fmt.Errorf("wait for room group layout projection: %w", err)
 			}
+
+			c.logger.Info("Moved room to group", "room_id", roomID, "group_id", targetGroupID, "actor_id", actorID)
+			c.notifyRoomLayoutChanged(ctx, actorID, "move_room")
 			return nil
 		}
 		if !errors.Is(err, events.ErrConflict) {

--- a/cli/internal/core/room_groups_live_events_test.go
+++ b/cli/internal/core/room_groups_live_events_test.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"hmans.de/chatto/internal/core/subjects"
+	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
 
@@ -188,6 +189,132 @@ func TestRoomLayout_LiveEventOnMoveRoomToGroup(t *testing.T) {
 	_ = nc.Flush()
 
 	expectRoomGroupsUpdated(t, ch, "actor")
+}
+
+func TestRoomLayout_MoveNotificationWaitsForProjectionCatchUp(t *testing.T) {
+	harness := newTestEventHarness(t)
+	ctx := testContext(t)
+
+	groupLayout := NewRoomGroupLayoutProjection()
+	groupLayoutProjector := harness.projector(groupLayout)
+	core := &ChattoCore{
+		nc:             harness.nc,
+		logger:         testCoreLogger(),
+		EventPublisher: harness.publisher,
+	}
+	core.roomModel = newTestRoomModel(t, nil, nil, groupLayout, groupLayoutProjector, nil, nil, nil, nil, nil, nil)
+
+	setupEvents := []*corev1.Event{
+		newEvent("actor", groupCreatedEvent("G-source", "Source", "")),
+		newEvent("actor", groupCreatedEvent("G-target", "Target", "")),
+		newEvent("actor", roomAddedToGroupEvent("G-source", "R1")),
+	}
+	for i, event := range setupEvents {
+		subject := evtstream.GroupAggregate(groupIDOfTestGroupEvent(t, event)).SubjectFor(event)
+		seq, err := harness.publisher.AppendEventually(ctx, subject, event)
+		if err != nil {
+			t.Fatalf("append setup event %d: %v", i, err)
+		}
+		if err := groupLayout.Apply(event, seq); err != nil {
+			t.Fatalf("project setup event %d: %v", i, err)
+		}
+	}
+
+	type notificationObservation struct {
+		msg     *nats.Msg
+		groupID string
+	}
+	observations := make(chan notificationObservation, 4)
+	subject := subjects.LiveSyncConfigEvent("room_groups_updated")
+	sub, err := harness.nc.Subscribe(subject, func(msg *nats.Msg) {
+		observations <- notificationObservation{
+			msg:     msg,
+			groupID: core.roomModel.roomGroupForRoom("R1"),
+		}
+	})
+	if err != nil {
+		t.Fatalf("Subscribe(%s): %v", subject, err)
+	}
+	t.Cleanup(func() { _ = sub.Unsubscribe() })
+	if err := harness.nc.Flush(); err != nil {
+		t.Fatalf("flush subscription: %v", err)
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- core.MoveRoomToGroup(ctx, "actor", "R1", "G-target")
+	}()
+
+	addedSubject := evtstream.GroupAggregate("G-target").Subject(evtstream.EventRoomAddedToGroup)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		addedEvents, _, err := core.EventPublisher.SubjectEvents(ctx, addedSubject)
+		if err != nil {
+			t.Fatalf("read target room-added events: %v", err)
+		}
+		if len(addedEvents) == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for move batch to commit")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if err := harness.nc.Flush(); err != nil {
+		t.Fatalf("flush while projection is stopped: %v", err)
+	}
+
+	select {
+	case observation := <-observations:
+		t.Fatalf("received room-layout invalidation before projection catch-up (projected group %q)", observation.groupID)
+	case <-time.After(25 * time.Millisecond):
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("MoveRoomToGroup returned before projection catch-up: %v", err)
+	default:
+	}
+	if got := core.roomModel.roomGroupForRoom("R1"); got != "G-source" {
+		t.Fatalf("projected room group before catch-up = %q, want G-source", got)
+	}
+
+	startTestProjector(t, groupLayoutProjector)
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("MoveRoomToGroup after projection catch-up: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for MoveRoomToGroup after projection catch-up")
+	}
+	if err := harness.nc.Flush(); err != nil {
+		t.Fatalf("flush notification: %v", err)
+	}
+
+	select {
+	case observation := <-observations:
+		var event corev1.LiveEvent
+		if err := proto.Unmarshal(observation.msg.Data, &event); err != nil {
+			t.Fatalf("unmarshal published event: %v", err)
+		}
+		if event.GetRoomGroupsUpdated() == nil {
+			t.Fatalf("expected RoomGroupsUpdatedEvent, got %T", event.Event)
+		}
+		if event.GetActorId() != "actor" {
+			t.Errorf("ActorId = %q, want actor", event.GetActorId())
+		}
+		if observation.groupID != "G-target" {
+			t.Errorf("projected room group when notification arrived = %q, want G-target", observation.groupID)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for RoomGroupsUpdatedEvent")
+	}
+
+	select {
+	case <-observations:
+		t.Fatal("received more than one room-layout invalidation")
+	case <-time.After(25 * time.Millisecond):
+	}
 }
 
 func TestRoomLayout_LiveEventOnCreateRoom(t *testing.T) {

--- a/docs/architecture/subjects-and-events.md
+++ b/docs/architecture/subjects-and-events.md
@@ -352,6 +352,12 @@ Patterns: `live.sync.>` for transient `LiveEvent` pubsub and `live.evt.>` for ra
 | `live.sync.member.deleted`                                | Server-level membership invalidation after account deletion |
 | `live.sync.room.{kind}.{roomId}.user_typing`             | User typing in a room        |
 
+Cross-group room and sidebar-link moves publish
+`live.sync.config.room_groups_updated` only after the local
+`RoomGroupLayoutProjection` has applied the final domain fact in the committed
+atomic batch. The command path owns this barrier and the best-effort
+invalidation; projection replay does not publish transient signals.
+
 Voice call lifecycle and participant transitions are durable room EVT facts:
 `evt.room.{roomId}.call_started`, `evt.room.{roomId}.call_joined`,
 `evt.room.{roomId}.call_left`, and `evt.room.{roomId}.call_ended`. JetStream


### PR DESCRIPTION
## Why

`MoveRoomToGroup` could publish its transient room-layout invalidation while the
local `RoomGroupLayoutProjection` still served the old group. A local consumer
could react immediately and rebuild from stale projected state even though the
durable move had committed successfully.

## What changed

- wait through the final domain event in the committed atomic move batch before publishing `room_groups_updated` or returning
- retain the existing durable events, aggregate ownership, authorization fence, and group-subject OCC behavior
- cover the ordering contract with a stopped-projector integration test that observes notification timing, mutation completion, exact notification count, and projected state at delivery
- document that this best-effort invalidation is command-owned and never emitted by projection replay

## Test plan

- `mise x -- go test ./internal/core -run 'TestRoomLayout_(MoveNotificationWaitsForProjectionCatchUp|LiveEventOnMoveRoomToGroup)$' -count=20 -timeout 30s`
- `mise x -- go test -race ./internal/core -run '^TestRoomLayout_MoveNotificationWaitsForProjectionCatchUp$' -count=1 -timeout 30s`
- `mise test-cli`

All checks passed locally and in GitHub CI.

## Compatibility and operations

No protobuf, public API, persisted-event, subject, authorization, OCC, migration,
or rollout changes. A successful room move can now wait slightly longer for the
local projection before returning and notifying clients.

Closes #1958.
