### PR TITLE
feat(desktop): sign Windows releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
   build-desktop-release:
     if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/chatto-desktop/v')) || (github.event_name == 'workflow_dispatch' && inputs.target == 'desktop') }}
     name: build-desktop-release (${{ matrix.platform }})
-    environment: desktop-signing
+    environment: ${{ matrix.environment }}
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -168,16 +168,34 @@ jobs:
         include:
           - platform: linux
             os: ubuntu-latest
+            environment: desktop-signing
           - platform: macos
             os: macos-15
+            environment: desktop-signing
           - platform: windows
             os: windows-latest
+            environment: desktop-windows-signing
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      - name: Verify trusted desktop ref
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git fetch origin '+refs/heads/main:refs/remotes/origin/main'
+          if ! git merge-base --is-ancestor HEAD origin/main; then
+            echo "::error::Desktop signing is restricted to commits reachable from origin/main."
+            exit 1
+          fi
 
       - name: Setup environment
         uses: ./.github/actions/setup
@@ -295,6 +313,35 @@ jobs:
             echo "CHATTO_MACOS_NOTARY_API_ISSUER_ID=${NOTARY_API_ISSUER_ID}"
           } >> "$GITHUB_ENV"
 
+      - name: Validate Windows signing configuration
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          AZURE_CLIENT_ID: ${{ secrets.CHATTO_WINDOWS_AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.CHATTO_WINDOWS_AZURE_TENANT_ID }}
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.CHATTO_WINDOWS_AZURE_SUBSCRIPTION_ID }}
+          SIGNING_ENDPOINT: ${{ vars.CHATTO_WINDOWS_SIGNING_ENDPOINT }}
+          SIGNING_ACCOUNT_NAME: ${{ vars.CHATTO_WINDOWS_SIGNING_ACCOUNT_NAME }}
+          CERTIFICATE_PROFILE_NAME: ${{ vars.CHATTO_WINDOWS_CERTIFICATE_PROFILE_NAME }}
+          EXPECTED_PUBLISHER: ${{ vars.CHATTO_WINDOWS_EXPECTED_PUBLISHER }}
+        run: |
+          $required = @{
+            CHATTO_WINDOWS_AZURE_CLIENT_ID = $env:AZURE_CLIENT_ID
+            CHATTO_WINDOWS_AZURE_TENANT_ID = $env:AZURE_TENANT_ID
+            CHATTO_WINDOWS_AZURE_SUBSCRIPTION_ID = $env:AZURE_SUBSCRIPTION_ID
+            CHATTO_WINDOWS_SIGNING_ENDPOINT = $env:SIGNING_ENDPOINT
+            CHATTO_WINDOWS_SIGNING_ACCOUNT_NAME = $env:SIGNING_ACCOUNT_NAME
+            CHATTO_WINDOWS_CERTIFICATE_PROFILE_NAME = $env:CERTIFICATE_PROFILE_NAME
+            CHATTO_WINDOWS_EXPECTED_PUBLISHER = $env:EXPECTED_PUBLISHER
+          }
+          $missing = @($required.GetEnumerator() | Where-Object {
+            [string]::IsNullOrWhiteSpace([string]$_.Value)
+          } | ForEach-Object Key)
+          if ($missing.Count -gt 0) {
+            Write-Error "The following Windows release settings are not configured: $($missing -join ', ')"
+            exit 1
+          }
+
       - name: Build desktop bundle
         shell: bash
         env:
@@ -307,6 +354,30 @@ jobs:
             mise desktop-build
           fi
 
+      - name: Log in to Azure for Windows signing
+        if: runner.os == 'Windows'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.CHATTO_WINDOWS_AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.CHATTO_WINDOWS_AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.CHATTO_WINDOWS_AZURE_SUBSCRIPTION_ID }}
+
+      - name: Sign Windows desktop bundle
+        if: runner.os == 'Windows'
+        uses: azure/artifact-signing-action@v2
+        with:
+          endpoint: ${{ vars.CHATTO_WINDOWS_SIGNING_ENDPOINT }}
+          signing-account-name: ${{ vars.CHATTO_WINDOWS_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ vars.CHATTO_WINDOWS_CERTIFICATE_PROFILE_NAME }}
+          files-folder: ${{ github.workspace }}\apps\desktop\dist\windows
+          files-folder-filter: exe,dll,node
+          files-folder-recurse: true
+          file-digest: SHA256
+          timestamp-rfc3161: http://timestamp.acs.microsoft.com
+          timestamp-digest: SHA256
+          description: Chatto Desktop
+          description-url: https://chatto.run
+
       - name: Verify bundled frontend version
         shell: bash
         env:
@@ -315,6 +386,44 @@ jobs:
           jq -e --arg expected "$EXPECTED_VERSION" \
             '.version == $expected' \
             apps/frontend/build/_app/version.json
+
+      - name: Verify Windows bundle signatures
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          EXPECTED_PUBLISHER: ${{ vars.CHATTO_WINDOWS_EXPECTED_PUBLISHER }}
+        run: |
+          $bundle = Resolve-Path "apps/desktop/dist/windows"
+          $files = @(Get-ChildItem -LiteralPath $bundle -File -Recurse | Where-Object {
+            $_.Extension -in '.exe', '.dll', '.node'
+          })
+          if ($files.Count -eq 0) {
+            Write-Error "The Windows bundle contains no executable files to verify."
+            exit 1
+          }
+
+          $failed = $false
+          foreach ($file in $files) {
+            $signature = Get-AuthenticodeSignature -LiteralPath $file.FullName
+            $publisher = $signature.SignerCertificate.Subject
+            $hasExpectedPublisher = [string]::Equals(
+              $publisher,
+              $env:EXPECTED_PUBLISHER,
+              [System.StringComparison]::OrdinalIgnoreCase
+            )
+            if (
+              $signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
+              -not $hasExpectedPublisher -or
+              $null -eq $signature.TimeStamperCertificate
+            ) {
+              Write-Error "$($file.FullName): status=$($signature.Status), publisher='$publisher', timestamped=$($null -ne $signature.TimeStamperCertificate)"
+              $failed = $true
+            }
+          }
+          if ($failed) {
+            exit 1
+          }
+          Write-Host "Verified $($files.Count) signed Windows executable files from '$env:EXPECTED_PUBLISHER'."
 
       - name: Package macOS release
         if: runner.os == 'macOS'

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -43,10 +43,12 @@ The build task first produces the frontend, then packages the host-platform
 bundle beneath `apps/desktop/dist/`. macOS builds include the native
 ScreenCaptureKit game-capture helper and its pinned LiveKit frameworks. CI
 checks and packages macOS, Windows, and Linux bundles, verifies the nested macOS
-helper, and validates the complete app signature. Ordinary local and pull-request
-builds use ad-hoc signing. Release builds use Developer ID signing, the hardened
-runtime, and Apple notarisation, then staple and validate the notarisation ticket
-before creating the release archive.
+helper, and validates platform signatures. Ordinary local and pull-request macOS
+builds use ad-hoc signing; ordinary Windows and Linux builds remain unsigned.
+Release builds use Developer ID signing and Apple notarisation on macOS and
+Microsoft Artifact Signing on Windows. CI verifies every shipped Windows
+executable and library against ChattoCorp's expected publisher identity and
+requires an RFC 3161 timestamp before creating the release archive.
 
 ### Configure macOS release signing
 
@@ -100,6 +102,76 @@ export CHATTO_MACOS_NOTARY_API_KEY_ID='KEY_ID'
 export CHATTO_MACOS_NOTARY_API_ISSUER_ID='ISSUER_UUID'
 mise desktop-build
 ```
+
+### Configure Windows release signing
+
+Windows releases use Microsoft Artifact Signing (formerly Trusted Signing) with
+GitHub's short-lived OpenID Connect credentials. No code-signing private key is
+exported to GitHub Actions.
+
+An Azure administrator must complete the one-time service setup:
+
+1. Create an Artifact Signing account and an organization-validated **Public
+   Trust** certificate profile for ChattoCorp GmbH. Record the account endpoint,
+   account name, profile name, and the complete certificate subject shown by the
+   issued profile.
+2. Create a Microsoft Entra application and service principal for the release
+   workflow. Add a **GitHub Actions deploying Azure resources** federated
+   credential for organization `chattocorp` (`261891647`), repository `chatto`
+   (`1205013299`), and environment `desktop-windows-signing`, with audience
+   `api://AzureADTokenExchange`. Azure generates the immutable-ID subject
+   `repo:chattocorp@261891647/chatto@1205013299:environment:desktop-windows-signing`.
+3. Grant that service principal only the **Artifact Signing Certificate Profile
+   Signer** role, scoped to the Chatto Desktop signing account.
+4. Create a protected `desktop-windows-signing` Actions environment and add the
+   following secrets and variables to it. Keep the macOS credentials in the
+   existing `desktop-signing` environment so the two platforms cannot access
+   one another's signing credentials.
+
+| Kind | Name | Value |
+| --- | --- | --- |
+| Secret | `CHATTO_WINDOWS_AZURE_CLIENT_ID` | Entra application (client) ID |
+| Secret | `CHATTO_WINDOWS_AZURE_TENANT_ID` | Entra directory (tenant) ID |
+| Secret | `CHATTO_WINDOWS_AZURE_SUBSCRIPTION_ID` | Azure subscription ID |
+| Variable | `CHATTO_WINDOWS_SIGNING_ENDPOINT` | Regional account endpoint, including `https://` |
+| Variable | `CHATTO_WINDOWS_SIGNING_ACCOUNT_NAME` | Artifact Signing account name |
+| Variable | `CHATTO_WINDOWS_CERTIFICATE_PROFILE_NAME` | Public Trust certificate profile name |
+| Variable | `CHATTO_WINDOWS_EXPECTED_PUBLISHER` | Complete certificate subject, exactly as Windows reports it |
+
+Configure `desktop-windows-signing` to permit deployments only from
+`chatto-desktop/v*` tags and the `main` branch used for manually dispatched
+verification builds. Require a reviewer, who must approve a release before the
+Windows runner can request an Azure token.
+Enable prevention of self-review when another authorised reviewer is available;
+do not enable it for a single-reviewer environment, because that would make
+releases impossible. The release workflow fails before building when any
+setting is missing. After building, it signs every `.exe`, `.dll`, and native
+`.node` module recursively with SHA-256 and an RFC 3161 timestamp, then rejects
+missing, invalid, untimestamped, or unexpectedly published signatures before
+packaging the ZIP.
+
+Before the first tagged release, manually run the `release` workflow with the
+`desktop` target on `main`, approve the protected environment, and inspect the
+Windows verification ZIP on a clean supported Windows installation. In File
+Explorer, the Digital Signatures tab on `chatto-desktop.exe` must show the same
+publisher configured in `CHATTO_WINDOWS_EXPECTED_PUBLISHER`; PowerShell's
+`Get-AuthenticodeSignature` must report `Valid`.
+
+Artifact Signing keeps the signing keys and short-lived leaf certificates in
+Azure, so routine renewal does not require rotating a PFX secret. Renew the
+organization validation and certificate profile before Azure reports expiry.
+When replacing a profile, preserve the exact publisher subject, update only
+`CHATTO_WINDOWS_CERTIFICATE_PROFILE_NAME`, and complete the manual verification
+build before releasing. Do not change `CHATTO_WINDOWS_EXPECTED_PUBLISHER` unless
+the publisher identity is deliberately migrating and the installer/update plan
+has been reviewed.
+
+For emergency revocation, first remove the Entra role assignment or federated
+credential to stop new signatures, then revoke or disable the affected
+certificate profile in Azure. Remove the GitHub environment values, review
+Azure and GitHub audit logs, replace the Entra application if its identity was
+compromised, and publish incident-specific user guidance before signing with a
+replacement identity.
 
 Electron handles camera, microphone, and notification permission requests only
 for the fixed app origin. Screen sharing presents a native source picker.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -59,10 +59,13 @@ server release component.
 
 Merging a Chatto Desktop release PR creates a draft GitHub release and the
 component tag. The release workflow checks and builds macOS, Windows, and Linux
-bundles from that tag, uploads archives and SHA-256 checksums, then publishes
-the release. These artifacts are currently unsigned experimental builds.
-Platform signing and notarisation must be added before presenting them as
-trusted general-user downloads.
+bundles from that tag, signs and notarises the macOS bundle, signs and verifies
+every Windows executable against the expected ChattoCorp publisher identity,
+uploads archives and SHA-256 checksums, then publishes the release. Linux and
+ordinary CI artifacts remain unsigned experimental builds. Windows and macOS
+use separate protected signing environments. Signing-service provisioning,
+protected-environment settings, renewal, and emergency revocation are
+documented in [`apps/desktop/README.md`](../apps/desktop/README.md).
 
 The desktop shell version and the bundled Chatto frontend version answer
 different questions. The desktop version identifies packaging and runtime
@@ -72,9 +75,14 @@ version embedded by the tagged commit.
 Before publishing a tag, the release workflow can verify the complete desktop
 packaging path without creating a release or building a Chatto server image.
 Run the `release` workflow manually, select the `desktop` target, and optionally
-provide a branch, tag, or commit in the `ref` input. The workflow builds and
-packages all three platforms, generates the same checksum file used by a tagged
-release, and uploads the assembled files as a one-day verification artifact.
+provide a branch, tag, or commit reachable from `origin/main` in the `ref`
+input. Signed desktop builds reject other commits before running repository
+code or requesting signing credentials. The workflow builds and packages all
+three platforms, generates the same checksum file used by a tagged release, and
+uploads the assembled files as a one-day verification artifact.
+
+Desktop release tags must also point to commits reachable from `origin/main`.
+The signing jobs enforce this before running repository code.
 
 ## Create a stable release branch
 

--- a/docs/fdr/FDR-034-chatto-desktop.md
+++ b/docs/fdr/FDR-034-chatto-desktop.md
@@ -1,7 +1,7 @@
 # FDR-034: Chatto Desktop
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-13
+**Last reviewed:** 2026-08-18
 
 ## Overview
 
@@ -40,9 +40,11 @@ system-browser authentication, and clean-machine media behavior are hardened.
   Acknowledged lifecycle control keeps the UI in a stopping state until the
   helper disconnects its LiveKit companion and exits. Hosts without this
   capability keep the browser's ordinary source chooser.
-- macOS, Windows, and Linux bundles are built in CI. Experimental macOS
-  artifacts are ad-hoc signed, while the other platform artifacts remain
-  unsigned until trusted platform signing and macOS notarisation are added.
+- macOS, Windows, and Linux bundles are built in CI. Release macOS artifacts
+  are Developer ID signed and notarised. Release Windows executables and
+  libraries are signed through Microsoft Artifact Signing with ChattoCorp's
+  stable publisher identity and timestamped before CI packages them. Local,
+  pull-request, and Linux artifacts are not trusted release builds.
 - Chatto Desktop has an independent version and changelog. Its release tags use
   `chatto-desktop/v{version}` and do not change the Chatto server version.
 - Each release rebuilds and embeds the official frontend from the Desktop tag's
@@ -117,15 +119,23 @@ different from Chatto server releases.
 **Tradeoff:** Compatibility diagnostics must distinguish the desktop shell
 version from the bundled Chatto client version.
 
-### 6. Build all supported host bundles before signing them
+### 6. Build all supported host bundles and sign trusted releases
 
-**Decision:** CI checks and builds macOS, Windows, and Linux bundles. Early
-artifacts may be published unsigned, but trusted signing and notarisation remain
-a separate release-hardening milestone.
+**Decision:** CI checks and builds macOS, Windows, and Linux bundles. The
+protected release workflow Developer ID signs and notarises macOS, and uses
+Microsoft Artifact Signing with GitHub OpenID Connect to sign Windows PE files.
+It validates macOS acceptance and every Windows signature, timestamp, and
+publisher subject before packaging. Linux remains unsigned until its
+update-capable package and trust model are selected.
 **Why:** Cross-platform builds catch packaging drift and let contributors test
-the application before release credentials are available.
-**Tradeoff:** Operating systems may warn about or block unsigned artifacts, and
-CI assembly alone does not prove clean-machine WebRTC behavior.
+the application before release credentials are available. Managed Windows
+signing keeps the private key out of GitHub while a protected environment and
+least-privilege Azure role restrict which revisions can request signatures.
+Windows and macOS use separate protected environments so neither platform's
+runner can access the other platform's signing credentials.
+**Tradeoff:** Ordinary CI artifacts remain unsigned, Windows signing depends on
+Azure availability and organization validation, and CI signature checks do not
+replace clean-machine installation or WebRTC verification.
 
 ### 7. Expose desktop-only capabilities through narrow optional bridges
 
@@ -187,7 +197,6 @@ media path that can adapt to each receiver.
 
 - How system-browser OAuth callbacks and normal external links should return to
   or focus the application on every platform.
-- Which platform and architecture becomes the first signed release target.
 - Which installer and automatic-update strategy should follow the first
   downloadable archives.
 - Whether Electron's shipped codec set covers every media artifact Chatto

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -43,7 +43,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-07-30 |
 | [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-07-19 |
 | [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-07-31 |
-| [FDR-034](FDR-034-chatto-desktop.md) | Chatto Desktop | Experimental | 2026-08-13 |
+| [FDR-034](FDR-034-chatto-desktop.md) | Chatto Desktop | Experimental | 2026-08-18 |
 | [FDR-035](FDR-035-slow-mode.md) | Slow Mode | Active | 2026-08-11 |
 | [FDR-036](FDR-036-invite-links.md) | Invite Links | Active | 2026-08-11 |
 | [FDR-037](FDR-037-pinned-messages.md) | Pinned Messages | Active | 2026-08-11 |


### PR DESCRIPTION
## Why

Chatto Desktop's Windows release archive is currently unsigned, causing Windows trust warnings and leaving no stable verified publisher identity for future installers and updates.

## What changed

- Sign every shipped Windows `.exe`, `.dll`, and native `.node` module through Microsoft Artifact Signing with GitHub OIDC, SHA-256, and RFC 3161 timestamps.
- Fail closed on missing configuration, invalid or untimestamped signatures, an unexpected publisher subject, and manually selected refs not reachable from `origin/main`.
- Isolate Windows credentials in `desktop-windows-signing` and document provisioning, protected-environment policy, renewal, revocation, and release verification in the Desktop FDR and operator guides.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise test-desktop` — 24 tests passed.
- `mise x -- actionlint .github/workflows/*.yml` — passed.
- `mise license-check` — 2,962/2,962 files compliant.
- `git diff --check origin/main...HEAD` — passed.
- Post-merge: dispatch the `release` workflow with target `desktop` from `main`, approve `desktop-windows-signing`, and inspect the signed verification ZIP on a clean supported Windows system.

Advances #1945.
