### PR TITLE
docs(events): document integration and logging contracts

### DIFF
--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -2,26 +2,29 @@
 
 `hmans.de/chatto/pkg/events` is an envelope-neutral event-sourcing framework
 for NATS JetStream. It provides optimistic-concurrency-controlled publication,
-ordered projection replay, startup-readiness and read-your-writes barriers, and
-optional snapshot or checkpoint lifecycles, and bounded durable pull-worker
-execution.
+ordered projection replay, startup and read-your-writes barriers, optional
+snapshot or checkpoint restore, bounded subject reads, and bounded durable
+pull-worker execution.
 
-Mutation callbacks can choose their consistency boundary explicitly:
+The intended reader is an application integrator. This module owns ordering,
+OCC, replay, and delivery mechanics; the application owns event codecs,
+subjects, authorization, stream identity, consumer configuration, and domain
+completion rules. The package must not import an application's envelope or
+domain types.
 
-- `AtSubject(filter)` reruns a decision only when that subject or aggregate
-  filter changes; and
-- `AtStreamTail()` reruns a decision after any intervening stream event, which
-  is useful for invariants that genuinely span the complete stream.
+## Publish opaque events
 
-`EncodedEventLog.ExecuteMutation` captures the chosen boundary, invokes the
-application decision, atomically commits its opaque records with OCC, and
-reruns the complete decision after conflicts. Applications still own
-projection catch-up and authorization, and logical event IDs must remain
-stable across attempts.
+Mutation callbacks choose their consistency boundary explicitly:
 
-Single-record decisions use an ordinary OCC publish. Multi-record decisions
-use JetStream atomic batch publication and therefore require the bound stream
-to enable `AllowAtomicPublish`.
+- `AtSubject(filter)` reruns a decision when that subject or aggregate filter
+  changes; and
+- `AtStreamTail()` reruns a decision after any intervening stream event, for
+  invariants that span the complete stream.
+
+`ExecuteMutation` invokes the application decision, atomically commits opaque
+records with OCC, and reruns the complete decision after conflicts. Logical
+event IDs must remain stable across attempts. Multi-record decisions require
+the bound stream to enable JetStream `AllowAtomicPublish`.
 
 ```go
 result, err := log.ExecuteMutation(ctx, events.AtSubject(aggregateFilter),
@@ -31,17 +34,90 @@ result, err := log.ExecuteMutation(ctx, events.AtSubject(aggregateFilter),
 	})
 ```
 
-Applications retain ownership of their event codecs, subject policy, stream
-identity, storage coordinates, and runtime composition. The module does not
-import Chatto or Authling domain packages.
+## Build a projection
 
-`DurableWorker` runs an application-configured JetStream pull consumer with
-bounded concurrency, progress heartbeats, confirmed acknowledgements, delayed
-retry, poison-delivery termination, and reconnect-safe fetch retries. Applications retain ownership of the
-consumer contract and domain completion checks; handlers receive only opaque
-bytes and stable delivery metadata. Handlers must honor context cancellation;
-the worker hands active deliveries back immediately but retains handler
-ownership until they stop.
+Projection implementations must be non-nil pointers. The pointer is an
+ownership invariant: the projector and the application's read side must share
+one mutable state object.
+
+```go
+projection := &MyProjection{}
+projector := events.NewDecodedProjector(js, stream, projection, decodeEvent, logger)
+
+go projector.Run(ctx) // one Run call per Projector instance
+if err := projector.WaitForStartup(ctx); err != nil {
+	// Do not serve reads after a failed startup replay.
+}
+```
+
+`Run` is single-use. After cancellation or failure, construct a new projector.
+Use `WaitFor`, `WaitForCurrent`, or a subject-aware `StreamPosition` when a
+caller needs read-your-writes visibility.
+
+## Snapshots and checkpoints
+
+Snapshots are disposable replay accelerators, not authoritative event data.
+Configure either `ConfigureSnapshots` or `ConfigureCheckpoint` before `Run`,
+never both. Snapshot sources must return the requested contract ID, stream
+name, stream incarnation, and a cutoff no newer than the startup target. The
+projector validates those bindings again and cold-replays retained events when
+a snapshot is unavailable or invalid. Stream identity changes during restore
+fail the run rather than applying state across stream incarnations.
+
+`CaptureSnapshot` takes an apply barrier and includes the applied cutoff and
+stream identity. Publication remains application-owned and must use its own
+cross-replica OCC. Checkpoint implementations must atomically commit their
+derived state and cutoff, and must implement reset/rebuild behavior for an
+invalid checkpoint.
+
+## Read in bounded pages
+
+Use `SubjectRecordsAfterPage` for potentially long subject histories. Pass the
+returned `LastSequence` as the next cursor; it is an opaque stream position and
+does not expose a JetStream consumer name or storage coordinate.
+
+```go
+page, err := log.SubjectRecordsAfterPage(ctx, subject, afterSeq, 500, 16<<20)
+for _, record := range page.Records {
+	// Decode and process the opaque bytes.
+}
+if page.More {
+	next, err := log.SubjectRecordsAfterPage(ctx, subject, page.LastSequence, 500, 16<<20)
+	_ = next
+}
+```
+
+`SubjectRecordsAfter` remains as a compatibility convenience for callers that
+explicitly need one materialized result. New code should use pages or process
+each page before requesting the next one.
+
+## Run durable work
+
+`DurableWorker` runs an already configured JetStream pull consumer with bounded
+concurrency, progress heartbeats, confirmed acknowledgements, delayed retry,
+poison-delivery termination, and reconnect-safe fetch retries. It never
+creates, deletes, or retires the consumer; those are application-owned
+resource migrations. A worker is single-use, and handlers must honor context
+cancellation and be safe under at-least-once delivery.
+
+```go
+worker, err := events.NewDurableWorker(consumer, handle, events.DurableWorkerOptions{
+	MaxConcurrent: 4,
+})
+if err != nil {
+	return err
+}
+return worker.Run(ctx)
+```
+
+## Logging and data safety
+
+The framework accepts a nil `Logger` and replaces it with a no-op logger. When
+a logger is supplied, the framework may emit caller-provided subjects,
+projection keys, event IDs, stream identities, and handler errors as
+diagnostic fields. Callers must ensure those values are opaque operational
+identifiers and contain no personal data, credentials, tokens, raw request
+values, or secrets. The framework does not redact caller-provided metadata.
 
 ## Status
 

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -77,13 +77,18 @@ returned `LastSequence` as the next cursor; it is an opaque stream position and
 does not expose a JetStream consumer name or storage coordinate.
 
 ```go
-page, err := log.SubjectRecordsAfterPage(ctx, subject, afterSeq, 500, 16<<20)
-for _, record := range page.Records {
-	// Decode and process the opaque bytes.
-}
-if page.More {
-	next, err := log.SubjectRecordsAfterPage(ctx, subject, page.LastSequence, 500, 16<<20)
-	_ = next
+for {
+	page, err := log.SubjectRecordsAfterPage(ctx, subject, afterSeq, 500, 16<<20)
+	if err != nil {
+		return err
+	}
+	for _, record := range page.Records {
+		// Decode and process the opaque bytes.
+	}
+	if !page.More {
+		break
+	}
+	afterSeq = page.LastSequence
 }
 ```
 

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -26,8 +26,10 @@ const (
 var ErrDurableWorkerAlreadyStarted = errors.New("durable worker already started")
 
 // DurableDelivery is one opaque event delivered by a durable JetStream pull
-// consumer. Applications own decoding, validation, projection catch-up, and
-// idempotency. Data is detached from the underlying JetStream message.
+// consumer. Subject is caller-owned operational metadata and may be logged;
+// it must be an opaque, non-sensitive subject. Applications own decoding,
+// validation, projection catch-up, and idempotency. Data is detached from the
+// underlying JetStream message.
 type DurableDelivery struct {
 	Subject        string
 	Data           []byte

--- a/pkg/events/encoded_event_log.go
+++ b/pkg/events/encoded_event_log.go
@@ -58,14 +58,15 @@ func (p StreamPosition) IsZero() bool {
 }
 
 // EncodedRecord is one opaque durable event payload. ID becomes the NATS
-// message ID and therefore must be stable across retries.
+// message ID, may appear in diagnostics, and therefore must be a stable,
+// opaque, non-sensitive identifier across retries.
 type EncodedRecord struct {
 	ID   string
 	Data []byte
 }
 
 // EncodedSubjectRecord preserves a durable subject alongside its opaque
-// payload.
+// payload. Subject is caller-owned metadata and must be safe to log.
 type EncodedSubjectRecord struct {
 	Subject  string
 	Sequence uint64

--- a/pkg/events/logger.go
+++ b/pkg/events/logger.go
@@ -2,7 +2,10 @@ package events
 
 // Logger is the small logging surface used by event-sourcing mechanics.
 // *log.Logger from github.com/charmbracelet/log satisfies it. Constructors
-// accept a nil Logger and replace it with a no-op logger.
+// accept a nil Logger and replace it with a no-op logger. Implementations may
+// receive caller-provided subjects, projection keys, event IDs, stream
+// identities, and handler errors as diagnostic fields; callers must keep those
+// values opaque and free of personal data, credentials, tokens, and secrets.
 type Logger interface {
 	Debug(msg interface{}, keyvals ...interface{})
 	Info(msg interface{}, keyvals ...interface{})


### PR DESCRIPTION
## Why

The shared framework's integration and logging contracts were not documented clearly enough for external consumers, and examples could encourage unsafe logging.

## What changed

Documented integration boundaries, lifecycle expectations, paged reads, and safe logging guidance for the application-neutral events package.

## Compatibility

Documentation only; no runtime, API, or persistence behavior changed.

## Test plan

- `mise test-events`
- `mise license-check`

