### PR TITLE
fix(realtime): refresh active calls after room access

### DIFF
--- a/apps/frontend/e2e/voice-call.spec.ts
+++ b/apps/frontend/e2e/voice-call.spec.ts
@@ -460,6 +460,48 @@ test.describe('Voice calls', () => {
     });
   });
 
+  test('active call becomes visible when the viewer joins its room', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    const alice = await createAndLoginTestUser(page);
+    await chatPage.goto();
+    const roomName = `call-visibility-${Date.now()}`;
+    await chatPage.createRoom(roomName);
+    const { roomId } = await getIdsFromUrlViaConnect(page);
+
+    await withServerUser(browser!, serverURL, async ({ page: page2, chatPage: chatPage2 }) => {
+      const room = chatPage2.roomList.getByRole('link', { name: `# ${roomName}` });
+      const callIcon = room.getByTestId('room-call-icon');
+      await expect(callIcon).not.toBeVisible();
+
+      await expect(joinCallViaConnect(page, roomId)).resolves.toBe(true);
+      await expect(listActiveCallRoomIdsViaConnect(page2)).resolves.toEqual([]);
+
+      await joinRoomViaConnect(page2, roomId);
+
+      await expect(room).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(callIcon).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(callIcon.getByTestId('active-call-pulse-icon')).toBeVisible();
+
+      await chatPage2.enterRoom(roomName);
+      const callTab = page2
+        .locator('[data-testid="room-sidebar-toggle"]:visible')
+        .getByLabel('Show call');
+      await expect(callTab.getByTestId('active-call-pulse-icon')).toBeVisible({
+        timeout: TIMEOUTS.REALTIME_EVENT
+      });
+      await callTab.click();
+
+      const observerPanel = page2.getByTestId('call-observer-panel');
+      await expect(observerPanel).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+      await expect(observerPanel.getByTitle(alice.displayName)).toBeVisible();
+      await expect(page2.getByTestId('call-join-button')).toHaveText('Join call');
+    });
+  });
+
   test('active-call icon and participant avatar appear for a DM participant', async ({
     page,
     chatPage,

--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -681,6 +681,9 @@ func (s *HTTPServer) realtimeProjectionFrameForEventWithRooms(ctx context.Contex
 		if err := appendRoomTimelineIfMember(roomID); err != nil {
 			return nil, false, err
 		}
+		if err := appendViewerSensitiveResources(); err != nil {
+			return nil, false, err
+		}
 		if err := appendSourceTimeline(roomID); err != nil {
 			return nil, false, err
 		}
@@ -705,9 +708,9 @@ func (s *HTTPServer) realtimeProjectionFrameForEventWithRooms(ctx context.Contex
 			// A universal-membership revocation must remove already-decrypted
 			// timeline state in the same ordered projection event as metadata.
 			appendRoomTimelineClear(roomID)
-			if err := appendViewerSensitiveResources(); err != nil {
-				return nil, false, err
-			}
+		}
+		if err := appendViewerSensitiveResources(); err != nil {
+			return nil, false, err
 		}
 	case *corev1.Event_RoomSlowModeChanged:
 		if err := appendRoom(payload.RoomSlowModeChanged.GetRoomId()); err != nil {
@@ -720,6 +723,9 @@ func (s *HTTPServer) realtimeProjectionFrameForEventWithRooms(ctx context.Contex
 		}
 		if evt.GetActorId() == viewerID {
 			if err := appendRoomTimeline(roomID); err != nil {
+				return nil, false, err
+			}
+			if err := appendViewerSensitiveResources(); err != nil {
 				return nil, false, err
 			}
 		}

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/gorilla/websocket"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/connectapi"
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/evtstream"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
@@ -1362,6 +1364,95 @@ func TestRealtimeWebSocketMaterializesRetainedRoomAfterViewerGainsAccess(t *test
 	t.Fatal("retained room did not materialize after the viewer gained access")
 }
 
+func TestRealtimeWebSocketReplacesActiveCallsWhenViewerGainsRoomAccess(t *testing.T) {
+	env := setupWebSocketTestServer(t)
+	env.httpServer.config.LiveKit = config.LiveKitConfig{
+		Enabled:   true,
+		URL:       "ws://livekit.example.test",
+		APIKey:    "test-key",
+		APISecret: "test-secret",
+	}
+	env.httpServer.connectAPI = connectapi.New(env.core, env.httpServer.config, env.httpServer.version)
+
+	alice, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-call-alice", "Alice", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser Alice: %v", err)
+	}
+	bob, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-call-bob", "Bob", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser Bob: %v", err)
+	}
+	room, err := env.core.CreateRoom(env.ctx, alice.Id, core.KindChannel, "", "rt-call-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
+	}
+	if _, err := env.core.JoinRoom(env.ctx, alice.Id, core.KindChannel, alice.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom Alice: %v", err)
+	}
+	if err := env.core.HandleCallParticipantJoined(env.ctx, room.Id, alice.Id); err != nil {
+		t.Fatalf("HandleCallParticipantJoined Alice: %v", err)
+	}
+
+	snapshot, err := env.httpServer.connectAPI.BuildRealtimeProjectionSnapshot(env.ctx, bob.Id, nil)
+	if err != nil {
+		t.Fatalf("BuildRealtimeProjectionSnapshot Bob: %v", err)
+	}
+	if len(snapshot.ActiveCalls) != 0 {
+		t.Fatalf("pre-membership active calls = %+v, want none", snapshot.ActiveCalls)
+	}
+
+	bobToken, err := env.core.CreateAuthToken(env.ctx, bob.Id)
+	if err != nil {
+		t.Fatalf("CreateAuthToken Bob: %v", err)
+	}
+	conn := env.connectRealtime(t)
+	subscribeRealtime(t, conn, bobToken)
+	sendRealtimeClientFrame(t, conn, &realtimev1.RealtimeClientFrame{Frame: &realtimev1.RealtimeClientFrame_HydrateRoom{
+		HydrateRoom: &realtimev1.RealtimeHydrateRoom{RoomId: room.Id},
+	}})
+	frame, ok := readRealtimeServerFrame(t, conn, 5*time.Second)
+	if !ok || frame.GetError().GetCode() != "room_unavailable" || frame.GetError().GetFatal() {
+		t.Fatalf("pre-membership hydration frame = %+v, want non-fatal room_unavailable", frame)
+	}
+
+	if _, err := env.core.AddMember(env.ctx, alice.Id, core.KindChannel, room.Id, bob.Id); err != nil {
+		t.Fatalf("AddMember Bob: %v", err)
+	}
+	projection := waitRealtimeProjectionEvent(t, conn, 5*time.Second, func(projection *realtimev1.RealtimeProjectionEvent) bool {
+		var hasRoom, hasCalls bool
+		for _, operation := range projection.GetOperations() {
+			upsert := operation.GetRoomUpsert()
+			hasRoom = hasRoom || upsert.GetRoom().GetRoom().GetId() == room.Id
+			hasCalls = hasCalls || operation.GetActiveCallsReplace() != nil
+		}
+		return hasRoom && hasCalls
+	})
+	if projection == nil {
+		t.Fatal("timed out waiting for room access and active-call replacement")
+	}
+
+	var gotRoom, gotTimeline, gotNotifications bool
+	var calls []*apiv1.ActiveCall
+	for _, operation := range projection.GetOperations() {
+		if upsert := operation.GetRoomUpsert(); upsert.GetRoom().GetRoom().GetId() == room.Id {
+			gotRoom = upsert.GetRoom().GetViewerState().GetIsMember() && slices.Contains(upsert.GetMemberUserIds(), bob.Id)
+		}
+		if timeline := operation.GetRoomTimelineReplace(); timeline.GetRoomId() == room.Id {
+			gotTimeline = true
+		}
+		if replacement := operation.GetActiveCallsReplace(); replacement != nil {
+			calls = replacement.GetCalls()
+		}
+		gotNotifications = gotNotifications || operation.GetNotificationsReplace() != nil
+	}
+	if !gotRoom || !gotTimeline || !gotNotifications {
+		t.Fatalf("room access projection room=%t timeline=%t notifications=%t; operations=%+v", gotRoom, gotTimeline, gotNotifications, projection.GetOperations())
+	}
+	if len(calls) != 1 || calls[0].GetRoom().GetId() != room.Id || len(calls[0].GetParticipants()) != 1 || calls[0].GetParticipants()[0].GetUser().GetId() != alice.Id {
+		t.Fatalf("post-membership active calls = %+v, want Alice in room %q", calls, room.Id)
+	}
+}
+
 func TestRealtimeWebSocketUniversalMembershipTransitionsScrubAndRestoreOnlyRetainedTimelines(t *testing.T) {
 	env := setupWebSocketTestServer(t)
 	owner, err := env.core.CreateUser(env.ctx, core.SystemActorID, "rt-universal-owner", "RT Universal Owner", "password123")
@@ -1450,8 +1541,8 @@ func TestRealtimeWebSocketUniversalMembershipTransitionsScrubAndRestoreOnlyRetai
 		if !gotRoom || gotTimeline != wantTimeline || gotMessage != wantMessage {
 			t.Fatalf("%s: room=%t timeline=%t message=%t, want room=true timeline=%t message=%t; operations=%+v", name, gotRoom, gotTimeline, gotMessage, wantTimeline, wantMessage, projection.GetOperations())
 		}
-		if !wantMember && (!gotCalls || !gotNotifications) {
-			t.Fatalf("%s: revocation omitted active-call/notification replacements; operations=%+v", name, projection.GetOperations())
+		if !gotCalls || !gotNotifications {
+			t.Fatalf("%s: access transition omitted active-call/notification replacements; operations=%+v", name, projection.GetOperations())
 		}
 	}
 
@@ -1599,25 +1690,22 @@ func TestRealtimeWebSocketRestoresRetainedTimelineAfterUnarchive(t *testing.T) {
 	if _, err := env.core.UnarchiveRoom(env.ctx, viewer.Id, core.KindChannel, room.Id); err != nil {
 		t.Fatalf("UnarchiveRoom: %v", err)
 	}
-	deadline = time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
-		frame, ok := readRealtimeServerFrame(t, conn, time.Until(deadline))
-		if !ok {
-			break
-		}
-		for _, operation := range frame.GetProjectionEvent().GetOperations() {
-			timeline := operation.GetRoomTimelineReplace()
-			if timeline.GetRoomId() != room.Id {
-				continue
-			}
-			for _, event := range timeline.GetPage().GetEvents() {
-				if event.GetId() == message.Id {
-					return
+	projection := waitRealtimeProjectionEvent(t, conn, 5*time.Second, func(projection *realtimev1.RealtimeProjectionEvent) bool {
+		var gotMessage, gotCalls, gotNotifications bool
+		for _, operation := range projection.GetOperations() {
+			if timeline := operation.GetRoomTimelineReplace(); timeline.GetRoomId() == room.Id {
+				for _, event := range timeline.GetPage().GetEvents() {
+					gotMessage = gotMessage || event.GetId() == message.Id
 				}
 			}
+			gotCalls = gotCalls || operation.GetActiveCallsReplace() != nil
+			gotNotifications = gotNotifications || operation.GetNotificationsReplace() != nil
 		}
+		return gotMessage && gotCalls && gotNotifications
+	})
+	if projection == nil {
+		t.Fatal("unarchive did not restore retained timeline and viewer-sensitive resources")
 	}
-	t.Fatal("unarchive did not restore the retained room timeline")
 }
 
 func TestRealtimeWebSocketAdvancesPastRetainedUnarchiveForNonMember(t *testing.T) {

--- a/docs/architecture/realtime-delivery.md
+++ b/docs/architecture/realtime-delivery.md
@@ -190,16 +190,22 @@ materialising room timelines, while older projection-v1 clients safely reapply
 the familiar state and advance their cursor.
 
 Effective membership changes are authoritative timeline boundaries. When a
-universal room stops granting membership, live mapping pairs its current room
-state with an empty replacement for any retained timeline plus authoritative
-active-call and notification replacements; loss of room
-visibility uses `room_remove`, which has the same eviction effect. The browser
-also scrubs canonical rows, mounted room stores, open thread stores, optimistic
-state, call and notification mirrors, and in-flight reads as soon as projected
+viewer gains room access through a join, Universal membership, or unarchive,
+live mapping pairs the current room and any retained timeline with
+authoritative active-call and notification replacements. Newly visible calls
+therefore appear without a compacted reset or page reload.
+
+When a Universal room stops granting membership, live mapping pairs its
+current room state with an empty replacement for any retained timeline plus
+the same viewer-sensitive replacements; loss of room visibility uses
+`room_remove`, which has the same eviction effect. The browser scrubs
+canonical rows, mounted room stores, open thread stores, optimistic state,
+call and notification mirrors, and in-flight reads as soon as projected
 membership becomes false. It also disconnects local call media for that room
-without issuing a redundant leave command. The privacy fence stays closed until an explicit
-positive membership operation arrives, so delayed pagination, previews,
-read-your-writes responses, and timeline replacements cannot restore plaintext.
+without issuing a redundant leave command. The privacy fence stays closed
+until an explicit positive membership operation arrives, so delayed pagination,
+previews, read-your-writes responses, and timeline replacements cannot restore
+plaintext.
 
 The browser keeps only the non-plaintext retained-room intent. If membership
 later returns, the server rematerialises the current window only for that
@@ -391,10 +397,11 @@ one-shot presentation effects, while replay and finite reconciliation omit it.
 Viewer preferences, thread follow/read state, profile changes, server layout,
 and member removal likewise mutate the client only through projection
 operations. Active calls converge through `active_calls_replace` in the
-compacted prefix and after every durable call transition. Transient frames have
-no durable cursor; finite pending-notification and presence state are
-reconciled explicitly on every subscription. The process-wide PresenceHub
-retains current presence and fans out later transitions.
+compacted prefix, after every durable call transition, and when room access
+changes the set visible to the viewer. Transient frames have no durable cursor;
+finite pending-notification and presence state are reconciled explicitly on
+every subscription. The process-wide PresenceHub retains current presence and
+fans out later transitions.
 
 A `user_remove` operation purges copied profile fields from room membership,
 timeline includes, notification actors, active-call participants, retained


### PR DESCRIPTION
## Why

Users who gained room access while a call was already running did not receive the newly authorised call state until reloading because live membership mapping omitted the viewer-sensitive replacement included by compacted bootstrap.

## What changed

- Emit existing active-call and notification replacements alongside room/timeline state for self or administrative joins, Universal membership restoration, and unarchive.
- Cover the mapper with WebSocket integration tests and the reported receiver-side voice-call browser flow.
- Document active-call convergence after room-access changes in the realtime architecture inventory.

## API compatibility

- Behavioural change; temporal client/server impact described below.

Older client → newer server: Existing protocol-2 clients consume the existing replacement operations and converge without reconnecting.

Newer client → older server: No new client behaviour is required; older servers retain the previous reload-to-converge limitation.

Capability discovery or minimum client/server version: None; protocol version 2 and all wire shapes are unchanged.

## Test plan

- `mise test-cli` — passed.
- Focused realtime HTTP-server tests after rebasing onto `main` — passed.
- `mise x -- pnpm exec playwright test e2e/voice-call.spec.ts --retries=0` — 14 passed.
- `mise lint-frontend`, Prettier, and `git diff --check` — passed.
- Public protobuf Buf breaking check against `origin/main` — passed.
- Chrome DevTools two-user verification without reload — room/call indicators and observer panel converged; receiver console clean.
