### PR TITLE
feat(admin): report durable worker health

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-diagnostics.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-diagnostics.mdx
@@ -49,3 +49,5 @@ Owner-only operational diagnostics for the Chatto server.
 | `system_info` | [`AdminSystemInfo`](/reference/connectrpc-api/types/#chatto-admin-v1-AdminSystemInfo) | Broker connection, account, and JetStream state. |
 | `projections` | repeated [`AdminProjectionState`](/reference/connectrpc-api/types/#chatto-admin-v1-AdminProjectionState) | Event-sourced projection health and memory estimates. |
 | `asset_cleanup` | [`AdminAssetCleanupStatus`](/reference/connectrpc-api/types/#chatto-admin-v1-AdminAssetCleanupStatus) | Recoverable physical deletion worker health. |
+| `durable_workers` | repeated [`AdminDurableWorkerStatus`](/reference/connectrpc-api/types/#chatto-admin-v1-AdminDurableWorkerStatus) | Known durable worker queues and their current broker-derived health. |
+| `projections_available` | `optional bool` | Whether projection diagnostics were collected successfully. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -1011,7 +1011,7 @@ Broker-derived health for one known durable worker queue.
 | `pending_count` | `string` | Deliveries not yet handed to a handler. |
 | `ack_pending_count` | `string` | Deliveries awaiting acknowledgement; this does not prove handler liveness. |
 | `waiting_count` | `string` | Pull requests currently waiting for work. |
-| `redelivered_count` | `string` | Cumulative redelivery count for the consumer's current lifetime. |
+| `redelivered_count` | `string` | Redelivered messages that remain unacknowledged. |
 | `last_delivered_sequence` | `string` | Latest EVT stream sequence delivered to this queue. |
 | `ack_floor_sequence` | `string` | Highest contiguous EVT stream sequence acknowledged by this queue. |
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -998,6 +998,23 @@ Current NATS server connection metadata.
 | `max_payload` | `int64` | Maximum payload accepted by the connected NATS server. |
 | `rtt` | `string` | Round-trip latency to the connected NATS server. |
 
+<a id="chatto-admin-v1-AdminDurableWorkerStatus"></a>
+
+### AdminDurableWorkerStatus
+
+Broker-derived health for one known durable worker queue.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | Stable machine-readable worker key. |
+| `health` | [`AdminDurableWorkerHealth`](#chatto-admin-v1-AdminDurableWorkerHealth) | Current availability and work state. |
+| `pending_count` | `string` | Deliveries not yet handed to a handler. |
+| `ack_pending_count` | `string` | Deliveries awaiting acknowledgement; this does not prove handler liveness. |
+| `waiting_count` | `string` | Pull requests currently waiting for work. |
+| `redelivered_count` | `string` | Cumulative redelivery count for the consumer's current lifetime. |
+| `last_delivered_sequence` | `string` | Latest EVT stream sequence delivered to this queue. |
+| `ack_floor_sequence` | `string` | Highest contiguous EVT stream sequence acknowledged by this queue. |
+
 <a id="chatto-admin-v1-AdminNatsConsumerInfo"></a>
 
 ### AdminNatsConsumerInfo
@@ -1553,6 +1570,22 @@ Operator-facing state for the shared durable asset cleanup queue.
 | `ADMIN_ASSET_CLEANUP_HEALTH_RETRYING` | `4` | No value description provided. |
 | `ADMIN_ASSET_CLEANUP_HEALTH_STALLED` | `5` | No value description provided. |
 | `ADMIN_ASSET_CLEANUP_HEALTH_UNAVAILABLE` | `6` | Cleanup diagnostics could not be read; other system diagnostics remain valid. |
+
+<a id="chatto-admin-v1-AdminDurableWorkerHealth"></a>
+
+### AdminDurableWorkerHealth
+
+Operator-facing state derived from a durable consumer.
+
+| Name | Number | Description |
+| --- | --- | --- |
+| `ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED` | `0` | No value description provided. |
+| `ADMIN_DURABLE_WORKER_HEALTH_INACTIVE` | `1` | This optional worker is not required by current server configuration. |
+| `ADMIN_DURABLE_WORKER_HEALTH_HEALTHY` | `2` | A worker is waiting and all known work is acknowledged. |
+| `ADMIN_DURABLE_WORKER_HEALTH_WORKING` | `3` | A worker is available and unacknowledged work remains. |
+| `ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED` | `4` | An acknowledgement is pending, but broker state cannot prove whether a handler is active or the delivery is awaiting recovery after a crash. |
+| `ADMIN_DURABLE_WORKER_HEALTH_STALLED` | `5` | The consumer exists but has neither a waiting pull nor an ack-pending delivery. |
+| `ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE` | `6` | The required consumer is unavailable. |
 
 <a id="chatto-admin-v1-PermissionDecision"></a>
 

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -1740,7 +1740,7 @@ Broker-derived health for one known durable worker queue.
 | `pending_count` | `string` | Deliveries not yet handed to a handler. |
 | `ack_pending_count` | `string` | Deliveries awaiting acknowledgement; this does not prove handler liveness. |
 | `waiting_count` | `string` | Pull requests currently waiting for work. |
-| `redelivered_count` | `string` | Cumulative redelivery count for the consumer's current lifetime. |
+| `redelivered_count` | `string` | Redelivered messages that remain unacknowledged. |
 | `last_delivered_sequence` | `string` | Latest EVT stream sequence delivered to this queue. |
 | `ack_floor_sequence` | `string` | Highest contiguous EVT stream sequence acknowledged by this queue. |
 

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -49,6 +49,8 @@ Owner-only operational diagnostics for the Chatto server.
 | `system_info` | [`AdminSystemInfo`](#chatto-admin-v1-AdminSystemInfo) | Broker connection, account, and JetStream state. |
 | `projections` | repeated [`AdminProjectionState`](#chatto-admin-v1-AdminProjectionState) | Event-sourced projection health and memory estimates. |
 | `asset_cleanup` | [`AdminAssetCleanupStatus`](#chatto-admin-v1-AdminAssetCleanupStatus) | Recoverable physical deletion worker health. |
+| `durable_workers` | repeated [`AdminDurableWorkerStatus`](#chatto-admin-v1-AdminDurableWorkerStatus) | Known durable worker queues and their current broker-derived health. |
+| `projections_available` | `optional bool` | Whether projection diagnostics were collected successfully. |
 
 
 <a id="chatto-admin-v1-AdminEventLogService"></a>
@@ -1725,6 +1727,25 @@ Current NATS server connection metadata.
 
 
 
+<a id="chatto-admin-v1-AdminDurableWorkerStatus"></a>
+
+### AdminDurableWorkerStatus
+
+Broker-derived health for one known durable worker queue.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `key` | `string` | Stable machine-readable worker key. |
+| `health` | [`AdminDurableWorkerHealth`](#chatto-admin-v1-AdminDurableWorkerHealth) | Current availability and work state. |
+| `pending_count` | `string` | Deliveries not yet handed to a handler. |
+| `ack_pending_count` | `string` | Deliveries awaiting acknowledgement; this does not prove handler liveness. |
+| `waiting_count` | `string` | Pull requests currently waiting for work. |
+| `redelivered_count` | `string` | Cumulative redelivery count for the consumer's current lifetime. |
+| `last_delivered_sequence` | `string` | Latest EVT stream sequence delivered to this queue. |
+| `ack_floor_sequence` | `string` | Highest contiguous EVT stream sequence acknowledged by this queue. |
+
+
+
 <a id="chatto-admin-v1-AdminNatsConsumerInfo"></a>
 
 ### AdminNatsConsumerInfo
@@ -2183,6 +2204,23 @@ Operator-facing state for the shared durable asset cleanup queue.
 | `ADMIN_ASSET_CLEANUP_HEALTH_RETRYING` | `4` | No value description provided. |
 | `ADMIN_ASSET_CLEANUP_HEALTH_STALLED` | `5` | No value description provided. |
 | `ADMIN_ASSET_CLEANUP_HEALTH_UNAVAILABLE` | `6` | Cleanup diagnostics could not be read; other system diagnostics remain valid. |
+
+
+<a id="chatto-admin-v1-AdminDurableWorkerHealth"></a>
+
+### AdminDurableWorkerHealth
+
+Operator-facing state derived from a durable consumer.
+
+| Name | Number | Description |
+| --- | --- | --- |
+| `ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED` | `0` | No value description provided. |
+| `ADMIN_DURABLE_WORKER_HEALTH_INACTIVE` | `1` | This optional worker is not required by current server configuration. |
+| `ADMIN_DURABLE_WORKER_HEALTH_HEALTHY` | `2` | A worker is waiting and all known work is acknowledged. |
+| `ADMIN_DURABLE_WORKER_HEALTH_WORKING` | `3` | A worker is available and unacknowledged work remains. |
+| `ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED` | `4` | An acknowledgement is pending, but broker state cannot prove whether a handler is active or the delivery is awaiting recovery after a crash. |
+| `ADMIN_DURABLE_WORKER_HEALTH_STALLED` | `5` | The consumer exists but has neither a waiting pull nor an ack-pending delivery. |
+| `ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE` | `6` | The required consumer is unavailable. |
 
 
 <a id="chatto-admin-v1-PermissionDecision"></a>

--- a/apps/frontend/messages/ar/admin.json
+++ b/apps/frontend/messages/ar/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "غير محدود",
       "all_subjects": "جميع المواضيع",
       "pending_state": "معلق",
+      "worker_unconfirmed": "غير مؤكد",
       "rtt": "RTT",
       "max_payload": "أقصى حجم للبيانات",
       "server_id": "معرّف الخادم",

--- a/apps/frontend/messages/cs-CZ/admin.json
+++ b/apps/frontend/messages/cs-CZ/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "neomezené",
       "all_subjects": "všechny předměty",
       "pending_state": "Čeká na vyřízení",
+      "worker_unconfirmed": "Nepotvrzeno",
       "rtt": "RTT",
       "max_payload": "Maximální užitečné zatížení",
       "server_id": "ID serveru",

--- a/apps/frontend/messages/de-AT/admin.json
+++ b/apps/frontend/messages/de-AT/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "unbegrenzt",
       "all_subjects": "alle Subjects",
       "pending_state": "Ausstehend",
+      "worker_unconfirmed": "Unbestätigt",
       "rtt": "RTT",
       "max_payload": "Maximale Nutzlast",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/de-CH/admin.json
+++ b/apps/frontend/messages/de-CH/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "unbegrenzt",
       "all_subjects": "alle Subjects",
       "pending_state": "Ausstehend",
+      "worker_unconfirmed": "Unbestätigt",
       "rtt": "RTT",
       "max_payload": "Maximale Nutzlast",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/de-DE/admin.json
+++ b/apps/frontend/messages/de-DE/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "unbegrenzt",
       "all_subjects": "alle Subjects",
       "pending_state": "Ausstehend",
+      "worker_unconfirmed": "Unbestätigt",
       "rtt": "RTT",
       "max_payload": "Maximale Nutzlast",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/en-GB/admin.json
+++ b/apps/frontend/messages/en-GB/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "unlimited",
       "all_subjects": "all subjects",
       "pending_state": "Pending",
+      "worker_unconfirmed": "Unconfirmed",
       "rtt": "RTT",
       "max_payload": "Max Payload",
       "server_id": "Server ID",

--- a/apps/frontend/messages/eo/admin.json
+++ b/apps/frontend/messages/eo/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "senlima",
       "all_subjects": "ĉiuj temoj",
       "pending_state": "Pritraktata",
+      "worker_unconfirmed": "Nekonfirmita",
       "rtt": "RTT",
       "max_payload": "Maksimuma Utila Ŝarĝo",
       "server_id": "Servila ID",

--- a/apps/frontend/messages/es-419/admin.json
+++ b/apps/frontend/messages/es-419/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "ilimitado",
       "all_subjects": "todos los temas",
       "pending_state": "Pendiente",
+      "worker_unconfirmed": "Sin confirmar",
       "rtt": "RTT",
       "max_payload": "Carga útil máxima",
       "server_id": "ID del servidor",

--- a/apps/frontend/messages/es-ES/admin.json
+++ b/apps/frontend/messages/es-ES/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "ilimitado",
       "all_subjects": "todos los temas",
       "pending_state": "Pendiente",
+      "worker_unconfirmed": "Sin confirmar",
       "rtt": "RTT",
       "max_payload": "Carga útil máxima",
       "server_id": "ID del servidor",

--- a/apps/frontend/messages/et-EE/admin.json
+++ b/apps/frontend/messages/et-EE/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "piiramatu",
       "all_subjects": "kõik õppeained",
       "pending_state": "Ootel",
+      "worker_unconfirmed": "Kinnitamata",
       "rtt": "RTT",
       "max_payload": "Maksimaalne kandevõime",
       "server_id": "Serveri ID",

--- a/apps/frontend/messages/fr-CA/admin.json
+++ b/apps/frontend/messages/fr-CA/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "illimité",
       "all_subjects": "tous les sujets",
       "pending_state": "En attente",
+      "worker_unconfirmed": "Non confirmé",
       "rtt": "RTT",
       "max_payload": "Charge utile maximale",
       "server_id": "ID du serveur",

--- a/apps/frontend/messages/fr-FR/admin.json
+++ b/apps/frontend/messages/fr-FR/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "illimité",
       "all_subjects": "tous les sujets",
       "pending_state": "En attente",
+      "worker_unconfirmed": "Non confirmé",
       "rtt": "RTT",
       "max_payload": "Charge utile maximale",
       "server_id": "ID du serveur",

--- a/apps/frontend/messages/he-IL/admin.json
+++ b/apps/frontend/messages/he-IL/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "ללא הגבלה",
       "all_subjects": "כל הנושאים",
       "pending_state": "בהמתנה",
+      "worker_unconfirmed": "לא מאומת",
       "rtt": "RTT",
       "max_payload": "מטען מרבי",
       "server_id": "מזהה שרת",

--- a/apps/frontend/messages/it-IT/admin.json
+++ b/apps/frontend/messages/it-IT/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "illimitato",
       "all_subjects": "tutti i soggetti",
       "pending_state": "In sospeso",
+      "worker_unconfirmed": "Non confermato",
       "rtt": "RTT",
       "max_payload": "Carico utile massimo",
       "server_id": "ID del server",

--- a/apps/frontend/messages/ja-JP/admin.json
+++ b/apps/frontend/messages/ja-JP/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "無制限",
       "all_subjects": "すべての科目",
       "pending_state": "保留中",
+      "worker_unconfirmed": "未確認",
       "rtt": "RTT",
       "max_payload": "最大ペイロード",
       "server_id": "サーバーID",

--- a/apps/frontend/messages/lv-LV/admin.json
+++ b/apps/frontend/messages/lv-LV/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "neierobežots",
       "all_subjects": "visi priekšmeti",
       "pending_state": "Gaida",
+      "worker_unconfirmed": "Neapstiprināts",
       "rtt": "RTT",
       "max_payload": "Maksimālā kravnesība",
       "server_id": "Servera ID",

--- a/apps/frontend/messages/nb-NO/admin.json
+++ b/apps/frontend/messages/nb-NO/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "ubegrenset",
       "all_subjects": "alle fag",
       "pending_state": "Venter",
+      "worker_unconfirmed": "Ubekreftet",
       "rtt": "RTT",
       "max_payload": "Maks nyttelast",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/nl-BE/admin.json
+++ b/apps/frontend/messages/nl-BE/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "onbeperkt",
       "all_subjects": "alle onderwerpen",
       "pending_state": "In behandeling",
+      "worker_unconfirmed": "Onbevestigd",
       "rtt": "RTT",
       "max_payload": "Maximale lading",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/nl-NL/admin.json
+++ b/apps/frontend/messages/nl-NL/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "onbeperkt",
       "all_subjects": "alle onderwerpen",
       "pending_state": "In behandeling",
+      "worker_unconfirmed": "Onbevestigd",
       "rtt": "RTT",
       "max_payload": "Maximale lading",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/pl-PL/admin.json
+++ b/apps/frontend/messages/pl-PL/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "bez ograniczeń",
       "all_subjects": "wszystkie tematy",
       "pending_state": "Oczekuje",
+      "worker_unconfirmed": "Niepotwierdzony",
       "rtt": "RTT",
       "max_payload": "Maksymalna ładowność",
       "server_id": "Identyfikator serwera",

--- a/apps/frontend/messages/pt-BR/admin.json
+++ b/apps/frontend/messages/pt-BR/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "ilimitado",
       "all_subjects": "todos os assuntos",
       "pending_state": "Pendente",
+      "worker_unconfirmed": "Não confirmado",
       "rtt": "RTT",
       "max_payload": "Carga útil máxima",
       "server_id": "ID do servidor",

--- a/apps/frontend/messages/pt-PT/admin.json
+++ b/apps/frontend/messages/pt-PT/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "ilimitado",
       "all_subjects": "todos os assuntos",
       "pending_state": "Pendente",
+      "worker_unconfirmed": "Não confirmado",
       "rtt": "RTT",
       "max_payload": "Carga útil máxima",
       "server_id": "ID do servidor",

--- a/apps/frontend/messages/ru-RU/admin.json
+++ b/apps/frontend/messages/ru-RU/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "неограниченный",
       "all_subjects": "все предметы",
       "pending_state": "Ожидается",
+      "worker_unconfirmed": "Не подтверждено",
       "rtt": "РТТ",
       "max_payload": "Макс. полезная нагрузка",
       "server_id": "Идентификатор сервера",

--- a/apps/frontend/messages/sv-SE/admin.json
+++ b/apps/frontend/messages/sv-SE/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "obegränsat",
       "all_subjects": "alla ämnen",
       "pending_state": "Väntar",
+      "worker_unconfirmed": "Obekräftad",
       "rtt": "RTT",
       "max_payload": "Max nyttolast",
       "server_id": "Server-ID",

--- a/apps/frontend/messages/tr-TR/admin.json
+++ b/apps/frontend/messages/tr-TR/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "sınırsız",
       "all_subjects": "tüm konular",
       "pending_state": "Beklemede",
+      "worker_unconfirmed": "Doğrulanmadı",
       "rtt": "RTT",
       "max_payload": "Maksimum Yük",
       "server_id": "Sunucu Kimliği",

--- a/apps/frontend/messages/uk-UA/admin.json
+++ b/apps/frontend/messages/uk-UA/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "без обмежень",
       "all_subjects": "усі теми",
       "pending_state": "Очікує на розгляд",
+      "worker_unconfirmed": "Не підтверджено",
       "rtt": "RTT",
       "max_payload": "Максимальне корисне навантаження",
       "server_id": "Ідентифікатор сервера",

--- a/apps/frontend/messages/zh-CN/admin.json
+++ b/apps/frontend/messages/zh-CN/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "无限制",
       "all_subjects": "所有 subject",
       "pending_state": "待处理",
+      "worker_unconfirmed": "未确认",
       "rtt": "RTT",
       "max_payload": "Payload 上限",
       "server_id": "服务器 ID",

--- a/apps/frontend/messages/zh-TW/admin.json
+++ b/apps/frontend/messages/zh-TW/admin.json
@@ -247,6 +247,7 @@
       "unlimited": "無限制",
       "all_subjects": "所有 subject",
       "pending_state": "待處理",
+      "worker_unconfirmed": "未確認",
       "rtt": "RTT",
       "max_payload": "Payload 上限",
       "server_id": "伺服器 ID",

--- a/apps/frontend/src/lib/api-client-tests/adminDiagnostics.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/adminDiagnostics.spec.ts
@@ -1,5 +1,8 @@
 import { protoInt64, Timestamp } from '@bufbuild/protobuf';
-import { AdminAssetCleanupHealth } from '@chatto/api-types/admin/v1/diagnostics_pb';
+import {
+  AdminAssetCleanupHealth,
+  AdminDurableWorkerHealth
+} from '@chatto/api-types/admin/v1/diagnostics_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { getAdminSystemInfo } from '$lib/api-client/adminDiagnostics';
 
@@ -100,6 +103,7 @@ describe('getAdminSystemInfo', () => {
           dmRoomCount: 2
         }
       },
+      projectionsAvailable: true,
       projections: [
         {
           key: 'rooms',
@@ -154,7 +158,19 @@ describe('getAdminSystemInfo', () => {
         lastPassFailed: true,
         lastInspectedSequence: '41',
         latestDeletionSequence: '44'
-      }
+      },
+      durableWorkers: [
+        {
+          key: 'user_key_shredding',
+          health: AdminDurableWorkerHealth.WORKING,
+          pendingCount: '2',
+          ackPendingCount: '1',
+          waitingCount: '1',
+          redeliveredCount: '3',
+          lastDeliveredSequence: '44',
+          ackFloorSequence: '41'
+        }
+      ]
     });
 
     const controller = new AbortController();
@@ -176,11 +192,15 @@ describe('getAdminSystemInfo', () => {
     );
     expect(info.connection.maxPayload).toBe(1048576);
     expect(info.account.storageUsed).toBe(750);
+    expect(info.accountAvailable).toBe(true);
     expect(info.nats.totalMessages).toBe(12);
+    expect(info.natsAvailable).toBe(true);
     expect(info.nats.streams[0].bytes).toBe(3456);
     expect(info.nats.consumers[0].pending).toBe(7);
     expect(info.stats.userCount).toBe(5);
+    expect(info.statsAvailable).toBe(true);
     expect(info.projections[0].startupDurationSeconds).toBe(0.25);
+    expect(info.projectionsAvailable).toBe(true);
     expect(info.projections[0].metrics[0].bytes).toBe(768);
     expect(info.projections[1].startupDurationSeconds).toBeNull();
     expect(info.assetCleanup).toEqual({
@@ -196,6 +216,18 @@ describe('getAdminSystemInfo', () => {
       lastInspectedSequence: '41',
       latestDeletionSequence: '44'
     });
+    expect(info.durableWorkers).toEqual([
+      {
+        key: 'user_key_shredding',
+        health: 'working',
+        pendingCount: '2',
+        ackPendingCount: '1',
+        waitingCount: '1',
+        redeliveredCount: '3',
+        lastDeliveredSequence: '44',
+        ackFloorSequence: '41'
+      }
+    ]);
   });
 
   it('maps missing nested sections to empty defaults and omits auth headers without a token', async () => {
@@ -211,9 +243,13 @@ describe('getAdminSystemInfo', () => {
     expect(mocks.getSystemInfo).toHaveBeenCalledWith({}, { headers: undefined });
     expect(info.connection.connected).toBe(false);
     expect(info.account.storageUsed).toBe(0);
+    expect(info.accountAvailable).toBe(false);
+    expect(info.natsAvailable).toBe(false);
     expect(info.nats.streams).toEqual([]);
     expect(info.stats.userCount).toBe(0);
+    expect(info.statsAvailable).toBe(false);
     expect(info.projections).toEqual([]);
+    expect(info.projectionsAvailable).toBe(true);
     expect(info.assetCleanup).toEqual({
       available: false,
       health: 'unavailable',
@@ -227,11 +263,13 @@ describe('getAdminSystemInfo', () => {
       lastInspectedSequence: '0',
       latestDeletionSequence: '0'
     });
+    expect(info.durableWorkers).toEqual([]);
   });
 
   it('treats explicitly unavailable cleanup diagnostics as unavailable', async () => {
     mocks.getSystemInfo.mockResolvedValue({
       projections: [],
+      projectionsAvailable: false,
       assetCleanup: {
         health: AdminAssetCleanupHealth.UNAVAILABLE,
         pendingCount: protoInt64.parse(7),
@@ -244,5 +282,6 @@ describe('getAdminSystemInfo', () => {
 
     expect(info.assetCleanup.available).toBe(false);
     expect(info.assetCleanup.health).toBe('unavailable');
+    expect(info.projectionsAvailable).toBe(false);
   });
 });

--- a/apps/frontend/src/lib/api-client/adminDiagnostics.ts
+++ b/apps/frontend/src/lib/api-client/adminDiagnostics.ts
@@ -1,6 +1,9 @@
 import { authHeaders, createChattoClient } from './connect.js';
 import { AdminDiagnosticsService } from '@chatto/api-types/admin/v1/diagnostics_connect';
-import { AdminAssetCleanupHealth } from '@chatto/api-types/admin/v1/diagnostics_pb';
+import {
+  AdminAssetCleanupHealth,
+  AdminDurableWorkerHealth
+} from '@chatto/api-types/admin/v1/diagnostics_pb';
 
 export type AdminDiagnosticsAPIConfig = {
   baseUrl: string;
@@ -11,10 +14,26 @@ export type AdminDiagnosticsAPIConfig = {
 export type AdminSystemInfo = {
   connection: AdminConnectionInfo;
   account: AdminAccountInfo;
+  accountAvailable: boolean;
   nats: AdminNatsStats;
+  natsAvailable: boolean;
   stats: AdminServerStats;
+  statsAvailable: boolean;
   projections: AdminProjectionState[];
+  projectionsAvailable: boolean;
   assetCleanup: AdminAssetCleanupStatus;
+  durableWorkers: AdminDurableWorkerStatus[];
+};
+
+export type AdminDurableWorkerStatus = {
+  key: string;
+  health: 'inactive' | 'healthy' | 'working' | 'unconfirmed' | 'stalled' | 'unavailable';
+  pendingCount: string;
+  ackPendingCount: string;
+  waitingCount: string;
+  redeliveredCount: string;
+  lastDeliveredSequence: string;
+  ackFloorSequence: string;
 };
 
 export type AdminAssetCleanupStatus = {
@@ -151,6 +170,25 @@ function assetCleanupHealth(
   }
 }
 
+function durableWorkerHealth(
+  health: AdminDurableWorkerHealth | undefined
+): AdminDurableWorkerStatus['health'] {
+  switch (health) {
+    case AdminDurableWorkerHealth.INACTIVE:
+      return 'inactive';
+    case AdminDurableWorkerHealth.HEALTHY:
+      return 'healthy';
+    case AdminDurableWorkerHealth.WORKING:
+      return 'working';
+    case AdminDurableWorkerHealth.UNCONFIRMED:
+      return 'unconfirmed';
+    case AdminDurableWorkerHealth.STALLED:
+      return 'stalled';
+    default:
+      return 'unavailable';
+  }
+}
+
 export async function getAdminSystemInfo(
   config: AdminDiagnosticsAPIConfig,
   options: { signal?: AbortSignal } = {}
@@ -186,6 +224,8 @@ export async function getAdminSystemInfo(
       consumers: systemInfo?.account?.consumers ?? 0,
       consumersUsed: systemInfo?.account?.consumersUsed ?? 0
     },
+    accountAvailable: systemInfo?.account != null,
+    natsAvailable: systemInfo?.nats != null,
     nats: {
       totalMessages: Number(systemInfo?.nats?.totalMessages ?? 0),
       totalBytes: Number(systemInfo?.nats?.totalBytes ?? 0),
@@ -228,6 +268,7 @@ export async function getAdminSystemInfo(
       channelRoomCount: systemInfo?.stats?.channelRoomCount ?? 0,
       dmRoomCount: systemInfo?.stats?.dmRoomCount ?? 0
     },
+    statsAvailable: systemInfo?.stats != null,
     assetCleanup: {
       available: cleanupAvailable,
       health: assetCleanupHealth(cleanup?.health),
@@ -241,6 +282,16 @@ export async function getAdminSystemInfo(
       lastInspectedSequence: cleanup?.lastInspectedSequence ?? '0',
       latestDeletionSequence: cleanup?.latestDeletionSequence ?? '0'
     },
+    durableWorkers: (response.durableWorkers ?? []).map((worker) => ({
+      key: worker.key,
+      health: durableWorkerHealth(worker.health),
+      pendingCount: worker.pendingCount,
+      ackPendingCount: worker.ackPendingCount,
+      waitingCount: worker.waitingCount,
+      redeliveredCount: worker.redeliveredCount,
+      lastDeliveredSequence: worker.lastDeliveredSequence,
+      ackFloorSequence: worker.ackFloorSequence
+    })),
     projections: response.projections.map((projection) => ({
       key: projection.key,
       name: projection.name,
@@ -262,6 +313,7 @@ export async function getAdminSystemInfo(
         value: Number(metric.value),
         bytes: Number(metric.bytes)
       }))
-    }))
+    })),
+    projectionsAvailable: response.projectionsAvailable ?? true
   };
 }

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
@@ -10,6 +10,7 @@
   import { queryClient } from '$lib/query/client';
   import { m } from '$lib/i18n/messages';
   import AssetCleanupPanel from './AssetCleanupPanel.svelte';
+  import DurableWorkersPanel from './DurableWorkersPanel.svelte';
 
   const serverScope = useServerScope();
 
@@ -35,8 +36,8 @@
         : String(systemInfoQuery.error)
   );
 
-  const streams = $derived(systemInfo?.nats.streams ?? []);
-  const consumers = $derived(systemInfo?.nats.consumers ?? []);
+  const streams = $derived(systemInfo?.nats?.streams ?? []);
+  const consumers = $derived(systemInfo?.nats?.consumers ?? []);
   const projections = $derived(
     [...(systemInfo?.projections ?? [])].sort((a, b) => {
       if (a.failed !== b.failed) return a.failed ? -1 : 1;
@@ -70,7 +71,7 @@
     consumers.reduce((sum, consumer) => sum + consumer.redelivered, 0)
   );
   const averageEventBytes = $derived(
-    systemInfo && systemInfo.nats.totalMessages > 0
+    systemInfo?.natsAvailable && systemInfo.nats.totalMessages > 0
       ? systemInfo.nats.totalBytes / systemInfo.nats.totalMessages
       : 0
   );
@@ -174,6 +175,7 @@
           </div>
         </Panel>
 
+        {#if systemInfo.accountAvailable}
         <div>
           <h2 class="mb-3 text-sm font-semibold text-muted uppercase">
             {m('admin.system.jetstream_account')}
@@ -219,7 +221,11 @@
             />
           </div>
         </div>
+        {:else}
+          <Hint>{m('admin.system.asset_cleanup_unavailable')}</Hint>
+        {/if}
 
+        {#if systemInfo.natsAvailable}
         <div>
           <h2 class="mb-3 text-sm font-semibold text-muted uppercase">
             {m('admin.system.stream_activity')}
@@ -265,7 +271,7 @@
           </div>
         </div>
 
-        <div class="grid gap-4 lg:grid-cols-3">
+        <div class="grid gap-4 lg:grid-cols-2">
           <Panel title={m('admin.system.stream_summary')} icon="iconify icon-[uil--chart-line]">
             <div class="grid grid-cols-2 gap-x-6 gap-y-4">
               <div>
@@ -322,38 +328,6 @@
             </div>
           </Panel>
 
-          <Panel title={m('admin.system.projection_summary')} icon="iconify icon-[uil--layers]">
-            <div class="grid grid-cols-2 gap-x-6 gap-y-4">
-              <div>
-                <div class="text-sm text-muted">{m('admin.system.projections')}</div>
-                <div class="font-mono text-lg">{formatNumber(projections.length)}</div>
-              </div>
-              <div>
-                <div class="text-sm text-muted">{m('admin.system.entries')}</div>
-                <div class="font-mono text-lg">{formatNumber(totalEntries)}</div>
-              </div>
-              <div>
-                <div class="text-sm text-muted">{m('admin.system.projection_memory')}</div>
-                <div class="font-mono text-lg">{formatBytes(totalEstimatedBytes)}</div>
-              </div>
-              <div>
-                <div class="text-sm text-muted">{m('admin.system.average_entry_size')}</div>
-                <div class="font-mono text-lg">{formatBytes(averageProjectionEntryBytes)}</div>
-              </div>
-              <div>
-                <div class="text-sm text-muted">{m('admin.system.projection_failures')}</div>
-                <div class={['font-mono text-lg', failedProjectionCount > 0 ? 'text-danger' : '']}>
-                  {formatNumber(failedProjectionCount)}
-                </div>
-              </div>
-              <div>
-                <div class="text-sm text-muted">{m('admin.system.projection_lag')}</div>
-                <div class={['font-mono text-lg', laggingCount > 0 ? 'text-warning' : '']}>
-                  {formatNumber(laggingCount)}
-                </div>
-              </div>
-            </div>
-          </Panel>
         </div>
 
         <Panel title={m('admin.system.streams')} icon="iconify icon-[uil--exchange]" noPadding>
@@ -452,6 +426,43 @@
             {/snippet}
           </DataTable>
         </Panel>
+        {:else}
+          <Hint>{m('admin.system.asset_cleanup_unavailable')}</Hint>
+        {/if}
+
+        {#if systemInfo.projectionsAvailable}
+        <Panel title={m('admin.system.projection_summary')} icon="iconify icon-[uil--layers]">
+          <div class="grid grid-cols-2 gap-x-6 gap-y-4 md:grid-cols-3">
+            <div>
+              <div class="text-sm text-muted">{m('admin.system.projections')}</div>
+              <div class="font-mono text-lg">{formatNumber(projections.length)}</div>
+            </div>
+            <div>
+              <div class="text-sm text-muted">{m('admin.system.entries')}</div>
+              <div class="font-mono text-lg">{formatNumber(totalEntries)}</div>
+            </div>
+            <div>
+              <div class="text-sm text-muted">{m('admin.system.projection_memory')}</div>
+              <div class="font-mono text-lg">{formatBytes(totalEstimatedBytes)}</div>
+            </div>
+            <div>
+              <div class="text-sm text-muted">{m('admin.system.average_entry_size')}</div>
+              <div class="font-mono text-lg">{formatBytes(averageProjectionEntryBytes)}</div>
+            </div>
+            <div>
+              <div class="text-sm text-muted">{m('admin.system.projection_failures')}</div>
+              <div class={['font-mono text-lg', failedProjectionCount > 0 ? 'text-danger' : '']}>
+                {formatNumber(failedProjectionCount)}
+              </div>
+            </div>
+            <div>
+              <div class="text-sm text-muted">{m('admin.system.projection_lag')}</div>
+              <div class={['font-mono text-lg', laggingCount > 0 ? 'text-warning' : '']}>
+                {formatNumber(laggingCount)}
+              </div>
+            </div>
+          </div>
+        </Panel>
 
         <Panel
           title={m('admin.system.projections')}
@@ -525,7 +536,11 @@
             {/snippet}
           </DataTable>
         </Panel>
+        {:else}
+          <Hint>{m('admin.system.asset_cleanup_unavailable')}</Hint>
+        {/if}
 
+        <DurableWorkersPanel workers={systemInfo.durableWorkers} />
         <AssetCleanupPanel status={systemInfo.assetCleanup} />
       {/if}
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte
@@ -1,0 +1,94 @@
+<script lang="ts">
+	import type { AdminDurableWorkerStatus } from '$lib/api-client/adminDiagnostics';
+	import { DataTable, Panel } from '$lib/components/admin';
+	import { Pill } from '$lib/ui';
+	import { m } from '$lib/i18n/messages';
+
+	let { workers }: { workers: AdminDurableWorkerStatus[] } = $props();
+
+	function healthLabel(health: AdminDurableWorkerStatus['health']): string {
+		switch (health) {
+			case 'healthy':
+				return m('admin.system.asset_cleanup_healthy');
+			case 'working':
+				return m('admin.system.asset_cleanup_in_progress');
+			case 'unconfirmed':
+				return m('admin.system.pending_state');
+			case 'stalled':
+				return m('admin.system.asset_cleanup_stalled');
+			case 'inactive':
+				return m('admin.system.asset_cleanup_inactive');
+			default:
+				return m('admin.system.asset_cleanup_unavailable');
+		}
+	}
+
+	function healthTone(
+		health: AdminDurableWorkerStatus['health']
+	): 'success' | 'action' | 'danger' | 'muted' {
+		switch (health) {
+			case 'healthy':
+				return 'success';
+			case 'working':
+				return 'action';
+			case 'unconfirmed':
+				return 'muted';
+			case 'stalled':
+				return 'danger';
+			default:
+				return 'muted';
+		}
+	}
+
+	function formatCount(value: string): string {
+		try {
+			return BigInt(value).toLocaleString();
+		} catch {
+			return value;
+		}
+	}
+</script>
+
+<Panel
+	title={m('admin.system.durable', { name: m('admin.system.consumers') })}
+	icon="iconify icon-[uil--cog]"
+	noPadding
+>
+	<DataTable
+		items={workers}
+		columns={6}
+		emptyMessage={m('admin.system.asset_cleanup_unavailable')}
+	>
+		{#snippet header()}
+			<th class="table-header-cell">{m('admin.system.consumer')}</th>
+			<th class="table-header-cell">{m('admin.system.state')}</th>
+			<th class="table-header-cell">{m('admin.system.pending')}</th>
+			<th class="table-header-cell">{m('admin.system.ack_pending')}</th>
+			<th class="table-header-cell">{m('admin.system.redelivered')}</th>
+			<th class="table-header-cell">{m('admin.system.acked_through')}</th>
+		{/snippet}
+		{#snippet row(worker)}
+			<td class="px-4 py-3">
+				<div class="font-mono text-sm">{worker.key}</div>
+			</td>
+			<td class="px-4 py-3">
+				<Pill tone={healthTone(worker.health)}>{healthLabel(worker.health)}</Pill>
+			</td>
+			<td class="px-4 py-3 font-mono text-sm">
+				<span class={[worker.pendingCount !== '0' ? 'font-semibold text-warning' : '']}>
+					{formatCount(worker.pendingCount)}
+				</span>
+			</td>
+			<td class="px-4 py-3 font-mono text-sm">
+				{formatCount(worker.ackPendingCount)}
+			</td>
+			<td class="px-4 py-3 font-mono text-sm">
+				{formatCount(worker.redeliveredCount)}
+			</td>
+			<td class="px-4 py-3 whitespace-nowrap">
+				<div class="font-mono text-sm">{worker.ackFloorSequence}</div>
+				<div class="font-mono text-xs text-muted">/ {worker.lastDeliveredSequence}</div>
+			</td>
+		{/snippet}
+	</DataTable>
+</Panel>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte
@@ -13,7 +13,7 @@
 			case 'working':
 				return m('admin.system.asset_cleanup_in_progress');
 			case 'unconfirmed':
-				return m('admin.system.pending_state');
+				return m('admin.system.worker_unconfirmed');
 			case 'stalled':
 				return m('admin.system.asset_cleanup_stalled');
 			case 'inactive':

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte.spec.ts
@@ -1,0 +1,32 @@
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it } from 'vitest';
+import DurableWorkersPanel from './DurableWorkersPanel.svelte';
+
+describe('DurableWorkersPanel', () => {
+	it('shows broker-derived worker health and queue state', () => {
+		const { container } = render(DurableWorkersPanel, {
+			props: {
+				workers: [
+					{
+						key: 'user_key_shredding',
+						health: 'working',
+						pendingCount: '2',
+						ackPendingCount: '1',
+						waitingCount: '1',
+						redeliveredCount: '3',
+						lastDeliveredSequence: '44',
+						ackFloorSequence: '41'
+					}
+				]
+			}
+		});
+
+		expect(container.textContent).toContain('In progress');
+		expect(container.textContent).toContain('user_key_shredding');
+	});
+
+	it('shows unavailable when an older server reports no worker diagnostics', () => {
+		const { container } = render(DurableWorkersPanel, { props: { workers: [] } });
+		expect(container.textContent).toContain('Unavailable');
+	});
+});

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/DurableWorkersPanel.svelte.spec.ts
@@ -29,4 +29,25 @@ describe('DurableWorkersPanel', () => {
 		const { container } = render(DurableWorkersPanel, { props: { workers: [] } });
 		expect(container.textContent).toContain('Unavailable');
 	});
+
+	it('labels ambiguous handler liveness as unconfirmed', () => {
+		const { container } = render(DurableWorkersPanel, {
+			props: {
+				workers: [
+					{
+						key: 'asset_cleanup',
+						health: 'unconfirmed',
+						pendingCount: '0',
+						ackPendingCount: '1',
+						waitingCount: '0',
+						redeliveredCount: '1',
+						lastDeliveredSequence: '44',
+						ackFloorSequence: '43'
+					}
+				]
+			}
+		});
+
+		expect(container.textContent).toContain('Unconfirmed');
+	});
 });

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/system.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/system.page.svelte.spec.ts
@@ -53,6 +53,7 @@ const systemInfo = {
     consumers: 20,
     consumersUsed: 3
   },
+  accountAvailable: true,
   nats: {
     totalMessages: 10,
     totalBytes: 1000,
@@ -61,12 +62,15 @@ const systemInfo = {
     streams: [],
     consumers: []
   },
+  natsAvailable: true,
   stats: {
     userCount: 4,
     channelRoomCount: 2,
     dmRoomCount: 1
   },
+  statsAvailable: true,
   projections: [],
+  projectionsAvailable: true,
   assetCleanup: {
     available: false,
     health: 'unavailable',
@@ -79,7 +83,8 @@ const systemInfo = {
     lastPassFailed: false,
     lastInspectedSequence: '0',
     latestDeletionSequence: '0'
-  }
+  },
+  durableWorkers: []
 };
 
 async function settle() {
@@ -144,5 +149,16 @@ describe('server admin system diagnostics', () => {
       connection: { ...systemInfo.connection, serverName: 'refreshed-server' }
     });
     await vi.waitFor(() => expect(container.textContent).toContain('refreshed-server'));
+  });
+
+  it('keeps unrelated diagnostics visible when JetStream telemetry is unavailable', async () => {
+    mocks.getAdminSystemInfo.mockResolvedValue({ ...systemInfo, natsAvailable: false });
+    const { container } = render(SystemPage);
+    await settle();
+
+    expect(container.textContent).toContain('test-server');
+    expect(container.textContent).toContain('Unavailable');
+    expect(container.textContent).toContain('Projection Summary');
+    expect(container.textContent).not.toContain('Stream Activity');
   });
 });

--- a/cli/internal/connectapi/admin_diagnostics.go
+++ b/cli/internal/connectapi/admin_diagnostics.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"connectrpc.com/connect"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/chatto/internal/core"
 	adminv1 "hmans.de/chatto/internal/pb/chatto/admin/v1"
@@ -27,10 +28,48 @@ func (s *adminDiagnosticsService) GetSystemInfo(ctx context.Context, _ *connect.
 	}
 
 	return connect.NewResponse(&adminv1.GetSystemInfoResponse{
-		SystemInfo:   adminSystemInfo(diagnostics),
-		Projections:  adminProjectionStates(diagnostics.Projections),
-		AssetCleanup: adminAssetCleanupStatus(diagnostics.AssetCleanup),
+		SystemInfo:           adminSystemInfo(diagnostics),
+		Projections:          adminProjectionStates(diagnostics.Projections),
+		AssetCleanup:         adminAssetCleanupStatus(diagnostics.AssetCleanup),
+		DurableWorkers:       adminDurableWorkerStatuses(diagnostics.DurableWorkers),
+		ProjectionsAvailable: proto.Bool(diagnostics.ProjectionsAvailable),
 	}), nil
+}
+
+func adminDurableWorkerStatuses(statuses []core.DurableWorkerAdminStatus) []*adminv1.AdminDurableWorkerStatus {
+	out := make([]*adminv1.AdminDurableWorkerStatus, 0, len(statuses))
+	for _, status := range statuses {
+		out = append(out, &adminv1.AdminDurableWorkerStatus{
+			Key:                   status.Key,
+			Health:                adminDurableWorkerHealth(status.Health),
+			PendingCount:          strconv.FormatUint(status.PendingCount, 10),
+			AckPendingCount:       strconv.FormatUint(status.AckPendingCount, 10),
+			WaitingCount:          strconv.FormatUint(uint64(max(status.WaitingCount, 0)), 10),
+			RedeliveredCount:      strconv.FormatUint(uint64(max(status.RedeliveredCount, 0)), 10),
+			LastDeliveredSequence: strconv.FormatUint(status.LastDeliveredSequence, 10),
+			AckFloorSequence:      strconv.FormatUint(status.AckFloorSequence, 10),
+		})
+	}
+	return out
+}
+
+func adminDurableWorkerHealth(health core.DurableWorkerHealth) adminv1.AdminDurableWorkerHealth {
+	switch health {
+	case core.DurableWorkerHealthInactive:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_INACTIVE
+	case core.DurableWorkerHealthHealthy:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_HEALTHY
+	case core.DurableWorkerHealthWorking:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_WORKING
+	case core.DurableWorkerHealthUnconfirmed:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED
+	case core.DurableWorkerHealthStalled:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_STALLED
+	case core.DurableWorkerHealthUnavailable:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE
+	default:
+		return adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED
+	}
 }
 
 func adminAssetCleanupStatus(status core.AssetCleanupAdminStatus) *adminv1.AdminAssetCleanupStatus {
@@ -107,7 +146,7 @@ func adminConnectionInfo(info *core.ConnectionInfo) *adminv1.AdminConnectionInfo
 
 func adminAccountInfo(info *core.AccountInfo) *adminv1.AdminAccountInfo {
 	if info == nil {
-		return &adminv1.AdminAccountInfo{}
+		return nil
 	}
 	return &adminv1.AdminAccountInfo{
 		Memory:        int64(info.Memory),
@@ -123,7 +162,7 @@ func adminAccountInfo(info *core.AccountInfo) *adminv1.AdminAccountInfo {
 
 func adminServerStats(stats *core.ServerStats) *adminv1.AdminServerStats {
 	if stats == nil {
-		return &adminv1.AdminServerStats{}
+		return nil
 	}
 	return &adminv1.AdminServerStats{
 		UserCount:        int32(stats.UserCount),
@@ -134,7 +173,7 @@ func adminServerStats(stats *core.ServerStats) *adminv1.AdminServerStats {
 
 func adminNatsStats(stats *core.JetStreamStats) *adminv1.AdminNatsStats {
 	if stats == nil {
-		return &adminv1.AdminNatsStats{}
+		return nil
 	}
 
 	streams := make([]*adminv1.AdminNatsStreamInfo, 0, len(stats.Streams))

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -1202,8 +1202,42 @@ func TestAdminDiagnosticsServiceGetSystemInfoRequiresOwner(t *testing.T) {
 	if len(resp.Msg.GetProjections()) == 0 {
 		t.Fatal("Projections len = 0, want projection diagnostics")
 	}
+	if !resp.Msg.GetProjectionsAvailable() {
+		t.Fatal("ProjectionsAvailable = false, want true")
+	}
 	if resp.Msg.GetAssetCleanup() == nil {
 		t.Fatal("AssetCleanup = nil")
+	}
+	if len(resp.Msg.GetDurableWorkers()) != 4 {
+		t.Fatalf("DurableWorkers len = %d, want 4", len(resp.Msg.GetDurableWorkers()))
+	}
+}
+
+func TestAdminDurableWorkerStatusMapping(t *testing.T) {
+	mapped := adminDurableWorkerStatuses([]core.DurableWorkerAdminStatus{{
+		Key:                   "call_key_cleanup",
+		Health:                core.DurableWorkerHealthWorking,
+		PendingCount:          3,
+		AckPendingCount:       1,
+		WaitingCount:          1,
+		RedeliveredCount:      2,
+		LastDeliveredSequence: 44,
+		AckFloorSequence:      41,
+	}})
+	if len(mapped) != 1 {
+		t.Fatalf("mapped len = %d, want 1", len(mapped))
+	}
+	if mapped[0].GetHealth() != adminv1.AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_WORKING || mapped[0].GetPendingCount() != "3" {
+		t.Fatalf("mapped status = %+v", mapped[0])
+	}
+	if mapped[0].GetLastDeliveredSequence() != "44" || mapped[0].GetAckFloorSequence() != "41" {
+		t.Fatalf("mapped sequences = %+v", mapped[0])
+	}
+}
+
+func TestAdminNatsStatsPreservesUnavailablePresence(t *testing.T) {
+	if got := adminNatsStats(nil); got != nil {
+		t.Fatalf("adminNatsStats(nil) = %+v, want nil", got)
 	}
 }
 

--- a/cli/internal/core/admin_diagnostics.go
+++ b/cli/internal/core/admin_diagnostics.go
@@ -6,12 +6,14 @@ import (
 )
 
 type AdminDiagnostics struct {
-	Connection   *ConnectionInfo
-	Account      *AccountInfo
-	Stats        *ServerStats
-	JetStream    *JetStreamStats
-	Projections  []ProjectionAdminState
-	AssetCleanup AssetCleanupAdminStatus
+	Connection           *ConnectionInfo
+	Account              *AccountInfo
+	Stats                *ServerStats
+	JetStream            *JetStreamStats
+	Projections          []ProjectionAdminState
+	ProjectionsAvailable bool
+	AssetCleanup         AssetCleanupAdminStatus
+	DurableWorkers       []DurableWorkerAdminStatus
 }
 
 func (c *ChattoCore) GetAdminDiagnostics(ctx context.Context, actorID string) (*AdminDiagnostics, error) {
@@ -28,19 +30,24 @@ func (c *ChattoCore) GetAdminDiagnostics(ctx context.Context, actorID string) (*
 
 	accountInfo, err := c.GetAccountInfo(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get account info: %w", err)
+		c.logger.Warn("Failed to read JetStream account diagnostics", "error", err)
+		accountInfo = nil
 	}
 	stats, err := c.GetStats(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get server stats: %w", err)
+		c.logger.Warn("Failed to read server statistics", "error", err)
+		stats = nil
 	}
 	jetStreamStats, err := c.GetJetStreamStats(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("get NATS stats: %w", err)
+		c.logger.Warn("Failed to read JetStream diagnostics", "error", err)
+		jetStreamStats = nil
 	}
 	projections, err := c.ProjectionAdminStates(ctx)
+	projectionsAvailable := err == nil
 	if err != nil {
-		return nil, fmt.Errorf("projection states: %w", err)
+		c.logger.Warn("Failed to read projection diagnostics", "error", err)
+		projections = nil
 	}
 	assetCleanup, err := c.assetModel.AdminCleanupStatus(ctx)
 	if err != nil {
@@ -49,11 +56,13 @@ func (c *ChattoCore) GetAdminDiagnostics(ctx context.Context, actorID string) (*
 	}
 
 	return &AdminDiagnostics{
-		Connection:   c.GetConnectionInfo(),
-		Account:      accountInfo,
-		Stats:        stats,
-		JetStream:    jetStreamStats,
-		Projections:  projections,
-		AssetCleanup: assetCleanup,
+		Connection:           c.GetConnectionInfo(),
+		Account:              accountInfo,
+		Stats:                stats,
+		JetStream:            jetStreamStats,
+		Projections:          projections,
+		ProjectionsAvailable: projectionsAvailable,
+		AssetCleanup:         assetCleanup,
+		DurableWorkers:       durableWorkerAdminStatuses(jetStreamStats, c.VideoUploadsEnabled),
 	}, nil
 }

--- a/cli/internal/core/admin_diagnostics_test.go
+++ b/cli/internal/core/admin_diagnostics_test.go
@@ -43,6 +43,9 @@ func TestGetAdminDiagnosticsRequiresOwner(t *testing.T) {
 	if len(diagnostics.Projections) == 0 {
 		t.Fatal("Projections len = 0, want projection diagnostics")
 	}
+	if !diagnostics.ProjectionsAvailable {
+		t.Fatal("ProjectionsAvailable = false, want true")
+	}
 
 	core.assetModel.cleanupConsumer = nil
 	diagnostics, err = core.GetAdminDiagnostics(ctx, owner.Id)

--- a/cli/internal/core/durable_worker_status.go
+++ b/cli/internal/core/durable_worker_status.go
@@ -1,0 +1,89 @@
+package core
+
+const assetProcessingConsumerName = "chatto-asset-processing-v1"
+
+// DurableWorkerHealth is broker-derived health for a known durable queue.
+type DurableWorkerHealth int
+
+const (
+	DurableWorkerHealthInactive DurableWorkerHealth = iota
+	DurableWorkerHealthHealthy
+	DurableWorkerHealthWorking
+	DurableWorkerHealthUnconfirmed
+	DurableWorkerHealthStalled
+	DurableWorkerHealthUnavailable
+)
+
+// DurableWorkerAdminStatus contains owner-only operational queue metadata.
+type DurableWorkerAdminStatus struct {
+	Key                   string
+	Health                DurableWorkerHealth
+	PendingCount          uint64
+	AckPendingCount       uint64
+	WaitingCount          int
+	RedeliveredCount      int
+	LastDeliveredSequence uint64
+	AckFloorSequence      uint64
+}
+
+type durableWorkerDiagnosticSpec struct {
+	key          string
+	streamName   string
+	consumerName string
+	required     bool
+}
+
+func durableWorkerAdminStatuses(stats *JetStreamStats, videoUploadsEnabled bool) []DurableWorkerAdminStatus {
+	specs := []durableWorkerDiagnosticSpec{
+		{key: "asset_cleanup", streamName: "EVT", consumerName: assetCleanupConsumerName, required: true},
+		{key: "call_key_cleanup", streamName: "EVT", consumerName: callKeyCleanupConsumerName, required: true},
+		{key: "user_key_shredding", streamName: "EVT", consumerName: userKeyShreddingConsumerName, required: true},
+		{key: "asset_processing", streamName: "EVT", consumerName: assetProcessingConsumerName, required: videoUploadsEnabled},
+	}
+	type consumerCoordinate struct{ stream, name string }
+	consumers := make(map[consumerCoordinate]ConsumerStats)
+	if stats != nil {
+		for _, consumer := range stats.Consumers {
+			consumers[consumerCoordinate{stream: consumer.Stream, name: consumer.Name}] = consumer
+		}
+	}
+
+	statuses := make([]DurableWorkerAdminStatus, 0, len(specs))
+	for _, spec := range specs {
+		consumer, found := consumers[consumerCoordinate{stream: spec.streamName, name: spec.consumerName}]
+		if !found {
+			health := DurableWorkerHealthInactive
+			if spec.required {
+				health = DurableWorkerHealthUnavailable
+			}
+			statuses = append(statuses, DurableWorkerAdminStatus{Key: spec.key, Health: health})
+			continue
+		}
+
+		pendingCount := consumer.Pending
+		hasUnacknowledgedWork := pendingCount > 0 || consumer.AckPending > 0
+		health := DurableWorkerHealthInactive
+		switch {
+		case !spec.required:
+		case consumer.Waiting > 0 && hasUnacknowledgedWork:
+			health = DurableWorkerHealthWorking
+		case consumer.Waiting > 0:
+			health = DurableWorkerHealthHealthy
+		case consumer.AckPending > 0:
+			health = DurableWorkerHealthUnconfirmed
+		default:
+			health = DurableWorkerHealthStalled
+		}
+		statuses = append(statuses, DurableWorkerAdminStatus{
+			Key:                   spec.key,
+			Health:                health,
+			PendingCount:          pendingCount,
+			AckPendingCount:       uint64(max(consumer.AckPending, 0)),
+			WaitingCount:          consumer.Waiting,
+			RedeliveredCount:      consumer.Redelivered,
+			LastDeliveredSequence: consumer.DeliveredStreamSeq,
+			AckFloorSequence:      consumer.AckFloorStreamSeq,
+		})
+	}
+	return statuses
+}

--- a/cli/internal/core/durable_worker_status_test.go
+++ b/cli/internal/core/durable_worker_status_test.go
@@ -1,0 +1,51 @@
+package core
+
+import "testing"
+
+func TestDurableWorkerAdminStatusesDeriveAvailabilityAndWork(t *testing.T) {
+	statuses := durableWorkerAdminStatuses(&JetStreamStats{Consumers: []ConsumerStats{
+		{Stream: "OTHER", Name: assetCleanupConsumerName, Waiting: 1},
+		{Stream: "EVT", Name: assetCleanupConsumerName, Waiting: 1, DeliveredStreamSeq: 40, AckFloorStreamSeq: 40},
+		{Stream: "EVT", Name: callKeyCleanupConsumerName, Pending: 2, AckPending: 1, Waiting: 1, Redelivered: 3},
+		{Stream: "EVT", Name: userKeyShreddingConsumerName},
+		{Stream: "EVT", Name: assetProcessingConsumerName, Waiting: 0, Pending: 4},
+	}}, false)
+
+	byKey := make(map[string]DurableWorkerAdminStatus, len(statuses))
+	for _, status := range statuses {
+		byKey[status.Key] = status
+	}
+	if got := byKey["asset_cleanup"]; got.Health != DurableWorkerHealthHealthy || got.AckFloorSequence != 40 {
+		t.Fatalf("asset cleanup status = %+v", got)
+	}
+	if got := byKey["call_key_cleanup"]; got.Health != DurableWorkerHealthWorking || got.PendingCount != 2 || got.AckPendingCount != 1 || got.RedeliveredCount != 3 {
+		t.Fatalf("call key cleanup status = %+v", got)
+	}
+	if got := byKey["user_key_shredding"]; got.Health != DurableWorkerHealthStalled {
+		t.Fatalf("user key shredding status = %+v, want stalled", got)
+	}
+	if got := byKey["asset_processing"]; got.Health != DurableWorkerHealthInactive {
+		t.Fatalf("asset processing status = %+v, want inactive", got)
+	}
+}
+
+func TestDurableWorkerAdminStatusesDoNotInferHandlerLivenessFromAckPending(t *testing.T) {
+	statuses := durableWorkerAdminStatuses(&JetStreamStats{Consumers: []ConsumerStats{
+		{Stream: "EVT", Name: assetCleanupConsumerName, AckPending: 1},
+	}}, false)
+	if got := statuses[0]; got.Health != DurableWorkerHealthUnconfirmed || got.AckPendingCount != 1 {
+		t.Fatalf("asset cleanup status = %+v, want unconfirmed", got)
+	}
+}
+
+func TestDurableWorkerAdminStatusesReportMissingRequiredConsumers(t *testing.T) {
+	statuses := durableWorkerAdminStatuses(nil, true)
+	if len(statuses) != 4 {
+		t.Fatalf("statuses len = %d, want 4", len(statuses))
+	}
+	for _, status := range statuses {
+		if status.Health != DurableWorkerHealthUnavailable {
+			t.Fatalf("%s health = %v, want unavailable", status.Key, status.Health)
+		}
+	}
+}

--- a/cli/internal/pb/chatto/admin/v1/diagnostics.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/diagnostics.pb.go
@@ -22,6 +22,75 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Operator-facing state derived from a durable consumer.
+type AdminDurableWorkerHealth int32
+
+const (
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED AdminDurableWorkerHealth = 0
+	// This optional worker is not required by current server configuration.
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_INACTIVE AdminDurableWorkerHealth = 1
+	// A worker is waiting and all known work is acknowledged.
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_HEALTHY AdminDurableWorkerHealth = 2
+	// A worker is available and unacknowledged work remains.
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_WORKING AdminDurableWorkerHealth = 3
+	// An acknowledgement is pending, but broker state cannot prove whether a
+	// handler is active or the delivery is awaiting recovery after a crash.
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED AdminDurableWorkerHealth = 4
+	// The consumer exists but has neither a waiting pull nor an ack-pending delivery.
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_STALLED AdminDurableWorkerHealth = 5
+	// The required consumer is unavailable.
+	AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE AdminDurableWorkerHealth = 6
+)
+
+// Enum value maps for AdminDurableWorkerHealth.
+var (
+	AdminDurableWorkerHealth_name = map[int32]string{
+		0: "ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED",
+		1: "ADMIN_DURABLE_WORKER_HEALTH_INACTIVE",
+		2: "ADMIN_DURABLE_WORKER_HEALTH_HEALTHY",
+		3: "ADMIN_DURABLE_WORKER_HEALTH_WORKING",
+		4: "ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED",
+		5: "ADMIN_DURABLE_WORKER_HEALTH_STALLED",
+		6: "ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE",
+	}
+	AdminDurableWorkerHealth_value = map[string]int32{
+		"ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED": 0,
+		"ADMIN_DURABLE_WORKER_HEALTH_INACTIVE":    1,
+		"ADMIN_DURABLE_WORKER_HEALTH_HEALTHY":     2,
+		"ADMIN_DURABLE_WORKER_HEALTH_WORKING":     3,
+		"ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED": 4,
+		"ADMIN_DURABLE_WORKER_HEALTH_STALLED":     5,
+		"ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE": 6,
+	}
+)
+
+func (x AdminDurableWorkerHealth) Enum() *AdminDurableWorkerHealth {
+	p := new(AdminDurableWorkerHealth)
+	*p = x
+	return p
+}
+
+func (x AdminDurableWorkerHealth) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (AdminDurableWorkerHealth) Descriptor() protoreflect.EnumDescriptor {
+	return file_chatto_admin_v1_diagnostics_proto_enumTypes[0].Descriptor()
+}
+
+func (AdminDurableWorkerHealth) Type() protoreflect.EnumType {
+	return &file_chatto_admin_v1_diagnostics_proto_enumTypes[0]
+}
+
+func (x AdminDurableWorkerHealth) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use AdminDurableWorkerHealth.Descriptor instead.
+func (AdminDurableWorkerHealth) EnumDescriptor() ([]byte, []int) {
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{0}
+}
+
 // Operator-facing state for the shared durable asset cleanup queue.
 type AdminAssetCleanupHealth int32
 
@@ -69,11 +138,11 @@ func (x AdminAssetCleanupHealth) String() string {
 }
 
 func (AdminAssetCleanupHealth) Descriptor() protoreflect.EnumDescriptor {
-	return file_chatto_admin_v1_diagnostics_proto_enumTypes[0].Descriptor()
+	return file_chatto_admin_v1_diagnostics_proto_enumTypes[1].Descriptor()
 }
 
 func (AdminAssetCleanupHealth) Type() protoreflect.EnumType {
-	return &file_chatto_admin_v1_diagnostics_proto_enumTypes[0]
+	return &file_chatto_admin_v1_diagnostics_proto_enumTypes[1]
 }
 
 func (x AdminAssetCleanupHealth) Number() protoreflect.EnumNumber {
@@ -82,7 +151,7 @@ func (x AdminAssetCleanupHealth) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use AdminAssetCleanupHealth.Descriptor instead.
 func (AdminAssetCleanupHealth) EnumDescriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{0}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{1}
 }
 
 // Request to read owner-only server diagnostics.
@@ -130,9 +199,13 @@ type GetSystemInfoResponse struct {
 	// Event-sourced projection health and memory estimates.
 	Projections []*AdminProjectionState `protobuf:"bytes,2,rep,name=projections,proto3" json:"projections,omitempty"`
 	// Recoverable physical deletion worker health.
-	AssetCleanup  *AdminAssetCleanupStatus `protobuf:"bytes,3,opt,name=asset_cleanup,json=assetCleanup,proto3" json:"asset_cleanup,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	AssetCleanup *AdminAssetCleanupStatus `protobuf:"bytes,3,opt,name=asset_cleanup,json=assetCleanup,proto3" json:"asset_cleanup,omitempty"`
+	// Known durable worker queues and their current broker-derived health.
+	DurableWorkers []*AdminDurableWorkerStatus `protobuf:"bytes,4,rep,name=durable_workers,json=durableWorkers,proto3" json:"durable_workers,omitempty"`
+	// Whether projection diagnostics were collected successfully.
+	ProjectionsAvailable *bool `protobuf:"varint,5,opt,name=projections_available,json=projectionsAvailable,proto3,oneof" json:"projections_available,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *GetSystemInfoResponse) Reset() {
@@ -186,6 +259,129 @@ func (x *GetSystemInfoResponse) GetAssetCleanup() *AdminAssetCleanupStatus {
 	return nil
 }
 
+func (x *GetSystemInfoResponse) GetDurableWorkers() []*AdminDurableWorkerStatus {
+	if x != nil {
+		return x.DurableWorkers
+	}
+	return nil
+}
+
+func (x *GetSystemInfoResponse) GetProjectionsAvailable() bool {
+	if x != nil && x.ProjectionsAvailable != nil {
+		return *x.ProjectionsAvailable
+	}
+	return false
+}
+
+// Broker-derived health for one known durable worker queue.
+type AdminDurableWorkerStatus struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable machine-readable worker key.
+	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Current availability and work state.
+	Health AdminDurableWorkerHealth `protobuf:"varint,2,opt,name=health,proto3,enum=chatto.admin.v1.AdminDurableWorkerHealth" json:"health,omitempty"`
+	// Deliveries not yet handed to a handler.
+	PendingCount string `protobuf:"bytes,3,opt,name=pending_count,json=pendingCount,proto3" json:"pending_count,omitempty"`
+	// Deliveries awaiting acknowledgement; this does not prove handler liveness.
+	AckPendingCount string `protobuf:"bytes,4,opt,name=ack_pending_count,json=ackPendingCount,proto3" json:"ack_pending_count,omitempty"`
+	// Pull requests currently waiting for work.
+	WaitingCount string `protobuf:"bytes,5,opt,name=waiting_count,json=waitingCount,proto3" json:"waiting_count,omitempty"`
+	// Cumulative redelivery count for the consumer's current lifetime.
+	RedeliveredCount string `protobuf:"bytes,6,opt,name=redelivered_count,json=redeliveredCount,proto3" json:"redelivered_count,omitempty"`
+	// Latest EVT stream sequence delivered to this queue.
+	LastDeliveredSequence string `protobuf:"bytes,7,opt,name=last_delivered_sequence,json=lastDeliveredSequence,proto3" json:"last_delivered_sequence,omitempty"`
+	// Highest contiguous EVT stream sequence acknowledged by this queue.
+	AckFloorSequence string `protobuf:"bytes,8,opt,name=ack_floor_sequence,json=ackFloorSequence,proto3" json:"ack_floor_sequence,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *AdminDurableWorkerStatus) Reset() {
+	*x = AdminDurableWorkerStatus{}
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdminDurableWorkerStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdminDurableWorkerStatus) ProtoMessage() {}
+
+func (x *AdminDurableWorkerStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdminDurableWorkerStatus.ProtoReflect.Descriptor instead.
+func (*AdminDurableWorkerStatus) Descriptor() ([]byte, []int) {
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *AdminDurableWorkerStatus) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *AdminDurableWorkerStatus) GetHealth() AdminDurableWorkerHealth {
+	if x != nil {
+		return x.Health
+	}
+	return AdminDurableWorkerHealth_ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED
+}
+
+func (x *AdminDurableWorkerStatus) GetPendingCount() string {
+	if x != nil {
+		return x.PendingCount
+	}
+	return ""
+}
+
+func (x *AdminDurableWorkerStatus) GetAckPendingCount() string {
+	if x != nil {
+		return x.AckPendingCount
+	}
+	return ""
+}
+
+func (x *AdminDurableWorkerStatus) GetWaitingCount() string {
+	if x != nil {
+		return x.WaitingCount
+	}
+	return ""
+}
+
+func (x *AdminDurableWorkerStatus) GetRedeliveredCount() string {
+	if x != nil {
+		return x.RedeliveredCount
+	}
+	return ""
+}
+
+func (x *AdminDurableWorkerStatus) GetLastDeliveredSequence() string {
+	if x != nil {
+		return x.LastDeliveredSequence
+	}
+	return ""
+}
+
+func (x *AdminDurableWorkerStatus) GetAckFloorSequence() string {
+	if x != nil {
+		return x.AckFloorSequence
+	}
+	return ""
+}
+
 // Current health of recoverable message-owned asset deletion.
 type AdminAssetCleanupStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -227,7 +423,7 @@ type AdminAssetCleanupStatus struct {
 
 func (x *AdminAssetCleanupStatus) Reset() {
 	*x = AdminAssetCleanupStatus{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[2]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -239,7 +435,7 @@ func (x *AdminAssetCleanupStatus) String() string {
 func (*AdminAssetCleanupStatus) ProtoMessage() {}
 
 func (x *AdminAssetCleanupStatus) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[2]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -252,7 +448,7 @@ func (x *AdminAssetCleanupStatus) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminAssetCleanupStatus.ProtoReflect.Descriptor instead.
 func (*AdminAssetCleanupStatus) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{2}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *AdminAssetCleanupStatus) GetHealth() AdminAssetCleanupHealth {
@@ -348,7 +544,7 @@ type AdminSystemInfo struct {
 
 func (x *AdminSystemInfo) Reset() {
 	*x = AdminSystemInfo{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[3]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -360,7 +556,7 @@ func (x *AdminSystemInfo) String() string {
 func (*AdminSystemInfo) ProtoMessage() {}
 
 func (x *AdminSystemInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[3]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -373,7 +569,7 @@ func (x *AdminSystemInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminSystemInfo.ProtoReflect.Descriptor instead.
 func (*AdminSystemInfo) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{3}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *AdminSystemInfo) GetConnection() *AdminConnectionInfo {
@@ -425,7 +621,7 @@ type AdminConnectionInfo struct {
 
 func (x *AdminConnectionInfo) Reset() {
 	*x = AdminConnectionInfo{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[4]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -437,7 +633,7 @@ func (x *AdminConnectionInfo) String() string {
 func (*AdminConnectionInfo) ProtoMessage() {}
 
 func (x *AdminConnectionInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[4]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -450,7 +646,7 @@ func (x *AdminConnectionInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminConnectionInfo.ProtoReflect.Descriptor instead.
 func (*AdminConnectionInfo) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{4}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *AdminConnectionInfo) GetConnected() bool {
@@ -520,7 +716,7 @@ type AdminAccountInfo struct {
 
 func (x *AdminAccountInfo) Reset() {
 	*x = AdminAccountInfo{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[5]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -532,7 +728,7 @@ func (x *AdminAccountInfo) String() string {
 func (*AdminAccountInfo) ProtoMessage() {}
 
 func (x *AdminAccountInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[5]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -545,7 +741,7 @@ func (x *AdminAccountInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminAccountInfo.ProtoReflect.Descriptor instead.
 func (*AdminAccountInfo) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{5}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *AdminAccountInfo) GetMemory() int64 {
@@ -619,7 +815,7 @@ type AdminServerStats struct {
 
 func (x *AdminServerStats) Reset() {
 	*x = AdminServerStats{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[6]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -631,7 +827,7 @@ func (x *AdminServerStats) String() string {
 func (*AdminServerStats) ProtoMessage() {}
 
 func (x *AdminServerStats) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[6]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -644,7 +840,7 @@ func (x *AdminServerStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminServerStats.ProtoReflect.Descriptor instead.
 func (*AdminServerStats) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{6}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AdminServerStats) GetUserCount() int32 {
@@ -689,7 +885,7 @@ type AdminNatsStats struct {
 
 func (x *AdminNatsStats) Reset() {
 	*x = AdminNatsStats{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[7]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -701,7 +897,7 @@ func (x *AdminNatsStats) String() string {
 func (*AdminNatsStats) ProtoMessage() {}
 
 func (x *AdminNatsStats) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[7]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -714,7 +910,7 @@ func (x *AdminNatsStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNatsStats.ProtoReflect.Descriptor instead.
 func (*AdminNatsStats) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{7}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *AdminNatsStats) GetTotalMessages() int64 {
@@ -790,7 +986,7 @@ type AdminNatsStreamInfo struct {
 
 func (x *AdminNatsStreamInfo) Reset() {
 	*x = AdminNatsStreamInfo{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[8]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -802,7 +998,7 @@ func (x *AdminNatsStreamInfo) String() string {
 func (*AdminNatsStreamInfo) ProtoMessage() {}
 
 func (x *AdminNatsStreamInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[8]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -815,7 +1011,7 @@ func (x *AdminNatsStreamInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNatsStreamInfo.ProtoReflect.Descriptor instead.
 func (*AdminNatsStreamInfo) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{8}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *AdminNatsStreamInfo) GetName() string {
@@ -936,7 +1132,7 @@ type AdminNatsConsumerInfo struct {
 
 func (x *AdminNatsConsumerInfo) Reset() {
 	*x = AdminNatsConsumerInfo{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[9]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -948,7 +1144,7 @@ func (x *AdminNatsConsumerInfo) String() string {
 func (*AdminNatsConsumerInfo) ProtoMessage() {}
 
 func (x *AdminNatsConsumerInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[9]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -961,7 +1157,7 @@ func (x *AdminNatsConsumerInfo) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminNatsConsumerInfo.ProtoReflect.Descriptor instead.
 func (*AdminNatsConsumerInfo) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{9}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *AdminNatsConsumerInfo) GetStream() string {
@@ -1117,7 +1313,7 @@ type AdminProjectionState struct {
 
 func (x *AdminProjectionState) Reset() {
 	*x = AdminProjectionState{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[10]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1129,7 +1325,7 @@ func (x *AdminProjectionState) String() string {
 func (*AdminProjectionState) ProtoMessage() {}
 
 func (x *AdminProjectionState) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[10]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1142,7 +1338,7 @@ func (x *AdminProjectionState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminProjectionState.ProtoReflect.Descriptor instead.
 func (*AdminProjectionState) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{10}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *AdminProjectionState) GetKey() string {
@@ -1272,7 +1468,7 @@ type AdminProjectionMetric struct {
 
 func (x *AdminProjectionMetric) Reset() {
 	*x = AdminProjectionMetric{}
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[11]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1284,7 +1480,7 @@ func (x *AdminProjectionMetric) String() string {
 func (*AdminProjectionMetric) ProtoMessage() {}
 
 func (x *AdminProjectionMetric) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[11]
+	mi := &file_chatto_admin_v1_diagnostics_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1297,7 +1493,7 @@ func (x *AdminProjectionMetric) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AdminProjectionMetric.ProtoReflect.Descriptor instead.
 func (*AdminProjectionMetric) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{11}
+	return file_chatto_admin_v1_diagnostics_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *AdminProjectionMetric) GetName() string {
@@ -1326,12 +1522,24 @@ var File_chatto_admin_v1_diagnostics_proto protoreflect.FileDescriptor
 const file_chatto_admin_v1_diagnostics_proto_rawDesc = "" +
 	"\n" +
 	"!chatto/admin/v1/diagnostics.proto\x12\x0fchatto.admin.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x16\n" +
-	"\x14GetSystemInfoRequest\"\xf2\x01\n" +
+	"\x14GetSystemInfoRequest\"\x9a\x03\n" +
 	"\x15GetSystemInfoResponse\x12A\n" +
 	"\vsystem_info\x18\x01 \x01(\v2 .chatto.admin.v1.AdminSystemInfoR\n" +
 	"systemInfo\x12G\n" +
 	"\vprojections\x18\x02 \x03(\v2%.chatto.admin.v1.AdminProjectionStateR\vprojections\x12M\n" +
-	"\rasset_cleanup\x18\x03 \x01(\v2(.chatto.admin.v1.AdminAssetCleanupStatusR\fassetCleanup\"\xf2\x04\n" +
+	"\rasset_cleanup\x18\x03 \x01(\v2(.chatto.admin.v1.AdminAssetCleanupStatusR\fassetCleanup\x12R\n" +
+	"\x0fdurable_workers\x18\x04 \x03(\v2).chatto.admin.v1.AdminDurableWorkerStatusR\x0edurableWorkers\x128\n" +
+	"\x15projections_available\x18\x05 \x01(\bH\x00R\x14projectionsAvailable\x88\x01\x01B\x18\n" +
+	"\x16_projections_available\"\xf8\x02\n" +
+	"\x18AdminDurableWorkerStatus\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12A\n" +
+	"\x06health\x18\x02 \x01(\x0e2).chatto.admin.v1.AdminDurableWorkerHealthR\x06health\x12#\n" +
+	"\rpending_count\x18\x03 \x01(\tR\fpendingCount\x12*\n" +
+	"\x11ack_pending_count\x18\x04 \x01(\tR\x0fackPendingCount\x12#\n" +
+	"\rwaiting_count\x18\x05 \x01(\tR\fwaitingCount\x12+\n" +
+	"\x11redelivered_count\x18\x06 \x01(\tR\x10redeliveredCount\x126\n" +
+	"\x17last_delivered_sequence\x18\a \x01(\tR\x15lastDeliveredSequence\x12,\n" +
+	"\x12ack_floor_sequence\x18\b \x01(\tR\x10ackFloorSequence\"\xf2\x04\n" +
 	"\x17AdminAssetCleanupStatus\x12@\n" +
 	"\x06health\x18\x01 \x01(\x0e2(.chatto.admin.v1.AdminAssetCleanupHealthR\x06health\x12#\n" +
 	"\rpending_count\x18\x02 \x01(\x03R\fpendingCount\x12J\n" +
@@ -1443,7 +1651,15 @@ const file_chatto_admin_v1_diagnostics_proto_rawDesc = "" +
 	"\x15AdminProjectionMetric\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\x03R\x05value\x12\x14\n" +
-	"\x05bytes\x18\x03 \x01(\x03R\x05bytes*\xc0\x02\n" +
+	"\x05bytes\x18\x03 \x01(\x03R\x05bytes*\xc6\x02\n" +
+	"\x18AdminDurableWorkerHealth\x12+\n" +
+	"'ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED\x10\x00\x12(\n" +
+	"$ADMIN_DURABLE_WORKER_HEALTH_INACTIVE\x10\x01\x12'\n" +
+	"#ADMIN_DURABLE_WORKER_HEALTH_HEALTHY\x10\x02\x12'\n" +
+	"#ADMIN_DURABLE_WORKER_HEALTH_WORKING\x10\x03\x12+\n" +
+	"'ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED\x10\x04\x12'\n" +
+	"#ADMIN_DURABLE_WORKER_HEALTH_STALLED\x10\x05\x12+\n" +
+	"'ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE\x10\x06*\xc0\x02\n" +
 	"\x17AdminAssetCleanupHealth\x12*\n" +
 	"&ADMIN_ASSET_CLEANUP_HEALTH_UNSPECIFIED\x10\x00\x12'\n" +
 	"#ADMIN_ASSET_CLEANUP_HEALTH_INACTIVE\x10\x01\x12+\n" +
@@ -1468,47 +1684,51 @@ func file_chatto_admin_v1_diagnostics_proto_rawDescGZIP() []byte {
 	return file_chatto_admin_v1_diagnostics_proto_rawDescData
 }
 
-var file_chatto_admin_v1_diagnostics_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_chatto_admin_v1_diagnostics_proto_msgTypes = make([]protoimpl.MessageInfo, 12)
+var file_chatto_admin_v1_diagnostics_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+var file_chatto_admin_v1_diagnostics_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
 var file_chatto_admin_v1_diagnostics_proto_goTypes = []any{
-	(AdminAssetCleanupHealth)(0),    // 0: chatto.admin.v1.AdminAssetCleanupHealth
-	(*GetSystemInfoRequest)(nil),    // 1: chatto.admin.v1.GetSystemInfoRequest
-	(*GetSystemInfoResponse)(nil),   // 2: chatto.admin.v1.GetSystemInfoResponse
-	(*AdminAssetCleanupStatus)(nil), // 3: chatto.admin.v1.AdminAssetCleanupStatus
-	(*AdminSystemInfo)(nil),         // 4: chatto.admin.v1.AdminSystemInfo
-	(*AdminConnectionInfo)(nil),     // 5: chatto.admin.v1.AdminConnectionInfo
-	(*AdminAccountInfo)(nil),        // 6: chatto.admin.v1.AdminAccountInfo
-	(*AdminServerStats)(nil),        // 7: chatto.admin.v1.AdminServerStats
-	(*AdminNatsStats)(nil),          // 8: chatto.admin.v1.AdminNatsStats
-	(*AdminNatsStreamInfo)(nil),     // 9: chatto.admin.v1.AdminNatsStreamInfo
-	(*AdminNatsConsumerInfo)(nil),   // 10: chatto.admin.v1.AdminNatsConsumerInfo
-	(*AdminProjectionState)(nil),    // 11: chatto.admin.v1.AdminProjectionState
-	(*AdminProjectionMetric)(nil),   // 12: chatto.admin.v1.AdminProjectionMetric
-	(*timestamppb.Timestamp)(nil),   // 13: google.protobuf.Timestamp
+	(AdminDurableWorkerHealth)(0),    // 0: chatto.admin.v1.AdminDurableWorkerHealth
+	(AdminAssetCleanupHealth)(0),     // 1: chatto.admin.v1.AdminAssetCleanupHealth
+	(*GetSystemInfoRequest)(nil),     // 2: chatto.admin.v1.GetSystemInfoRequest
+	(*GetSystemInfoResponse)(nil),    // 3: chatto.admin.v1.GetSystemInfoResponse
+	(*AdminDurableWorkerStatus)(nil), // 4: chatto.admin.v1.AdminDurableWorkerStatus
+	(*AdminAssetCleanupStatus)(nil),  // 5: chatto.admin.v1.AdminAssetCleanupStatus
+	(*AdminSystemInfo)(nil),          // 6: chatto.admin.v1.AdminSystemInfo
+	(*AdminConnectionInfo)(nil),      // 7: chatto.admin.v1.AdminConnectionInfo
+	(*AdminAccountInfo)(nil),         // 8: chatto.admin.v1.AdminAccountInfo
+	(*AdminServerStats)(nil),         // 9: chatto.admin.v1.AdminServerStats
+	(*AdminNatsStats)(nil),           // 10: chatto.admin.v1.AdminNatsStats
+	(*AdminNatsStreamInfo)(nil),      // 11: chatto.admin.v1.AdminNatsStreamInfo
+	(*AdminNatsConsumerInfo)(nil),    // 12: chatto.admin.v1.AdminNatsConsumerInfo
+	(*AdminProjectionState)(nil),     // 13: chatto.admin.v1.AdminProjectionState
+	(*AdminProjectionMetric)(nil),    // 14: chatto.admin.v1.AdminProjectionMetric
+	(*timestamppb.Timestamp)(nil),    // 15: google.protobuf.Timestamp
 }
 var file_chatto_admin_v1_diagnostics_proto_depIdxs = []int32{
-	4,  // 0: chatto.admin.v1.GetSystemInfoResponse.system_info:type_name -> chatto.admin.v1.AdminSystemInfo
-	11, // 1: chatto.admin.v1.GetSystemInfoResponse.projections:type_name -> chatto.admin.v1.AdminProjectionState
-	3,  // 2: chatto.admin.v1.GetSystemInfoResponse.asset_cleanup:type_name -> chatto.admin.v1.AdminAssetCleanupStatus
-	0,  // 3: chatto.admin.v1.AdminAssetCleanupStatus.health:type_name -> chatto.admin.v1.AdminAssetCleanupHealth
-	13, // 4: chatto.admin.v1.AdminAssetCleanupStatus.oldest_pending_at:type_name -> google.protobuf.Timestamp
-	13, // 5: chatto.admin.v1.AdminAssetCleanupStatus.last_pass_at:type_name -> google.protobuf.Timestamp
-	13, // 6: chatto.admin.v1.AdminAssetCleanupStatus.last_successful_pass_at:type_name -> google.protobuf.Timestamp
-	13, // 7: chatto.admin.v1.AdminAssetCleanupStatus.updated_at:type_name -> google.protobuf.Timestamp
-	5,  // 8: chatto.admin.v1.AdminSystemInfo.connection:type_name -> chatto.admin.v1.AdminConnectionInfo
-	6,  // 9: chatto.admin.v1.AdminSystemInfo.account:type_name -> chatto.admin.v1.AdminAccountInfo
-	8,  // 10: chatto.admin.v1.AdminSystemInfo.nats:type_name -> chatto.admin.v1.AdminNatsStats
-	7,  // 11: chatto.admin.v1.AdminSystemInfo.stats:type_name -> chatto.admin.v1.AdminServerStats
-	9,  // 12: chatto.admin.v1.AdminNatsStats.streams:type_name -> chatto.admin.v1.AdminNatsStreamInfo
-	10, // 13: chatto.admin.v1.AdminNatsStats.consumers:type_name -> chatto.admin.v1.AdminNatsConsumerInfo
-	12, // 14: chatto.admin.v1.AdminProjectionState.metrics:type_name -> chatto.admin.v1.AdminProjectionMetric
-	1,  // 15: chatto.admin.v1.AdminDiagnosticsService.GetSystemInfo:input_type -> chatto.admin.v1.GetSystemInfoRequest
-	2,  // 16: chatto.admin.v1.AdminDiagnosticsService.GetSystemInfo:output_type -> chatto.admin.v1.GetSystemInfoResponse
-	16, // [16:17] is the sub-list for method output_type
-	15, // [15:16] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	6,  // 0: chatto.admin.v1.GetSystemInfoResponse.system_info:type_name -> chatto.admin.v1.AdminSystemInfo
+	13, // 1: chatto.admin.v1.GetSystemInfoResponse.projections:type_name -> chatto.admin.v1.AdminProjectionState
+	5,  // 2: chatto.admin.v1.GetSystemInfoResponse.asset_cleanup:type_name -> chatto.admin.v1.AdminAssetCleanupStatus
+	4,  // 3: chatto.admin.v1.GetSystemInfoResponse.durable_workers:type_name -> chatto.admin.v1.AdminDurableWorkerStatus
+	0,  // 4: chatto.admin.v1.AdminDurableWorkerStatus.health:type_name -> chatto.admin.v1.AdminDurableWorkerHealth
+	1,  // 5: chatto.admin.v1.AdminAssetCleanupStatus.health:type_name -> chatto.admin.v1.AdminAssetCleanupHealth
+	15, // 6: chatto.admin.v1.AdminAssetCleanupStatus.oldest_pending_at:type_name -> google.protobuf.Timestamp
+	15, // 7: chatto.admin.v1.AdminAssetCleanupStatus.last_pass_at:type_name -> google.protobuf.Timestamp
+	15, // 8: chatto.admin.v1.AdminAssetCleanupStatus.last_successful_pass_at:type_name -> google.protobuf.Timestamp
+	15, // 9: chatto.admin.v1.AdminAssetCleanupStatus.updated_at:type_name -> google.protobuf.Timestamp
+	7,  // 10: chatto.admin.v1.AdminSystemInfo.connection:type_name -> chatto.admin.v1.AdminConnectionInfo
+	8,  // 11: chatto.admin.v1.AdminSystemInfo.account:type_name -> chatto.admin.v1.AdminAccountInfo
+	10, // 12: chatto.admin.v1.AdminSystemInfo.nats:type_name -> chatto.admin.v1.AdminNatsStats
+	9,  // 13: chatto.admin.v1.AdminSystemInfo.stats:type_name -> chatto.admin.v1.AdminServerStats
+	11, // 14: chatto.admin.v1.AdminNatsStats.streams:type_name -> chatto.admin.v1.AdminNatsStreamInfo
+	12, // 15: chatto.admin.v1.AdminNatsStats.consumers:type_name -> chatto.admin.v1.AdminNatsConsumerInfo
+	14, // 16: chatto.admin.v1.AdminProjectionState.metrics:type_name -> chatto.admin.v1.AdminProjectionMetric
+	2,  // 17: chatto.admin.v1.AdminDiagnosticsService.GetSystemInfo:input_type -> chatto.admin.v1.GetSystemInfoRequest
+	3,  // 18: chatto.admin.v1.AdminDiagnosticsService.GetSystemInfo:output_type -> chatto.admin.v1.GetSystemInfoResponse
+	18, // [18:19] is the sub-list for method output_type
+	17, // [17:18] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_chatto_admin_v1_diagnostics_proto_init() }
@@ -1516,14 +1736,15 @@ func file_chatto_admin_v1_diagnostics_proto_init() {
 	if File_chatto_admin_v1_diagnostics_proto != nil {
 		return
 	}
-	file_chatto_admin_v1_diagnostics_proto_msgTypes[10].OneofWrappers = []any{}
+	file_chatto_admin_v1_diagnostics_proto_msgTypes[1].OneofWrappers = []any{}
+	file_chatto_admin_v1_diagnostics_proto_msgTypes[11].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_admin_v1_diagnostics_proto_rawDesc), len(file_chatto_admin_v1_diagnostics_proto_rawDesc)),
-			NumEnums:      1,
-			NumMessages:   12,
+			NumEnums:      2,
+			NumMessages:   13,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cli/internal/pb/chatto/admin/v1/diagnostics.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/diagnostics.pb.go
@@ -286,7 +286,7 @@ type AdminDurableWorkerStatus struct {
 	AckPendingCount string `protobuf:"bytes,4,opt,name=ack_pending_count,json=ackPendingCount,proto3" json:"ack_pending_count,omitempty"`
 	// Pull requests currently waiting for work.
 	WaitingCount string `protobuf:"bytes,5,opt,name=waiting_count,json=waitingCount,proto3" json:"waiting_count,omitempty"`
-	// Cumulative redelivery count for the consumer's current lifetime.
+	// Redelivered messages that remain unacknowledged.
 	RedeliveredCount string `protobuf:"bytes,6,opt,name=redelivered_count,json=redeliveredCount,proto3" json:"redelivered_count,omitempty"`
 	// Latest EVT stream sequence delivered to this queue.
 	LastDeliveredSequence string `protobuf:"bytes,7,opt,name=last_delivered_sequence,json=lastDeliveredSequence,proto3" json:"last_delivered_sequence,omitempty"`

--- a/docs/architecture/durable-effects.md
+++ b/docs/architecture/durable-effects.md
@@ -15,6 +15,12 @@ recovery.
 `events.DurableWorker` provides application-neutral bounded pull-consumer
 execution. Chatto owns each consumer's durable name, filters, ack
 policy, event decoding, projection barrier, idempotency, and terminal facts.
+Owner-only admin diagnostics classify the four known Chatto durable queues from
+their JetStream consumer state without adding process-local health as a source
+of truth. Waiting pulls demonstrate availability. Ack-pending deliveries
+without a waiting pull are unconfirmed because they may be actively handled or
+awaiting crash recovery; a present queue with neither is stalled. Lifetime
+redelivery counts remain informational rather than a current failure flag.
 
 | Effect | Durable fact or invariant | Immediate execution | Restart and multi-replica behavior | Current status |
 | ------ | ------------------------- | ------------------- | ---------------------------------- | -------------- |

--- a/docs/architecture/durable-effects.md
+++ b/docs/architecture/durable-effects.md
@@ -19,7 +19,7 @@ Owner-only admin diagnostics classify the four known Chatto durable queues from
 their JetStream consumer state without adding process-local health as a source
 of truth. Waiting pulls demonstrate availability. Ack-pending deliveries
 without a waiting pull are unconfirmed because they may be actively handled or
-awaiting crash recovery; a present queue with neither is stalled. Lifetime
+awaiting crash recovery; a present queue with neither is stalled. Unresolved
 redelivery counts remain informational rather than a current failure flag.
 
 | Effect | Durable fact or invariant | Immediate execution | Restart and multi-replica behavior | Current status |

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -55,6 +55,15 @@ socket.
 | `chatto.api.v1` | `AssetService`, `AssetUploadService`, `MessageSearchService`, `MessageService`, `MyAccountService`, `NotificationPreferencesService`, `NotificationService`, `PushNotificationService`, `RoleService`, `RoomDirectoryService`, `RoomService`, `ServerService`, `ThreadService`, `UserService`, `ViewerService`, `VoiceCallService` | Authenticated user |
 | `chatto.admin.v1` | `AdminDiagnosticsService`, `AdminEventLogService`, `AdminPermissionService`, `AdminRoleService`, `AdminRoomLayoutService`, `AdminServerService`, `AdminUserService` | Authenticated user; methods enforce administrative permissions |
 
+`AdminDiagnosticsService.GetSystemInfo` is owner-only and includes
+broker-derived status for Chatto's known durable worker queues. The additive
+worker list is absent on older servers; clients must treat that as diagnostics
+unavailable rather than as a healthy empty set.
+JetStream account, stream/consumer, server-statistics, and projection telemetry
+is independently optional. Message presence or the projection-availability flag
+records whether collection succeeded, so one failure does not suppress unrelated
+system diagnostics or turn unavailable metrics into healthy-looking zeroes.
+
 ## Mounted operator services
 
 | Package | Service | Access policy |

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -98,11 +98,11 @@ Users can attach files to messages — images, videos, documents — via drag-an
 **Why:** A committed deletion must remain recoverable when immediate storage cleanup fails, the process exits, or another replica committed the event. Resolving the immutable creation fact preserves that guarantee without duplicating storage metadata in the deletion event or depending on a mutable projection.
 **Tradeoff:** Each cleanup requires an aggregate-history lookup, and a fresh worker replays prior deletion facts idempotently. Beta room-scoped events cannot gain the same guarantee without a migration or unsafe backend-key inference, and server branding/avatar cleanup remains outside this message-owned worker.
 
-### 12. Cleanup health is shared and owner-visible
+### 12. Durable worker health is shared and owner-visible
 
-**Decision:** Owner-only admin diagnostics read the shared JetStream consumer directly and expose initializing, healthy, retrying, or unavailable queue state plus queue depth and delivery progress. Legacy pass timestamps, heartbeats, and oldest-pending age remain absent because continuously delivered work has no elected scan pass. The Server Admin System tab renders this status without exposing asset IDs, filenames, storage keys, raw errors, or a reclaimed-byte estimate.
-**Why:** Automatic retry is only operationally useful when self-hosters can tell whether the durable queue is caught up or still has work. JetStream consumer state makes that result consistent regardless of which replica serves the admin request.
-**Tradeoff:** Consumer metadata does not prove worker liveness or expose the age of the oldest pending delivery. Counts describe queued and in-flight retry work, not historical deletion totals, and idempotent cleanup cannot reliably attribute reclaimed bytes.
+**Decision:** Owner-only admin diagnostics derive asset cleanup and the other known durable-worker queue states directly from JetStream. The System tab reports inactive, healthy, working, unconfirmed, stalled, or unavailable state plus queue depth, ack-pending deliveries, cumulative redeliveries, and delivery progress. It does not expose asset IDs, filenames, storage keys, raw errors, or a reclaimed-byte estimate.
+**Why:** Automatic retry is only operationally useful when self-hosters can tell whether the worker is available and whether durable work remains. Shared consumer state makes that answer consistent regardless of which replica serves the admin request.
+**Tradeoff:** Broker state is point-in-time. Waiting pulls demonstrate availability, but an ack-pending delivery without a waiter may be actively handled or awaiting recovery after a crash, so diagnostics report that state as unconfirmed. Cumulative redeliveries do not identify which current item retried, and the consumer does not expose the age of its oldest pending delivery. Counts describe queued and unacknowledged work, not historical deletion totals, and idempotent cleanup cannot reliably attribute reclaimed bytes.
 
 ## Permissions
 

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -100,9 +100,9 @@ Users can attach files to messages — images, videos, documents — via drag-an
 
 ### 12. Durable worker health is shared and owner-visible
 
-**Decision:** Owner-only admin diagnostics derive asset cleanup and the other known durable-worker queue states directly from JetStream. The System tab reports inactive, healthy, working, unconfirmed, stalled, or unavailable state plus queue depth, ack-pending deliveries, cumulative redeliveries, and delivery progress. It does not expose asset IDs, filenames, storage keys, raw errors, or a reclaimed-byte estimate.
+**Decision:** Owner-only admin diagnostics derive asset cleanup and the other known durable-worker queue states directly from JetStream. The System tab reports inactive, healthy, working, unconfirmed, stalled, or unavailable state plus queue depth, ack-pending deliveries, unresolved redeliveries, and delivery progress. It does not expose asset IDs, filenames, storage keys, raw errors, or a reclaimed-byte estimate.
 **Why:** Automatic retry is only operationally useful when self-hosters can tell whether the worker is available and whether durable work remains. Shared consumer state makes that answer consistent regardless of which replica serves the admin request.
-**Tradeoff:** Broker state is point-in-time. Waiting pulls demonstrate availability, but an ack-pending delivery without a waiter may be actively handled or awaiting recovery after a crash, so diagnostics report that state as unconfirmed. Cumulative redeliveries do not identify which current item retried, and the consumer does not expose the age of its oldest pending delivery. Counts describe queued and unacknowledged work, not historical deletion totals, and idempotent cleanup cannot reliably attribute reclaimed bytes.
+**Tradeoff:** Broker state is point-in-time. Waiting pulls demonstrate availability, but an ack-pending delivery without a waiter may be actively handled or awaiting recovery after a crash, so diagnostics report that state as unconfirmed. The unresolved-redelivery count resets as messages are acknowledged and does not identify which current item retried; the consumer also does not expose the age of its oldest pending delivery. Counts describe queued and unacknowledged work, not historical deletion totals, and idempotent cleanup cannot reliably attribute reclaimed bytes.
 
 ## Permissions
 

--- a/docs/fdr/FDR-021-admin-dashboard.md
+++ b/docs/fdr/FDR-021-admin-dashboard.md
@@ -14,7 +14,7 @@ The server-management section gives owners and admins visibility into the server
 - Admin-capable users enter server management through the gear icon in the server name pane header. The server sidebar switches from room navigation to management navigation with a Back to Server affordance.
 - Delegated managers enter a specific room or room group through its contextual settings action. Resource pages use effective scoped permissions and do not imply access to unrelated server-management pages.
 - **Users page** — paginated list of all server members with login, email, roles, verification status. Admins can edit profiles, assign roles, suspend, or delete users when they hold the relevant permission.
-- **System Info page** — owner-only page showing backing message-broker connection status, storage account limits and current usage, stream/consumer health, projection health (lag, entry counts, and rough memory estimates), and `AdminDiagnosticsService.GetSystemInfo` stats (user count, channel room count, DM room count).
+- **System Info page** — owner-only page showing backing message-broker connection status, storage account limits and current usage, stream/consumer health, known durable-worker queue health, projection health (lag, entry counts, and rough memory estimates), and `AdminDiagnosticsService.GetSystemInfo` stats (user count, channel room count, DM room count).
 - **Audit log page** — chronological diagnostic event-log view for forensic review, grouped by event creation date. The list view uses `AdminEventLogService.ListEvents`; the detail view uses `AdminEventLogService.GetEvent` to show the raw payload JSON for human inspection.
 - The audit log UI can be filtered by exact event type and exact actor ID. Event type suggestions come from the admin event-log API; the actor field reuses the server member lookup but still accepts synthetic actor IDs such as `system:bootstrap`. The API also supports inclusive created-at bounds for callers, but the server-management page does not expose time-range controls.
 - The audit/event-log API returns `totalCount` as a 64-bit value because it reflects retained stream message counts, which can exceed 32-bit integer range on long-running servers.
@@ -51,6 +51,16 @@ The server-management section gives owners and admins visibility into the server
 **Decision:** Raw storage subjects, stream/consumer names, payload JSON, projection metric names, and memory estimates are documented as diagnostic values. The admin diagnostics APIs are intentional operator APIs, but clients should not parse those raw values as stable product-domain data.
 **Why:** Operators need visibility into what the runtime is doing, especially during the 0.1 stabilization lane. At the same time, these values reflect storage and projection implementation details that may evolve as the event-sourcing model settles.
 **Tradeoff:** Third-party admin clients can display diagnostics but should treat raw strings and JSON as best-effort inspection data. If a future integration needs a stable audit export format, it should get a dedicated schema instead of depending on diagnostic payloads.
+
+Known durable workers use stable diagnostic keys and stream-scoped,
+broker-derived state. A waiting pull demonstrates availability; unacknowledged
+work with an available worker is working. Ack-pending work without a waiting
+pull is explicitly unconfirmed because broker state cannot distinguish a busy
+handler from a crashed handler awaiting redelivery. A declared consumer with
+neither is stalled. Cumulative redelivery counts remain informational and do
+not by themselves make current health look failed. Core-owned consumers are
+required; asset processing is inactive whenever video uploads are disabled,
+even if its durable consumer remains retained.
 
 ### 6. Event-log filters are bounded diagnostic scans
 

--- a/docs/fdr/FDR-021-admin-dashboard.md
+++ b/docs/fdr/FDR-021-admin-dashboard.md
@@ -57,8 +57,8 @@ broker-derived state. A waiting pull demonstrates availability; unacknowledged
 work with an available worker is working. Ack-pending work without a waiting
 pull is explicitly unconfirmed because broker state cannot distinguish a busy
 handler from a crashed handler awaiting redelivery. A declared consumer with
-neither is stalled. Cumulative redelivery counts remain informational and do
-not by themselves make current health look failed. Core-owned consumers are
+neither is stalled. Currently unacknowledged redeliveries remain informational
+and do not by themselves make current health look failed. Core-owned consumers are
 required; asset processing is inactive whenever video uploads are disabled,
 even if its durable consumer remains retained.
 

--- a/packages/api-types/src/chatto/admin/v1/diagnostics_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/diagnostics_pb.ts
@@ -7,6 +7,71 @@ import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialM
 import { Message, proto3, protoInt64, Timestamp } from "@bufbuild/protobuf";
 
 /**
+ * Operator-facing state derived from a durable consumer.
+ *
+ * @generated from enum chatto.admin.v1.AdminDurableWorkerHealth
+ */
+export enum AdminDurableWorkerHealth {
+  /**
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * This optional worker is not required by current server configuration.
+   *
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_INACTIVE = 1;
+   */
+  INACTIVE = 1,
+
+  /**
+   * A worker is waiting and all known work is acknowledged.
+   *
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_HEALTHY = 2;
+   */
+  HEALTHY = 2,
+
+  /**
+   * A worker is available and unacknowledged work remains.
+   *
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_WORKING = 3;
+   */
+  WORKING = 3,
+
+  /**
+   * An acknowledgement is pending, but broker state cannot prove whether a
+   * handler is active or the delivery is awaiting recovery after a crash.
+   *
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED = 4;
+   */
+  UNCONFIRMED = 4,
+
+  /**
+   * The consumer exists but has neither a waiting pull nor an ack-pending delivery.
+   *
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_STALLED = 5;
+   */
+  STALLED = 5,
+
+  /**
+   * The required consumer is unavailable.
+   *
+   * @generated from enum value: ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE = 6;
+   */
+  UNAVAILABLE = 6,
+}
+// Retrieve enum metadata with: proto3.getEnumType(AdminDurableWorkerHealth)
+proto3.util.setEnumType(AdminDurableWorkerHealth, "chatto.admin.v1.AdminDurableWorkerHealth", [
+  { no: 0, name: "ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED" },
+  { no: 1, name: "ADMIN_DURABLE_WORKER_HEALTH_INACTIVE" },
+  { no: 2, name: "ADMIN_DURABLE_WORKER_HEALTH_HEALTHY" },
+  { no: 3, name: "ADMIN_DURABLE_WORKER_HEALTH_WORKING" },
+  { no: 4, name: "ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED" },
+  { no: 5, name: "ADMIN_DURABLE_WORKER_HEALTH_STALLED" },
+  { no: 6, name: "ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE" },
+]);
+
+/**
  * Operator-facing state for the shared durable asset cleanup queue.
  *
  * @generated from enum chatto.admin.v1.AdminAssetCleanupHealth
@@ -120,6 +185,20 @@ export class GetSystemInfoResponse extends Message<GetSystemInfoResponse> {
    */
   assetCleanup?: AdminAssetCleanupStatus;
 
+  /**
+   * Known durable worker queues and their current broker-derived health.
+   *
+   * @generated from field: repeated chatto.admin.v1.AdminDurableWorkerStatus durable_workers = 4;
+   */
+  durableWorkers: AdminDurableWorkerStatus[] = [];
+
+  /**
+   * Whether projection diagnostics were collected successfully.
+   *
+   * @generated from field: optional bool projections_available = 5;
+   */
+  projectionsAvailable?: boolean;
+
   constructor(data?: PartialMessage<GetSystemInfoResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -131,6 +210,8 @@ export class GetSystemInfoResponse extends Message<GetSystemInfoResponse> {
     { no: 1, name: "system_info", kind: "message", T: AdminSystemInfo },
     { no: 2, name: "projections", kind: "message", T: AdminProjectionState, repeated: true },
     { no: 3, name: "asset_cleanup", kind: "message", T: AdminAssetCleanupStatus },
+    { no: 4, name: "durable_workers", kind: "message", T: AdminDurableWorkerStatus, repeated: true },
+    { no: 5, name: "projections_available", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetSystemInfoResponse {
@@ -147,6 +228,103 @@ export class GetSystemInfoResponse extends Message<GetSystemInfoResponse> {
 
   static equals(a: GetSystemInfoResponse | PlainMessage<GetSystemInfoResponse> | undefined, b: GetSystemInfoResponse | PlainMessage<GetSystemInfoResponse> | undefined): boolean {
     return proto3.util.equals(GetSystemInfoResponse, a, b);
+  }
+}
+
+/**
+ * Broker-derived health for one known durable worker queue.
+ *
+ * @generated from message chatto.admin.v1.AdminDurableWorkerStatus
+ */
+export class AdminDurableWorkerStatus extends Message<AdminDurableWorkerStatus> {
+  /**
+   * Stable machine-readable worker key.
+   *
+   * @generated from field: string key = 1;
+   */
+  key = "";
+
+  /**
+   * Current availability and work state.
+   *
+   * @generated from field: chatto.admin.v1.AdminDurableWorkerHealth health = 2;
+   */
+  health = AdminDurableWorkerHealth.UNSPECIFIED;
+
+  /**
+   * Deliveries not yet handed to a handler.
+   *
+   * @generated from field: string pending_count = 3;
+   */
+  pendingCount = "";
+
+  /**
+   * Deliveries awaiting acknowledgement; this does not prove handler liveness.
+   *
+   * @generated from field: string ack_pending_count = 4;
+   */
+  ackPendingCount = "";
+
+  /**
+   * Pull requests currently waiting for work.
+   *
+   * @generated from field: string waiting_count = 5;
+   */
+  waitingCount = "";
+
+  /**
+   * Cumulative redelivery count for the consumer's current lifetime.
+   *
+   * @generated from field: string redelivered_count = 6;
+   */
+  redeliveredCount = "";
+
+  /**
+   * Latest EVT stream sequence delivered to this queue.
+   *
+   * @generated from field: string last_delivered_sequence = 7;
+   */
+  lastDeliveredSequence = "";
+
+  /**
+   * Highest contiguous EVT stream sequence acknowledged by this queue.
+   *
+   * @generated from field: string ack_floor_sequence = 8;
+   */
+  ackFloorSequence = "";
+
+  constructor(data?: PartialMessage<AdminDurableWorkerStatus>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.admin.v1.AdminDurableWorkerStatus";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "health", kind: "enum", T: proto3.getEnumType(AdminDurableWorkerHealth) },
+    { no: 3, name: "pending_count", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "ack_pending_count", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "waiting_count", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 6, name: "redelivered_count", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 7, name: "last_delivered_sequence", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 8, name: "ack_floor_sequence", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AdminDurableWorkerStatus {
+    return new AdminDurableWorkerStatus().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AdminDurableWorkerStatus {
+    return new AdminDurableWorkerStatus().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AdminDurableWorkerStatus {
+    return new AdminDurableWorkerStatus().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AdminDurableWorkerStatus | PlainMessage<AdminDurableWorkerStatus> | undefined, b: AdminDurableWorkerStatus | PlainMessage<AdminDurableWorkerStatus> | undefined): boolean {
+    return proto3.util.equals(AdminDurableWorkerStatus, a, b);
   }
 }
 

--- a/packages/api-types/src/chatto/admin/v1/diagnostics_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/diagnostics_pb.ts
@@ -273,7 +273,7 @@ export class AdminDurableWorkerStatus extends Message<AdminDurableWorkerStatus> 
   waitingCount = "";
 
   /**
-   * Cumulative redelivery count for the consumer's current lifetime.
+   * Redelivered messages that remain unacknowledged.
    *
    * @generated from field: string redelivered_count = 6;
    */

--- a/proto/chatto/admin/v1/diagnostics.proto
+++ b/proto/chatto/admin/v1/diagnostics.proto
@@ -33,7 +33,7 @@ message AdminDurableWorkerStatus {
   string ack_pending_count = 4;
   // Pull requests currently waiting for work.
   string waiting_count = 5;
-  // Cumulative redelivery count for the consumer's current lifetime.
+  // Redelivered messages that remain unacknowledged.
   string redelivered_count = 6;
   // Latest EVT stream sequence delivered to this queue.
   string last_delivered_sequence = 7;

--- a/proto/chatto/admin/v1/diagnostics.proto
+++ b/proto/chatto/admin/v1/diagnostics.proto
@@ -15,6 +15,48 @@ message GetSystemInfoResponse {
   repeated AdminProjectionState projections = 2;
   // Recoverable physical deletion worker health.
   AdminAssetCleanupStatus asset_cleanup = 3;
+  // Known durable worker queues and their current broker-derived health.
+  repeated AdminDurableWorkerStatus durable_workers = 4;
+  // Whether projection diagnostics were collected successfully.
+  optional bool projections_available = 5;
+}
+
+// Broker-derived health for one known durable worker queue.
+message AdminDurableWorkerStatus {
+  // Stable machine-readable worker key.
+  string key = 1;
+  // Current availability and work state.
+  AdminDurableWorkerHealth health = 2;
+  // Deliveries not yet handed to a handler.
+  string pending_count = 3;
+  // Deliveries awaiting acknowledgement; this does not prove handler liveness.
+  string ack_pending_count = 4;
+  // Pull requests currently waiting for work.
+  string waiting_count = 5;
+  // Cumulative redelivery count for the consumer's current lifetime.
+  string redelivered_count = 6;
+  // Latest EVT stream sequence delivered to this queue.
+  string last_delivered_sequence = 7;
+  // Highest contiguous EVT stream sequence acknowledged by this queue.
+  string ack_floor_sequence = 8;
+}
+
+// Operator-facing state derived from a durable consumer.
+enum AdminDurableWorkerHealth {
+  ADMIN_DURABLE_WORKER_HEALTH_UNSPECIFIED = 0;
+  // This optional worker is not required by current server configuration.
+  ADMIN_DURABLE_WORKER_HEALTH_INACTIVE = 1;
+  // A worker is waiting and all known work is acknowledged.
+  ADMIN_DURABLE_WORKER_HEALTH_HEALTHY = 2;
+  // A worker is available and unacknowledged work remains.
+  ADMIN_DURABLE_WORKER_HEALTH_WORKING = 3;
+  // An acknowledgement is pending, but broker state cannot prove whether a
+  // handler is active or the delivery is awaiting recovery after a crash.
+  ADMIN_DURABLE_WORKER_HEALTH_UNCONFIRMED = 4;
+  // The consumer exists but has neither a waiting pull nor an ack-pending delivery.
+  ADMIN_DURABLE_WORKER_HEALTH_STALLED = 5;
+  // The required consumer is unavailable.
+  ADMIN_DURABLE_WORKER_HEALTH_UNAVAILABLE = 6;
 }
 
 // Current health of recoverable message-owned asset deletion.


### PR DESCRIPTION
## Why

Durable workers recover work through shared JetStream consumers, but owners had
no consolidated way to see whether those queues were available across replicas,
building backlog, or awaiting recovery. The existing diagnostics endpoint also
treated optional telemetry failures as fatal, hiding unrelated information.

## What changed

- Adds an owner-only durable-worker status list to
  `AdminDiagnosticsService.GetSystemInfo`, with stable keys and exact decimal
  counters for the four known Chatto workers.
- Derives service-level state from stream-scoped shared consumer data across all
  replicas. Ack-pending work without a waiting pull is `UNCONFIRMED`, because
  broker state cannot distinguish an active handler from a crashed handler
  awaiting redelivery.
- Reports disabled asset processing as inactive even when its durable consumer
  remains retained.
- Makes account, stream/consumer, server-statistics, projection, and cleanup
  diagnostics best-effort. Unavailable telemetry is represented through message
  presence or an optional availability field instead of healthy-looking zeroes.
- Adds the durable-worker table to Server Admin → System while preserving the
  richer asset-cleanup recovery panel.
- Updates FDRs, architecture inventory, generated clients, and ConnectRPC API
  reference documentation.

## Compatibility and operations

- Classification: additive experimental administrative API change.
- Older clients ignore the new fields on newer servers.
- Newer clients treat a missing worker list from an older server as unavailable
  diagnostics. The optional projection-availability field defaults to available
  when absent, preserving projection lists returned by older servers.
- No persisted schema, migration, capability-discovery, or rollout change.
- The endpoint remains owner-only and exposes no PII or worker payloads.

## Test plan

- `mise test-cli` — passed (all CLI packages).
- Final focused Go tests for durable-worker derivation, diagnostics mapping, and
  owner access — passed.
- Frontend suites passed by layer: 1,120 server tests, 1,571 Chromium client
  tests, 179 Storybook tests, and 5 performance-comparison tests. Final focused
  adapter/panel/page tests — passed.
- `mise codegen-proto` and public `buf breaking` check against `origin/main` —
  passed.
- `mise license-check` — passed.
- Svelte autofixer — no issues.
- Chrome DevTools — verified the final System page with all four workers and the
  asset-cleanup panel; no console warnings or errors after navigation.
- GitHub CI — pending.
