### PR TITLE
fix(frontend): preserve inline ordered-list content

### DIFF
--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -548,11 +548,9 @@ describe('MessageContent component', () => {
     const startedItems = Array.from(started!.querySelectorAll(':scope > li'));
 
     const textLeft = (element: Element) => {
-      const text = Array.from(element.childNodes).find((node) => node.nodeType === Node.TEXT_NODE);
-      if (!text) throw new Error('Expected a direct text node in the list item');
-      const range = document.createRange();
-      range.selectNodeContents(text);
-      return range.getBoundingClientRect().left;
+      const content = element.querySelector(':scope > .list-item-content, :scope > p');
+      if (!content) throw new Error('Expected content in the list item');
+      return content.getBoundingClientRect().left;
     };
 
     expect(textLeft(longItems[0]!)).toBeCloseTo(textLeft(longItems[9]!), 0);
@@ -580,6 +578,24 @@ describe('MessageContent component', () => {
 
     expect(styles.direction).toBe('ltr');
     expect(styles.unicodeBidi).toBe('isolate');
+  });
+
+  it('keeps inline code flowing with ordered-list item text', async () => {
+    const { container } = renderMessage(
+      '1. Connect to `/api/realtime` using `chatto.realtime.v1` protobuf frames for live updates.'
+    );
+
+    await expect.poll(() => container.querySelectorAll('ol code').length).toBe(2);
+    const content = q(container, 'ol > li > .list-item-content')!;
+    const codes = Array.from(content.querySelectorAll('code'));
+
+    expect(window.getComputedStyle(codes[0]!).display).toBe('inline');
+    expect(codes[0]!.getBoundingClientRect().width).toBeLessThan(
+      content.getBoundingClientRect().width
+    );
+    expect(codes[1]!.getBoundingClientRect().width).toBeLessThan(
+      content.getBoundingClientRect().width
+    );
   });
 
   it('styles blockquotes as distinct quote blocks', async () => {

--- a/apps/frontend/src/lib/markdown.test.ts
+++ b/apps/frontend/src/lib/markdown.test.ts
@@ -295,6 +295,16 @@ describe('renderMarkdown', () => {
       const html = await renderMarkdown('`*not bold*`');
       expect(html).toContain('<code>*not bold*</code>');
     });
+
+    it('groups inline content in tight list items', async () => {
+      const html = await renderMarkdown(
+        '1. Connect to `/api/realtime` using `chatto.realtime.v1`.'
+      );
+
+      expect(html).toContain(
+        '<li><span class="list-item-content">Connect to <code>/api/realtime</code> using <code>chatto.realtime.v1</code>.</span>'
+      );
+    });
   });
 
   describe('code blocks', () => {

--- a/apps/frontend/src/lib/markdown.ts
+++ b/apps/frontend/src/lib/markdown.ts
@@ -379,6 +379,14 @@ function renderChatLineBreak(tokens: Token[], idx: number): string {
   return lineAfterBreakIsWhitespaceOnly(tokens, idx) ? '' : '<br>\n';
 }
 
+function renderParagraphOpen(tokens: Token[], idx: number): string {
+  return tokens[idx].hidden ? '<span class="list-item-content">' : '<p>';
+}
+
+function renderParagraphClose(tokens: Token[], idx: number): string {
+  return tokens[idx].hidden ? '</span>\n' : '</p>\n';
+}
+
 function normalizeInlineNonBreakingSpaces(state: StateCore): void {
   for (let i = 0; i < state.tokens.length; i++) {
     const token = state.tokens[i];
@@ -451,6 +459,11 @@ function initialize(): void {
   md.renderer.rules.hardbreak = renderChatLineBreak;
   md.renderer.rules.table_open = () => '<div class="table-scroll" tabindex="0"><table>\n';
   md.renderer.rules.table_close = () => '</table></div>\n';
+  // Markdown-it hides paragraph tags in tight lists. Keep their inline content
+  // grouped so ordered-list grid markers do not turn each inline element into
+  // a separate grid row.
+  md.renderer.rules.paragraph_open = renderParagraphOpen;
+  md.renderer.rules.paragraph_close = renderParagraphClose;
 
   // Customize link rendering for security
   const defaultLinkRender =


### PR DESCRIPTION
## Summary

- Apply the user-confirmed ordered-list fix from release PR #2009 to `main`.
- Keep Markdown-it tight-list inline content grouped so adaptive ordered-list grids cannot place inline elements on separate rows.
- Preserve adaptive marker alignment while restoring normal wrapping for inline code and other formatting, with renderer and browser-component regression coverage.

## Validation

- `mise x -- pnpm --filter chatto-frontend exec vitest run src/lib/markdown.test.ts src/lib/components/MessageContent.svelte.spec.ts` (125 tests)
- `mise x -- pnpm run check:frontend`
- ESLint and Prettier
