### PR TITLE
feat(frontend): refine room group sidebar sections

### DIFF
--- a/apps/frontend/e2e/pages/ChatPage.ts
+++ b/apps/frontend/e2e/pages/ChatPage.ts
@@ -22,6 +22,13 @@ export class ChatPage {
     return this.page.locator('.room-list');
   }
 
+  /** Return a sidebar room link without depending on its room-type icon. */
+  getRoomLink(roomName: string): Locator {
+    return this.roomList
+      .getByRole('link')
+      .filter({ has: this.page.getByText(roomName, { exact: true }) });
+  }
+
   /**
    * Navigate to the chat page.
    * Note: users may be redirected to the server root, their last room, or
@@ -65,7 +72,7 @@ export class ChatPage {
    * Always waits for room UI to be ready before returning.
    */
   async enterRoom(roomName: string): Promise<RoomPage> {
-    const link = this.roomList.getByRole('link', { name: `# ${roomName}` });
+    const link = this.getRoomLink(roomName);
     await expect(link).toBeVisible();
 
     // Check if already in this room (aria-current="page" indicates active link)

--- a/apps/frontend/e2e/realtime-sync.test.ts
+++ b/apps/frontend/e2e/realtime-sync.test.ts
@@ -99,8 +99,8 @@ test.describe('Real-time synchronization', () => {
     await chatPage.goto();
 
     // User is auto-joined to general and announcements
-    await expect(chatPage.roomList.getByText('# general')).toBeVisible();
-    await expect(chatPage.roomList.getByText('# announcements')).toBeVisible();
+    await expect(chatPage.getRoomLink('general')).toBeVisible();
+    await expect(chatPage.getRoomLink('announcements')).toBeVisible();
 
     // Create a room (user is auto-joined as creator)
     const testRoomName = `testing-${Date.now()}`;

--- a/apps/frontend/e2e/room-auto-join.test.ts
+++ b/apps/frontend/e2e/room-auto-join.test.ts
@@ -17,16 +17,14 @@ test.describe('Room auto-join', () => {
     await chatPage.goto();
 
     // User B: Create account and open the server
-    await withServerUser(browser!, serverURL, async ({ page: page2 }) => {
+    await withServerUser(browser!, serverURL, async ({ page: page2, chatPage: chatPage2 }) => {
       // Verify User B sees both default auto-join rooms in the sidebar
-      const roomList = page2.locator('.room-list');
-
       // "general" should be visible (auto-joined)
-      const generalRoom = roomList.getByRole('link', { name: '# general' });
+      const generalRoom = chatPage2.getRoomLink('general');
       await expect(generalRoom).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
       // "announcements" should be visible (auto-joined)
-      const announcementsRoom = roomList.getByRole('link', { name: '# announcements' });
+      const announcementsRoom = chatPage2.getRoomLink('announcements');
       await expect(announcementsRoom).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
 
       // User B can click on a room and see its content (confirming they're a member)

--- a/apps/frontend/e2e/unread-indicators.test.ts
+++ b/apps/frontend/e2e/unread-indicators.test.ts
@@ -320,8 +320,8 @@ test.describe('Unread indicators', () => {
     await waitForRoomReady(page, 'announcements');
 
     // Both rooms should have no unread indicator since we've viewed them
-    const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
-    const announcementsLink = chatPage.roomList.locator('a', { hasText: '# announcements' });
+    const generalLink = chatPage.getRoomLink('general');
+    const announcementsLink = chatPage.getRoomLink('announcements');
 
     await expect(generalLink).not.toHaveClass(/sidebar-item-attention/);
     await expect(announcementsLink).not.toHaveClass(/sidebar-item-attention/);

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -19,6 +19,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import CollapsibleGroup from '$lib/ui/CollapsibleGroup.svelte';
+  import RoomGroupSection from '$lib/components/chat/RoomGroupSection.svelte';
   import EmptyState from '$lib/ui/EmptyState.svelte';
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import { buildDirectMessagePresentation, type UserAvatarUserView } from '$lib/render/users';
@@ -342,12 +343,24 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       <span class="flex-1 truncate">{presentation.label}</span>
     {:else}
       {#if isJoined}
-        <span
-          class={[
-            'sidebar-icon',
-            showUnread && room.id !== activeRoomId ? 'text-text-top' : 'text-muted'
-          ]}>#</span
-        >
+        {#if room.isUniversal}
+          <span
+            class={[
+              'iconify sidebar-icon icon-[uil--globe]',
+              showUnread && room.id !== activeRoomId ? 'text-text-top' : 'text-muted'
+            ]}
+            role="img"
+            aria-label={m('room.directory.universal')}
+            title={m('room.directory.universal_title')}
+          ></span>
+        {:else}
+          <span
+            class={[
+              'sidebar-icon',
+              showUnread && room.id !== activeRoomId ? 'text-text-top' : 'text-muted'
+            ]}>#</span
+          >
+        {/if}
       {:else if room.viewerCanJoinRoom}
         <span class="sidebar-icon text-muted">+</span>
       {:else}
@@ -417,41 +430,43 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     {m('room_list.empty_suffix')}
   </EmptyState>
 {:else}
-  <nav class="room-list sidebar-nav p-2 md:w-full">
+  <nav class="room-list md:w-full">
     {#if navigation.roomGroups.length > 0}
-      <!-- Room-set layout -->
       {#each visibleSets as set, i (set.id)}
-        <CollapsibleGroup
+        <RoomGroupSection
           label={set.name}
           items={getSetItems(set)}
           item={sidebarLink}
           persistKey={serverStorageKey(activeServerId, `collapsible:set:${set.id}`)}
           keepVisibleWhenCollapsed={isGroupItemHighlighted}
-          class={i === 0 ? 'mt-4 first:mt-0' : 'mt-4'}
           contextMenuTrigger={groupMenuTrigger(set)}
+          separated={i > 0}
         />
       {/each}
     {:else if sortedRooms.length > 0}
       <!-- No layout configured yet — alphabetical fallback. -->
-      <CollapsibleGroup
-        label={m('common.rooms')}
-        items={sortedRooms}
-        item={navigationRoomLink}
-        persistKey={serverStorageKey(activeServerId, 'collapsible:rooms')}
-        keepVisibleWhenCollapsed={isHighlighted}
-        class="mt-4 first:mt-0"
-      />
+      <div class="p-2">
+        <CollapsibleGroup
+          label={m('common.rooms')}
+          items={sortedRooms}
+          item={navigationRoomLink}
+          persistKey={serverStorageKey(activeServerId, 'collapsible:rooms')}
+          keepVisibleWhenCollapsed={isHighlighted}
+        />
+      </div>
     {/if}
 
     {#if dmRooms.length > 0}
-      <CollapsibleGroup
-        label={m('room_list.direct_messages')}
-        items={dmRooms}
-        item={navigationRoomLink}
-        persistKey={serverStorageKey(activeServerId, 'collapsible:dms')}
-        keepVisibleWhenCollapsed={isHighlighted}
-        class="mt-4"
-      />
+      <div class="px-2 pb-2">
+        <CollapsibleGroup
+          label={m('room_list.direct_messages')}
+          items={dmRooms}
+          item={navigationRoomLink}
+          persistKey={serverStorageKey(activeServerId, 'collapsible:dms')}
+          keepVisibleWhenCollapsed={isHighlighted}
+          class={visibleSets.length > 0 || sortedRooms.length > 0 ? 'mt-4' : ''}
+        />
+      </div>
     {/if}
   </nav>
 {/if}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -765,6 +765,43 @@ describe('RoomList', () => {
     expect(icon?.classList.contains('text-muted')).toBe(false);
   });
 
+  it('uses the established globe icon for universal joined rooms', async () => {
+    const universal = mocks.store.navigation.rooms.find(
+      (room: { id: string }) => room.id === 'channel-1'
+    ) as unknown as { isUniversal: boolean };
+    universal.isUniversal = true;
+
+    const { container } = render(RoomList);
+
+    const row = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
+    await expect.element(row).toBeInTheDocument();
+    const icon = q(row, '[class~="icon-[uil--globe]"]');
+    await expect.element(icon).toHaveAttribute('aria-label', 'Universal');
+    expect(icon?.getAttribute('title')).toBeTruthy();
+  });
+
+  it('renders room groups as sections and keeps notification rooms visible while collapsed', async () => {
+    setRoomNotificationCount('channel-1', 1);
+    mocks.store.navigation.roomGroups = [
+      {
+        id: 'community',
+        name: 'Community',
+        viewerCanManageGroup: false,
+        roomIds: ['channel-1', 'joinable-channel']
+      }
+    ];
+    localStorage.setItem('chatto:i:origin:collapsible:set:community', '1');
+
+    const { container } = render(RoomList);
+
+    await expect.element(q(container, '[data-testid="room-group-section"]')).toBeInTheDocument();
+    await expect
+      .element(q(container, '[data-testid="room-group-section"] button'))
+      .toHaveAttribute('aria-expanded', 'false');
+    await expect.element(q(container, '[href="/chat/-/channel-1"]')).toBeInTheDocument();
+    expect(container.querySelector('[href="/chat/-/joinable-channel"]')).toBeNull();
+  });
+
   it('renders server-local sidebar links as same-tab anchors resolved against the active server', async () => {
     mocks.store.navigation.roomGroups = [
       {

--- a/apps/frontend/src/lib/components/chat/RoomGroupSection.stories.svelte
+++ b/apps/frontend/src/lib/components/chat/RoomGroupSection.stories.svelte
@@ -1,0 +1,83 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import RoomGroupSection from './RoomGroupSection.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Chat/Room group section',
+    component: RoomGroupSection,
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: {
+          component:
+            'Collapsible room-group navigation section. Highlighted rooms remain visible while the section is collapsed.'
+        }
+      }
+    }
+  });
+
+  const rooms = [
+    { id: 'announcements', label: 'announcements', universal: true, highlighted: false },
+    { id: 'random-chat', label: 'random-chat', universal: false, highlighted: true },
+    { id: 'development', label: 'chatto-development', universal: false, highlighted: false }
+  ];
+</script>
+
+{#snippet room(room: (typeof rooms)[number])}
+  <button type="button" class={['sidebar-item text-start', room.highlighted && 'bg-surface']}>
+    {#if room.universal}
+      <span
+        class="iconify sidebar-icon icon-[uil--globe] text-muted"
+        role="img"
+        aria-label="Universal room"
+      ></span>
+    {:else}
+      <span class="sidebar-icon text-muted">#</span>
+    {/if}
+    <span class="min-w-0 flex-1 truncate">{room.label}</span>
+  </button>
+{/snippet}
+
+<Story name="Adjacent sections" asChild>
+  <div class="w-72 bg-background">
+    <RoomGroupSection
+      label="Chatto"
+      items={rooms}
+      item={room}
+      persistKey="storybook:room-group-section:first"
+      keepVisibleWhenCollapsed={(entry) => entry.highlighted}
+    />
+    <RoomGroupSection
+      label="Chatto Cloud"
+      items={rooms.slice(0, 2)}
+      item={room}
+      persistKey="storybook:room-group-section:second"
+      keepVisibleWhenCollapsed={(entry) => entry.highlighted}
+      separated
+    />
+  </div>
+</Story>
+
+<Story name="Collapsed with active room" asChild>
+  <div class="w-72 bg-background">
+    <RoomGroupSection
+      label="Chatto"
+      items={rooms}
+      item={room}
+      persistKey="storybook:room-group-section:collapsed"
+      defaultCollapsed
+      keepVisibleWhenCollapsed={(entry) => entry.highlighted}
+    />
+  </div>
+</Story>
+
+<Story name="Empty manageable group" asChild>
+  <div class="w-72 bg-background">
+    <RoomGroupSection
+      label="Private projects"
+      items={[]}
+      item={room}
+      persistKey="storybook:room-group-section:empty"
+    />
+  </div>
+</Story>

--- a/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte
+++ b/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte
@@ -1,0 +1,103 @@
+<!--
+@component
+
+A persistent, collapsible room-group section for the server sidebar. Collapsing
+a section hides ordinary entries while keeping caller-identified attention rows
+visible, so active rooms, calls, unread rooms, and notifications remain
+reachable.
+-->
+<script module lang="ts">
+  import { SvelteMap } from 'svelte/reactivity';
+  import { Codecs, StorageSlot } from '$lib/storage/slot';
+
+  const collapsedByKey = new SvelteMap<string, boolean>();
+
+  function loadCollapsed(key: string, fallback: boolean): boolean {
+    const cached = collapsedByKey.get(key);
+    if (cached !== undefined) return cached;
+    return new StorageSlot(key, fallback, Codecs.boolean).get();
+  }
+
+  function saveCollapsed(key: string, value: boolean): void {
+    collapsedByKey.set(key, value);
+    new StorageSlot(key, value, Codecs.boolean).set(value);
+  }
+</script>
+
+<script lang="ts" generics="T extends { id: string }">
+  import type { Snippet } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
+  import { slide } from 'svelte/transition';
+  import { COMPACT_MOTION_DURATION_MS, expoOutTransition } from '$lib/ui/motion';
+
+  interface Props {
+    label: string;
+    items: T[];
+    item: Snippet<[T]>;
+    /** Whether to draw the full-width divider preceding this section. */
+    separated?: boolean;
+    /** Optional right-click/long-press behavior for the group header. */
+    contextMenuTrigger?: Attachment<HTMLElement>;
+    /** Unique localStorage key for persisting collapsed state. */
+    persistKey: string;
+    /** Collapsed state when no preference is stored. */
+    defaultCollapsed?: boolean;
+    keepVisibleWhenCollapsed?: (item: T) => boolean;
+  }
+
+  let {
+    label,
+    items,
+    item,
+    separated = false,
+    contextMenuTrigger,
+    persistKey,
+    defaultCollapsed = false,
+    keepVisibleWhenCollapsed
+  }: Props = $props();
+
+  const collapsed = $derived(loadCollapsed(persistKey, defaultCollapsed));
+  const visibleItems = $derived(
+    collapsed ? items.filter((entry) => keepVisibleWhenCollapsed?.(entry) ?? false) : items
+  );
+
+  function toggle(): void {
+    saveCollapsed(persistKey, !collapsed);
+  }
+</script>
+
+<section
+  class={separated ? 'border-t border-border' : undefined}
+  data-testid="room-group-section"
+>
+  <div class="px-2 py-1.5">
+    <button
+      type="button"
+      onclick={toggle}
+      aria-expanded={!collapsed}
+      class="flex min-h-8 w-full min-w-0 cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-start text-xs font-semibold tracking-wider text-muted uppercase transition-colors hover:text-text"
+      {@attach contextMenuTrigger}
+    >
+      <span class="sidebar-icon">
+        <span
+          class={[
+            'iconify transition-transform icon-[uil--angle-right-b]',
+            collapsed ? 'rtl:-scale-x-100' : 'rotate-90'
+          ]}
+          aria-hidden="true"
+        ></span>
+      </span>
+      <span class="min-w-0 flex-1 truncate">{label}</span>
+    </button>
+
+    {#if visibleItems.length > 0}
+      <div class="flex flex-col gap-0.5">
+        {#each visibleItems as entry (entry.id)}
+          <div transition:slide={expoOutTransition(COMPACT_MOTION_DURATION_MS)}>
+            {@render item(entry)}
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+</section>

--- a/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte.spec.ts
@@ -1,0 +1,68 @@
+import { render } from 'vitest-browser-svelte';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { q, testSnippet } from '$lib/test-utils';
+import RoomGroupSection from './RoomGroupSection.svelte';
+
+const items = [{ id: 'general' }, { id: 'announcements' }];
+
+beforeEach(() => localStorage.clear());
+
+describe('RoomGroupSection', () => {
+  it('persists its collapsed state and keeps highlighted entries visible', async () => {
+    const persistKey = 'test:room-group-section:collapse';
+    const { container } = render(RoomGroupSection, {
+      props: {
+        label: 'Community',
+        items,
+        item: testSnippet('<span data-testid="room-group-entry">Room</span>'),
+        persistKey,
+        keepVisibleWhenCollapsed: (entry) => entry.id === 'announcements'
+      }
+    });
+
+    const toggle = q(container, 'button');
+    await expect.element(toggle).toHaveAttribute('aria-expanded', 'true');
+    expect(container.querySelectorAll('[data-testid="room-group-entry"]')).toHaveLength(2);
+
+    toggle?.click();
+
+    await expect.element(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect
+      .poll(() => container.querySelectorAll('[data-testid="room-group-entry"]').length)
+      .toBe(1);
+    expect(localStorage.getItem(persistKey)).toBe('1');
+  });
+
+  it('draws a full-width divider when it follows another room group', () => {
+    const { container } = render(RoomGroupSection, {
+      props: {
+        label: 'Community',
+        items,
+        item: testSnippet('<span>Room</span>'),
+        persistKey: 'test:room-group-section:divider',
+        separated: true
+      }
+    });
+
+    const section = q(container, '[data-testid="room-group-section"]');
+    expect(section?.classList).toContain('border-t');
+    expect(section?.classList).toContain('border-border');
+  });
+
+  it('mirrors its collapsed inline-end disclosure icon in RTL', () => {
+    const { container } = render(RoomGroupSection, {
+      props: {
+        label: 'Community',
+        items,
+        item: testSnippet('<span>Room</span>'),
+        persistKey: 'test:room-group-section:rtl',
+        defaultCollapsed: true
+      }
+    });
+
+    const icon = q(container, '.iconify');
+    expect(icon?.classList).toContain('icon-[uil--angle-right-b]');
+    expect(icon?.classList).toContain('rtl:-scale-x-100');
+    expect(icon?.classList).not.toContain('rotate-90');
+  });
+});


### PR DESCRIPTION
## Why

Room groups currently read as loose collapsible lists and use more vertical space than necessary.

## What changed

- Render configured room groups as compact, full-width sidebar sections separated by subtle 1px dividers while preserving persisted collapse state and visibility for active or notified rooms.
- Use a globe icon for joined universal rooms, leave direct messages and the alphabetical fallback unchanged, and make E2E room selectors independent of the room-type icon.
- Add focused component coverage plus Storybook states.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: No impact.
- Newer client → older server: No impact.
- Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest --run --project=client src/lib/RoomList.svelte.spec.ts src/lib/components/chat/RoomGroupSection.svelte.spec.ts` — 35 tests passed.
- Focused Playwright regression run across composer, realtime sync, room auto-join, and unread indicators — 6 tests passed.
- `mise lint-frontend` — design-system guardrails, Svelte diagnostics, and ESLint passed with 0 errors and 0 warnings.
- Production Storybook build passed; Chrome DevTools review covered light/dark themes, a 360px viewport, expanded/collapsed states, and a clean console.
