### PR TITLE
fix(events): guard single-run lifecycles

### DIFF
--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -20,6 +20,11 @@ const (
 	defaultDurableWorkerHeartbeatInterval = 30 * time.Second
 )
 
+// ErrDurableWorkerAlreadyStarted is returned when Run is called more than once
+// on the same worker. A worker owns one process-local execution lifecycle; make
+// a new worker for a restarted consumer loop.
+var ErrDurableWorkerAlreadyStarted = errors.New("durable worker already started")
+
 // DurableDelivery is one opaque event delivered by a durable JetStream pull
 // consumer. Applications own decoding, validation, projection catch-up, and
 // idempotency. Data is detached from the underlying JetStream message.
@@ -57,6 +62,8 @@ type DurableWorker struct {
 	consumer jetstream.Consumer
 	handle   DurableDeliveryHandler
 	opts     DurableWorkerOptions
+	runMu    sync.Mutex
+	started  bool
 }
 
 type retryDeliveryError struct {
@@ -129,8 +136,9 @@ func NewDurableWorker(
 	return &DurableWorker{consumer: consumer, handle: handle, opts: opts}, nil
 }
 
-// Run fetches and processes deliveries until the context is cancelled. Fetch
-// failures are retried because durable workers must survive transient broker
+// Run fetches and processes deliveries until the context is cancelled. It may
+// be called only once per worker. Fetch failures are retried because durable
+// workers must survive transient broker
 // outages. Cancellation first stops outstanding fetches, then stops progress
 // heartbeats and negatively acknowledges active deliveries before waiting for
 // their handlers to stop. This ordering prevents the stopping worker from
@@ -139,6 +147,13 @@ func (w *DurableWorker) Run(ctx context.Context) error {
 	if w == nil || w.consumer == nil || w.handle == nil {
 		return fmt.Errorf("durable worker is not configured")
 	}
+	w.runMu.Lock()
+	if w.started {
+		w.runMu.Unlock()
+		return ErrDurableWorkerAlreadyStarted
+	}
+	w.started = true
+	w.runMu.Unlock()
 
 	handlerCtx, cancelHandlers := context.WithCancel(context.WithoutCancel(ctx))
 	var group sync.WaitGroup

--- a/pkg/events/durable_worker_test.go
+++ b/pkg/events/durable_worker_test.go
@@ -92,6 +92,32 @@ func TestDurableWorkerProcessesOpaqueDeliveriesAndAcknowledges(t *testing.T) {
 	}
 }
 
+func TestDurableWorkerRejectsRepeatedRun(t *testing.T) {
+	_, stream := setupTestStream(t)
+	ctx := testContext(t)
+	consumer := createDurableWorkerTestConsumer(t, ctx, stream, "worker-single-run", time.Second)
+	worker, err := events.NewDurableWorker(consumer, func(context.Context, events.DurableDelivery) error {
+		return nil
+	}, events.DurableWorkerOptions{MaxConcurrent: 1, FetchMaxWait: time.Second, Logger: testLogger()})
+	if err != nil {
+		t.Fatalf("NewDurableWorker: %v", err)
+	}
+	workerCtx, cancel := context.WithCancel(ctx)
+	runErr := make(chan error, 1)
+	go func() { runErr <- worker.Run(workerCtx) }()
+	waitFor(t, time.Second, func() bool {
+		info, err := consumer.Info(ctx)
+		return err == nil && info.NumWaiting == 1
+	})
+	if err := worker.Run(context.Background()); !errors.Is(err, events.ErrDurableWorkerAlreadyStarted) {
+		t.Fatalf("repeated worker Run error = %v, want ErrDurableWorkerAlreadyStarted", err)
+	}
+	cancel()
+	if err := <-runErr; err != nil {
+		t.Fatalf("first worker Run: %v", err)
+	}
+}
+
 func TestDurableWorkerRetriesFailedDelivery(t *testing.T) {
 	js, stream := setupTestStream(t)
 	ctx := testContext(t)

--- a/pkg/events/projector.go
+++ b/pkg/events/projector.go
@@ -25,6 +25,11 @@ var ErrProjectionSubjectNotConsumed = errors.New("projection does not consume su
 // one supplied by the caller.
 var ErrProjectionSequenceSubjectMismatch = errors.New("projection wait sequence subject mismatch")
 
+// ErrProjectorAlreadyStarted is returned when Run is called more than once on
+// the same projector. A projector owns one ordered consumer lifecycle and
+// cannot be restarted after its context is cancelled or its run fails.
+var ErrProjectorAlreadyStarted = errors.New("projector already started")
+
 // Projection replay is a sequential bulk read. NATS defaults to a 500-message
 // client buffer, which turns histories of many small event records into many
 // latency-bound pull requests on a remote JetStream cluster. A byte window
@@ -289,7 +294,8 @@ type sequencedDecodedEvent struct {
 	sequence uint64
 }
 
-// Projector runs the consumer + apply loop for one projection.
+// Projector runs the consumer + apply loop for one projection. A Projector is
+// single-run: create a new instance when the consumer lifecycle must restart.
 type Projector struct {
 	js                jetstream.JetStream
 	stream            jetstream.Stream
@@ -974,16 +980,21 @@ func (p *Projector) fail(seq uint64, err error) {
 	p.waiters = nil
 }
 
-// Run starts the consumer + apply loop. Blocks until ctx is cancelled.
-// Returns the context's error on shutdown.
+// Run starts the consumer + apply loop once. Blocks until ctx is cancelled.
+// Returns ErrProjectorAlreadyStarted for a repeated or concurrent call, and
+// the context's error on shutdown.
 func (p *Projector) Run(ctx context.Context) (runErr error) {
 	defer func() {
-		if runErr != nil && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, context.DeadlineExceeded) {
+		if runErr != nil && !errors.Is(runErr, ErrProjectorAlreadyStarted) && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, context.DeadlineExceeded) {
 			p.fail(0, runErr)
 		}
 	}()
 	startedAt := time.Now()
 	p.mu.Lock()
+	if p.started {
+		p.mu.Unlock()
+		return ErrProjectorAlreadyStarted
+	}
 	p.started = true
 	if p.startupStartedAt.IsZero() {
 		p.startupStartedAt = startedAt

--- a/pkg/events/projector_codec_test.go
+++ b/pkg/events/projector_codec_test.go
@@ -196,6 +196,25 @@ func TestDecodedProjectorAllowsNilLogger(t *testing.T) {
 	})
 }
 
+func TestProjectorRejectsRepeatedRun(t *testing.T) {
+	js, stream := setupTestStream(t)
+	projector := NewDecodedProjector(
+		js,
+		stream,
+		&nilSafeCodecTestProjection{},
+		func([]byte) (DecodedEvent[codecTestEvent], error) {
+			return DecodedEvent[codecTestEvent]{Event: codecTestEvent{name: "event"}, ID: "event"}, nil
+		},
+		testLogger(),
+	)
+	stop := runConsumerProjector(t, projector)
+	waitFor(t, 2*time.Second, func() bool { return projector.Status().StartupComplete })
+	if err := projector.Run(context.Background()); !errors.Is(err, ErrProjectorAlreadyStarted) {
+		t.Fatalf("repeated projector Run error = %v, want ErrProjectorAlreadyStarted", err)
+	}
+	stop()
+}
+
 func TestProjectorRejectsMismatchedSnapshotBinding(t *testing.T) {
 	js, stream := setupTestStream(t)
 	eventLog := NewEncodedEventLog(js, stream, testLogger())


### PR DESCRIPTION
## Why

Projector and worker lifecycle methods could be started more than once, leading to duplicate loops and ambiguous shutdown behavior.

## What changed

Guarded single-run lifecycle entry points so repeated starts are rejected or safely ignored according to the existing lifecycle contract.

## Compatibility

No public protocol or persistence behavior changed. Valid one-time startup and shutdown flows remain unchanged.

## Test plan

- `mise test-events`
- Go race and vet checks for the events module

