### PR TITLE
fix(events): validate snapshot bindings

### DIFF
--- a/cli/internal/core/projection_snapshot_storage.go
+++ b/cli/internal/core/projection_snapshot_storage.go
@@ -64,7 +64,10 @@ func (s projectionSnapshotSource) LoadProjectionSnapshot(ctx context.Context, re
 	}
 	return events.ProjectionSnapshot{
 		GenerationID:   loaded.GenerationID,
+		ContractID:     request.ContractID,
+		StreamName:     request.StreamName,
 		CutoffSequence: loaded.CutoffSequence,
+		StreamIdentity: loaded.StreamIdentity,
 		CreatedAt:      loaded.CreatedAt,
 		Payload:        loaded.Payload,
 	}, nil

--- a/cli/internal/evtstream/events_integration_test.go
+++ b/cli/internal/evtstream/events_integration_test.go
@@ -736,11 +736,24 @@ type gatedSnapshotSource struct {
 	snapshot ProjectionSnapshot
 }
 
-func (s *gatedSnapshotSource) LoadProjectionSnapshot(ctx context.Context, _ ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
+func completeTestSnapshot(snapshot ProjectionSnapshot, request ProjectionSnapshotLoadRequest) ProjectionSnapshot {
+	if snapshot.ContractID == "" {
+		snapshot.ContractID = request.ContractID
+	}
+	if snapshot.StreamName == "" {
+		snapshot.StreamName = request.StreamName
+	}
+	if snapshot.StreamIdentity == "" {
+		snapshot.StreamIdentity = request.StreamIdentity
+	}
+	return snapshot
+}
+
+func (s *gatedSnapshotSource) LoadProjectionSnapshot(ctx context.Context, request ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
 	close(s.started)
 	select {
 	case <-s.release:
-		return s.snapshot, nil
+		return completeTestSnapshot(s.snapshot, request), nil
 	case <-ctx.Done():
 		return ProjectionSnapshot{}, ctx.Err()
 	}
@@ -754,7 +767,7 @@ func (s *blockingSnapshotSource) LoadProjectionSnapshot(ctx context.Context, _ P
 
 func (s *staticSnapshotSource) LoadProjectionSnapshot(_ context.Context, request ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
 	s.request = request
-	return s.snapshot, s.err
+	return completeTestSnapshot(s.snapshot, request), s.err
 }
 
 func (s *identityBoundSnapshotSource) LoadProjectionSnapshot(_ context.Context, request ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
@@ -762,7 +775,7 @@ func (s *identityBoundSnapshotSource) LoadProjectionSnapshot(_ context.Context, 
 	if request.StreamIdentity != s.streamIdentity {
 		return ProjectionSnapshot{}, errors.New("snapshot stream identity changed")
 	}
-	return s.snapshot, nil
+	return completeTestSnapshot(s.snapshot, request), nil
 }
 
 func newBlockingProjection(subs ...string) *blockingProjection {

--- a/pkg/events/projector.go
+++ b/pkg/events/projector.go
@@ -201,10 +201,13 @@ type snapshotContractProjectionState interface {
 }
 
 // ProjectionSnapshot is projection state restored from a source or captured
-// for publication. Captures include the stream identity bound to the projector
-// run; restored snapshots rely on the identity already validated by the source.
+// for publication. Restored snapshots must carry the contract, stream name,
+// and stream identity that were validated by the source; the Projector checks
+// those bindings again before applying the payload.
 type ProjectionSnapshot struct {
 	GenerationID   string
+	ContractID     string
+	StreamName     string
 	CutoffSequence uint64
 	StreamIdentity string
 	CreatedAt      time.Time
@@ -554,7 +557,17 @@ func (p *Projector) CaptureSnapshot(ctx context.Context) (ProjectionSnapshot, er
 			return ProjectionSnapshot{}, fmt.Errorf("stream identity changed during projector run")
 		}
 	}
-	return ProjectionSnapshot{CutoffSequence: seq, StreamIdentity: streamIdentity, Payload: payload}, nil
+	p.mu.Lock()
+	contractID := p.snapshotContractID
+	p.mu.Unlock()
+	streamName := p.stream.CachedInfo().Config.Name
+	return ProjectionSnapshot{
+		ContractID:     contractID,
+		StreamName:     streamName,
+		CutoffSequence: seq,
+		StreamIdentity: streamIdentity,
+		Payload:        payload,
+	}, nil
 }
 
 func (p *Projector) resolveCurrentStreamIdentity(ctx context.Context, resolve StreamIdentityResolver) (string, error) {
@@ -1288,6 +1301,23 @@ func (p *Projector) restoreForRun(ctx context.Context, targetSeq uint64) error {
 			"stage", "restore",
 			"error", err)
 		return coldRestore()
+	}
+	if snapshot.ContractID != contractID || snapshot.StreamName != info.Config.Name || snapshot.StreamIdentity != streamIdentity {
+		p.logger.Warn("Projection snapshot binding rejected; replaying EVT",
+			"projection", key,
+			"stage", "restore_validate",
+			"generation_id", snapshot.GenerationID,
+			"snapshot_contract_id", snapshot.ContractID,
+			"snapshot_stream_name", snapshot.StreamName,
+			"snapshot_stream_identity", snapshot.StreamIdentity)
+		return coldRestore()
+	}
+	currentIdentity, err := p.resolveCurrentStreamIdentity(loadCtx, resolveStreamIdentity)
+	if err != nil {
+		return fmt.Errorf("recheck projection snapshot stream identity: %w", err)
+	}
+	if currentIdentity != streamIdentity {
+		return fmt.Errorf("projection snapshot stream identity changed while loading")
 	}
 	if snapshot.CutoffSequence > targetSeq {
 		p.logger.Warn("Projection snapshot cutoff rejected; replaying EVT",

--- a/pkg/events/projector_codec_test.go
+++ b/pkg/events/projector_codec_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/nats-io/nats.go/jetstream"
 	. "hmans.de/chatto/pkg/events"
 )
 
@@ -77,6 +78,29 @@ func (p *codecTestProjection) Restore(snapshot []byte) error {
 		p.events = strings.Split(string(snapshot), ",")
 	}
 	return nil
+}
+
+func (*codecTestProjection) SnapshotContractID() string { return "codec-test-v1" }
+
+type mismatchedCodecSnapshotSource struct{}
+
+func (mismatchedCodecSnapshotSource) LoadProjectionSnapshot(context.Context, ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
+	return ProjectionSnapshot{
+		ContractID:     "wrong-contract",
+		StreamName:     "WRONG_STREAM",
+		StreamIdentity: "wrong-stream",
+		Payload:        []byte("must-not-restore"),
+	}, nil
+}
+
+type requestBoundCodecSnapshotSource struct{}
+
+func (requestBoundCodecSnapshotSource) LoadProjectionSnapshot(_ context.Context, request ProjectionSnapshotLoadRequest) (ProjectionSnapshot, error) {
+	return ProjectionSnapshot{
+		ContractID:     request.ContractID,
+		StreamName:     request.StreamName,
+		StreamIdentity: request.StreamIdentity,
+	}, nil
 }
 
 type codecTestBatchProjection struct {
@@ -170,6 +194,64 @@ func TestDecodedProjectorAllowsNilLogger(t *testing.T) {
 	waitFor(t, 2*time.Second, func() bool {
 		return projector.Status().StartupComplete
 	})
+}
+
+func TestProjectorRejectsMismatchedSnapshotBinding(t *testing.T) {
+	js, stream := setupTestStream(t)
+	eventLog := NewEncodedEventLog(js, stream, testLogger())
+	ctx := testContext(t)
+	if _, err := eventLog.Append(ctx, "evt.codec.binding.created", EncodedRecord{ID: "one", Data: []byte("one:alpha")}); err != nil {
+		t.Fatal(err)
+	}
+
+	projection := &codecTestProjection{subject: "evt.codec.binding.created"}
+	projector := NewDecodedProjector(js, stream, projection, decodeCodecTestEvent, testLogger())
+	identity := "codec-stream"
+	if err := projector.ConfigureSnapshots("codec", mismatchedCodecSnapshotSource{}, func(*jetstream.StreamInfo) (string, error) {
+		return identity, nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go func() { _ = projector.Run(runCtx) }()
+	waitFor(t, 2*time.Second, func() bool { return projector.Status().StartupComplete })
+	if events, _ := projection.applied(); !slices.Equal(events, []string{"alpha"}) {
+		t.Fatalf("events = %v, want cold replay after binding rejection", events)
+	}
+	if projector.Status().SnapshotRestored {
+		t.Fatal("mismatched snapshot reported as restored")
+	}
+}
+
+func TestProjectorFailsWhenSnapshotStreamChangesDuringLoad(t *testing.T) {
+	js, stream := setupTestStream(t)
+	projection := &codecTestProjection{subject: "evt.codec.binding.changed"}
+	projector := NewDecodedProjector(js, stream, projection, decodeCodecTestEvent, testLogger())
+	identityCalls := 0
+	if err := projector.ConfigureSnapshots("codec", requestBoundCodecSnapshotSource{}, func(*jetstream.StreamInfo) (string, error) {
+		identityCalls++
+		if identityCalls >= 3 {
+			return "changed-stream", nil
+		}
+		return "codec-stream", nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errCh := make(chan error, 1)
+	go func() { errCh <- projector.Run(runCtx) }()
+	select {
+	case err := <-errCh:
+		if err == nil || !strings.Contains(err.Error(), "stream identity changed while loading") {
+			t.Fatalf("Run error = %v, want stream identity change failure", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("projector did not fail after snapshot stream identity changed")
+	}
 }
 
 func TestDecodedProjectorReplaysApplicationCodecInOrder(t *testing.T) {


### PR DESCRIPTION
## Why

Snapshot bindings could be accepted without proving that their projection and codec agree, allowing incompatible restore paths to surface later.

## What changed

Validate snapshot bindings during setup so projection, codec, and binding metadata must agree before a projector starts.

## Compatibility

No persisted format was changed. Valid existing bindings remain compatible; invalid combinations fail during initialization.

## Test plan

- `mise test-events`
- Go race and vet checks for the events module

