### PR TITLE
fix(events): require pointer projections

### DIFF
--- a/cli/internal/evtstream/events_integration_test.go
+++ b/cli/internal/evtstream/events_integration_test.go
@@ -1698,7 +1698,7 @@ func TestProjectorCaptureWaitsForApplyBarrier(t *testing.T) {
 		t.Fatal(err)
 	}
 	base := newBlockingProjection(RoomSubjectFilter())
-	projector := NewProjector(js, stream, structSnapshotBlockingProjection{blockingProjection: base}, testLogger())
+	projector := NewProjector(js, stream, &structSnapshotBlockingProjection{blockingProjection: base}, testLogger())
 	runCtx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go func() { _ = projector.Run(runCtx) }()

--- a/pkg/events/projector.go
+++ b/pkg/events/projector.go
@@ -375,8 +375,10 @@ type seqWaiter struct {
 	ch  chan struct{}
 }
 
-// NewDecodedProjector binds an application projection and decoder to a stream.
-// It does not start the consumer; call Run for that. The decoder is the only
+// NewDecodedProjector binds a non-nil pointer projection and decoder to a
+// stream. It does not start the consumer; call Run for that. Requiring a
+// pointer prevents the projector and application read side from receiving
+// separate value copies of mutable projection state. The decoder is the only
 // boundary between opaque stored records and application event values.
 func NewDecodedProjector[E any](
 	js jetstream.JetStream,
@@ -387,6 +389,9 @@ func NewDecodedProjector[E any](
 ) *Projector {
 	if isNilProjection(proj) {
 		panic("events: projector requires a non-nil projection")
+	}
+	if reflect.ValueOf(proj).Kind() != reflect.Pointer {
+		panic("events: projector requires a pointer projection")
 	}
 	if decoder == nil {
 		panic("events: projector requires a non-nil event decoder")

--- a/pkg/events/projector_codec_test.go
+++ b/pkg/events/projector_codec_test.go
@@ -27,6 +27,16 @@ func (*nilSafeCodecTestProjection) Apply(codecTestEvent, uint64) error {
 	return nil
 }
 
+type valueCodecTestProjection struct{}
+
+func (valueCodecTestProjection) Subjects() []string {
+	return []string{"evt.codec.value.created"}
+}
+
+func (valueCodecTestProjection) Apply(codecTestEvent, uint64) error {
+	return nil
+}
+
 type codecTestProjection struct {
 	mu        sync.Mutex
 	subject   string
@@ -130,6 +140,16 @@ func TestDecodedProjectorRejectsTypedNilProjection(t *testing.T) {
 		}
 	}()
 	NewDecodedProjector(nil, nil, projection, decodeCodecTestEvent, testLogger())
+}
+
+func TestDecodedProjectorRejectsValueProjection(t *testing.T) {
+	defer func() {
+		if recover() == nil {
+			t.Fatal("NewDecodedProjector accepted a value projection")
+		}
+	}()
+
+	NewDecodedProjector(nil, nil, valueCodecTestProjection{}, decodeCodecTestEvent, testLogger())
 }
 
 func TestDecodedProjectorAllowsNilLogger(t *testing.T) {


### PR DESCRIPTION
## Why

Projection values are mutated and restored through pointers. Accepting non-pointer projections defers the failure until runtime and makes ownership ambiguous.

## What changed

Projection registration now requires pointer values and reports the misuse at setup time.

## Compatibility

This hardens an existing runtime invariant. Valid pointer-based projections are unchanged; invalid registrations now fail earlier and more clearly.

## Test plan

- `mise test-events`
- Go race and vet checks for the events module

