### PR TITLE
feat(dev): add bind-mounted Compose watch stack

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -35,6 +35,11 @@ available_in = [ "local" ]
 default = true
 icon = "boxes"
 
+[scripts.run.compose-watch]
+command = "exec docker compose up --build --watch"
+available_in = [ "local" ]
+icon = "refresh-cw"
+
 [prompts]
 create_pr = "Create a full GitHub pull request for the current branch, not a draft PR."
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,11 @@ workspace-specific `*.orb.local` domains. The checkout directory is the
 Compose project name; for a worktree named `<workspace>`, Chatto is available
 at `https://chatto.<workspace>.orb.local`. The other origins follow the names
 listed in the [Complete Local Stack](README.md#complete-local-stack) section.
+Use Conductor's **Compose (watch)** run mode, Paseo's `compose-watch` script, or
+`docker compose up --build --watch` when dependency-manifest and development-
+image changes should restart or rebuild the affected services automatically.
+Ordinary Chatto, Authling, and Storybook source changes live-reload in either
+mode through the bind-mounted checkout.
 
 The repository-level Conductor settings are shared in
 `.conductor/settings.toml`, and the repository-level Paseo settings are shared

--- a/README.md
+++ b/README.md
@@ -30,15 +30,26 @@ repository once it no longer needs frequent atomic changes with the shared
 The root [`compose.yml`](compose.yml) runs Chatto, Authling, Mailpit, LiveKit,
 Storybook, and the Chatto docs website together on
 [OrbStack](https://docs.orbstack.dev/docker/domains). It builds every
-repository-owned service from the current checkout, gives Chatto and Authling
-separate persistent embedded-NATS storage, and configures Chatto to use
-Authling as an OpenID Connect provider through Chatto's public Client ID
-Metadata Document, without preregistering Chatto in Authling. Compose derives
-the project name from the checkout directory, keeping containers and OrbStack
-domains isolated between worktrees.
+repository-owned service from the current checkout. Chatto, Authling, and
+Storybook run from bind-mounted project files with container-native dependency
+volumes and live reloads. The stack gives Chatto and Authling separate
+persistent embedded-NATS storage and configures Chatto to use Authling as an
+OpenID Connect provider through Chatto's public Client ID Metadata Document,
+without preregistering Chatto in Authling. Compose derives the project name
+from the checkout directory, keeping containers and OrbStack domains isolated
+between worktrees.
 
 ```sh
 docker compose up --build
+```
+
+Vite, Storybook, and the Go development processes reload ordinary source
+changes themselves. Add Compose's optional watch mode to restart services when
+dependency manifests change and rebuild the shared development image when its
+Dockerfile changes:
+
+```sh
+docker compose up --build --watch
 ```
 
 For a checkout in a directory named `<project>`, open these OrbStack-managed

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -195,7 +195,32 @@ const testConfig = process.env.VITEST ? await createTestConfig() : undefined;
 
 async function createServePlugins() {
   const { default: devtoolsJson } = await import('vite-plugin-devtools-json');
-  return [devtoolsJson()];
+  return [proxyClientConfiguration(), devtoolsJson()];
+}
+
+function proxyClientConfiguration(): Plugin {
+  return {
+    name: 'chatto-client-configuration-proxy',
+    enforce: 'pre',
+    configureServer(server) {
+      if (!process.env.CHATTO_BACKEND_URL) return;
+
+      server.middlewares.use('/client-config.json', async (_request, response, next) => {
+        try {
+          const backendResponse = await fetch(new URL('/client-config.json', backendTarget));
+          response.statusCode = backendResponse.status;
+          response.setHeader(
+            'Content-Type',
+            backendResponse.headers.get('content-type') ?? 'application/json'
+          );
+          response.setHeader('Cache-Control', 'no-store');
+          response.end(Buffer.from(await backendResponse.arrayBuffer()));
+        } catch (error) {
+          next(error as Error);
+        }
+      });
+    }
+  };
 }
 
 export default defineConfig(async ({ command }) => {

--- a/compose.yml
+++ b/compose.yml
@@ -37,15 +37,46 @@ services:
   storybook:
     build:
       context: .
-      dockerfile: apps/frontend/Dockerfile.storybook
+      dockerfile: docker/Dockerfile.dev
+    command: ["docker/compose-dev-entrypoint.sh", "storybook"]
+    init: true
+    volumes:
+      - type: bind
+        source: .
+        target: /workspace
+      - storybook_node_modules:/workspace/node_modules
+      - storybook_frontend_node_modules:/workspace/apps/frontend/node_modules
+      - storybook_api_types_node_modules:/workspace/packages/api-types/node_modules
+      - storybook_lingua_node_modules:/workspace/packages/lingua/node_modules
+      - storybook_pnpm_store:/pnpm-store
     labels:
       dev.orbstack.http-port: "8080"
+    develop:
+      watch:
+        - action: rebuild
+          path: docker/Dockerfile.dev
+        - action: restart
+          path: docker/compose-dev-entrypoint.sh
+        - action: restart
+          path: package.json
+        - action: restart
+          path: pnpm-lock.yaml
+        - action: restart
+          path: pnpm-workspace.yaml
+        - action: restart
+          path: .npmrc
+        - action: restart
+          path: apps/frontend/package.json
+        - action: restart
+          path: packages/api-types/package.json
+        - action: restart
+          path: packages/lingua/package.json
 
   authling:
     build:
       context: .
-      dockerfile: authling/Dockerfile
-    command: ["run"]
+      dockerfile: docker/Dockerfile.dev
+    command: ["docker/compose-dev-entrypoint.sh", "authling"]
     init: true
     depends_on:
       mailpit:
@@ -64,21 +95,45 @@ services:
       AUTHLING_SMTP_TLS: opportunistic
       AUTHLING_SMTP_FROM: authling@authling.local
     volumes:
+      - type: bind
+        source: .
+        target: /workspace
       - authling_data:/data
+      - authling_node_modules:/workspace/authling/node_modules
+      - authling_web_node_modules:/workspace/authling/web/node_modules
+      - authling_pnpm_store:/pnpm-store
+      - compose_go_mod_cache:/go/pkg/mod
+      - compose_go_build_cache:/root/.cache/go-build
     labels:
       dev.orbstack.http-port: "8080"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--spider", "--header=Host: authling.${COMPOSE_PROJECT_NAME}.orb.local", "http://127.0.0.1:8080/"]
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--header", "Host: authling.${COMPOSE_PROJECT_NAME}.orb.local", "http://127.0.0.1:8080/"]
       interval: 2s
       timeout: 2s
       retries: 30
       start_period: 10s
+    develop:
+      watch:
+        - action: rebuild
+          path: docker/Dockerfile.dev
+        - action: restart
+          path: docker/compose-dev-entrypoint.sh
+        - action: restart
+          path: authling/package.json
+        - action: restart
+          path: authling/pnpm-lock.yaml
+        - action: restart
+          path: authling/pnpm-workspace.yaml
+        - action: restart
+          path: authling/.npmrc
+        - action: restart
+          path: authling/web/package.json
 
   chatto:
     build:
       context: .
-      dockerfile: docker/Dockerfile.compose
-    command: ["run"]
+      dockerfile: docker/Dockerfile.dev
+    command: ["docker/compose-dev-entrypoint.sh", "chatto"]
     init: true
     depends_on:
       authling:
@@ -88,10 +143,12 @@ services:
       mailpit:
         condition: service_started
     environment:
+      CHATTO_DEVELOPMENT_VERSION: 0.5.0-dev
+      CHATTO_BACKEND_URL: http://127.0.0.1:4001
       CHATTO_LOG_LEVEL: debug
       CHATTO_LOG_FORMAT: text
       CHATTO_WEBSERVER_URL: https://chatto.${COMPOSE_PROJECT_NAME}.orb.local
-      CHATTO_WEBSERVER_PORT: "4000"
+      CHATTO_WEBSERVER_PORT: "4001"
       CHATTO_WEBSERVER_COOKIE_SIGNING_SECRET: 871a846584490a6153305533cce100b8e6f39d4184c2fb499d2ed198a9ed37a3
       CHATTO_WEBSERVER_COOKIE_ENCRYPTION_SECRET: a3955a342ba4cb4ffb457a1177295779fbbb73f8e22cd4f68ecb9fb584afcf66
       CHATTO_FRONTEND_AUTHLING_ISSUER: https://authling.${COMPOSE_PROJECT_NAME}.orb.local
@@ -140,17 +197,63 @@ services:
       CHATTO_BOOTSTRAP_USERS_1_EMAIL: bob@example.com
       CHATTO_BOOTSTRAP_USERS_1_PASSWORD: foobar123
       CHATTO_BOOTSTRAP_SERVER_NAME: Chatto + Authling
+      VITE_PORT: "4000"
     volumes:
+      - type: bind
+        source: .
+        target: /workspace
       - chatto_data:/data
+      - chatto_node_modules:/workspace/node_modules
+      - chatto_frontend_node_modules:/workspace/apps/frontend/node_modules
+      - chatto_api_types_node_modules:/workspace/packages/api-types/node_modules
+      - chatto_lingua_node_modules:/workspace/packages/lingua/node_modules
+      - chatto_pnpm_store:/pnpm-store
+      - compose_go_mod_cache:/go/pkg/mod
+      - compose_go_build_cache:/root/.cache/go-build
     labels:
       dev.orbstack.http-port: "4000"
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--spider", "--header=Host: chatto.${COMPOSE_PROJECT_NAME}.orb.local", "http://127.0.0.1:4000/readyz"]
+      test: ["CMD", "curl", "--fail", "--silent", "--show-error", "--header", "Host: chatto.${COMPOSE_PROJECT_NAME}.orb.local", "http://127.0.0.1:4001/readyz"]
       interval: 2s
       timeout: 2s
       retries: 60
       start_period: 20s
+    develop:
+      watch:
+        - action: rebuild
+          path: docker/Dockerfile.dev
+        - action: restart
+          path: docker/compose-dev-entrypoint.sh
+        - action: restart
+          path: package.json
+        - action: restart
+          path: pnpm-lock.yaml
+        - action: restart
+          path: pnpm-workspace.yaml
+        - action: restart
+          path: .npmrc
+        - action: restart
+          path: apps/frontend/package.json
+        - action: restart
+          path: packages/api-types/package.json
+        - action: restart
+          path: packages/lingua/package.json
 
 volumes:
+  authling_node_modules:
+  authling_pnpm_store:
   authling_data:
+  authling_web_node_modules:
+  chatto_api_types_node_modules:
   chatto_data:
+  chatto_frontend_node_modules:
+  chatto_lingua_node_modules:
+  chatto_node_modules:
+  chatto_pnpm_store:
+  compose_go_build_cache:
+  compose_go_mod_cache:
+  storybook_api_types_node_modules:
+  storybook_frontend_node_modules:
+  storybook_lingua_node_modules:
+  storybook_node_modules:
+  storybook_pnpm_store:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,4 +1,13 @@
-FROM golang:1.26
+FROM node:22-trixie-slim AS node
+
+FROM golang:1.26.2-trixie
+
+# Chatto and Authling both build browser assets before starting their Go
+# development servers. Reuse the official Node distribution on the matching
+# Debian base instead of installing a second, distribution-owned toolchain.
+COPY --from=node /usr/local/ /usr/local/
+
+RUN corepack enable pnpm && corepack install --global pnpm@10.26.0
 
 RUN apt-get update && apt-get install -y --no-install-recommends xz-utils ffmpeg && rm -rf /var/lib/apt/lists/*
 
@@ -16,9 +25,4 @@ RUN set -eux; \
     mv /tmp/watchexec-*/watchexec /usr/local/bin/watchexec; \
     rm -rf /tmp/watchexec*
 
-WORKDIR /app
-
-# Bake in the cli/ tree so the image can run standalone in Kubernetes or other
-# containerized development environments. When used under Compose this is
-# overlaid by the bind-mount and adds no runtime cost.
-COPY cli ./cli
+WORKDIR /workspace

--- a/docker/Dockerfile.dev.dockerignore
+++ b/docker/Dockerfile.dev.dockerignore
@@ -1,7 +1,25 @@
-# Ignore everything by default.
-*
-
-# Backend source needed by Dockerfile.dev.
-!cli/
-cli/data/
-cli/bin/
+# The Compose development image contains toolchains only. Allow the small set
+# of files used as Compose Watch triggers, but do not send application source.
+**
+!docker/
+!docker/Dockerfile.dev
+!docker/compose-dev-entrypoint.sh
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!.npmrc
+!apps/
+!apps/frontend/
+!apps/frontend/package.json
+!packages/
+!packages/api-types/
+!packages/api-types/package.json
+!packages/lingua/
+!packages/lingua/package.json
+!authling/
+!authling/package.json
+!authling/pnpm-lock.yaml
+!authling/pnpm-workspace.yaml
+!authling/.npmrc
+!authling/web/
+!authling/web/package.json

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,8 +21,11 @@ automation.
   explicit operator overrides.
 - `Dockerfile.frontend.prebuilt` packages the already-built frontend static
   files into the release-only `ghcr.io/chattocorp/chatto-client` image.
-- `Dockerfile.dev` is the backend development image for containerized local or
-  cluster development.
+- `Dockerfile.dev` is the Go, Node.js, and file-watching toolchain image used by
+  the root Compose development stack. Compose bind-mounts the checkout instead
+  of baking project source into this image.
+- `compose-dev-entrypoint.sh` installs container-native workspace dependencies
+  and starts Chatto, Authling, or Storybook with polling live reloads.
 - `Dockerfile.frontend.dev` is the frontend development image used by
   containerized local or cluster development.
 - `*.dockerignore` files are scoped to individual root-context Dockerfiles.

--- a/docker/compose-dev-entrypoint.sh
+++ b/docker/compose-dev-entrypoint.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# Run bind-mounted Chatto development services with container-native
+# dependencies and polling file watchers.
+set -Eeuo pipefail
+
+readonly workspace=/workspace
+readonly pnpm_store=/pnpm-store
+declare -a child_pids=()
+
+cd "$workspace"
+
+stop_children() {
+    if ((${#child_pids[@]} == 0)); then
+        return
+    fi
+
+    kill -TERM "${child_pids[@]}" 2>/dev/null || true
+    wait "${child_pids[@]}" 2>/dev/null || true
+}
+
+wait_for_children() {
+    local status=0
+
+    trap stop_children EXIT HUP INT TERM
+    wait -n "${child_pids[@]}" || status=$?
+    return "$status"
+}
+
+install_chatto_web_dependencies() {
+    pnpm install \
+        --frozen-lockfile \
+        --store-dir "$pnpm_store" \
+        --filter chatto-frontend...
+    pnpm --filter @chatto/api-types --filter @chatto/lingua build
+}
+
+watch_chatto_packages() {
+    watchexec \
+        --restart \
+        --poll 500ms \
+        --watch packages/api-types \
+        --watch packages/lingua \
+        --ignore 'packages/api-types/dist/**' \
+        --ignore 'packages/lingua/dist/**' \
+        --exts ts,json \
+        -- pnpm --filter @chatto/api-types --filter @chatto/lingua build
+}
+
+run_chatto_backend() {
+    cd "$workspace/cli"
+    go build -trimpath -tags "bootstrap nomsgpack" \
+        -ldflags "-X main.Version=${CHATTO_DEVELOPMENT_VERSION:-0.5.0-dev}" \
+        -o /tmp/chatto-dev .
+    cd /data
+    exec /tmp/chatto-dev run
+}
+
+run_chatto() {
+    install_chatto_web_dependencies
+    mkdir -p cli/internal/http_server/.client
+    touch cli/internal/http_server/.client/.gitkeep
+
+    watchexec \
+        --restart \
+        --poll 500ms \
+        --watch cli \
+        --watch pkg \
+        --ignore 'cli/bin/**' \
+        --ignore 'cli/internal/http_server/.client/**' \
+        -- docker/compose-dev-entrypoint.sh chatto-backend &
+    child_pids+=("$!")
+
+    watch_chatto_packages &
+    child_pids+=("$!")
+
+    pnpm --filter chatto-frontend dev &
+    child_pids+=("$!")
+
+    wait_for_children
+}
+
+run_authling_server() {
+    cd "$workspace/authling"
+    GOWORK=off go tool templ generate
+    pnpm --dir web build
+    GOWORK=off go build -trimpath -o /tmp/authling-dev ./cmd/authling
+    cd /data
+    exec /tmp/authling-dev run
+}
+
+run_authling() {
+    (
+        cd authling
+        pnpm install \
+            --frozen-lockfile \
+            --store-dir "$pnpm_store" \
+            --filter authling-web-assets...
+    )
+
+    exec watchexec \
+        --restart \
+        --poll 500ms \
+        --watch authling \
+        --watch pkg \
+        --ignore 'authling/bin/**' \
+        --ignore 'authling/internal/web/assets/**' \
+        --ignore authling/internal/web/pages_templ.go \
+        -- docker/compose-dev-entrypoint.sh authling-server
+}
+
+run_storybook() {
+    install_chatto_web_dependencies
+
+    watch_chatto_packages &
+    child_pids+=("$!")
+
+    pnpm --dir apps/frontend exec storybook dev \
+        --host 0.0.0.0 \
+        --port 8080 \
+        --no-open &
+    child_pids+=("$!")
+
+    wait_for_children
+}
+
+case "${1:-}" in
+    authling)
+        run_authling
+        ;;
+    authling-server)
+        run_authling_server
+        ;;
+    chatto)
+        run_chatto
+        ;;
+    chatto-backend)
+        run_chatto_backend
+        ;;
+    storybook)
+        run_storybook
+        ;;
+    *)
+        echo "usage: $0 {authling|chatto|storybook}" >&2
+        exit 2
+        ;;
+esac

--- a/mise.toml
+++ b/mise.toml
@@ -581,6 +581,8 @@ goreleaser check
 actionlint .github/workflows/*.yml
 
 docker/nats-wrapper_test.sh
+bash -n docker/compose-dev-entrypoint.sh
+docker compose config --quiet
 
 docker buildx build --check --build-arg TARGETARCH=amd64 -f docker/Dockerfile.dev .
 docker buildx build --check -f docker/Dockerfile.frontend.dev .

--- a/paseo.json
+++ b/paseo.json
@@ -6,6 +6,9 @@
   "scripts": {
     "compose": {
       "command": "exec docker compose up --build"
+    },
+    "compose-watch": {
+      "command": "exec docker compose up --build --watch"
     }
   },
   "metadataGeneration": {


### PR DESCRIPTION
## Why

The Compose development stack baked repository sources into service images, making normal edit/reload cycles unnecessarily rebuild-heavy.

## What changed

- Run Chatto, Authling, and Storybook from the bind-mounted checkout while keeping dependencies and Go caches in container-native volumes.
- Add polling process reloads for Go and workspace packages, plus optional Compose Watch restart/rebuild rules exposed through Compose, Conductor, and Paseo.
- Serve Chatto's generated Authling client configuration through Vite and document the updated workflow.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise verify-docker` — passed.
- `docker compose build chatto authling storybook` — passed.
- `mise x -- pnpm --filter chatto-frontend check` and targeted Prettier check — passed with no errors or warnings.
- `mise license-check` and `git diff --check` — passed.
- Full-stack runtime checks confirmed healthy Chatto/Authling services, Go source reloads, manifest-triggered Compose Watch restarts, and the generated Authling client configuration.
- Chrome DevTools loaded Chatto sign-in and Storybook with no console warnings or errors.
