### PR TITLE
perf(core): defer server member detail hydration

### DIFF
--- a/cli/internal/core/admin_user_management.go
+++ b/cli/internal/core/admin_user_management.go
@@ -82,11 +82,10 @@ func (c *ChattoCore) ListAdminMembers(ctx context.Context, actorID string, input
 
 	users := make([]AdminMember, 0, len(members))
 	for _, member := range members {
-		user, err := c.GetUser(ctx, member.UserID)
-		if err != nil {
+		if member.User == nil {
 			continue
 		}
-		adminMember, err := c.adminMemberForViewer(ctx, actorID, user, explicitServerRoles(member.Roles))
+		adminMember, err := c.adminMemberForViewer(ctx, actorID, member.User, explicitServerRoles(member.Roles))
 		if err != nil {
 			return nil, err
 		}

--- a/cli/internal/core/admin_user_management_test.go
+++ b/cli/internal/core/admin_user_management_test.go
@@ -132,6 +132,76 @@ func TestChattoCore_AdminMemberReads(t *testing.T) {
 	}
 }
 
+func TestChattoCore_ListAdminMembersPaginationRolesAndDeletion(t *testing.T) {
+	c, _ := setupTestCore(t)
+	ctx := testContext(t)
+
+	admin, err := c.CreateUser(ctx, SystemActorID, "member-page-admin", "Member Page Admin", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser admin: %v", err)
+	}
+	if err := c.AssignAdminRole(ctx, admin.Id); err != nil {
+		t.Fatalf("AssignAdminRole: %v", err)
+	}
+
+	var users []string
+	for _, login := range []string{"member-page-one", "member-page-two", "member-page-three"} {
+		user, err := c.CreateUser(ctx, SystemActorID, login, "PAGINATED Member", "password123")
+		if err != nil {
+			t.Fatalf("CreateUser %s: %v", login, err)
+		}
+		users = append(users, user.Id)
+	}
+	if err := c.AssignServerRole(ctx, SystemActorID, users[1], RoleModerator); err != nil {
+		t.Fatalf("AssignServerRole: %v", err)
+	}
+
+	page, err := c.ListAdminMembers(ctx, admin.Id, AdminMemberListInput{
+		Search: "paginated MEM",
+		Limit:  1,
+		Offset: 1,
+	})
+	if err != nil {
+		t.Fatalf("ListAdminMembers: %v", err)
+	}
+	if page.TotalCount != 3 || !page.HasMore || len(page.Users) != 1 {
+		t.Fatalf("page = users:%d total:%d hasMore:%v, want 1/3/true", len(page.Users), page.TotalCount, page.HasMore)
+	}
+	if page.Users[0].ID != users[1] {
+		t.Fatalf("page user = %q, want %q", page.Users[0].ID, users[1])
+	}
+	if got := page.Users[0].Roles; len(got) != 1 || got[0] != RoleModerator {
+		t.Fatalf("page roles = %v, want explicit moderator only", got)
+	}
+
+	serverMembers, total, err := c.GetServerMembers(ctx, "member-page-two", 1, 0)
+	if err != nil {
+		t.Fatalf("GetServerMembers: %v", err)
+	}
+	if total != 1 || len(serverMembers) != 1 || serverMembers[0].User == nil {
+		t.Fatalf("server members = %+v total:%d, want one hydrated member", serverMembers, total)
+	}
+	if got := serverMembers[0].Roles; len(got) != 2 || got[0] != RoleEveryone || got[1] != RoleModerator {
+		t.Fatalf("server member roles = %v, want everyone and moderator", got)
+	}
+
+	if err := c.DeleteUser(ctx, SystemActorID, users[1]); err != nil {
+		t.Fatalf("DeleteUser: %v", err)
+	}
+	afterDelete, err := c.ListAdminMembers(ctx, admin.Id, AdminMemberListInput{Search: "paginated mem", Limit: 10})
+	if err != nil {
+		t.Fatalf("ListAdminMembers after deletion: %v", err)
+	}
+	if afterDelete.TotalCount != 2 || len(afterDelete.Users) != 2 || afterDelete.HasMore {
+		t.Fatalf("after deletion = users:%d total:%d hasMore:%v, want 2/2/false", len(afterDelete.Users), afterDelete.TotalCount, afterDelete.HasMore)
+	}
+	for _, member := range afterDelete.Users {
+		if member.ID == users[1] || member.Deleted {
+			t.Fatalf("deleted user remained in list: %+v", member)
+		}
+	}
+}
+
 func TestChattoCore_AdminRoleAssignmentAuthorization(t *testing.T) {
 	t.Run("unauthenticated actor is rejected", func(t *testing.T) {
 		c, _ := setupTestCore(t)

--- a/cli/internal/core/spaces.go
+++ b/cli/internal/core/spaces.go
@@ -130,6 +130,7 @@ func (c *ChattoCore) GetAssetCount(ctx context.Context) (int, error) {
 // ServerMemberWithRoles represents a server member with their assigned roles.
 type ServerMemberWithRoles struct {
 	UserID string
+	User   *corev1.User
 	Roles  []string
 }
 
@@ -140,80 +141,60 @@ type ServerMemberWithRoles struct {
 // Post-#330 every authenticated user is implicitly a server member, so this
 // iterates the full user list rather than space-membership records.
 func (c *ChattoCore) GetServerMembers(ctx context.Context, search string, limit, offset int) ([]ServerMemberWithRoles, int, error) {
-	type memberWithUser struct {
-		member ServerMemberWithRoles
-		user   *corev1.User
-	}
-
 	allUsers, err := c.ListUsers(ctx)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to list users: %w", err)
 	}
 
-	userIDs := make([]string, 0, len(allUsers))
-	for _, u := range allUsers {
-		userIDs = append(userIDs, u.Id)
-	}
-
-	if len(userIDs) == 0 {
-		return []ServerMemberWithRoles{}, 0, nil
-	}
-
-	// Normalize search term for case-insensitive matching
-	searchLower := strings.ToLower(strings.TrimSpace(search))
-
-	// Filter and build results
-	var matches []memberWithUser
-	for _, userID := range userIDs {
-		// Get user data
-		user, err := c.GetUser(ctx, userID)
+	matches, totalCount := serverMemberUserPage(allUsers, search, limit, offset)
+	result := make([]ServerMemberWithRoles, 0, len(matches))
+	for _, user := range matches {
+		// The caller is iterating server members, so the virtual "everyone"
+		// role applies. Prepend it to the selected page's explicit assignments.
+		assigned, err := c.GetUserRoles(ctx, user.GetId())
 		if err != nil {
-			c.logger.Warn("Failed to get user for server member listing", "user_id", userID, "error", err)
-			continue // Skip users we can't fetch
-		}
-
-		// Apply search filter if provided
-		if searchLower != "" {
-			loginMatch := strings.Contains(strings.ToLower(user.Login), searchLower)
-			displayNameMatch := strings.Contains(strings.ToLower(user.DisplayName), searchLower)
-			if !loginMatch && !displayNameMatch {
-				continue // Doesn't match search
-			}
-		}
-
-		// Get user's roles (caller is iterating server members so virtual
-		// "everyone" applies — prepend it explicitly).
-		assigned, err := c.GetUserRoles(ctx, userID)
-		if err != nil {
-			c.logger.Warn("Failed to get user roles for server member listing", "user_id", userID, "error", err)
+			c.logger.Warn("Failed to get user roles for server member listing", "user_id", user.GetId(), "error", err)
 			assigned = nil
 		}
-		roles := append([]string{RoleEveryone}, assigned...)
-
-		matches = append(matches, memberWithUser{
-			member: ServerMemberWithRoles{
-				UserID: userID,
-				Roles:  roles,
-			},
-			user: user,
+		result = append(result, ServerMemberWithRoles{
+			UserID: user.GetId(),
+			User:   user,
+			Roles:  append([]string{RoleEveryone}, assigned...),
 		})
+	}
+
+	return result, totalCount, nil
+}
+
+func serverMemberUserPage(allUsers []*corev1.User, search string, limit, offset int) ([]*corev1.User, int) {
+	searchLower := strings.ToLower(strings.TrimSpace(search))
+	matches := make([]*corev1.User, 0, len(allUsers))
+	for _, user := range allUsers {
+		if searchLower != "" {
+			loginMatch := strings.Contains(strings.ToLower(user.GetLogin()), searchLower)
+			displayNameMatch := strings.Contains(strings.ToLower(user.GetDisplayName()), searchLower)
+			if !loginMatch && !displayNameMatch {
+				continue
+			}
+		}
+		matches = append(matches, user)
 	}
 
 	// Sort by created_at (oldest first), with null values sorted to end by login
 	sort.Slice(matches, func(i, j int) bool {
 		// Both null: sort alphabetically by login
-		if matches[i].user.CreatedAt == nil && matches[j].user.CreatedAt == nil {
-			return strings.ToLower(matches[i].user.Login) < strings.ToLower(matches[j].user.Login)
+		if matches[i].GetCreatedAt() == nil && matches[j].GetCreatedAt() == nil {
+			return strings.ToLower(matches[i].GetLogin()) < strings.ToLower(matches[j].GetLogin())
 		}
 		// Null timestamps sort to the end
-		if matches[i].user.CreatedAt == nil {
+		if matches[i].GetCreatedAt() == nil {
 			return false
 		}
-		if matches[j].user.CreatedAt == nil {
+		if matches[j].GetCreatedAt() == nil {
 			return true
 		}
 		// Both have timestamps: sort by time (oldest first)
-		return matches[i].user.CreatedAt.AsTime().Before(matches[j].user.CreatedAt.AsTime())
+		return matches[i].GetCreatedAt().AsTime().Before(matches[j].GetCreatedAt().AsTime())
 	})
 
 	// Get total count before pagination
@@ -221,18 +202,11 @@ func (c *ChattoCore) GetServerMembers(ctx context.Context, search string, limit,
 
 	// Apply pagination
 	if offset >= len(matches) {
-		return []ServerMemberWithRoles{}, totalCount, nil
+		return []*corev1.User{}, totalCount
 	}
 	matches = matches[offset:]
 	if limit > 0 && len(matches) > limit {
 		matches = matches[:limit]
 	}
-
-	// Extract ServerMemberWithRoles from sorted results
-	result := make([]ServerMemberWithRoles, len(matches))
-	for i, m := range matches {
-		result[i] = m.member
-	}
-
-	return result, totalCount, nil
+	return matches, totalCount
 }

--- a/cli/internal/core/spaces_test.go
+++ b/cli/internal/core/spaces_test.go
@@ -3,7 +3,84 @@ package core
 import (
 	"errors"
 	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 )
+
+func TestServerMemberUserPage(t *testing.T) {
+	oldest := timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+	newest := timestamppb.New(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC))
+	users := []*corev1.User{
+		{Id: "nil-z", Login: "Zulu", DisplayName: "Legacy Zulu"},
+		{Id: "new", Login: "bravo", DisplayName: "Second Match", CreatedAt: newest},
+		{Id: "nil-a", Login: "alpha", DisplayName: "Legacy Alpha"},
+		{Id: "old", Login: "FIRST-match", DisplayName: "Oldest", CreatedAt: oldest},
+	}
+
+	tests := []struct {
+		name      string
+		search    string
+		limit     int
+		offset    int
+		wantIDs   []string
+		wantTotal int
+	}{
+		{
+			name:      "orders timestamps before nil timestamps and nil timestamps by login",
+			wantIDs:   []string{"old", "new", "nil-a", "nil-z"},
+			wantTotal: 4,
+		},
+		{
+			name:      "matches login case insensitively",
+			search:    "FiRsT",
+			wantIDs:   []string{"old"},
+			wantTotal: 1,
+		},
+		{
+			name:      "matches display name substrings case insensitively",
+			search:    "cOnD mAt",
+			wantIDs:   []string{"new"},
+			wantTotal: 1,
+		},
+		{
+			name:      "calculates total before pagination",
+			limit:     2,
+			offset:    1,
+			wantIDs:   []string{"new", "nil-a"},
+			wantTotal: 4,
+		},
+		{
+			name:      "returns an empty page beyond the result set",
+			limit:     2,
+			offset:    10,
+			wantIDs:   []string{},
+			wantTotal: 4,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, total := serverMemberUserPage(users, tt.search, tt.limit, tt.offset)
+			if total != tt.wantTotal {
+				t.Fatalf("total = %d, want %d", total, tt.wantTotal)
+			}
+			gotIDs := make([]string, 0, len(got))
+			for _, user := range got {
+				gotIDs = append(gotIDs, user.GetId())
+			}
+			if len(gotIDs) != len(tt.wantIDs) {
+				t.Fatalf("IDs = %v, want %v", gotIDs, tt.wantIDs)
+			}
+			for i := range gotIDs {
+				if gotIDs[i] != tt.wantIDs[i] {
+					t.Fatalf("IDs = %v, want %v", gotIDs, tt.wantIDs)
+				}
+			}
+		})
+	}
+}
 
 func TestSeedDefaultRooms(t *testing.T) {
 	t.Run("creates announcements and general in the seed Lobby group", func(t *testing.T) {


### PR DESCRIPTION
## Summary

- reuse the detached users already returned by `ListUsers` instead of hydrating every account a second time
- filter, sort, count, and paginate the lightweight user rows before fetching role assignments
- carry the selected user snapshot into admin-member assembly so `ListAdminMembers` does not call `GetUser` again
- add focused coverage for search, created-time and nil-time ordering, pagination metadata, implicit/explicit roles, and deleted-user exclusion

## Why

`GetServerMembers` previously called `ListUsers`, extracted every ID, fetched every user again, and loaded every user's roles before pagination. `ListAdminMembers` then fetched each selected user a third time while assembling the response. That made every admin page perform redundant detail work proportional to the server's entire account count, including exact searches that returned one row.

The optimized path scans and sorts the already-hydrated user rows, calculates `totalCount`, applies offset/limit, and only then fetches roles and admin details for the selected page.

## Performance

Identical local large-server runs used the `large-e2e-v1` fixture (2,048 synthetic users and 50,000 messages) and five-sample medians.

| Measurement | Baseline median (range) | Candidate median (range) | Median change |
| --- | ---: | ---: | ---: |
| Member list API | 82.278 ms (72.348–102.230) | 72.444 ms (68.848–76.410) | -12.0% |
| Exact member search API | 81.729 ms (74.554–104.749) | 67.599 ms (65.560–74.028) | -17.3% |
| Members page | 559.173 ms (529.043–643.136) | 413.556 ms (412.916–425.657) | -26.0% |
| Large timeline page | 1,394.576 ms (1,374.099–1,402.716) | 869.018 ms (858.869–881.835) | -37.7% |
| Realtime delivery | 397.953 ms (394.367–510.699) | 389.297 ms (387.006–397.619) | -2.2% |

`mise compare-e2e-performance` reports no regression-budget failures. Timeline and realtime measurements did not regress.

## Correctness and compatibility

- `mise x -- go test ./internal/core -run 'TestServerMemberUserPage|TestChattoCore_(AdminMemberReads|ListAdminMembersPaginationRolesAndDeletion)' -timeout 60s`
- `mise x -- go test ./internal/core -timeout 10m`
- `mise test-cli`
- baseline and candidate `mise test-e2e-performance` runs plus `mise compare-e2e-performance`
- independent adversarial review found no actionable issues

Authorization, case-insensitive login/display-name substring search, created-time ordering and nil fallback, pagination metadata, implicit `everyone` plus explicit roles, and deleted-user behavior are unchanged. The public protobuf API and response shapes are unchanged; no generated artifacts or client migration are required.

## Remaining scaling limits

Substring search and created-time ordering still require hydrating and scanning active user rows, then sorting the matches. That lightweight work remains proportional to the account count; role assignments and admin-only details are now bounded to the selected page.
