### PR TITLE
docs(architecture): define the Loom Architecture

### DIFF
--- a/.agents/skills/chatto-event-sourcing/SKILL.md
+++ b/.agents/skills/chatto-event-sourcing/SKILL.md
@@ -5,7 +5,10 @@ description: "Use when designing, implementing, reviewing, debugging, or documen
 
 # Chatto Event Sourcing
 
-Use this skill whenever touching durable domain state in Chatto. It is a guardrail checklist for the event-sourced architecture, not a replacement for the architecture docs.
+Use this skill whenever touching durable domain state in Chatto. Apply the
+repository-wide [`loom-architecture`](../loom-architecture/SKILL.md) skill
+alongside it for the shared architectural invariants. This skill adds
+Chatto-specific guardrails and does not replace the architecture docs.
 
 ## Start Here
 

--- a/.agents/skills/loom-architecture/SKILL.md
+++ b/.agents/skills/loom-architecture/SKILL.md
@@ -5,103 +5,59 @@ description: Apply the Loom Architecture—Log-Oriented Outcomes and Materializa
 
 # Loom Architecture
 
-Use this skill as an implementation and review checklist for applications and
-frameworks that follow the Loom Architecture: one authoritative event log,
-disposable materializations, and durable outcomes.
+Loom stands for **Log-Oriented Outcomes and Materializations**. It is an
+architecture for building event-sourced applications on NATS and JetStream.
 
-## Preserve the Loom Invariants
+```text
+commands -> EVT -> materializations
+                -> durable workers -> outcomes
+```
 
-- Give each independent application its own NATS account. Do not share an
-  application account merely because applications use the same NATS server or
-  run in the same operating-system process.
-- Keep one primary JetStream event stream with the logical role `EVT` inside
-  that account. Let the application own its physical name, subjects,
-  vocabulary, aggregate boundaries, identity, configuration, and lifecycle.
-- Treat committed durable facts as authoritative. Do not make a projection,
-  snapshot, checkpoint, durable-consumer position, cache, or external index an
-  alternate source of truth.
-- Require OCC for event mutations. Match the OCC subject or filter to the state
-  used by the decision, wait for that projection frontier, and re-run the
-  complete decision after a conflict.
-- Use committed stream positions for readiness and local read-your-writes.
-  Do not infer business causality between unrelated aggregates from incidental
-  global stream order.
-- Keep event envelopes and codecs application-owned. Protobuf is a valid
-  choice, but it is not a framework or Loom invariant.
-- Keep runtime state, expiring workflows, secrets, binary objects, and
-  transient signals outside `EVT` unless they represent a durable domain fact.
+## Log-oriented
 
-## Design Materializations
+Each application runs in its own NATS account. Within that account, one primary
+JetStream stream—conventionally called `EVT`—holds the application's durable
+domain events.
 
-Treat projections as disposable materializations of retained events:
+The event log is the source of truth. Commands decide what should happen and
+append new events only if the relevant history has not changed. This is
+optimistic concurrency control: concurrent changes cannot silently overwrite
+each other. Applications define their own events, subjects, and aggregate
+boundaries. Events may use Protobuf, but Loom does not require a particular
+encoding.
 
-- Let a projection store its derived state in RAM, NATS, local durable
-  storage, or an external system according to its access and recovery needs.
-- Keep `Apply` deterministic and side-effect-free. Replay and multiple replicas
-  must not multiply an external effect.
-- Declare consumed subjects precisely and keep the projector's readiness
-  frontier with the projection it owns.
-- Fail the affected capability when decode, apply, or startup replay fails.
-  Never serve partial state as if it were current.
+## Materializations
 
-Choose one restore strategy per projection:
+Materializations are views of the event log built for a particular use. They
+are commonly called projections or read models. A materialization may live in
+RAM, in NATS, in a local database, or in an external system.
 
-- Use no persistence and cold-replay `EVT` by default.
-- Use a portable snapshot for replaceable state that benefits from shared
-  object storage.
-- Use a local checkpoint when the projection can atomically persist its
-  derived changes and EVT cutoff in its own store.
-- Never combine a snapshot and checkpoint as competing restore authorities.
+Materializations are derived state, not another source of truth. They can be
+discarded and rebuilt by replaying the event log. Snapshots and checkpoints can
+make that rebuild faster, but they are still disposable and are not backups of
+the event log.
 
-Bind every restored artifact to its projection key, opaque contract ID, stream
-name and incarnation, and replay cutoff. Treat missing, corrupt, incompatible,
-future, or retention-gapped artifacts as unavailable acceleration, not truth.
-Review snapshot contents for privacy, deletion, cryptographic-erasure, and key
-exposure risks.
+A Loom framework can provide reusable projection bases, especially for
+in-memory projections, plus snapshot repository interfaces and implementations
+for storage such as NATS Object Store or S3-compatible object storage.
 
-A framework may provide a snapshot repository interface and implementations
-for stores such as NATS Object Store or S3-compatible object storage. Keep
-these contracts payload-agnostic: the application owns serialization,
-encryption and privacy policy, retention, cleanup, resource names, storage
-configuration, and key management.
+## Outcomes
 
-## Design Outcomes
+Outcomes are reliable asynchronous work caused by committed events: sending an
+email, calling a webhook, updating another system, or performing any other
+follow-up that must survive a restart.
 
-Use durable workers when a committed fact requires work that must survive a
-crash, dependency outage, replica handoff, or scale-to-zero interval.
+Durable workers use named JetStream consumers so unfinished work remains
+available after crashes or handoffs between processes. Delivery is at least
+once, so outcome handlers must tolerate receiving the same event more than
+once. Projections only derive state; durable workers perform external effects.
 
-- Configure a named durable JetStream consumer at the application boundary.
-- Make handlers safe under at-least-once delivery through idempotency,
-  terminal-state checks, or an OCC-protected completion record.
-- Let the shared worker own bounded fetch execution, heartbeats,
-  acknowledgement, retry, poison termination, cancellation, and shutdown
-  handoff.
-- Keep consumer names, filters, starting policy, creation, rollout,
-  replacement, and retirement application-owned.
-- Do not delete a deployment-wide consumer when one worker or replica stops.
-- Define mixed-version and rollback behavior before changing a durable
-  consumer contract.
+## Framework and application
 
-Do not use a process-local queue, timer, or lease as the only recovery path for
-a required external effect. A lease may reduce duplicate work, but it does not
-replace durable discovery or fence writes.
+The framework supplies the reusable mechanics for publishing events, replaying
+materializations, taking and restoring snapshots, and running durable workers.
+The application supplies the domain: its event types, subjects, decisions,
+projection logic, outcome handlers, and operational policy.
 
-## Review a Change
-
-Answer these questions before considering Loom work complete:
-
-1. Which application and NATS account own the data?
-2. Is the value a durable fact, materialization, outcome state, runtime value,
-   secret, object, or transient signal?
-3. Which aggregate subject or filter is the OCC boundary?
-4. Which projections consume the fact, and which must be current before the
-   command or subsequent read returns?
-5. Can every materialization rebuild from retained facts, and is its restore
-   artifact bound to the correct contract, stream incarnation, and cutoff?
-6. Does every required external effect have durable discovery and an
-   at-least-once-safe handler?
-7. Who owns each durable consumer's creation, versioned identity, rollout, and
-   retirement?
-8. What happens during startup, replay, conflict, dependency failure, rolling
-   deployment, rollback, and stream recreation?
-9. Which focused tests demonstrate those answers?
+In short: events record what happened, materializations make those facts easy
+to use, and durable workers reliably turn them into external outcomes.

--- a/.agents/skills/loom-architecture/SKILL.md
+++ b/.agents/skills/loom-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: loom-architecture
-description: Apply the Loom Architecture—Log-Oriented Outcomes and Materializations—when designing, implementing, reviewing, debugging, or documenting NATS and JetStream event-sourced applications. Use for work involving NATS account boundaries, a primary event stream, optimistic concurrency control, projections and read-your-writes, snapshots or checkpoints, snapshot repositories, durable workers, or reliable external effects.
+description: Apply the repository-wide Loom Architecture—Log-Oriented Outcomes and Materializations—when designing, implementing, reviewing, debugging, or documenting NATS and JetStream event-sourced applications. Use for work involving NATS account boundaries, a primary event stream, optimistic concurrency control, projections and read-your-writes, snapshots or checkpoints, snapshot repositories, durable workers, or reliable external effects.
 ---
 
 # Loom Architecture
@@ -9,15 +9,16 @@ Loom stands for **Log-Oriented Outcomes and Materializations**. It is an
 architecture for building event-sourced applications on NATS and JetStream.
 
 ```text
-commands -> EVT -> materializations
-                -> durable workers -> outcomes
+commands -> event log (EVT role) -> materializations
+                                 -> durable workers -> outcomes
 ```
 
 ## Log-oriented
 
 Each application runs in its own NATS account. Within that account, one primary
-JetStream stream—conventionally called `EVT`—holds the application's durable
-domain events.
+JetStream stream holds the application's durable domain events. Loom calls the
+stream's logical role `EVT`; the application chooses its physical resource
+name.
 
 The event log is the source of truth. Commands decide what should happen and
 append new events only if the relevant history has not changed. This is

--- a/.agents/skills/loom-architecture/SKILL.md
+++ b/.agents/skills/loom-architecture/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: loom-architecture
+description: Apply the repository-wide Loom Architecture—Log-Oriented Outcomes and Materializations—when designing, implementing, reviewing, debugging, or documenting NATS and JetStream event-sourced application state. Use for Chatto, Authling, or shared-framework work involving NATS account boundaries, the primary EVT stream, optimistic concurrency control, projections and read-your-writes, snapshots or checkpoints, snapshot repositories, durable workers, or reliable external effects.
+---
+
+# Loom Architecture
+
+Apply the Loom Architecture as the shared application pattern across Chatto,
+Authling, and the reusable events framework. Treat
+[`ADR-073`](../../../docs/adr/ADR-073-define-the-loom-architecture.md) as the
+canonical definition; use this skill as its implementation and review
+checklist.
+
+## Route the Work First
+
+Classify the change before designing it:
+
+- For Chatto, read the root and `cli/AGENTS.md`, then apply
+  [`chatto-event-sourcing`](../chatto-event-sourcing/SKILL.md) for product
+  subjects, services, projections, public delivery, compatibility, and
+  documentation.
+- For Authling, read the root and `authling/AGENTS.md`, then use Authling's own
+  ADRs, FDRs, architecture inventory, and glossary. Do not import Chatto policy
+  or storage coordinates.
+- For shared framework code, read both product instruction files, the target
+  module's `AGENTS.md`, ADR-057, and its module-specific ADR. Keep the code
+  application-neutral and drive new public surface from a concrete consumer.
+
+Keep each product independently versioned, deployable, and movable. Never let
+co-location in this repository turn Authling into a Chatto component.
+
+## Preserve the Loom Invariants
+
+- Give each independent application its own NATS account. Never share a
+  Chatto application account with Authling.
+- Keep one primary JetStream event stream with the logical role `EVT` inside
+  that account. Let the application own its physical name, subjects,
+  vocabulary, aggregate boundaries, identity, configuration, and lifecycle.
+- Treat committed durable facts as authoritative. Do not make a projection,
+  snapshot, checkpoint, durable-consumer position, cache, or external index an
+  alternate source of truth.
+- Require OCC for event mutations. Match the OCC subject or filter to the state
+  used by the decision, wait for that projection frontier, and re-run the
+  complete decision after a conflict.
+- Use committed stream positions for readiness and local read-your-writes.
+  Do not infer business causality between unrelated aggregates from incidental
+  global stream order.
+- Keep event envelopes and codecs application-owned. Protobuf is used by the
+  current applications but is not a framework or Loom invariant.
+- Keep runtime state, expiring workflows, secrets, binary objects, and
+  transient signals outside `EVT` unless they represent a durable domain fact.
+
+## Design Materializations
+
+Treat projections as disposable materializations of retained events:
+
+- Let a projection store its derived state in RAM, NATS, local durable
+  storage, or an external system according to its access and recovery needs.
+- Keep `Apply` deterministic and side-effect-free. Replay and multiple replicas
+  must not multiply an external effect.
+- Declare consumed subjects precisely and keep the projector's readiness
+  frontier with the projection it owns.
+- Fail the affected capability when decode, apply, or startup replay fails.
+  Never serve partial state as if it were current.
+- Use `pkg/events.MemoryProjection` as the current reusable in-memory locking
+  base where appropriate. Do not claim that the framework already supplies
+  storage-specific projection bases that have not been extracted.
+
+Choose one restore strategy per projection:
+
+- Use no persistence and cold-replay `EVT` by default.
+- Use a portable snapshot for replaceable state that benefits from shared
+  object storage.
+- Use a local checkpoint when the projection can atomically persist its
+  derived changes and EVT cutoff in its own store.
+- Never combine a snapshot and checkpoint as competing restore authorities.
+
+Bind every restored artifact to its projection key, opaque contract ID, stream
+name and incarnation, and replay cutoff. Treat missing, corrupt, incompatible,
+future, or retention-gapped artifacts as unavailable acceleration, not truth.
+Review snapshot contents for privacy, deletion, cryptographic-erasure, and key
+exposure risks.
+
+The framework currently supplies snapshot capture and restore capability
+hooks; Chatto owns the current repository and NATS Object Store/S3 adapters.
+When extracting reusable repository interfaces or implementations, require a
+concrete second application, accept opaque application payloads and metadata,
+and keep product configuration, Protobufs, encryption policy, resource names,
+paths, retention, and cleanup policy outside the shared package.
+
+## Design Outcomes
+
+Use durable workers when a committed fact requires work that must survive a
+crash, dependency outage, replica handoff, or scale-to-zero interval.
+
+- Configure a named durable JetStream consumer at the application boundary.
+- Make handlers safe under at-least-once delivery through idempotency,
+  terminal-state checks, or an OCC-protected completion record.
+- Let the shared worker own bounded fetch execution, heartbeats,
+  acknowledgement, retry, poison termination, cancellation, and shutdown
+  handoff.
+- Keep consumer names, filters, starting policy, creation, rollout,
+  replacement, and retirement application-owned.
+- Do not delete a deployment-wide consumer when one worker or replica stops.
+- Define mixed-version and rollback behavior before changing a durable
+  consumer contract.
+
+Do not use a process-local queue, timer, or lease as the only recovery path for
+a required external effect. A lease may reduce duplicate work, but it does not
+replace durable discovery or fence writes.
+
+## Review a Change
+
+Answer these questions before considering Loom work complete:
+
+1. Which application and NATS account own the data?
+2. Is the value a durable fact, materialization, outcome state, runtime value,
+   secret, object, or transient signal?
+3. Which aggregate subject or filter is the OCC boundary?
+4. Which projections consume the fact, and which must be current before the
+   command or subsequent read returns?
+5. Can every materialization rebuild from retained facts, and is its restore
+   artifact bound to the correct contract, stream incarnation, and cutoff?
+6. Does every required external effect have durable discovery and an
+   at-least-once-safe handler?
+7. Who owns each durable consumer's creation, versioned identity, rollout, and
+   retirement?
+8. Does the change preserve application-neutral framework boundaries and the
+   independent Chatto/Authling release and extraction paths?
+9. What happens during startup, replay, conflict, dependency failure, rolling
+   deployment, rollback, and stream recreation?
+10. Which focused tests and product-owned documentation prove those answers?
+
+Update the applicable ADRs and current architecture inventories when the
+topology or responsibilities change. Update product FDRs for user-visible
+behavior and product glossaries for product vocabulary. Keep the Loom name and
+repository-wide framework decisions in root documentation rather than copying
+cross-product architecture into either product's namespace.

--- a/.agents/skills/loom-architecture/SKILL.md
+++ b/.agents/skills/loom-architecture/SKILL.md
@@ -9,25 +9,6 @@ Use this skill as an implementation and review checklist for applications and
 frameworks that follow the Loom Architecture: one authoritative event log,
 disposable materializations, and durable outcomes.
 
-## Establish the Boundaries
-
-Before designing a change:
-
-- Identify the application, its NATS account, and the component that owns the
-  data or effect.
-- Separate architectural invariants, application policy, and reusable
-  framework mechanics.
-- Read the host project's instructions and its application- or
-  framework-specific architecture before changing code.
-- Keep reusable framework code independent of application-owned domains,
-  configuration, event envelopes, subjects, resource names, and lifecycle
-  policy.
-- Drive new framework surface from concrete application needs rather than
-  speculative generality.
-
-Co-location does not erase application boundaries. Independently deployed
-applications remain independently versioned, configurable, and operable.
-
 ## Preserve the Loom Invariants
 
 - Give each independent application its own NATS account. Do not share an
@@ -62,9 +43,6 @@ Treat projections as disposable materializations of retained events:
   frontier with the projection it owns.
 - Fail the affected capability when decode, apply, or startup replay fails.
   Never serve partial state as if it were current.
-- Prefer framework-provided projection bases where they match the storage and
-  concurrency model. Do not claim support for storage-specific bases that have
-  not actually been implemented.
 
 Choose one restore strategy per projection:
 
@@ -81,12 +59,11 @@ future, or retention-gapped artifacts as unavailable acceleration, not truth.
 Review snapshot contents for privacy, deletion, cryptographic-erasure, and key
 exposure risks.
 
-Snapshot repositories should accept opaque application payloads and metadata.
-Keep application configuration, serialization types, encryption policy,
-resource names, paths, retention, and cleanup policy outside reusable
-repository implementations. Add shared repository interfaces or storage
-adapters only once concrete application needs establish the smallest useful
-contract.
+A framework may provide a snapshot repository interface and implementations
+for stores such as NATS Object Store or S3-compatible object storage. Keep
+these contracts payload-agnostic: the application owns serialization,
+encryption and privacy policy, retention, cleanup, resource names, storage
+configuration, and key management.
 
 ## Design Outcomes
 
@@ -125,14 +102,6 @@ Answer these questions before considering Loom work complete:
    at-least-once-safe handler?
 7. Who owns each durable consumer's creation, versioned identity, rollout, and
    retirement?
-8. Does the change preserve application-neutral framework boundaries and each
-   application's independent deployment and evolution?
-9. What happens during startup, replay, conflict, dependency failure, rolling
+8. What happens during startup, replay, conflict, dependency failure, rolling
    deployment, rollback, and stream recreation?
-10. Which focused tests and application-owned documentation prove those
-    answers?
-
-Update the relevant architecture decisions, architecture inventory, feature
-documentation, and glossary when topology, responsibilities, behavior, or
-vocabulary changes. Keep Loom invariants distinct from application-specific
-decisions.
+9. Which focused tests demonstrate those answers?

--- a/.agents/skills/loom-architecture/SKILL.md
+++ b/.agents/skills/loom-architecture/SKILL.md
@@ -1,38 +1,38 @@
 ---
 name: loom-architecture
-description: Apply the repository-wide Loom Architecture—Log-Oriented Outcomes and Materializations—when designing, implementing, reviewing, debugging, or documenting NATS and JetStream event-sourced application state. Use for Chatto, Authling, or shared-framework work involving NATS account boundaries, the primary EVT stream, optimistic concurrency control, projections and read-your-writes, snapshots or checkpoints, snapshot repositories, durable workers, or reliable external effects.
+description: Apply the Loom Architecture—Log-Oriented Outcomes and Materializations—when designing, implementing, reviewing, debugging, or documenting NATS and JetStream event-sourced applications. Use for work involving NATS account boundaries, a primary event stream, optimistic concurrency control, projections and read-your-writes, snapshots or checkpoints, snapshot repositories, durable workers, or reliable external effects.
 ---
 
 # Loom Architecture
 
-Apply the Loom Architecture as the shared application pattern across Chatto,
-Authling, and the reusable events framework. Treat
-[`ADR-073`](../../../docs/adr/ADR-073-define-the-loom-architecture.md) as the
-canonical definition; use this skill as its implementation and review
-checklist.
+Use this skill as an implementation and review checklist for applications and
+frameworks that follow the Loom Architecture: one authoritative event log,
+disposable materializations, and durable outcomes.
 
-## Route the Work First
+## Establish the Boundaries
 
-Classify the change before designing it:
+Before designing a change:
 
-- For Chatto, read the root and `cli/AGENTS.md`, then apply
-  [`chatto-event-sourcing`](../chatto-event-sourcing/SKILL.md) for product
-  subjects, services, projections, public delivery, compatibility, and
-  documentation.
-- For Authling, read the root and `authling/AGENTS.md`, then use Authling's own
-  ADRs, FDRs, architecture inventory, and glossary. Do not import Chatto policy
-  or storage coordinates.
-- For shared framework code, read both product instruction files, the target
-  module's `AGENTS.md`, ADR-057, and its module-specific ADR. Keep the code
-  application-neutral and drive new public surface from a concrete consumer.
+- Identify the application, its NATS account, and the component that owns the
+  data or effect.
+- Separate architectural invariants, application policy, and reusable
+  framework mechanics.
+- Read the host project's instructions and its application- or
+  framework-specific architecture before changing code.
+- Keep reusable framework code independent of application-owned domains,
+  configuration, event envelopes, subjects, resource names, and lifecycle
+  policy.
+- Drive new framework surface from concrete application needs rather than
+  speculative generality.
 
-Keep each product independently versioned, deployable, and movable. Never let
-co-location in this repository turn Authling into a Chatto component.
+Co-location does not erase application boundaries. Independently deployed
+applications remain independently versioned, configurable, and operable.
 
 ## Preserve the Loom Invariants
 
-- Give each independent application its own NATS account. Never share a
-  Chatto application account with Authling.
+- Give each independent application its own NATS account. Do not share an
+  application account merely because applications use the same NATS server or
+  run in the same operating-system process.
 - Keep one primary JetStream event stream with the logical role `EVT` inside
   that account. Let the application own its physical name, subjects,
   vocabulary, aggregate boundaries, identity, configuration, and lifecycle.
@@ -45,8 +45,8 @@ co-location in this repository turn Authling into a Chatto component.
 - Use committed stream positions for readiness and local read-your-writes.
   Do not infer business causality between unrelated aggregates from incidental
   global stream order.
-- Keep event envelopes and codecs application-owned. Protobuf is used by the
-  current applications but is not a framework or Loom invariant.
+- Keep event envelopes and codecs application-owned. Protobuf is a valid
+  choice, but it is not a framework or Loom invariant.
 - Keep runtime state, expiring workflows, secrets, binary objects, and
   transient signals outside `EVT` unless they represent a durable domain fact.
 
@@ -62,9 +62,9 @@ Treat projections as disposable materializations of retained events:
   frontier with the projection it owns.
 - Fail the affected capability when decode, apply, or startup replay fails.
   Never serve partial state as if it were current.
-- Use `pkg/events.MemoryProjection` as the current reusable in-memory locking
-  base where appropriate. Do not claim that the framework already supplies
-  storage-specific projection bases that have not been extracted.
+- Prefer framework-provided projection bases where they match the storage and
+  concurrency model. Do not claim support for storage-specific bases that have
+  not actually been implemented.
 
 Choose one restore strategy per projection:
 
@@ -81,12 +81,12 @@ future, or retention-gapped artifacts as unavailable acceleration, not truth.
 Review snapshot contents for privacy, deletion, cryptographic-erasure, and key
 exposure risks.
 
-The framework currently supplies snapshot capture and restore capability
-hooks; Chatto owns the current repository and NATS Object Store/S3 adapters.
-When extracting reusable repository interfaces or implementations, require a
-concrete second application, accept opaque application payloads and metadata,
-and keep product configuration, Protobufs, encryption policy, resource names,
-paths, retention, and cleanup policy outside the shared package.
+Snapshot repositories should accept opaque application payloads and metadata.
+Keep application configuration, serialization types, encryption policy,
+resource names, paths, retention, and cleanup policy outside reusable
+repository implementations. Add shared repository interfaces or storage
+adapters only once concrete application needs establish the smallest useful
+contract.
 
 ## Design Outcomes
 
@@ -125,14 +125,14 @@ Answer these questions before considering Loom work complete:
    at-least-once-safe handler?
 7. Who owns each durable consumer's creation, versioned identity, rollout, and
    retirement?
-8. Does the change preserve application-neutral framework boundaries and the
-   independent Chatto/Authling release and extraction paths?
+8. Does the change preserve application-neutral framework boundaries and each
+   application's independent deployment and evolution?
 9. What happens during startup, replay, conflict, dependency failure, rolling
    deployment, rollback, and stream recreation?
-10. Which focused tests and product-owned documentation prove those answers?
+10. Which focused tests and application-owned documentation prove those
+    answers?
 
-Update the applicable ADRs and current architecture inventories when the
-topology or responsibilities change. Update product FDRs for user-visible
-behavior and product glossaries for product vocabulary. Keep the Loom name and
-repository-wide framework decisions in root documentation rather than copying
-cross-product architecture into either product's namespace.
+Update the relevant architecture decisions, architecture inventory, feature
+documentation, and glossary when topology, responsibilities, behavior, or
+vocabulary changes. Keep Loom invariants distinct from application-specific
+decisions.

--- a/.agents/skills/loom-architecture/agents/openai.yaml
+++ b/.agents/skills/loom-architecture/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Loom Architecture"
+  short_description: "Apply the shared NATS event-sourcing architecture"
+  default_prompt: "Use $loom-architecture to design or review this NATS and JetStream state flow."

--- a/authling/docs/GLOSSARY.md
+++ b/authling/docs/GLOSSARY.md
@@ -48,6 +48,22 @@ read and write access through explicit consent for the `account_data` scope.
 the durable, always-online peer; each user device is another peer with its own
 local `MergeableStore`.
 
+## Backend
+
+**Loom Architecture** — Repository-wide event-sourced architecture adopted by
+Authling, built around one authoritative event log, disposable
+materializations, and durable outcomes. See
+[root ADR-073](../../docs/adr/ADR-073-define-the-loom-architecture.md) and
+[Authling ADR-001](adr/ADR-001-event-sourced-nats-architecture.md).
+
+**Materialization** — Loom term for disposable state derived from the event
+log; Authling's in-memory projections are materializations. See
+[root ADR-073](../../docs/adr/ADR-073-define-the-loom-architecture.md).
+
+**Outcome** — Loom term for reliable asynchronous work caused by a committed
+event and performed by a durable worker. See
+[root ADR-073](../../docs/adr/ADR-073-define-the-loom-architecture.md).
+
 ## Data protection
 
 **Cryptographic erasure** — Making encrypted Authling data permanently

--- a/authling/docs/adr/ADR-001-event-sourced-nats-architecture.md
+++ b/authling/docs/adr/ADR-001-event-sourced-nats-architecture.md
@@ -28,6 +28,9 @@ subjects, stream identity, resource names, domain policy, or application
 composition. Root
 [ADR-057](../../../docs/adr/ADR-057-temporarily-incubate-authling.md) requires
 the two products to remain independently buildable and separable.
+Root [ADR-073](../../../docs/adr/ADR-073-define-the-loom-architecture.md) names
+the repository-wide application pattern around these mechanics the Loom
+Architecture.
 
 ## Decision
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -134,6 +134,8 @@ Infrastructure jargon. If only contributors say the word, it goes here.
 
 **JetStream** — NATS's persistence layer (streams + KV buckets). Chatto's primary data store. See [ADR-001](adr/ADR-001-nats-jetstream-as-primary-data-store.md).
 
+**Loom Architecture** — Repository-wide event-sourced architecture used by Chatto, built around one authoritative event log, disposable materializations, and durable outcomes. See [ADR-073](adr/ADR-073-define-the-loom-architecture.md).
+
 **Stream** — JetStream append-only log. Chatto's event-sourcing stream is `EVT`, which stores durable domain facts. See [ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) and the [NATS resource inventory](architecture/nats-resources.md).
 
 **KV (Key-Value Bucket)** — JetStream-backed key/value store. Chatto uses several current buckets, especially `RUNTIME_STATE`, `MEMORY_CACHE`, and `ENCRYPTION_KEYS`; event-sourced domain state is sourced from `EVT`. See [ADR-033](adr/ADR-033-event-sourced-state-with-projections.md).
@@ -143,6 +145,10 @@ Infrastructure jargon. If only contributors say the word, it goes here.
 **Event** — Durable domain fact stored on `EVT` using the `corev1.Event` wrapper. Contrast with *Live Event*.
 
 **Projection** — Derived read model rebuilt from `EVT` and owned independently by each consuming process. Persistence is optional: a projection may cold-replay every time, use an encrypted snapshot, or checkpoint a disposable local index and EVT cutoff for tail replay. `EVT` remains the source of truth. See [ADR-033](adr/ADR-033-event-sourced-state-with-projections.md) and [ADR-054](adr/ADR-054-optional-projection-persistence.md).
+
+**Materialization** — Loom term for disposable state derived from the event log; Chatto projections are materializations and may live in RAM, NATS, local storage, or an external store. See [ADR-073](adr/ADR-073-define-the-loom-architecture.md).
+
+**Outcome** — Loom term for reliable asynchronous work caused by a committed event and performed by a durable worker, such as sending an email or updating another system. See [ADR-073](adr/ADR-073-define-the-loom-architecture.md).
 
 **Auth generation** — Per-user authentication epoch derived from durable user events. Cookie sessions, bearer tokens, and OAuth authorization codes are valid only when their stored generation matches the user's current generation. See [FDR-023](fdr/FDR-023-authentication-and-sessions.md).
 

--- a/docs/adr/ADR-033-event-sourced-state-with-projections.md
+++ b/docs/adr/ADR-033-event-sourced-state-with-projections.md
@@ -20,6 +20,10 @@ Event sourcing inverts the relationship: events are the truth, state is derived.
 
 This is a large change. The migration is per-aggregate and phased; that strategy is the subject of [ADR-035](ADR-035-per-aggregate-phased-migration.md). The shape of the event log itself — single stream vs. many — is the subject of [ADR-034](ADR-034-single-event-stream.md). This ADR commits to the model.
 
+[ADR-073](ADR-073-define-the-loom-architecture.md) later names the
+repository-wide application pattern built around this decision the Loom
+Architecture.
+
 ## Decision
 
 Adopt event sourcing as the storage pattern for domain state.

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -10,6 +10,10 @@ That package now owns proven NATS JetStream mechanics for mandatory OCC,
 ordered projection replay, read-your-writes barriers, failure propagation, and
 optional restore capabilities.
 
+[ADR-073](ADR-073-define-the-loom-architecture.md) later names the wider
+application pattern around this framework the Loom Architecture. This ADR
+continues to define the narrower package boundary and current ownership split.
+
 Chatto's composition layer has also accumulated application policy around those
 mechanics: stable diagnostic keys, display names, memory estimates, snapshot
 eligibility, domain model ownership, and the concrete `corev1.Event` envelope.

--- a/docs/adr/ADR-073-define-the-loom-architecture.md
+++ b/docs/adr/ADR-073-define-the-loom-architecture.md
@@ -1,0 +1,185 @@
+# ADR-073: Define the Loom Architecture
+
+**Date:** 2026-08-14
+
+**Status:** Accepted
+
+## Context
+
+Chatto's event-sourced state, single `EVT` stream, projections, optional
+projection persistence, and durable effect workers were established through
+[ADR-033](ADR-033-event-sourced-state-with-projections.md),
+[ADR-034](ADR-034-single-event-stream.md),
+[ADR-050](ADR-050-ephemeral-encrypted-projection-snapshots.md),
+[ADR-054](ADR-054-optional-projection-persistence.md), and
+[ADR-069](ADR-069-explicit-durable-consumer-lifecycle.md). ADR-056 then began
+extracting the reusable mechanics into the application-neutral `pkg/events`
+module. Authling's own ADR-001 applies the same shape as the concrete second
+application while preserving a separate product and NATS account.
+
+"Event-sourcing framework" describes the reusable package, but not the wider
+application architecture. That architecture also includes the account and
+trust boundary, application-owned events and subjects, derived read models,
+snapshot repositories, durable effects, and the division between framework
+mechanics and product policy. Without a shared name, those pieces are easy to
+discuss as unrelated implementation choices or accidentally generalize from
+one product's composition.
+
+## Decision
+
+Name this shared architectural style **the Loom Architecture**, expanded as
+**Log-Oriented Outcomes and Materializations**.
+
+- **Log-oriented** means durable domain decisions converge on one
+  optimistic-concurrency-controlled event log rather than a collection of
+  independently authoritative mutable stores.
+- **Outcomes** are reliable asynchronous effects derived from committed facts
+  through durable workers.
+- **Materializations** are disposable read models derived from the log,
+  including in-memory projections, NATS-backed state, local indexes, and
+  external stores.
+
+The name describes an architecture, not a package, executable, public API, or
+new product. Existing module names and imports remain unchanged.
+
+### Application boundary and authoritative log
+
+Each independent application operates through its own NATS account. A Chatto
+runtime and an Authling runtime never share an application account, even when
+they are deployed in one NATS server or may eventually be composed in one
+operating-system process.
+
+Inside that account, the application owns one primary JetStream stream with the
+logical role `EVT`. The application owns its physical resource name, subjects,
+event vocabulary, aggregate boundaries, retention and replication policy,
+stream-incarnation identity, and resource lifecycle. Durable domain facts in
+that stream are authoritative; projections and effect-delivery state do not
+become alternate authorities for the same facts.
+
+Applications own their encoded event envelope and compatibility policy.
+Chatto and Authling currently use application-owned Protobuf envelopes, but
+Protobuf is not a Loom Architecture requirement and the shared framework stays
+envelope-neutral.
+
+```text
+commands
+   |
+   | decide from caught-up state, append with OCC
+   v
+primary EVT stream in the application's NATS account
+   |                                      |
+   | ordered replay                       | durable delivery
+   v                                      v
+materializations                       workers
+(RAM, NATS, local or external)            |
+   |                                      v
+   `- optional snapshots/checkpoints   external outcomes
+```
+
+Commands that decide from projected state must wait for the relevant
+projection frontier and append with OCC over the same aggregate subject or
+subject filter represented by that state. Conflict retries re-evaluate the
+complete decision from current state. A successful append returns a durable
+position that can serve as a local read-your-writes barrier.
+
+The single stream provides one durable sequence for replay and readiness, but
+applications must not infer domain causality between unrelated aggregates from
+their incidental global sequence order. Cross-aggregate invariants need an
+explicit OCC boundary or durable application facts.
+
+Not every value belongs in `EVT`. Expiring workflow state, sessions, secrets,
+content-addressed blobs, and purely transient signals use stores appropriate to
+their lifecycle. A durable security or business fact remains an event even
+when related credentials, payload objects, or caches live elsewhere.
+
+### Materializations and restore acceleration
+
+A projection declares the facts it consumes and applies them in stream order.
+Its state may live in process RAM, NATS, a local durable index, or another
+external store. Projection code derives state only; it must not perform an
+external side effect from `Apply`, because replay and multiple application
+replicas would repeat that effect.
+
+The shared events framework owns reusable ordering, replay, readiness,
+read-your-writes, failure, and shutdown mechanics. It may provide
+storage-specific bases where a concrete shared use case proves them. Its
+current `MemoryProjection` base provides in-process locking, while persistence
+remains an optional capability rather than part of every projection contract.
+
+Snapshots and checkpoints are disposable replay accelerators, not event-log
+backups. Every restored artifact must be bound to its projection key, opaque
+contract ID, stream name and incarnation, and replay cutoff. Missing, corrupt,
+incompatible, future, or retention-gapped state falls back to cold replay when
+safe; it must never silently become authority.
+
+The intended shared-framework boundary includes reusable snapshot repository
+interfaces and proven storage implementations, including NATS Object Store and
+S3-compatible backends, once concrete needs in more than one application show
+the smallest useful contract. Until that extraction occurs, the framework
+provides snapshot capture and restore hooks while applications own repository
+implementation, encryption and privacy policy, retention, publication,
+cleanup, storage configuration, and key management. Extracted repository code
+must accept application-owned opaque payloads and metadata without importing a
+product's configuration, Protobufs, resource names, or storage paths.
+
+### Outcomes and durable workers
+
+An external side effect required by a committed fact must remain discoverable
+after crashes, replica changes, and temporary dependency failures. Named
+JetStream durable consumers provide that recovery position; handlers must be
+safe under at-least-once delivery.
+
+The shared framework may own bounded pulling, progress heartbeats,
+acknowledgement, retry, poison-delivery termination, cancellation, and shutdown
+handoff. The application owns consumer creation, names, filters, delivery
+policy, rollout and retirement, event decoding, idempotency, and the definition
+of successful or terminal domain work. A worker process stopping must not erase
+the deployment-wide durable consumer.
+
+### Shared packages
+
+`pkg/events` is the core reusable implementation of Loom mechanics.
+`pkg/natsruntime` optionally supplies application-neutral embedded NATS process
+lifecycle. `pkg/datacrypto` and `pkg/appconfig` are supporting shared modules,
+not defining parts of the Loom Architecture. None of these packages may absorb
+Chatto or Authling domain policy merely to shorten application wiring.
+
+Use the repository-local `loom-architecture` skill when designing,
+implementing, reviewing, debugging, or documenting this architecture. Apply
+the product-specific instructions and skills in addition when a change affects
+Chatto or Authling behavior.
+
+## Consequences
+
+Chatto, Authling, and the shared framework gain concise vocabulary for the
+architecture they use without making either product part of the other. Design
+reviews can distinguish architecture invariants from current package surface
+and from application policy.
+
+The name does not make `pkg/events` stable or require APIs to use Loom
+terminology. A later ADR can rename the architecture without migrating stored
+data or public APIs.
+
+One primary event stream keeps backup, replay, readiness, and operational
+reasoning small, but it also shares stream-level replication, retention, and
+write capacity across the application's durable domain. A future application
+that needs multiple authoritative streams would be a deliberate variation or
+revision of the Loom Architecture rather than an invisible implementation
+detail.
+
+Reusable snapshot repositories become an explicit framework direction, but
+their extraction remains evidence-driven. Product storage and security policy
+must not leak into the shared API, and snapshots remain optional acceleration
+rather than a prerequisite for adopting the architecture.
+
+## Related
+
+- [ADR-033](ADR-033-event-sourced-state-with-projections.md)
+- [ADR-034](ADR-034-single-event-stream.md)
+- [ADR-050](ADR-050-ephemeral-encrypted-projection-snapshots.md)
+- [ADR-054](ADR-054-optional-projection-persistence.md)
+- [ADR-056](ADR-056-extractable-nats-event-sourcing-framework.md)
+- [ADR-057](ADR-057-temporarily-incubate-authling.md)
+- [ADR-058](ADR-058-application-neutral-embedded-nats-runtime.md)
+- [ADR-069](ADR-069-explicit-durable-consumer-lifecycle.md)
+- [Authling ADR-001](../../authling/docs/adr/ADR-001-event-sourced-nats-architecture.md)

--- a/docs/adr/ADR-073-define-the-loom-architecture.md
+++ b/docs/adr/ADR-073-define-the-loom-architecture.md
@@ -96,9 +96,11 @@ when related credentials, payload objects, or caches live elsewhere.
 
 A projection declares the facts it consumes and applies them in stream order.
 Its state may live in process RAM, NATS, a local durable index, or another
-external store. Projection code derives state only; it must not perform an
-external side effect from `Apply`, because replay and multiple application
-replicas would repeat that effect.
+external store. `Apply` may update the materialization's own derived store and,
+for a checkpointed projection, atomically commit its EVT cutoff. It must not
+perform an outcome or mutate state outside that materialization, such as
+sending an email, calling a webhook, or updating an unrelated system, because
+replay and multiple application replicas may apply the same event again.
 
 The shared events framework owns reusable ordering, replay, readiness,
 read-your-writes, failure, and shutdown mechanics. It may provide

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -1,6 +1,9 @@
 # Architecture Decision Records
 
-This directory contains Architecture Decision Records (ADRs) for the Chatto project. ADRs document significant architectural decisions along with their context and consequences.
+This directory contains Architecture Decision Records (ADRs) for Chatto and
+for explicitly repository-wide monorepo or shared-framework decisions. ADRs
+document significant architectural decisions along with their context and
+consequences.
 
 For more about ADRs, see [Michael Nygard's article](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
 
@@ -84,3 +87,4 @@ replace part of their original design.
 | [ADR-070](ADR-070-deterministic-invite-link-capabilities.md) | Derive Invite-Link Capabilities from Durable EVT Identity | Accepted | 2026-08-11 |
 | [ADR-071](ADR-071-cimd-identified-open-oauth-clients.md) | Identify Open OAuth Clients through CIMD | Accepted | 2026-08-11 |
 | [ADR-072](ADR-072-optional-host-capabilities-in-the-shared-frontend.md) | Optional Host Capabilities in the Shared Frontend | Accepted | 2026-08-13 |
+| [ADR-073](ADR-073-define-the-loom-architecture.md) | Define the Loom Architecture | Accepted | 2026-08-14 |

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -1,10 +1,11 @@
 # Events
 
-`hmans.de/chatto/pkg/events` is an envelope-neutral event-sourcing framework
-for NATS JetStream. It provides optimistic-concurrency-controlled publication,
-ordered projection replay, startup and read-your-writes barriers, optional
-snapshot or checkpoint restore, bounded subject reads, and bounded durable
-pull-worker execution.
+`hmans.de/chatto/pkg/events` supplies the core reusable mechanics for the
+repository-wide [Loom Architecture](../../docs/adr/ADR-073-define-the-loom-architecture.md).
+It is an envelope-neutral event-sourcing framework for NATS JetStream,
+providing optimistic-concurrency-controlled publication, ordered projection
+replay, startup and read-your-writes barriers, optional snapshot or checkpoint
+restore, bounded subject reads, and bounded durable pull-worker execution.
 
 The intended reader is an application integrator. This module owns ordering,
 OCC, replay, and delivery mechanics; the application owns event codecs,


### PR DESCRIPTION
## Why

Give the shared NATS/JetStream application architecture a concise repository-wide name and guidance without coupling Chatto and Authling.

## What changed

- Define the Loom Architecture ("Log-Oriented Outcomes and Materializations") in ADR-073, including NATS-account isolation, authoritative `EVT`, materializations, snapshots, and durable workers
- Add a concise, plain-English, repository-wide `loom-architecture` skill and connect the existing Chatto, Authling, and `pkg/events` documentation to it
- Clarify that `EVT` is a logical role and that persisted projections may update their own materialized stores during `Apply`
- Record Loom, materialization, and outcome terminology in the product-owned Chatto and Authling glossaries

## API compatibility

- No public API, protocol, or runtime behaviour changes
- Older client → newer server: no impact
- Newer client → older server: no impact
- Capability discovery and minimum client/server version: unchanged

## Test plan

- `quick_validate.py .agents/skills/loom-architecture`
- Local documentation link checks
- `git diff --check`
- `mise license-check`
- Read-only forward test explaining Loom through a generic order-management application
