### PR TITLE
fix(events): add bounded subject reads

### DIFF
--- a/cli/internal/evtstream/publisher.go
+++ b/cli/internal/evtstream/publisher.go
@@ -38,6 +38,11 @@ type Publisher struct {
 	log *events.EncodedEventLog
 }
 
+const (
+	subjectEventsPageSize     = 500
+	subjectEventsPageMaxBytes = 16 * 1024 * 1024
+)
+
 // NewPublisher constructs a Chatto event publisher bound to a stream.
 func NewPublisher(js jetstream.JetStream, stream jetstream.Stream, logger events.Logger) *Publisher {
 	return &Publisher{log: events.NewEncodedEventLog(js, stream, logger)}
@@ -244,17 +249,27 @@ func (p *Publisher) SubjectEventsWithSubjectsAfter(
 	subject string,
 	afterSeq uint64,
 ) ([]*SubjectEvent, uint64, error) {
-	records, lastSeq, err := p.log.SubjectRecordsAfter(ctx, subject, afterSeq)
-	if err != nil {
-		return nil, lastSeq, err
-	}
-	events := make([]*SubjectEvent, 0, len(records))
-	for _, record := range records {
-		var event corev1.Event
-		if err := proto.Unmarshal(record.Data, &event); err != nil {
-			return nil, 0, fmt.Errorf("unmarshal event at seq %d: %w", record.Sequence, err)
+	var events []*SubjectEvent
+	var lastSeq uint64
+	for {
+		page, err := p.log.SubjectRecordsAfterPage(ctx, subject, afterSeq, subjectEventsPageSize, subjectEventsPageMaxBytes)
+		if err != nil {
+			return nil, lastSeq, err
 		}
-		events = append(events, &SubjectEvent{Subject: record.Subject, Event: &event})
+		for _, record := range page.Records {
+			var event corev1.Event
+			if err := proto.Unmarshal(record.Data, &event); err != nil {
+				return nil, 0, fmt.Errorf("unmarshal event at seq %d: %w", record.Sequence, err)
+			}
+			events = append(events, &SubjectEvent{Subject: record.Subject, Event: &event})
+		}
+		if page.LastSequence > lastSeq {
+			lastSeq = page.LastSequence
+		}
+		if !page.More || len(page.Records) == 0 {
+			break
+		}
+		afterSeq = page.LastSequence
 	}
 	return events, lastSeq, nil
 }

--- a/pkg/events/encoded_event_log.go
+++ b/pkg/events/encoded_event_log.go
@@ -35,6 +35,10 @@ var ErrMissingOCC = errors.New("missing optimistic concurrency guard")
 // the complete batch.
 var ErrInvalidBatchOCC = errors.New("invalid optimistic concurrency guard placement")
 
+// ErrInvalidSubjectReadLimit marks a page request that cannot provide a
+// bounded result.
+var ErrInvalidSubjectReadLimit = errors.New("invalid subject record read limit")
+
 // StreamPosition identifies a committed stream sequence together with the
 // subject or subject filter that made that sequence relevant to the caller.
 type StreamPosition struct {
@@ -458,13 +462,29 @@ func (l *EncodedEventLog) LastSubjectPosition(
 	return SubjectPosition(subjectOrFilter, seq), nil
 }
 
-// SubjectRecordsAfter returns opaque records matching subject with stream
-// sequence greater than afterSeq, plus the last matching sequence.
-func (l *EncodedEventLog) SubjectRecordsAfter(
+// SubjectRecordPage is one bounded page of opaque subject records.
+// LastSequence is suitable as the afterSeq cursor for the next page.
+type SubjectRecordPage struct {
+	Records      []EncodedSubjectRecord
+	LastSequence uint64
+	More         bool
+}
+
+// SubjectRecordsAfterPage returns at most maxRecords matching opaque records
+// after afterSeq. When maxBytes is positive, the returned payload bytes are
+// also bounded by maxBytes. More indicates that the page's point-in-time
+// result had additional records. Callers can pass LastSequence to the next
+// request without exposing JetStream consumer coordinates.
+func (l *EncodedEventLog) SubjectRecordsAfterPage(
 	ctx context.Context,
 	subject string,
 	afterSeq uint64,
-) ([]EncodedSubjectRecord, uint64, error) {
+	maxRecords int,
+	maxBytes int,
+) (SubjectRecordPage, error) {
+	if maxRecords <= 0 || maxBytes < 0 {
+		return SubjectRecordPage{}, ErrInvalidSubjectReadLimit
+	}
 	deliverPolicy := jetstream.DeliverAllPolicy
 	var startSeq uint64
 	if afterSeq > 0 {
@@ -480,47 +500,85 @@ func (l *EncodedEventLog) SubjectRecordsAfter(
 		InactiveThreshold: 30 * time.Second,
 	})
 	if err != nil {
-		return nil, 0, err
+		return SubjectRecordPage{}, err
 	}
 	defer l.stream.DeleteConsumer(context.Background(), consumer.CachedInfo().Name)
 
 	info, err := consumer.Info(ctx)
 	if err != nil {
-		return nil, 0, err
+		return SubjectRecordPage{}, err
 	}
-
-	remaining := int(info.NumPending)
-	records := make([]EncodedSubjectRecord, 0, remaining)
-	var lastSeq uint64
-	for remaining > 0 {
-		batchSize := min(remaining, 500)
+	target := min(uint64(maxRecords), info.NumPending)
+	page := SubjectRecordPage{Records: make([]EncodedSubjectRecord, 0, target)}
+	var bytesRead int
+	for uint64(len(page.Records)) < target {
+		batchSize := int(target - uint64(len(page.Records)))
+		if maxBytes > 0 {
+			// Fetch one message at a time so a message that would exceed the
+			// byte window causes an explicit error instead of being silently
+			// omitted from a page.
+			batchSize = 1
+		}
 		msgs, err := consumer.Fetch(batchSize, jetstream.FetchMaxWait(10*time.Second))
 		if err != nil {
 			if errors.Is(err, jetstream.ErrNoMessages) {
 				break
 			}
-			return nil, 0, err
+			return SubjectRecordPage{}, err
 		}
 
 		fetched := 0
 		for msg := range msgs.Messages() {
 			fetched++
+			data := msg.Data()
+			if maxBytes > 0 && (len(data) > maxBytes || bytesRead+len(data) > maxBytes) {
+				return SubjectRecordPage{}, fmt.Errorf("%w: page payload exceeds %d bytes", ErrInvalidSubjectReadLimit, maxBytes)
+			}
 			meta, err := msg.Metadata()
 			if err != nil {
-				return nil, 0, fmt.Errorf("message metadata: %w", err)
+				return SubjectRecordPage{}, fmt.Errorf("message metadata: %w", err)
 			}
-			lastSeq = meta.Sequence.Stream
-			records = append(records, EncodedSubjectRecord{
+			sequence := meta.Sequence.Stream
+			page.LastSequence = sequence
+			page.Records = append(page.Records, EncodedSubjectRecord{
 				Subject:  msg.Subject(),
-				Sequence: lastSeq,
+				Sequence: sequence,
 				ID:       msg.Headers().Get(jetstream.MsgIDHeader),
-				Data:     bytes.Clone(msg.Data()),
+				Data:     bytes.Clone(data),
 			})
+			bytesRead += len(data)
 		}
 		if fetched == 0 {
 			break
 		}
-		remaining -= fetched
+	}
+	page.More = info.NumPending > uint64(len(page.Records))
+	return page, nil
+}
+
+// SubjectRecordsAfter returns all opaque records matching subject with stream
+// sequence greater than afterSeq, plus the last matching sequence. New callers
+// that need a bounded allocation should use SubjectRecordsAfterPage instead.
+func (l *EncodedEventLog) SubjectRecordsAfter(
+	ctx context.Context,
+	subject string,
+	afterSeq uint64,
+) ([]EncodedSubjectRecord, uint64, error) {
+	var records []EncodedSubjectRecord
+	var lastSeq uint64
+	for {
+		page, err := l.SubjectRecordsAfterPage(ctx, subject, afterSeq, 500, 0)
+		if err != nil {
+			return nil, 0, err
+		}
+		records = append(records, page.Records...)
+		if page.LastSequence > 0 {
+			lastSeq = page.LastSequence
+		}
+		if !page.More || len(page.Records) == 0 {
+			break
+		}
+		afterSeq = page.LastSequence
 	}
 	return records, lastSeq, nil
 }

--- a/pkg/events/encoded_event_log_test.go
+++ b/pkg/events/encoded_event_log_test.go
@@ -54,6 +54,70 @@ func TestEncodedEventLogPreservesOpaqueRecord(t *testing.T) {
 	}
 }
 
+func TestSubjectRecordsAfterPageBoundsRecordsAndBytes(t *testing.T) {
+	js, stream := setupTestStream(t)
+	eventLog := NewEncodedEventLog(js, stream, testLogger())
+	ctx := testContext(t)
+	subject := "evt.compatibility.page.created"
+	for i := 0; i < 5; i++ {
+		if _, err := eventLog.AppendEventually(ctx, subject, EncodedRecord{
+			ID:   "page-" + strconv.Itoa(i),
+			Data: []byte("data"),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first, err := eventLog.SubjectRecordsAfterPage(ctx, subject, 0, 2, 100)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first.Records) != 2 || !first.More || first.LastSequence == 0 {
+		t.Fatalf("first page = %+v, want two records and more", first)
+	}
+	second, err := eventLog.SubjectRecordsAfterPage(ctx, subject, first.LastSequence, 2, 100)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(second.Records) != 2 || !second.More || second.LastSequence <= first.LastSequence {
+		t.Fatalf("second page = %+v, want two records and more", second)
+	}
+	third, err := eventLog.SubjectRecordsAfterPage(ctx, subject, second.LastSequence, 2, 100)
+	if err != nil {
+		t.Fatalf("third page: %v", err)
+	}
+	if len(third.Records) != 1 || third.More || third.LastSequence <= second.LastSequence {
+		t.Fatalf("third page = %+v, want final record", third)
+	}
+
+	if _, err := eventLog.SubjectRecordsAfterPage(ctx, subject, 0, 2, 5); !errors.Is(err, ErrInvalidSubjectReadLimit) {
+		t.Fatalf("byte-bounded page error = %v, want ErrInvalidSubjectReadLimit", err)
+	}
+	bytePage, err := eventLog.SubjectRecordsAfterPage(ctx, subject, 0, 1, 4)
+	if err != nil {
+		t.Fatalf("single-record byte page: %v", err)
+	}
+	if len(bytePage.Records) != 1 || !bytePage.More {
+		t.Fatalf("byte page = %+v, want one record and more", bytePage)
+	}
+}
+
+func TestSubjectRecordsAfterPageRejectsUnboundedLimits(t *testing.T) {
+	js, stream := setupTestStream(t)
+	eventLog := NewEncodedEventLog(js, stream, testLogger())
+	ctx := testContext(t)
+	for name, limits := range map[string][2]int{
+		"zero records":   {0, 1},
+		"negative bytes": {1, -1},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := eventLog.SubjectRecordsAfterPage(ctx, "evt.compatibility.page.invalid", 0, limits[0], limits[1]); !errors.Is(err, ErrInvalidSubjectReadLimit) {
+				t.Fatalf("error = %v, want ErrInvalidSubjectReadLimit", err)
+			}
+		})
+	}
+}
+
 func TestEncodedEventLogAppendAtFilterUsesWildcardTail(t *testing.T) {
 	js, stream := setupTestStream(t)
 	eventLog := NewEncodedEventLog(js, stream, testLogger())


### PR DESCRIPTION
## Summary

- add a bounded `SubjectRecordsAfterPage` API with record and payload-byte limits
- preserve the existing all-records method as a compatibility wrapper over bounded pages
- migrate Chatto's typed subject-event reader to page through the opaque log
- add coverage for page cursors, record limits, byte limits, and invalid limits

## Why

The previous bulk read eagerly materialized every matching event into one allocation. Long-lived subjects could therefore turn a routine read into unbounded client memory growth. Pages keep each JetStream pull and returned allocation bounded while retaining an opaque stream-sequence cursor.

## API compatibility

This is additive and compatible. Existing callers of `SubjectRecordsAfter` continue to work; new callers should use `SubjectRecordsAfterPage` when they need bounded allocations.

## Verification

- `mise test-cli`
- `GOWORK=off go test -race ./...` in `pkg/events`
- `GOWORK=off go vet ./...` in `pkg/events`
- `go test ./internal/evtstream -count=1`
- `git diff --check`

Stacked on #1991.