### PR TITLE
fix(frontend): preserve composer drag selections

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -130,13 +130,19 @@
   });
 </script>
 
-<!-- svelte-ignore a11y_click_events_have_key_events -->
 <!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
   {@attach composer.observeResize}
   class="flex flex-col gap-2 p-2"
-  onclick={(event) => {
-    if (!(event.target as HTMLElement).closest('button, a, input, label, select, .tiptap')) {
+  onpointerdown={(event) => {
+    const target = event.target;
+    // Keep this on pointerdown: a release-time click after selecting into the
+    // padding would refocus the editor and collapse the selection.
+    if (
+      event.button === 0 &&
+      target instanceof Element &&
+      !target.closest('button, a, input, label, select, .tiptap')
+    ) {
       composer.editorApi?.focus();
     }
   }}

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -443,6 +443,25 @@ describe('MessageComposer', () => {
       expect(toolbar?.contains(q(container, 'button[aria-label="Send message"]'))).toBe(true);
     });
 
+    it('preserves an editor selection when a mouse drag ends over composer padding', async () => {
+      const { container } = renderMessageComposer({ roomId: 'room-selection-padding' });
+      const editor = await findEditor(container);
+      const surface = q(container, '[data-testid="composer-input-surface"]')!;
+      await typeInEditor(editor, 'keep this selected');
+      await selectEditorContents(editor);
+
+      editor.dispatchEvent(
+        new PointerEvent('pointerdown', { bubbles: true, button: 0, pointerType: 'mouse' })
+      );
+      surface.dispatchEvent(
+        new PointerEvent('pointerup', { bubbles: true, button: 0, pointerType: 'mouse' })
+      );
+      surface.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+      await tick();
+
+      expect(window.getSelection()?.toString()).toBe('keep this selected');
+    });
+
     it('uses the composer width to control labels and keeps formatting controls on one row', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
 


### PR DESCRIPTION
## Why

Dragging a text selection from the composer editor into its padding collapsed the selection when the mouse button was released.

## What changed

- Focus composer padding on primary `pointerdown`, before a selection drag can produce a release-time click.
- Preserve padding-to-focus behaviour while ignoring editor content and interactive controls.
- Add browser-component regression coverage for releasing a selection drag over composer padding.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `MessageComposer.svelte.spec.ts`: 138 tests passed.
- `mise lint-frontend`: passed with zero errors or warnings.
- Svelte autofixer: no issues.
- Chrome DevTools: selection remained intact after release over padding, and a direct padding press still focused the editor.
