### PR TITLE
fix(events): require pointer projections

### DIFF
--- a/cli/internal/evtstream/events_integration_test.go
+++ b/cli/internal/evtstream/events_integration_test.go
@@ -1698,7 +1698,7 @@ func TestProjectorCaptureWaitsForApplyBarrier(t *testing.T) {
 		t.Fatal(err)
 	}
 	base := newBlockingProjection(RoomSubjectFilter())
-	projector := NewProjector(js, stream, structSnapshotBlockingProjection{blockingProjection: base}, testLogger())
+	projector := NewProjector(js, stream, &structSnapshotBlockingProjection{blockingProjection: base}, testLogger())
 	runCtx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go func() { _ = projector.Run(runCtx) }()

--- a/pkg/events/projector.go
+++ b/pkg/events/projector.go
@@ -375,8 +375,10 @@ type seqWaiter struct {
 	ch  chan struct{}
 }
 
-// NewDecodedProjector binds an application projection and decoder to a stream.
-// It does not start the consumer; call Run for that. The decoder is the only
+// NewDecodedProjector binds a non-nil pointer projection and decoder to a
+// stream. It does not start the consumer; call Run for that. Requiring a
+// pointer prevents the projector and application read side from receiving
+// separate value copies of mutable projection state. The decoder is the only
 // boundary between opaque stored records and application event values.
 func NewDecodedProjector[E any](
 	js jetstream.JetStream,
@@ -387,6 +389,9 @@ func NewDecodedProjector[E any](
 ) *Projector {
 	if isNilProjection(proj) {
 		panic("events: projector requires a non-nil projection")
+	}
+	if reflect.ValueOf(proj).Kind() != reflect.Pointer {
+		panic("events: projector requires a pointer projection")
 	}
 	if decoder == nil {
 		panic("events: projector requires a non-nil event decoder")

--- a/pkg/events/projector_codec_test.go
+++ b/pkg/events/projector_codec_test.go
@@ -27,6 +27,16 @@ func (*nilSafeCodecTestProjection) Apply(codecTestEvent, uint64) error {
 	return nil
 }
 
+type valueCodecTestProjection struct{}
+
+func (valueCodecTestProjection) Subjects() []string {
+	return []string{"evt.codec.value.created"}
+}
+
+func (valueCodecTestProjection) Apply(codecTestEvent, uint64) error {
+	return nil
+}
+
 type codecTestProjection struct {
 	mu        sync.Mutex
 	subject   string
@@ -130,6 +140,16 @@ func TestDecodedProjectorRejectsTypedNilProjection(t *testing.T) {
 		}
 	}()
 	NewDecodedProjector(nil, nil, projection, decodeCodecTestEvent, testLogger())
+}
+
+func TestDecodedProjectorRejectsValueProjection(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("NewDecodedProjector accepted a value projection")
+		}
+	}()
+
+	NewDecodedProjector(nil, nil, valueCodecTestProjection{}, decodeCodecTestEvent, testLogger())
 }
 
 func TestDecodedProjectorAllowsNilLogger(t *testing.T) {


### PR DESCRIPTION
## Summary

- enforce the shared event projector's pointer-ownership invariant at the low-level constructor
- add coverage proving value projections are rejected
- update the existing CLI snapshot test fixture to pass a pointer projection

## Why

Projection instances carry mutable read-side state. Accepting a value here can silently split that state between the projector and its owning application object. ADR-056 requires pointer projection implementations, so this slice makes the invariant executable at the framework boundary.

## Verification

- `mise test-cli`
- `GOWORK=off go test -race ./...` in `pkg/events`
- `GOWORK=off go vet ./...` in `pkg/events`
- `git diff --check`

Stacked on #1988.