### PR TITLE
fix(desktop): identify bundled frontend builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,6 +183,41 @@ jobs:
         with:
           install-cli-deps: "false"
 
+      - name: Resolve desktop version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            version="${GITHUB_REF_NAME#chatto-desktop/v}"
+          else
+            version="$(jq -r '.version' apps/desktop/package.json)"
+          fi
+          sha="$(git rev-parse HEAD)"
+
+          if [[ -z "$version" || "$version" == "null" ]]; then
+            echo "::error::Could not determine the Chatto Desktop version."
+            exit 1
+          fi
+          if [[ -z "$sha" ]]; then
+            echo "::error::Could not determine the checked-out commit."
+            exit 1
+          fi
+
+          frontend_version="${version}+${sha:0:12}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "sha=${sha}" >> "$GITHUB_OUTPUT"
+          echo "frontend_version=${frontend_version}" >> "$GITHUB_OUTPUT"
+
+          {
+            echo "### Chatto Desktop"
+            echo
+            echo "- Commit: \`${sha}\`"
+            echo "- Desktop version: \`${version}\`"
+            echo "- Bundled frontend version: \`${frontend_version}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Check and test desktop shell
         run: mise test-desktop
 
@@ -192,23 +227,17 @@ jobs:
 
       - name: Build desktop bundle
         run: mise desktop-build
+        env:
+          CHATTO_BUILD_VERSION: ${{ steps.version.outputs.frontend_version }}
 
-      - name: Resolve desktop version
-        id: version
+      - name: Verify bundled frontend version
         shell: bash
+        env:
+          EXPECTED_VERSION: ${{ steps.version.outputs.frontend_version }}
         run: |
-          if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            version="${GITHUB_REF_NAME#chatto-desktop/v}"
-          else
-            version="$(jq -r '.version' apps/desktop/package.json)"
-          fi
-
-          if [[ -z "$version" || "$version" == "null" ]]; then
-            echo "::error::Could not determine the Chatto Desktop version."
-            exit 1
-          fi
-
-          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          jq -e --arg expected "$EXPECTED_VERSION" \
+            '.version == $expected' \
+            apps/frontend/build/_app/version.json
 
       - name: Package macOS release
         if: runner.os == 'macOS'

--- a/docs/fdr/FDR-034-chatto-desktop.md
+++ b/docs/fdr/FDR-034-chatto-desktop.md
@@ -45,6 +45,10 @@ system-browser authentication, and clean-machine media behavior are hardened.
   unsigned until trusted platform signing and macOS notarisation are added.
 - Chatto Desktop has an independent version and changelog. Its release tags use
   `chatto-desktop/v{version}` and do not change the Chatto server version.
+- Each release rebuilds and embeds the official frontend from the Desktop tag's
+  commit. The frontend build identity combines the Desktop version with that
+  commit's abbreviated SHA so the bundled source revision remains explicit
+  even while Chatto and Chatto Desktop release independently.
 - The application requires a network connection. It does not provide an
   offline Chatto experience.
 - Servers recognize the built-in `chatto://desktop` OAuth client and its exact
@@ -104,8 +108,10 @@ must tightly constrain popup and navigation behavior.
 ### 5. Release the desktop shell independently
 
 **Decision:** Chatto Desktop uses an independent pre-1.0 release stream,
-changelog, tag namespace, and artifacts while continuing to bundle a specific
-official frontend revision.
+changelog, tag namespace, and artifacts while continuing to bundle the official
+frontend revision at its release tag. Release builds identify that frontend as
+`{desktop-version}+{commit-sha}` and verify the generated identity before
+packaging.
 **Why:** Desktop packaging, platform fixes, and runtime upgrades have a cadence
 different from Chatto server releases.
 **Tradeoff:** Compatibility diagnostics must distinguish the desktop shell


### PR DESCRIPTION
## Why

Chatto Desktop rebuilt the current frontend but identified it only with the independently released frontend package version, obscuring the exact source revision bundled in an artifact.

## What changed

- Derive the bundled frontend identity as `{desktop-version}+{commit-sha}` from the actual checked-out release ref.
- Inject and verify that identity before packaging, expose release provenance in the workflow summary, and document the invariant in FDR-034.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- actionlint .github/workflows/release.yml`
- Complete frontend build and generated `_app/version.json` assertion with `0.1.0-alpha.2+59aee59e6bd5`
- Complete macOS `mise desktop-build` and packaged-app `_app/version.json` assertion with the same identity
- `git diff --check`
