### PR TITLE
fix(desktop): require immutable GitHub OIDC subjects

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,6 +427,11 @@ jobs:
             Write-Error "The Windows bundle contains no executable files to verify."
             exit 1
           }
+          $application = Join-Path $bundle "chatto-desktop.exe"
+          if (-not (Test-Path -LiteralPath $application -PathType Leaf)) {
+            Write-Error "The Windows bundle does not contain chatto-desktop.exe."
+            exit 1
+          }
 
           $failed = $false
           foreach ($file in $files) {
@@ -437,9 +442,14 @@ jobs:
               $env:EXPECTED_PUBLISHER,
               [System.StringComparison]::OrdinalIgnoreCase
             )
+            $requiresExpectedPublisher = [string]::Equals(
+              $file.FullName,
+              $application,
+              [System.StringComparison]::OrdinalIgnoreCase
+            )
             if (
               $signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid -or
-              -not $hasExpectedPublisher -or
+              ($requiresExpectedPublisher -and -not $hasExpectedPublisher) -or
               $null -eq $signature.TimeStamperCertificate
             ) {
               Write-Error "$($file.FullName): status=$($signature.Status), publisher='$publisher', timestamped=$($null -ne $signature.TimeStamperCertificate)"
@@ -449,7 +459,7 @@ jobs:
           if ($failed) {
             exit 1
           }
-          Write-Host "Verified $($files.Count) signed Windows executable files from '$env:EXPECTED_PUBLISHER'."
+          Write-Host "Verified $($files.Count) valid, timestamped Windows executable signatures; chatto-desktop.exe is published by '$env:EXPECTED_PUBLISHER'."
 
       - name: Package macOS release
         if: runner.os == 'macOS'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,6 +177,7 @@ jobs:
             environment: desktop-windows-signing
     runs-on: ${{ matrix.os }}
     permissions:
+      actions: read
       contents: read
       id-token: write
     steps:
@@ -194,6 +195,31 @@ jobs:
           git fetch origin '+refs/heads/main:refs/remotes/origin/main'
           if ! git merge-base --is-ancestor HEAD origin/main; then
             echo "::error::Desktop signing is restricted to commits reachable from origin/main."
+            exit 1
+          fi
+
+      - name: Verify immutable GitHub OIDC subject
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_SUBJECT_PREFIX: repo:chattocorp@261891647/chatto@1205013299
+        run: |
+          set -euo pipefail
+
+          if ! configuration="$(
+            gh api \
+              -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/${GITHUB_REPOSITORY}/actions/oidc/customization/sub" \
+              --jq '[.use_default, .use_immutable_subject, .sub_claim_prefix] | @tsv'
+          )"; then
+            echo "::error::Could not read the repository's GitHub OIDC configuration."
+            exit 1
+          fi
+
+          expected_configuration="$(printf 'true\ttrue\t%s' "$EXPECTED_SUBJECT_PREFIX")"
+          if [[ "$configuration" != "$expected_configuration" ]]; then
+            echo "::error::Enable the repository's default immutable GitHub OIDC subject before configuring Azure federation. Expected prefix '${EXPECTED_SUBJECT_PREFIX}'."
             exit 1
           fi
 

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -115,15 +115,38 @@ An Azure administrator must complete the one-time service setup:
    Trust** certificate profile for ChattoCorp GmbH. Record the account endpoint,
    account name, profile name, and the complete certificate subject shown by the
    issued profile.
-2. Create a Microsoft Entra application and service principal for the release
+2. In the GitHub repository's Actions OIDC settings, enable immutable OIDC
+   subject claims. Do this before creating the Azure federated credential:
+   repositories created before 15 July 2026 otherwise
+   continue to issue name-based subjects that Azure will reject when configured
+   with the immutable subject below. Repository administrators can configure and
+   verify the setting with the GitHub CLI:
+
+   ```sh
+   gh api --method PUT \
+     -H "X-GitHub-Api-Version: 2026-03-10" \
+     repos/chattocorp/chatto/actions/oidc/customization/sub \
+     -F use_default=true \
+     -F use_immutable_subject=true
+   gh api \
+     -H "X-GitHub-Api-Version: 2026-03-10" \
+     repos/chattocorp/chatto/actions/oidc/customization/sub
+   ```
+
+   The response must report `"use_default": true`,
+   `"use_immutable_subject": true`, and the prefix
+   `repo:chattocorp@261891647/chatto@1205013299`. The prefix shown by this API
+   intentionally omits the job context; an OIDC token requested by the signing
+   job appends `:environment:desktop-windows-signing`.
+3. Create a Microsoft Entra application and service principal for the release
    workflow. Add a **GitHub Actions deploying Azure resources** federated
    credential for organization `chattocorp` (`261891647`), repository `chatto`
    (`1205013299`), and environment `desktop-windows-signing`, with audience
    `api://AzureADTokenExchange`. Azure generates the immutable-ID subject
    `repo:chattocorp@261891647/chatto@1205013299:environment:desktop-windows-signing`.
-3. Grant that service principal only the **Artifact Signing Certificate Profile
+4. Grant that service principal only the **Artifact Signing Certificate Profile
    Signer** role, scoped to the Chatto Desktop signing account.
-4. Create a protected `desktop-windows-signing` Actions environment and add the
+5. Create a protected `desktop-windows-signing` Actions environment and add the
    following secrets and variables to it. Keep the macOS credentials in the
    existing `desktop-signing` environment so the two platforms cannot access
    one another's signing credentials.
@@ -145,10 +168,11 @@ Windows runner can request an Azure token.
 Enable prevention of self-review when another authorised reviewer is available;
 do not enable it for a single-reviewer environment, because that would make
 releases impossible. The release workflow fails before building when any
-setting is missing. After building, it signs every `.exe`, `.dll`, and native
-`.node` module recursively with SHA-256 and an RFC 3161 timestamp, then rejects
-missing, invalid, untimestamped, or unexpectedly published signatures before
-packaging the ZIP.
+setting is missing or when the repository is not using the documented default
+immutable OIDC subject. After building, it signs every `.exe`, `.dll`, and
+native `.node` module recursively with SHA-256 and an RFC 3161 timestamp, then
+rejects missing, invalid, untimestamped, or unexpectedly published signatures
+before packaging the ZIP.
 
 Before the first tagged release, manually run the `release` workflow with the
 `desktop` target on `main`, approve the protected environment, and inspect the

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -47,8 +47,9 @@ helper, and validates platform signatures. Ordinary local and pull-request macOS
 builds use ad-hoc signing; ordinary Windows and Linux builds remain unsigned.
 Release builds use Developer ID signing and Apple notarisation on macOS and
 Microsoft Artifact Signing on Windows. CI verifies every shipped Windows
-executable and library against ChattoCorp's expected publisher identity and
-requires an RFC 3161 timestamp before creating the release archive.
+executable and library has a valid RFC 3161-timestamped signature, and verifies
+`chatto-desktop.exe` against ChattoCorp's expected publisher identity before
+creating the release archive.
 
 ### Configure macOS release signing
 
@@ -171,8 +172,10 @@ releases impossible. The release workflow fails before building when any
 setting is missing or when the repository is not using the documented default
 immutable OIDC subject. After building, it signs every `.exe`, `.dll`, and
 native `.node` module recursively with SHA-256 and an RFC 3161 timestamp, then
-rejects missing, invalid, untimestamped, or unexpectedly published signatures
-before packaging the ZIP.
+rejects missing, invalid, or untimestamped signatures before packaging the ZIP.
+The main `chatto-desktop.exe` must also report the expected ChattoCorp publisher;
+bundled third-party libraries may retain their original valid publisher, such
+as Microsoft.
 
 Before the first tagged release, manually run the `release` workflow with the
 `desktop` target on `main`, approve the protected environment, and inspect the

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -60,12 +60,12 @@ server release component.
 Merging a Chatto Desktop release PR creates a draft GitHub release and the
 component tag. The release workflow checks and builds macOS, Windows, and Linux
 bundles from that tag, signs and notarises the macOS bundle, signs and verifies
-every Windows executable against the expected ChattoCorp publisher identity,
-uploads archives and SHA-256 checksums, then publishes the release. Linux and
-ordinary CI artifacts remain unsigned experimental builds. Windows and macOS
-use separate protected signing environments. Signing-service provisioning,
-protected-environment settings, renewal, and emergency revocation are
-documented in [`apps/desktop/README.md`](../apps/desktop/README.md).
+every Windows executable, requires the expected ChattoCorp publisher on the
+main application, uploads archives and SHA-256 checksums, then publishes the
+release. Linux and ordinary CI artifacts remain unsigned experimental builds.
+Windows and macOS use separate protected signing environments. Signing-service
+provisioning, protected-environment settings, renewal, and emergency revocation
+are documented in [`apps/desktop/README.md`](../apps/desktop/README.md).
 
 The desktop shell version and the bundled Chatto frontend version answer
 different questions. The desktop version identifies packaging and runtime

--- a/docs/fdr/FDR-034-chatto-desktop.md
+++ b/docs/fdr/FDR-034-chatto-desktop.md
@@ -42,9 +42,11 @@ system-browser authentication, and clean-machine media behavior are hardened.
   capability keep the browser's ordinary source chooser.
 - macOS, Windows, and Linux bundles are built in CI. Release macOS artifacts
   are Developer ID signed and notarised. Release Windows executables and
-  libraries are signed through Microsoft Artifact Signing with ChattoCorp's
-  stable publisher identity and timestamped before CI packages them. Local,
-  pull-request, and Linux artifacts are not trusted release builds.
+  libraries are signed and timestamped through Microsoft Artifact Signing
+  before CI packages them. The main application must report ChattoCorp's stable
+  publisher identity; bundled third-party libraries may retain their original
+  valid publisher. Local, pull-request, and Linux artifacts are not trusted
+  release builds.
 - Chatto Desktop has an independent version and changelog. Its release tags use
   `chatto-desktop/v{version}` and do not change the Chatto server version.
 - Each release rebuilds and embeds the official frontend from the Desktop tag's
@@ -124,9 +126,10 @@ version from the bundled Chatto client version.
 **Decision:** CI checks and builds macOS, Windows, and Linux bundles. The
 protected release workflow Developer ID signs and notarises macOS, and uses
 Microsoft Artifact Signing with GitHub OpenID Connect to sign Windows PE files.
-It validates macOS acceptance and every Windows signature, timestamp, and
-publisher subject before packaging. Linux remains unsigned until its
-update-capable package and trust model are selected.
+It validates macOS acceptance, every Windows signature and timestamp, and the
+main application's publisher subject before packaging. Bundled third-party
+libraries may retain their original valid publisher. Linux remains unsigned
+until its update-capable package and trust model are selected.
 **Why:** Cross-platform builds catch packaging drift and let contributors test
 the application before release credentials are available. Managed Windows
 signing keeps the private key out of GitHub while a protected environment and


### PR DESCRIPTION
## Why

The post-merge Desktop verification issued the legacy name-based GitHub OIDC subject, so Azure rejected it because its federated credential expected immutable organisation and repository IDs.

## What changed

The setup guide now enables and verifies immutable GitHub OIDC subjects before Azure federation, and explains that GitHub's reported prefix omits the environment context. The Windows release job now checks the live default OIDC configuration before building, requires every bundled executable to have a valid timestamped signature, and reserves the ChattoCorp publisher requirement for the main application so valid vendor-signed dependencies are accepted.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x actionlint -- actionlint .github/workflows/release.yml` — passed.
- `git diff --check` — passed.
- Manual Desktop release run 32149458571, attempt 2 — the immutable OIDC subject, `azure/login@v3`, and Artifact Signing of all nine Windows binaries passed.
- Attempt 2 exposed the former signature-policy check rejecting the valid, timestamped Microsoft signature on `d3dcompiler_47.dll`; a rerun of the corrected check is pending.
