### PR TITLE
feat(desktop): sign and notarise macOS releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,7 @@ jobs:
   build-desktop-release:
     if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chatto-desktop/v')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'desktop') }}
     name: build-desktop-release (${{ matrix.platform }})
+    environment: desktop-signing
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -225,10 +226,86 @@ jobs:
         if: runner.os == 'macOS'
         run: mise test-desktop-macos-capture
 
+      - name: Configure macOS signing
+        if: runner.os == 'macOS'
+        shell: bash
+        env:
+          CERTIFICATE_BASE64: ${{ secrets.CHATTO_MACOS_CERTIFICATE_BASE64 }}
+          CERTIFICATE_PASSWORD: ${{ secrets.CHATTO_MACOS_CERTIFICATE_PASSWORD }}
+          NOTARY_API_KEY_BASE64: ${{ secrets.CHATTO_MACOS_NOTARY_API_KEY_BASE64 }}
+          NOTARY_API_KEY_ID: ${{ secrets.CHATTO_MACOS_NOTARY_API_KEY_ID }}
+          NOTARY_API_ISSUER_ID: ${{ secrets.CHATTO_MACOS_NOTARY_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+
+          for variable in \
+            CERTIFICATE_BASE64 \
+            CERTIFICATE_PASSWORD \
+            NOTARY_API_KEY_BASE64 \
+            NOTARY_API_KEY_ID \
+            NOTARY_API_ISSUER_ID; do
+            if [[ -z "${!variable}" ]]; then
+              echo "::error::The ${variable} macOS release secret is not configured."
+              exit 1
+            fi
+          done
+
+          certificate_path="$RUNNER_TEMP/chatto-developer-id.p12"
+          api_key_path="$RUNNER_TEMP/AuthKey_${NOTARY_API_KEY_ID}.p8"
+          keychain_path="$RUNNER_TEMP/chatto-signing.keychain-db"
+          keychain_password="$(openssl rand -hex 24)"
+
+          {
+            echo "CHATTO_MACOS_NOTARY_API_KEY=${api_key_path}"
+            echo "CHATTO_MACOS_SIGNING_KEYCHAIN=${keychain_path}"
+            echo "CHATTO_MACOS_SIGNING_CERTIFICATE=${certificate_path}"
+          } >> "$GITHUB_ENV"
+
+          printf '%s' "$CERTIFICATE_BASE64" | base64 --decode > "$certificate_path"
+          printf '%s' "$NOTARY_API_KEY_BASE64" | base64 --decode > "$api_key_path"
+          chmod 600 "$certificate_path" "$api_key_path"
+
+          security create-keychain -p "$keychain_password" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$keychain_password" "$keychain_path"
+          security import "$certificate_path" \
+            -k "$keychain_path" \
+            -P "$CERTIFICATE_PASSWORD" \
+            -T /usr/bin/codesign \
+            -T /usr/bin/security
+          security set-key-partition-list \
+            -S apple-tool:,apple: \
+            -s \
+            -k "$keychain_password" \
+            "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+
+          signing_identity="$(
+            security find-identity -v -p codesigning "$keychain_path" |
+              awk '/Developer ID Application:/ { print $2; exit }'
+          )"
+          if [[ -z "$signing_identity" ]]; then
+            echo "::error::The certificate does not contain a Developer ID Application identity."
+            exit 1
+          fi
+
+          {
+            echo "CHATTO_MACOS_SIGN_IDENTITY=${signing_identity}"
+            echo "CHATTO_MACOS_NOTARY_API_KEY_ID=${NOTARY_API_KEY_ID}"
+            echo "CHATTO_MACOS_NOTARY_API_ISSUER_ID=${NOTARY_API_ISSUER_ID}"
+          } >> "$GITHUB_ENV"
+
       - name: Build desktop bundle
-        run: mise desktop-build
+        shell: bash
         env:
           CHATTO_BUILD_VERSION: ${{ steps.version.outputs.frontend_version }}
+          DEBUG: ${{ runner.os == 'macOS' && 'electron-notarize*' || '' }}
+        run: |
+          if [[ "$RUNNER_OS" == "macOS" ]]; then
+            mise desktop-build 2>&1 | tee "$RUNNER_TEMP/chatto-macos-notarization.log"
+          else
+            mise desktop-build
+          fi
 
       - name: Verify bundled frontend version
         shell: bash
@@ -248,10 +325,32 @@ jobs:
           helper="apps/desktop/dist/Chatto Desktop.app/Contents/Helpers/Chatto Capture Helper.app/Contents/MacOS/chatto-macos-capture-probe"
           test -x "$helper"
           codesign --verify --deep --strict --verbose=2 "apps/desktop/dist/Chatto Desktop.app"
+          xcrun stapler validate "apps/desktop/dist/Chatto Desktop.app"
+          spctl --assess --type execute --verbose=4 "apps/desktop/dist/Chatto Desktop.app"
           mkdir -p .context/desktop-release
           ditto -c -k --sequesterRsrc --keepParent \
             "apps/desktop/dist/Chatto Desktop.app" \
             ".context/desktop-release/chatto-desktop_${VERSION}_macOS_${RUNNER_ARCH}.zip"
+
+      - name: Upload macOS notarisation log
+        if: runner.os == 'macOS' && always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: desktop-notarisation-log-${{ github.run_id }}-${{ runner.arch }}
+          path: ${{ runner.temp }}/chatto-macos-notarization.log
+          if-no-files-found: warn
+          retention-days: 90
+
+      - name: Remove macOS signing credentials
+        if: runner.os == 'macOS' && always()
+        shell: bash
+        run: |
+          if [[ -n "${CHATTO_MACOS_SIGNING_KEYCHAIN:-}" ]]; then
+            security delete-keychain "$CHATTO_MACOS_SIGNING_KEYCHAIN" || true
+          fi
+          rm -f \
+            "${CHATTO_MACOS_SIGNING_CERTIFICATE:-$RUNNER_TEMP/chatto-developer-id.p12}" \
+            "${CHATTO_MACOS_NOTARY_API_KEY:-$RUNNER_TEMP/chatto-notary-api-key.p8}"
 
       - name: Package Linux release
         if: runner.os == 'Linux'

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -43,9 +43,63 @@ The build task first produces the frontend, then packages the host-platform
 bundle beneath `apps/desktop/dist/`. macOS builds include the native
 ScreenCaptureKit game-capture helper and its pinned LiveKit frameworks. CI
 checks and packages macOS, Windows, and Linux bundles, verifies the nested macOS
-helper, and validates the complete app signature. The current release archives
-use ad-hoc signing, so macOS may warn about or block them until production
-Developer ID signing and notarisation are added.
+helper, and validates the complete app signature. Ordinary local and pull-request
+builds use ad-hoc signing. Release builds use Developer ID signing, the hardened
+runtime, and Apple notarisation, then staple and validate the notarisation ticket
+before creating the release archive.
+
+### Configure macOS release signing
+
+An Apple Developer Program Account Holder must create a **Developer ID
+Application** certificate for direct distribution. Export the certificate and
+private key from Keychain Access as a password-protected `.p12` file. In App
+Store Connect, create a team API key with App Manager access and download its
+one-time `.p8` private key.
+
+Base64-encode both files without line wrapping:
+
+```sh
+base64 -i chatto-developer-id.p12 | tr -d '\n'
+base64 -i AuthKey_KEY_ID.p8 | tr -d '\n'
+```
+
+Add these secrets to the protected `desktop-signing` Actions environment, not
+as repository-wide secrets:
+
+| Secret | Value |
+| --- | --- |
+| `CHATTO_MACOS_CERTIFICATE_BASE64` | Base64-encoded `.p12` file |
+| `CHATTO_MACOS_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` file |
+| `CHATTO_MACOS_NOTARY_API_KEY_BASE64` | Base64-encoded App Store Connect `.p8` key |
+| `CHATTO_MACOS_NOTARY_API_KEY_ID` | App Store Connect API key ID |
+| `CHATTO_MACOS_NOTARY_API_ISSUER_ID` | App Store Connect team issuer ID |
+
+The environment permits deployments only from `chatto-desktop/v*` tags and the
+`main` branch used for manually dispatched verification builds. Its required
+reviewer must approve a release before any matrix runner can access the signing
+secrets. The desktop release workflow then fails closed when any secret is
+absent. On its macOS runner it imports the certificate into a temporary
+keychain, signs every nested executable in dependency order, submits the app to
+Apple's notary service, and removes the temporary credentials even when the
+build fails.
+
+Every macOS release attempt uploads a `desktop-notarisation-log-*` artifact with
+90-day retention. The log includes the complete Apple notary-service response
+for successful submissions as well as failures, while the Electron notarisation
+library redacts authentication arguments. Review accepted submissions for
+warnings before publishing the resulting archive.
+
+For a local Developer ID build, install the certificate in the login keychain
+and set the signing identity and all three notarisation variables before running
+`mise desktop-build`:
+
+```sh
+export CHATTO_MACOS_SIGN_IDENTITY='Developer ID Application: ChattoCorp GmbH (TEAMID)'
+export CHATTO_MACOS_NOTARY_API_KEY="$PWD/AuthKey_KEY_ID.p8"
+export CHATTO_MACOS_NOTARY_API_KEY_ID='KEY_ID'
+export CHATTO_MACOS_NOTARY_API_ISSUER_ID='ISSUER_UUID'
+mise desktop-build
+```
 
 Electron handles camera, microphone, and notification permission requests only
 for the fixed app origin. Screen sharing presents a native source picker.
@@ -55,7 +109,7 @@ is sandboxed.
 
 ## Prototype boundaries
 
-This scaffold does not yet provide production signing/notarisation, auto-update,
-OS deep links, installers, or end-to-end desktop tests. Some identity providers
+This scaffold does not yet provide auto-update, OS deep links, installers, or
+end-to-end desktop tests. Some identity providers
 reject authentication inside embedded user agents, so a system-browser OAuth
 handoff may still be required before treating this as a general release.

--- a/apps/desktop/native/macos-capture-probe/README.md
+++ b/apps/desktop/native/macos-capture-probe/README.md
@@ -137,8 +137,8 @@ This places the executable in a background application at
 `Chatto Desktop.app/Contents/Helpers/Chatto Capture Helper.app`. The helper has
 the stable bundle identifier `run.chatto.desktop.capture-helper`, and the
 packager signs it in dependency order with the rest of the Electron bundle.
-Current local and CI artifacts use ad-hoc signing; a production build still
-needs a stable Developer ID identity and notarisation. macOS CI asserts that
+Local and pull-request artifacts use ad-hoc signing; release artifacts use a
+stable Developer ID identity and Apple notarisation. macOS CI asserts that
 the helper is executable, can start without invoking capture, has its framework
 rpath, and satisfies the complete app bundle's strict signature validation.
 Ad-hoc builds disable hardened runtime because they have no Team ID; builds

--- a/apps/desktop/scripts/build.mjs
+++ b/apps/desktop/scripts/build.mjs
@@ -5,6 +5,7 @@ import { packager } from "@electron/packager";
 import packageJson from "../package.json" with { type: "json" };
 import { pruneElectronLocales } from "./locales.mjs";
 import { embedMacOSCaptureHelper } from "./macos-capture-helper.mjs";
+import { macOSDistributionOptions } from "./macos-signing.mjs";
 import { macOSVersions, releaseBuildVersion } from "./version.mjs";
 
 const desktopRoot = path.resolve(
@@ -18,12 +19,9 @@ const platform = process.platform;
 const electronChecksum = process.env.CHATTO_ELECTRON_CHECKSUM;
 const electronArchiveName = `electron-v${packageJson.devDependencies.electron}-${platform}-${process.arch}.zip`;
 const embedCaptureHelper = platform === "darwin";
-const macOSSignIdentity =
-  platform === "darwin"
-    ? (process.env.CHATTO_MACOS_SIGN_IDENTITY ?? "-")
-    : undefined;
 const macVersions =
   platform === "darwin" ? macOSVersions(packageJson.version) : undefined;
+const macOSDistribution = macOSDistributionOptions(platform, process.env);
 const supportedLocales = (
   await readdir(path.resolve(desktopRoot, "../frontend/messages"), {
     withFileTypes: true,
@@ -73,20 +71,18 @@ const [bundleRoot] = await packager({
     ? [
         async ({ buildPath }) => {
           const appBundle = path.resolve(buildPath, "../../..");
+          const prunedLocales = await pruneElectronLocales(
+            appBundle,
+            platform,
+            supportedLocales,
+          );
+          logPrunedLocales(prunedLocales);
           await embedMacOSCaptureHelper(appBundle, macVersions);
         },
       ]
     : undefined,
-  osxSign:
-    platform === "darwin"
-      ? {
-          identity: macOSSignIdentity,
-          identityValidation: macOSSignIdentity !== "-",
-          optionsForFile: () => ({
-            hardenedRuntime: macOSSignIdentity !== "-",
-          }),
-        }
-      : undefined,
+  osxSign: macOSDistribution.osxSign,
+  osxNotarize: macOSDistribution.osxNotarize,
   ignore: [
     /^\/dist(?:\/|$)/,
     /^\/native(?:\/|$)/,
@@ -100,14 +96,11 @@ const appBundle =
   platform === "darwin"
     ? path.join(bundleRoot, `${packageJson.productName}.app`)
     : bundleRoot;
-const prunedLocales = await pruneElectronLocales(
-  appBundle,
-  platform,
-  supportedLocales,
-);
-console.log(
-  `Removed ${prunedLocales.removedLocales} unused Electron locale resources (${(prunedLocales.removedBytes / 1024 / 1024).toFixed(1)} MiB)`,
-);
+if (platform !== "darwin") {
+  logPrunedLocales(
+    await pruneElectronLocales(appBundle, platform, supportedLocales),
+  );
+}
 
 if (platform === "darwin") {
   await rename(
@@ -121,3 +114,9 @@ if (platform === "darwin") {
 }
 
 await rm(packagerOut, { recursive: true, force: true });
+
+function logPrunedLocales(prunedLocales) {
+  console.log(
+    `Removed ${prunedLocales.removedLocales} unused Electron locale resources (${(prunedLocales.removedBytes / 1024 / 1024).toFixed(1)} MiB)`,
+  );
+}

--- a/apps/desktop/scripts/macos-signing.mjs
+++ b/apps/desktop/scripts/macos-signing.mjs
@@ -1,0 +1,42 @@
+/** Resolve macOS signing and notarisation options from the build environment. */
+export function macOSDistributionOptions(platform, environment) {
+  if (platform !== "darwin") {
+    return { osxNotarize: undefined, osxSign: undefined };
+  }
+
+  const identity = environment.CHATTO_MACOS_SIGN_IDENTITY?.trim() || "-";
+  const notaryValues = {
+    appleApiIssuer:
+      environment.CHATTO_MACOS_NOTARY_API_ISSUER_ID?.trim() || undefined,
+    appleApiKey:
+      environment.CHATTO_MACOS_NOTARY_API_KEY?.trim() || undefined,
+    appleApiKeyId:
+      environment.CHATTO_MACOS_NOTARY_API_KEY_ID?.trim() || undefined,
+  };
+  const requestedNotarisation = Object.values(notaryValues).some(Boolean);
+
+  if (requestedNotarisation && identity === "-") {
+    throw new Error(
+      "CHATTO_MACOS_SIGN_IDENTITY is required when notarisation is configured.",
+    );
+  }
+  if (
+    requestedNotarisation &&
+    Object.values(notaryValues).some((value) => !value)
+  ) {
+    throw new Error(
+      "CHATTO_MACOS_NOTARY_API_KEY, CHATTO_MACOS_NOTARY_API_KEY_ID, and CHATTO_MACOS_NOTARY_API_ISSUER_ID must be set together.",
+    );
+  }
+
+  return {
+    osxNotarize: requestedNotarisation ? notaryValues : undefined,
+    osxSign: {
+      identity,
+      identityValidation: identity !== "-",
+      optionsForFile: () => ({
+        hardenedRuntime: identity !== "-",
+      }),
+    },
+  };
+}

--- a/apps/desktop/scripts/macos-signing.test.mjs
+++ b/apps/desktop/scripts/macos-signing.test.mjs
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { macOSDistributionOptions } from "./macos-signing.mjs";
+
+test("uses ad-hoc signing for ordinary macOS builds", () => {
+  const options = macOSDistributionOptions("darwin", {});
+
+  assert.equal(options.osxSign.identity, "-");
+  assert.equal(options.osxSign.identityValidation, false);
+  assert.deepEqual(options.osxSign.optionsForFile(), {
+    hardenedRuntime: false,
+  });
+  assert.equal(options.osxNotarize, undefined);
+});
+
+test("configures Developer ID signing and notarisation", () => {
+  const options = macOSDistributionOptions("darwin", {
+    CHATTO_MACOS_SIGN_IDENTITY: "Developer ID Application: ChattoCorp GmbH",
+    CHATTO_MACOS_NOTARY_API_KEY: "/tmp/AuthKey_123.p8",
+    CHATTO_MACOS_NOTARY_API_KEY_ID: "KEY123",
+    CHATTO_MACOS_NOTARY_API_ISSUER_ID: "issuer-id",
+  });
+
+  assert.equal(
+    options.osxSign.identity,
+    "Developer ID Application: ChattoCorp GmbH",
+  );
+  assert.equal(options.osxSign.identityValidation, true);
+  assert.deepEqual(options.osxSign.optionsForFile(), {
+    hardenedRuntime: true,
+  });
+  assert.deepEqual(options.osxNotarize, {
+    appleApiIssuer: "issuer-id",
+    appleApiKey: "/tmp/AuthKey_123.p8",
+    appleApiKeyId: "KEY123",
+  });
+});
+
+test("rejects incomplete notarisation credentials", () => {
+  assert.throws(
+    () =>
+      macOSDistributionOptions("darwin", {
+        CHATTO_MACOS_SIGN_IDENTITY: "Developer ID Application",
+        CHATTO_MACOS_NOTARY_API_KEY: "/tmp/key.p8",
+      }),
+    /must be set together/,
+  );
+});
+
+test("does not configure signing on other platforms", () => {
+  assert.deepEqual(
+    macOSDistributionOptions("linux", {}),
+    { osxNotarize: undefined, osxSign: undefined },
+  );
+});


### PR DESCRIPTION
## Why

Chatto Desktop macOS releases need a trusted Developer ID signature and Apple notarisation so Gatekeeper can validate downloaded builds.

## What changed

Release builds now import protected signing credentials into a temporary keychain, enable hardened runtime signing, notarise and staple the app, validate it with `codesign`, `stapler`, and `spctl`, retain redacted notarisation logs, and clean up credentials; packaging mutations now happen before signing, while local and PR builds retain ad-hoc signing.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise test-desktop` — 24 tests passed.
- `mise desktop-build` — local macOS app built successfully with the nested capture helper and frameworks.
- `codesign --verify --deep --strict --verbose=2 "apps/desktop/dist/Chatto Desktop.app"` — passed for the local ad-hoc bundle.
- `mise x -- actionlint .github/workflows/release.yml`, `mise license-check`, and `git diff --check` — passed.
- A manually dispatched `desktop` release workflow on `main` will provide the first end-to-end Developer ID and Apple notary-service verification without publishing a release.
