### PR TITLE
feat(auth): allow operators to disable password login

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,6 +342,8 @@ leave a dev stack running in a detached or yielded terminal session.
 
 - Pick the lowest test layer that exercises the change, but do not stop below
   the layer where the bug could occur.
+- When testing an early rejection, use input that would fail a later check. The
+  test should still return the early error.
 - Svelte runtime errors, hydration issues, missing context, and `$effect` loops
   require mounting a component or browser verification.
 - Native macOS Desktop helper behavior should have focused Swift tests wired

--- a/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
@@ -47,7 +47,7 @@ For production use, please review the file and **at least**:
 It is also strongly recommended that you:
 
 - review the `[core.assets.s3]` section if you want to use an external object store for uploaded files (optional, but recommended; you can enable this later if you wish)
-- choose whether to allow direct registration, and configure at least one tested SSO provider before setting `auth.password_login = false`
+- choose whether to allow direct registration, and configure at least one tested SSO provider before setting `auth.direct_login = false`
 - review the `[push]` section if you want to support native push notifications
 - review the `[video]` section if you want to support video uploads
 - review the `[livekit]` section if you want to support voice and video calls (requires LiveKit)

--- a/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
@@ -47,7 +47,7 @@ For production use, please review the file and **at least**:
 It is also strongly recommended that you:
 
 - review the `[core.assets.s3]` section if you want to use an external object store for uploaded files (optional, but recommended; you can enable this later if you wish)
-- make a decision to either enable `auth.direct_registration` or configure at least one SSO provider (you can use both together!)
+- choose whether to allow direct registration, and configure at least one tested SSO provider before setting `auth.password_login = false`
 - review the `[push]` section if you want to support native push notifications
 - review the `[video]` section if you want to support video uploads
 - review the `[livekit]` section if you want to support voice and video calls (requires LiveKit)

--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -226,7 +226,7 @@ for private STUN and fixed-IP alternatives.
 
 The setup above enables direct email/password registration, which requires SMTP because Chatto sends registration codes by email. SMTP is also used for email verification and password reset.
 
-If you do not want public email/password registration after the first owner exists, set `CHATTO_AUTH_DIRECT_REGISTRATION=false`. Existing users can still sign in with passwords or configured SSO providers. For an SSO-only deployment, configure and test a provider first, then also set `CHATTO_AUTH_PASSWORD_LOGIN=false` on every replica.
+If you do not want public email/password registration after the first owner exists, set `CHATTO_AUTH_DIRECT_REGISTRATION=false`. Existing users can still sign in with passwords or configured SSO providers. For an SSO-only deployment, configure and test a provider first, then also set `CHATTO_AUTH_DIRECT_LOGIN=false` on every replica.
 
 ### Push Notifications
 

--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -226,7 +226,7 @@ for private STUN and fixed-IP alternatives.
 
 The setup above enables direct email/password registration, which requires SMTP because Chatto sends registration codes by email. SMTP is also used for email verification and password reset.
 
-If you do not want public email/password registration after the first owner exists, set `CHATTO_AUTH_DIRECT_REGISTRATION=false`. Users can still sign in through configured SSO providers.
+If you do not want public email/password registration after the first owner exists, set `CHATTO_AUTH_DIRECT_REGISTRATION=false`. Existing users can still sign in with passwords or configured SSO providers. For an SSO-only deployment, configure and test a provider first, then also set `CHATTO_AUTH_PASSWORD_LOGIN=false` on every replica.
 
 ### Push Notifications
 

--- a/apps/docs-website/src/content/docs/guides/operations/identity-login.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/identity-login.mdx
@@ -26,7 +26,7 @@ Configure and test at least one external provider before disabling password logi
 
 ```toml
 [auth]
-password_login = false
+direct_login = false
 direct_registration = false
 ```
 
@@ -34,14 +34,14 @@ direct_registration = false
 <TabItem label="Environment">
 
 ```bash
-CHATTO_AUTH_PASSWORD_LOGIN=false
+CHATTO_AUTH_DIRECT_LOGIN=false
 CHATTO_AUTH_DIRECT_REGISTRATION=false
 ```
 
 </TabItem>
 </Tabs>
 
-With `password_login = false`, Chatto rejects `/auth/login` and advertises the disabled capability through public server discovery. The bundled login page then shows only configured external providers. Existing sessions stay valid, and registration remains independently controlled by `direct_registration`.
+With `direct_login = false`, Chatto rejects `/auth/login` and advertises the disabled capability through public server discovery. The bundled login page then shows only configured external providers. Existing sessions stay valid, and registration remains independently controlled by `direct_registration`.
 
 <Aside type="caution">
   Disabling password login without a working external provider can lock signed-out users out. Keep an operator recovery path and apply the same authentication configuration to every replica.

--- a/apps/docs-website/src/content/docs/guides/operations/identity-login.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/identity-login.mdx
@@ -17,6 +17,36 @@ Chatto supports local password accounts, email verification and reset flows, ext
 | Mixed community | Allow local accounts and selected external providers. |
 | Passwordless external login | Ensure users keep at least one linked provider and understand recovery paths. |
 
+## SSO-Only Login
+
+Configure and test at least one external provider before disabling password login. To make the server SSO-only, disable both password sign-in and direct email/password registration on every serving replica:
+
+<Tabs>
+<TabItem label="TOML">
+
+```toml
+[auth]
+password_login = false
+direct_registration = false
+```
+
+</TabItem>
+<TabItem label="Environment">
+
+```bash
+CHATTO_AUTH_PASSWORD_LOGIN=false
+CHATTO_AUTH_DIRECT_REGISTRATION=false
+```
+
+</TabItem>
+</Tabs>
+
+With `password_login = false`, Chatto rejects `/auth/login` and advertises the disabled capability through public server discovery. The bundled login page then shows only configured external providers. Existing sessions stay valid, and registration remains independently controlled by `direct_registration`.
+
+<Aside type="caution">
+  Disabling password login without a working external provider can lock signed-out users out. Keep an operator recovery path and apply the same authentication configuration to every replica.
+</Aside>
+
 ## SMTP Email
 
 SMTP is needed for verification and password reset email flows. Configure it before inviting members if you expect self-service account recovery.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -896,6 +896,7 @@ Login and registration options exposed before authentication.
 | `providers` | repeated [`ProviderMetadata`](#chatto-api-v1-ProviderMetadata) | Configured login providers. |
 | `authorize_url` | `string` | URL for the legacy authorization flow, when enabled. |
 | `account_creation_policy` | [`AccountCreationPolicy`](#chatto-api-v1-AccountCreationPolicy) | Admission policy for direct registration and provider auto-provisioning. |
+| `password_login_enabled` | `optional bool` | Whether users can sign in directly with a username or email address and password. Absent on older servers, where clients should treat password login as enabled. |
 
 <a id="chatto-api-v1-ServerPublicProfile"></a>
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -896,7 +896,7 @@ Login and registration options exposed before authentication.
 | `providers` | repeated [`ProviderMetadata`](#chatto-api-v1-ProviderMetadata) | Configured login providers. |
 | `authorize_url` | `string` | URL for the legacy authorization flow, when enabled. |
 | `account_creation_policy` | [`AccountCreationPolicy`](#chatto-api-v1-AccountCreationPolicy) | Admission policy for direct registration and provider auto-provisioning. |
-| `password_login_enabled` | `optional bool` | Whether users can sign in directly with a username or email address and password. Absent on older servers, where clients should treat password login as enabled. |
+| `direct_login_enabled` | `optional bool` | Whether users can sign in directly with a username or email address and password. Absent on older servers, where clients should treat direct login as enabled. |
 
 <a id="chatto-api-v1-ServerPublicProfile"></a>
 

--- a/apps/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/apps/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -330,7 +330,11 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
 </EnvVar>
 
 <EnvVar name="CHATTO_AUTH_DIRECT_REGISTRATION" toml="auth.direct_registration" default="true">
-  Enable direct (email/password) registration. When `false`, the registration page is hidden and the registration API returns `403`. Users can still sign in via configured SSO providers.
+  Enable direct (email/password) registration. When `false`, the registration page is hidden and the registration API returns `403`. Existing users can still sign in through enabled password login or configured SSO providers.
+</EnvVar>
+
+<EnvVar name="CHATTO_AUTH_PASSWORD_LOGIN" toml="auth.password_login" default="true">
+  Enable direct sign-in with a username or email address and password. When `false`, the password form and recovery link are hidden and the password login endpoint returns `403`. Existing sessions, registration, and authenticated password management are unaffected.
 </EnvVar>
 
 <EnvVar name="CHATTO_AUTH_TOKEN_TTL" toml="auth.token_ttl" default="90d">

--- a/apps/docs-website/src/content/docs/reference/environment-variables.mdx
+++ b/apps/docs-website/src/content/docs/reference/environment-variables.mdx
@@ -333,7 +333,7 @@ Only used when `storage_backend` is set to `s3`. See the [S3 Storage guide](/gui
   Enable direct (email/password) registration. When `false`, the registration page is hidden and the registration API returns `403`. Existing users can still sign in through enabled password login or configured SSO providers.
 </EnvVar>
 
-<EnvVar name="CHATTO_AUTH_PASSWORD_LOGIN" toml="auth.password_login" default="true">
+<EnvVar name="CHATTO_AUTH_DIRECT_LOGIN" toml="auth.direct_login" default="true">
   Enable direct sign-in with a username or email address and password. When `false`, the password form and recovery link are hidden and the password login endpoint returns `403`. Existing sessions, registration, and authenticated password management are unaffected.
 </EnvVar>
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -4541,7 +4541,7 @@ Login and registration options exposed before authentication.
 | `providers` | repeated [`ProviderMetadata`](#chatto-api-v1-ProviderMetadata) | Configured login providers. |
 | `authorize_url` | `string` | URL for the legacy authorization flow, when enabled. |
 | `account_creation_policy` | [`AccountCreationPolicy`](#chatto-api-v1-AccountCreationPolicy) | Admission policy for direct registration and provider auto-provisioning. |
-| `password_login_enabled` | `optional bool` | Whether users can sign in directly with a username or email address and password. Absent on older servers, where clients should treat password login as enabled. |
+| `direct_login_enabled` | `optional bool` | Whether users can sign in directly with a username or email address and password. Absent on older servers, where clients should treat direct login as enabled. |
 
 
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -4541,6 +4541,7 @@ Login and registration options exposed before authentication.
 | `providers` | repeated [`ProviderMetadata`](#chatto-api-v1-ProviderMetadata) | Configured login providers. |
 | `authorize_url` | `string` | URL for the legacy authorization flow, when enabled. |
 | `account_creation_policy` | [`AccountCreationPolicy`](#chatto-api-v1-AccountCreationPolicy) | Admission policy for direct registration and provider auto-provisioning. |
+| `password_login_enabled` | `optional bool` | Whether users can sign in directly with a username or email address and password. Absent on older servers, where clients should treat password login as enabled. |
 
 
 

--- a/apps/frontend/src/lib/api-client-tests/server.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/server.spec.ts
@@ -40,7 +40,7 @@ describe('getPublicServerInfo', () => {
       },
       login: {
         directRegistrationEnabled: true,
-        passwordLoginEnabled: false,
+        directLoginEnabled: false,
         authorizeUrl: '/oauth/authorize',
         providers: [
           {
@@ -67,7 +67,7 @@ describe('getPublicServerInfo', () => {
       version: '9.8.7',
       authorizeUrl: '/oauth/authorize',
       directRegistrationEnabled: true,
-      passwordLoginEnabled: false,
+      directLoginEnabled: false,
       accountCreationPolicy: 'open',
       welcomeMessage: 'welcome',
       description: 'description',
@@ -97,7 +97,7 @@ describe('getPublicServerInfo', () => {
 
     await expect(getPublicServerInfo('https://chat.example.test')).resolves.toMatchObject({
       name: 'Chatto',
-      passwordLoginEnabled: true,
+      directLoginEnabled: true,
       welcomeMessage: null,
       description: null,
       iconUrl: null,

--- a/apps/frontend/src/lib/api-client-tests/server.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/server.spec.ts
@@ -40,6 +40,7 @@ describe('getPublicServerInfo', () => {
       },
       login: {
         directRegistrationEnabled: true,
+        passwordLoginEnabled: false,
         authorizeUrl: '/oauth/authorize',
         providers: [
           {
@@ -66,6 +67,7 @@ describe('getPublicServerInfo', () => {
       version: '9.8.7',
       authorizeUrl: '/oauth/authorize',
       directRegistrationEnabled: true,
+      passwordLoginEnabled: false,
       accountCreationPolicy: 'open',
       welcomeMessage: 'welcome',
       description: 'description',
@@ -95,6 +97,7 @@ describe('getPublicServerInfo', () => {
 
     await expect(getPublicServerInfo('https://chat.example.test')).resolves.toMatchObject({
       name: 'Chatto',
+      passwordLoginEnabled: true,
       welcomeMessage: null,
       description: null,
       iconUrl: null,

--- a/apps/frontend/src/lib/api-client/server.ts
+++ b/apps/frontend/src/lib/api-client/server.ts
@@ -17,6 +17,7 @@ export type PublicServerInfo = {
   version: string;
   authorizeUrl: string;
   directRegistrationEnabled: boolean;
+  passwordLoginEnabled: boolean;
   accountCreationPolicy: 'open' | 'invite_only';
   welcomeMessage: string | null;
   description: string | null;
@@ -41,6 +42,7 @@ export async function getPublicServerInfo(
     version: profile.version,
     authorizeUrl: response.login?.authorizeUrl ?? '',
     directRegistrationEnabled: response.login?.directRegistrationEnabled ?? false,
+    passwordLoginEnabled: response.login?.passwordLoginEnabled ?? true,
     accountCreationPolicy:
       response.login?.accountCreationPolicy === AccountCreationPolicy.INVITE_ONLY
         ? 'invite_only'

--- a/apps/frontend/src/lib/api-client/server.ts
+++ b/apps/frontend/src/lib/api-client/server.ts
@@ -17,7 +17,7 @@ export type PublicServerInfo = {
   version: string;
   authorizeUrl: string;
   directRegistrationEnabled: boolean;
-  passwordLoginEnabled: boolean;
+  directLoginEnabled: boolean;
   accountCreationPolicy: 'open' | 'invite_only';
   welcomeMessage: string | null;
   description: string | null;
@@ -42,7 +42,7 @@ export async function getPublicServerInfo(
     version: profile.version,
     authorizeUrl: response.login?.authorizeUrl ?? '',
     directRegistrationEnabled: response.login?.directRegistrationEnabled ?? false,
-    passwordLoginEnabled: response.login?.passwordLoginEnabled ?? true,
+    directLoginEnabled: response.login?.directLoginEnabled ?? true,
     accountCreationPolicy:
       response.login?.accountCreationPolicy === AccountCreationPolicy.INVITE_ONLY
         ? 'invite_only'

--- a/apps/frontend/src/lib/state/server/state.spec.ts
+++ b/apps/frontend/src/lib/state/server/state.spec.ts
@@ -8,6 +8,7 @@ function publicServerInfo(overrides: Partial<PublicServerInfo> = {}): PublicServ
     version: '0.5.0',
     authorizeUrl: '/oauth/authorize',
     directRegistrationEnabled: false,
+    passwordLoginEnabled: false,
     accountCreationPolicy: 'open',
     welcomeMessage: 'welcome',
     description: 'a server for acme',
@@ -46,6 +47,7 @@ describe('ServerInfoState.init()', () => {
     expect(state.welcomeMessage).toBe('welcome');
     expect(state.description).toBe('a server for acme');
     expect(state.directRegistrationEnabled).toBe(false);
+    expect(state.passwordLoginEnabled).toBe(false);
     expect(state.videoProcessingEnabled).toBe(false);
     expect(state.messageEditWindowSeconds).toBe(3 * 60 * 60);
     expect(consoleError).not.toHaveBeenCalled();

--- a/apps/frontend/src/lib/state/server/state.spec.ts
+++ b/apps/frontend/src/lib/state/server/state.spec.ts
@@ -8,7 +8,7 @@ function publicServerInfo(overrides: Partial<PublicServerInfo> = {}): PublicServ
     version: '0.5.0',
     authorizeUrl: '/oauth/authorize',
     directRegistrationEnabled: false,
-    passwordLoginEnabled: false,
+    directLoginEnabled: false,
     accountCreationPolicy: 'open',
     welcomeMessage: 'welcome',
     description: 'a server for acme',
@@ -47,7 +47,7 @@ describe('ServerInfoState.init()', () => {
     expect(state.welcomeMessage).toBe('welcome');
     expect(state.description).toBe('a server for acme');
     expect(state.directRegistrationEnabled).toBe(false);
-    expect(state.passwordLoginEnabled).toBe(false);
+    expect(state.directLoginEnabled).toBe(false);
     expect(state.videoProcessingEnabled).toBe(false);
     expect(state.messageEditWindowSeconds).toBe(3 * 60 * 60);
     expect(consoleError).not.toHaveBeenCalled();

--- a/apps/frontend/src/lib/state/server/state.svelte.ts
+++ b/apps/frontend/src/lib/state/server/state.svelte.ts
@@ -26,6 +26,7 @@ export class ServerInfoState {
   bannerUrl = $state<string | null>(null);
   iconUrl = $state<string | null>(null);
   directRegistrationEnabled = $state(true);
+  passwordLoginEnabled = $state(true);
   pushNotificationsEnabled = $state(false);
   vapidPublicKey = $state<string | null>(null);
   livekitUrl = $state<string | null>(null);
@@ -114,6 +115,7 @@ export class ServerInfoState {
       this.iconUrl = info.iconUrl;
       this.bannerUrl = info.bannerUrl;
       this.directRegistrationEnabled = info.directRegistrationEnabled;
+      this.passwordLoginEnabled = info.passwordLoginEnabled;
     } catch (err) {
       this.error = err instanceof Error ? err.message : String(err);
       console.error(`[server:${this.#label}] failed to load server info`, err);

--- a/apps/frontend/src/lib/state/server/state.svelte.ts
+++ b/apps/frontend/src/lib/state/server/state.svelte.ts
@@ -26,7 +26,7 @@ export class ServerInfoState {
   bannerUrl = $state<string | null>(null);
   iconUrl = $state<string | null>(null);
   directRegistrationEnabled = $state(true);
-  passwordLoginEnabled = $state(true);
+  directLoginEnabled = $state(true);
   pushNotificationsEnabled = $state(false);
   vapidPublicKey = $state<string | null>(null);
   livekitUrl = $state<string | null>(null);
@@ -115,7 +115,7 @@ export class ServerInfoState {
       this.iconUrl = info.iconUrl;
       this.bannerUrl = info.bannerUrl;
       this.directRegistrationEnabled = info.directRegistrationEnabled;
-      this.passwordLoginEnabled = info.passwordLoginEnabled;
+      this.directLoginEnabled = info.directLoginEnabled;
     } catch (err) {
       this.error = err instanceof Error ? err.message : String(err);
       console.error(`[server:${this.#label}] failed to load server info`, err);

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -1208,6 +1208,7 @@ describe('ServerStateStore live server updates', () => {
       iconUrl: 'https://cdn/icon.webp',
       bannerUrl: 'https://cdn/banner.webp',
       directRegistrationEnabled: false,
+      passwordLoginEnabled: false,
       accountCreationPolicy: 'open',
       authProviders: []
     });

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -1208,7 +1208,7 @@ describe('ServerStateStore live server updates', () => {
       iconUrl: 'https://cdn/icon.webp',
       bannerUrl: 'https://cdn/banner.webp',
       directRegistrationEnabled: false,
-      passwordLoginEnabled: false,
+      directLoginEnabled: false,
       accountCreationPolicy: 'open',
       authProviders: []
     });

--- a/apps/frontend/src/routes/layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/layout.svelte.spec.ts
@@ -136,6 +136,7 @@ function renderLayout() {
     version: 'test',
     authorizeUrl: '/oauth/authorize',
     directRegistrationEnabled: true,
+    passwordLoginEnabled: true,
     accountCreationPolicy: 'open',
     welcomeMessage: null,
     description: null,

--- a/apps/frontend/src/routes/layout.svelte.spec.ts
+++ b/apps/frontend/src/routes/layout.svelte.spec.ts
@@ -136,7 +136,7 @@ function renderLayout() {
     version: 'test',
     authorizeUrl: '/oauth/authorize',
     directRegistrationEnabled: true,
-    passwordLoginEnabled: true,
+    directLoginEnabled: true,
     accountCreationPolicy: 'open',
     welcomeMessage: null,
     description: null,

--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -345,6 +345,10 @@
       </div>
     {/if}
 
+    {#if !passwordLoginEnabled && displayedError}
+      <Hint tone="danger">{displayedError}</Hint>
+    {/if}
+
     {#if passwordLoginEnabled}
       <Form onsubmit={handleSubmit}>
         <TextInput

--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -46,6 +46,7 @@
     authProviders.filter((provider) => provider.id !== authlingProviderId)
   );
   const directRegistrationEnabled = $derived(data.serverInfo?.directRegistrationEnabled ?? true);
+  const passwordLoginEnabled = $derived(data.serverInfo?.passwordLoginEnabled ?? true);
   const isAuthenticating = $derived(isLoading || selectedProviderId !== null);
   const pageError = $derived(
     pageErrorDismissed ? '' : loginErrorMessage(data.loginErrorCode || '')
@@ -315,7 +316,7 @@
 
     {@render authlingSignIn()}
 
-    {#if authlingAvailable}
+    {#if authlingAvailable && (visibleAuthProviders.length > 0 || passwordLoginEnabled)}
       <Divider label={m('common.or')} />
     {/if}
 
@@ -338,52 +339,56 @@
           </Button>
         {/each}
 
-        <Divider label={m('common.or')} />
+        {#if passwordLoginEnabled}
+          <Divider label={m('common.or')} />
+        {/if}
       </div>
     {/if}
 
-    <Form onsubmit={handleSubmit}>
-      <TextInput
-        id="identifier"
-        label={m('auth.login.identifier_label')}
-        bind:value={identifier}
-        placeholder={m('common.email_placeholder')}
-        disabled={isAuthenticating}
-        required
-        autocomplete="username"
-        autofocus
-      />
+    {#if passwordLoginEnabled}
+      <Form onsubmit={handleSubmit}>
+        <TextInput
+          id="identifier"
+          label={m('auth.login.identifier_label')}
+          bind:value={identifier}
+          placeholder={m('common.email_placeholder')}
+          disabled={isAuthenticating}
+          required
+          autocomplete="username"
+          autofocus
+        />
 
-      <TextInput
-        id="password"
-        label={m('common.password')}
-        type="password"
-        bind:value={password}
-        placeholder={m('common.password_placeholder')}
-        disabled={isAuthenticating}
-        required
-        autocomplete="current-password"
-      />
+        <TextInput
+          id="password"
+          label={m('common.password')}
+          type="password"
+          bind:value={password}
+          placeholder={m('common.password_placeholder')}
+          disabled={isAuthenticating}
+          required
+          autocomplete="current-password"
+        />
 
-      {#if displayedError}
-        <Hint tone="danger">{displayedError}</Hint>
-      {/if}
+        {#if displayedError}
+          <Hint tone="danger">{displayedError}</Hint>
+        {/if}
 
-      <Button
-        type="submit"
-        size="lg"
-        disabled={!canSubmit || isAuthenticating}
-        loading={isLoading}
-        loadingText={m('auth.login.signing_in')}
-      >
-        <span class="iconify icon-[mdi--login]"></span>
-        {m('common.sign_in')}
-      </Button>
-    </Form>
+        <Button
+          type="submit"
+          size="lg"
+          disabled={!canSubmit || isAuthenticating}
+          loading={isLoading}
+          loadingText={m('auth.login.signing_in')}
+        >
+          <span class="iconify icon-[mdi--login]"></span>
+          {m('common.sign_in')}
+        </Button>
+      </Form>
 
-    <div class="mt-4 text-center">
-      <a href={resolve('/forgot-password')} class="link">{m('auth.login.forgot_password')}</a>
-    </div>
+      <div class="mt-4 text-center">
+        <a href={resolve('/forgot-password')} class="link">{m('auth.login.forgot_password')}</a>
+      </div>
+    {/if}
 
     {#if directRegistrationEnabled}
       <Divider label={m('common.or')} />

--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -46,7 +46,7 @@
     authProviders.filter((provider) => provider.id !== authlingProviderId)
   );
   const directRegistrationEnabled = $derived(data.serverInfo?.directRegistrationEnabled ?? true);
-  const passwordLoginEnabled = $derived(data.serverInfo?.passwordLoginEnabled ?? true);
+  const directLoginEnabled = $derived(data.serverInfo?.directLoginEnabled ?? true);
   const isAuthenticating = $derived(isLoading || selectedProviderId !== null);
   const pageError = $derived(
     pageErrorDismissed ? '' : loginErrorMessage(data.loginErrorCode || '')
@@ -316,7 +316,7 @@
 
     {@render authlingSignIn()}
 
-    {#if authlingAvailable && (visibleAuthProviders.length > 0 || passwordLoginEnabled)}
+    {#if authlingAvailable && (visibleAuthProviders.length > 0 || directLoginEnabled)}
       <Divider label={m('common.or')} />
     {/if}
 
@@ -339,17 +339,17 @@
           </Button>
         {/each}
 
-        {#if passwordLoginEnabled}
+        {#if directLoginEnabled}
           <Divider label={m('common.or')} />
         {/if}
       </div>
     {/if}
 
-    {#if !passwordLoginEnabled && displayedError}
+    {#if !directLoginEnabled && displayedError}
       <Hint tone="danger">{displayedError}</Hint>
     {/if}
 
-    {#if passwordLoginEnabled}
+    {#if directLoginEnabled}
       <Form onsubmit={handleSubmit}>
         <TextInput
           id="identifier"

--- a/apps/frontend/src/routes/login/login.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/login/login.page.svelte.spec.ts
@@ -98,42 +98,46 @@ describe('frontend Authling sign-in', () => {
     );
   });
 
-	it('shows configured providers without password controls when password login is disabled', async () => {
-		mocks.getClientConfiguration.mockResolvedValue({ version: 1, authling: null });
-		const { getByRole, getByLabelText } = render(LoginPage, {
-			props: {
-				data: {
-					...standaloneData,
-					serverInfo: {
-						name: 'SSO Community',
-						version: '0.5.0',
-						authorizeUrl: '/oauth/authorize',
-						directRegistrationEnabled: false,
-						passwordLoginEnabled: false,
-						accountCreationPolicy: 'open',
-						welcomeMessage: null,
-						description: null,
-						iconUrl: null,
-						bannerUrl: null,
-						authProviders: [
-							{
-								id: 'company',
-								type: 'oidc',
-								label: 'Company SSO',
-								loginUrl: '/auth/providers/company',
-								issuerUrl: 'https://id.example',
-								autoProvision: false
-							}
-						]
-					},
-					serverInfoLoaded: true
-				}
-			}
-		});
+  it('shows provider errors without password controls when password login is disabled', async () => {
+    mocks.getClientConfiguration.mockResolvedValue({ version: 1, authling: null });
+    const { getByRole, getByLabelText, getByText } = render(LoginPage, {
+      props: {
+        data: {
+          ...standaloneData,
+          loginErrorCode: 'provider_failed',
+          serverInfo: {
+            name: 'SSO Community',
+            version: '0.5.0',
+            authorizeUrl: '/oauth/authorize',
+            directRegistrationEnabled: false,
+            passwordLoginEnabled: false,
+            accountCreationPolicy: 'open',
+            welcomeMessage: null,
+            description: null,
+            iconUrl: null,
+            bannerUrl: null,
+            authProviders: [
+              {
+                id: 'company',
+                type: 'oidc',
+                label: 'Company SSO',
+                loginUrl: '/auth/providers/company',
+                issuerUrl: 'https://id.example',
+                autoProvision: false
+              }
+            ]
+          },
+          serverInfoLoaded: true
+        }
+      }
+    });
 
-		await expect.element(getByRole('link', { name: 'Continue with Company SSO' })).toBeVisible();
-		await expect.element(getByLabelText('Username or Email')).not.toBeInTheDocument();
-		await expect.element(getByLabelText('Password')).not.toBeInTheDocument();
-		await expect.element(getByRole('link', { name: 'Forgot password?' })).not.toBeInTheDocument();
-	});
+    await expect.element(getByRole('link', { name: 'Continue with Company SSO' })).toBeVisible();
+    await expect
+      .element(getByText('The sign-in provider could not complete authentication. Please try again.'))
+      .toBeVisible();
+    await expect.element(getByLabelText('Username or Email')).not.toBeInTheDocument();
+    await expect.element(getByLabelText('Password')).not.toBeInTheDocument();
+    await expect.element(getByRole('link', { name: 'Forgot password?' })).not.toBeInTheDocument();
+  });
 });

--- a/apps/frontend/src/routes/login/login.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/login/login.page.svelte.spec.ts
@@ -97,4 +97,43 @@ describe('frontend Authling sign-in', () => {
       expect.objectContaining({ id: 'remote' })
     );
   });
+
+	it('shows configured providers without password controls when password login is disabled', async () => {
+		mocks.getClientConfiguration.mockResolvedValue({ version: 1, authling: null });
+		const { getByRole, getByLabelText } = render(LoginPage, {
+			props: {
+				data: {
+					...standaloneData,
+					serverInfo: {
+						name: 'SSO Community',
+						version: '0.5.0',
+						authorizeUrl: '/oauth/authorize',
+						directRegistrationEnabled: false,
+						passwordLoginEnabled: false,
+						accountCreationPolicy: 'open',
+						welcomeMessage: null,
+						description: null,
+						iconUrl: null,
+						bannerUrl: null,
+						authProviders: [
+							{
+								id: 'company',
+								type: 'oidc',
+								label: 'Company SSO',
+								loginUrl: '/auth/providers/company',
+								issuerUrl: 'https://id.example',
+								autoProvision: false
+							}
+						]
+					},
+					serverInfoLoaded: true
+				}
+			}
+		});
+
+		await expect.element(getByRole('link', { name: 'Continue with Company SSO' })).toBeVisible();
+		await expect.element(getByLabelText('Username or Email')).not.toBeInTheDocument();
+		await expect.element(getByLabelText('Password')).not.toBeInTheDocument();
+		await expect.element(getByRole('link', { name: 'Forgot password?' })).not.toBeInTheDocument();
+	});
 });

--- a/apps/frontend/src/routes/login/login.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/login/login.page.svelte.spec.ts
@@ -110,7 +110,7 @@ describe('frontend Authling sign-in', () => {
             version: '0.5.0',
             authorizeUrl: '/oauth/authorize',
             directRegistrationEnabled: false,
-            passwordLoginEnabled: false,
+            directLoginEnabled: false,
             accountCreationPolicy: 'open',
             welcomeMessage: null,
             description: null,

--- a/apps/frontend/src/routes/register/register.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/register/register.page.svelte.spec.ts
@@ -16,6 +16,7 @@ function serverInfo(overrides: Partial<PublicServerInfo> = {}): PublicServerInfo
     version: '0.5.0',
     authorizeUrl: '/oauth/authorize',
     directRegistrationEnabled: true,
+    passwordLoginEnabled: true,
     accountCreationPolicy: 'invite_only',
     welcomeMessage: null,
     description: null,

--- a/apps/frontend/src/routes/register/register.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/register/register.page.svelte.spec.ts
@@ -16,7 +16,7 @@ function serverInfo(overrides: Partial<PublicServerInfo> = {}): PublicServerInfo
     version: '0.5.0',
     authorizeUrl: '/oauth/authorize',
     directRegistrationEnabled: true,
-    passwordLoginEnabled: true,
+    directLoginEnabled: true,
     accountCreationPolicy: 'invite_only',
     welcomeMessage: null,
     description: null,

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -72,7 +72,7 @@ var initCmd = &cobra.Command{
 
 		// Build configuration
 		directRegistration := true
-		passwordLogin := true
+		directLogin := true
 		unlimited := -1
 		cfg := config.ChattoConfig{
 			General: config.GeneralConfig{
@@ -81,7 +81,7 @@ var initCmd = &cobra.Command{
 			},
 			Auth: config.AuthConfig{
 				DirectRegistration: &directRegistration,
-				PasswordLogin:      &passwordLogin,
+				DirectLogin:        &directLogin,
 				EmailOTP: config.EmailOTPConfig{
 					ThrottlingEnabled: &directRegistration,
 					TTL:               config.Duration(15 * time.Minute),

--- a/cli/cmd/init.go
+++ b/cli/cmd/init.go
@@ -72,6 +72,7 @@ var initCmd = &cobra.Command{
 
 		// Build configuration
 		directRegistration := true
+		passwordLogin := true
 		unlimited := -1
 		cfg := config.ChattoConfig{
 			General: config.GeneralConfig{
@@ -80,6 +81,7 @@ var initCmd = &cobra.Command{
 			},
 			Auth: config.AuthConfig{
 				DirectRegistration: &directRegistration,
+				PasswordLogin:      &passwordLogin,
 				EmailOTP: config.EmailOTPConfig{
 					ThrottlingEnabled: &directRegistration,
 					TTL:               config.Duration(15 * time.Minute),

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -109,7 +109,7 @@ func TestInitGeneratesCoreSecret(t *testing.T) {
 	if !strings.Contains(rawText, "\n# [[auth.providers]]\n# id = 'github'\n# type = 'github'") {
 		t.Fatal("generated config should include a commented GitHub auth provider example")
 	}
-	if !strings.Contains(rawText, "\npassword_login = true\n") {
+	if !strings.Contains(rawText, "\ndirect_login = true\n") {
 		t.Fatal("generated config should explicitly enable password login")
 	}
 	if !strings.Contains(rawText, "\n[auth.email_otp]\n") {

--- a/cli/cmd/init_test.go
+++ b/cli/cmd/init_test.go
@@ -109,6 +109,9 @@ func TestInitGeneratesCoreSecret(t *testing.T) {
 	if !strings.Contains(rawText, "\n# [[auth.providers]]\n# id = 'github'\n# type = 'github'") {
 		t.Fatal("generated config should include a commented GitHub auth provider example")
 	}
+	if !strings.Contains(rawText, "\npassword_login = true\n") {
+		t.Fatal("generated config should explicitly enable password login")
+	}
 	if !strings.Contains(rawText, "\n[auth.email_otp]\n") {
 		t.Fatal("generated config should include an active auth.email_otp section")
 	}

--- a/cli/internal/config/auth.go
+++ b/cli/internal/config/auth.go
@@ -71,7 +71,7 @@ func IsAllowedAuthProviderType(providerType string) bool {
 
 type AuthConfig struct {
 	DirectRegistration    *bool                `toml:"direct_registration" env:"CHATTO_AUTH_DIRECT_REGISTRATION" comment:"Enable direct (email/password) registration. When false, self-service account creation is disabled; existing accounts can still sign in. Default: true."`
-	PasswordLogin         *bool                `toml:"password_login" env:"CHATTO_AUTH_PASSWORD_LOGIN" comment:"Enable direct login with a username or email address and password. When false, users must sign in via configured SSO providers. Default: true."`
+	DirectLogin           *bool                `toml:"direct_login" env:"CHATTO_AUTH_DIRECT_LOGIN" comment:"Enable direct login with a username or email address and password. When false, users must sign in via configured SSO providers. Default: true."`
 	AccountCreationPolicy string               `toml:"account_creation_policy,commented" env:"CHATTO_AUTH_ACCOUNT_CREATION_POLICY" comment:"Account admission policy: open or invite_only. Default: open. Upgrade every serving replica before enabling invite_only."`
 	TokenTTL              Duration             `toml:"token_ttl,commented" env:"CHATTO_AUTH_TOKEN_TTL" comment:"TTL for bearer auth tokens. Supports human-readable durations like '90d', '2160h'. Default: 90d."`
 	EmailOTP              EmailOTPConfig       `toml:"email_otp,commented" comment:"Email OTP guardrails for registration and email verification."`
@@ -145,12 +145,12 @@ func (c *AuthConfig) DirectRegistrationOrDefault() bool {
 	return *c.DirectRegistration
 }
 
-// PasswordLoginOrDefault returns whether direct password login is enabled (default: true).
-func (c *AuthConfig) PasswordLoginOrDefault() bool {
-	if c.PasswordLogin == nil {
+// DirectLoginOrDefault returns whether direct password login is enabled (default: true).
+func (c *AuthConfig) DirectLoginOrDefault() bool {
+	if c.DirectLogin == nil {
 		return true
 	}
-	return *c.PasswordLogin
+	return *c.DirectLogin
 }
 
 // EnabledProviders returns a list of configured SSO provider IDs.

--- a/cli/internal/config/auth.go
+++ b/cli/internal/config/auth.go
@@ -70,7 +70,8 @@ func IsAllowedAuthProviderType(providerType string) bool {
 }
 
 type AuthConfig struct {
-	DirectRegistration    *bool                `toml:"direct_registration" env:"CHATTO_AUTH_DIRECT_REGISTRATION" comment:"Enable direct (email/password) registration. When false, users can only sign in via SSO providers. Default: true."`
+	DirectRegistration    *bool                `toml:"direct_registration" env:"CHATTO_AUTH_DIRECT_REGISTRATION" comment:"Enable direct (email/password) registration. When false, self-service account creation is disabled; existing accounts can still sign in. Default: true."`
+	PasswordLogin         *bool                `toml:"password_login" env:"CHATTO_AUTH_PASSWORD_LOGIN" comment:"Enable direct login with a username or email address and password. When false, users must sign in via configured SSO providers. Default: true."`
 	AccountCreationPolicy string               `toml:"account_creation_policy,commented" env:"CHATTO_AUTH_ACCOUNT_CREATION_POLICY" comment:"Account admission policy: open or invite_only. Default: open. Upgrade every serving replica before enabling invite_only."`
 	TokenTTL              Duration             `toml:"token_ttl,commented" env:"CHATTO_AUTH_TOKEN_TTL" comment:"TTL for bearer auth tokens. Supports human-readable durations like '90d', '2160h'. Default: 90d."`
 	EmailOTP              EmailOTPConfig       `toml:"email_otp,commented" comment:"Email OTP guardrails for registration and email verification."`
@@ -142,6 +143,14 @@ func (c *AuthConfig) DirectRegistrationOrDefault() bool {
 		return true
 	}
 	return *c.DirectRegistration
+}
+
+// PasswordLoginOrDefault returns whether direct password login is enabled (default: true).
+func (c *AuthConfig) PasswordLoginOrDefault() bool {
+	if c.PasswordLogin == nil {
+		return true
+	}
+	return *c.PasswordLogin
 }
 
 // EnabledProviders returns a list of configured SSO provider IDs.

--- a/cli/internal/config/auth_test.go
+++ b/cli/internal/config/auth_test.go
@@ -23,13 +23,13 @@ func TestAuthConfig_AccountCreationPolicy(t *testing.T) {
 	}
 }
 
-func TestAuthConfig_PasswordLogin(t *testing.T) {
-	if !(&AuthConfig{}).PasswordLoginOrDefault() {
+func TestAuthConfig_DirectLogin(t *testing.T) {
+	if !(&AuthConfig{}).DirectLoginOrDefault() {
 		t.Fatal("unset password login = false, want true")
 	}
 
 	disabled := false
-	if (&AuthConfig{PasswordLogin: &disabled}).PasswordLoginOrDefault() {
+	if (&AuthConfig{DirectLogin: &disabled}).DirectLoginOrDefault() {
 		t.Fatal("disabled password login = true, want false")
 	}
 }
@@ -136,7 +136,7 @@ func TestReadConfig_EmailOTPFromEnv(t *testing.T) {
 	t.Setenv("CHATTO_AUTH_EMAIL_OTP_MAX_DELIVERED_CODES", "6")
 	t.Setenv("CHATTO_AUTH_EMAIL_OTP_MAX_WRONG_ATTEMPTS", "3")
 	t.Setenv("CHATTO_AUTH_ACCOUNT_CREATION_POLICY", AccountCreationPolicyInviteOnly)
-	t.Setenv("CHATTO_AUTH_PASSWORD_LOGIN", "false")
+	t.Setenv("CHATTO_AUTH_DIRECT_LOGIN", "false")
 
 	cfg, err := ReadConfig("")
 	if err != nil {
@@ -157,8 +157,8 @@ func TestReadConfig_EmailOTPFromEnv(t *testing.T) {
 	if got := cfg.Auth.AccountCreationPolicyOrDefault(); got != AccountCreationPolicyInviteOnly {
 		t.Errorf("CHATTO_AUTH_ACCOUNT_CREATION_POLICY = %q, want invite_only", got)
 	}
-	if cfg.Auth.PasswordLoginOrDefault() {
-		t.Error("CHATTO_AUTH_PASSWORD_LOGIN = true, want false")
+	if cfg.Auth.DirectLoginOrDefault() {
+		t.Error("CHATTO_AUTH_DIRECT_LOGIN = true, want false")
 	}
 }
 

--- a/cli/internal/config/auth_test.go
+++ b/cli/internal/config/auth_test.go
@@ -23,6 +23,17 @@ func TestAuthConfig_AccountCreationPolicy(t *testing.T) {
 	}
 }
 
+func TestAuthConfig_PasswordLogin(t *testing.T) {
+	if !(&AuthConfig{}).PasswordLoginOrDefault() {
+		t.Fatal("unset password login = false, want true")
+	}
+
+	disabled := false
+	if (&AuthConfig{PasswordLogin: &disabled}).PasswordLoginOrDefault() {
+		t.Fatal("disabled password login = true, want false")
+	}
+}
+
 func TestEmailOTPConfig_Defaults(t *testing.T) {
 	c := &EmailOTPConfig{}
 	if got := c.ThrottlingEnabledOrDefault(); got != true {
@@ -125,6 +136,7 @@ func TestReadConfig_EmailOTPFromEnv(t *testing.T) {
 	t.Setenv("CHATTO_AUTH_EMAIL_OTP_MAX_DELIVERED_CODES", "6")
 	t.Setenv("CHATTO_AUTH_EMAIL_OTP_MAX_WRONG_ATTEMPTS", "3")
 	t.Setenv("CHATTO_AUTH_ACCOUNT_CREATION_POLICY", AccountCreationPolicyInviteOnly)
+	t.Setenv("CHATTO_AUTH_PASSWORD_LOGIN", "false")
 
 	cfg, err := ReadConfig("")
 	if err != nil {
@@ -144,6 +156,9 @@ func TestReadConfig_EmailOTPFromEnv(t *testing.T) {
 	}
 	if got := cfg.Auth.AccountCreationPolicyOrDefault(); got != AccountCreationPolicyInviteOnly {
 		t.Errorf("CHATTO_AUTH_ACCOUNT_CREATION_POLICY = %q, want invite_only", got)
+	}
+	if cfg.Auth.PasswordLoginOrDefault() {
+		t.Error("CHATTO_AUTH_PASSWORD_LOGIN = true, want false")
 	}
 }
 

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -57,8 +57,8 @@ func TestServerDiscoveryServiceGetServerPublicMetadata(t *testing.T) {
 	if !msg.GetLogin().GetDirectRegistrationEnabled() {
 		t.Fatal("DirectRegistrationEnabled = false, want true")
 	}
-	if msg.GetLogin().PasswordLoginEnabled == nil || !msg.GetLogin().GetPasswordLoginEnabled() {
-		t.Fatal("PasswordLoginEnabled is absent or false, want explicit true")
+	if msg.GetLogin().DirectLoginEnabled == nil || !msg.GetLogin().GetDirectLoginEnabled() {
+		t.Fatal("DirectLoginEnabled is absent or false, want explicit true")
 	}
 	if msg.GetLogin().GetAccountCreationPolicy() != apiv1.AccountCreationPolicy_ACCOUNT_CREATION_POLICY_OPEN {
 		t.Fatalf("AccountCreationPolicy = %v, want OPEN", msg.GetLogin().GetAccountCreationPolicy())
@@ -81,18 +81,18 @@ func TestServerDiscoveryServiceGetServerPublicMetadata(t *testing.T) {
 	}
 }
 
-func TestServerDiscoveryServiceGetServerReportsDisabledPasswordLogin(t *testing.T) {
+func TestServerDiscoveryServiceGetServerReportsDisabledDirectLogin(t *testing.T) {
 	disabled := false
 	api := New(nil, config.ChattoConfig{
-		Auth: config.AuthConfig{PasswordLogin: &disabled},
+		Auth: config.AuthConfig{DirectLogin: &disabled},
 	}, "9.8.7")
 
 	resp, err := (&serverDiscoveryService{api: api}).GetServer(context.Background(), connect.NewRequest(&discoveryv1.GetServerRequest{}))
 	if err != nil {
 		t.Fatalf("GetServer: %v", err)
 	}
-	if resp.Msg.GetLogin().PasswordLoginEnabled == nil || resp.Msg.GetLogin().GetPasswordLoginEnabled() {
-		t.Fatal("PasswordLoginEnabled is absent or true, want explicit false")
+	if resp.Msg.GetLogin().DirectLoginEnabled == nil || resp.Msg.GetLogin().GetDirectLoginEnabled() {
+		t.Fatal("DirectLoginEnabled is absent or true, want explicit false")
 	}
 }
 

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -57,6 +57,9 @@ func TestServerDiscoveryServiceGetServerPublicMetadata(t *testing.T) {
 	if !msg.GetLogin().GetDirectRegistrationEnabled() {
 		t.Fatal("DirectRegistrationEnabled = false, want true")
 	}
+	if msg.GetLogin().PasswordLoginEnabled == nil || !msg.GetLogin().GetPasswordLoginEnabled() {
+		t.Fatal("PasswordLoginEnabled is absent or false, want explicit true")
+	}
 	if msg.GetLogin().GetAccountCreationPolicy() != apiv1.AccountCreationPolicy_ACCOUNT_CREATION_POLICY_OPEN {
 		t.Fatalf("AccountCreationPolicy = %v, want OPEN", msg.GetLogin().GetAccountCreationPolicy())
 	}
@@ -75,6 +78,21 @@ func TestServerDiscoveryServiceGetServerPublicMetadata(t *testing.T) {
 	}
 	if !provider.GetAutoProvision() {
 		t.Fatal("provider AutoProvision = false, want true")
+	}
+}
+
+func TestServerDiscoveryServiceGetServerReportsDisabledPasswordLogin(t *testing.T) {
+	disabled := false
+	api := New(nil, config.ChattoConfig{
+		Auth: config.AuthConfig{PasswordLogin: &disabled},
+	}, "9.8.7")
+
+	resp, err := (&serverDiscoveryService{api: api}).GetServer(context.Background(), connect.NewRequest(&discoveryv1.GetServerRequest{}))
+	if err != nil {
+		t.Fatalf("GetServer: %v", err)
+	}
+	if resp.Msg.GetLogin().PasswordLoginEnabled == nil || resp.Msg.GetLogin().GetPasswordLoginEnabled() {
+		t.Fatal("PasswordLoginEnabled is absent or true, want explicit false")
 	}
 }
 

--- a/cli/internal/connectapi/server.go
+++ b/cli/internal/connectapi/server.go
@@ -31,12 +31,12 @@ func (s *serverDiscoveryService) GetServer(ctx context.Context, _ *connect.Reque
 	if err != nil {
 		return nil, err
 	}
-	passwordLoginEnabled := s.api.config.Auth.PasswordLoginOrDefault()
+	directLoginEnabled := s.api.config.Auth.DirectLoginOrDefault()
 	response := &discoveryv1.GetServerResponse{
 		Profile: profile,
 		Login: &apiv1.ServerLogin{
 			DirectRegistrationEnabled: s.api.config.Auth.DirectRegistrationOrDefault(),
-			PasswordLoginEnabled:      &passwordLoginEnabled,
+			DirectLoginEnabled:        &directLoginEnabled,
 			Providers:                 apiAuthProviders(s.api.config.Auth.PublicProviders()),
 			AuthorizeUrl:              "/oauth/authorize",
 			AccountCreationPolicy:     apiAccountCreationPolicy(s.api.config.Auth.AccountCreationPolicyOrDefault()),

--- a/cli/internal/connectapi/server.go
+++ b/cli/internal/connectapi/server.go
@@ -31,10 +31,12 @@ func (s *serverDiscoveryService) GetServer(ctx context.Context, _ *connect.Reque
 	if err != nil {
 		return nil, err
 	}
+	passwordLoginEnabled := s.api.config.Auth.PasswordLoginOrDefault()
 	response := &discoveryv1.GetServerResponse{
 		Profile: profile,
 		Login: &apiv1.ServerLogin{
 			DirectRegistrationEnabled: s.api.config.Auth.DirectRegistrationOrDefault(),
+			PasswordLoginEnabled:      &passwordLoginEnabled,
 			Providers:                 apiAuthProviders(s.api.config.Auth.PublicProviders()),
 			AuthorizeUrl:              "/oauth/authorize",
 			AccountCreationPolicy:     apiAccountCreationPolicy(s.api.config.Auth.AccountCreationPolicyOrDefault()),

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -169,6 +169,11 @@ func (s *HTTPServer) setupAuthRoutes() {
 	// Password login endpoint
 	// Accepts login name (username) via "login" or "identifier" field
 	auth.POST("login", func(c *gin.Context) {
+		if !s.config.Auth.PasswordLoginOrDefault() {
+			c.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled"})
+			return
+		}
+
 		var loginRequest struct {
 			Login      string `json:"login"`
 			Identifier string `json:"identifier"` // Alternative field name used by frontend

--- a/cli/internal/http_server/auth.go
+++ b/cli/internal/http_server/auth.go
@@ -169,7 +169,7 @@ func (s *HTTPServer) setupAuthRoutes() {
 	// Password login endpoint
 	// Accepts login name (username) via "login" or "identifier" field
 	auth.POST("login", func(c *gin.Context) {
-		if !s.config.Auth.PasswordLoginOrDefault() {
+		if !s.config.Auth.DirectLoginOrDefault() {
 			c.JSON(http.StatusForbidden, gin.H{"error": "Password login is disabled"})
 			return
 		}

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -714,7 +714,7 @@ func TestAuthRoutes_Login_DisabledReturns403BeforeCredentialValidation(t *testin
 
 	body, _ := json.Marshal(map[string]string{
 		"login":    "disabledlogin",
-		"password": "password123",
+		"password": "definitely-wrong",
 	})
 	resp, err := client.Post(ts.URL+"/auth/login", "application/json", bytes.NewReader(body))
 	if err != nil {

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -702,6 +702,41 @@ func TestAuthRoutes_Login_Success(t *testing.T) {
 	}
 }
 
+func TestAuthRoutes_Login_DisabledReturns403BeforeCredentialValidation(t *testing.T) {
+	disabled := false
+	ts, client, chattoCore := setupTestHTTPServerWithHook(t, func(server *HTTPServer) {
+		server.config.Auth.PasswordLogin = &disabled
+	})
+	ctx := testContext(t)
+	if _, err := chattoCore.CreateUser(ctx, "system", "disabledlogin", "Disabled Login", "password123"); err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"login":    "disabledlogin",
+		"password": "password123",
+	})
+	resp, err := client.Post(ts.URL+"/auth/login", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST /auth/login: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	var responseBody map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&responseBody); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if responseBody["error"] != "Password login is disabled" {
+		t.Fatalf("error = %q, want password-login-disabled response", responseBody["error"])
+	}
+	if cookies := client.Jar.Cookies(resp.Request.URL); len(cookies) != 0 {
+		t.Fatalf("disabled login created cookies: %+v", cookies)
+	}
+}
+
 func TestAuthRoutes_Login_WithIdentifier(t *testing.T) {
 	ts, client, chattoCore := setupTestHTTPServer(t)
 	ctx := testContext(t)

--- a/cli/internal/http_server/server_test.go
+++ b/cli/internal/http_server/server_test.go
@@ -705,7 +705,7 @@ func TestAuthRoutes_Login_Success(t *testing.T) {
 func TestAuthRoutes_Login_DisabledReturns403BeforeCredentialValidation(t *testing.T) {
 	disabled := false
 	ts, client, chattoCore := setupTestHTTPServerWithHook(t, func(server *HTTPServer) {
-		server.config.Auth.PasswordLogin = &disabled
+		server.config.Auth.DirectLogin = &disabled
 	})
 	ctx := testContext(t)
 	if _, err := chattoCore.CreateUser(ctx, "system", "disabledlogin", "Disabled Login", "password123"); err != nil {

--- a/cli/internal/pb/chatto/api/v1/server.pb.go
+++ b/cli/internal/pb/chatto/api/v1/server.pb.go
@@ -176,8 +176,11 @@ type ServerLogin struct {
 	AuthorizeUrl string `protobuf:"bytes,3,opt,name=authorize_url,json=authorizeUrl,proto3" json:"authorize_url,omitempty"`
 	// Admission policy for direct registration and provider auto-provisioning.
 	AccountCreationPolicy AccountCreationPolicy `protobuf:"varint,4,opt,name=account_creation_policy,json=accountCreationPolicy,proto3,enum=chatto.api.v1.AccountCreationPolicy" json:"account_creation_policy,omitempty"`
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// Whether users can sign in directly with a username or email address and password.
+	// Absent on older servers, where clients should treat password login as enabled.
+	PasswordLoginEnabled *bool `protobuf:"varint,5,opt,name=password_login_enabled,json=passwordLoginEnabled,proto3,oneof" json:"password_login_enabled,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
 }
 
 func (x *ServerLogin) Reset() {
@@ -238,6 +241,13 @@ func (x *ServerLogin) GetAccountCreationPolicy() AccountCreationPolicy {
 	return AccountCreationPolicy_ACCOUNT_CREATION_POLICY_UNSPECIFIED
 }
 
+func (x *ServerLogin) GetPasswordLoginEnabled() bool {
+	if x != nil && x.PasswordLoginEnabled != nil {
+		return *x.PasswordLoginEnabled
+	}
+	return false
+}
+
 var File_chatto_api_v1_server_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_server_proto_rawDesc = "" +
@@ -254,12 +264,14 @@ const file_chatto_api_v1_server_proto_rawDesc = "" +
 	"\t_logo_urlB\r\n" +
 	"\v_banner_urlB\x12\n" +
 	"\x10_welcome_messageB\x0e\n" +
-	"\f_description\"\x8f\x02\n" +
+	"\f_description\"\xe5\x02\n" +
 	"\vServerLogin\x12>\n" +
 	"\x1bdirect_registration_enabled\x18\x01 \x01(\bR\x19directRegistrationEnabled\x12=\n" +
 	"\tproviders\x18\x02 \x03(\v2\x1f.chatto.api.v1.ProviderMetadataR\tproviders\x12#\n" +
 	"\rauthorize_url\x18\x03 \x01(\tR\fauthorizeUrl\x12\\\n" +
-	"\x17account_creation_policy\x18\x04 \x01(\x0e2$.chatto.api.v1.AccountCreationPolicyR\x15accountCreationPolicy*\x8b\x01\n" +
+	"\x17account_creation_policy\x18\x04 \x01(\x0e2$.chatto.api.v1.AccountCreationPolicyR\x15accountCreationPolicy\x129\n" +
+	"\x16password_login_enabled\x18\x05 \x01(\bH\x00R\x14passwordLoginEnabled\x88\x01\x01B\x19\n" +
+	"\x17_password_login_enabled*\x8b\x01\n" +
 	"\x15AccountCreationPolicy\x12'\n" +
 	"#ACCOUNT_CREATION_POLICY_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cACCOUNT_CREATION_POLICY_OPEN\x10\x01\x12'\n" +
@@ -303,6 +315,7 @@ func file_chatto_api_v1_server_proto_init() {
 	}
 	file_chatto_api_v1_common_proto_init()
 	file_chatto_api_v1_server_proto_msgTypes[0].OneofWrappers = []any{}
+	file_chatto_api_v1_server_proto_msgTypes[1].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/cli/internal/pb/chatto/api/v1/server.pb.go
+++ b/cli/internal/pb/chatto/api/v1/server.pb.go
@@ -177,10 +177,10 @@ type ServerLogin struct {
 	// Admission policy for direct registration and provider auto-provisioning.
 	AccountCreationPolicy AccountCreationPolicy `protobuf:"varint,4,opt,name=account_creation_policy,json=accountCreationPolicy,proto3,enum=chatto.api.v1.AccountCreationPolicy" json:"account_creation_policy,omitempty"`
 	// Whether users can sign in directly with a username or email address and password.
-	// Absent on older servers, where clients should treat password login as enabled.
-	PasswordLoginEnabled *bool `protobuf:"varint,5,opt,name=password_login_enabled,json=passwordLoginEnabled,proto3,oneof" json:"password_login_enabled,omitempty"`
-	unknownFields        protoimpl.UnknownFields
-	sizeCache            protoimpl.SizeCache
+	// Absent on older servers, where clients should treat direct login as enabled.
+	DirectLoginEnabled *bool `protobuf:"varint,5,opt,name=direct_login_enabled,json=directLoginEnabled,proto3,oneof" json:"direct_login_enabled,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *ServerLogin) Reset() {
@@ -241,9 +241,9 @@ func (x *ServerLogin) GetAccountCreationPolicy() AccountCreationPolicy {
 	return AccountCreationPolicy_ACCOUNT_CREATION_POLICY_UNSPECIFIED
 }
 
-func (x *ServerLogin) GetPasswordLoginEnabled() bool {
-	if x != nil && x.PasswordLoginEnabled != nil {
-		return *x.PasswordLoginEnabled
+func (x *ServerLogin) GetDirectLoginEnabled() bool {
+	if x != nil && x.DirectLoginEnabled != nil {
+		return *x.DirectLoginEnabled
 	}
 	return false
 }
@@ -264,14 +264,14 @@ const file_chatto_api_v1_server_proto_rawDesc = "" +
 	"\t_logo_urlB\r\n" +
 	"\v_banner_urlB\x12\n" +
 	"\x10_welcome_messageB\x0e\n" +
-	"\f_description\"\xe5\x02\n" +
+	"\f_description\"\xdf\x02\n" +
 	"\vServerLogin\x12>\n" +
 	"\x1bdirect_registration_enabled\x18\x01 \x01(\bR\x19directRegistrationEnabled\x12=\n" +
 	"\tproviders\x18\x02 \x03(\v2\x1f.chatto.api.v1.ProviderMetadataR\tproviders\x12#\n" +
 	"\rauthorize_url\x18\x03 \x01(\tR\fauthorizeUrl\x12\\\n" +
-	"\x17account_creation_policy\x18\x04 \x01(\x0e2$.chatto.api.v1.AccountCreationPolicyR\x15accountCreationPolicy\x129\n" +
-	"\x16password_login_enabled\x18\x05 \x01(\bH\x00R\x14passwordLoginEnabled\x88\x01\x01B\x19\n" +
-	"\x17_password_login_enabled*\x8b\x01\n" +
+	"\x17account_creation_policy\x18\x04 \x01(\x0e2$.chatto.api.v1.AccountCreationPolicyR\x15accountCreationPolicy\x125\n" +
+	"\x14direct_login_enabled\x18\x05 \x01(\bH\x00R\x12directLoginEnabled\x88\x01\x01B\x17\n" +
+	"\x15_direct_login_enabled*\x8b\x01\n" +
 	"\x15AccountCreationPolicy\x12'\n" +
 	"#ACCOUNT_CREATION_POLICY_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cACCOUNT_CREATION_POLICY_OPEN\x10\x01\x12'\n" +

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -119,8 +119,11 @@ credentialed CORS; cross-origin authentication is bearer-only, while cookie
 fallback is restricted to the configured server origin.
 
 The discovery response includes the server software version as public
-pre-authentication state. The bundled client refreshes it per server and owns
-an internal feature-to-minimum-server-version table for compatibility gates.
+pre-authentication state, along with configured provider metadata and the
+independently configured direct-registration and password-login capabilities.
+The password-login capability uses scalar presence so a new client treats an
+older server that omits it as enabled. The bundled client refreshes discovery
+per server and owns an internal feature-to-minimum-server-version table for compatibility gates.
 The 0.5 client requires the 0.5 server baseline before opening realtime
 protocol 2, the only accepted behavioral version. The
 `chatto.realtime.v1` suffix remains the protobuf namespace.

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -120,8 +120,8 @@ fallback is restricted to the configured server origin.
 
 The discovery response includes the server software version as public
 pre-authentication state, along with configured provider metadata and the
-independently configured direct-registration and password-login capabilities.
-The password-login capability uses scalar presence so a new client treats an
+independently configured direct-registration and direct-login capabilities.
+The direct-login capability uses scalar presence so a new client treats an
 older server that omits it as enabled. The bundled client refreshes discovery
 per server and owns an internal feature-to-minimum-server-version table for compatibility gates.
 The 0.5 client requires the 0.5 server baseline before opening realtime

--- a/docs/fdr/FDR-023-authentication-and-sessions.md
+++ b/docs/fdr/FDR-023-authentication-and-sessions.md
@@ -1,7 +1,7 @@
 # FDR-023: Authentication & Sessions
 
 **Status:** Active
-**Last reviewed:** 2026-08-12
+**Last reviewed:** 2026-08-14
 
 ## Overview
 
@@ -9,7 +9,7 @@ Chatto authenticates users with typed opaque runtime credentials. API and multi-
 
 ## Behavior
 
-- **Login** — users sign in with login + password on a `/login` page. The page is also used for redirect-after-signup.
+- **Login** — users sign in with login + password on a `/login` page. Operators can disable password login independently from direct registration. When disabled, the server rejects password-login requests before credential validation and public discovery tells clients not to render the password form or recovery link. Existing sessions, registration, and authenticated password management remain unchanged. The page is also used for redirect-after-signup and continues to offer configured external providers.
 - **External provider login** — operators configure repeated `[[auth.providers]]` entries or equivalent counted `CHATTO_AUTH_PROVIDERS_<index>_<field>` environment variables. Supported provider types are `oidc`, `github`, `gitlab`, `google`, and `discord`. The login page renders buttons from `chatto.discovery.v1.ServerDiscoveryService.GetServer` login providers, and provider flows use `/auth/providers/{providerID}` plus `/auth/providers/{providerID}/callback`. OIDC also keeps `/auth/oidc` and `/auth/oidc/callback` as compatibility aliases for older clients and provider registrations. A matched browser login establishes the HTTP-only cookie session and redirects without a bearer credential; when provider login is nested inside Chatto OAuth authorization, the existing PKCE authorization-code flow continues instead.
 - **CIMD public client** — OIDC providers may use a confidential client secret or Chatto's public client ID at `{webserver.url}/oauth/client-metadata.json`. The metadata document declares the exact callback URIs for OIDC providers configured with that client ID and requires Authorization Code with public token authentication, allowing CIMD-aware issuers to use Chatto without preregistration.
 - **Chatto OAuth client identity** — browser client applications use their HTTPS CIMD URL as `client_id`; Chatto retrieves the document, verifies its self-identified client ID, public-client grant shape, and exact redirect URI, then binds that client ID through consent, authorization code exchange, and the resulting opaque access token. Metadata retrieval is bounded and blocks special-use network destinations. Chatto Desktop uses the built-in `chatto://desktop` client identity and exact popup callback. Native CIMD clients may declare private-use callbacks with `application_type = "native"`. CIMD identity means the app is identifiable, not endorsed; user consent is still required.
@@ -106,6 +106,12 @@ Chatto authenticates users with typed opaque runtime credentials. API and multi-
 **Decision:** Known server metadata, device-local Chatto sessions, and the frontend's Authling grant have separate state owners. Cross-boundary sign-out commands run through one client account coordinator. The legacy combined browser-storage record remains only as a compatibility adapter.
 **Why:** A synchronized server can be known while signed out, and public account data must never gain access to local Chatto credentials. Separate ownership also prevents entries learned from one Authling account from leaking into another account. See ADR-064.
 **Tradeoff:** The frontend retains a composed server view and combined persisted shape during migration, so the adapter and coordinator require explicit tests.
+
+### 8d. Operator-controlled password login
+
+**Decision:** Password sign-in is a deployment configuration capability, separate from direct registration and from whether an account retains a password. Public discovery reports the capability before authentication, while the password-login endpoint remains authoritative and rejects disabled requests before inspecting credentials. Existing runtime credentials are not revoked when the setting changes.
+**Why:** SSO-only deployments need to close the local password entry point without migrating accounts, deleting fallback credentials, or coupling sign-in policy to account-creation policy. Discovery lets compatible clients present only valid choices, and endpoint enforcement protects against older or custom clients.
+**Tradeoff:** Older clients do not understand the discovery capability and can still display a form that the server rejects. Operators must configure every serving replica consistently and retain a tested provider or recovery path to avoid locking signed-out users out.
 
 ### 9. EVT audit facts without raw secrets
 

--- a/packages/api-types/src/chatto/api/v1/server_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/server_pb.ts
@@ -158,11 +158,11 @@ export class ServerLogin extends Message<ServerLogin> {
 
   /**
    * Whether users can sign in directly with a username or email address and password.
-   * Absent on older servers, where clients should treat password login as enabled.
+   * Absent on older servers, where clients should treat direct login as enabled.
    *
-   * @generated from field: optional bool password_login_enabled = 5;
+   * @generated from field: optional bool direct_login_enabled = 5;
    */
-  passwordLoginEnabled?: boolean;
+  directLoginEnabled?: boolean;
 
   constructor(data?: PartialMessage<ServerLogin>) {
     super();
@@ -176,7 +176,7 @@ export class ServerLogin extends Message<ServerLogin> {
     { no: 2, name: "providers", kind: "message", T: ProviderMetadata, repeated: true },
     { no: 3, name: "authorize_url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "account_creation_policy", kind: "enum", T: proto3.getEnumType(AccountCreationPolicy) },
-    { no: 5, name: "password_login_enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
+    { no: 5, name: "direct_login_enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ServerLogin {

--- a/packages/api-types/src/chatto/api/v1/server_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/server_pb.ts
@@ -156,6 +156,14 @@ export class ServerLogin extends Message<ServerLogin> {
    */
   accountCreationPolicy = AccountCreationPolicy.UNSPECIFIED;
 
+  /**
+   * Whether users can sign in directly with a username or email address and password.
+   * Absent on older servers, where clients should treat password login as enabled.
+   *
+   * @generated from field: optional bool password_login_enabled = 5;
+   */
+  passwordLoginEnabled?: boolean;
+
   constructor(data?: PartialMessage<ServerLogin>) {
     super();
     proto3.util.initPartial(data, this);
@@ -168,6 +176,7 @@ export class ServerLogin extends Message<ServerLogin> {
     { no: 2, name: "providers", kind: "message", T: ProviderMetadata, repeated: true },
     { no: 3, name: "authorize_url", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "account_creation_policy", kind: "enum", T: proto3.getEnumType(AccountCreationPolicy) },
+    { no: 5, name: "password_login_enabled", kind: "scalar", T: 8 /* ScalarType.BOOL */, opt: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ServerLogin {

--- a/proto/chatto/api/v1/server.proto
+++ b/proto/chatto/api/v1/server.proto
@@ -41,6 +41,6 @@ message ServerLogin {
   // Admission policy for direct registration and provider auto-provisioning.
   AccountCreationPolicy account_creation_policy = 4;
   // Whether users can sign in directly with a username or email address and password.
-  // Absent on older servers, where clients should treat password login as enabled.
-  optional bool password_login_enabled = 5;
+  // Absent on older servers, where clients should treat direct login as enabled.
+  optional bool direct_login_enabled = 5;
 }

--- a/proto/chatto/api/v1/server.proto
+++ b/proto/chatto/api/v1/server.proto
@@ -40,4 +40,7 @@ message ServerLogin {
   string authorize_url = 3;
   // Admission policy for direct registration and provider auto-provisioning.
   AccountCreationPolicy account_creation_policy = 4;
+  // Whether users can sign in directly with a username or email address and password.
+  // Absent on older servers, where clients should treat password login as enabled.
+  optional bool password_login_enabled = 5;
 }


### PR DESCRIPTION
## Summary

- add `auth.direct_login` / `CHATTO_AUTH_DIRECT_LOGIN`, defaulting to enabled
- enforce the setting at `/auth/login` and advertise it through public server discovery
- hide password and recovery controls on SSO-only login pages while preserving provider actions and callback errors
- document the operator workflow, compatibility behavior, FDR decision, and runtime interface
- clarify the agent testing rule for proving that an early rejection runs before later validation

## Compatibility

This is an additive public protobuf change and an opt-in behavioural change to the legacy password-login endpoint. New clients treat the capability as enabled when older servers omit it. Older clients may still display the password form against a server where operators disabled it, but the server rejects the request with HTTP 403.

## Verification

- focused Go config, discovery, and HTTP auth tests
- complete `cli/internal/http_server` package tests
- focused frontend mapper, state, and mounted login-page tests
- `mise lint-frontend`
- forced production frontend build
- docs website build
- `mise codegen-proto` and API-types build
- Buf breaking check against `origin/main`
- Svelte autofixer
- Chrome DevTools verification at desktop and mobile sizes

The full frontend suite passed all 130 server test files / 1,155 tests. Its Chromium phase did not provide a clean full-suite signal because Vite repeatedly re-optimized existing dependencies and reloaded the run; the focused Chromium login-page tests passed independently.

## Documentation

- updates [FDR-023](docs/fdr/FDR-023-authentication-and-sessions.md)
- updates the [interfaces inventory](docs/architecture/interfaces.md)
- adds SSO-only deployment and configuration guidance
