### PR TITLE
fix(ci): publish desktop releases without checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
         run: |
           gh release upload "$GITHUB_REF_NAME" .context/desktop-release/* --clobber
           gh release edit "$GITHUB_REF_NAME" --draft=false


### PR DESCRIPTION
## Why

Desktop release assembly runs without a repository checkout, so GitHub CLI could not resolve `chattocorp/chatto`; asset upload failed and releases remained empty drafts.

## What changed

- Set `GH_REPO` from `github.repository` for the Desktop upload-and-publish step, keeping the assembly job checkout-free.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Unaffected.

Newer client → older server: Unaffected.

Capability discovery or minimum client/server version: Unaffected.

## Test plan

- `mise x -- actionlint .github/workflows/*.yml`
- `git diff --check origin/main...HEAD`
- Recovered `chatto-desktop/v0.1.0-alpha.2` by running the exact upload and publish commands from `/tmp` with `GH_REPO`; GitHub API and an unauthenticated Chrome session confirmed the published prerelease and all four expected assets.
