### PR TITLE
feat(authling): add auditable password reset recovery

### DIFF
--- a/authling/AGENTS.md
+++ b/authling/AGENTS.md
@@ -42,10 +42,10 @@ to its own repository.
   issuers remain first-class.
 - The current experimental runtime persists and replays local accounts,
   exposes server-rendered verified-email signup, password login, browser
-  sessions, and logout, and provides the narrow OpenID Connect surface recorded
-  in FDR-004. It has no public account-management, application-data, document,
-  or synchronization API. Do not document other planned identity-provider
-  behavior as implemented.
+  sessions, password reset, and logout, and provides the narrow OpenID Connect
+  surface recorded in FDR-004. It has no public account-management,
+  application-data, document, or synchronization API. Do not document other
+  planned identity-provider behavior as implemented.
 
 ## Code And Dependency Boundaries
 
@@ -129,6 +129,39 @@ repository skills as non-product infrastructure.
 - Default to least privilege and fail closed when identity, key, issuer, or
   authorization state is unavailable.
 
+## Identity Events And Recovery
+
+- Treat `authling.core.v1.Event` and every reachable event payload as a
+  persisted storage contract. Existing fields and oneof tags must never be
+  removed, renumbered, reused, or incompatibly retyped. New event variants
+  require historical-replay and mixed-version rollout reasoning.
+- Durable, PII-free identity and security facts belong in `AUTHLING_EVT`.
+  Expiring OTP digests, recovery bearers, attempt counters, delivery limits,
+  and other workflow coordination belong in encrypted
+  `AUTHLING_RUNTIME_STATE`, not permanent event history.
+- Never put raw email addresses, login identifiers, provider subjects, IP
+  addresses, user agents, OTPs, recovery bearers, reset links, or equivalent
+  sensitive material in event envelopes, event payloads, subjects, runtime
+  keys, URLs, or logs. Correlate related durable facts with opaque identifiers.
+- When auditability requires an event before an external effect, commit the
+  event before creating the dependent workflow or performing that effect.
+  State precisely what the event proves, such as request acceptance rather
+  than successful email delivery.
+- Commands that append to an existing aggregate must use subject-level OCC.
+  After a conflict, wait for and re-read the authoritative projection, then
+  decide from the command's semantic preconditions. An audit-only event may
+  advance an aggregate tail without changing its credential or identity state.
+- Projectors must validate and deterministically replay every historical event.
+  An audit-only event may intentionally leave the materialized account model
+  unchanged, but it must not be silently ignored or weaken replay validation.
+- Account recovery and identity mutations must explicitly define their effect
+  on stable account IDs and OIDC `sub` values, verified identifiers, Authling
+  browser sessions, issued OIDC tokens, and relying-party sessions.
+- Enumeration resistance covers the complete observable flow, including HTTP
+  status, browser copy, delivery behavior, storage failures, and timing where
+  practical. Do not preserve attacker-controlled failures permanently merely
+  to make them auditable; use bounded operational or runtime state instead.
+
 ## Releases And Compatibility
 
 - Authling's Release Please component is `authling/`, its version source is
@@ -149,6 +182,7 @@ Run Authling's own `mise` tasks from the `authling/` directory:
 
 ```sh
 cd authling
+mise codegen
 mise test
 mise test-e2e
 mise build
@@ -165,3 +199,8 @@ protocol tests when behavior crosses HTTP, OIDC, NATS, JetStream, cryptographic,
 or process-lifecycle boundaries. Browser end-to-end tests use a dedicated
 Authling process, Mailpit process, port range, and temporary data directory per
 test; do not point them at development state or share a process across tests.
+Persisted-event and recovery changes require relevant malformed-event,
+historical replay or restart, OCC conflict, enumeration-resistance, and
+PII/recovery-material leakage tests. Regenerate and commit derived protobuf or
+templ output after changing its source. Review visible Authling browser changes
+with Chrome DevTools MCP in addition to running the relevant automated tests.

--- a/authling/README.md
+++ b/authling/README.md
@@ -2,7 +2,7 @@
 
 Authling is a standalone, self-hostable OpenID Connect identity provider. Its
 experimental runtime currently provides verified-email signup, encrypted local
-credentials, password login, revocable browser sessions, and a small
+credentials, password login and reset, revocable browser sessions, and a small
 Authorization Code OpenID Provider for conventional and CIMD clients. It also
 stores only identity-provider state; application data and synchronization are
 outside its scope.
@@ -81,8 +81,9 @@ mise dev
 ```
 
 The development configuration serves Authling at <http://localhost:8080>, with
-signup at <http://localhost:8080/signup> and login at
-<http://localhost:8080/login>. Mailpit receives SMTP on port 1025 and shows
+signup at <http://localhost:8080/signup>, login at
+<http://localhost:8080/login>, and password reset at
+<http://localhost:8080/password-reset>. Mailpit receives SMTP on port 1025 and shows
 captured messages at <http://127.0.0.1:8025>. Set
 `AUTHLING_HTTP_BIND_ADDRESS` to override the Authling listener and
 `AUTHLING_HTTP_PUBLIC_URL` to its externally visible origin. The checked-in

--- a/authling/TODO.md
+++ b/authling/TODO.md
@@ -17,8 +17,8 @@ current runtime in `docs/architecture/`.
 
 ## Later account and authentication work
 
-- [ ] Add password recovery and email-address change flows
-- [ ] Define credential rotation and session revocation policies
+- [ ] Add a verified email-address change flow
+- [ ] Define signed-in credential rotation and selective session revocation policies
 - [ ] Design upstream SSO through Goth-supported providers
 - [ ] Define secure upstream-account linking and email-collision behavior
 - [ ] Implement an event-backed orphan-key cleanup worker and crash/race tests
@@ -39,7 +39,7 @@ current runtime in `docs/architecture/`.
 
 ## Later user interface work
 
-- [ ] Design recovery, consent, and account-linking experiences
+- [ ] Design email-change, MFA-recovery, consent, and account-linking experiences
 
 ## Documentation
 

--- a/authling/docs/GLOSSARY.md
+++ b/authling/docs/GLOSSARY.md
@@ -23,9 +23,16 @@ inside an encrypted credential payload.
 verification challenge to account creation. It is not an account and expires
 after 15 minutes.
 
+**Password reset flow** — Short-lived, encrypted runtime state that carries an
+email challenge and binds successful recovery to the password credential that
+was current when the flow began. It expires after 15 minutes and is not a
+durable account fact.
+
 **Browser session** — Short-lived, server-side runtime state that binds an
 opaque browser cookie to one account after signup or login. A session is not a
 durable account fact and can be revoked independently from other sessions.
+Password reset invalidates every session issued under the account's older
+authentication version.
 
 **Issuer** — The immutable public URL identifying one Authling deployment as
 one OpenID Provider. Tokens and discovery use this exact value; changing it is

--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -10,11 +10,11 @@ and `run`. `run` loads the standalone configuration, opens Authling's NATS
 storage, starts every required projection, waits for startup replay, starts the
 HTTP listener, and then runs until its process context is cancelled.
 
-The HTTP surface contains server-rendered signup, login, consent, account, and
-logout pages plus embedded browser assets. It also exposes OpenID Connect
-discovery, authorization, token, UserInfo, and JWKS endpoints. Authling exposes
-no public account-management, application-data, document, or synchronization
-API.
+The HTTP surface contains server-rendered signup, login, password-reset,
+consent, account, and logout pages plus embedded browser assets. It also
+exposes OpenID Connect discovery, authorization, token, UserInfo, and JWKS
+endpoints. Authling exposes no public account-management, application-data,
+document, or synchronization API.
 
 ## Configuration
 
@@ -76,7 +76,7 @@ storage-path, logging, and deployment policy.
 | Resource | Kind | Storage | Subjects | Purpose |
 |----------|------|---------|----------|---------|
 | `AUTHLING_EVT` | Stream | File, S2-compressed | `authling.evt.>` | Authoritative Authling event history |
-| `AUTHLING_RUNTIME_STATE` | KV bucket | File, history 1 | Opaque HMAC-derived keys | Encrypted signup, session, OIDC request, code, and access-token state, plus bounded delivery and login-attempt counters |
+| `AUTHLING_RUNTIME_STATE` | KV bucket | File, history 1 | Opaque HMAC-derived keys | Encrypted signup, password-reset, session, OIDC request, code, and access-token state, plus bounded delivery and login-attempt counters |
 | `AUTHLING_KEYS` | KV bucket | File, history 1 | Opaque key references | Workflow, OIDC signing, user, and wrapped credential data keys |
 
 `AUTHLING_EVT` enables JetStream atomic publication for future multi-event
@@ -96,6 +96,8 @@ Persisted records use the `authling.core.v1.Event` protobuf envelope:
 | Event | Subject | Aggregate | Contents |
 |-------|---------|-----------|----------|
 | `AccountCreatedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account ID and envelope creation time |
+| `PasswordResetRequestedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account and credential-event IDs; the envelope ID identifies the audit request |
+| `PasswordChangedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, credential-key, and optional reset-request references plus the replacement encrypted password verifier |
 | `EmailClaimedEvent` | `authling.evt.account-registry` | Account registry | Opaque account ID only |
 | `IssuerEstablishedEvent` | `authling.evt.issuer` | Issuer singleton | Immutable issuer URL and opaque signing-key reference and ID |
 
@@ -113,9 +115,12 @@ The account model consumes `authling.evt.account.*` and
 During replay it resolves and decrypts local credentials and rebuilds a keyed
 digest index of normalized emails. It retains encrypted verifier fields and
 opaque key references, but neither plaintext email nor plaintext password
-verifiers. Local authentication resolves and decrypts a verifier only for one
-bounded Argon2id comparison; absent accounts resolve a persistent synthetic
-key hierarchy and encrypted dummy verifier through the same storage path.
+verifiers. Password-reset requests validate their account and credential
+binding without adding derived model state. Password changes replace the
+current encrypted verifier and advance a durable account authentication
+version. Local authentication resolves and decrypts a verifier only for one
+bounded Argon2id comparison; absent accounts resolve a persistent synthetic key
+hierarchy and encrypted dummy verifier through the same storage path.
 
 The runtime does not become ready until the projection has replayed its captured
 startup history. A decode or apply failure fails the projection and runtime.
@@ -159,7 +164,23 @@ the explicit loopback development mode.
 Session records are authenticated-encrypted in runtime state beneath
 HMAC-derived keys. They have a 24-hour absolute lifetime and a one-hour
 inactivity limit. Activity updates use OCC and never extend the absolute
-deadline. Logout deletes the server record before clearing the cookie.
+deadline. Each session records the account authentication version current at
+issuance. A password reset advances that durable version, invalidating every
+older session across replicas and restarts. Logout deletes the server record
+before clearing the cookie.
+
+`GET /password-reset` starts verified-email recovery. Three POST endpoints
+create an expiring flow, verify its six-digit code, and commit a new password.
+Claimed and unclaimed valid addresses follow the same email-delivery and
+browser path. After delivery limits accept an existing account's request, a
+PII-free `PasswordResetRequestedEvent` must commit before flow creation or SMTP
+delivery; absent accounts have no aggregate on which to record one. Encrypted
+flow state is bound to that audit event and the credential event current at
+start. Account-subject OCC prevents concurrent stale flows from overwriting a
+newer password while tolerating intervening request-audit appends. Successful
+completion links `PasswordChangedEvent` to the request event, preserves the
+account ID and email claim, creates a new browser session, and can resume an
+interrupted OIDC consent request.
 
 OpenID Connect mounts discovery at `/.well-known/openid-configuration` and its
 protocol endpoints below `/oauth/`. Authorization accepts only code flow,
@@ -178,13 +199,14 @@ winner. ID tokens use the persistent RS256 key; JWKS publishes only its public
 part. The initial UserInfo response contains only the account ID as `sub`.
 
 The HTTP server bounds header, body-read, response-write, and idle time. Signup
-also caps request bodies, globally limits OTP delivery, and bounds concurrent
-SMTP calls per process.
+and password reset also cap request bodies, globally limit OTP delivery, and
+bound concurrent SMTP and completion work per process.
 
 ## Deliberately absent
 
-The runtime does not yet contain recovery, account erasure, session lists or
-account-wide session revocation, OIDC refresh tokens or key rotation,
+The runtime does not yet contain email-address change, signed-in password
+change, MFA recovery, account erasure, session lists or selective remote
+session revocation, OIDC refresh tokens or key rotation,
 diagnostic endpoints, or backup tooling. Application data, documents, and
 generic synchronization are deliberately outside Authling's identity-provider
 boundary.

--- a/authling/docs/fdr/FDR-003-local-login-and-browser-sessions.md
+++ b/authling/docs/fdr/FDR-003-local-login-and-browser-sessions.md
@@ -1,7 +1,7 @@
 # FDR-003: Local Login and Browser Sessions
 
 **Status:** Experimental
-**Last reviewed:** 2026-07-31
+**Last reviewed:** 2026-08-14
 
 ## Overview
 
@@ -31,6 +31,10 @@ experience.
   sessions.
 - Sessions remain valid across an Authling process restart when the browser
   still has its session cookie and runtime storage remains available.
+- Sessions carry the account's durable authentication version. Password reset
+  advances that version and invalidates every older Authling browser session,
+  including across process restarts; the completing browser receives a new
+  session.
 - Protected pages reject absent, expired, malformed, forged, and revoked
   sessions. Cross-origin login and logout submissions are rejected.
 - The configured public origin is canonical: requests for another host are
@@ -46,8 +50,8 @@ experience.
 **Decision:** The browser carries only an opaque random bearer; the account and
 lifetime state remain in expiring Authling runtime storage.
 
-**Why:** Server-side state makes logout and expiry authoritative, reveals no
-account data in the cookie, and leaves room for future account-wide revocation.
+**Why:** Server-side state makes logout, expiry, and password-reset invalidation
+authoritative and reveals no account data in the cookie.
 
 **Tradeoff:** Every authenticated browser request depends on runtime-storage
 availability.
@@ -97,11 +101,8 @@ attempt budget.
 
 ## Limitations
 
-- There is no "remember me", session list, remote session revocation,
-  password-change revocation, or user-visible authentication history yet.
-- The first slice does not accept return URLs. OIDC authorization will add
-  integrity-protected continuation state rather than an open redirect
-  parameter.
+- There is no "remember me", session list, selective remote session revocation,
+  signed-in password change, or user-visible authentication history yet.
 - Password-only login is a single-factor authentication ceremony. Authling
   does not yet implement MFA or phishing-resistant authenticators.
 - Authling's listener does not terminate TLS. Production operators must expose
@@ -114,7 +115,8 @@ attempt budget.
   [ADR-002](../adr/ADR-002-hierarchical-keys-and-cryptographic-erasure.md),
   [ADR-003](../adr/ADR-003-server-rendered-templ-ui.md)
 - **Features:** [FDR-001](FDR-001-standalone-account-runtime.md),
-  [FDR-002](FDR-002-verified-email-signup.md)
+  [FDR-002](FDR-002-verified-email-signup.md),
+  [FDR-006](FDR-006-password-reset.md)
 - **Security baseline:** [NIST SP 800-63B](https://pages.nist.gov/800-63-4/sp800-63b.html),
   [OWASP Authentication](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html),
   and [OWASP Session Management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)

--- a/authling/docs/fdr/FDR-006-password-reset.md
+++ b/authling/docs/fdr/FDR-006-password-reset.md
@@ -1,0 +1,151 @@
+# FDR-006: Password Reset
+
+**Status:** Experimental
+**Last reviewed:** 2026-08-14
+
+## Overview
+
+Authling lets a person who controls a local account's verified email address
+replace its password through a short-lived email-code flow. The account ID,
+email claim, and OpenID Connect `sub` remain unchanged.
+
+## Behavior
+
+- The sign-in page links to password reset. A person submits an email address,
+  enters the six-digit code from the email, and chooses a new password under
+  the same policy used by signup.
+- Every syntactically valid email address follows the same flow and email
+  delivery path whether or not it currently identifies an account. Browser
+  copy does not disclose account existence.
+- After rate limits accept a request for an existing account, Authling commits
+  a `PasswordResetRequestedEvent` before creating the flow or sending email.
+  The event contains only the account ID and current credential event ID; its
+  envelope ID is the opaque recovery request identifier. Requests for absent
+  accounts cannot produce an account-scoped event.
+- A flow and its code expire after 15 minutes. Five incorrect code attempts
+  exhaust the challenge. Delivery is limited per normalized address and
+  globally, and SMTP and password-completion concurrency are bounded.
+- A flow is bound to the exact password credential current when its code was
+  issued. A concurrent password reset that commits first makes every older
+  flow stale; a stale flow cannot overwrite the newer password.
+- Completing a reset appends a durable `PasswordChangedEvent` linked to its
+  `PasswordResetRequestedEvent`. It preserves the account's stable ID and
+  credential key hierarchy while replacing the encrypted Argon2id verifier.
+- A successful reset advances the account's durable authentication version.
+  Authling browser sessions created under an older version stop validating,
+  including after a process restart. The completing browser receives a new
+  session and continues to its account or its interrupted OIDC consent request.
+- Previously issued OIDC ID and access tokens are not revoked. They expire
+  after five minutes, and relying-party sessions remain under the relying
+  party's control.
+
+## Design Decisions
+
+### 1. Separate auditable facts from recovery secrets
+
+**Decision:** An accepted request for an existing account and its resulting
+password change are durable events. The request event is mandatory before flow
+creation or email delivery, and the change references its request event ID.
+One-time-code digests and attempt state remain authenticated-encrypted runtime
+records under non-reversible keys. The submitted email is not retained in the
+event or flow after delivery.
+
+**Why:** The fact that recovery was initiated is a security-relevant audit
+signal. The code, bearer, and attempt mechanics are expiring coordination that
+must not become permanent identity history.
+
+**Tradeoff:** A request event says that Authling accepted the request, not that
+SMTP delivery succeeded. Incorrect-code attempts are not durable audit events;
+recording attacker-controlled attempts permanently would create an event-log
+growth vector. Losing runtime state cancels the in-progress flow, which the
+person must restart.
+
+### 2. Do not reveal whether an address is registered
+
+**Decision:** Authling sends the same reset message for claimed and unclaimed
+valid addresses, presents the same code form, and reveals no account state
+until after control of the submitted mailbox has been demonstrated.
+
+**Why:** Different responses or an omitted email would turn recovery into an
+account-enumeration endpoint.
+
+**Tradeoff:** An unclaimed address can receive an unsolicited but harmless
+reset code, and its verified flow cannot complete.
+
+### 3. Bind completion to the observed credential
+
+**Decision:** The encrypted flow records the account, credential event, and
+request event IDs observed at start. Completion compares the credential
+binding with the current projection and appends against the observed
+account-subject tail using OCC. Audit-only reset requests advance that tail but
+do not stale a flow whose credential remains current.
+
+**Why:** Two independently verified recovery flows must never overwrite each
+other according to completion timing after one has already changed the
+credential.
+
+**Tradeoff:** A person must restart an older flow after any intervening
+password change.
+
+### 4. Invalidate Authling sessions by durable generation
+
+**Decision:** Every password change advances an account authentication version.
+Browser sessions record the version at issuance and fail closed when it no
+longer matches.
+
+**Why:** Reset is frequently a response to suspected credential compromise.
+Generation checks revoke every pre-reset Authling browser session without a
+session index or process-local coordination and remain effective after restart.
+
+**Tradeoff:** There is no selective preservation of another browser session.
+The completing browser is deliberately reauthenticated with a new session.
+
+### 5. Reuse the credential data key
+
+**Decision:** `PasswordChangedEvent` encrypts its verifier with the local
+credential's existing data key and new event-specific AAD.
+
+**Why:** Authling cannot destroy the prior key while historical account events
+still require it during replay. Adding a new key would not erase the older
+verifier and would increase key-management complexity without improving the
+current erasure guarantee.
+
+**Tradeoff:** Historical password verifiers remain decryptable to a live
+Authling process with key-store access until erasure-aware replay and key
+retirement are implemented.
+
+## Security and Failure Behavior
+
+- Flow tokens and OTPs never appear in URLs or logs. The browser carries the
+  opaque flow token only in form fields.
+- Request audit events contain no email, OTP, flow token, IP address, user
+  agent, or other recovery material. A successful change carries only the
+  opaque request-event reference needed to correlate the audit trail.
+- Flow state and password verifiers are authenticated-encrypted with distinct,
+  versioned AAD domains. Ciphertext cannot be moved between creation and change
+  events or between credentials without failing authentication.
+- Wrong, repeated, expired, absent-account, and stale-flow completion paths are
+  bounded and fail closed. Storage, projection, key-vault, or email failures do
+  not masquerade as success.
+- All reset POSTs require Authling's canonical browser origin and have bounded
+  request bodies.
+
+## Limitations
+
+- Authling does not currently support signed-in password change, email-address
+  change, MFA recovery, recovery codes, administrator recovery, or user-visible
+  authentication history.
+- Password reset does not revoke already issued OIDC tokens or sessions held by
+  relying parties. Token revocation and RP-initiated logout are separate future
+  protocol work.
+- The built-in password blocklist is intentionally small and is not yet a
+  maintained compromised-password corpus.
+
+## Related
+
+- **ADRs:** [ADR-001](../adr/ADR-001-event-sourced-nats-architecture.md),
+  [ADR-002](../adr/ADR-002-hierarchical-keys-and-cryptographic-erasure.md),
+  [ADR-003](../adr/ADR-003-server-rendered-templ-ui.md)
+- **Features:** [FDR-002](FDR-002-verified-email-signup.md),
+  [FDR-003](FDR-003-local-login-and-browser-sessions.md),
+  [FDR-004](FDR-004-openid-connect-provider.md)

--- a/authling/docs/fdr/INDEX.md
+++ b/authling/docs/fdr/INDEX.md
@@ -13,3 +13,4 @@ record planned behavior as active functionality.
 | [FDR-003](FDR-003-local-login-and-browser-sessions.md) | Local Login and Browser Sessions | Experimental | 2026-07-31 |
 | [FDR-004](FDR-004-openid-connect-provider.md) | OpenID Connect Provider | Experimental | 2026-08-01 |
 | [FDR-005](FDR-005-account-data-sync.md) | Account Data Synchronization | Retired | 2026-08-14 |
+| [FDR-006](FDR-006-password-reset.md) | Password Reset | Experimental | 2026-08-14 |

--- a/authling/e2e/fixtures/mailpit.ts
+++ b/authling/e2e/fixtures/mailpit.ts
@@ -30,6 +30,36 @@ export async function waitForVerificationCode(
   mailpitURL: string,
   timeoutMs = 10_000
 ): Promise<string> {
+  return waitForCode(
+    request,
+    mailpitURL,
+    'Your Authling verification code',
+    /verification code is ([0-9]{6})\./,
+    timeoutMs
+  );
+}
+
+export async function waitForPasswordResetCode(
+  request: APIRequestContext,
+  mailpitURL: string,
+  timeoutMs = 10_000
+): Promise<string> {
+  return waitForCode(
+    request,
+    mailpitURL,
+    'Your Authling password reset code',
+    /password reset code is ([0-9]{6})\./,
+    timeoutMs
+  );
+}
+
+async function waitForCode(
+  request: APIRequestContext,
+  mailpitURL: string,
+  subject: string,
+  pattern: RegExp,
+  timeoutMs: number
+): Promise<string> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const response = await request.get(`${mailpitURL}/api/v1/messages`);
@@ -40,8 +70,8 @@ export async function waitForVerificationCode(
         const messageResponse = await request.get(`${mailpitURL}/api/v1/message/${latest.ID}`);
         if (messageResponse.ok()) {
           const message = (await messageResponse.json()) as Message;
-          if (message.Subject === 'Your Authling verification code') {
-            const match = /verification code is ([0-9]{6})\./.exec(message.Text);
+          if (message.Subject === subject) {
+            const match = pattern.exec(message.Text);
             if (match) return match[1];
           }
         }
@@ -49,5 +79,5 @@ export async function waitForVerificationCode(
     }
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
-  throw new Error(`Mailpit did not receive an Authling verification code within ${timeoutMs}ms`);
+  throw new Error(`Mailpit did not receive ${subject} within ${timeoutMs}ms`);
 }

--- a/authling/e2e/password-reset.test.ts
+++ b/authling/e2e/password-reset.test.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from 'node:crypto';
+import { completeSignup } from './fixtures/signup';
+import { waitForPasswordResetCode } from './fixtures/mailpit';
+import { expect, test } from './setup';
+
+const originalPassword = 'correct horse battery staple';
+const replacementPassword = 'an entirely new uncommon password';
+
+test('resets the password without changing sub and invalidates other browser sessions', async ({
+  browser,
+  page,
+  request,
+  stack
+}) => {
+  const email = `reset-${randomUUID()}@example.invalid`;
+  const accountID = await completeSignup(page, request, stack, email, originalPassword);
+
+  const otherContext = await browser.newContext({ baseURL: stack.baseURL });
+  const otherPage = await otherContext.newPage();
+  await otherPage.goto('/login');
+  await otherPage.getByLabel('Email address').fill(email);
+  await otherPage.getByLabel('Password').fill(originalPassword);
+  await otherPage.getByRole('button', { name: 'Sign in' }).click();
+  await expect(otherPage.getByRole('heading', { name: 'Your account' })).toBeVisible();
+
+  await page.goto('/login');
+  await page.getByRole('link', { name: 'Forgot your password?' }).click();
+  await expect(page.getByRole('heading', { name: 'Reset your password' })).toBeVisible();
+  await page.getByLabel('Email address').fill(email.toUpperCase());
+  await page.getByRole('button', { name: 'Email me a reset code' }).click();
+  await expect(page.getByRole('heading', { name: 'Check your email' })).toBeVisible();
+
+  const code = await waitForPasswordResetCode(request, stack.mailpitURL);
+  await page.getByLabel('Password reset code').fill(code);
+  await page.getByRole('button', { name: 'Verify code' }).click();
+  await expect(page.getByRole('heading', { name: 'Choose a new password' })).toBeVisible();
+  await expect(page.getByText('signs out your other Authling browser sessions')).toBeVisible();
+  await page.getByLabel('New password').fill(replacementPassword);
+  await page.getByRole('button', { name: 'Reset password' }).click();
+  await expect(page.getByRole('heading', { name: 'Your account' })).toBeVisible();
+  await expect(page.locator('code')).toHaveText(accountID);
+
+  await otherPage.goto('/account');
+  await expect(otherPage).toHaveURL(/\/login$/);
+  await otherContext.close();
+
+  await page.getByRole('button', { name: 'Sign out' }).click();
+  await page.getByLabel('Email address').fill(email);
+  await page.getByLabel('Password').fill(originalPassword);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('alert')).toHaveText('The email address or password is incorrect.');
+
+  await page.getByLabel('Email address').fill(email);
+  await page.getByLabel('Password').fill(replacementPassword);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Your account' })).toBeVisible();
+  await expect(page.locator('code')).toHaveText(accountID);
+});

--- a/authling/e2e/security.test.ts
+++ b/authling/e2e/security.test.ts
@@ -16,7 +16,17 @@ test('serves the public pages with browser security headers', async ({ page }) =
   await expect(page.getByRole('heading', { name: 'Create your account' })).toBeVisible();
 });
 
-for (const path of ['/login', '/logout', '/signup', '/signup/verify', '/signup/complete', '/oidc/consent']) {
+for (const path of [
+  '/login',
+  '/logout',
+  '/signup',
+  '/signup/verify',
+  '/signup/complete',
+  '/password-reset',
+  '/password-reset/verify',
+  '/password-reset/complete',
+  '/oidc/consent'
+]) {
   test(`rejects cross-origin form submission to ${path}`, async ({ request, stack }) => {
     const response = await request.post(`${stack.baseURL}${path}`, {
       headers: {

--- a/authling/internal/accounts/accounts.go
+++ b/authling/internal/accounts/accounts.go
@@ -58,10 +58,15 @@ func (commonPasswordError) Is(target error) bool { return target == ErrInvalidPa
 // mismatches so callers cannot disclose which email addresses are registered.
 var ErrInvalidCredentials = errors.New("invalid email or password")
 
+// ErrCredentialChanged indicates that a recovery flow was issued for an older
+// password credential and must not overwrite the current one.
+var ErrCredentialChanged = errors.New("password credential changed")
+
 // Account is the current projected structural state of an Authling account.
 type Account struct {
-	ID        string
-	CreatedAt time.Time
+	ID                    string
+	CreatedAt             time.Time
+	AuthenticationVersion uint64
 }
 
 type protectedCredential struct {
@@ -71,6 +76,15 @@ type protectedCredential struct {
 	credentialKeyRef           string
 	passwordVerifierNonce      []byte
 	passwordVerifierCiphertext []byte
+	passwordVerifierAAD        []byte
+}
+
+// PasswordResetTarget binds an expiring recovery flow to the credential that
+// was current when the email challenge was issued.
+type PasswordResetTarget struct {
+	AccountID         string
+	CredentialEventID string
+	RequestEventID    string
 }
 
 // Projection rebuilds the active account registry from durable events.
@@ -97,6 +111,39 @@ func (*Projection) Subjects() []string {
 
 // Apply adds one durable account fact to the in-memory registry.
 func (p *Projection) Apply(event *corev1.Event, _ uint64) error {
+	if requested := event.GetPasswordResetRequested(); requested != nil {
+		p.RLock()
+		defer p.RUnlock()
+		account, ok := p.accounts[requested.GetAccountId()]
+		if !ok {
+			return fmt.Errorf("password reset request references an absent account")
+		}
+		credential, ok := p.credentials[account.ID]
+		if !ok || credential.eventID != requested.GetCredentialEventId() {
+			return fmt.Errorf("password reset request references another credential")
+		}
+		return nil
+	}
+	if changed := event.GetPasswordChanged(); changed != nil {
+		p.Lock()
+		defer p.Unlock()
+		account, ok := p.accounts[changed.GetAccountId()]
+		if !ok {
+			return fmt.Errorf("password change references an absent account")
+		}
+		credential, ok := p.credentials[account.ID]
+		if !ok || credential.userKeyRef != changed.GetUserKeyRef() || credential.credentialKeyRef != changed.GetCredentialKeyRef() {
+			return fmt.Errorf("password change references another credential hierarchy")
+		}
+		credential.eventID = event.GetId()
+		credential.passwordVerifierNonce = append([]byte(nil), changed.GetPasswordVerifierNonce()...)
+		credential.passwordVerifierCiphertext = append([]byte(nil), changed.GetPasswordVerifierCiphertext()...)
+		credential.passwordVerifierAAD = passwordChangedAAD(event.GetId(), account.ID, credential.userKeyRef, credential.credentialKeyRef)
+		p.credentials[account.ID] = credential
+		account.AuthenticationVersion++
+		p.accounts[account.ID] = account
+		return nil
+	}
 	payload := event.GetAccountCreated()
 	if payload == nil {
 		claim := event.GetEmailClaimed()
@@ -177,6 +224,7 @@ func (p *Projection) Apply(event *corev1.Event, _ uint64) error {
 			credentialKeyRef:           payload.GetCredentialKeyRef(),
 			passwordVerifierNonce:      append([]byte(nil), payload.GetPasswordVerifierNonce()...),
 			passwordVerifierCiphertext: append([]byte(nil), payload.GetPasswordVerifierCiphertext()...),
+			passwordVerifierAAD:        credentialAAD(event.GetId(), account.ID, payload.GetUserKeyRef(), payload.GetCredentialKeyRef(), "password-verifier"),
 		}
 		p.keyReferences[payload.GetUserKeyRef()] = struct{}{}
 		p.keyReferences[payload.GetCredentialKeyRef()] = struct{}{}
@@ -215,12 +263,36 @@ func (p *Projection) credentialForEmail(email string) (protectedCredential, bool
 	return credential, ok
 }
 
+func (p *Projection) credentialForAccount(accountID string) (protectedCredential, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	credential, ok := p.credentials[accountID]
+	return credential, ok
+}
+
+func (p *Projection) passwordResetTarget(email string) (PasswordResetTarget, bool) {
+	credential, ok := p.credentialForEmail(email)
+	if !ok {
+		return PasswordResetTarget{}, false
+	}
+	return PasswordResetTarget{AccountID: credential.accountID, CredentialEventID: credential.eventID}, true
+}
+
 // Get returns one projected account.
 func (p *Projection) Get(accountID string) (Account, bool) {
 	p.RLock()
 	defer p.RUnlock()
 	account, ok := p.accounts[accountID]
 	return account, ok
+}
+
+// AuthenticationVersion returns the durable credential generation used to
+// invalidate browser sessions created before a password change.
+func (p *Projection) AuthenticationVersion(accountID string) (uint64, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	account, ok := p.accounts[accountID]
+	return account.AuthenticationVersion, ok
 }
 
 // UserKeyRef returns the opaque user-key reference for an account that has a
@@ -282,6 +354,7 @@ func NewService(
 		dummyCredential: protectedCredential{
 			accountID: accountID, eventID: eventID, userKeyRef: userRef, credentialKeyRef: dataRef,
 			passwordVerifierNonce: sealed.Nonce, passwordVerifierCiphertext: sealed.Ciphertext,
+			passwordVerifierAAD: credentialAAD(eventID, accountID, userRef, dataRef, "password-verifier"),
 		},
 	}, nil
 }
@@ -324,15 +397,12 @@ func (s *Service) Create(ctx context.Context) (Account, error) {
 // establish email ownership before invoking this command.
 func (s *Service) CreateLocal(ctx context.Context, email, password string) (Account, error) {
 	email = NormalizeEmail(email)
-	password = norm.NFC.String(password)
 	if s.handle.Projection().HasEmail(email) {
 		return Account{}, ErrEmailClaimed
 	}
-	if utf8.RuneCountInString(password) < s.passwordMinimumLength || len(password) > 1024 {
-		return Account{}, invalidPasswordError{minimumLength: s.passwordMinimumLength}
-	}
-	if isCommonPassword(password) {
-		return Account{}, commonPasswordError{}
+	password, err := validatePassword(password, s.passwordMinimumLength)
+	if err != nil {
+		return Account{}, err
 	}
 	verifier, err := hashPassword(password)
 	if err != nil {
@@ -429,6 +499,21 @@ func credentialAAD(eventID, accountID, userRef, dataRef, field string) []byte {
 	return []byte("authling:event:v1\x00AccountCreated\x00" + eventID + "\x00" + accountID + "\x00credentials\x001\x00" + userRef + "\x00" + dataRef + "\x00" + field)
 }
 
+func passwordChangedAAD(eventID, accountID, userRef, dataRef string) []byte {
+	return []byte("authling:event:v1\x00PasswordChanged\x00" + eventID + "\x00" + accountID + "\x00credentials\x001\x00" + userRef + "\x00" + dataRef + "\x00password-verifier")
+}
+
+func validatePassword(password string, minimumLength int) (string, error) {
+	password = norm.NFC.String(password)
+	if utf8.RuneCountInString(password) < minimumLength || len(password) > 1024 {
+		return "", invalidPasswordError{minimumLength: minimumLength}
+	}
+	if isCommonPassword(password) {
+		return "", commonPasswordError{}
+	}
+	return password, nil
+}
+
 func hashPassword(password string) (string, error) {
 	salt := make([]byte, 16)
 	if _, err := rand.Read(salt); err != nil {
@@ -453,6 +538,147 @@ func (s *Service) HasEmail(email string) bool {
 	return s.handle.Projection().HasEmail(NormalizeEmail(email))
 }
 
+// RecordPasswordResetRequested appends an account-scoped audit fact for an
+// existing normalized local email and returns the credential binding for the
+// recovery flow. Callers must not expose whether a target exists.
+func (s *Service) RecordPasswordResetRequested(ctx context.Context, email string) (PasswordResetTarget, bool, error) {
+	email = NormalizeEmail(email)
+	eventID, err := ids.New("evt")
+	if err != nil {
+		return PasswordResetTarget{}, false, err
+	}
+	createdAt := timestamppb.Now()
+	for range 5 {
+		target, ok := s.handle.Projection().passwordResetTarget(email)
+		if !ok {
+			return PasswordResetTarget{}, false, nil
+		}
+		accountID := target.AccountID
+		tail, err := s.publisher.AccountTail(ctx, accountID)
+		if err != nil {
+			return PasswordResetTarget{}, false, fmt.Errorf("read password reset account tail: %w", err)
+		}
+		subject, err := evtstream.AccountSubject(accountID)
+		if err != nil {
+			return PasswordResetTarget{}, false, fmt.Errorf("resolve password reset account subject: %w", err)
+		}
+		if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
+			return PasswordResetTarget{}, false, fmt.Errorf("wait for password reset account: %w", err)
+		}
+		target, ok = s.handle.Projection().passwordResetTarget(email)
+		if !ok {
+			return PasswordResetTarget{}, false, nil
+		}
+		if target.AccountID != accountID {
+			continue
+		}
+		event := &corev1.Event{Id: eventID, CreatedAt: createdAt, Event: &corev1.Event_PasswordResetRequested{PasswordResetRequested: &corev1.PasswordResetRequestedEvent{
+			AccountId: target.AccountID, CredentialEventId: target.CredentialEventID,
+		}}}
+		position, err := s.publisher.AppendPasswordResetRequested(ctx, event, tail)
+		if errors.Is(err, events.ErrConflict) {
+			continue
+		}
+		if err != nil {
+			return PasswordResetTarget{}, false, fmt.Errorf("commit password reset request: %w", err)
+		}
+		if err := s.handle.Projector().WaitFor(ctx, position); err != nil {
+			return PasswordResetTarget{}, false, fmt.Errorf("wait for password reset request: %w", err)
+		}
+		target.RequestEventID = eventID
+		return target, true, nil
+	}
+	return PasswordResetTarget{}, false, fmt.Errorf("password reset request conflict")
+}
+
+// AuthenticationVersion returns the generation embedded in new browser
+// sessions. Password changes advance it durably.
+func (s *Service) AuthenticationVersion(accountID string) (uint64, bool) {
+	return s.handle.Projection().AuthenticationVersion(accountID)
+}
+
+// ResetPassword replaces a local password only if the credential bound to the
+// recovery flow is still current. The stable account ID and email are unchanged.
+func (s *Service) ResetPassword(ctx context.Context, target PasswordResetTarget, password string) (Account, error) {
+	if target.AccountID == "" || target.CredentialEventID == "" || target.RequestEventID == "" {
+		return Account{}, ErrCredentialChanged
+	}
+	password, err := validatePassword(password, s.passwordMinimumLength)
+	if err != nil {
+		return Account{}, err
+	}
+	tail, credential, err := s.passwordResetCredentialAtTail(ctx, target)
+	if err != nil {
+		return Account{}, err
+	}
+	verifier, err := hashPassword(password)
+	if err != nil {
+		return Account{}, err
+	}
+	dataKey, err := s.vault.ResolveDataKey(ctx, credential.credentialKeyRef, credential.userKeyRef)
+	if err != nil {
+		return Account{}, fmt.Errorf("resolve password credential key: %w", err)
+	}
+	defer clear(dataKey)
+	eventID, err := ids.New("evt")
+	if err != nil {
+		return Account{}, err
+	}
+	sealedVerifier, err := datacrypto.Seal(dataKey, []byte(verifier), passwordChangedAAD(eventID, target.AccountID, credential.userKeyRef, credential.credentialKeyRef))
+	if err != nil {
+		return Account{}, err
+	}
+	event := &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_PasswordChanged{PasswordChanged: &corev1.PasswordChangedEvent{
+		AccountId: target.AccountID, UserKeyRef: credential.userKeyRef, CredentialKeyRef: credential.credentialKeyRef,
+		CredentialEnvelopeVersion: 1, PasswordVerifierNonce: sealedVerifier.Nonce, PasswordVerifierCiphertext: sealedVerifier.Ciphertext,
+		PasswordResetRequestEventId: target.RequestEventID,
+	}}}
+	for range 5 {
+		position, err := s.publisher.AppendPasswordChanged(ctx, event, tail)
+		if errors.Is(err, events.ErrConflict) {
+			tail, _, err = s.passwordResetCredentialAtTail(ctx, target)
+			if err != nil {
+				return Account{}, err
+			}
+			continue
+		}
+		if err != nil {
+			return Account{}, fmt.Errorf("commit password change: %w", err)
+		}
+		if err := s.handle.Projector().WaitFor(ctx, position); err != nil {
+			return Account{}, fmt.Errorf("wait for password change: %w", err)
+		}
+		account, ok := s.handle.Projection().Get(target.AccountID)
+		if !ok {
+			return Account{}, fmt.Errorf("reset account is absent from projection")
+		}
+		return account, nil
+	}
+	return Account{}, fmt.Errorf("password change conflict")
+}
+
+func (s *Service) passwordResetCredentialAtTail(ctx context.Context, target PasswordResetTarget) (uint64, protectedCredential, error) {
+	tail, err := s.publisher.AccountTail(ctx, target.AccountID)
+	if err != nil {
+		return 0, protectedCredential{}, fmt.Errorf("read account tail: %w", err)
+	}
+	if tail == 0 {
+		return 0, protectedCredential{}, ErrCredentialChanged
+	}
+	subject, err := evtstream.AccountSubject(target.AccountID)
+	if err != nil {
+		return 0, protectedCredential{}, ErrCredentialChanged
+	}
+	if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
+		return 0, protectedCredential{}, fmt.Errorf("wait for account credential: %w", err)
+	}
+	credential, ok := s.handle.Projection().credentialForAccount(target.AccountID)
+	if !ok || credential.eventID != target.CredentialEventID {
+		return 0, protectedCredential{}, ErrCredentialChanged
+	}
+	return tail, credential, nil
+}
+
 // AuthenticateLocal verifies an email/password credential without retaining
 // plaintext protected data in the projection. Absent accounts still perform
 // the same Argon2id work as password mismatches.
@@ -472,7 +698,7 @@ func (s *Service) AuthenticateLocal(ctx context.Context, email, password string)
 		dataKey,
 		credential.passwordVerifierCiphertext,
 		credential.passwordVerifierNonce,
-		credentialAAD(credential.eventID, credential.accountID, credential.userKeyRef, credential.credentialKeyRef, "password-verifier"),
+		credential.passwordVerifierAAD,
 	)
 	if err != nil {
 		return Account{}, fmt.Errorf("decrypt password verifier: %w", err)

--- a/authling/internal/accounts/accounts_test.go
+++ b/authling/internal/accounts/accounts_test.go
@@ -1,0 +1,34 @@
+package accounts
+
+import (
+	"errors"
+	"testing"
+
+	"hmans.de/chatto/pkg/datacrypto"
+)
+
+func TestPasswordChangedVerifierRejectsAADSubstitution(t *testing.T) {
+	key, err := datacrypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clear(key)
+	aad := passwordChangedAAD("evt_change", "acc_example", "key_user", "key_credential")
+	sealed, err := datacrypto.Seal(key, []byte("argon2 verifier"), aad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, substituted := range map[string][]byte{
+		"event type": credentialAAD("evt_change", "acc_example", "key_user", "key_credential", "password-verifier"),
+		"event ID":   passwordChangedAAD("evt_other", "acc_example", "key_user", "key_credential"),
+		"account":    passwordChangedAAD("evt_change", "acc_other", "key_user", "key_credential"),
+		"user key":   passwordChangedAAD("evt_change", "acc_example", "key_other", "key_credential"),
+		"data key":   passwordChangedAAD("evt_change", "acc_example", "key_user", "key_other"),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := datacrypto.Open(key, sealed.Ciphertext, sealed.Nonce, substituted); !errors.Is(err, datacrypto.ErrDecryptionFailed) {
+				t.Fatalf("substitution error = %v, want ErrDecryptionFailed", err)
+			}
+		})
+	}
+}

--- a/authling/internal/app/runtime.go
+++ b/authling/internal/app/runtime.go
@@ -21,6 +21,7 @@ import (
 	"hmans.de/authling/internal/logging"
 	"hmans.de/authling/internal/natsruntime"
 	"hmans.de/authling/internal/oidcprovider"
+	"hmans.de/authling/internal/passwordreset"
 	"hmans.de/authling/internal/registration"
 	"hmans.de/authling/internal/sessions"
 	"hmans.de/authling/internal/storage"
@@ -39,6 +40,8 @@ type Runtime struct {
 	Accounts *accounts.Service
 	// Registration owns the verified-email signup workflow.
 	Registration *registration.Service
+	// PasswordReset owns verified-email password recovery.
+	PasswordReset *passwordreset.Service
 	// Authentication owns local login throttling and credential verification.
 	Authentication *authentication.Service
 	// Sessions owns first-party browser session runtime state.
@@ -102,7 +105,7 @@ func newRuntime(ctx context.Context, cfg config.Config, logger events.Logger, se
 	if err != nil {
 		return closeOnError(fmt.Errorf("open account service: %w", err))
 	}
-	sessionService := sessions.New(stores.RuntimeState, js, workflowKey)
+	sessionService := sessions.New(stores.RuntimeState, js, workflowKey, accountService.AuthenticationVersion)
 	issuerProjection := issuer.NewProjection()
 	issuerHandle := events.NewDecodedProjectionHandle(js, stream, issuerProjection, evtstream.Decode, logger)
 	issuerService := issuer.NewService(publisher, issuerHandle, vault, cfg.HTTP.PublicURLOrDefault())
@@ -124,6 +127,7 @@ func newRuntime(ctx context.Context, cfg config.Config, logger events.Logger, se
 		issuer:         issuerService,
 		Accounts:       accountService,
 		Registration:   registration.New(stores.RuntimeState, js, workflowKey, sender, accountService),
+		PasswordReset:  passwordreset.New(stores.RuntimeState, js, workflowKey, sender, accountService),
 		Authentication: authentication.New(stores.RuntimeState, js, workflowKey, accountService),
 		Sessions:       sessionService,
 		OIDC:           oidcService,
@@ -198,6 +202,7 @@ func Serve(ctx context.Context, cfg config.Config, logger *slog.Logger) (serveEr
 			Accounts:          runtime.Accounts,
 			Authentication:    runtime.Authentication,
 			Registration:      runtime.Registration,
+			PasswordReset:     runtime.PasswordReset,
 			Sessions:          runtime.Sessions,
 			OIDC:              runtime.OIDC,
 			SecureCookies:     cfg.HTTP.SecureCookies(),

--- a/authling/internal/app/runtime_test.go
+++ b/authling/internal/app/runtime_test.go
@@ -1,9 +1,11 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -20,8 +22,13 @@ import (
 	"hmans.de/authling/internal/accounts"
 	"hmans.de/authling/internal/config"
 	"hmans.de/authling/internal/email"
+	"hmans.de/authling/internal/evtstream"
 	"hmans.de/authling/internal/logging"
+	"hmans.de/authling/internal/passwordreset"
+	corev1 "hmans.de/authling/internal/pb/authling/core/v1"
 	"hmans.de/authling/internal/registration"
+	"hmans.de/authling/internal/sessions"
+	"hmans.de/authling/internal/storage"
 	"hmans.de/authling/internal/web"
 )
 
@@ -414,6 +421,143 @@ func TestBrowserSessionSurvivesRestartAndCanBeRevoked(t *testing.T) {
 	stopTestRuntime(t, restarted, cancelRestarted, restartedErrors)
 }
 
+func TestPasswordResetChangesCredentialAndInvalidatesOlderSessionsAcrossRestart(t *testing.T) {
+	cfg := embeddedTestConfig(t)
+	sender := &capturingSender{}
+	first, cancelFirst, firstErrors := startTestRuntime(t, cfg, sender)
+	account, err := first.Accounts.CreateLocal(testContext(t), "recover@example.com", "the original uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldSession, _, err := first.Sessions.Create(testContext(t), account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	flow, err := first.PasswordReset.Start(testContext(t), " Recover@Example.com ")
+	if err != nil {
+		t.Fatalf("start password reset: %v", err)
+	}
+	if sender.last().Subject != "Your Authling password reset code" {
+		t.Fatalf("password reset subject = %q", sender.last().Subject)
+	}
+	code := regexp.MustCompile(`\b[0-9]{6}\b`).FindString(sender.last().Body)
+	requestEvent, requestRecord := lastAccountEvent(t, first, account.ID)
+	request := requestEvent.GetPasswordResetRequested()
+	if request == nil || request.GetAccountId() != account.ID || request.GetCredentialEventId() == "" {
+		t.Fatalf("password reset request audit event = %+v", requestEvent)
+	}
+	if bytes.Contains(requestRecord, []byte("recover@example.com")) || bytes.Contains(requestRecord, []byte(code)) {
+		t.Fatal("password reset request audit event contains email or recovery code")
+	}
+	if err := first.PasswordReset.Verify(testContext(t), flow, code); err != nil {
+		t.Fatalf("verify password reset: %v", err)
+	}
+	if _, err := first.PasswordReset.Complete(testContext(t), flow, "short"); !errors.Is(err, accounts.ErrInvalidPassword) {
+		t.Fatalf("short replacement password error = %v, want ErrInvalidPassword", err)
+	}
+	changed, err := first.PasswordReset.Complete(testContext(t), flow, "the replacement uncommon password")
+	if err != nil {
+		t.Fatalf("complete password reset: %v", err)
+	}
+	if changed.ID != account.ID || changed.AuthenticationVersion != account.AuthenticationVersion+1 {
+		t.Fatalf("changed account = %+v, original = %+v", changed, account)
+	}
+	changeEvent, _ := lastAccountEvent(t, first, account.ID)
+	if got := changeEvent.GetPasswordChanged().GetPasswordResetRequestEventId(); got != requestEvent.GetId() {
+		t.Fatalf("password change request event ID = %q, want %q", got, requestEvent.GetId())
+	}
+	if _, err := first.Authentication.Login(testContext(t), "recover@example.com", "the original uncommon password"); !errors.Is(err, accounts.ErrInvalidCredentials) {
+		t.Fatalf("old password login error = %v, want ErrInvalidCredentials", err)
+	}
+	if authenticated, err := first.Authentication.Login(testContext(t), "recover@example.com", "the replacement uncommon password"); err != nil || authenticated != changed {
+		t.Fatalf("new password login = %+v, %v; want %+v", authenticated, err, changed)
+	}
+	if _, err := first.Sessions.Validate(testContext(t), oldSession); !errors.Is(err, sessions.ErrNotFound) {
+		t.Fatalf("older session validation error = %v, want ErrNotFound", err)
+	}
+	if _, err := first.PasswordReset.Complete(testContext(t), flow, "another replacement password"); !errors.Is(err, passwordreset.ErrInvalidFlow) {
+		t.Fatalf("reused reset error = %v, want ErrInvalidFlow", err)
+	}
+	stopTestRuntime(t, first, cancelFirst, firstErrors)
+
+	restarted, cancelRestarted, restartedErrors := startTestRuntime(t, cfg, sender)
+	defer stopTestRuntime(t, restarted, cancelRestarted, restartedErrors)
+	if authenticated, err := restarted.Authentication.Login(testContext(t), "recover@example.com", "the replacement uncommon password"); err != nil || authenticated.ID != account.ID || authenticated.AuthenticationVersion != 1 {
+		t.Fatalf("restarted login = %+v, %v", authenticated, err)
+	}
+	if _, err := restarted.Sessions.Validate(testContext(t), oldSession); !errors.Is(err, sessions.ErrNotFound) {
+		t.Fatalf("restarted older session validation error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestPasswordResetHidesAbsentAccountsAndRejectsStaleConcurrentFlows(t *testing.T) {
+	sender := &capturingSender{}
+	runtime, cancel, runErrors := startTestRuntime(t, embeddedTestConfig(t), sender)
+	defer stopTestRuntime(t, runtime, cancel, runErrors)
+	if _, err := runtime.Accounts.CreateLocal(testContext(t), "race-reset@example.com", "the original reset race password"); err != nil {
+		t.Fatal(err)
+	}
+
+	flows := make([]string, 2)
+	for i := range flows {
+		flow, err := runtime.PasswordReset.Start(testContext(t), "race-reset@example.com")
+		if err != nil {
+			t.Fatalf("start reset %d: %v", i, err)
+		}
+		flows[i] = flow
+	}
+	for i, message := range sender.all() {
+		code := regexp.MustCompile(`\b[0-9]{6}\b`).FindString(message.Body)
+		if err := runtime.PasswordReset.Verify(testContext(t), flows[i], code); err != nil {
+			t.Fatalf("verify reset %d: %v", i, err)
+		}
+	}
+	start := make(chan struct{})
+	results := make(chan error, 2)
+	for i, flow := range flows {
+		go func() {
+			<-start
+			_, err := runtime.PasswordReset.Complete(testContext(t), flow, fmt.Sprintf("replacement reset race password %d", i))
+			results <- err
+		}()
+	}
+	close(start)
+	var successes, stale int
+	for range 2 {
+		err := <-results
+		if err == nil {
+			successes++
+		} else if errors.Is(err, passwordreset.ErrInvalidFlow) {
+			stale++
+		} else {
+			t.Fatalf("concurrent reset error = %v", err)
+		}
+	}
+	if successes != 1 || stale != 1 {
+		t.Fatalf("concurrent reset successes=%d stale=%d, want 1/1", successes, stale)
+	}
+
+	beforeAbsent := sender.count()
+	eventsBeforeAbsent := eventCount(t, runtime)
+	absentFlow, err := runtime.PasswordReset.Start(testContext(t), "absent-reset@example.com")
+	if err != nil {
+		t.Fatalf("start absent reset: %v", err)
+	}
+	if sender.count() != beforeAbsent+1 {
+		t.Fatal("absent account did not follow the email-delivery path")
+	}
+	if got := eventCount(t, runtime); got != eventsBeforeAbsent {
+		t.Fatalf("absent account added %d durable audit events", got-eventsBeforeAbsent)
+	}
+	absentCode := regexp.MustCompile(`\b[0-9]{6}\b`).FindString(sender.last().Body)
+	if err := runtime.PasswordReset.Verify(testContext(t), absentFlow, absentCode); err != nil {
+		t.Fatalf("verify absent reset: %v", err)
+	}
+	if _, err := runtime.PasswordReset.Complete(testContext(t), absentFlow, "a sufficiently long absent password"); !errors.Is(err, passwordreset.ErrInvalidFlow) {
+		t.Fatalf("complete absent reset error = %v, want ErrInvalidFlow", err)
+	}
+}
+
 func TestLoginThrottlesAfterTenFailedAttempts(t *testing.T) {
 	sender := &capturingSender{}
 	runtime, cancel, runErrors := startTestRuntime(t, embeddedTestConfig(t), sender)
@@ -644,4 +788,38 @@ func testContext(t *testing.T) context.Context {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	t.Cleanup(cancel)
 	return ctx
+}
+
+func lastAccountEvent(t *testing.T, runtime *Runtime, accountID string) (*corev1.Event, []byte) {
+	t.Helper()
+	js, err := runtime.connection.NATS.JetStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	subject, err := evtstream.AccountSubject(accountID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	record, err := js.GetLastMsg(storage.EventStreamName, subject)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoded, err := evtstream.Decode(record.Data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return decoded.Event, record.Data
+}
+
+func eventCount(t *testing.T, runtime *Runtime) uint64 {
+	t.Helper()
+	js, err := runtime.connection.NATS.JetStream()
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := js.StreamInfo(storage.EventStreamName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info.State.Msgs
 }

--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -44,6 +44,15 @@ func (p *Publisher) AccountRegistryTail(ctx context.Context) (uint64, error) {
 	return p.log.LastSubjectSeq(ctx, accountRegistrySubject)
 }
 
+// AccountTail returns the current OCC token for one account aggregate.
+func (p *Publisher) AccountTail(ctx context.Context, accountID string) (uint64, error) {
+	subject, err := AccountSubject(accountID)
+	if err != nil {
+		return 0, err
+	}
+	return p.log.LastSubjectSeq(ctx, subject)
+}
+
 // AppendRegisteredAccount commits a local account against a previously read
 // registry tail.
 func (p *Publisher) AppendRegisteredAccount(ctx context.Context, accountEvent, claimEvent *corev1.Event, expectedRegistry uint64) (events.StreamPosition, error) {
@@ -98,6 +107,58 @@ func (p *Publisher) AppendAccountCreated(
 		return events.StreamPosition{}, err
 	}
 	sequence, err := p.log.AppendAt(ctx, subject, record, 0)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	return events.SubjectPosition(subject, sequence), nil
+}
+
+// AppendPasswordChanged replaces a credential at an explicitly observed
+// account tail so concurrent reset flows cannot overwrite each other.
+func (p *Publisher) AppendPasswordChanged(
+	ctx context.Context,
+	event *corev1.Event,
+	expectedTail uint64,
+) (events.StreamPosition, error) {
+	payload := event.GetPasswordChanged()
+	if payload == nil {
+		return events.StreamPosition{}, fmt.Errorf("append password changed: event payload is not password_changed")
+	}
+	subject, err := AccountSubject(payload.GetAccountId())
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	record, err := encode(event)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	return events.SubjectPosition(subject, sequence), nil
+}
+
+// AppendPasswordResetRequested records an accepted recovery request at an
+// explicitly observed account tail.
+func (p *Publisher) AppendPasswordResetRequested(
+	ctx context.Context,
+	event *corev1.Event,
+	expectedTail uint64,
+) (events.StreamPosition, error) {
+	payload := event.GetPasswordResetRequested()
+	if payload == nil {
+		return events.StreamPosition{}, fmt.Errorf("append password reset requested: event payload is not password_reset_requested")
+	}
+	subject, err := AccountSubject(payload.GetAccountId())
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	record, err := encode(event)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
@@ -171,6 +232,19 @@ func validate(event *corev1.Event) error {
 	case *corev1.Event_EmailClaimed:
 		if !validSubjectToken(payload.EmailClaimed.GetAccountId()) {
 			return fmt.Errorf("invalid account id")
+		}
+	case *corev1.Event_PasswordChanged:
+		credential := payload.PasswordChanged
+		if !validSubjectToken(credential.GetAccountId()) || credential.GetCredentialEnvelopeVersion() != 1 || !validSubjectToken(credential.GetUserKeyRef()) || !validSubjectToken(credential.GetCredentialKeyRef()) || len(credential.GetPasswordVerifierNonce()) == 0 || len(credential.GetPasswordVerifierCiphertext()) == 0 {
+			return fmt.Errorf("password credential envelope is incomplete or unsupported")
+		}
+		if requestID := credential.GetPasswordResetRequestEventId(); requestID != "" && !validSubjectToken(requestID) {
+			return fmt.Errorf("password reset request event id is invalid")
+		}
+	case *corev1.Event_PasswordResetRequested:
+		request := payload.PasswordResetRequested
+		if !validSubjectToken(request.GetAccountId()) || !validSubjectToken(request.GetCredentialEventId()) {
+			return fmt.Errorf("password reset request is incomplete")
 		}
 	case *corev1.Event_IssuerEstablished:
 		if payload.IssuerEstablished.GetIssuer() == "" || payload.IssuerEstablished.GetSigningKeyRef() == "" || payload.IssuerEstablished.GetSigningKeyId() == "" {

--- a/authling/internal/evtstream/evtstream_test.go
+++ b/authling/internal/evtstream/evtstream_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"hmans.de/authling/internal/config"
 	"hmans.de/authling/internal/logging"
@@ -43,12 +44,64 @@ func TestAppendAccountCreatedUsesAggregateOCC(t *testing.T) {
 	}
 }
 
+func TestAppendPasswordChangedUsesObservedAccountTail(t *testing.T) {
+	connection, err := natsruntime.Open(t.Context(), config.NATSConfig{
+		Embedded: config.EmbeddedNATSConfig{Enabled: true, DataDir: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("open NATS: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := connection.Close(); err != nil {
+			t.Errorf("close NATS: %v", err)
+		}
+	})
+	js, stream, err := storage.Open(t.Context(), connection.NATS, 1)
+	if err != nil {
+		t.Fatalf("open storage: %v", err)
+	}
+	logger := logging.Events{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	publisher := NewPublisher(events.NewEncodedEventLog(js, stream, logger))
+	if _, err := publisher.AppendAccountCreated(t.Context(), accountCreatedEvent("evt_created")); err != nil {
+		t.Fatalf("append account creation: %v", err)
+	}
+	tail, err := publisher.AccountTail(t.Context(), "acc_test")
+	if err != nil || tail == 0 {
+		t.Fatalf("account tail = %d, %v", tail, err)
+	}
+	request := passwordResetRequestedEvent("evt_reset_request")
+	if _, err := publisher.AppendPasswordResetRequested(t.Context(), request, tail); err != nil {
+		t.Fatalf("append password reset request: %v", err)
+	}
+	requestTail, err := publisher.AccountTail(t.Context(), "acc_test")
+	if err != nil || requestTail <= tail {
+		t.Fatalf("account tail after reset request = %d, %v", requestTail, err)
+	}
+	first := passwordChangedEvent("evt_password_first")
+	first.GetPasswordChanged().PasswordResetRequestEventId = request.GetId()
+	if _, err := publisher.AppendPasswordChanged(t.Context(), first, requestTail); err != nil {
+		t.Fatalf("append password change: %v", err)
+	}
+	if _, err := publisher.AppendPasswordChanged(t.Context(), passwordChangedEvent("evt_password_stale"), requestTail); !errors.Is(err, events.ErrConflict) {
+		t.Fatalf("stale password change error = %v, want events.ErrConflict", err)
+	}
+}
+
 func TestDecodeRejectsMalformedEvents(t *testing.T) {
 	if _, err := Decode([]byte("not protobuf")); err == nil {
 		t.Fatal("decode malformed event succeeded")
 	}
 	if _, err := Decode(nil); err == nil || !strings.Contains(err.Error(), "id is required") {
 		t.Fatalf("decode empty event error = %v, want missing id", err)
+	}
+	malformed := passwordResetRequestedEvent("evt_reset_request")
+	malformed.GetPasswordResetRequested().CredentialEventId = ""
+	data, err := proto.Marshal(malformed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "password reset request is incomplete") {
+		t.Fatalf("decode incomplete password reset request error = %v", err)
 	}
 }
 
@@ -65,5 +118,31 @@ func accountCreatedEvent(eventID string) *corev1.Event {
 		Event: &corev1.Event_AccountCreated{
 			AccountCreated: &corev1.AccountCreatedEvent{AccountId: "acc_test"},
 		},
+	}
+}
+
+func passwordChangedEvent(eventID string) *corev1.Event {
+	return &corev1.Event{
+		Id:        eventID,
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_PasswordChanged{PasswordChanged: &corev1.PasswordChangedEvent{
+			AccountId:                  "acc_test",
+			UserKeyRef:                 "key_user",
+			CredentialKeyRef:           "key_credential",
+			CredentialEnvelopeVersion:  1,
+			PasswordVerifierNonce:      []byte("nonce"),
+			PasswordVerifierCiphertext: []byte("ciphertext"),
+		}},
+	}
+}
+
+func passwordResetRequestedEvent(eventID string) *corev1.Event {
+	return &corev1.Event{
+		Id:        eventID,
+		CreatedAt: timestamppb.Now(),
+		Event: &corev1.Event_PasswordResetRequested{PasswordResetRequested: &corev1.PasswordResetRequestedEvent{
+			AccountId:         "acc_test",
+			CredentialEventId: "evt_created",
+		}},
 	}
 }

--- a/authling/internal/passwordreset/passwordreset.go
+++ b/authling/internal/passwordreset/passwordreset.go
@@ -1,0 +1,352 @@
+// Package passwordreset owns Authling's verified-email password recovery workflow.
+package passwordreset
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/mail"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	"hmans.de/authling/internal/accounts"
+	"hmans.de/authling/internal/email"
+	"hmans.de/authling/internal/storage"
+	"hmans.de/chatto/pkg/datacrypto"
+)
+
+const FlowTTL = 15 * time.Minute
+const maxWrongAttempts = 5
+const maxCompletionAttempts = 5
+const maxDeliveredCodes = 10
+const maxGlobalDeliveredCodes = 1000
+const maxConcurrentDeliveries = 8
+const maxConcurrentCompletions = 4
+
+var (
+	ErrInvalidEmail   = errors.New("enter a valid email address")
+	ErrInvalidCode    = errors.New("the code is invalid or has expired")
+	ErrInvalidFlow    = errors.New("the password reset has expired; start again")
+	errTooManyCodes   = errors.New("too many password reset codes requested")
+	errCompletionBusy = errors.New("password reset completion capacity exhausted")
+)
+
+type flowState struct {
+	Target             accounts.PasswordResetTarget `json:"target"`
+	CodeDigest         []byte                       `json:"code_digest"`
+	WrongAttempts      int                          `json:"wrong_attempts"`
+	Verified           bool                         `json:"verified"`
+	Completing         bool                         `json:"completing"`
+	CompletionAttempts int                          `json:"completion_attempts"`
+	ExpiresAt          time.Time                    `json:"expires_at"`
+}
+
+type sealedState struct {
+	Version           int `json:"version"`
+	Nonce, Ciphertext []byte
+}
+
+// Service coordinates expiring recovery state, email delivery, and durable
+// password changes without exposing whether an address has an account.
+type Service struct {
+	kv              jetstream.KeyValue
+	js              jetstream.JetStream
+	key             []byte
+	sender          email.Sender
+	accounts        *accounts.Service
+	deliverySlots   chan struct{}
+	completionSlots chan struct{}
+}
+
+// New constructs the password-reset workflow.
+func New(kv jetstream.KeyValue, js jetstream.JetStream, key []byte, sender email.Sender, accountService *accounts.Service) *Service {
+	return &Service{kv: kv, js: js, key: append([]byte(nil), key...), sender: sender, accounts: accountService, deliverySlots: make(chan struct{}, maxConcurrentDeliveries), completionSlots: make(chan struct{}, maxConcurrentCompletions)}
+}
+
+// PasswordMinimumLength returns the active local password policy for form rendering.
+func (s *Service) PasswordMinimumLength() int { return s.accounts.PasswordMinimumLength() }
+
+// Start creates an opaque recovery flow and sends a six-digit code. Existing
+// and absent addresses take the same externally observable delivery path.
+func (s *Service) Start(ctx context.Context, rawEmail string) (string, error) {
+	normalized, err := normalizeAndValidateEmail(rawEmail)
+	if err != nil {
+		return "", err
+	}
+	token, err := randomToken(32)
+	if err != nil {
+		return "", err
+	}
+	code, err := verificationCode()
+	if err != nil {
+		return "", err
+	}
+	if err := s.reserveDelivery(ctx, normalized); err != nil {
+		return "", err
+	}
+	reserved := true
+	delivered := false
+	defer func() {
+		if reserved && !delivered {
+			cleanupContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = s.rollbackDelivery(cleanupContext, normalized)
+		}
+	}()
+	target, _, err := s.accounts.RecordPasswordResetRequested(ctx, normalized)
+	if err != nil {
+		return "", fmt.Errorf("record password reset request: %w", err)
+	}
+	state := flowState{Target: target, CodeDigest: keyedDigest(s.key, "code\x00"+token+"\x00"+code), ExpiresAt: time.Now().UTC().Add(FlowTTL)}
+	key := s.flowKey(token)
+	data, err := s.seal(key, state)
+	if err != nil {
+		return "", err
+	}
+	if _, err := s.kv.Create(ctx, key, data, jetstream.KeyTTL(FlowTTL)); err != nil {
+		return "", fmt.Errorf("store password reset flow: %w", err)
+	}
+	body := fmt.Sprintf("Your Authling password reset code is %s.\n\nIt expires in 15 minutes. If you did not request this, you can ignore this message.\n", code)
+	if err := s.send(ctx, email.Message{To: normalized, Subject: "Your Authling password reset code", Body: body}); err != nil {
+		_ = s.kv.Delete(ctx, key)
+		return "", fmt.Errorf("deliver password reset code: %w", err)
+	}
+	delivered = true
+	return token, nil
+}
+
+// Verify consumes a correct OTP logically. Wrong and repeated attempts share
+// one bounded counter and one public error.
+func (s *Service) Verify(ctx context.Context, token, code string) error {
+	key := s.flowKey(token)
+	entry, state, err := s.read(ctx, key)
+	if err != nil || !time.Now().Before(state.ExpiresAt) || state.Verified || state.WrongAttempts >= maxWrongAttempts {
+		return ErrInvalidCode
+	}
+	want := keyedDigest(s.key, "code\x00"+token+"\x00"+strings.TrimSpace(code))
+	if !hmac.Equal(state.CodeDigest, want) {
+		state.WrongAttempts++
+		if _, updateErr := s.update(ctx, key, entry.Revision(), state); updateErr != nil {
+			return ErrInvalidCode
+		}
+		return ErrInvalidCode
+	}
+	state.Verified = true
+	state.CodeDigest = nil
+	_, err = s.update(ctx, key, entry.Revision(), state)
+	return err
+}
+
+// Complete replaces the password only when the credential bound to the flow
+// is still current. The flow is consumed after success or a stale binding.
+func (s *Service) Complete(ctx context.Context, token, password string) (accounts.Account, error) {
+	key := s.flowKey(token)
+	entry, state, err := s.read(ctx, key)
+	if err != nil || !time.Now().Before(state.ExpiresAt) || !state.Verified || state.Completing || state.CompletionAttempts >= maxCompletionAttempts {
+		return accounts.Account{}, ErrInvalidFlow
+	}
+	select {
+	case s.completionSlots <- struct{}{}:
+		defer func() { <-s.completionSlots }()
+	case <-ctx.Done():
+		return accounts.Account{}, ctx.Err()
+	default:
+		return accounts.Account{}, errCompletionBusy
+	}
+	state.Completing = true
+	state.CompletionAttempts++
+	completionRevision, err := s.update(ctx, key, entry.Revision(), state)
+	if err != nil {
+		return accounts.Account{}, ErrInvalidFlow
+	}
+	if state.Target.AccountID == "" || state.Target.CredentialEventID == "" {
+		_ = s.kv.Delete(ctx, key, jetstream.LastRevision(completionRevision))
+		return accounts.Account{}, ErrInvalidFlow
+	}
+	account, err := s.accounts.ResetPassword(ctx, state.Target, password)
+	if err != nil {
+		if errors.Is(err, accounts.ErrCredentialChanged) {
+			_ = s.kv.Delete(ctx, key, jetstream.LastRevision(completionRevision))
+			return accounts.Account{}, ErrInvalidFlow
+		}
+		state.Completing = false
+		_, _ = s.update(ctx, key, completionRevision, state)
+		return accounts.Account{}, err
+	}
+	_ = s.kv.Delete(ctx, key, jetstream.LastRevision(completionRevision))
+	return account, nil
+}
+
+func (s *Service) flowKey(token string) string {
+	return "password-reset." + base64.RawURLEncoding.EncodeToString(keyedDigest(s.key, "flow\x00"+token))
+}
+
+func (s *Service) seal(key string, state flowState) ([]byte, error) {
+	plain, err := json.Marshal(state)
+	if err != nil {
+		return nil, err
+	}
+	defer clear(plain)
+	sealed, err := datacrypto.Seal(s.key, plain, []byte("authling:password-reset-runtime:v1\x00"+key))
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(sealedState{Version: 1, Nonce: sealed.Nonce, Ciphertext: sealed.Ciphertext})
+}
+
+func (s *Service) read(ctx context.Context, key string) (jetstream.KeyValueEntry, flowState, error) {
+	entry, err := s.kv.Get(ctx, key)
+	if err != nil {
+		return nil, flowState{}, err
+	}
+	var sealed sealedState
+	if err := json.Unmarshal(entry.Value(), &sealed); err != nil || sealed.Version != 1 {
+		return nil, flowState{}, ErrInvalidFlow
+	}
+	plain, err := datacrypto.Open(s.key, sealed.Ciphertext, sealed.Nonce, []byte("authling:password-reset-runtime:v1\x00"+key))
+	if err != nil {
+		return nil, flowState{}, ErrInvalidFlow
+	}
+	defer clear(plain)
+	var state flowState
+	if err := json.Unmarshal(plain, &state); err != nil {
+		return nil, flowState{}, ErrInvalidFlow
+	}
+	return entry, state, nil
+}
+
+func (s *Service) update(ctx context.Context, key string, revision uint64, state flowState) (uint64, error) {
+	data, err := s.seal(key, state)
+	if err != nil {
+		return 0, err
+	}
+	remaining := time.Until(state.ExpiresAt)
+	if remaining <= 0 {
+		return 0, ErrInvalidFlow
+	}
+	updated, err := storage.UpdateKeyWithTTL(ctx, s.js, storage.RuntimeStateBucket, key, data, revision, remaining)
+	if err != nil {
+		return 0, ErrInvalidFlow
+	}
+	return updated, nil
+}
+
+type deliveryCounter struct {
+	Count int `json:"count"`
+}
+
+func (s *Service) deliveryKey(address string) string {
+	return "password-reset-limit." + base64.RawURLEncoding.EncodeToString(keyedDigest(s.key, "delivery\x00"+address))
+}
+
+func (s *Service) reserveDelivery(ctx context.Context, address string) error {
+	if err := s.reserveCounter(ctx, "password-reset-limit.global", maxGlobalDeliveredCodes); err != nil {
+		return err
+	}
+	if err := s.reserveCounter(ctx, s.deliveryKey(address), maxDeliveredCodes); err != nil {
+		_ = s.rollbackCounter(ctx, "password-reset-limit.global")
+		return err
+	}
+	return nil
+}
+
+func (s *Service) reserveCounter(ctx context.Context, key string, limit int) error {
+	for range 16 {
+		entry, err := s.kv.Get(ctx, key)
+		if errors.Is(err, jetstream.ErrKeyNotFound) {
+			data, _ := json.Marshal(deliveryCounter{Count: 1})
+			if _, err := s.kv.Create(ctx, key, data, jetstream.KeyTTL(FlowTTL)); err == nil {
+				return nil
+			}
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read password reset delivery limit: %w", err)
+		}
+		var counter deliveryCounter
+		if json.Unmarshal(entry.Value(), &counter) != nil {
+			return fmt.Errorf("decode password reset delivery limit")
+		}
+		if counter.Count >= limit {
+			return errTooManyCodes
+		}
+		counter.Count++
+		data, _ := json.Marshal(counter)
+		if _, err := storage.UpdateKeyWithTTL(ctx, s.js, storage.RuntimeStateBucket, key, data, entry.Revision(), FlowTTL); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("update password reset delivery limit")
+}
+
+func (s *Service) rollbackDelivery(ctx context.Context, address string) error {
+	return errors.Join(s.rollbackCounter(ctx, s.deliveryKey(address)), s.rollbackCounter(ctx, "password-reset-limit.global"))
+}
+
+func (s *Service) rollbackCounter(ctx context.Context, key string) error {
+	entry, err := s.kv.Get(ctx, key)
+	if err != nil {
+		return nil
+	}
+	var counter deliveryCounter
+	if json.Unmarshal(entry.Value(), &counter) != nil {
+		return nil
+	}
+	if counter.Count <= 1 {
+		return s.kv.Delete(ctx, key, jetstream.LastRevision(entry.Revision()))
+	}
+	counter.Count--
+	data, _ := json.Marshal(counter)
+	_, err = storage.UpdateKeyWithTTL(ctx, s.js, storage.RuntimeStateBucket, key, data, entry.Revision(), FlowTTL)
+	return err
+}
+
+func (s *Service) send(ctx context.Context, message email.Message) error {
+	select {
+	case s.deliverySlots <- struct{}{}:
+		defer func() { <-s.deliverySlots }()
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return fmt.Errorf("email delivery capacity exhausted")
+	}
+	return s.sender.SendContext(ctx, message)
+}
+
+func normalizeAndValidateEmail(raw string) (string, error) {
+	value := accounts.NormalizeEmail(raw)
+	parsed, err := mail.ParseAddress(value)
+	if err != nil || parsed.Address != value || strings.ContainsAny(value, "\r\n") {
+		return "", ErrInvalidEmail
+	}
+	return value, nil
+}
+
+func keyedDigest(key []byte, value string) []byte {
+	h := hmac.New(sha256.New, key)
+	_, _ = h.Write([]byte(value))
+	return h.Sum(nil)
+}
+
+func randomToken(size int) (string, error) {
+	data := make([]byte, size)
+	if _, err := rand.Read(data); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func verificationCode() (string, error) {
+	var b [4]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	n := uint32(b[0])<<24 | uint32(b[1])<<16 | uint32(b[2])<<8 | uint32(b[3])
+	return fmt.Sprintf("%06d", n%1000000), nil
+}

--- a/authling/internal/pb/authling/core/v1/event.pb.go
+++ b/authling/internal/pb/authling/core/v1/event.pb.go
@@ -37,6 +37,8 @@ type Event struct {
 	//	*Event_AccountCreated
 	//	*Event_EmailClaimed
 	//	*Event_IssuerEstablished
+	//	*Event_PasswordChanged
+	//	*Event_PasswordResetRequested
 	Event         isEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -120,6 +122,24 @@ func (x *Event) GetIssuerEstablished() *IssuerEstablishedEvent {
 	return nil
 }
 
+func (x *Event) GetPasswordChanged() *PasswordChangedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_PasswordChanged); ok {
+			return x.PasswordChanged
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetPasswordResetRequested() *PasswordResetRequestedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_PasswordResetRequested); ok {
+			return x.PasswordResetRequested
+		}
+	}
+	return nil
+}
+
 type isEvent_Event interface {
 	isEvent_Event()
 }
@@ -136,11 +156,23 @@ type Event_IssuerEstablished struct {
 	IssuerEstablished *IssuerEstablishedEvent `protobuf:"bytes,102,opt,name=issuer_established,json=issuerEstablished,proto3,oneof"`
 }
 
+type Event_PasswordChanged struct {
+	PasswordChanged *PasswordChangedEvent `protobuf:"bytes,103,opt,name=password_changed,json=passwordChanged,proto3,oneof"`
+}
+
+type Event_PasswordResetRequested struct {
+	PasswordResetRequested *PasswordResetRequestedEvent `protobuf:"bytes,104,opt,name=password_reset_requested,json=passwordResetRequested,proto3,oneof"`
+}
+
 func (*Event_AccountCreated) isEvent_Event() {}
 
 func (*Event_EmailClaimed) isEvent_Event() {}
 
 func (*Event_IssuerEstablished) isEvent_Event() {}
+
+func (*Event_PasswordChanged) isEvent_Event() {}
+
+func (*Event_PasswordResetRequested) isEvent_Event() {}
 
 // IssuerEstablishedEvent permanently binds one Authling deployment to its
 // externally visible OpenID Connect issuer and initial signing-key identity.
@@ -354,18 +386,171 @@ func (x *AccountCreatedEvent) GetPasswordVerifierCiphertext() []byte {
 	return nil
 }
 
+// PasswordChangedEvent replaces one local account's password verifier without
+// changing its stable account identity or verified email address.
+type PasswordChangedEvent struct {
+	state                      protoimpl.MessageState `protogen:"open.v1"`
+	AccountId                  string                 `protobuf:"bytes,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	UserKeyRef                 string                 `protobuf:"bytes,2,opt,name=user_key_ref,json=userKeyRef,proto3" json:"user_key_ref,omitempty"`
+	CredentialKeyRef           string                 `protobuf:"bytes,3,opt,name=credential_key_ref,json=credentialKeyRef,proto3" json:"credential_key_ref,omitempty"`
+	CredentialEnvelopeVersion  uint32                 `protobuf:"varint,4,opt,name=credential_envelope_version,json=credentialEnvelopeVersion,proto3" json:"credential_envelope_version,omitempty"`
+	PasswordVerifierNonce      []byte                 `protobuf:"bytes,5,opt,name=password_verifier_nonce,json=passwordVerifierNonce,proto3" json:"password_verifier_nonce,omitempty"`
+	PasswordVerifierCiphertext []byte                 `protobuf:"bytes,6,opt,name=password_verifier_ciphertext,json=passwordVerifierCiphertext,proto3" json:"password_verifier_ciphertext,omitempty"`
+	// The audit event that initiated this recovery-driven change. Historical
+	// password changes written before request auditing leave this empty.
+	PasswordResetRequestEventId string `protobuf:"bytes,7,opt,name=password_reset_request_event_id,json=passwordResetRequestEventId,proto3" json:"password_reset_request_event_id,omitempty"`
+	unknownFields               protoimpl.UnknownFields
+	sizeCache                   protoimpl.SizeCache
+}
+
+func (x *PasswordChangedEvent) Reset() {
+	*x = PasswordChangedEvent{}
+	mi := &file_authling_core_v1_event_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PasswordChangedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PasswordChangedEvent) ProtoMessage() {}
+
+func (x *PasswordChangedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_authling_core_v1_event_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PasswordChangedEvent.ProtoReflect.Descriptor instead.
+func (*PasswordChangedEvent) Descriptor() ([]byte, []int) {
+	return file_authling_core_v1_event_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *PasswordChangedEvent) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *PasswordChangedEvent) GetUserKeyRef() string {
+	if x != nil {
+		return x.UserKeyRef
+	}
+	return ""
+}
+
+func (x *PasswordChangedEvent) GetCredentialKeyRef() string {
+	if x != nil {
+		return x.CredentialKeyRef
+	}
+	return ""
+}
+
+func (x *PasswordChangedEvent) GetCredentialEnvelopeVersion() uint32 {
+	if x != nil {
+		return x.CredentialEnvelopeVersion
+	}
+	return 0
+}
+
+func (x *PasswordChangedEvent) GetPasswordVerifierNonce() []byte {
+	if x != nil {
+		return x.PasswordVerifierNonce
+	}
+	return nil
+}
+
+func (x *PasswordChangedEvent) GetPasswordVerifierCiphertext() []byte {
+	if x != nil {
+		return x.PasswordVerifierCiphertext
+	}
+	return nil
+}
+
+func (x *PasswordChangedEvent) GetPasswordResetRequestEventId() string {
+	if x != nil {
+		return x.PasswordResetRequestEventId
+	}
+	return ""
+}
+
+// PasswordResetRequestedEvent records an accepted recovery request for an
+// existing local account without retaining the submitted email or flow secret.
+// The envelope event ID is the opaque recovery request identifier.
+type PasswordResetRequestedEvent struct {
+	state             protoimpl.MessageState `protogen:"open.v1"`
+	AccountId         string                 `protobuf:"bytes,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	CredentialEventId string                 `protobuf:"bytes,2,opt,name=credential_event_id,json=credentialEventId,proto3" json:"credential_event_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *PasswordResetRequestedEvent) Reset() {
+	*x = PasswordResetRequestedEvent{}
+	mi := &file_authling_core_v1_event_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *PasswordResetRequestedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*PasswordResetRequestedEvent) ProtoMessage() {}
+
+func (x *PasswordResetRequestedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_authling_core_v1_event_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use PasswordResetRequestedEvent.ProtoReflect.Descriptor instead.
+func (*PasswordResetRequestedEvent) Descriptor() ([]byte, []int) {
+	return file_authling_core_v1_event_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *PasswordResetRequestedEvent) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *PasswordResetRequestedEvent) GetCredentialEventId() string {
+	if x != nil {
+		return x.CredentialEventId
+	}
+	return ""
+}
+
 var File_authling_core_v1_event_proto protoreflect.FileDescriptor
 
 const file_authling_core_v1_event_proto_rawDesc = "" +
 	"\n" +
-	"\x1cauthling/core/v1/event.proto\x12\x10authling.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd4\x02\n" +
+	"\x1cauthling/core/v1/event.proto\x12\x10authling.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x94\x04\n" +
 	"\x05Event\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
 	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12P\n" +
 	"\x0faccount_created\x18d \x01(\v2%.authling.core.v1.AccountCreatedEventH\x00R\x0eaccountCreated\x12J\n" +
 	"\remail_claimed\x18e \x01(\v2#.authling.core.v1.EmailClaimedEventH\x00R\femailClaimed\x12Y\n" +
-	"\x12issuer_established\x18f \x01(\v2(.authling.core.v1.IssuerEstablishedEventH\x00R\x11issuerEstablishedB\a\n" +
+	"\x12issuer_established\x18f \x01(\v2(.authling.core.v1.IssuerEstablishedEventH\x00R\x11issuerEstablished\x12S\n" +
+	"\x10password_changed\x18g \x01(\v2&.authling.core.v1.PasswordChangedEventH\x00R\x0fpasswordChanged\x12i\n" +
+	"\x18password_reset_requested\x18h \x01(\v2-.authling.core.v1.PasswordResetRequestedEventH\x00R\x16passwordResetRequestedB\a\n" +
 	"\x05event\"~\n" +
 	"\x16IssuerEstablishedEvent\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12&\n" +
@@ -385,7 +570,21 @@ const file_authling_core_v1_event_proto_rawDesc = "" +
 	"\x10email_ciphertext\x18\x05 \x01(\fR\x0femailCiphertext\x12>\n" +
 	"\x1bcredential_envelope_version\x18\x06 \x01(\rR\x19credentialEnvelopeVersion\x126\n" +
 	"\x17password_verifier_nonce\x18\a \x01(\fR\x15passwordVerifierNonce\x12@\n" +
-	"\x1cpassword_verifier_ciphertext\x18\b \x01(\fR\x1apasswordVerifierCiphertextB7Z5hmans.de/authling/internal/pb/authling/core/v1;corev1b\x06proto3"
+	"\x1cpassword_verifier_ciphertext\x18\b \x01(\fR\x1apasswordVerifierCiphertext\"\x85\x03\n" +
+	"\x14PasswordChangedEvent\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\tR\taccountId\x12 \n" +
+	"\fuser_key_ref\x18\x02 \x01(\tR\n" +
+	"userKeyRef\x12,\n" +
+	"\x12credential_key_ref\x18\x03 \x01(\tR\x10credentialKeyRef\x12>\n" +
+	"\x1bcredential_envelope_version\x18\x04 \x01(\rR\x19credentialEnvelopeVersion\x126\n" +
+	"\x17password_verifier_nonce\x18\x05 \x01(\fR\x15passwordVerifierNonce\x12@\n" +
+	"\x1cpassword_verifier_ciphertext\x18\x06 \x01(\fR\x1apasswordVerifierCiphertext\x12D\n" +
+	"\x1fpassword_reset_request_event_id\x18\a \x01(\tR\x1bpasswordResetRequestEventId\"l\n" +
+	"\x1bPasswordResetRequestedEvent\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\tR\taccountId\x12.\n" +
+	"\x13credential_event_id\x18\x02 \x01(\tR\x11credentialEventIdB7Z5hmans.de/authling/internal/pb/authling/core/v1;corev1b\x06proto3"
 
 var (
 	file_authling_core_v1_event_proto_rawDescOnce sync.Once
@@ -399,24 +598,28 @@ func file_authling_core_v1_event_proto_rawDescGZIP() []byte {
 	return file_authling_core_v1_event_proto_rawDescData
 }
 
-var file_authling_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_authling_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_authling_core_v1_event_proto_goTypes = []any{
-	(*Event)(nil),                  // 0: authling.core.v1.Event
-	(*IssuerEstablishedEvent)(nil), // 1: authling.core.v1.IssuerEstablishedEvent
-	(*EmailClaimedEvent)(nil),      // 2: authling.core.v1.EmailClaimedEvent
-	(*AccountCreatedEvent)(nil),    // 3: authling.core.v1.AccountCreatedEvent
-	(*timestamppb.Timestamp)(nil),  // 4: google.protobuf.Timestamp
+	(*Event)(nil),                       // 0: authling.core.v1.Event
+	(*IssuerEstablishedEvent)(nil),      // 1: authling.core.v1.IssuerEstablishedEvent
+	(*EmailClaimedEvent)(nil),           // 2: authling.core.v1.EmailClaimedEvent
+	(*AccountCreatedEvent)(nil),         // 3: authling.core.v1.AccountCreatedEvent
+	(*PasswordChangedEvent)(nil),        // 4: authling.core.v1.PasswordChangedEvent
+	(*PasswordResetRequestedEvent)(nil), // 5: authling.core.v1.PasswordResetRequestedEvent
+	(*timestamppb.Timestamp)(nil),       // 6: google.protobuf.Timestamp
 }
 var file_authling_core_v1_event_proto_depIdxs = []int32{
-	4, // 0: authling.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	6, // 0: authling.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
 	3, // 1: authling.core.v1.Event.account_created:type_name -> authling.core.v1.AccountCreatedEvent
 	2, // 2: authling.core.v1.Event.email_claimed:type_name -> authling.core.v1.EmailClaimedEvent
 	1, // 3: authling.core.v1.Event.issuer_established:type_name -> authling.core.v1.IssuerEstablishedEvent
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	4, // 4: authling.core.v1.Event.password_changed:type_name -> authling.core.v1.PasswordChangedEvent
+	5, // 5: authling.core.v1.Event.password_reset_requested:type_name -> authling.core.v1.PasswordResetRequestedEvent
+	6, // [6:6] is the sub-list for method output_type
+	6, // [6:6] is the sub-list for method input_type
+	6, // [6:6] is the sub-list for extension type_name
+	6, // [6:6] is the sub-list for extension extendee
+	0, // [0:6] is the sub-list for field type_name
 }
 
 func init() { file_authling_core_v1_event_proto_init() }
@@ -428,6 +631,8 @@ func file_authling_core_v1_event_proto_init() {
 		(*Event_AccountCreated)(nil),
 		(*Event_EmailClaimed)(nil),
 		(*Event_IssuerEstablished)(nil),
+		(*Event_PasswordChanged)(nil),
+		(*Event_PasswordResetRequested)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -435,7 +640,7 @@ func file_authling_core_v1_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_authling_core_v1_event_proto_rawDesc), len(file_authling_core_v1_event_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/authling/internal/sessions/sessions.go
+++ b/authling/internal/sessions/sessions.go
@@ -33,11 +33,16 @@ var ErrNotFound = errors.New("session not found")
 
 // Session is the authenticated server-side browser state.
 type Session struct {
-	AccountID  string    `json:"account_id"`
-	CreatedAt  time.Time `json:"created_at"`
-	LastSeenAt time.Time `json:"last_seen_at"`
-	ExpiresAt  time.Time `json:"expires_at"`
+	AccountID             string    `json:"account_id"`
+	AuthenticationVersion uint64    `json:"authentication_version,omitempty"`
+	CreatedAt             time.Time `json:"created_at"`
+	LastSeenAt            time.Time `json:"last_seen_at"`
+	ExpiresAt             time.Time `json:"expires_at"`
 }
+
+// AuthenticationVersionResolver returns the durable credential generation for
+// an account. A changed generation invalidates sessions issued before it.
+type AuthenticationVersionResolver func(accountID string) (uint64, bool)
 
 type sealedState struct {
 	Version    int    `json:"version"`
@@ -47,15 +52,16 @@ type sealedState struct {
 
 // Service stores encrypted session state in Authling's runtime KV bucket.
 type Service struct {
-	kv  jetstream.KeyValue
-	js  jetstream.JetStream
-	key []byte
-	now func() time.Time
+	kv                    jetstream.KeyValue
+	js                    jetstream.JetStream
+	key                   []byte
+	now                   func() time.Time
+	authenticationVersion AuthenticationVersionResolver
 }
 
 // New constructs the browser-session boundary.
-func New(kv jetstream.KeyValue, js jetstream.JetStream, key []byte) *Service {
-	return &Service{kv: kv, js: js, key: append([]byte(nil), key...), now: time.Now}
+func New(kv jetstream.KeyValue, js jetstream.JetStream, key []byte, authenticationVersion AuthenticationVersionResolver) *Service {
+	return &Service{kv: kv, js: js, key: append([]byte(nil), key...), now: time.Now, authenticationVersion: authenticationVersion}
 }
 
 // Create starts a new authenticated browser session and returns its bearer
@@ -72,6 +78,13 @@ func (s *Service) Create(ctx context.Context, accountID string) (string, Session
 	clear(random)
 	now := s.now().UTC()
 	state := Session{AccountID: accountID, CreatedAt: now, LastSeenAt: now, ExpiresAt: now.Add(AbsoluteLifetime)}
+	if s.authenticationVersion != nil {
+		version, ok := s.authenticationVersion(accountID)
+		if !ok {
+			return "", Session{}, fmt.Errorf("create session for absent account")
+		}
+		state.AuthenticationVersion = version
+	}
 	key := s.sessionKey(token)
 	data, err := s.seal(key, state)
 	if err != nil {
@@ -109,6 +122,13 @@ func (s *Service) validate(ctx context.Context, token string, touch bool) (Sessi
 		if !now.Before(state.ExpiresAt) || now.Sub(state.LastSeenAt) >= InactivityLifetime {
 			_ = s.kv.Delete(ctx, key)
 			return Session{}, ErrNotFound
+		}
+		if s.authenticationVersion != nil {
+			version, ok := s.authenticationVersion(state.AccountID)
+			if !ok || version != state.AuthenticationVersion {
+				_ = s.kv.Delete(ctx, key)
+				return Session{}, ErrNotFound
+			}
 		}
 		if !touch {
 			return state, nil

--- a/authling/internal/sessions/sessions_test.go
+++ b/authling/internal/sessions/sessions_test.go
@@ -121,6 +121,26 @@ func TestSessionRejectsForgedTokensWithoutKVLookup(t *testing.T) {
 	}
 }
 
+func TestSessionRejectsAnOlderAuthenticationVersion(t *testing.T) {
+	service, _, cleanup := testService(t)
+	defer cleanup()
+	version := uint64(3)
+	service.authenticationVersion = func(accountID string) (uint64, bool) {
+		return version, accountID == "acc_versioned"
+	}
+	token, created, err := service.Create(t.Context(), "acc_versioned")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.AuthenticationVersion != version {
+		t.Fatalf("authentication version = %d, want %d", created.AuthenticationVersion, version)
+	}
+	version++
+	if _, err := service.Validate(t.Context(), token); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("validate older authentication version error = %v, want ErrNotFound", err)
+	}
+}
+
 func testService(t *testing.T) (*Service, storage.Stores, func()) {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
@@ -147,7 +167,7 @@ func testService(t *testing.T) (*Service, storage.Stores, func()) {
 		connection.Close()
 		t.Fatal(err)
 	}
-	service := New(stores.RuntimeState, js, key)
+	service := New(stores.RuntimeState, js, key, nil)
 	clear(key)
 	return service, stores, func() {
 		cancel()

--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"net/url"
 	"strconv"
 	"hmans.de/authling/internal/oidcprovider"
 )
@@ -53,7 +54,77 @@ templ loginPage(message, oidcRequest string) {
 			<label class="block"><span class="font-medium">Password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="password" autocomplete="current-password" maxlength="1024" required/></label>
 			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Sign in</button>
 		</form>
+		<p class="mt-4 text-sm"><a class="font-semibold text-authling-700 underline dark:text-authling-200" href={ passwordResetURL(oidcRequest) }>Forgot your password?</a></p>
 		<p class="mt-6 text-sm text-slate-500">No account yet? <a class="font-semibold text-authling-700 underline dark:text-authling-200" href="/signup">Create one</a>.</p>
+	}
+}
+
+func passwordResetURL(oidcRequest string) string {
+	if oidcRequest == "" {
+		return "/password-reset"
+	}
+	return "/password-reset?id=" + url.QueryEscape(oidcRequest)
+}
+
+templ passwordResetPage(message, oidcRequest string) {
+	@layout("Reset your password") {
+		<h1 class="text-3xl font-semibold tracking-tight">Reset your password</h1>
+		<p class="mt-3 text-slate-600 dark:text-slate-300">We’ll email you a six-digit password reset code.</p>
+		if message != "" {
+			<p role="alert" class="mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100">{ message }</p>
+		}
+		<form class="mt-8 space-y-5" method="post" action="/password-reset">
+			if oidcRequest != "" {
+				<input type="hidden" name="oidc_request" value={ oidcRequest }/>
+			}
+			<label class="block"><span class="font-medium">Email address</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="email" name="email" autocomplete="email" autofocus required/></label>
+			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Email me a reset code</button>
+		</form>
+		<p class="mt-6 text-sm text-slate-500"><a class="font-semibold text-authling-700 underline dark:text-authling-200" href="/login">Return to sign in</a>.</p>
+	}
+}
+
+templ passwordResetCodePage(flow, message, oidcRequest string) {
+	@layout("Enter your password reset code") {
+		<h1 class="text-3xl font-semibold tracking-tight">Check your email</h1>
+		<p class="mt-3 text-slate-600 dark:text-slate-300">If that address can be used, we sent a six-digit code. It expires in 15 minutes.</p>
+		if message != "" {
+			<p role="alert" class="mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100">{ message }</p>
+		}
+		<form class="mt-8 space-y-5" method="post" action="/password-reset/verify">
+			<input type="hidden" name="flow" value={ flow }/>
+			if oidcRequest != "" {
+				<input type="hidden" name="oidc_request" value={ oidcRequest }/>
+			}
+			<label class="block"><span class="font-medium">Password reset code</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></label>
+			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Verify code</button>
+		</form>
+	}
+}
+
+templ newPasswordPage(flow, message string, passwordMinimumLength int, oidcRequest string) {
+	@layout("Choose a new password") {
+		<h1 class="text-3xl font-semibold tracking-tight">Choose a new password</h1>
+		<p class="mt-3 text-slate-600 dark:text-slate-300">Use at least { strconv.Itoa(passwordMinimumLength) } characters. Changing your password signs out your other Authling browser sessions.</p>
+		if message != "" {
+			<p role="alert" class="mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100">{ message }</p>
+		}
+		<form class="mt-8 space-y-5" method="post" action="/password-reset/complete">
+			<input type="hidden" name="flow" value={ flow }/>
+			if oidcRequest != "" {
+				<input type="hidden" name="oidc_request" value={ oidcRequest }/>
+			}
+			<label class="block"><span class="font-medium">New password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="password" autocomplete="new-password" minlength={ strconv.Itoa(passwordMinimumLength) } maxlength="1024" autofocus required/></label>
+			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Reset password</button>
+		</form>
+	}
+}
+
+templ passwordResetCompletePage() {
+	@layout("Password reset") {
+		<h1 class="text-3xl font-semibold tracking-tight">Your password was reset</h1>
+		<p class="mt-3 text-slate-600 dark:text-slate-300">Your new password is ready. Sign in to continue.</p>
+		<a class="mt-8 inline-flex rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" href="/login">Sign in</a>
 	}
 }
 

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -10,6 +10,7 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"hmans.de/authling/internal/oidcprovider"
+	"net/url"
 	"strconv"
 )
 
@@ -41,7 +42,7 @@ func layout(title string) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 15, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 16, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -155,7 +156,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 46, Col: 113}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 47, Col: 113}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -178,7 +179,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var8 string
 				templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 50, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 51, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var8)
 				if templ_7745c5c3_Err != nil {
@@ -189,7 +190,20 @@ func loginPage(message, oidcRequest string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"email\" name=\"email\" autocomplete=\"email\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">Password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"password\" autocomplete=\"current-password\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Sign in</button></form><p class=\"mt-6 text-sm text-slate-500\">No account yet? <a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"/signup\">Create one</a>.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"email\" name=\"email\" autocomplete=\"email\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">Password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"password\" autocomplete=\"current-password\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Sign in</button></form><p class=\"mt-4 text-sm\"><a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var9 templ.SafeURL
+			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinURLErrs(passwordResetURL(oidcRequest))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 57, Col: 138}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "\">Forgot your password?</a></p><p class=\"mt-6 text-sm text-slate-500\">No account yet? <a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"/signup\">Create one</a>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -203,7 +217,14 @@ func loginPage(message, oidcRequest string) templ.Component {
 	})
 }
 
-func consentPage(request oidcprovider.ConsentRequest) templ.Component {
+func passwordResetURL(oidcRequest string) string {
+	if oidcRequest == "" {
+		return "/password-reset"
+	}
+	return "/password-reset?id=" + url.QueryEscape(oidcRequest)
+}
+
+func passwordResetPage(message, oidcRequest string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -219,12 +240,12 @@ func consentPage(request oidcprovider.ConsentRequest) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var9 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var9 == nil {
-			templ_7745c5c3_Var9 = templ.NopComponent
+		templ_7745c5c3_Var10 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var10 == nil {
+			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var10 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var11 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -236,52 +257,59 @@ func consentPage(request oidcprovider.ConsentRequest) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<h1 class=\"text-3xl font-semibold tracking-tight\">Authorize ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<h1 class=\"text-3xl font-semibold tracking-tight\">Reset your password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">We’ll email you a six-digit password reset code.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var11 string
-			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientName)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 62, Col: 82}
+			if message != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var12 string
+				templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 74, Col: 113}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "?</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\"><strong>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var12 string
-			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientHost)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 63, Col: 81}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</strong> is asking for access to your account.</p><div class=\"mt-5 rounded-xl border border-slate-300 p-4 dark:border-slate-700\"><p class=\"font-medium\">This application will be able to:</p><ul class=\"mt-2 list-disc space-y-2 pl-5 text-sm text-slate-600 dark:text-slate-300\"><li>Know your stable account identifier.</li></ul></div><form class=\"mt-8 grid gap-3\" method=\"post\" action=\"/oidc/consent\"><input type=\"hidden\" name=\"id\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/password-reset\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var13 string
-			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(request.ID)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 71, Col: 52}
+			if oidcRequest != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<input type=\"hidden\" name=\"oidc_request\" value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var13 string
+				templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 78, Col: 64}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "\"> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var13)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "\"> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\" name=\"decision\" value=\"allow\">Authorize</button> <button class=\"w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" type=\"submit\" name=\"decision\" value=\"deny\">Deny</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"email\" name=\"email\" autocomplete=\"email\" autofocus required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Email me a reset code</button></form><p class=\"mt-6 text-sm text-slate-500\"><a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"/login\">Return to sign in</a>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Authorize access").Render(templ.WithChildren(ctx, templ_7745c5c3_Var10), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Reset your password").Render(templ.WithChildren(ctx, templ_7745c5c3_Var11), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -289,7 +317,7 @@ func consentPage(request oidcprovider.ConsentRequest) templ.Component {
 	})
 }
 
-func signupPage(message string) templ.Component {
+func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -322,36 +350,407 @@ func signupPage(message string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<h1 class=\"text-3xl font-semibold tracking-tight\">Create your account</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">We’ll email you a six-digit verification code.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<h1 class=\"text-3xl font-semibold tracking-tight\">Check your email</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">If that address can be used, we sent a six-digit code. It expires in 15 minutes.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if message != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 83, Col: 113}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 92, Col: 113}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/signup\"><label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"email\" name=\"email\" autocomplete=\"email\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Email me a code</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/password-reset/verify\"><input type=\"hidden\" name=\"flow\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var17 string
+			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 95, Col: 48}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var17)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if oidcRequest != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<input type=\"hidden\" name=\"oidc_request\" value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var18 string
+				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 97, Col: 64}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var18)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\"> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<label class=\"block\"><span class=\"font-medium\">Password reset code</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify code</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Create your Authling account").Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Enter your password reset code").Render(templ.WithChildren(ctx, templ_7745c5c3_Var15), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func newPasswordPage(flow, message string, passwordMinimumLength int, oidcRequest string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var19 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var19 == nil {
+			templ_7745c5c3_Var19 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var20 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "<h1 class=\"text-3xl font-semibold tracking-tight\">Choose a new password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Use at least ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var21 string
+			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 108, Col: 103}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " characters. Changing your password signs out your other Authling browser sessions.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if message != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var22 string
+				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 110, Col: 113}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/password-reset/complete\"><input type=\"hidden\" name=\"flow\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var23 string
+			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 113, Col: 48}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var23)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\"> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if oidcRequest != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<input type=\"hidden\" name=\"oidc_request\" value=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var24 string
+				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 115, Col: 64}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var24)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "\"> ")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<label class=\"block\"><span class=\"font-medium\">New password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"password\" autocomplete=\"new-password\" minlength=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var25 string
+			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 117, Col: 263}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "\" maxlength=\"1024\" autofocus required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Reset password</button></form>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = layout("Choose a new password").Render(templ.WithChildren(ctx, templ_7745c5c3_Var20), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func passwordResetCompletePage() templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var26 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var26 == nil {
+			templ_7745c5c3_Var26 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var27 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<h1 class=\"text-3xl font-semibold tracking-tight\">Your password was reset</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Your new password is ready. Sign in to continue.</p><a class=\"mt-8 inline-flex rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" href=\"/login\">Sign in</a>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = layout("Password reset").Render(templ.WithChildren(ctx, templ_7745c5c3_Var27), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func consentPage(request oidcprovider.ConsentRequest) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var28 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var28 == nil {
+			templ_7745c5c3_Var28 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var29 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<h1 class=\"text-3xl font-semibold tracking-tight\">Authorize ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var30 string
+			templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientName)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 133, Col: 82}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "?</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\"><strong>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var31 string
+			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientHost)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 134, Col: 81}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</strong> is asking for access to your account.</p><div class=\"mt-5 rounded-xl border border-slate-300 p-4 dark:border-slate-700\"><p class=\"font-medium\">This application will be able to:</p><ul class=\"mt-2 list-disc space-y-2 pl-5 text-sm text-slate-600 dark:text-slate-300\"><li>Know your stable account identifier.</li></ul></div><form class=\"mt-8 grid gap-3\" method=\"post\" action=\"/oidc/consent\"><input type=\"hidden\" name=\"id\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var32 string
+			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.ResolveAttributeValue(request.ID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 142, Col: 52}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var32)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\"> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\" name=\"decision\" value=\"allow\">Authorize</button> <button class=\"w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" type=\"submit\" name=\"decision\" value=\"deny\">Deny</button></form>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = layout("Authorize access").Render(templ.WithChildren(ctx, templ_7745c5c3_Var29), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func signupPage(message string) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var33 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var33 == nil {
+			templ_7745c5c3_Var33 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var34 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "<h1 class=\"text-3xl font-semibold tracking-tight\">Create your account</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">We’ll email you a six-digit verification code.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if message != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var35 string
+				templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 154, Col: 113}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/signup\"><label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"email\" name=\"email\" autocomplete=\"email\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Email me a code</button></form>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = layout("Create your Authling account").Render(templ.WithChildren(ctx, templ_7745c5c3_Var34), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -375,12 +774,12 @@ func codePage(flow, message string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var17 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var17 == nil {
-			templ_7745c5c3_Var17 = templ.NopComponent
+		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var36 == nil {
+			templ_7745c5c3_Var36 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var18 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var37 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -392,49 +791,49 @@ func codePage(flow, message string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<h1 class=\"text-3xl font-semibold tracking-tight\">Check your email</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">If that address can be used, we sent a six-digit code. It expires in 15 minutes.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<h1 class=\"text-3xl font-semibold tracking-tight\">Check your email</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">If that address can be used, we sent a six-digit code. It expires in 15 minutes.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if message != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var19 string
-				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				var templ_7745c5c3_Var38 string
+				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 97, Col: 113}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 168, Col: 113}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/signup/verify\"><input type=\"hidden\" name=\"flow\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/signup/verify\"><input type=\"hidden\" name=\"flow\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var20 string
-			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
+			var templ_7745c5c3_Var39 string
+			templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 100, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 171, Col: 48}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var39)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\"> <label class=\"block\"><span class=\"font-medium\">Verification code</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify email</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\"> <label class=\"block\"><span class=\"font-medium\">Verification code</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify email</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Verify your email").Render(templ.WithChildren(ctx, templ_7745c5c3_Var18), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Verify your email").Render(templ.WithChildren(ctx, templ_7745c5c3_Var37), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -458,12 +857,12 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var21 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var21 == nil {
-			templ_7745c5c3_Var21 = templ.NopComponent
+		templ_7745c5c3_Var40 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var40 == nil {
+			templ_7745c5c3_Var40 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var22 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var41 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -475,75 +874,75 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<h1 class=\"text-3xl font-semibold tracking-tight\">Choose a password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Use at least ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "<h1 class=\"text-3xl font-semibold tracking-tight\">Choose a password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Use at least ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var23 string
-			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
+			var templ_7745c5c3_Var42 string
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 110, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 181, Col: 103}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, " characters. Spaces and passphrases are welcome.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, " characters. Spaces and passphrases are welcome.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if message != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var24 string
-				templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				var templ_7745c5c3_Var43 string
+				templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 112, Col: 113}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 183, Col: 113}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "</p>")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/signup/complete\"><input type=\"hidden\" name=\"flow\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/signup/complete\"><input type=\"hidden\" name=\"flow\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var25 string
-			templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
+			var templ_7745c5c3_Var44 string
+			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 115, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 186, Col: 48}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var25)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\"> <label class=\"block\"><span class=\"font-medium\">Password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"password\" autocomplete=\"new-password\" minlength=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var44)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var26 string
-			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 116, Col: 259}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\"> <label class=\"block\"><span class=\"font-medium\">Password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"password\" autocomplete=\"new-password\" minlength=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Create account</button></form>")
+			var templ_7745c5c3_Var45 string
+			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 187, Col: 259}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var45)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Create account</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Choose a password").Render(templ.WithChildren(ctx, templ_7745c5c3_Var22), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Choose a password").Render(templ.WithChildren(ctx, templ_7745c5c3_Var41), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -567,12 +966,12 @@ func accountCreatedPage(accountID string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var27 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var27 == nil {
-			templ_7745c5c3_Var27 = templ.NopComponent
+		templ_7745c5c3_Var46 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var46 == nil {
+			templ_7745c5c3_Var46 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var28 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var47 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -584,26 +983,26 @@ func accountCreatedPage(accountID string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<h1 class=\"text-3xl font-semibold tracking-tight\">Your account is ready</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Your email was verified and your account was created.</p><p class=\"mt-6 text-sm text-slate-500\">Account ID: <code>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<h1 class=\"text-3xl font-semibold tracking-tight\">Your account is ready</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Your email was verified and your account was created.</p><p class=\"mt-6 text-sm text-slate-500\">Account ID: <code>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
+			var templ_7745c5c3_Var48 string
+			templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 126, Col: 70}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 197, Col: 70}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "</code></p><a class=\"mt-8 inline-flex rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" href=\"/login\">Sign in</a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</code></p><a class=\"mt-8 inline-flex rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" href=\"/login\">Sign in</a>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Account created").Render(templ.WithChildren(ctx, templ_7745c5c3_Var28), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Account created").Render(templ.WithChildren(ctx, templ_7745c5c3_Var47), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -627,12 +1026,12 @@ func accountPage(accountID string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var30 == nil {
-			templ_7745c5c3_Var30 = templ.NopComponent
+		templ_7745c5c3_Var49 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var49 == nil {
+			templ_7745c5c3_Var49 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var31 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var50 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -644,26 +1043,26 @@ func accountPage(accountID string) templ.Component {
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "<p class=\"mb-3 text-sm font-semibold tracking-widest text-authling-600 uppercase dark:text-authling-200\">Signed in</p><h1 class=\"text-3xl font-semibold tracking-tight\">Your account</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Your browser has an active Authling session.</p><p class=\"mt-6 text-sm text-slate-500\">Account ID: <code>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<p class=\"mb-3 text-sm font-semibold tracking-widest text-authling-600 uppercase dark:text-authling-200\">Signed in</p><h1 class=\"text-3xl font-semibold tracking-tight\">Your account</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Your browser has an active Authling session.</p><p class=\"mt-6 text-sm text-slate-500\">Account ID: <code>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var32 string
-			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
+			var templ_7745c5c3_Var51 string
+			templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 136, Col: 70}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 207, Col: 70}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "</code></p><form class=\"mt-8\" method=\"post\" action=\"/logout\"><button class=\"w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" type=\"submit\">Sign out</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</code></p><form class=\"mt-8\" method=\"post\" action=\"/logout\"><button class=\"w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" type=\"submit\">Sign out</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Your Authling account").Render(templ.WithChildren(ctx, templ_7745c5c3_Var31), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Your Authling account").Render(templ.WithChildren(ctx, templ_7745c5c3_Var50), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/authling/internal/web/web.go
+++ b/authling/internal/web/web.go
@@ -17,6 +17,7 @@ import (
 	"hmans.de/authling/internal/accounts"
 	"hmans.de/authling/internal/authentication"
 	"hmans.de/authling/internal/oidcprovider"
+	"hmans.de/authling/internal/passwordreset"
 	"hmans.de/authling/internal/registration"
 	"hmans.de/authling/internal/sessions"
 )
@@ -37,6 +38,7 @@ type Dependencies struct {
 	Accounts       *accounts.Service
 	Authentication *authentication.Service
 	Registration   *registration.Service
+	PasswordReset  *passwordreset.Service
 	Sessions       *sessions.Service
 	OIDC           *oidcprovider.Service
 	SecureCookies  bool
@@ -108,6 +110,109 @@ func Handler(dependencies ...Dependencies) http.Handler {
 		}
 		if err := establishSession(w, r, deps, account.ID); err != nil {
 			render(w, r, http.StatusServiceUnavailable, loginPage("We couldn't sign you in. Please try again later.", requestID))
+			return
+		}
+		if requestID != "" {
+			redirect(w, r, "/oidc/consent?id="+url.QueryEscape(requestID))
+			return
+		}
+		redirect(w, r, "/account")
+	})
+	mux.HandleFunc("GET /password-reset", func(w http.ResponseWriter, r *http.Request) {
+		requestID := r.URL.Query().Get("id")
+		if requestID != "" && (deps.OIDC == nil || !validConsentRequest(r, deps.OIDC, requestID)) {
+			http.Error(w, "authorization request unavailable", http.StatusBadRequest)
+			return
+		}
+		render(w, r, http.StatusOK, passwordResetPage("", requestID))
+	})
+	mux.HandleFunc("POST /password-reset", func(w http.ResponseWriter, r *http.Request) {
+		if deps.PasswordReset == nil {
+			http.Error(w, "password reset unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !sameOrigin(r, publicOrigin) {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+		if err := r.ParseForm(); err != nil {
+			render(w, r, http.StatusBadRequest, passwordResetPage("Invalid form submission.", ""))
+			return
+		}
+		requestID := r.FormValue("oidc_request")
+		if requestID != "" && (deps.OIDC == nil || !validConsentRequest(r, deps.OIDC, requestID)) {
+			http.Error(w, "authorization request unavailable", http.StatusBadRequest)
+			return
+		}
+		flow, err := deps.PasswordReset.Start(r.Context(), r.FormValue("email"))
+		if err != nil {
+			render(w, r, http.StatusUnprocessableEntity, passwordResetPage(publicPasswordResetStartError(err), requestID))
+			return
+		}
+		render(w, r, http.StatusOK, passwordResetCodePage(flow, "", requestID))
+	})
+	mux.HandleFunc("POST /password-reset/verify", func(w http.ResponseWriter, r *http.Request) {
+		if deps.PasswordReset == nil {
+			http.Error(w, "password reset unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !sameOrigin(r, publicOrigin) {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		requestID := r.FormValue("oidc_request")
+		if requestID != "" && (deps.OIDC == nil || !validConsentRequest(r, deps.OIDC, requestID)) {
+			http.Error(w, "authorization request unavailable", http.StatusBadRequest)
+			return
+		}
+		flow := r.FormValue("flow")
+		if err := deps.PasswordReset.Verify(r.Context(), flow, r.FormValue("code")); err != nil {
+			render(w, r, http.StatusUnprocessableEntity, passwordResetCodePage(flow, passwordreset.ErrInvalidCode.Error(), requestID))
+			return
+		}
+		render(w, r, http.StatusOK, newPasswordPage(flow, "", deps.PasswordReset.PasswordMinimumLength(), requestID))
+	})
+	mux.HandleFunc("POST /password-reset/complete", func(w http.ResponseWriter, r *http.Request) {
+		if deps.PasswordReset == nil {
+			http.Error(w, "password reset unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !sameOrigin(r, publicOrigin) {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		requestID := r.FormValue("oidc_request")
+		if requestID != "" && (deps.OIDC == nil || !validConsentRequest(r, deps.OIDC, requestID)) {
+			http.Error(w, "authorization request unavailable", http.StatusBadRequest)
+			return
+		}
+		flow := r.FormValue("flow")
+		account, err := deps.PasswordReset.Complete(r.Context(), flow, r.FormValue("password"))
+		if errors.Is(err, accounts.ErrInvalidPassword) {
+			render(w, r, http.StatusUnprocessableEntity, newPasswordPage(flow, err.Error(), deps.PasswordReset.PasswordMinimumLength(), requestID))
+			return
+		}
+		if err != nil {
+			render(w, r, http.StatusUnprocessableEntity, passwordResetPage(passwordreset.ErrInvalidFlow.Error(), requestID))
+			return
+		}
+		if deps.Sessions == nil {
+			render(w, r, http.StatusOK, passwordResetCompletePage())
+			return
+		}
+		if err := establishSession(w, r, deps, account.ID); err != nil {
+			render(w, r, http.StatusServiceUnavailable, passwordResetCompletePage())
 			return
 		}
 		if requestID != "" {
@@ -447,6 +552,13 @@ func publicStartError(err error) string {
 		return registration.ErrInvalidEmail.Error()
 	}
 	return "We couldn't send a verification code. Please try again later."
+}
+
+func publicPasswordResetStartError(err error) string {
+	if errors.Is(err, passwordreset.ErrInvalidEmail) {
+		return passwordreset.ErrInvalidEmail.Error()
+	}
+	return "We couldn't send a password reset code. Please try again later."
 }
 
 func sameOrigin(r *http.Request, expected *url.URL) bool {

--- a/authling/internal/web/web_test.go
+++ b/authling/internal/web/web_test.go
@@ -38,8 +38,30 @@ func TestLoginPageAutofocusesEmail(t *testing.T) {
 	if response.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
 	}
-	if body := response.Body.String(); !strings.Contains(body, `name="email" autocomplete="email" autofocus`) {
+	body := response.Body.String()
+	if !strings.Contains(body, `name="email" autocomplete="email" autofocus`) {
 		t.Fatalf("login page email input does not have autofocus: %q", body)
+	}
+	if !strings.Contains(body, `href="/password-reset"`) || !strings.Contains(body, "Forgot your password?") {
+		t.Fatalf("login page does not link to password reset: %q", body)
+	}
+}
+
+func TestPasswordResetPageRendersWithoutAccountDisclosure(t *testing.T) {
+	request := httptest.NewRequest(http.MethodGet, "/password-reset", nil)
+	response := httptest.NewRecorder()
+
+	Handler().ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", response.Code, http.StatusOK)
+	}
+	body := response.Body.String()
+	if !strings.Contains(body, "Reset your password") || !strings.Contains(body, `action="/password-reset"`) {
+		t.Fatalf("body does not contain the password reset form: %q", body)
+	}
+	if strings.Contains(body, "account exists") || strings.Contains(body, "account not found") || strings.Contains(body, "<script") {
+		t.Fatalf("password reset page has disclosure or script content: %q", body)
 	}
 }
 

--- a/authling/proto/authling/core/v1/event.proto
+++ b/authling/proto/authling/core/v1/event.proto
@@ -21,6 +21,8 @@ message Event {
     AccountCreatedEvent account_created = 100;
     EmailClaimedEvent email_claimed = 101;
     IssuerEstablishedEvent issuer_established = 102;
+    PasswordChangedEvent password_changed = 103;
+    PasswordResetRequestedEvent password_reset_requested = 104;
   }
 }
 
@@ -52,4 +54,27 @@ message AccountCreatedEvent {
   uint32 credential_envelope_version = 6;
   bytes password_verifier_nonce = 7;
   bytes password_verifier_ciphertext = 8;
+}
+
+// PasswordChangedEvent replaces one local account's password verifier without
+// changing its stable account identity or verified email address.
+message PasswordChangedEvent {
+  string account_id = 1;
+  string user_key_ref = 2;
+  string credential_key_ref = 3;
+  uint32 credential_envelope_version = 4;
+  bytes password_verifier_nonce = 5;
+  bytes password_verifier_ciphertext = 6;
+
+  // The audit event that initiated this recovery-driven change. Historical
+  // password changes written before request auditing leave this empty.
+  string password_reset_request_event_id = 7;
+}
+
+// PasswordResetRequestedEvent records an accepted recovery request for an
+// existing local account without retaining the submitted email or flow secret.
+// The envelope event ID is the opaque recovery request identifier.
+message PasswordResetRequestedEvent {
+  string account_id = 1;
+  string credential_event_id = 2;
 }


### PR DESCRIPTION
## Why

Authling's verified local accounts need a secure self-service recovery path with a durable, PII-free signal that a reset was requested.

## What changed

Adds an enumeration-resistant email-code password-reset flow, correlated request/change events with account-level OCC, durable browser-session invalidation, bounded encrypted workflow state, server-rendered pages, end-to-end coverage, FDR/runtime documentation, and stronger Authling agent rules for identity events and recovery.

## API compatibility

- Additive and compatible.

Chatto auth, discovery, API, admin, and realtime contracts are unchanged; Authling gains additive server-rendered HTTP routes and persisted event variants, needs no older-client migration or capability negotiation, and exposes no new recovery UI when a newer browser visits an older server.

## Test plan

- `cd authling && mise codegen` — passed.
- `cd authling && mise test` — passed in standalone and workspace modes.
- `cd authling && mise test-e2e` — passed, 22 tests.
- `cd authling && mise build` — passed.
- `git diff --check` — passed.
- Manual Chrome DevTools MCP review remains outstanding because that MCP was unavailable in this session; Playwright exercised the complete visible reset flow.
