### PR TITLE
ci: run pull request workflows for stack bases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ on:
       - labeled
       - unlabeled
       - ready_for_review
-    branches:
-      - main
-      - 'release-[0-9]*'
 
 concurrency:
   # PRs share a group so superseded revisions are cancelled. Pushes use their


### PR DESCRIPTION
## Why

GitHub stacked pull requests use non-default base branches. The CI workflow's `pull_request.branches` restriction excluded those bases, so only the bottom PR received checks.

## What changed

Removed the branch restriction from the `pull_request` trigger. CI now runs for every pull request, including each native stack layer.

## Compatibility

No product or public API behavior changed. This only changes CI trigger coverage.

## Test plan

- `actionlint .github/workflows/ci.yml`

