### PR TITLE
feat(events): add durable pull-worker execution

### DIFF
--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -60,6 +60,7 @@ type ChattoCore struct {
 	projectionSnapshotWorker *projectionSnapshotWorker
 	natsRecoveryState        atomic.Int32
 	natsRecoveryStartedAt    atomic.Int64
+	natsRecoveredReconnects  atomic.Uint64
 
 	// VideoMaxUploadSize is the maximum size for video uploads in bytes.
 	// When set (> 0), video attachments use this limit instead of the asset limit.
@@ -179,6 +180,7 @@ func (c *ChattoCore) Run(ctx context.Context) error {
 			return fmt.Errorf("ensure channel rooms in a group: %w", err)
 		}
 		if c.nc.IsConnected() {
+			c.natsRecoveredReconnects.Store(c.nc.Stats().Reconnects)
 			c.natsRecoveryState.CompareAndSwap(natsRecoveryStarting, natsRecoveryReady)
 		}
 		close(c.bootDone)
@@ -311,6 +313,9 @@ func (c *ChattoCore) Ready(ctx context.Context) error {
 	}
 	if c.natsRecoveryState.Load() != natsRecoveryReady {
 		return fmt.Errorf("NATS recovery is not complete")
+	}
+	if c.natsRecoveredReconnects.Load() != c.nc.Stats().Reconnects {
+		return fmt.Errorf("NATS reconnect has not been recovered")
 	}
 	if _, err := c.storage.runtimeStateKV.Status(ctx); err != nil {
 		return fmt.Errorf("RUNTIME_STATE not ready: %w", err)

--- a/cli/internal/core/nats_recovery.go
+++ b/cli/internal/core/nats_recovery.go
@@ -127,6 +127,15 @@ func (c *ChattoCore) runNATSRecovery(ctx context.Context, statuses <-chan nats.S
 				if !continuityLost || recoveryCancel != nil {
 					suspend()
 				}
+			case c.natsRecoveredReconnects.Load() != c.nc.Stats().Reconnects:
+				// Status callbacks are advisory and may be coalesced during a
+				// fast local restart. The reconnect counter is monotonic, so it
+				// also fences readiness when the transition notifications race.
+				if !continuityLost {
+					c.logger.Warn("NATS reconnect detected; suspending readiness and realtime delivery")
+					suspend()
+				}
+				startRecovery()
 			case continuityLost:
 				startRecovery()
 			}

--- a/cli/internal/core/nats_recovery.go
+++ b/cli/internal/core/nats_recovery.go
@@ -114,6 +114,7 @@ func (c *ChattoCore) runNATSRecovery(ctx context.Context, statuses <-chan nats.S
 			if c.myEventsModel != nil && c.myEventsModel.hub != nil {
 				c.myEventsModel.hub.beginGeneration()
 			}
+			c.natsRecoveredReconnects.Store(c.nc.Stats().Reconnects)
 			c.natsRecoveryState.Store(natsRecoveryReady)
 			c.natsRecoveryStartedAt.Store(0)
 			continuityLost = false

--- a/cli/internal/video/unit.go
+++ b/cli/internal/video/unit.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -15,6 +14,7 @@ import (
 	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/runtimeunit"
+	"hmans.de/chatto/pkg/events"
 )
 
 const (
@@ -80,8 +80,28 @@ func (Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 
 	workerCtx, stopWorker := context.WithCancel(ctx)
 	workerDone := make(chan error, 1)
+	worker, err := events.NewDurableWorker(
+		consumer,
+		func(ctx context.Context, delivery events.DurableDelivery) error {
+			return processDelivery(ctx, delivery, runtime, processor, env.Logger)
+		},
+		events.DurableWorkerOptions{
+			MaxConcurrent:     env.Config.AssetProcessing.MaxConcurrentJobsOrDefault(),
+			FetchMaxWait:      time.Second,
+			RetryDelay:        retryDelay,
+			AckTimeout:        acknowledgeTimeout,
+			HeartbeatInterval: deliveryHeartbeat,
+			Logger:            env.Logger,
+		},
+	)
+	if err != nil {
+		stopWorker()
+		stopProjection()
+		<-projectionDone
+		return fmt.Errorf("configure asset-processing worker: %w", err)
+	}
 	go func() {
-		workerDone <- runConsumer(workerCtx, consumer, runtime, processor, env.Config.AssetProcessing.MaxConcurrentJobsOrDefault(), env.Logger)
+		workerDone <- worker.Run(workerCtx)
 	}()
 
 	var workerErr, projectionErr error
@@ -137,105 +157,48 @@ func createConsumer(ctx context.Context, js jetstream.JetStream) (jetstream.Cons
 	return consumer, nil
 }
 
-func runConsumer(
-	ctx context.Context,
-	consumer jetstream.Consumer,
-	runtime processingRuntime,
-	processor assetProcessor,
-	maxConcurrent int,
-	logger *log.Logger,
-) error {
-	for ctx.Err() == nil {
-		batch, err := consumer.Fetch(maxConcurrent, jetstream.FetchMaxWait(time.Second))
-		if err != nil {
-			if ctx.Err() != nil {
-				return nil
-			}
-			return fmt.Errorf("fetch asset-processing work: %w", err)
-		}
-		var wg sync.WaitGroup
-		for msg := range batch.Messages() {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				processDelivery(ctx, msg, runtime, processor, logger)
-			}()
-		}
-		wg.Wait()
-		if err := batch.Error(); err != nil && ctx.Err() == nil {
-			return fmt.Errorf("receive asset-processing work: %w", err)
-		}
-	}
-	return nil
-}
-
 func processDelivery(
 	ctx context.Context,
-	msg jetstream.Msg,
+	delivery events.DurableDelivery,
 	runtime processingRuntime,
 	processor assetProcessor,
 	logger *log.Logger,
-) {
-	metadata, err := msg.Metadata()
-	if err != nil {
-		logger.Error("Asset-processing delivery metadata unavailable", "error", err)
-		_ = msg.NakWithDelay(retryDelay)
-		return
-	}
+) error {
 	var event corev1.Event
-	if err := proto.Unmarshal(msg.Data(), &event); err != nil {
+	if err := proto.Unmarshal(delivery.Data, &event); err != nil {
 		logger.Error("Terminating malformed asset-processing delivery", "error", err)
-		_ = msg.TermWithReason("invalid Chatto event envelope")
-		return
+		return events.TerminateDelivery("invalid Chatto event envelope", err)
 	}
 	started := event.GetAssetProcessingStarted()
 	if started == nil || started.GetAssetId() == "" || started.GetMessageEventId() == "" {
 		logger.Error("Terminating invalid asset-processing request", "event_id", event.GetId())
-		_ = msg.TermWithReason("invalid asset-processing request")
-		return
+		return events.TerminateDelivery("invalid asset-processing request", errors.New("missing asset-processing request fields"))
 	}
-	if err := runtime.WaitForEvent(ctx, msg.Subject(), metadata.Sequence.Stream); err != nil {
+	if err := runtime.WaitForEvent(ctx, delivery.Subject, delivery.StreamSequence); err != nil {
 		if ctx.Err() == nil {
 			logger.Warn("Asset projection did not reach queue delivery", "asset_id", started.GetAssetId(), "error", err)
 		}
-		_ = msg.NakWithDelay(retryDelay)
-		return
+		return err
 	}
 	if assetProcessingTerminal(runtime.AssetState(started.GetAssetId())) {
-		ackDelivery(ctx, msg, logger)
-		return
+		return nil
 	}
 
-	heartbeatDone := make(chan struct{})
-	go func() {
-		ticker := time.NewTicker(deliveryHeartbeat)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-heartbeatDone:
-				return
-			case <-ticker.C:
-				if err := msg.InProgress(); err != nil {
-					logger.Warn("Asset-processing delivery heartbeat failed", "asset_id", started.GetAssetId(), "error", err)
-				}
-			}
-		}
-	}()
-	err = processor.ProcessAsset(ctx, started.GetAssetId(), started.GetMessageEventId())
-	close(heartbeatDone)
+	err := processor.ProcessAsset(ctx, started.GetAssetId(), started.GetMessageEventId())
 
 	if assetProcessingTerminal(runtime.AssetState(started.GetAssetId())) {
-		ackDelivery(ctx, msg, logger)
-		return
+		return nil
 	}
 	if err != nil && ctx.Err() == nil {
 		logger.Warn("Asset processing remains retryable", "asset_id", started.GetAssetId(), "error", err)
 	}
 	if ctx.Err() != nil {
-		_ = msg.Nak()
-	} else {
-		_ = msg.NakWithDelay(retryDelay)
+		return ctx.Err()
 	}
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("asset processing did not reach terminal state")
 }
 
 func assetProcessingTerminal(state core.AssetState) bool {
@@ -244,14 +207,6 @@ func assetProcessingTerminal(state core.AssetState) bool {
 	}
 	manifest := state.VideoManifest
 	return manifest != nil && (manifest.Succeeded != nil || manifest.Failed != nil)
-}
-
-func ackDelivery(ctx context.Context, msg jetstream.Msg, logger *log.Logger) {
-	ackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), acknowledgeTimeout)
-	defer cancel()
-	if err := msg.DoubleAck(ackCtx); err != nil {
-		logger.Warn("Asset-processing acknowledgement was not confirmed", "error", err)
-	}
 }
 
 var _ runtimeunit.Unit = Unit{}

--- a/cli/internal/video/unit_test.go
+++ b/cli/internal/video/unit_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/charmbracelet/log"
-	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
@@ -17,6 +16,7 @@ import (
 	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/internal/testutil"
+	"hmans.de/chatto/pkg/events"
 )
 
 type fakeProcessingRuntime struct {
@@ -54,30 +54,7 @@ func (p *fakeAssetProcessor) ProcessAsset(ctx context.Context, assetID, messageI
 	return p.process(ctx, assetID, messageID)
 }
 
-type fakeDelivery struct {
-	data       []byte
-	doubleAcks int
-	naks       int
-	nakDelay   time.Duration
-	terms      int
-}
-
-func (m *fakeDelivery) Metadata() (*jetstream.MsgMetadata, error) {
-	return &jetstream.MsgMetadata{Sequence: jetstream.SequencePair{Stream: 42}}, nil
-}
-func (m *fakeDelivery) Data() []byte                           { return m.data }
-func (m *fakeDelivery) Headers() nats.Header                   { return nil }
-func (m *fakeDelivery) Subject() string                        { return "evt.asset.A-video.asset_processing_started" }
-func (m *fakeDelivery) Reply() string                          { return "" }
-func (m *fakeDelivery) Ack() error                             { return nil }
-func (m *fakeDelivery) DoubleAck(context.Context) error        { m.doubleAcks++; return nil }
-func (m *fakeDelivery) Nak() error                             { m.naks++; return nil }
-func (m *fakeDelivery) NakWithDelay(delay time.Duration) error { m.nakDelay = delay; return nil }
-func (m *fakeDelivery) InProgress() error                      { return nil }
-func (m *fakeDelivery) Term() error                            { m.terms++; return nil }
-func (m *fakeDelivery) TermWithReason(string) error            { m.terms++; return nil }
-
-func processingDelivery(t *testing.T) *fakeDelivery {
+func processingDelivery(t *testing.T) events.DurableDelivery {
 	t.Helper()
 	event := &corev1.Event{
 		Id: "E-request",
@@ -92,7 +69,11 @@ func processingDelivery(t *testing.T) *fakeDelivery {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return &fakeDelivery{data: data}
+	return events.DurableDelivery{
+		Subject:        "evt.asset.A-video.asset_processing_started",
+		Data:           data,
+		StreamSequence: 42,
+	}
 }
 
 func TestProcessDeliveryAcknowledgesOnlyAfterTerminalState(t *testing.T) {
@@ -103,13 +84,13 @@ func TestProcessDeliveryAcknowledgesOnlyAfterTerminalState(t *testing.T) {
 	}}
 	msg := processingDelivery(t)
 
-	processDelivery(context.Background(), msg, runtime, processor, log.New(io.Discard))
+	err := processDelivery(context.Background(), msg, runtime, processor, log.New(io.Discard))
 
 	if processor.calls != 1 || runtime.waits != 1 {
 		t.Fatalf("processor calls = %d, projection waits = %d; want 1, 1", processor.calls, runtime.waits)
 	}
-	if msg.doubleAcks != 1 || msg.nakDelay != 0 {
-		t.Fatalf("acks = %d, nak delay = %v; want confirmed ack only", msg.doubleAcks, msg.nakDelay)
+	if err != nil {
+		t.Fatalf("processDelivery = %v, want successful terminal result", err)
 	}
 }
 
@@ -120,10 +101,10 @@ func TestProcessDeliveryNaksRetryableWork(t *testing.T) {
 	}}
 	msg := processingDelivery(t)
 
-	processDelivery(context.Background(), msg, runtime, processor, log.New(io.Discard))
+	err := processDelivery(context.Background(), msg, runtime, processor, log.New(io.Discard))
 
-	if msg.doubleAcks != 0 || msg.nakDelay != retryDelay {
-		t.Fatalf("acks = %d, nak delay = %v; want delayed retry", msg.doubleAcks, msg.nakDelay)
+	if err == nil || err.Error() != "temporary failure" {
+		t.Fatalf("processDelivery = %v, want temporary failure", err)
 	}
 }
 
@@ -243,5 +224,3 @@ func fetchOne(t *testing.T, consumer jetstream.Consumer) jetstream.Msg {
 	t.Fatal("consumer returned no work")
 	return nil
 }
-
-var _ jetstream.Msg = (*fakeDelivery)(nil)

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -85,8 +85,11 @@ Applications supply an already configured durable JetStream pull consumer and
 an opaque-byte handler. The framework bounds local concurrency and owns message
 heartbeats, acknowledgement, retry, termination, and shutdown handoff. The
 application still defines what constitutes valid input, successful completion,
-and an idempotent retry. Chatto's asset-processing runtime unit is the first
-production consumer and retains its existing durable consumer contract.
+and an idempotent retry. Handlers must honor cancellation: the framework stops
+heartbeats and hands active deliveries back immediately, but retains lifecycle
+ownership until those handlers return. Chatto's asset-processing runtime unit
+is the first production consumer and retains its existing durable consumer
+contract.
 
 Chatto owns its versioned EVT incarnation format and the
 `chatto.evt.incarnation` stream metadata through `internal/evtstream`.

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -85,7 +85,9 @@ Applications supply an already configured durable JetStream pull consumer and
 an opaque-byte handler. The framework bounds local concurrency and owns message
 heartbeats, acknowledgement, retry, termination, and shutdown handoff. The
 application still defines what constitutes valid input, successful completion,
-and an idempotent retry. Handlers must honor cancellation: the framework stops
+and an idempotent retry. Transient pull failures are retried so an embedded
+worker does not turn a recoverable broker restart into a process failure.
+Handlers must honor cancellation: the framework stops
 heartbeats and hands active deliveries back immediately, but retains lifecycle
 ownership until those handlers return. Chatto's asset-processing runtime unit
 is the first production consumer and retains its existing durable consumer

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -34,6 +34,9 @@ Framework-owned responsibilities are:
   mechanics;
 - stream positions and projection readiness barriers;
 - ordered consumer, replay, startup batching, and failure lifecycles;
+- bounded durable pull-worker execution over application-configured consumers,
+  including progress heartbeats, confirmed acknowledgement, delayed retry, and
+  poison-delivery termination;
 - optional snapshot and local-checkpoint capability hooks that bind persisted
   state to an opaque application-supplied stream identity; and
 - a typed `ProjectionHandle` that keeps a projection with the exact projector
@@ -47,6 +50,8 @@ Chatto-owned responsibilities remain:
 - stable registration keys, display names, admin memory estimates, and
   diagnostic inventory;
 - stream identity discovery, metadata naming, format, and validation;
+- durable consumer names, stream selection, subject filters, delivery policy,
+  domain decoding, idempotency, and terminal-state decisions;
 - snapshot enablement, repository, encryption, retention, and worker policy;
   and
 - runtime composition in `ChattoCore`.
@@ -74,6 +79,14 @@ readiness, snapshots, checkpoints, and failure handling.
 `SequencedEvent`, and publisher APIs as specializations over `corev1.Event` and
 its unchanged protobuf codec. The events module has no production dependency
 on Chatto protobufs or subject policy.
+
+`DurableWorker` is the matching envelope-neutral effect-execution boundary.
+Applications supply an already configured durable JetStream pull consumer and
+an opaque-byte handler. The framework bounds local concurrency and owns message
+heartbeats, acknowledgement, retry, termination, and shutdown handoff. The
+application still defines what constitutes valid input, successful completion,
+and an idempotent retry. Chatto's asset-processing runtime unit is the first
+production consumer and retains its existing durable consumer contract.
 
 Chatto owns its versioned EVT incarnation format and the
 `chatto.evt.incarnation` stream metadata through `internal/evtstream`.
@@ -123,6 +136,11 @@ New event-sourcing mechanics should be evaluated for the `pkg/events/` module;
 new Chatto policy should stay in `internal/core` or the owning runtime unit.
 This creates a reviewable extraction boundary without forcing premature API
 stability or generic abstractions.
+
+Durable workers can share transport and process-lifecycle mechanics without
+turning product effects into a framework-owned business outbox. Because the
+consumer configuration remains application-owned, rolling-deployment policy
+and persisted consumer names stay visible at the composition boundary.
 
 The handle adds one small generic API and an identity check for adapting
 existing projectors. It intentionally does not absorb registration metadata or

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -39,7 +39,9 @@ import Chatto or Authling domain packages.
 bounded concurrency, progress heartbeats, confirmed acknowledgements, delayed
 retry, and poison-delivery termination. Applications retain ownership of the
 consumer contract and domain completion checks; handlers receive only opaque
-bytes and stable delivery metadata.
+bytes and stable delivery metadata. Handlers must honor context cancellation;
+the worker hands active deliveries back immediately but retains handler
+ownership until they stop.
 
 ## Status
 

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -3,7 +3,8 @@
 `hmans.de/chatto/pkg/events` is an envelope-neutral event-sourcing framework
 for NATS JetStream. It provides optimistic-concurrency-controlled publication,
 ordered projection replay, startup-readiness and read-your-writes barriers, and
-optional snapshot or checkpoint lifecycles.
+optional snapshot or checkpoint lifecycles, and bounded durable pull-worker
+execution.
 
 Mutation callbacks can choose their consistency boundary explicitly:
 
@@ -33,6 +34,12 @@ result, err := log.ExecuteMutation(ctx, events.AtSubject(aggregateFilter),
 Applications retain ownership of their event codecs, subject policy, stream
 identity, storage coordinates, and runtime composition. The module does not
 import Chatto or Authling domain packages.
+
+`DurableWorker` runs an application-configured JetStream pull consumer with
+bounded concurrency, progress heartbeats, confirmed acknowledgements, delayed
+retry, and poison-delivery termination. Applications retain ownership of the
+consumer contract and domain completion checks; handlers receive only opaque
+bytes and stable delivery metadata.
 
 ## Status
 

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -37,7 +37,7 @@ import Chatto or Authling domain packages.
 
 `DurableWorker` runs an application-configured JetStream pull consumer with
 bounded concurrency, progress heartbeats, confirmed acknowledgements, delayed
-retry, and poison-delivery termination. Applications retain ownership of the
+retry, poison-delivery termination, and reconnect-safe fetch retries. Applications retain ownership of the
 consumer contract and domain completion checks; handlers receive only opaque
 bytes and stable delivery metadata. Handlers must honor context cancellation;
 the worker hands active deliveries back immediately but retains handler

--- a/pkg/events/doc.go
+++ b/pkg/events/doc.go
@@ -3,9 +3,9 @@
 //
 // It owns opaque OCC publication, selectable subject or whole-stream mutation
 // boundaries, ordered projection replay, readiness barriers, projection
-// handles, and optional snapshot/checkpoint lifecycles. Applications own event
-// codecs, subject policy, projection catch-up, authorization, and stream
-// identity.
+// handles, optional snapshot/checkpoint lifecycles, and bounded durable
+// pull-worker execution. Applications own event codecs, subject policy,
+// projection catch-up, authorization, consumer contracts, and stream identity.
 //
 // This package is an independently versioned incubation module. Its API is not
 // yet covered by a stability promise.

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	defaultDurableWorkerFetchWait         = time.Second
+	defaultDurableWorkerFetchRetryDelay   = time.Second
 	defaultDurableWorkerRetryDelay        = 30 * time.Second
 	defaultDurableWorkerAckTimeout        = 5 * time.Second
 	defaultDurableWorkerHeartbeatInterval = 30 * time.Second
@@ -41,6 +42,7 @@ type DurableDeliveryHandler func(context.Context, DurableDelivery) error
 type DurableWorkerOptions struct {
 	MaxConcurrent     int
 	FetchMaxWait      time.Duration
+	FetchRetryDelay   time.Duration
 	RetryDelay        time.Duration
 	AckTimeout        time.Duration
 	HeartbeatInterval time.Duration
@@ -109,6 +111,9 @@ func NewDurableWorker(
 	if opts.FetchMaxWait <= 0 {
 		opts.FetchMaxWait = defaultDurableWorkerFetchWait
 	}
+	if opts.FetchRetryDelay <= 0 {
+		opts.FetchRetryDelay = defaultDurableWorkerFetchRetryDelay
+	}
 	if opts.RetryDelay <= 0 {
 		opts.RetryDelay = defaultDurableWorkerRetryDelay
 	}
@@ -121,9 +126,10 @@ func NewDurableWorker(
 	return &DurableWorker{consumer: consumer, handle: handle, opts: opts}, nil
 }
 
-// Run fetches and processes deliveries until the context is cancelled or a
-// consumer fetch fails. Cancellation stops progress heartbeats and negatively
-// acknowledges active deliveries before waiting for their handlers to stop.
+// Run fetches and processes deliveries until the context is cancelled. Fetch
+// failures are retried because durable workers must survive transient broker
+// outages. Cancellation stops progress heartbeats and negatively acknowledges
+// active deliveries before waiting for their handlers to stop.
 func (w *DurableWorker) Run(ctx context.Context) error {
 	if w == nil || w.consumer == nil || w.handle == nil {
 		return fmt.Errorf("durable worker is not configured")
@@ -153,7 +159,11 @@ func (w *DurableWorker) Run(ctx context.Context) error {
 			if runCtx.Err() != nil {
 				return nil
 			}
-			return fmt.Errorf("fetch durable work: %w", err)
+			w.logWarn("Durable work fetch failed; retrying", "error", err)
+			if !waitForDurableWorkerRetry(runCtx, w.opts.FetchRetryDelay) {
+				return nil
+			}
+			continue
 		}
 
 		messages := batch.Messages()
@@ -191,10 +201,24 @@ func (w *DurableWorker) Run(ctx context.Context) error {
 			}
 		}
 		if err := batch.Error(); err != nil && runCtx.Err() == nil {
-			return fmt.Errorf("receive durable work: %w", err)
+			w.logWarn("Durable work receive failed; retrying", "error", err)
+			if !waitForDurableWorkerRetry(runCtx, w.opts.FetchRetryDelay) {
+				return nil
+			}
 		}
 	}
 	return nil
+}
+
+func waitForDurableWorkerRetry(ctx context.Context, delay time.Duration) bool {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
 }
 
 func (w *DurableWorker) process(ctx context.Context, msg jetstream.Msg) {

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -127,28 +127,48 @@ func (w *DurableWorker) Run(ctx context.Context) error {
 	if w == nil || w.consumer == nil || w.handle == nil {
 		return fmt.Errorf("durable worker is not configured")
 	}
-	for ctx.Err() == nil {
+
+	runCtx, cancel := context.WithCancel(ctx)
+	var group sync.WaitGroup
+	defer func() {
+		cancel()
+		group.Wait()
+	}()
+
+	active := make(chan struct{}, w.opts.MaxConcurrent)
+	for runCtx.Err() == nil {
+		select {
+		case active <- struct{}{}:
+		case <-runCtx.Done():
+			return nil
+		}
+
 		batch, err := w.consumer.Fetch(
-			w.opts.MaxConcurrent,
+			1,
 			jetstream.FetchMaxWait(w.opts.FetchMaxWait),
 		)
 		if err != nil {
-			if ctx.Err() != nil {
+			<-active
+			if runCtx.Err() != nil {
 				return nil
 			}
 			return fmt.Errorf("fetch durable work: %w", err)
 		}
 
-		var group sync.WaitGroup
+		received := false
 		for msg := range batch.Messages() {
+			received = true
 			group.Add(1)
-			go func() {
+			go func(msg jetstream.Msg) {
 				defer group.Done()
-				w.process(ctx, msg)
-			}()
+				defer func() { <-active }()
+				w.process(runCtx, msg)
+			}(msg)
 		}
-		group.Wait()
-		if err := batch.Error(); err != nil && ctx.Err() == nil {
+		if !received {
+			<-active
+		}
+		if err := batch.Error(); err != nil && runCtx.Err() == nil {
 			return fmt.Errorf("receive durable work: %w", err)
 		}
 	}
@@ -171,18 +191,38 @@ func (w *DurableWorker) process(ctx context.Context, msg jetstream.Msg) {
 		NumDelivered:   metadata.NumDelivered,
 	}
 
-	heartbeatDone := make(chan struct{})
-	go w.heartbeat(msg, delivery, heartbeatDone)
-	err = w.handle(ctx, delivery)
-	close(heartbeatDone)
+	result := make(chan error, 1)
+	go func() { result <- w.handle(ctx, delivery) }()
 
-	if ctx.Err() != nil {
-		if nakErr := msg.Nak(); nakErr != nil {
-			w.logWarn("Durable delivery handoff failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", nakErr)
+	heartbeat := time.NewTicker(w.opts.HeartbeatInterval)
+	defer heartbeat.Stop()
+	for {
+		select {
+		case err = <-result:
+			if ctx.Err() != nil {
+				w.handoff(msg, delivery)
+				return
+			}
+			w.finish(ctx, msg, delivery, err)
+			return
+		case <-ctx.Done():
+			w.handoff(msg, delivery)
+			return
+		case <-heartbeat.C:
+			if err := msg.InProgress(); err != nil {
+				w.logWarn("Durable delivery heartbeat failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", err)
+			}
 		}
-		return
 	}
+}
 
+func (w *DurableWorker) handoff(msg jetstream.Msg, delivery DurableDelivery) {
+	if err := msg.Nak(); err != nil {
+		w.logWarn("Durable delivery handoff failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", err)
+	}
+}
+
+func (w *DurableWorker) finish(ctx context.Context, msg jetstream.Msg, delivery DurableDelivery, err error) {
 	var terminateErr *terminateDeliveryError
 	if errors.As(err, &terminateErr) {
 		if termErr := msg.TermWithReason(terminateErr.reason); termErr != nil {
@@ -205,21 +245,6 @@ func (w *DurableWorker) process(ctx context.Context, msg jetstream.Msg) {
 	defer cancel()
 	if err := msg.DoubleAck(ackCtx); err != nil {
 		w.logWarn("Durable delivery acknowledgement was not confirmed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", err)
-	}
-}
-
-func (w *DurableWorker) heartbeat(msg jetstream.Msg, delivery DurableDelivery, done <-chan struct{}) {
-	ticker := time.NewTicker(w.opts.HeartbeatInterval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-done:
-			return
-		case <-ticker.C:
-			if err := msg.InProgress(); err != nil {
-				w.logWarn("Durable delivery heartbeat failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", err)
-			}
-		}
 	}
 }
 

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -1,0 +1,248 @@
+package events
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+const (
+	defaultDurableWorkerFetchWait         = time.Second
+	defaultDurableWorkerRetryDelay        = 30 * time.Second
+	defaultDurableWorkerAckTimeout        = 5 * time.Second
+	defaultDurableWorkerHeartbeatInterval = 30 * time.Second
+)
+
+// DurableDelivery is one opaque event delivered by a durable JetStream pull
+// consumer. Applications own decoding, validation, projection catch-up, and
+// idempotency. Data is detached from the underlying JetStream message.
+type DurableDelivery struct {
+	Subject        string
+	Data           []byte
+	StreamSequence uint64
+	PublishedAt    time.Time
+	NumDelivered   uint64
+}
+
+// DurableDeliveryHandler performs one at-least-once piece of work. Returning
+// nil acknowledges the delivery. Other errors retry after the worker's default
+// delay unless wrapped with RetryDeliveryAfter or TerminateDelivery.
+type DurableDeliveryHandler func(context.Context, DurableDelivery) error
+
+// DurableWorkerOptions controls process-local execution. The application
+// remains responsible for the durable consumer's stream, name, filters,
+// acknowledgement policy, and rollout contract.
+type DurableWorkerOptions struct {
+	MaxConcurrent     int
+	FetchMaxWait      time.Duration
+	RetryDelay        time.Duration
+	AckTimeout        time.Duration
+	HeartbeatInterval time.Duration
+	Logger            Logger
+}
+
+// DurableWorker runs bounded, at-least-once work from an application-owned
+// durable JetStream pull consumer.
+type DurableWorker struct {
+	consumer jetstream.Consumer
+	handle   DurableDeliveryHandler
+	opts     DurableWorkerOptions
+}
+
+type retryDeliveryError struct {
+	err   error
+	delay time.Duration
+}
+
+func (e *retryDeliveryError) Error() string { return e.err.Error() }
+func (e *retryDeliveryError) Unwrap() error { return e.err }
+
+type terminateDeliveryError struct {
+	err    error
+	reason string
+}
+
+func (e *terminateDeliveryError) Error() string { return e.err.Error() }
+func (e *terminateDeliveryError) Unwrap() error { return e.err }
+
+// RetryDeliveryAfter overrides the worker's default retry delay for one
+// handler failure. A non-positive delay asks JetStream to redeliver promptly.
+func RetryDeliveryAfter(err error, delay time.Duration) error {
+	if err == nil {
+		err = errors.New("durable delivery retry requested")
+	}
+	return &retryDeliveryError{err: err, delay: delay}
+}
+
+// TerminateDelivery marks malformed or permanently unsupported input as
+// non-retryable. The reason is recorded by JetStream and should not contain
+// secrets or personally identifiable information.
+func TerminateDelivery(reason string, err error) error {
+	if err == nil {
+		err = errors.New("durable delivery terminated")
+	}
+	return &terminateDeliveryError{err: err, reason: reason}
+}
+
+// NewDurableWorker validates and constructs a worker. It does not create or
+// modify the supplied consumer.
+func NewDurableWorker(
+	consumer jetstream.Consumer,
+	handle DurableDeliveryHandler,
+	opts DurableWorkerOptions,
+) (*DurableWorker, error) {
+	if consumer == nil {
+		return nil, fmt.Errorf("durable worker consumer is nil")
+	}
+	if handle == nil {
+		return nil, fmt.Errorf("durable worker handler is nil")
+	}
+	if opts.MaxConcurrent <= 0 {
+		return nil, fmt.Errorf("durable worker max concurrency must be positive")
+	}
+	if opts.FetchMaxWait <= 0 {
+		opts.FetchMaxWait = defaultDurableWorkerFetchWait
+	}
+	if opts.RetryDelay <= 0 {
+		opts.RetryDelay = defaultDurableWorkerRetryDelay
+	}
+	if opts.AckTimeout <= 0 {
+		opts.AckTimeout = defaultDurableWorkerAckTimeout
+	}
+	if opts.HeartbeatInterval <= 0 {
+		opts.HeartbeatInterval = defaultDurableWorkerHeartbeatInterval
+	}
+	return &DurableWorker{consumer: consumer, handle: handle, opts: opts}, nil
+}
+
+// Run fetches and processes deliveries until the context is cancelled or a
+// consumer fetch fails. Cancellation leaves active work unacknowledged so it
+// can be handed to another worker.
+func (w *DurableWorker) Run(ctx context.Context) error {
+	if w == nil || w.consumer == nil || w.handle == nil {
+		return fmt.Errorf("durable worker is not configured")
+	}
+	for ctx.Err() == nil {
+		batch, err := w.consumer.Fetch(
+			w.opts.MaxConcurrent,
+			jetstream.FetchMaxWait(w.opts.FetchMaxWait),
+		)
+		if err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return fmt.Errorf("fetch durable work: %w", err)
+		}
+
+		var group sync.WaitGroup
+		for msg := range batch.Messages() {
+			group.Add(1)
+			go func() {
+				defer group.Done()
+				w.process(ctx, msg)
+			}()
+		}
+		group.Wait()
+		if err := batch.Error(); err != nil && ctx.Err() == nil {
+			return fmt.Errorf("receive durable work: %w", err)
+		}
+	}
+	return nil
+}
+
+func (w *DurableWorker) process(ctx context.Context, msg jetstream.Msg) {
+	metadata, err := msg.Metadata()
+	if err != nil {
+		w.logError("Durable delivery metadata unavailable", "error", err)
+		w.retry(msg, w.opts.RetryDelay)
+		return
+	}
+
+	delivery := DurableDelivery{
+		Subject:        msg.Subject(),
+		Data:           bytes.Clone(msg.Data()),
+		StreamSequence: metadata.Sequence.Stream,
+		PublishedAt:    metadata.Timestamp,
+		NumDelivered:   metadata.NumDelivered,
+	}
+
+	heartbeatDone := make(chan struct{})
+	go w.heartbeat(msg, delivery, heartbeatDone)
+	err = w.handle(ctx, delivery)
+	close(heartbeatDone)
+
+	if ctx.Err() != nil {
+		if nakErr := msg.Nak(); nakErr != nil {
+			w.logWarn("Durable delivery handoff failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", nakErr)
+		}
+		return
+	}
+
+	var terminateErr *terminateDeliveryError
+	if errors.As(err, &terminateErr) {
+		if termErr := msg.TermWithReason(terminateErr.reason); termErr != nil {
+			w.logWarn("Durable delivery termination failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", termErr)
+		}
+		return
+	}
+
+	if err != nil {
+		delay := w.opts.RetryDelay
+		var retryErr *retryDeliveryError
+		if errors.As(err, &retryErr) {
+			delay = retryErr.delay
+		}
+		w.retry(msg, delay)
+		return
+	}
+
+	ackCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), w.opts.AckTimeout)
+	defer cancel()
+	if err := msg.DoubleAck(ackCtx); err != nil {
+		w.logWarn("Durable delivery acknowledgement was not confirmed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", err)
+	}
+}
+
+func (w *DurableWorker) heartbeat(msg jetstream.Msg, delivery DurableDelivery, done <-chan struct{}) {
+	ticker := time.NewTicker(w.opts.HeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			return
+		case <-ticker.C:
+			if err := msg.InProgress(); err != nil {
+				w.logWarn("Durable delivery heartbeat failed", "subject", delivery.Subject, "stream_sequence", delivery.StreamSequence, "error", err)
+			}
+		}
+	}
+}
+
+func (w *DurableWorker) retry(msg jetstream.Msg, delay time.Duration) {
+	var err error
+	if delay > 0 {
+		err = msg.NakWithDelay(delay)
+	} else {
+		err = msg.Nak()
+	}
+	if err != nil {
+		w.logWarn("Durable delivery retry request failed", "subject", msg.Subject(), "error", err)
+	}
+}
+
+func (w *DurableWorker) logWarn(message interface{}, keyvals ...interface{}) {
+	if w.opts.Logger != nil {
+		w.opts.Logger.Warn(message, keyvals...)
+	}
+}
+
+func (w *DurableWorker) logError(message interface{}, keyvals ...interface{}) {
+	if w.opts.Logger != nil {
+		w.opts.Logger.Error(message, keyvals...)
+	}
+}

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -156,8 +156,13 @@ func (w *DurableWorker) Run(ctx context.Context) error {
 			return fmt.Errorf("fetch durable work: %w", err)
 		}
 
+		messages := batch.Messages()
 		received := false
-		for msg := range batch.Messages() {
+		select {
+		case msg, ok := <-messages:
+			if !ok {
+				break
+			}
 			received = true
 			group.Add(1)
 			go func(msg jetstream.Msg) {
@@ -165,9 +170,25 @@ func (w *DurableWorker) Run(ctx context.Context) error {
 				defer func() { <-active }()
 				w.process(runCtx, msg)
 			}(msg)
+		case <-runCtx.Done():
+			<-active
+			return nil
 		}
 		if !received {
 			<-active
+		} else {
+			// Fetch(1) owns at most one message, but the batch result is not
+			// complete until its channel closes. Keep cancellation selectable
+			// while waiting so an idle or disconnected consumer cannot pin
+			// application shutdown.
+			select {
+			case _, ok := <-messages:
+				if ok {
+					return fmt.Errorf("receive durable work: fetch returned more than one message")
+				}
+			case <-runCtx.Done():
+				return nil
+			}
 		}
 		if err := batch.Error(); err != nil && runCtx.Err() == nil {
 			return fmt.Errorf("receive durable work: %w", err)

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -29,9 +29,10 @@ type DurableDelivery struct {
 	NumDelivered   uint64
 }
 
-// DurableDeliveryHandler performs one at-least-once piece of work. Returning
-// nil acknowledges the delivery. Other errors retry after the worker's default
-// delay unless wrapped with RetryDeliveryAfter or TerminateDelivery.
+// DurableDeliveryHandler performs one at-least-once piece of work. It must stop
+// promptly when its context is cancelled. Returning nil acknowledges the
+// delivery. Other errors retry after the worker's default delay unless wrapped
+// with RetryDeliveryAfter or TerminateDelivery.
 type DurableDeliveryHandler func(context.Context, DurableDelivery) error
 
 // DurableWorkerOptions controls process-local execution. The application
@@ -121,8 +122,8 @@ func NewDurableWorker(
 }
 
 // Run fetches and processes deliveries until the context is cancelled or a
-// consumer fetch fails. Cancellation leaves active work unacknowledged so it
-// can be handed to another worker.
+// consumer fetch fails. Cancellation stops progress heartbeats and negatively
+// acknowledges active deliveries before waiting for their handlers to stop.
 func (w *DurableWorker) Run(ctx context.Context) error {
 	if w == nil || w.consumer == nil || w.handle == nil {
 		return fmt.Errorf("durable worker is not configured")
@@ -207,6 +208,9 @@ func (w *DurableWorker) process(ctx context.Context, msg jetstream.Msg) {
 			return
 		case <-ctx.Done():
 			w.handoff(msg, delivery)
+			// Retain ownership of the handler goroutine. Applications must honor
+			// cancellation so their dependencies cannot outlive the worker.
+			<-result
 			return
 		case <-heartbeat.C:
 			if err := msg.InProgress(); err != nil {

--- a/pkg/events/durable_worker_test.go
+++ b/pkg/events/durable_worker_test.go
@@ -1,0 +1,223 @@
+package events_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/pkg/events"
+)
+
+func TestDurableWorkerProcessesOpaqueDeliveriesAndAcknowledges(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-ack", time.Second)
+	for _, payload := range []string{"first", "second"} {
+		if _, err := js.Publish(ctx, "evt.worker.ack", []byte(payload)); err != nil {
+			t.Fatalf("publish %s: %v", payload, err)
+		}
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	handledCh := make(chan struct{}, 2)
+	var mu sync.Mutex
+	var handled []string
+	worker, err := events.NewDurableWorker(consumer, func(_ context.Context, delivery events.DurableDelivery) error {
+		if delivery.Subject != "evt.worker.ack" || delivery.StreamSequence == 0 || delivery.PublishedAt.IsZero() || delivery.NumDelivered == 0 {
+			t.Errorf("delivery metadata = %+v", delivery)
+		}
+		mu.Lock()
+		handled = append(handled, string(delivery.Data))
+		mu.Unlock()
+		handledCh <- struct{}{}
+		return nil
+	}, events.DurableWorkerOptions{MaxConcurrent: 2, Logger: testLogger()})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	for range 2 {
+		<-handledCh
+	}
+	waitForDurableWorkerConsumerSettled(t, ctx, consumer)
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	slices.Sort(handled)
+	if !slices.Equal(handled, []string{"first", "second"}) {
+		t.Fatalf("handled = %v", handled)
+	}
+}
+
+func TestDurableWorkerRetriesFailedDelivery(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-retry", time.Second)
+	if _, err := js.Publish(ctx, "evt.worker.retry", []byte("retry")); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	completed := make(chan struct{})
+	var mu sync.Mutex
+	var deliveries []uint64
+	worker, err := events.NewDurableWorker(consumer, func(_ context.Context, delivery events.DurableDelivery) error {
+		mu.Lock()
+		deliveries = append(deliveries, delivery.NumDelivered)
+		attempt := len(deliveries)
+		mu.Unlock()
+		if attempt == 1 {
+			return events.RetryDeliveryAfter(errors.New("temporarily unavailable"), 10*time.Millisecond)
+		}
+		close(completed)
+		return nil
+	}, events.DurableWorkerOptions{MaxConcurrent: 1, FetchMaxWait: 20 * time.Millisecond, Logger: testLogger()})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	<-completed
+	waitForDurableWorkerConsumerSettled(t, ctx, consumer)
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(deliveries) != 2 || deliveries[0] != 1 || deliveries[1] < 2 {
+		t.Fatalf("delivery attempts = %v, want first and redelivery", deliveries)
+	}
+}
+
+func TestDurableWorkerTerminatesPoisonDeliveryAndContinues(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-term", time.Second)
+	for _, payload := range []string{"poison", "valid"} {
+		if _, err := js.Publish(ctx, "evt.worker.term", []byte(payload)); err != nil {
+			t.Fatalf("publish %s: %v", payload, err)
+		}
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	handledCh := make(chan struct{}, 2)
+	var mu sync.Mutex
+	counts := map[string]int{}
+	worker, err := events.NewDurableWorker(consumer, func(_ context.Context, delivery events.DurableDelivery) error {
+		payload := string(delivery.Data)
+		mu.Lock()
+		counts[payload]++
+		mu.Unlock()
+		handledCh <- struct{}{}
+		if payload == "poison" {
+			return events.TerminateDelivery("unsupported test payload", errors.New("poison input"))
+		}
+		return nil
+	}, events.DurableWorkerOptions{MaxConcurrent: 2, Logger: testLogger()})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	for range 2 {
+		<-handledCh
+	}
+	waitForDurableWorkerConsumerSettled(t, ctx, consumer)
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if counts["poison"] != 1 || counts["valid"] != 1 {
+		t.Fatalf("handled counts = %v", counts)
+	}
+}
+
+func TestDurableWorkerHeartbeatsLongRunningDelivery(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-heartbeat", 40*time.Millisecond)
+	if _, err := js.Publish(ctx, "evt.worker.heartbeat", []byte("slow")); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	completed := make(chan struct{})
+	var calls int
+	var mu sync.Mutex
+	worker, err := events.NewDurableWorker(consumer, func(_ context.Context, _ events.DurableDelivery) error {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+		time.Sleep(120 * time.Millisecond)
+		close(completed)
+		return nil
+	}, events.DurableWorkerOptions{
+		MaxConcurrent:     1,
+		FetchMaxWait:      20 * time.Millisecond,
+		HeartbeatInterval: 10 * time.Millisecond,
+		Logger:            testLogger(),
+	})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	<-completed
+	waitForDurableWorkerConsumerSettled(t, ctx, consumer)
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if calls != 1 {
+		t.Fatalf("handler calls = %d, want 1", calls)
+	}
+}
+
+func waitForDurableWorkerConsumerSettled(t *testing.T, ctx context.Context, consumer jetstream.Consumer) {
+	t.Helper()
+	waitFor(t, 5*time.Second, func() bool {
+		info, err := consumer.Info(ctx)
+		return err == nil && info.NumPending == 0 && info.NumAckPending == 0
+	})
+}
+
+func createDurableWorkerTestConsumer(t *testing.T, ctx context.Context, stream jetstream.Stream, name string, ackWait time.Duration) jetstream.Consumer {
+	t.Helper()
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
+		Name:          name,
+		Durable:       name,
+		DeliverPolicy: jetstream.DeliverAllPolicy,
+		AckPolicy:     jetstream.AckExplicitPolicy,
+		AckWait:       ackWait,
+		MaxDeliver:    -1,
+		FilterSubject: "evt.worker.>",
+		ReplayPolicy:  jetstream.ReplayInstantPolicy,
+		MaxAckPending: 8,
+	})
+	if err != nil {
+		t.Fatalf("create worker consumer: %v", err)
+	}
+	return consumer
+}

--- a/pkg/events/durable_worker_test.go
+++ b/pkg/events/durable_worker_test.go
@@ -195,12 +195,120 @@ func TestDurableWorkerHeartbeatsLongRunningDelivery(t *testing.T) {
 	}
 }
 
+func TestDurableWorkerCancellationHandsOffBlockedHandler(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-cancel", 40*time.Millisecond)
+	if _, err := js.Publish(ctx, "evt.worker.cancel", []byte("blocked")); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	started := make(chan struct{})
+	release := make(chan struct{})
+	worker, err := events.NewDurableWorker(consumer, func(context.Context, events.DurableDelivery) error {
+		close(started)
+		<-release
+		return nil
+	}, events.DurableWorkerOptions{
+		MaxConcurrent:     1,
+		FetchMaxWait:      20 * time.Millisecond,
+		HeartbeatInterval: 10 * time.Millisecond,
+		Logger:            testLogger(),
+	})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	<-started
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker shutdown waited for blocked handler")
+	}
+
+	redelivery := fetchDurableWorkerTestMessage(t, consumer)
+	if got := string(redelivery.Data()); got != "blocked" {
+		t.Fatalf("redelivery data = %q", got)
+	}
+	if err := redelivery.DoubleAck(ctx); err != nil {
+		t.Fatalf("acknowledge redelivery: %v", err)
+	}
+	close(release)
+}
+
+func TestDurableWorkerReplenishesConcurrencyAroundBlockedDelivery(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-replenish", time.Second)
+	for _, payload := range []string{"blocked", "second", "third"} {
+		if _, err := js.Publish(ctx, "evt.worker.replenish", []byte(payload)); err != nil {
+			t.Fatalf("publish %s: %v", payload, err)
+		}
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	release := make(chan struct{})
+	started := make(chan string, 3)
+	worker, err := events.NewDurableWorker(consumer, func(_ context.Context, delivery events.DurableDelivery) error {
+		payload := string(delivery.Data)
+		started <- payload
+		if payload == "blocked" {
+			<-release
+		}
+		return nil
+	}, events.DurableWorkerOptions{MaxConcurrent: 2, FetchMaxWait: 20 * time.Millisecond, Logger: testLogger()})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+
+	seen := map[string]bool{}
+	for len(seen) < 3 {
+		select {
+		case payload := <-started:
+			seen[payload] = true
+		case <-time.After(time.Second):
+			t.Fatalf("later work did not replenish free concurrency; started = %v", seen)
+		}
+	}
+	close(release)
+	waitForDurableWorkerConsumerSettled(t, ctx, consumer)
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+}
+
 func waitForDurableWorkerConsumerSettled(t *testing.T, ctx context.Context, consumer jetstream.Consumer) {
 	t.Helper()
 	waitFor(t, 5*time.Second, func() bool {
 		info, err := consumer.Info(ctx)
 		return err == nil && info.NumPending == 0 && info.NumAckPending == 0
 	})
+}
+
+func fetchDurableWorkerTestMessage(t *testing.T, consumer jetstream.Consumer) jetstream.Msg {
+	t.Helper()
+	batch, err := consumer.Fetch(1, jetstream.FetchMaxWait(5*time.Second))
+	if err != nil {
+		t.Fatalf("fetch delivery: %v", err)
+	}
+	for msg := range batch.Messages() {
+		return msg
+	}
+	if err := batch.Error(); err != nil {
+		t.Fatalf("receive delivery: %v", err)
+	}
+	t.Fatal("consumer returned no delivery")
+	return nil
 }
 
 func createDurableWorkerTestConsumer(t *testing.T, ctx context.Context, stream jetstream.Stream, name string, ackWait time.Duration) jetstream.Consumer {

--- a/pkg/events/durable_worker_test.go
+++ b/pkg/events/durable_worker_test.go
@@ -247,6 +247,37 @@ func TestDurableWorkerCancellationHandsOffBlockedHandler(t *testing.T) {
 	}
 }
 
+func TestDurableWorkerCancellationStopsIdleFetch(t *testing.T) {
+	_, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-idle-cancel", time.Second)
+	worker, err := events.NewDurableWorker(consumer, func(context.Context, events.DurableDelivery) error {
+		t.Fatal("idle worker unexpectedly received a delivery")
+		return nil
+	}, events.DurableWorkerOptions{
+		MaxConcurrent: 1,
+		FetchMaxWait:  time.Minute,
+		Logger:        testLogger(),
+	})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("idle worker did not stop after cancellation")
+	}
+}
+
 func TestDurableWorkerReplenishesConcurrencyAroundBlockedDelivery(t *testing.T) {
 	js, stream := setupTestStream(t)
 	ctx := testContext(t)

--- a/pkg/events/durable_worker_test.go
+++ b/pkg/events/durable_worker_test.go
@@ -225,11 +225,8 @@ func TestDurableWorkerCancellationHandsOffBlockedHandler(t *testing.T) {
 	cancel()
 	select {
 	case err := <-runErr:
-		if err != nil {
-			t.Fatalf("Run: %v", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("worker shutdown waited for blocked handler")
+		t.Fatalf("worker abandoned blocked handler with result %v", err)
+	case <-time.After(100 * time.Millisecond):
 	}
 
 	redelivery := fetchDurableWorkerTestMessage(t, consumer)
@@ -240,6 +237,14 @@ func TestDurableWorkerCancellationHandsOffBlockedHandler(t *testing.T) {
 		t.Fatalf("acknowledge redelivery: %v", err)
 	}
 	close(release)
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("Run: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("worker did not stop after canceled handler returned")
+	}
 }
 
 func TestDurableWorkerReplenishesConcurrencyAroundBlockedDelivery(t *testing.T) {


### PR DESCRIPTION
## Why

Chatto's asset-processing runtime unit already had the right durable JetStream delivery model, but its fetch, concurrency, heartbeat, retry, acknowledgement, and shutdown mechanics were embedded in product code. User-key shredding and other post-commit effects need the same reliable execution shape without duplicating another worker implementation.

## Stack

1. **#1972 (this PR):** reusable durable worker and asset-processing proof
2. #1973: crash-safe user-key shredding
3. #1974: call-key and asset-cleanup migrations

## What changed

- Add an envelope-neutral `events.DurableWorker` that runs an application-configured JetStream pull consumer with bounded concurrency.
- Centralize delivery metadata extraction, progress heartbeats, confirmed acknowledgement, delayed retries, poison-delivery termination, cancellation handoff, and cooperative handler shutdown.
- Keep workers alive across transient broker/fetch failures and make idle fetch cancellation prompt.
- Replenish free concurrency continuously, so one slow delivery does not strand other worker capacity.
- Port asset processing to the public worker while keeping its existing `chatto-asset-processing-v1` consumer name, filters, ack policy, limits, and domain terminal-state checks.
- Fence Chatto readiness on the monotonic NATS reconnect generation, including fast reconnects whose status callbacks are coalesced, so volatile-state resynchronisation cannot be skipped.
- Document the framework/application boundary in the package documentation and ADR-056.

The framework remains opaque-byte and application-neutral. Chatto still owns the EVT stream and consumer contract, protobuf decoding, projection catch-up, domain idempotency, terminal facts, logging, and runtime composition.

## Compatibility and operations

- No persisted event, subject, public API, or user-visible behaviour changes.
- Existing durable consumer state and queued asset-processing work remain continuous because the consumer identity and configuration are unchanged.
- Delivery remains at least once. Handlers must remain idempotent and honor context cancellation.
- Transient NATS restarts suspend readiness until application recovery and volatile-state resynchronisation complete.

## Test plan

- `mise test-events`
- `(cd cli && mise x -- go test ./internal/video -timeout 60s)`
- `mise test-cli`
- repeated `TestChattoCoreRecoversAfterExternalNATSRestart`
- `mise license-check`
- independent code review

Refs #1377.
