### PR TITLE
fix(events): make nil loggers safe

### DIFF
--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -125,6 +125,7 @@ func NewDurableWorker(
 	if opts.HeartbeatInterval <= 0 {
 		opts.HeartbeatInterval = defaultDurableWorkerHeartbeatInterval
 	}
+	opts.Logger = normalizeLogger(opts.Logger)
 	return &DurableWorker{consumer: consumer, handle: handle, opts: opts}, nil
 }
 

--- a/pkg/events/encoded_event_log.go
+++ b/pkg/events/encoded_event_log.go
@@ -98,7 +98,7 @@ type EncodedEventLog struct {
 
 // NewEncodedEventLog binds opaque event-log mechanics to one JetStream stream.
 func NewEncodedEventLog(js jetstream.JetStream, stream jetstream.Stream, logger Logger) *EncodedEventLog {
-	return &EncodedEventLog{js: js, stream: stream, logger: logger}
+	return &EncodedEventLog{js: js, stream: stream, logger: normalizeLogger(logger)}
 }
 
 // StreamUsage returns the current message and byte totals for the bound stream.

--- a/pkg/events/logger.go
+++ b/pkg/events/logger.go
@@ -1,10 +1,25 @@
 package events
 
 // Logger is the small logging surface used by event-sourcing mechanics.
-// *log.Logger from github.com/charmbracelet/log satisfies it.
+// *log.Logger from github.com/charmbracelet/log satisfies it. Constructors
+// accept a nil Logger and replace it with a no-op logger.
 type Logger interface {
 	Debug(msg interface{}, keyvals ...interface{})
 	Info(msg interface{}, keyvals ...interface{})
 	Warn(msg interface{}, keyvals ...interface{})
 	Error(msg interface{}, keyvals ...interface{})
+}
+
+type noopLogger struct{}
+
+func (noopLogger) Debug(interface{}, ...interface{}) {}
+func (noopLogger) Info(interface{}, ...interface{})  {}
+func (noopLogger) Warn(interface{}, ...interface{})  {}
+func (noopLogger) Error(interface{}, ...interface{}) {}
+
+func normalizeLogger(logger Logger) Logger {
+	if logger == nil {
+		return noopLogger{}
+	}
+	return logger
 }

--- a/pkg/events/projector.go
+++ b/pkg/events/projector.go
@@ -391,6 +391,7 @@ func NewDecodedProjector[E any](
 	if decoder == nil {
 		panic("events: projector requires a non-nil event decoder")
 	}
+	logger = normalizeLogger(logger)
 
 	subjects := append([]string(nil), proj.Subjects()...)
 	replaySubjects := append([]string(nil), projectionReplaySubjects(proj, subjects)...)

--- a/pkg/events/projector_codec_test.go
+++ b/pkg/events/projector_codec_test.go
@@ -132,6 +132,26 @@ func TestDecodedProjectorRejectsTypedNilProjection(t *testing.T) {
 	NewDecodedProjector(nil, nil, projection, decodeCodecTestEvent, testLogger())
 }
 
+func TestDecodedProjectorAllowsNilLogger(t *testing.T) {
+	js, stream := setupTestStream(t)
+	projection := &nilSafeCodecTestProjection{}
+	projector := NewDecodedProjector(
+		js,
+		stream,
+		projection,
+		func([]byte) (DecodedEvent[codecTestEvent], error) {
+			return DecodedEvent[codecTestEvent]{Event: codecTestEvent{name: "event"}, ID: "event"}, nil
+		},
+		nil,
+	)
+
+	stop := runConsumerProjector(t, projector)
+	defer stop()
+	waitFor(t, 2*time.Second, func() bool {
+		return projector.Status().StartupComplete
+	})
+}
+
 func TestDecodedProjectorReplaysApplicationCodecInOrder(t *testing.T) {
 	js, stream := setupTestStream(t)
 	eventLog := NewEncodedEventLog(js, stream, testLogger())


### PR DESCRIPTION
## Why

Optional loggers are documented as safe to omit, but several event-framework paths could still panic when given a nil logger.

## What changed

Made logger setup and use nil-safe across the event framework, preserving silent operation when logging is not configured.

## Compatibility

No public API or persistence contract changed. Existing configured loggers retain their behavior.

## Test plan

- `mise test-events`
- Go race and vet checks for the events module
- `mise license-check`

