### PR TITLE
fix(api): redact password verifiers from audit payloads

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -1182,7 +1182,7 @@ One durable EVT entry decoded for operator inspection.
 | `event_id` | `string` | Durable event ID. |
 | `actor_id` | `string` | Actor user ID stored on the event. |
 | `created_at` | `google.protobuf.Timestamp` | Event creation timestamp. |
-| `payload_json` | `string` | Pretty-printed JSON representation of the event payload. |
+| `payload_json` | `string` | Pretty-printed, sanitized JSON representation of the event payload. Password verifiers are omitted. |
 
 <a id="chatto-admin-v1-AdminEventLogFilter"></a>
 

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -2138,7 +2138,7 @@ One durable EVT entry decoded for operator inspection.
 | `event_id` | `string` | Durable event ID. |
 | `actor_id` | `string` | Actor user ID stored on the event. |
 | `created_at` | `google.protobuf.Timestamp` | Event creation timestamp. |
-| `payload_json` | `string` | Pretty-printed JSON representation of the event payload. |
+| `payload_json` | `string` | Pretty-printed, sanitized JSON representation of the event payload. Password verifiers are omitted. |
 
 
 

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -1362,6 +1362,37 @@ func TestAdminEventLogServiceListsFiltersAndReadsEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateUser actor: %v", err)
 	}
+
+	passwordEvents, err := env.adminEventLog.ListEvents(ctx, connect.NewRequest(&adminv1.ListEventsRequest{
+		Limit: 10,
+		Filter: &adminv1.AdminEventLogFilter{
+			EventType: "UserPasswordHashChangedEvent",
+		},
+	}))
+	if err != nil {
+		t.Fatalf("ListEvents password changes: %v", err)
+	}
+	var passwordEntry *adminv1.AdminEventLogEntry
+	for _, candidate := range passwordEvents.Msg.GetEntries() {
+		if strings.Contains(candidate.GetPayloadJson(), actor.Id) {
+			passwordEntry = candidate
+			break
+		}
+	}
+	if passwordEntry == nil {
+		t.Fatalf("password-change event for user %q not found: %+v", actor.Id, passwordEvents.Msg.GetEntries())
+	}
+	if strings.Contains(passwordEntry.GetPayloadJson(), "passwordHash") {
+		t.Fatalf("ListEvents exposed passwordHash: %s", passwordEntry.GetPayloadJson())
+	}
+	passwordDetail, err := env.adminEventLog.GetEvent(ctx, connect.NewRequest(&adminv1.GetEventRequest{Sequence: passwordEntry.GetSequence()}))
+	if err != nil {
+		t.Fatalf("GetEvent password change: %v", err)
+	}
+	if strings.Contains(passwordDetail.Msg.GetEntry().GetPayloadJson(), "passwordHash") {
+		t.Fatalf("GetEvent exposed passwordHash: %s", passwordDetail.Msg.GetEntry().GetPayloadJson())
+	}
+
 	if _, err := env.core.JoinRoom(env.ctx, actor.Id, core.KindChannel, actor.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom actor: %v", err)
 	}

--- a/cli/internal/core/event_log.go
+++ b/cli/internal/core/event_log.go
@@ -338,11 +338,7 @@ func streamMsgToEventLogEntry(msg *jetstream.RawStreamMsg) (*EventLogEntry, erro
 	aggregateType, aggregateID := parseAggregateSubject(msg.Subject)
 	eventType := eventVariantName(&event)
 
-	payloadJSON, err := protojson.MarshalOptions{
-		Multiline:       true,
-		Indent:          "  ",
-		EmitUnpopulated: false,
-	}.Marshal(&event)
+	payloadJSON, err := marshalEventLogPayloadJSON(&event)
 	if err != nil {
 		return nil, fmt.Errorf("marshal payload json: %w", err)
 	}
@@ -358,6 +354,24 @@ func streamMsgToEventLogEntry(msg *jetstream.RawStreamMsg) (*EventLogEntry, erro
 		CreatedAt:     event.GetCreatedAt(),
 		PayloadJSON:   string(payloadJSON),
 	}, nil
+}
+
+// marshalEventLogPayloadJSON redacts password verifiers from the public audit
+// API without changing the durable event used by projections and replay.
+func marshalEventLogPayloadJSON(event *corev1.Event) ([]byte, error) {
+	redacted, ok := proto.Clone(event).(*corev1.Event)
+	if !ok {
+		return nil, errors.New("clone event for audit payload")
+	}
+	if passwordChanged := redacted.GetUserPasswordHashChanged(); passwordChanged != nil {
+		passwordChanged.PasswordHash = nil
+	}
+
+	return protojson.MarshalOptions{
+		Multiline:       true,
+		Indent:          "  ",
+		EmitUnpopulated: false,
+	}.Marshal(redacted)
 }
 
 func parseAggregateSubject(subject string) (aggregateType, aggregateID string) {

--- a/cli/internal/core/event_log_test.go
+++ b/cli/internal/core/event_log_test.go
@@ -1,0 +1,40 @@
+package core
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+)
+
+func TestMarshalEventLogPayloadJSONRedactsPasswordHash(t *testing.T) {
+	hash := []byte("$2a$10$password-verifier")
+	event := &corev1.Event{
+		Id:      "event-password-changed",
+		ActorId: "audited-actor",
+		Event: &corev1.Event_UserPasswordHashChanged{
+			UserPasswordHashChanged: &corev1.UserPasswordHashChangedEvent{
+				UserId:                      "target-user",
+				PasswordHash:                append([]byte(nil), hash...),
+				PreserveExistingCredentials: true,
+			},
+		},
+	}
+
+	payload, err := marshalEventLogPayloadJSON(event)
+	if err != nil {
+		t.Fatalf("marshalEventLogPayloadJSON: %v", err)
+	}
+	if strings.Contains(string(payload), "passwordHash") {
+		t.Fatalf("audit payload contains passwordHash: %s", payload)
+	}
+	for _, want := range []string{"userPasswordHashChanged", "target-user", "preserveExistingCredentials"} {
+		if !strings.Contains(string(payload), want) {
+			t.Fatalf("audit payload = %s, want retained field %q", payload, want)
+		}
+	}
+	if !bytes.Equal(event.GetUserPasswordHashChanged().GetPasswordHash(), hash) {
+		t.Fatalf("durable event password hash was mutated: %q", event.GetUserPasswordHashChanged().GetPasswordHash())
+	}
+}

--- a/cli/internal/pb/chatto/admin/v1/event_log.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/event_log.pb.go
@@ -454,7 +454,8 @@ type AdminEventLogEntry struct {
 	ActorId string `protobuf:"bytes,7,opt,name=actor_id,json=actorId,proto3" json:"actor_id,omitempty"`
 	// Event creation timestamp.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,8,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
-	// Pretty-printed JSON representation of the event payload.
+	// Pretty-printed, sanitized JSON representation of the event payload.
+	// Password verifiers are omitted.
 	PayloadJson   string `protobuf:"bytes,9,opt,name=payload_json,json=payloadJson,proto3" json:"payload_json,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/docs/fdr/FDR-021-admin-dashboard.md
+++ b/docs/fdr/FDR-021-admin-dashboard.md
@@ -1,7 +1,7 @@
 # FDR-021: Admin Dashboard & System Monitoring
 
 **Status:** Active
-**Last reviewed:** 2026-08-11
+**Last reviewed:** 2026-08-13
 
 ## Overview
 
@@ -15,7 +15,7 @@ The server-management section gives owners and admins visibility into the server
 - Delegated managers enter a specific room or room group through its contextual settings action. Resource pages use effective scoped permissions and do not imply access to unrelated server-management pages.
 - **Users page** — paginated list of all server members with login, email, roles, verification status. Admins can edit profiles, assign roles, suspend, or delete users when they hold the relevant permission.
 - **System Info page** — owner-only page showing backing message-broker connection status, storage account limits and current usage, stream/consumer health, known durable-worker queue health, projection health (lag, entry counts, and rough memory estimates), and `AdminDiagnosticsService.GetSystemInfo` stats (user count, channel room count, DM room count).
-- **Audit log page** — chronological diagnostic event-log view for forensic review, grouped by event creation date. The list view uses `AdminEventLogService.ListEvents`; the detail view uses `AdminEventLogService.GetEvent` to show the raw payload JSON for human inspection.
+- **Audit log page** — chronological diagnostic event-log view for forensic review, grouped by event creation date. The list view uses `AdminEventLogService.ListEvents`; the detail view uses `AdminEventLogService.GetEvent` to show sanitized payload JSON for human inspection. Password verifiers are omitted.
 - The audit log UI can be filtered by exact event type and exact actor ID. Event type suggestions come from the admin event-log API; the actor field reuses the server member lookup but still accepts synthetic actor IDs such as `system:bootstrap`. The API also supports inclusive created-at bounds for callers, but the server-management page does not expose time-range controls.
 - The audit/event-log API returns `totalCount` as a 64-bit value because it reflects retained stream message counts, which can exceed 32-bit integer range on long-running servers.
 - Filtered audit-log browsing is a bounded diagnostic scan over retained EVT rows, not an indexed analytics query. The connection reports `scannedCount`, `scanLimit`, and `scanLimited` so the UI can tell operators when older matches may exist beyond the inspected window.
@@ -48,7 +48,7 @@ The server-management section gives owners and admins visibility into the server
 
 ### 5. Diagnostic values are operator tooling, not product contracts
 
-**Decision:** Raw storage subjects, stream/consumer names, payload JSON, projection metric names, and memory estimates are documented as diagnostic values. The admin diagnostics APIs are intentional operator APIs, but clients should not parse those raw values as stable product-domain data.
+**Decision:** Raw storage subjects, stream/consumer names, sanitized payload JSON, projection metric names, and memory estimates are documented as diagnostic values. The admin diagnostics APIs are intentional operator APIs, but clients should not parse those values as stable product-domain data. Payload JSON omits password verifiers.
 **Why:** Operators need visibility into what the runtime is doing, especially during the 0.1 stabilization lane. At the same time, these values reflect storage and projection implementation details that may evolve as the event-sourcing model settles.
 **Tradeoff:** Third-party admin clients can display diagnostics but should treat raw strings and JSON as best-effort inspection data. If a future integration needs a stable audit export format, it should get a dedicated schema instead of depending on diagnostic payloads.
 

--- a/packages/api-types/src/chatto/admin/v1/event_log_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/event_log_pb.ts
@@ -436,7 +436,8 @@ export class AdminEventLogEntry extends Message<AdminEventLogEntry> {
   createdAt?: Timestamp;
 
   /**
-   * Pretty-printed JSON representation of the event payload.
+   * Pretty-printed, sanitized JSON representation of the event payload.
+   * Password verifiers are omitted.
    *
    * @generated from field: string payload_json = 9;
    */

--- a/proto/chatto/admin/v1/event_log.proto
+++ b/proto/chatto/admin/v1/event_log.proto
@@ -84,7 +84,8 @@ message AdminEventLogEntry {
   string actor_id = 7;
   // Event creation timestamp.
   google.protobuf.Timestamp created_at = 8;
-  // Pretty-printed JSON representation of the event payload.
+  // Pretty-printed, sanitized JSON representation of the event payload.
+  // Password verifiers are omitted.
   string payload_json = 9;
 }
 


### PR DESCRIPTION
## Why

An account holding only `admin.view-audit` could retrieve bcrypt password verifiers because the audit API serialized complete internal EVT payloads.

## What changed

- Clone password-change events and omit the verifier before audit JSON serialization, without changing durable EVT records
- Cover both list and detail RPCs with regression tests and document the sanitized response in the public contract and FDR

## API compatibility

- Behavioural change; the protobuf shape is unchanged, but `passwordHash` is no longer present in audit payload JSON
- Older client → newer server: existing calls continue to work and receive sanitized payloads
- Newer client → older server: existing calls work, but old server replicas may still expose the field
- Capability discovery or minimum client/server version: none; complete a rolling upgrade to remove vulnerable replicas

## Test plan

- `mise test-cli`
- `mise lint`
- `mise codegen-proto`
- Public API Buf compatibility check
- `mise license-check`
