### PR TITLE
fix(dockercompose): restart services unless stopped

### DIFF
--- a/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/docker-compose.mdx
@@ -63,6 +63,9 @@ hostname.
    docker compose up -d
    ```
 
+   All services use the `unless-stopped` restart policy, so Docker restarts
+   them after a failure or host reboot unless you stopped them manually.
+
    Caddy will automatically obtain TLS certificates for both domains. Visit `https://chat.example.com` to create your first account with the email address from `CHATTO_OWNERS_EMAILS`.
 
 </Steps>

--- a/examples/dockercompose/README.md
+++ b/examples/dockercompose/README.md
@@ -22,6 +22,9 @@ Visit `https://chat.example.com` and register with `admin@example.com`. Caddy
 obtains the HTTPS certificates automatically. The rest of this README explains
 the stack and the available customization options.
 
+All services use the `unless-stopped` restart policy, so Docker restarts them
+after a failure or host reboot unless you stopped them manually.
+
 `livekit.chat.example.com` is only an example. You can use any hostname you
 control, such as `calls.example.com`; update `CHATTO_LIVEKIT_URL` and the
 matching proxy route when using a different name.

--- a/examples/dockercompose/compose.yml
+++ b/examples/dockercompose/compose.yml
@@ -1,12 +1,14 @@
 services:
   nats:
     image: nats:latest
+    restart: unless-stopped
     command: ["--jetstream", "--store_dir=/data", "--auth=${NATS_TOKEN}"]
     volumes:
       - nats_data:/data
 
   livekit:
     image: livekit/livekit-server:latest
+    restart: unless-stopped
     command:
       - --config
       - /etc/livekit.yaml
@@ -21,6 +23,7 @@ services:
 
   chatto:
     image: ghcr.io/chattocorp/chatto:latest
+    restart: unless-stopped
     env_file: .env
     environment:
       PUID: "${PUID:-1000}"
@@ -32,6 +35,7 @@ services:
 
   caddy:
     image: caddy:latest
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Why

Docker Compose deployments should recover automatically after service failures and host reboots without overriding an operator's explicit stop.

## What changed

- Set `restart: unless-stopped` for NATS, LiveKit, Chatto, and Caddy.
- Document the restart behaviour in the example README and public deployment guide.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `docker compose config --quiet` with the example environment — passed.
- Inspected the rendered Compose model and confirmed all four services resolve to `unless-stopped` — passed.
- `mise x -- pnpm --filter docs-website build` — passed.
- `git diff --check` — passed.
