### PR TITLE
fix(storage): make asset cache single replica and optional

### DIFF
--- a/cli/internal/core/core_infrastructure.go
+++ b/cli/internal/core/core_infrastructure.go
@@ -39,7 +39,7 @@ func initializeCoreInfrastructure(
 		return nil, fmt.Errorf("failed to create JetStream context: %w", err)
 	}
 
-	storage, err := newStorage(js, ctx, cfg)
+	storage, err := newStorage(js, ctx, cfg, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize storage: %w", err)
 	}

--- a/cli/internal/core/storage.go
+++ b/cli/internal/core/storage.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/log"
 	"github.com/nats-io/nats.go/jetstream"
 
 	"hmans.de/chatto/internal/config"
@@ -32,7 +33,7 @@ type storage struct {
 }
 
 // newStorage initializes current JetStream resources.
-func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConfig) (*storage, error) {
+func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConfig, logger *log.Logger) (*storage, error) {
 	// Initialize KMS KEK bucket (excluded from backups for security). App-owned
 	// wrapped DEK records live in RUNTIME_STATE so normal backups keep encrypted
 	// content together with its wrapped content-key registry, but not the KEKs
@@ -76,17 +77,14 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 	var imageCacheStore jetstream.ObjectStore
 	if cfg.Assets.Cache.Enabled {
 		imageCacheStore, err = createJetStreamResourceWithRetry(ctx, func(ctx context.Context) (jetstream.ObjectStore, error) {
-			return js.CreateOrUpdateObjectStore(ctx, jetstream.ObjectStoreConfig{
-				Bucket:      "ASSET_CACHE",
-				Description: "Cached resized images",
-				Storage:     jetstream.FileStorage,
-				Compression: true,
-				TTL:         cfg.Assets.Cache.TTLOrDefault(),
-				Replicas:    cfg.Replicas,
-			})
+			return js.CreateOrUpdateObjectStore(ctx, assetCacheConfig(cfg))
 		})
 		if err != nil {
-			return nil, fmt.Errorf("failed to create ASSET_CACHE object store: %w", err)
+			// The cache is derived data. A storage outage must not prevent the
+			// server from starting; transformed assets will simply be regenerated.
+			logger.Warn("Image cache disabled after object store initialization failure",
+				"bucket", "ASSET_CACHE", "error", err)
+			imageCacheStore = nil
 		}
 	}
 
@@ -162,6 +160,19 @@ func newStorage(js jetstream.JetStream, ctx context.Context, cfg config.CoreConf
 		memoryCacheKV:   memoryCacheKV,
 		imageCacheStore: imageCacheStore,
 	}, nil
+}
+
+// assetCacheConfig keeps this derived cache on one NATS replica even when the
+// durable Chatto resources use a larger quorum.
+func assetCacheConfig(cfg config.CoreConfig) jetstream.ObjectStoreConfig {
+	return jetstream.ObjectStoreConfig{
+		Bucket:      "ASSET_CACHE",
+		Description: "Cached resized images",
+		Storage:     jetstream.FileStorage,
+		Compression: true,
+		TTL:         cfg.Assets.Cache.TTLOrDefault(),
+		Replicas:    1,
+	}
 }
 
 func memoryCacheConfig(cfg config.CoreConfig) jetstream.KeyValueConfig {

--- a/cli/internal/core/storage_test.go
+++ b/cli/internal/core/storage_test.go
@@ -1,0 +1,25 @@
+package core
+
+import (
+	"testing"
+	"time"
+
+	"hmans.de/chatto/internal/config"
+)
+
+func TestAssetCacheConfigUsesSingleReplica(t *testing.T) {
+	cfg := config.CoreConfig{}
+	cfg.Replicas = 5
+	cfg.Assets.Cache.TTL = config.Duration(3 * time.Hour)
+
+	got := assetCacheConfig(cfg)
+	if got.Bucket != "ASSET_CACHE" {
+		t.Fatalf("bucket = %q, want ASSET_CACHE", got.Bucket)
+	}
+	if got.Replicas != 1 {
+		t.Fatalf("replicas = %d, want 1", got.Replicas)
+	}
+	if got.TTL != 3*time.Hour {
+		t.Fatalf("TTL = %s, want 3h", got.TTL)
+	}
+}

--- a/docs/architecture/nats-resources.md
+++ b/docs/architecture/nats-resources.md
@@ -22,7 +22,7 @@ inventories.
 | KV bucket    | `ENCRYPTION_KEYS`   | File    | No     | KMS key-encryption keys and per-call LiveKit E2EE keys; excluded from backups |
 | Object store | `SERVER_ASSETS`     | File    | Yes    | Default/legacy NATS-backed persisted asset binaries                         |
 | Object store | `PROJECTION_SNAPSHOTS` | File | Yes    | Optional encrypted projection snapshot objects; configurable TTL defaults to seven days |
-| Object store | `ASSET_CACHE`       | File    | No     | Optional TTL cache for transformed image bytes                               |
+| Object store | `ASSET_CACHE`       | File (R1) | No     | Optional single-replica TTL cache for transformed image bytes; startup falls back to no cache if unavailable |
 | NATS Core    | `live.sync.>`       | None    | No     | Transient `corev1.LiveEvent` pubsub signals                                  |
 | Republish    | `live.evt.>`        | None    | No     | Raw committed `EVT` facts republished by JetStream for server-side live delivery |
 

--- a/docs/architecture/runtime-state.md
+++ b/docs/architecture/runtime-state.md
@@ -133,7 +133,7 @@ no longer imported.
 | `attachment-stable-v2.{attachmentId}.{paramsHash}`   | Cached attachment derivative at specific bounds |
 | `server.{assetId}.{paramsHash}`                      | Cached transform of a server asset               |
 
-Notes: Only created when `[core.assets.cache]` is enabled in config. Uses TTL for automatic expiration (default 7 days). Current cache entries for deleted assets are also evicted from the active attachment or server prefix during binary cleanup. Attachment cache namespaces are versioned when encoding changes so older bytes are not reused. `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). S2 compression enabled.
+Notes: Only created when `[core.assets.cache]` is enabled in config. It is intentionally a single-replica derived cache even when durable resources use a quorum. If the cache object store cannot be initialized, Chatto starts without it and regenerates transformed assets on demand. Uses TTL for automatic expiration (default 7 days). Current cache entries for deleted assets are also evicted from the active attachment or server prefix during binary cleanup. Attachment cache namespaces are versioned when encoding changes so older bytes are not reused. `paramsHash` is first 16 hex chars of SHA256(`{width}x{height}_{fit}`). S2 compression enabled.
 
 **PROJECTION_SNAPSHOTS keys:**
 


### PR DESCRIPTION
Closes #1544.

## Summary

- Configure the derived `ASSET_CACHE` object store with one replica regardless of the durable-resource quorum.
- Treat cache initialization as best-effort: if the cache is unavailable, Chatto logs the condition and starts without caching.
- Add focused coverage and update the NATS/runtime architecture inventory.

## Verification

- `mise x -- go test ./internal/core -run '^TestAssetCacheConfigUsesSingleReplica$' -count=1`
- `git diff --check`

The full `internal/core` package run was started but did not complete and was stopped; no failure output was produced.
