### PR TITLE
fix(frontend): preserve inline ordered-list content

### DIFF
--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -419,17 +419,33 @@ describe('MessageContent component', () => {
     const startedItems = Array.from(started!.querySelectorAll(':scope > li'));
 
     const textLeft = (element: Element) => {
-      const text = Array.from(element.childNodes).find((node) => node.nodeType === Node.TEXT_NODE);
-      if (!text) throw new Error('Expected a direct text node in the list item');
-      const range = document.createRange();
-      range.selectNodeContents(text);
-      return range.getBoundingClientRect().left;
+      const content = element.querySelector(':scope > .list-item-content, :scope > p');
+      if (!content) throw new Error('Expected content in the list item');
+      return content.getBoundingClientRect().left;
     };
 
     expect(textLeft(longItems[0]!)).toBeCloseTo(textLeft(longItems[9]!), 0);
     expect(textLeft(longItems[0]!)).toBeGreaterThan(textLeft(short!.querySelector('li')!));
     expect(textLeft(startedItems[0]!)).toBeCloseTo(textLeft(startedItems[1]!), 0);
     expect(textLeft(startedItems[0]!)).toBeGreaterThan(textLeft(short!.querySelector('li')!));
+  });
+
+  it('keeps inline code flowing with ordered-list item text', async () => {
+    const { container } = renderMessage(
+      '1. Connect to `/api/realtime` using `chatto.realtime.v1` protobuf frames for live updates.'
+    );
+
+    await expect.poll(() => container.querySelectorAll('ol code').length).toBe(2);
+    const content = q(container, 'ol > li > .list-item-content')!;
+    const codes = Array.from(content.querySelectorAll('code'));
+
+    expect(window.getComputedStyle(codes[0]!).display).toBe('inline');
+    expect(codes[0]!.getBoundingClientRect().width).toBeLessThan(
+      content.getBoundingClientRect().width
+    );
+    expect(codes[1]!.getBoundingClientRect().width).toBeLessThan(
+      content.getBoundingClientRect().width
+    );
   });
 
   it('styles blockquotes as distinct quote blocks', async () => {

--- a/apps/frontend/src/lib/markdown.test.ts
+++ b/apps/frontend/src/lib/markdown.test.ts
@@ -185,6 +185,16 @@ describe('renderMarkdown', () => {
       const html = await renderMarkdown('`*not bold*`');
       expect(html).toContain('<code>*not bold*</code>');
     });
+
+    it('groups inline content in tight list items', async () => {
+      const html = await renderMarkdown(
+        '1. Connect to `/api/realtime` using `chatto.realtime.v1`.'
+      );
+
+      expect(html).toContain(
+        '<li><span class="list-item-content">Connect to <code>/api/realtime</code> using <code>chatto.realtime.v1</code>.</span>'
+      );
+    });
   });
 
   describe('code blocks', () => {

--- a/apps/frontend/src/lib/markdown.ts
+++ b/apps/frontend/src/lib/markdown.ts
@@ -270,6 +270,14 @@ function renderChatLineBreak(tokens: Token[], idx: number): string {
   return lineAfterBreakIsWhitespaceOnly(tokens, idx) ? '' : '<br>\n';
 }
 
+function renderParagraphOpen(tokens: Token[], idx: number): string {
+  return tokens[idx].hidden ? '<span class="list-item-content">' : '<p>';
+}
+
+function renderParagraphClose(tokens: Token[], idx: number): string {
+  return tokens[idx].hidden ? '</span>\n' : '</p>\n';
+}
+
 function normalizeInlineNonBreakingSpaces(state: StateCore): void {
   for (let i = 0; i < state.tokens.length; i++) {
     const token = state.tokens[i];
@@ -328,6 +336,11 @@ function initialize(): void {
   md.core.ruler.after('inline', 'normalize_non_breaking_spaces', normalizeInlineNonBreakingSpaces);
   md.renderer.rules.softbreak = renderChatLineBreak;
   md.renderer.rules.hardbreak = renderChatLineBreak;
+  // Markdown-it hides paragraph tags in tight lists. Keep their inline content
+  // grouped so ordered-list grid markers do not turn each inline element into
+  // a separate grid row.
+  md.renderer.rules.paragraph_open = renderParagraphOpen;
+  md.renderer.rules.paragraph_close = renderParagraphClose;
 
   // Customize link rendering for security
   const defaultLinkRender =


### PR DESCRIPTION
## Summary

- Keep Markdown-it tight-list inline content grouped so adaptive ordered-list grids cannot place inline elements on separate rows.
- Preserve adaptive marker alignment while restoring normal wrapping for inline code and other formatting.
- Add renderer and browser-component regression coverage for the affected markup and layout.

## Validation

- `mise x -- pnpm --filter chatto-frontend exec vitest run src/lib/markdown.test.ts src/lib/components/MessageContent.svelte.spec.ts`
- `mise x -- pnpm --filter chatto-frontend check`
- ESLint, Prettier, Svelte autofixer, and Chrome DevTools visual verification
