### PR TITLE
fix(dockercompose): validate init-env arguments

### DIFF
--- a/examples/dockercompose/init-env.sh
+++ b/examples/dockercompose/init-env.sh
@@ -3,7 +3,7 @@ set -eu
 
 usage() {
 	cat <<'EOF'
-Usage: ./init-env.sh [--force] [domain] [owner-email] [smtp-from]
+Usage: ./init-env.sh [--force] <domain> <owner-email> [smtp-from]
 
 Creates .env and livekit.generated.yaml with matching generated secrets.
 
@@ -27,6 +27,11 @@ while [ "$#" -gt 0 ]; do
 			usage
 			exit 0
 			;;
+		-*)
+			echo "Unknown option: $1" >&2
+			usage >&2
+			exit 1
+			;;
 		*)
 			if [ -z "$domain" ]; then
 				domain=$1
@@ -43,6 +48,12 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 
+if [ -z "$domain" ] || [ -z "$owner_email" ]; then
+	echo "The domain and owner-email arguments are required." >&2
+	usage >&2
+	exit 1
+fi
+
 if ! command -v openssl >/dev/null 2>&1; then
 	echo "openssl is required to generate secrets" >&2
 	exit 1
@@ -58,11 +69,9 @@ if [ -e livekit.generated.yaml ] && [ "$force" != "true" ]; then
 	exit 1
 fi
 
-domain=${domain:-chat.example.com}
 domain=${domain#https://}
 domain=${domain#http://}
 domain=${domain%/}
-owner_email=${owner_email:-admin@example.com}
 smtp_from=${smtp_from:-noreply@example.com}
 
 rand_hex() {


### PR DESCRIPTION
## Summary

- require the domain and owner email arguments documented by the Docker Compose quick start
- reject unknown options instead of treating them as positional values
- retain the optional SMTP sender default

## Why

`init-env.sh` previously accepted missing arguments and silently generated a deployment configuration using example domain and owner values. Its catch-all positional parsing also treated unknown flags as configuration values.

This change makes invalid invocation fail with usage guidance before any files or secrets are generated.

## Validation

- `sh -n examples/dockercompose/init-env.sh`
- isolated checks for help, missing arguments, unknown options, excess arguments, and successful configuration generation
- `git diff --check`