### PR TITLE
feat(authling): add signed-in password change

### DIFF
--- a/authling/AGENTS.md
+++ b/authling/AGENTS.md
@@ -42,8 +42,9 @@ to its own repository.
   issuers remain first-class.
 - The current experimental runtime persists and replays local accounts,
   exposes server-rendered verified-email signup, password login, browser
-  sessions, password reset, verified email change, and logout, and provides the
-  narrow OpenID Connect surface recorded in FDR-004. It has no public
+  sessions, password reset, signed-in password change, verified email change,
+  and logout. It provides the narrow OpenID Connect surface recorded in
+  FDR-004. It has no public
   account-management, application-data, document, or synchronization API. Do
   not document other planned identity-provider behavior as implemented.
 

--- a/authling/README.md
+++ b/authling/README.md
@@ -2,10 +2,11 @@
 
 Authling is a standalone, self-hostable OpenID Connect identity provider. Its
 experimental runtime currently provides verified-email signup, encrypted local
-credentials, password login and reset, verified email change, revocable browser
-sessions, and a small Authorization Code OpenID Provider for conventional and
-CIMD clients. It also stores only identity-provider state; application data and
-synchronization are outside its scope.
+credentials, password login and reset, verified email change, signed-in
+password change, revocable browser sessions, and a small Authorization Code
+OpenID Provider for conventional and CIMD clients. It also stores only
+identity-provider state; application data and synchronization are outside its
+scope.
 
 Contributors must read [`AGENTS.md`](AGENTS.md) before making Authling changes.
 Authling's ADRs, FDRs, architecture inventory, and glossary live under
@@ -84,8 +85,9 @@ The development configuration serves Authling at <http://localhost:8080>, with
 signup at <http://localhost:8080/signup>, login at
 <http://localhost:8080/login>, and password reset at
 <http://localhost:8080/password-reset>. Signed-in accounts can change their
-verified email address from <http://localhost:8080/account>. Mailpit receives
-SMTP on port 1025 and shows captured messages at <http://127.0.0.1:8025>. Set
+verified email address or password from <http://localhost:8080/account>.
+Mailpit receives SMTP on port 1025 and shows captured messages at
+<http://127.0.0.1:8025>. Set
 `AUTHLING_HTTP_BIND_ADDRESS` to override the Authling listener and
 `AUTHLING_HTTP_PUBLIC_URL` to its externally visible origin. The checked-in
 configuration declares a loopback HTTP origin for local development.

--- a/authling/TODO.md
+++ b/authling/TODO.md
@@ -17,7 +17,7 @@ current runtime in `docs/architecture/`.
 
 ## Later account and authentication work
 
-- [ ] Define signed-in credential rotation and selective session revocation policies
+- [ ] Define selective browser-session revocation policies
 - [ ] Design upstream SSO through Goth-supported providers
 - [ ] Define secure upstream-account linking and email-collision behavior
 - [ ] Implement an event-backed orphan-key cleanup worker and crash/race tests

--- a/authling/docs/GLOSSARY.md
+++ b/authling/docs/GLOSSARY.md
@@ -28,6 +28,11 @@ email challenge and binds successful recovery to the password credential that
 was current when the flow began. It expires after 15 minutes and is not a
 durable account fact.
 
+**Signed-in password change** — A local-credential rotation authorized by an
+active browser session and the current password. It preserves the account ID,
+verified email, and OIDC `sub` while invalidating older Authling browser
+sessions.
+
 **Email change flow** — Short-lived, encrypted runtime state that binds a
 signed-in account and reauthenticated credential to its old and requested new
 addresses and an email challenge. It expires after 15 minutes and is not a
@@ -37,8 +42,8 @@ the older credential stale.
 **Browser session** — Short-lived, server-side runtime state that binds an
 opaque browser cookie to one account after signup or login. A session is not a
 durable account fact and can be revoked independently from other sessions.
-Password reset and verified email change invalidate every session issued under
-the account's older authentication version.
+Password reset, signed-in password change, and verified email change invalidate
+every session issued under the account's older authentication version.
 
 **Issuer** — The immutable public URL identifying one Authling deployment as
 one OpenID Provider. Tokens and discovery use this exact value; changing it is

--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -11,10 +11,10 @@ storage, starts every required projection, waits for startup replay, starts the
 HTTP listener, and then runs until its process context is cancelled.
 
 The HTTP surface contains server-rendered signup, login, password-reset,
-verified email-change, consent, account, and logout pages plus embedded browser
-assets. It also exposes OpenID Connect discovery, authorization, token,
-UserInfo, and JWKS endpoints. Authling exposes no public account-management,
-application-data, document, or synchronization API.
+signed-in password-change, verified email-change, consent, account, and logout
+pages plus embedded browser assets. It also exposes OpenID Connect discovery,
+authorization, token, UserInfo, and JWKS endpoints. Authling exposes no public
+account-management, application-data, document, or synchronization API.
 
 ## Configuration
 
@@ -33,8 +33,9 @@ carry a matching `Origin`; Fetch Metadata is an additional cross-site signal.
 The listener itself is plain HTTP, so production deployments terminate HTTPS
 at a reverse proxy. An explicit configuration switch lets canonical-origin
 checks consume proxy-overwritten `X-Forwarded-Host` and `X-Forwarded-Proto`;
-the direct listener must remain trusted-only in that mode. HTTPS deployments use a host-bound `__Host-` session cookie;
-the unprefixed cookie name exists only for loopback development.
+the direct listener must remain trusted-only in that mode. HTTPS deployments
+use a host-bound `__Host-` session cookie; the unprefixed cookie name exists
+only for loopback development.
 
 `authentication.password_minimum_length` sets the local signup password
 minimum and defaults to ten Unicode characters. Values from eight through 128
@@ -97,7 +98,7 @@ Persisted records use the `authling.core.v1.Event` protobuf envelope:
 |-------|---------|-----------|----------|
 | `AccountCreatedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account ID and envelope creation time |
 | `PasswordResetRequestedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account and credential-event IDs; the envelope ID identifies the audit request |
-| `PasswordChangedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, credential-key, and optional reset-request references plus the replacement encrypted password verifier |
+| `PasswordChangedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, credential-key, prior-credential, ceremony, and optional reset-request references plus the replacement encrypted password verifier |
 | `EmailChangeRequestedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account and reauthenticated credential-event IDs |
 | `EmailChangedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, credential-key, request, and prior-credential references plus the replacement encrypted email |
 | `EmailClaimedEvent` | `authling.evt.account-registry` | Account registry | Opaque account and optional staged credential-event IDs |
@@ -117,19 +118,20 @@ The account model consumes `authling.evt.account.*` and
 During replay it resolves and decrypts local credentials and rebuilds a keyed
 digest index of normalized emails. It retains encrypted verifier fields and
 opaque key references, but neither plaintext email nor plaintext password
-verifiers. Password-reset requests validate their account and credential
-binding without adding derived model state. Password changes replace the
-current encrypted verifier and advance a durable account authentication
-version. The model retains a bounded set of email-change requests per account
+verifiers. The model retains bounded password-reset request correlations so
+replay can validate recovery-produced password changes. Password changes
+validate their declared recovery or signed-in ceremony, replace the current
+encrypted verifier, and advance a durable account authentication version. The
+model retains a bounded set of email-change requests per account
 so replay can require the exact reauthentication audit chain without retaining
 abandoned request IDs without bound. An email-change account event stages its
 encrypted replacement; the adjacent correlated registry event swaps the active
 digest and credential and advances the authentication version. Local
-authentication and email-change reauthentication share distributed attempt
-limits and bounded Argon2 capacity. They resolve and decrypt a verifier only
-for one bounded Argon2id comparison; absent login accounts resolve a persistent
-synthetic key hierarchy and encrypted dummy verifier through the same storage
-path.
+authentication, signed-in password change, and email-change reauthentication
+share distributed attempt limits and bounded Argon2 capacity. They resolve and
+decrypt a verifier only for one bounded Argon2id comparison; absent login
+accounts resolve a persistent synthetic key hierarchy and encrypted dummy
+verifier through the same storage path.
 
 The runtime does not become ready until the projection has replayed its captured
 startup history. A decode or apply failure fails the projection and runtime.
@@ -174,9 +176,9 @@ Session records are authenticated-encrypted in runtime state beneath
 HMAC-derived keys. They have a 24-hour absolute lifetime and a one-hour
 inactivity limit. Activity updates use OCC and never extend the absolute
 deadline. Each session records the account authentication version current at
-issuance. Password reset and verified email change advance that durable
-version, invalidating every older session across replicas and restarts. Logout
-deletes the server record before clearing the cookie.
+issuance. Password reset, signed-in password change, and verified email change
+advance that durable version, invalidating every older session across replicas
+and restarts. Logout deletes the server record before clearing the cookie.
 
 `GET /password-reset` starts verified-email recovery. Three POST endpoints
 create an expiring flow, verify its six-digit code, and commit a new password.
@@ -213,6 +215,15 @@ recovery and session establishment. The completion POST redirects to the
 account page with a refresh-safe success result and, when needed, the
 old-address delivery warning.
 
+`GET /account/password` requires a valid browser session and renders signed-in
+password change. Its POST requires the current password, a distinct replacement
+that satisfies the configured password policy, and matching confirmation. The
+current-password check uses an OCC-backed distributed attempt limit and bounded
+Argon2 capacity. Completion appends a `PasswordChangedEvent` bound to the exact
+reauthenticated credential, advances the authentication version, invalidates
+older browser sessions, and creates a replacement session at that exact
+generation. The account ID, verified email, and OIDC `sub` remain unchanged.
+
 OpenID Connect mounts discovery at `/.well-known/openid-configuration` and its
 protocol endpoints below `/oauth/`. Authorization accepts only code flow,
 requires exactly the `openid` scope and S256 PKCE.
@@ -230,14 +241,14 @@ winner. ID tokens use the persistent RS256 key; JWKS publishes only its public
 part. The initial UserInfo response contains only the account ID as `sub`.
 
 The HTTP server bounds header, body-read, response-write, and idle time. Signup,
-password reset, and email change also cap request bodies, globally limit OTP
-delivery, and bound concurrent SMTP and completion work per process.
+password reset, signed-in password change, and email change also cap request
+bodies. OTP flows globally limit delivery and bound concurrent SMTP and
+completion work per process.
 
 ## Deliberately absent
 
-The runtime does not yet contain signed-in password change, MFA recovery,
-account erasure, session lists or selective remote
-session revocation, OIDC refresh tokens or key rotation,
+The runtime does not yet contain MFA recovery, account erasure, session lists
+or selective remote session revocation, OIDC refresh tokens or key rotation,
 diagnostic endpoints, or backup tooling. Application data, documents, and
 generic synchronization are deliberately outside Authling's identity-provider
 boundary.

--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -219,8 +219,9 @@ old-address delivery warning.
 password change. Its POST requires the current password, a distinct replacement
 that satisfies the configured password policy, and matching confirmation. The
 current-password check uses an OCC-backed distributed attempt limit and bounded
-Argon2 capacity. Completion appends a `PasswordChangedEvent` bound to the exact
-reauthenticated credential, advances the authentication version, invalidates
+Argon2 capacity. Completion waits through captured account and email-registry
+projection boundaries, then appends a `PasswordChangedEvent` bound to the exact
+reauthenticated credential. It advances the authentication version, invalidates
 older browser sessions, and creates a replacement session at that exact
 generation. The account ID, verified email, and OIDC `sub` remain unchanged.
 

--- a/authling/docs/fdr/FDR-003-local-login-and-browser-sessions.md
+++ b/authling/docs/fdr/FDR-003-local-login-and-browser-sessions.md
@@ -1,7 +1,7 @@
 # FDR-003: Local Login and Browser Sessions
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-14
+**Last reviewed:** 2026-08-20
 
 ## Overview
 
@@ -31,10 +31,10 @@ experience.
   sessions.
 - Sessions remain valid across an Authling process restart when the browser
   still has its session cookie and runtime storage remains available.
-- Sessions carry the account's durable authentication version. Password reset
-  and verified email change advance that version and invalidate every older
-  Authling browser session, including across process restarts; the completing
-  browser receives a new session.
+- Sessions carry the account's durable authentication version. Password reset,
+  signed-in password change, and verified email change advance that version
+  and invalidate every older Authling browser session, including across
+  process restarts; the completing browser receives a new session.
 - Protected pages reject absent, expired, malformed, forged, and revoked
   sessions. Cross-origin login and logout submissions are rejected.
 - The configured public origin is canonical: requests for another host are
@@ -103,7 +103,7 @@ attempt budget.
 ## Limitations
 
 - There is no "remember me", session list, selective remote session revocation,
-  signed-in password change, or user-visible authentication history yet.
+  or user-visible authentication history yet.
 - Password-only login is a single-factor authentication ceremony. Authling
   does not yet implement MFA or phishing-resistant authenticators.
 - Authling's listener does not terminate TLS. Production operators must expose
@@ -118,7 +118,8 @@ attempt budget.
 - **Features:** [FDR-001](FDR-001-standalone-account-runtime.md),
   [FDR-002](FDR-002-verified-email-signup.md),
   [FDR-006](FDR-006-password-reset.md),
-  [FDR-007](FDR-007-verified-email-change.md)
+  [FDR-007](FDR-007-verified-email-change.md),
+  [FDR-008](FDR-008-signed-in-password-change.md)
 - **Security baseline:** [NIST SP 800-63B](https://pages.nist.gov/800-63-4/sp800-63b.html),
   [OWASP Authentication](https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html),
   and [OWASP Session Management](https://cheatsheetseries.owasp.org/cheatsheets/Session_Management_Cheat_Sheet.html)

--- a/authling/docs/fdr/FDR-006-password-reset.md
+++ b/authling/docs/fdr/FDR-006-password-reset.md
@@ -1,7 +1,7 @@
 # FDR-006: Password Reset
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-14
+**Last reviewed:** 2026-08-20
 
 ## Overview
 
@@ -119,8 +119,9 @@ retirement are implemented.
 - Flow tokens and OTPs never appear in URLs or logs. The browser carries the
   opaque flow token only in form fields.
 - Request audit events contain no email, OTP, flow token, IP address, user
-  agent, or other recovery material. A successful change carries only the
-  opaque request-event reference needed to correlate the audit trail.
+  agent, or other recovery material. A successful change carries only its
+  ceremony kind and the opaque request- and credential-event references needed
+  to correlate the audit trail.
 - Flow state and password verifiers are authenticated-encrypted with distinct,
   versioned AAD domains. Ciphertext cannot be moved between creation and change
   events or between credentials without failing authentication.
@@ -132,9 +133,8 @@ retirement are implemented.
 
 ## Limitations
 
-- Authling does not currently support signed-in password change, email-address
-  change, MFA recovery, recovery codes, administrator recovery, or user-visible
-  authentication history.
+- Authling does not currently support MFA recovery, recovery codes,
+  administrator recovery, or user-visible authentication history.
 - Password reset does not revoke already issued OIDC tokens or sessions held by
   relying parties. Token revocation and RP-initiated logout are separate future
   protocol work.
@@ -148,4 +148,5 @@ retirement are implemented.
   [ADR-003](../adr/ADR-003-server-rendered-templ-ui.md)
 - **Features:** [FDR-002](FDR-002-verified-email-signup.md),
   [FDR-003](FDR-003-local-login-and-browser-sessions.md),
-  [FDR-004](FDR-004-openid-connect-provider.md)
+  [FDR-004](FDR-004-openid-connect-provider.md),
+  [FDR-008](FDR-008-signed-in-password-change.md)

--- a/authling/docs/fdr/FDR-007-verified-email-change.md
+++ b/authling/docs/fdr/FDR-007-verified-email-change.md
@@ -166,9 +166,8 @@ event rollout.
 
 ## Limitations
 
-- Authling does not yet provide selective session preservation, signed-in
-  password change, MFA recovery, administrator recovery, or a user-visible
-  authentication history.
+- Authling does not yet provide selective session preservation, MFA recovery,
+  administrator recovery, or a user-visible authentication history.
 - The security notice to the old address is best-effort and has no durable
   retry worker.
 - Existing OIDC tokens and relying-party sessions are not revoked.
@@ -178,4 +177,5 @@ event rollout.
 - [FDR-002: Verified Email Signup](FDR-002-verified-email-signup.md)
 - [FDR-003: Local Login and Browser Sessions](FDR-003-local-login-and-browser-sessions.md)
 - [FDR-006: Password Reset](FDR-006-password-reset.md)
+- [FDR-008: Signed-in Password Change](FDR-008-signed-in-password-change.md)
 - [Runtime architecture inventory](../architecture/INDEX.md)

--- a/authling/docs/fdr/FDR-008-signed-in-password-change.md
+++ b/authling/docs/fdr/FDR-008-signed-in-password-change.md
@@ -1,0 +1,134 @@
+# FDR-008: Signed-in Password Change
+
+**Status:** Experimental
+**Last reviewed:** 2026-08-20
+
+## Overview
+
+A signed-in person with a local Authling account can replace its password after
+re-entering the current password. The account ID, verified email address, and
+OpenID Connect `sub` remain unchanged.
+
+## Behavior
+
+- The account page links to password change. The form requires the current
+  password, a distinct replacement password under the active password policy,
+  and matching confirmation.
+- Incorrect current passwords share Authling's distributed attempt limits and
+  bounded password-verification capacity. Operational failures do not consume
+  the guessing budget.
+- A successful change records one durable, PII-free password-change fact bound
+  to the exact credential that was reauthenticated. Concurrent password or
+  email changes make an older reauthentication stale.
+- Completion advances the account authentication version, invalidating every
+  older Authling browser session across replicas and restarts. The completing
+  browser receives a fresh session and remains signed in.
+- The old password stops authenticating immediately after commit; the new
+  password authenticates the same account.
+- Already issued OIDC ID and access tokens are not revoked. They expire after
+  five minutes, and relying-party sessions remain under relying-party control.
+
+## Design Decisions
+
+### 1. Require the current password
+
+**Decision:** An active browser session alone cannot authorize password
+rotation. The person must re-enter the current local password.
+
+**Why:** A stolen unlocked browser should not be sufficient to establish a new
+long-term credential.
+
+**Tradeoff:** A signed-in person who no longer knows the password must use the
+verified-email password-reset flow.
+
+### 2. Record only the successful mutation durably
+
+**Decision:** The successful `PasswordChangedEvent` identifies a signed-in
+ceremony and the prior credential event. Failed guesses and form attempts are
+not permanent events; current-password failures use bounded runtime state for
+guessing controls.
+
+**Why:** The committed credential mutation is security-relevant audit history.
+Persisting attacker-controlled attempts would create an event-log growth vector
+without improving account recovery.
+
+**Tradeoff:** Authling does not yet expose a durable user-visible history of
+failed reauthentication attempts.
+
+### 3. Bind authorization to one credential generation
+
+**Decision:** The command uses account-subject OCC and succeeds only while the
+credential whose password was checked remains current. Unrelated audit-only
+events may advance the account tail and are retried without weakening the
+credential precondition.
+
+**Why:** A password proven before another credential mutation must not
+authorize a later overwrite. The event correlation also makes historical
+replay validate the same relationship.
+
+**Tradeoff:** A concurrent password or email change forces the person to sign
+in again before retrying.
+
+### 4. Invalidate older Authling sessions
+
+**Decision:** Password change advances the durable authentication version.
+Every older Authling browser session becomes invalid, while the completing
+browser receives a replacement session bound to the exact new generation.
+
+**Why:** Credential rotation is frequently a response to suspected compromise.
+Generation checks revoke sessions across replicas and restarts without an
+enumerable session index.
+
+**Tradeoff:** Other trusted Authling browser sessions cannot be preserved
+selectively in this initial feature.
+
+### 5. Preserve external identity continuity
+
+**Decision:** Password change preserves the account ID, verified email claim,
+OIDC `sub`, already issued OIDC tokens, and relying-party sessions.
+
+**Why:** The local password authenticates an existing identity; changing it is
+not a new identity or a protocol-wide logout operation.
+
+**Tradeoff:** A person cannot use password change to immediately revoke tokens
+or sessions already held by relying parties. Token revocation and RP-initiated
+logout remain separate protocol work.
+
+## Security and Failure Behavior
+
+- Passwords appear only in bounded same-origin POST bodies and transient
+  in-process command data. They never enter URLs, logs, event payloads,
+  subjects, or runtime keys.
+- The durable event contains only opaque account, key, and event references,
+  the ceremony kind, and the encrypted replacement verifier.
+- Wrong-current-password, throttled, stale-credential, key-vault, projection,
+  and storage paths fail closed. Infrastructure errors do not masquerade as a
+  credential mismatch or consume the guessing budget.
+- A failure after the event commits cannot restore the old password. If the
+  completing browser cannot receive a replacement session, it must sign in
+  with the new password.
+- The POST endpoint requires Authling's canonical browser origin and uses a
+  bounded request body.
+
+## Compatibility
+
+The persisted protobuf change is additive. Older readers already understand
+`PasswordChangedEvent` and ignore its new prior-credential and ceremony fields;
+new readers continue to accept historical events that leave them unspecified.
+No event migration is required, and mixed-version readers materialize the same
+credential and authentication-version change.
+
+## Limitations
+
+- Authling does not provide a session list, selective remote-session
+  revocation, MFA recovery, or user-visible authentication history.
+- Existing OIDC tokens and relying-party sessions are not revoked.
+
+## Related
+
+- **ADRs:** [ADR-001](../adr/ADR-001-event-sourced-nats-architecture.md),
+  [ADR-002](../adr/ADR-002-hierarchical-keys-and-cryptographic-erasure.md),
+  [ADR-003](../adr/ADR-003-server-rendered-templ-ui.md)
+- **FDRs:** [FDR-003](FDR-003-local-login-and-browser-sessions.md),
+  [FDR-006](FDR-006-password-reset.md),
+  [FDR-007](FDR-007-verified-email-change.md)

--- a/authling/docs/fdr/FDR-008-signed-in-password-change.md
+++ b/authling/docs/fdr/FDR-008-signed-in-password-change.md
@@ -57,14 +57,19 @@ failed reauthentication attempts.
 
 ### 3. Bind authorization to one credential generation
 
-**Decision:** The command uses account-subject OCC and succeeds only while the
-credential whose password was checked remains current. Unrelated audit-only
-events may advance the account tail and are retried without weakening the
-credential precondition.
+**Decision:** The command captures both the account and email-registry
+boundaries, waits for the projection through them, then uses account-subject
+OCC. It succeeds only while the credential whose password was checked remains
+current. Unrelated audit-only events may advance the account tail and are
+retried without weakening the credential precondition. The validated
+replacement travels inside the transient command target so completion cannot
+substitute another password.
 
 **Why:** A password proven before another credential mutation must not
-authorize a later overwrite. The event correlation also makes historical
-replay validate the same relationship.
+authorize a later overwrite. Waiting through the registry side of an atomic
+email-change batch prevents password change from observing its staged account
+event as though the older credential were still safe to mutate. The event
+correlation makes historical replay validate the same relationship.
 
 **Tradeoff:** A concurrent password or email change forces the person to sign
 in again before retrying.

--- a/authling/docs/fdr/INDEX.md
+++ b/authling/docs/fdr/INDEX.md
@@ -10,8 +10,9 @@ record planned behavior as active functionality.
 |---|---------|--------|---------------|
 | [FDR-001](FDR-001-standalone-account-runtime.md) | Standalone Account Runtime | Experimental | 2026-07-31 |
 | [FDR-002](FDR-002-verified-email-signup.md) | Verified Email Signup | Experimental | 2026-08-01 |
-| [FDR-003](FDR-003-local-login-and-browser-sessions.md) | Local Login and Browser Sessions | Experimental | 2026-07-31 |
+| [FDR-003](FDR-003-local-login-and-browser-sessions.md) | Local Login and Browser Sessions | Experimental | 2026-08-20 |
 | [FDR-004](FDR-004-openid-connect-provider.md) | OpenID Connect Provider | Experimental | 2026-08-01 |
 | [FDR-005](FDR-005-account-data-sync.md) | Account Data Synchronization | Retired | 2026-08-14 |
-| [FDR-006](FDR-006-password-reset.md) | Password Reset | Experimental | 2026-08-14 |
+| [FDR-006](FDR-006-password-reset.md) | Password Reset | Experimental | 2026-08-20 |
 | [FDR-007](FDR-007-verified-email-change.md) | Verified Email Change | Experimental | 2026-08-20 |
+| [FDR-008](FDR-008-signed-in-password-change.md) | Signed-in Password Change | Experimental | 2026-08-20 |

--- a/authling/e2e/password-change.test.ts
+++ b/authling/e2e/password-change.test.ts
@@ -1,0 +1,69 @@
+import { randomUUID } from 'node:crypto';
+import { completeSignup } from './fixtures/signup';
+import { expect, test } from './setup';
+
+const originalPassword = 'correct horse battery staple';
+const replacementPassword = 'an entirely new uncommon password';
+
+test('changes a signed-in password and invalidates other browser sessions', async ({
+  browser,
+  page,
+  request,
+  stack
+}) => {
+  const email = `password-change-${randomUUID()}@example.invalid`;
+  const accountID = await completeSignup(page, request, stack, email, originalPassword);
+
+  const otherContext = await browser.newContext({ baseURL: stack.baseURL });
+  const otherPage = await otherContext.newPage();
+  await otherPage.goto('/login');
+  await otherPage.getByLabel('Email address').fill(email);
+  await otherPage.getByLabel('Password').fill(originalPassword);
+  await otherPage.getByRole('button', { name: 'Sign in' }).click();
+  await expect(otherPage.getByRole('heading', { name: 'Your account' })).toBeVisible();
+
+  await page.getByRole('link', { name: 'Change password' }).click();
+  await expect(page.getByRole('heading', { name: 'Change your password' })).toBeVisible();
+  await expect(page.getByText('signs out your other Authling browser sessions')).toBeVisible();
+
+  await page.getByLabel('Current password').fill('the wrong current password');
+  await page.getByLabel('New password', { exact: true }).fill(replacementPassword);
+  await page.getByLabel('Confirm new password').fill(replacementPassword);
+  await page.getByRole('button', { name: 'Change password' }).click();
+  await expect(page.getByRole('alert')).toHaveText('The current password is incorrect.');
+
+  await page.getByLabel('Current password').fill(originalPassword);
+  await page.getByLabel('New password', { exact: true }).fill(originalPassword);
+  await page.getByLabel('Confirm new password').fill(originalPassword);
+  await page.getByRole('button', { name: 'Change password' }).click();
+  await expect(page.getByRole('alert')).toHaveText('new password must be different from the current password');
+
+  await page.getByLabel('Current password').fill(originalPassword);
+  await page.getByLabel('New password', { exact: true }).fill(replacementPassword);
+  await page.getByLabel('Confirm new password').fill(`${replacementPassword} mismatch`);
+  await page.getByRole('button', { name: 'Change password' }).click();
+  await expect(page.getByRole('alert')).toHaveText('New passwords do not match.');
+
+  await page.getByLabel('Current password').fill(originalPassword);
+  await page.getByLabel('New password', { exact: true }).fill(replacementPassword);
+  await page.getByLabel('Confirm new password').fill(replacementPassword);
+  await page.getByRole('button', { name: 'Change password' }).click();
+  await expect(page.getByRole('status')).toContainText('Your password was changed');
+  await expect(page.locator('code')).toHaveText(accountID);
+
+  await otherPage.goto('/account');
+  await expect(otherPage).toHaveURL(/\/login$/);
+  await otherContext.close();
+
+  await page.getByRole('button', { name: 'Sign out' }).click();
+  await page.getByLabel('Email address').fill(email);
+  await page.getByLabel('Password').fill(originalPassword);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('alert')).toHaveText('The email address or password is incorrect.');
+
+  await page.getByLabel('Email address').fill(email);
+  await page.getByLabel('Password').fill(replacementPassword);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByRole('heading', { name: 'Your account' })).toBeVisible();
+  await expect(page.locator('code')).toHaveText(accountID);
+});

--- a/authling/e2e/security.test.ts
+++ b/authling/e2e/security.test.ts
@@ -25,6 +25,7 @@ for (const path of [
   '/password-reset',
   '/password-reset/verify',
   '/password-reset/complete',
+  '/account/password',
   '/account/email',
   '/account/email/verify',
   '/account/email/complete',

--- a/authling/internal/accounts/accounts.go
+++ b/authling/internal/accounts/accounts.go
@@ -62,6 +62,10 @@ func (commonPasswordError) Is(target error) bool { return target == ErrInvalidPa
 // mismatches so callers cannot disclose which email addresses are registered.
 var ErrInvalidCredentials = errors.New("invalid email or password")
 
+// ErrPasswordUnchanged indicates that a signed-in password change selected
+// the account's current normalized password.
+var ErrPasswordUnchanged = errors.New("new password must be different from the current password")
+
 // ErrCredentialChanged indicates that an identity workflow was issued for an
 // older local credential or unavailable request and must not overwrite it.
 var ErrCredentialChanged = errors.New("local credential changed")
@@ -97,6 +101,13 @@ type PasswordResetTarget struct {
 	RequestEventID    string
 }
 
+// PasswordChangeTarget binds signed-in reauthentication to the credential
+// that was current when the existing password was verified.
+type PasswordChangeTarget struct {
+	AccountID         string
+	CredentialEventID string
+}
+
 // EmailChangeTarget binds an expiring verified-mailbox flow to the credential
 // for which the current password was reauthenticated.
 type EmailChangeTarget struct {
@@ -118,21 +129,29 @@ type emailChangeRequest struct {
 	sequence          uint64
 }
 
+type passwordResetRequest struct {
+	credentialEventID string
+	sequence          uint64
+}
+
 // This comfortably exceeds the global number of code deliveries possible
 // during one flow lifetime while bounding replay memory for abandoned audits.
 const maxTrackedEmailChangeRequestsPerAccount = 4096
 
+const maxTrackedPasswordResetRequestsPerAccount = 4096
+
 // Projection rebuilds the active account registry from durable events.
 type Projection struct {
 	events.MemoryProjection
-	accounts      map[string]Account
-	emails        map[[32]byte]string
-	pendingEmails map[string]pendingEmail
-	emailChanges  map[string]map[string]emailChangeRequest
-	credentials   map[string]protectedCredential
-	keyReferences map[string]struct{}
-	vault         *keyvault.Vault
-	indexKey      []byte
+	accounts       map[string]Account
+	emails         map[[32]byte]string
+	pendingEmails  map[string]pendingEmail
+	emailChanges   map[string]map[string]emailChangeRequest
+	passwordResets map[string]map[string]passwordResetRequest
+	credentials    map[string]protectedCredential
+	keyReferences  map[string]struct{}
+	vault          *keyvault.Vault
+	indexKey       []byte
 }
 
 // NewProjection creates the protected account projection.
@@ -148,8 +167,8 @@ func (*Projection) Subjects() []string {
 // Apply adds one durable account fact to the in-memory registry.
 func (p *Projection) Apply(event *corev1.Event, sequence uint64) error {
 	if requested := event.GetPasswordResetRequested(); requested != nil {
-		p.RLock()
-		defer p.RUnlock()
+		p.Lock()
+		defer p.Unlock()
 		account, ok := p.accounts[requested.GetAccountId()]
 		if !ok {
 			return fmt.Errorf("password reset request references an absent account")
@@ -158,6 +177,25 @@ func (p *Projection) Apply(event *corev1.Event, sequence uint64) error {
 		if !ok || credential.eventID != requested.GetCredentialEventId() {
 			return fmt.Errorf("password reset request references another credential")
 		}
+		if p.passwordResets == nil {
+			p.passwordResets = make(map[string]map[string]passwordResetRequest)
+		}
+		requests := p.passwordResets[account.ID]
+		if requests == nil {
+			requests = make(map[string]passwordResetRequest)
+			p.passwordResets[account.ID] = requests
+		}
+		if len(requests) >= maxTrackedPasswordResetRequestsPerAccount {
+			var oldestID string
+			oldestSequence := ^uint64(0)
+			for id, request := range requests {
+				if request.sequence < oldestSequence {
+					oldestID, oldestSequence = id, request.sequence
+				}
+			}
+			delete(requests, oldestID)
+		}
+		requests[event.GetId()] = passwordResetRequest{credentialEventID: requested.GetCredentialEventId(), sequence: sequence}
 		return nil
 	}
 	if requested := event.GetEmailChangeRequested(); requested != nil {
@@ -203,12 +241,32 @@ func (p *Projection) Apply(event *corev1.Event, sequence uint64) error {
 		if !ok || credential.userKeyRef != changed.GetUserKeyRef() || credential.credentialKeyRef != changed.GetCredentialKeyRef() {
 			return fmt.Errorf("password change references another credential hierarchy")
 		}
+		if prior := changed.GetPriorCredentialEventId(); prior != "" && credential.eventID != prior {
+			return fmt.Errorf("password change references another prior credential")
+		}
+		switch changed.GetKind() {
+		case corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_UNSPECIFIED:
+			// Historical password changes predate explicit ceremony and prior
+			// credential correlation.
+		case corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_RECOVERY:
+			request, ok := p.passwordResets[account.ID][changed.GetPasswordResetRequestEventId()]
+			if !ok || request.credentialEventID != changed.GetPriorCredentialEventId() {
+				return fmt.Errorf("password change references another recovery request")
+			}
+		case corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN:
+			if changed.GetPasswordResetRequestEventId() != "" {
+				return fmt.Errorf("signed-in password change references a recovery request")
+			}
+		default:
+			return fmt.Errorf("password change kind is unsupported")
+		}
 		credential.eventID = event.GetId()
 		credential.passwordVerifierNonce = append([]byte(nil), changed.GetPasswordVerifierNonce()...)
 		credential.passwordVerifierCiphertext = append([]byte(nil), changed.GetPasswordVerifierCiphertext()...)
 		credential.passwordVerifierAAD = passwordChangedAAD(event.GetId(), account.ID, credential.userKeyRef, credential.credentialKeyRef)
 		p.credentials[account.ID] = credential
 		delete(p.emailChanges, account.ID)
+		delete(p.passwordResets, account.ID)
 		account.AuthenticationVersion++
 		p.accounts[account.ID] = account
 		return nil
@@ -451,6 +509,17 @@ func (p *Projection) completedEmailChange(target EmailChangeTarget, newEmail str
 		return Account{}, false
 	}
 	account, ok := p.accounts[target.AccountID]
+	return account, ok
+}
+
+func (p *Projection) completedPasswordChange(accountID, eventID string) (Account, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	credential, ok := p.credentials[accountID]
+	if !ok || credential.eventID != eventID {
+		return Account{}, false
+	}
+	account, ok := p.accounts[accountID]
 	return account, ok
 }
 
@@ -726,6 +795,91 @@ func (s *Service) HasEmail(email string) bool {
 	return s.handle.Projection().HasEmail(NormalizeEmail(email))
 }
 
+// PreparePasswordChange reauthenticates one local account against its current
+// password, validates the replacement, and binds the command to that exact
+// credential generation. Callers must apply distributed guessing and Argon2
+// concurrency limits around it.
+func (s *Service) PreparePasswordChange(ctx context.Context, accountID, currentPassword, newPassword string) (PasswordChangeTarget, error) {
+	credential, ok := s.handle.Projection().credentialForAccount(accountID)
+	if !ok {
+		return PasswordChangeTarget{}, ErrInvalidCredentials
+	}
+	if err := s.verifyCredentialPassword(ctx, credential, currentPassword); err != nil {
+		return PasswordChangeTarget{}, err
+	}
+	currentPassword = norm.NFC.String(currentPassword)
+	newPassword, err := validatePassword(newPassword, s.passwordMinimumLength)
+	if err != nil {
+		return PasswordChangeTarget{}, err
+	}
+	if subtle.ConstantTimeCompare([]byte(currentPassword), []byte(newPassword)) == 1 {
+		return PasswordChangeTarget{}, ErrPasswordUnchanged
+	}
+	return PasswordChangeTarget{AccountID: accountID, CredentialEventID: credential.eventID}, nil
+}
+
+// ChangePassword replaces a signed-in account's password only if the
+// reauthenticated credential is still current. The stable account ID and
+// verified email are unchanged.
+func (s *Service) ChangePassword(ctx context.Context, target PasswordChangeTarget, password string) (Account, error) {
+	if target.AccountID == "" || target.CredentialEventID == "" {
+		return Account{}, ErrCredentialChanged
+	}
+	password, err := validatePassword(password, s.passwordMinimumLength)
+	if err != nil {
+		return Account{}, err
+	}
+	tail, credential, err := s.passwordCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+	if err != nil {
+		return Account{}, err
+	}
+	verifier, err := hashPassword(password)
+	if err != nil {
+		return Account{}, err
+	}
+	dataKey, err := s.vault.ResolveDataKey(ctx, credential.credentialKeyRef, credential.userKeyRef)
+	if err != nil {
+		return Account{}, fmt.Errorf("resolve password credential key: %w", err)
+	}
+	defer clear(dataKey)
+	eventID, err := ids.New("evt")
+	if err != nil {
+		return Account{}, err
+	}
+	sealedVerifier, err := datacrypto.Seal(dataKey, []byte(verifier), passwordChangedAAD(eventID, target.AccountID, credential.userKeyRef, credential.credentialKeyRef))
+	if err != nil {
+		return Account{}, err
+	}
+	event := &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_PasswordChanged{PasswordChanged: &corev1.PasswordChangedEvent{
+		AccountId: target.AccountID, UserKeyRef: credential.userKeyRef, CredentialKeyRef: credential.credentialKeyRef,
+		CredentialEnvelopeVersion: 1, PasswordVerifierNonce: sealedVerifier.Nonce, PasswordVerifierCiphertext: sealedVerifier.Ciphertext,
+		PriorCredentialEventId: target.CredentialEventID,
+		Kind:                   corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN,
+	}}}
+	for range 5 {
+		position, err := s.publisher.AppendPasswordChanged(ctx, event, tail)
+		if errors.Is(err, events.ErrConflict) {
+			tail, _, err = s.passwordCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+			if err != nil {
+				return Account{}, err
+			}
+			continue
+		}
+		if err != nil {
+			return Account{}, fmt.Errorf("commit signed-in password change: %w", err)
+		}
+		if err := s.handle.Projector().WaitFor(ctx, position); err != nil {
+			return Account{}, fmt.Errorf("wait for signed-in password change: %w", err)
+		}
+		account, ok := s.handle.Projection().completedPasswordChange(target.AccountID, eventID)
+		if !ok {
+			return Account{}, ErrCredentialChanged
+		}
+		return account, nil
+	}
+	return Account{}, fmt.Errorf("signed-in password change conflict")
+}
+
 // PrepareEmailChange reauthenticates one local account against its current
 // password and binds a prospective change to that exact credential version.
 // Callers must apply distributed guessing and concurrency limits around it.
@@ -989,6 +1143,8 @@ func (s *Service) ResetPassword(ctx context.Context, target PasswordResetTarget,
 		AccountId: target.AccountID, UserKeyRef: credential.userKeyRef, CredentialKeyRef: credential.credentialKeyRef,
 		CredentialEnvelopeVersion: 1, PasswordVerifierNonce: sealedVerifier.Nonce, PasswordVerifierCiphertext: sealedVerifier.Ciphertext,
 		PasswordResetRequestEventId: target.RequestEventID,
+		PriorCredentialEventId:      target.CredentialEventID,
+		Kind:                        corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_RECOVERY,
 	}}}
 	for range 5 {
 		position, err := s.publisher.AppendPasswordChanged(ctx, event, tail)
@@ -1005,9 +1161,9 @@ func (s *Service) ResetPassword(ctx context.Context, target PasswordResetTarget,
 		if err := s.handle.Projector().WaitFor(ctx, position); err != nil {
 			return Account{}, fmt.Errorf("wait for password change: %w", err)
 		}
-		account, ok := s.handle.Projection().Get(target.AccountID)
+		account, ok := s.handle.Projection().completedPasswordChange(target.AccountID, eventID)
 		if !ok {
-			return Account{}, fmt.Errorf("reset account is absent from projection")
+			return Account{}, ErrCredentialChanged
 		}
 		return account, nil
 	}
@@ -1015,22 +1171,26 @@ func (s *Service) ResetPassword(ctx context.Context, target PasswordResetTarget,
 }
 
 func (s *Service) passwordResetCredentialAtTail(ctx context.Context, target PasswordResetTarget) (uint64, protectedCredential, error) {
-	tail, err := s.publisher.AccountTail(ctx, target.AccountID)
+	return s.passwordCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+}
+
+func (s *Service) passwordCredentialAtTail(ctx context.Context, accountID, credentialEventID string) (uint64, protectedCredential, error) {
+	tail, err := s.publisher.AccountTail(ctx, accountID)
 	if err != nil {
 		return 0, protectedCredential{}, fmt.Errorf("read account tail: %w", err)
 	}
 	if tail == 0 {
 		return 0, protectedCredential{}, ErrCredentialChanged
 	}
-	subject, err := evtstream.AccountSubject(target.AccountID)
+	subject, err := evtstream.AccountSubject(accountID)
 	if err != nil {
 		return 0, protectedCredential{}, ErrCredentialChanged
 	}
 	if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
 		return 0, protectedCredential{}, fmt.Errorf("wait for account credential: %w", err)
 	}
-	credential, ok := s.handle.Projection().credentialForAccount(target.AccountID)
-	if !ok || credential.eventID != target.CredentialEventID {
+	credential, ok := s.handle.Projection().credentialForAccount(accountID)
+	if !ok || credential.eventID != credentialEventID {
 		return 0, protectedCredential{}, ErrCredentialChanged
 	}
 	return tail, credential, nil

--- a/authling/internal/accounts/accounts.go
+++ b/authling/internal/accounts/accounts.go
@@ -106,6 +106,9 @@ type PasswordResetTarget struct {
 type PasswordChangeTarget struct {
 	AccountID         string
 	CredentialEventID string
+	// newPassword is transient secret command data. It binds completion to the
+	// replacement that passed reauthentication and policy validation.
+	newPassword string
 }
 
 // EmailChangeTarget binds an expiring verified-mailbox flow to the credential
@@ -830,17 +833,17 @@ func (s *Service) PreparePasswordChange(ctx context.Context, accountID, currentP
 	if subtle.ConstantTimeCompare([]byte(currentPassword), []byte(newPassword)) == 1 {
 		return PasswordChangeTarget{}, ErrPasswordUnchanged
 	}
-	return PasswordChangeTarget{AccountID: accountID, CredentialEventID: credential.eventID}, nil
+	return PasswordChangeTarget{AccountID: accountID, CredentialEventID: credential.eventID, newPassword: newPassword}, nil
 }
 
 // ChangePassword replaces a signed-in account's password only if the
 // reauthenticated credential is still current. The stable account ID and
 // verified email are unchanged.
-func (s *Service) ChangePassword(ctx context.Context, target PasswordChangeTarget, password string) (Account, error) {
-	if target.AccountID == "" || target.CredentialEventID == "" {
+func (s *Service) ChangePassword(ctx context.Context, target PasswordChangeTarget) (Account, error) {
+	if target.AccountID == "" || target.CredentialEventID == "" || target.newPassword == "" {
 		return Account{}, ErrCredentialChanged
 	}
-	password, err := validatePassword(password, s.passwordMinimumLength)
+	password, err := validatePassword(target.newPassword, s.passwordMinimumLength)
 	if err != nil {
 		return Account{}, err
 	}

--- a/authling/internal/accounts/accounts.go
+++ b/authling/internal/accounts/accounts.go
@@ -494,6 +494,21 @@ func (p *Projection) credentialForAccount(accountID string) (protectedCredential
 	return credential, ok
 }
 
+// credentialForPasswordMutation rejects the interval in which an atomic email
+// change has staged its account event but its adjacent registry claim has not
+// yet activated the new credential. Appending against the old credential in
+// that interval would create an event that fails ordered replay after the
+// registry claim advances the credential generation.
+func (p *Projection) credentialForPasswordMutation(accountID string) (protectedCredential, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	if pending, ok := p.pendingEmails[accountID]; ok && pending.replaces {
+		return protectedCredential{}, false
+	}
+	credential, ok := p.credentials[accountID]
+	return credential, ok
+}
+
 func (p *Projection) hasEmailChangeRequest(target EmailChangeTarget) bool {
 	p.RLock()
 	defer p.RUnlock()
@@ -1186,10 +1201,19 @@ func (s *Service) passwordCredentialAtTail(ctx context.Context, accountID, crede
 	if err != nil {
 		return 0, protectedCredential{}, ErrCredentialChanged
 	}
+	registryTail, err := s.publisher.AccountRegistryTail(ctx)
+	if err != nil {
+		return 0, protectedCredential{}, fmt.Errorf("read account registry tail: %w", err)
+	}
 	if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
 		return 0, protectedCredential{}, fmt.Errorf("wait for account credential: %w", err)
 	}
-	credential, ok := s.handle.Projection().credentialForAccount(accountID)
+	if registryTail > 0 {
+		if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(evtstream.AccountRegistrySubject(), registryTail)); err != nil {
+			return 0, protectedCredential{}, fmt.Errorf("wait for account registry credential: %w", err)
+		}
+	}
+	credential, ok := s.handle.Projection().credentialForPasswordMutation(accountID)
 	if !ok || credential.eventID != credentialEventID {
 		return 0, protectedCredential{}, ErrCredentialChanged
 	}

--- a/authling/internal/accounts/accounts_test.go
+++ b/authling/internal/accounts/accounts_test.go
@@ -122,6 +122,39 @@ func TestPasswordChangeInvalidatesAcceptedEmailChangeRequests(t *testing.T) {
 	}
 }
 
+func TestSignedInPasswordChangeRequiresCurrentCredentialCorrelation(t *testing.T) {
+	projection := NewProjection(nil, []byte("index key"))
+	projection.accounts = map[string]Account{"acc_example": {ID: "acc_example"}}
+	projection.credentials = map[string]protectedCredential{"acc_example": {
+		accountID: "acc_example", eventID: "evt_current", userKeyRef: "key_user", credentialKeyRef: "key_credential",
+	}}
+	event := &corev1.Event{Id: "evt_password", CreatedAt: timestamppb.Now(), Event: &corev1.Event_PasswordChanged{PasswordChanged: &corev1.PasswordChangedEvent{
+		AccountId: "acc_example", UserKeyRef: "key_user", CredentialKeyRef: "key_credential",
+		CredentialEnvelopeVersion: 1, PasswordVerifierNonce: []byte("nonce"), PasswordVerifierCiphertext: []byte("ciphertext"),
+		PriorCredentialEventId: "evt_stale", Kind: corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN,
+	}}}
+	if err := projection.Apply(event, 2); err == nil || !strings.Contains(err.Error(), "prior credential") {
+		t.Fatalf("stale signed-in password change error = %v", err)
+	}
+}
+
+func TestRecoveryPasswordChangeRequiresAppliedRequest(t *testing.T) {
+	projection := NewProjection(nil, []byte("index key"))
+	projection.accounts = map[string]Account{"acc_example": {ID: "acc_example"}}
+	projection.credentials = map[string]protectedCredential{"acc_example": {
+		accountID: "acc_example", eventID: "evt_current", userKeyRef: "key_user", credentialKeyRef: "key_credential",
+	}}
+	event := &corev1.Event{Id: "evt_password", CreatedAt: timestamppb.Now(), Event: &corev1.Event_PasswordChanged{PasswordChanged: &corev1.PasswordChangedEvent{
+		AccountId: "acc_example", UserKeyRef: "key_user", CredentialKeyRef: "key_credential",
+		CredentialEnvelopeVersion: 1, PasswordVerifierNonce: []byte("nonce"), PasswordVerifierCiphertext: []byte("ciphertext"),
+		PasswordResetRequestEventId: "evt_request", PriorCredentialEventId: "evt_current",
+		Kind: corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_RECOVERY,
+	}}}
+	if err := projection.Apply(event, 2); err == nil || !strings.Contains(err.Error(), "recovery request") {
+		t.Fatalf("uncorrelated recovery password change error = %v", err)
+	}
+}
+
 func TestCompletedEmailChangeRequiresItsExactCredentialGeneration(t *testing.T) {
 	projection := NewProjection(nil, []byte("index key"))
 	projection.accounts = map[string]Account{"acc_example": {ID: "acc_example", AuthenticationVersion: 2}}

--- a/authling/internal/accounts/accounts_test.go
+++ b/authling/internal/accounts/accounts_test.go
@@ -101,6 +101,24 @@ func TestEmailReplacementClaimRequiresCorrelationButHistoricalCreationDoesNot(t 
 	}
 }
 
+func TestPasswordMutationRejectsTheSplitEmailChangeBatch(t *testing.T) {
+	projection := NewProjection(nil, []byte("index key"))
+	projection.credentials = map[string]protectedCredential{"acc_example": {
+		accountID: "acc_example", eventID: "evt_prior", userKeyRef: "key_user", credentialKeyRef: "key_credential",
+	}}
+	projection.pendingEmails = map[string]pendingEmail{"acc_example": {
+		eventID: "evt_email_change", replaces: true,
+		credential: protectedCredential{accountID: "acc_example", eventID: "evt_email_change"},
+	}}
+	if credential, ok := projection.credentialForPasswordMutation("acc_example"); ok {
+		t.Fatalf("password mutation observed staged email-change credential: %+v", credential)
+	}
+	delete(projection.pendingEmails, "acc_example")
+	if credential, ok := projection.credentialForPasswordMutation("acc_example"); !ok || credential.eventID != "evt_prior" {
+		t.Fatalf("password mutation credential after registry claim = %+v, %v", credential, ok)
+	}
+}
+
 func TestPasswordChangeInvalidatesAcceptedEmailChangeRequests(t *testing.T) {
 	projection := NewProjection(nil, []byte("index key"))
 	projection.accounts = map[string]Account{"acc_example": {ID: "acc_example"}}

--- a/authling/internal/app/runtime_test.go
+++ b/authling/internal/app/runtime_test.go
@@ -600,6 +600,40 @@ func TestSignedInPasswordChangeToleratesAnAuditEventAfterReauthentication(t *tes
 	if changed.AuthenticationVersion != account.AuthenticationVersion+1 {
 		t.Fatalf("changed authentication version = %d, want %d", changed.AuthenticationVersion, account.AuthenticationVersion+1)
 	}
+	if _, err := runtime.Authentication.Login(testContext(t), "password-audit@example.com", "the original uncommon password"); !errors.Is(err, accounts.ErrInvalidCredentials) {
+		t.Fatalf("original password after prepared change error = %v, want ErrInvalidCredentials", err)
+	}
+	if authenticated, err := runtime.Authentication.Login(testContext(t), "password-audit@example.com", "the replacement uncommon password"); err != nil || authenticated != changed {
+		t.Fatalf("prepared replacement login = %+v, %v; want %+v", authenticated, err, changed)
+	}
+}
+
+func TestSignedInPasswordChangeRejectsReauthenticationBeforeEmailChange(t *testing.T) {
+	sender := &capturingSender{}
+	runtime, cancel, runErrors := startTestRuntime(t, embeddedTestConfig(t), sender)
+	defer stopTestRuntime(t, runtime, cancel, runErrors)
+	account, err := runtime.Accounts.CreateLocal(testContext(t), "password-before-email@example.com", "the original uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := runtime.Accounts.PreparePasswordChange(testContext(t), account.ID, "the original uncommon password", "the replacement uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	flow, err := runtime.EmailChange.Start(testContext(t), account.ID, "the original uncommon password", "password-after-email@example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	code := regexp.MustCompile(`\b[0-9]{6}\b`).FindString(sender.last().Body)
+	if err := runtime.EmailChange.Verify(testContext(t), account.ID, flow, code); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.EmailChange.Complete(testContext(t), account.ID, flow); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.Accounts.ChangePassword(testContext(t), target); !errors.Is(err, accounts.ErrCredentialChanged) {
+		t.Fatalf("pre-email-change reauthentication error = %v, want ErrCredentialChanged", err)
+	}
 }
 
 func TestPasswordResetHidesAbsentAccountsAndRejectsStaleConcurrentFlows(t *testing.T) {

--- a/authling/internal/app/runtime_test.go
+++ b/authling/internal/app/runtime_test.go
@@ -431,6 +431,7 @@ func TestPasswordResetChangesCredentialAndInvalidatesOlderSessionsAcrossRestart(
 	if err != nil {
 		t.Fatal(err)
 	}
+	credentialEvent, _ := lastAccountEvent(t, first, account.ID)
 	oldSession, _, err := first.Sessions.Create(testContext(t), account.ID)
 	if err != nil {
 		t.Fatal(err)
@@ -465,8 +466,12 @@ func TestPasswordResetChangesCredentialAndInvalidatesOlderSessionsAcrossRestart(
 		t.Fatalf("changed account = %+v, original = %+v", changed, account)
 	}
 	changeEvent, _ := lastAccountEvent(t, first, account.ID)
-	if got := changeEvent.GetPasswordChanged().GetPasswordResetRequestEventId(); got != requestEvent.GetId() {
+	change := changeEvent.GetPasswordChanged()
+	if got := change.GetPasswordResetRequestEventId(); got != requestEvent.GetId() {
 		t.Fatalf("password change request event ID = %q, want %q", got, requestEvent.GetId())
+	}
+	if change.GetKind() != corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_RECOVERY || change.GetPriorCredentialEventId() != credentialEvent.GetId() {
+		t.Fatalf("recovery password change event = %+v", changeEvent)
 	}
 	if _, err := first.Authentication.Login(testContext(t), "recover@example.com", "the original uncommon password"); !errors.Is(err, accounts.ErrInvalidCredentials) {
 		t.Fatalf("old password login error = %v, want ErrInvalidCredentials", err)
@@ -489,6 +494,111 @@ func TestPasswordResetChangesCredentialAndInvalidatesOlderSessionsAcrossRestart(
 	}
 	if _, err := restarted.Sessions.Validate(testContext(t), oldSession); !errors.Is(err, sessions.ErrNotFound) {
 		t.Fatalf("restarted older session validation error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSignedInPasswordChangePreservesAccountAndInvalidatesOlderSessionsAcrossRestart(t *testing.T) {
+	cfg := embeddedTestConfig(t)
+	first, cancelFirst, firstErrors := startTestRuntime(t, cfg)
+	account, err := first.Accounts.CreateLocal(testContext(t), "change-password@example.com", "the original uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	credentialEvent, _ := lastAccountEvent(t, first, account.ID)
+	olderSession, _, err := first.Sessions.Create(testContext(t), account.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := first.Authentication.ChangePassword(testContext(t), account.ID, "wrong current password", "the replacement uncommon password"); !errors.Is(err, accounts.ErrInvalidCredentials) {
+		t.Fatalf("wrong current password error = %v, want ErrInvalidCredentials", err)
+	}
+	if _, err := first.Authentication.ChangePassword(testContext(t), account.ID, "the original uncommon password", "the original uncommon password"); !errors.Is(err, accounts.ErrPasswordUnchanged) {
+		t.Fatalf("unchanged password error = %v, want ErrPasswordUnchanged", err)
+	}
+	changed, err := first.Authentication.ChangePassword(testContext(t), account.ID, "the original uncommon password", "the replacement uncommon password")
+	if err != nil {
+		t.Fatalf("change signed-in password: %v", err)
+	}
+	if changed.ID != account.ID || changed.AuthenticationVersion != account.AuthenticationVersion+1 {
+		t.Fatalf("changed account = %+v, original = %+v", changed, account)
+	}
+	changeEvent, changeRecord := lastAccountEvent(t, first, account.ID)
+	payload := changeEvent.GetPasswordChanged()
+	if payload == nil || payload.GetKind() != corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN || payload.GetPriorCredentialEventId() != credentialEvent.GetId() || payload.GetPasswordResetRequestEventId() != "" {
+		t.Fatalf("signed-in password change event = %+v", changeEvent)
+	}
+	for _, secret := range []string{"the original uncommon password", "the replacement uncommon password", "change-password@example.com"} {
+		if bytes.Contains(changeRecord, []byte(secret)) {
+			t.Fatalf("password change event contains protected value %q", secret)
+		}
+	}
+	if _, err := first.Authentication.Login(testContext(t), "change-password@example.com", "the original uncommon password"); !errors.Is(err, accounts.ErrInvalidCredentials) {
+		t.Fatalf("old password login error = %v, want ErrInvalidCredentials", err)
+	}
+	if authenticated, err := first.Authentication.Login(testContext(t), "change-password@example.com", "the replacement uncommon password"); err != nil || authenticated != changed {
+		t.Fatalf("new password login = %+v, %v; want %+v", authenticated, err, changed)
+	}
+	if _, err := first.Sessions.Validate(testContext(t), olderSession); !errors.Is(err, sessions.ErrNotFound) {
+		t.Fatalf("older session validation error = %v, want ErrNotFound", err)
+	}
+	replacementSession, _, err := first.Sessions.CreateAtAuthenticationVersion(testContext(t), account.ID, changed.AuthenticationVersion)
+	if err != nil {
+		t.Fatalf("create replacement session: %v", err)
+	}
+	if _, err := first.Sessions.Validate(testContext(t), replacementSession); err != nil {
+		t.Fatalf("validate replacement session: %v", err)
+	}
+	stopTestRuntime(t, first, cancelFirst, firstErrors)
+
+	restarted, cancelRestarted, restartedErrors := startTestRuntime(t, cfg)
+	defer stopTestRuntime(t, restarted, cancelRestarted, restartedErrors)
+	if authenticated, err := restarted.Authentication.Login(testContext(t), "change-password@example.com", "the replacement uncommon password"); err != nil || authenticated != changed {
+		t.Fatalf("restarted login = %+v, %v; want %+v", authenticated, err, changed)
+	}
+	if _, err := restarted.Sessions.Validate(testContext(t), olderSession); !errors.Is(err, sessions.ErrNotFound) {
+		t.Fatalf("restarted older session validation error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestSignedInPasswordChangeRejectsAStaleReauthentication(t *testing.T) {
+	runtime, cancel, runErrors := startTestRuntime(t, embeddedTestConfig(t))
+	defer stopTestRuntime(t, runtime, cancel, runErrors)
+	account, err := runtime.Accounts.CreateLocal(testContext(t), "stale-password@example.com", "the original uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := runtime.Accounts.PreparePasswordChange(testContext(t), account.ID, "the original uncommon password", "first replacement uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.Authentication.ChangePassword(testContext(t), account.ID, "the original uncommon password", "second replacement uncommon password"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.Accounts.ChangePassword(testContext(t), target, "first replacement uncommon password"); !errors.Is(err, accounts.ErrCredentialChanged) {
+		t.Fatalf("stale password change error = %v, want ErrCredentialChanged", err)
+	}
+}
+
+func TestSignedInPasswordChangeToleratesAnAuditEventAfterReauthentication(t *testing.T) {
+	runtime, cancel, runErrors := startTestRuntime(t, embeddedTestConfig(t))
+	defer stopTestRuntime(t, runtime, cancel, runErrors)
+	account, err := runtime.Accounts.CreateLocal(testContext(t), "password-audit@example.com", "the original uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, err := runtime.Accounts.PreparePasswordChange(testContext(t), account.ID, "the original uncommon password", "the replacement uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := runtime.Accounts.RecordPasswordResetRequested(testContext(t), "password-audit@example.com"); err != nil || !ok {
+		t.Fatalf("record intervening audit event: present = %v, error = %v", ok, err)
+	}
+	changed, err := runtime.Accounts.ChangePassword(testContext(t), target, "the replacement uncommon password")
+	if err != nil {
+		t.Fatalf("change password after audit event: %v", err)
+	}
+	if changed.AuthenticationVersion != account.AuthenticationVersion+1 {
+		t.Fatalf("changed authentication version = %d, want %d", changed.AuthenticationVersion, account.AuthenticationVersion+1)
 	}
 }
 

--- a/authling/internal/app/runtime_test.go
+++ b/authling/internal/app/runtime_test.go
@@ -574,7 +574,7 @@ func TestSignedInPasswordChangeRejectsAStaleReauthentication(t *testing.T) {
 	if _, err := runtime.Authentication.ChangePassword(testContext(t), account.ID, "the original uncommon password", "second replacement uncommon password"); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := runtime.Accounts.ChangePassword(testContext(t), target, "first replacement uncommon password"); !errors.Is(err, accounts.ErrCredentialChanged) {
+	if _, err := runtime.Accounts.ChangePassword(testContext(t), target); !errors.Is(err, accounts.ErrCredentialChanged) {
 		t.Fatalf("stale password change error = %v, want ErrCredentialChanged", err)
 	}
 }
@@ -593,7 +593,7 @@ func TestSignedInPasswordChangeToleratesAnAuditEventAfterReauthentication(t *tes
 	if _, ok, err := runtime.Accounts.RecordPasswordResetRequested(testContext(t), "password-audit@example.com"); err != nil || !ok {
 		t.Fatalf("record intervening audit event: present = %v, error = %v", ok, err)
 	}
-	changed, err := runtime.Accounts.ChangePassword(testContext(t), target, "the replacement uncommon password")
+	changed, err := runtime.Accounts.ChangePassword(testContext(t), target)
 	if err != nil {
 		t.Fatalf("change password after audit event: %v", err)
 	}

--- a/authling/internal/authentication/authentication.go
+++ b/authling/internal/authentication/authentication.go
@@ -33,7 +33,7 @@ type attemptCounter struct {
 type accountAuthenticator interface {
 	AuthenticateLocal(context.Context, string, string) (accounts.Account, error)
 	PreparePasswordChange(context.Context, string, string, string) (accounts.PasswordChangeTarget, error)
-	ChangePassword(context.Context, accounts.PasswordChangeTarget, string) (accounts.Account, error)
+	ChangePassword(context.Context, accounts.PasswordChangeTarget) (accounts.Account, error)
 	PrepareEmailChange(context.Context, string, string, string) (accounts.EmailChangeTarget, error)
 }
 
@@ -174,7 +174,7 @@ func (s *Service) ChangePassword(ctx context.Context, accountID, currentPassword
 	if authErr != nil {
 		return accounts.Account{}, authErr
 	}
-	return s.accounts.ChangePassword(ctx, target, newPassword)
+	return s.accounts.ChangePassword(ctx, target)
 }
 
 func (s *Service) acquirePasswordSlot(ctx context.Context) (func(), error) {

--- a/authling/internal/authentication/authentication.go
+++ b/authling/internal/authentication/authentication.go
@@ -32,6 +32,8 @@ type attemptCounter struct {
 
 type accountAuthenticator interface {
 	AuthenticateLocal(context.Context, string, string) (accounts.Account, error)
+	PreparePasswordChange(context.Context, string, string, string) (accounts.PasswordChangeTarget, error)
+	ChangePassword(context.Context, accounts.PasswordChangeTarget, string) (accounts.Account, error)
 	PrepareEmailChange(context.Context, string, string, string) (accounts.EmailChangeTarget, error)
 }
 
@@ -133,6 +135,46 @@ func (s *Service) ReauthenticateEmailChange(ctx context.Context, accountID, pass
 		_ = s.kv.Delete(ctx, limit.key, jetstream.LastRevision(limit.revision))
 	}
 	return target, authErr
+}
+
+// ChangePassword reauthenticates a signed-in account under the same
+// distributed guessing and Argon2 concurrency defenses as login, then commits
+// the replacement while that exact credential remains current.
+func (s *Service) ChangePassword(ctx context.Context, accountID, currentPassword, newPassword string) (accounts.Account, error) {
+	release, err := s.acquirePasswordSlot(ctx)
+	if err != nil {
+		return accounts.Account{}, err
+	}
+	defer release()
+
+	key := s.attemptKey("password-change-reauth-attempt", accountID)
+	limit, err := s.readLimit(ctx, key)
+	if err != nil {
+		return accounts.Account{}, fmt.Errorf("read password change reauthentication limit: %w", err)
+	}
+	target, authErr := s.accounts.PreparePasswordChange(ctx, accountID, currentPassword, newPassword)
+	passwordAccepted := authErr == nil || errors.Is(authErr, accounts.ErrInvalidPassword) || errors.Is(authErr, accounts.ErrPasswordUnchanged)
+	if !passwordAccepted {
+		if !errors.Is(authErr, accounts.ErrInvalidCredentials) {
+			return accounts.Account{}, authErr
+		}
+		if !limit.limited {
+			if err := s.recordFailure(ctx, key); err != nil {
+				return accounts.Account{}, fmt.Errorf("record failed password change reauthentication: %w", err)
+			}
+		}
+		return accounts.Account{}, accounts.ErrInvalidCredentials
+	}
+	if limit.limited {
+		return accounts.Account{}, accounts.ErrInvalidCredentials
+	}
+	if limit.revision > 0 {
+		_ = s.kv.Delete(ctx, limit.key, jetstream.LastRevision(limit.revision))
+	}
+	if authErr != nil {
+		return accounts.Account{}, authErr
+	}
+	return s.accounts.ChangePassword(ctx, target, newPassword)
 }
 
 func (s *Service) acquirePasswordSlot(ctx context.Context) (func(), error) {

--- a/authling/internal/authentication/authentication_test.go
+++ b/authling/internal/authentication/authentication_test.go
@@ -25,7 +25,7 @@ func (s *stubAuthenticator) PreparePasswordChange(context.Context, string, strin
 	return accounts.PasswordChangeTarget{}, s.err
 }
 
-func (s *stubAuthenticator) ChangePassword(context.Context, accounts.PasswordChangeTarget, string) (accounts.Account, error) {
+func (s *stubAuthenticator) ChangePassword(context.Context, accounts.PasswordChangeTarget) (accounts.Account, error) {
 	return accounts.Account{}, s.err
 }
 

--- a/authling/internal/authentication/authentication_test.go
+++ b/authling/internal/authentication/authentication_test.go
@@ -21,6 +21,14 @@ func (s *stubAuthenticator) AuthenticateLocal(context.Context, string, string) (
 	return accounts.Account{}, s.err
 }
 
+func (s *stubAuthenticator) PreparePasswordChange(context.Context, string, string, string) (accounts.PasswordChangeTarget, error) {
+	return accounts.PasswordChangeTarget{}, s.err
+}
+
+func (s *stubAuthenticator) ChangePassword(context.Context, accounts.PasswordChangeTarget, string) (accounts.Account, error) {
+	return accounts.Account{}, s.err
+}
+
 func (s *stubAuthenticator) PrepareEmailChange(context.Context, string, string, string) (accounts.EmailChangeTarget, error) {
 	return accounts.EmailChangeTarget{}, s.err
 }
@@ -68,5 +76,36 @@ func TestOperationalFailureDoesNotConsumeAttemptBudget(t *testing.T) {
 	var counter attemptCounter
 	if err := json.Unmarshal(entry.Value(), &counter); err != nil || counter.Count != 1 {
 		t.Fatalf("attempt counter = %+v, decode error = %v; want count 1", counter, err)
+	}
+
+	authenticator.err = errors.New("key service unavailable")
+	if _, err := service.ChangePassword(ctx, "acct_test", "current password", "replacement password"); err == nil || errors.Is(err, accounts.ErrInvalidCredentials) {
+		t.Fatalf("operational password change error = %v", err)
+	}
+	passwordChangeKey := service.attemptKey("password-change-reauth-attempt", "acct_test")
+	if _, err := stores.RuntimeState.Get(ctx, passwordChangeKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("password change attempt counter after operational error = %v, want absent", err)
+	}
+
+	authenticator.err = accounts.ErrInvalidCredentials
+	if _, err := service.ChangePassword(ctx, "acct_test", "current password", "replacement password"); !errors.Is(err, accounts.ErrInvalidCredentials) {
+		t.Fatalf("password change credential mismatch error = %v", err)
+	}
+	entry, err = stores.RuntimeState.Get(ctx, passwordChangeKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(entry.Value(), &counter); err != nil || counter.Count != 1 {
+		t.Fatalf("password change attempt counter = %+v, decode error = %v; want count 1", counter, err)
+	}
+
+	// A password-policy rejection proves that the current password was valid,
+	// so it clears the guessing budget without committing a credential change.
+	authenticator.err = accounts.ErrInvalidPassword
+	if _, err := service.ChangePassword(ctx, "acct_test", "current password", "short"); !errors.Is(err, accounts.ErrInvalidPassword) {
+		t.Fatalf("password change policy error = %v", err)
+	}
+	if _, err := stores.RuntimeState.Get(ctx, passwordChangeKey); !errors.Is(err, jetstream.ErrKeyNotFound) {
+		t.Fatalf("password change attempt counter after accepted current password = %v, want absent", err)
 	}
 }

--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -304,6 +304,23 @@ func validate(event *corev1.Event) error {
 		if requestID := credential.GetPasswordResetRequestEventId(); requestID != "" && !validSubjectToken(requestID) {
 			return fmt.Errorf("password reset request event id is invalid")
 		}
+		if priorID := credential.GetPriorCredentialEventId(); priorID != "" && !validSubjectToken(priorID) {
+			return fmt.Errorf("password prior credential event id is invalid")
+		}
+		switch credential.GetKind() {
+		case corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_UNSPECIFIED:
+			// Historical events predate explicit ceremony correlation.
+		case corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_RECOVERY:
+			if !validSubjectToken(credential.GetPasswordResetRequestEventId()) || !validSubjectToken(credential.GetPriorCredentialEventId()) {
+				return fmt.Errorf("recovery password change correlation is incomplete")
+			}
+		case corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN:
+			if credential.GetPasswordResetRequestEventId() != "" || !validSubjectToken(credential.GetPriorCredentialEventId()) {
+				return fmt.Errorf("signed-in password change correlation is invalid")
+			}
+		default:
+			return fmt.Errorf("password change kind is unsupported")
+		}
 	case *corev1.Event_PasswordResetRequested:
 		request := payload.PasswordResetRequested
 		if !validSubjectToken(request.GetAccountId()) || !validSubjectToken(request.GetCredentialEventId()) {

--- a/authling/internal/evtstream/evtstream_test.go
+++ b/authling/internal/evtstream/evtstream_test.go
@@ -162,6 +162,15 @@ func TestDecodeRejectsMalformedEvents(t *testing.T) {
 	if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "email credential envelope is incomplete") {
 		t.Fatalf("decode incomplete email change error = %v", err)
 	}
+	malformed = passwordChangedEvent("evt_signed_in_change")
+	malformed.GetPasswordChanged().Kind = corev1.PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN
+	data, err = proto.Marshal(malformed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "signed-in password change correlation is invalid") {
+		t.Fatalf("decode uncorrelated signed-in password change error = %v", err)
+	}
 }
 
 func TestAccountSubjectRejectsUnsafeTokens(t *testing.T) {

--- a/authling/internal/pb/authling/core/v1/event.pb.go
+++ b/authling/internal/pb/authling/core/v1/event.pb.go
@@ -22,6 +22,55 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type PasswordChangeKind int32
+
+const (
+	PasswordChangeKind_PASSWORD_CHANGE_KIND_UNSPECIFIED PasswordChangeKind = 0
+	PasswordChangeKind_PASSWORD_CHANGE_KIND_RECOVERY    PasswordChangeKind = 1
+	PasswordChangeKind_PASSWORD_CHANGE_KIND_SIGNED_IN   PasswordChangeKind = 2
+)
+
+// Enum value maps for PasswordChangeKind.
+var (
+	PasswordChangeKind_name = map[int32]string{
+		0: "PASSWORD_CHANGE_KIND_UNSPECIFIED",
+		1: "PASSWORD_CHANGE_KIND_RECOVERY",
+		2: "PASSWORD_CHANGE_KIND_SIGNED_IN",
+	}
+	PasswordChangeKind_value = map[string]int32{
+		"PASSWORD_CHANGE_KIND_UNSPECIFIED": 0,
+		"PASSWORD_CHANGE_KIND_RECOVERY":    1,
+		"PASSWORD_CHANGE_KIND_SIGNED_IN":   2,
+	}
+)
+
+func (x PasswordChangeKind) Enum() *PasswordChangeKind {
+	p := new(PasswordChangeKind)
+	*p = x
+	return p
+}
+
+func (x PasswordChangeKind) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (PasswordChangeKind) Descriptor() protoreflect.EnumDescriptor {
+	return file_authling_core_v1_event_proto_enumTypes[0].Descriptor()
+}
+
+func (PasswordChangeKind) Type() protoreflect.EnumType {
+	return &file_authling_core_v1_event_proto_enumTypes[0]
+}
+
+func (x PasswordChangeKind) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use PasswordChangeKind.Descriptor instead.
+func (PasswordChangeKind) EnumDescriptor() ([]byte, []int) {
+	return file_authling_core_v1_event_proto_rawDescGZIP(), []int{0}
+}
+
 // Event is Authling's persisted envelope for durable domain facts.
 //
 // This message is a storage contract. Existing fields and oneof tags must not
@@ -442,8 +491,14 @@ type PasswordChangedEvent struct {
 	// The audit event that initiated this recovery-driven change. Historical
 	// password changes written before request auditing leave this empty.
 	PasswordResetRequestEventId string `protobuf:"bytes,7,opt,name=password_reset_request_event_id,json=passwordResetRequestEventId,proto3" json:"password_reset_request_event_id,omitempty"`
-	unknownFields               protoimpl.UnknownFields
-	sizeCache                   protoimpl.SizeCache
+	// The protected credential event that was current when this change was
+	// authorized. Historical password changes leave this empty.
+	PriorCredentialEventId string `protobuf:"bytes,8,opt,name=prior_credential_event_id,json=priorCredentialEventId,proto3" json:"prior_credential_event_id,omitempty"`
+	// The ceremony that authorized this change. Historical password changes
+	// leave this unspecified.
+	Kind          PasswordChangeKind `protobuf:"varint,9,opt,name=kind,proto3,enum=authling.core.v1.PasswordChangeKind" json:"kind,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *PasswordChangedEvent) Reset() {
@@ -523,6 +578,20 @@ func (x *PasswordChangedEvent) GetPasswordResetRequestEventId() string {
 		return x.PasswordResetRequestEventId
 	}
 	return ""
+}
+
+func (x *PasswordChangedEvent) GetPriorCredentialEventId() string {
+	if x != nil {
+		return x.PriorCredentialEventId
+	}
+	return ""
+}
+
+func (x *PasswordChangedEvent) GetKind() PasswordChangeKind {
+	if x != nil {
+		return x.Kind
+	}
+	return PasswordChangeKind_PASSWORD_CHANGE_KIND_UNSPECIFIED
 }
 
 // PasswordResetRequestedEvent records an accepted recovery request for an
@@ -772,7 +841,7 @@ const file_authling_core_v1_event_proto_rawDesc = "" +
 	"\x10email_ciphertext\x18\x05 \x01(\fR\x0femailCiphertext\x12>\n" +
 	"\x1bcredential_envelope_version\x18\x06 \x01(\rR\x19credentialEnvelopeVersion\x126\n" +
 	"\x17password_verifier_nonce\x18\a \x01(\fR\x15passwordVerifierNonce\x12@\n" +
-	"\x1cpassword_verifier_ciphertext\x18\b \x01(\fR\x1apasswordVerifierCiphertext\"\x85\x03\n" +
+	"\x1cpassword_verifier_ciphertext\x18\b \x01(\fR\x1apasswordVerifierCiphertext\"\xfa\x03\n" +
 	"\x14PasswordChangedEvent\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\tR\taccountId\x12 \n" +
@@ -782,7 +851,9 @@ const file_authling_core_v1_event_proto_rawDesc = "" +
 	"\x1bcredential_envelope_version\x18\x04 \x01(\rR\x19credentialEnvelopeVersion\x126\n" +
 	"\x17password_verifier_nonce\x18\x05 \x01(\fR\x15passwordVerifierNonce\x12@\n" +
 	"\x1cpassword_verifier_ciphertext\x18\x06 \x01(\fR\x1apasswordVerifierCiphertext\x12D\n" +
-	"\x1fpassword_reset_request_event_id\x18\a \x01(\tR\x1bpasswordResetRequestEventId\"l\n" +
+	"\x1fpassword_reset_request_event_id\x18\a \x01(\tR\x1bpasswordResetRequestEventId\x129\n" +
+	"\x19prior_credential_event_id\x18\b \x01(\tR\x16priorCredentialEventId\x128\n" +
+	"\x04kind\x18\t \x01(\x0e2$.authling.core.v1.PasswordChangeKindR\x04kind\"l\n" +
 	"\x1bPasswordResetRequestedEvent\x12\x1d\n" +
 	"\n" +
 	"account_id\x18\x01 \x01(\tR\taccountId\x12.\n" +
@@ -802,7 +873,11 @@ const file_authling_core_v1_event_proto_rawDesc = "" +
 	"emailNonce\x12)\n" +
 	"\x10email_ciphertext\x18\x06 \x01(\fR\x0femailCiphertext\x12@\n" +
 	"\x1demail_change_request_event_id\x18\a \x01(\tR\x19emailChangeRequestEventId\x129\n" +
-	"\x19prior_credential_event_id\x18\b \x01(\tR\x16priorCredentialEventIdB7Z5hmans.de/authling/internal/pb/authling/core/v1;corev1b\x06proto3"
+	"\x19prior_credential_event_id\x18\b \x01(\tR\x16priorCredentialEventId*\x81\x01\n" +
+	"\x12PasswordChangeKind\x12$\n" +
+	" PASSWORD_CHANGE_KIND_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dPASSWORD_CHANGE_KIND_RECOVERY\x10\x01\x12\"\n" +
+	"\x1ePASSWORD_CHANGE_KIND_SIGNED_IN\x10\x02B7Z5hmans.de/authling/internal/pb/authling/core/v1;corev1b\x06proto3"
 
 var (
 	file_authling_core_v1_event_proto_rawDescOnce sync.Once
@@ -816,32 +891,35 @@ func file_authling_core_v1_event_proto_rawDescGZIP() []byte {
 	return file_authling_core_v1_event_proto_rawDescData
 }
 
+var file_authling_core_v1_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_authling_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_authling_core_v1_event_proto_goTypes = []any{
-	(*Event)(nil),                       // 0: authling.core.v1.Event
-	(*IssuerEstablishedEvent)(nil),      // 1: authling.core.v1.IssuerEstablishedEvent
-	(*EmailClaimedEvent)(nil),           // 2: authling.core.v1.EmailClaimedEvent
-	(*AccountCreatedEvent)(nil),         // 3: authling.core.v1.AccountCreatedEvent
-	(*PasswordChangedEvent)(nil),        // 4: authling.core.v1.PasswordChangedEvent
-	(*PasswordResetRequestedEvent)(nil), // 5: authling.core.v1.PasswordResetRequestedEvent
-	(*EmailChangeRequestedEvent)(nil),   // 6: authling.core.v1.EmailChangeRequestedEvent
-	(*EmailChangedEvent)(nil),           // 7: authling.core.v1.EmailChangedEvent
-	(*timestamppb.Timestamp)(nil),       // 8: google.protobuf.Timestamp
+	(PasswordChangeKind)(0),             // 0: authling.core.v1.PasswordChangeKind
+	(*Event)(nil),                       // 1: authling.core.v1.Event
+	(*IssuerEstablishedEvent)(nil),      // 2: authling.core.v1.IssuerEstablishedEvent
+	(*EmailClaimedEvent)(nil),           // 3: authling.core.v1.EmailClaimedEvent
+	(*AccountCreatedEvent)(nil),         // 4: authling.core.v1.AccountCreatedEvent
+	(*PasswordChangedEvent)(nil),        // 5: authling.core.v1.PasswordChangedEvent
+	(*PasswordResetRequestedEvent)(nil), // 6: authling.core.v1.PasswordResetRequestedEvent
+	(*EmailChangeRequestedEvent)(nil),   // 7: authling.core.v1.EmailChangeRequestedEvent
+	(*EmailChangedEvent)(nil),           // 8: authling.core.v1.EmailChangedEvent
+	(*timestamppb.Timestamp)(nil),       // 9: google.protobuf.Timestamp
 }
 var file_authling_core_v1_event_proto_depIdxs = []int32{
-	8, // 0: authling.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
-	3, // 1: authling.core.v1.Event.account_created:type_name -> authling.core.v1.AccountCreatedEvent
-	2, // 2: authling.core.v1.Event.email_claimed:type_name -> authling.core.v1.EmailClaimedEvent
-	1, // 3: authling.core.v1.Event.issuer_established:type_name -> authling.core.v1.IssuerEstablishedEvent
-	4, // 4: authling.core.v1.Event.password_changed:type_name -> authling.core.v1.PasswordChangedEvent
-	5, // 5: authling.core.v1.Event.password_reset_requested:type_name -> authling.core.v1.PasswordResetRequestedEvent
-	6, // 6: authling.core.v1.Event.email_change_requested:type_name -> authling.core.v1.EmailChangeRequestedEvent
-	7, // 7: authling.core.v1.Event.email_changed:type_name -> authling.core.v1.EmailChangedEvent
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	9, // 0: authling.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	4, // 1: authling.core.v1.Event.account_created:type_name -> authling.core.v1.AccountCreatedEvent
+	3, // 2: authling.core.v1.Event.email_claimed:type_name -> authling.core.v1.EmailClaimedEvent
+	2, // 3: authling.core.v1.Event.issuer_established:type_name -> authling.core.v1.IssuerEstablishedEvent
+	5, // 4: authling.core.v1.Event.password_changed:type_name -> authling.core.v1.PasswordChangedEvent
+	6, // 5: authling.core.v1.Event.password_reset_requested:type_name -> authling.core.v1.PasswordResetRequestedEvent
+	7, // 6: authling.core.v1.Event.email_change_requested:type_name -> authling.core.v1.EmailChangeRequestedEvent
+	8, // 7: authling.core.v1.Event.email_changed:type_name -> authling.core.v1.EmailChangedEvent
+	0, // 8: authling.core.v1.PasswordChangedEvent.kind:type_name -> authling.core.v1.PasswordChangeKind
+	9, // [9:9] is the sub-list for method output_type
+	9, // [9:9] is the sub-list for method input_type
+	9, // [9:9] is the sub-list for extension type_name
+	9, // [9:9] is the sub-list for extension extendee
+	0, // [0:9] is the sub-list for field type_name
 }
 
 func init() { file_authling_core_v1_event_proto_init() }
@@ -863,13 +941,14 @@ func file_authling_core_v1_event_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_authling_core_v1_event_proto_rawDesc), len(file_authling_core_v1_event_proto_rawDesc)),
-			NumEnums:      0,
+			NumEnums:      1,
 			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_authling_core_v1_event_proto_goTypes,
 		DependencyIndexes: file_authling_core_v1_event_proto_depIdxs,
+		EnumInfos:         file_authling_core_v1_event_proto_enumTypes,
 		MessageInfos:      file_authling_core_v1_event_proto_msgTypes,
 	}.Build()
 	File_authling_core_v1_event_proto = out.File

--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -266,7 +266,7 @@ templ accountPage(accountID string, passwordChanged, emailChanged, notificationF
 	}
 }
 
-templ passwordChangePage(accountID, message string, passwordMinimumLength int) {
+templ passwordChangePage(message string, passwordMinimumLength int) {
 	@layout("Change your password") {
 		<h1 class="text-3xl font-semibold tracking-tight">Change your password</h1>
 		<p class="mt-3 text-slate-600 dark:text-slate-300">Enter your current password and choose a new one. This signs out your other Authling browser sessions.</p>
@@ -274,7 +274,6 @@ templ passwordChangePage(accountID, message string, passwordMinimumLength int) {
 			<p role="alert" class="mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100">{ message }</p>
 		}
 		<form class="mt-8 space-y-5" method="post" action="/account/password">
-			<input class="hidden" type="text" name="username" value={ accountID } autocomplete="username" readonly/>
 			<label class="block"><span class="font-medium">Current password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="current_password" autocomplete="current-password" maxlength="1024" autofocus required/></label>
 			<label class="block"><span class="font-medium">New password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="new_password" autocomplete="new-password" minlength={ strconv.Itoa(passwordMinimumLength) } maxlength="1024" required/></label>
 			<label class="block"><span class="font-medium">Confirm new password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="new_password_confirmation" autocomplete="new-password" minlength={ strconv.Itoa(passwordMinimumLength) } maxlength="1024" required/></label>

--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -243,11 +243,14 @@ templ accountCreatedPage(accountID string) {
 	}
 }
 
-templ accountPage(accountID string, emailChanged, notificationFailed bool) {
+templ accountPage(accountID string, passwordChanged, emailChanged, notificationFailed bool) {
 	@layout("Your Authling account") {
 		<p class="mb-3 text-sm font-semibold tracking-widest text-authling-600 uppercase dark:text-authling-200">Signed in</p>
 		<h1 class="text-3xl font-semibold tracking-tight">Your account</h1>
 		<p class="mt-3 text-slate-600 dark:text-slate-300">Your browser has an active Authling session.</p>
+		if passwordChanged {
+			<p role="status" class="mt-5 rounded-xl bg-green-50 p-4 text-green-900 dark:bg-green-950 dark:text-green-100">Your password was changed. Your other Authling browser sessions were signed out.</p>
+		}
 		if emailChanged {
 			<p role="status" class="mt-5 rounded-xl bg-green-50 p-4 text-green-900 dark:bg-green-950 dark:text-green-100">Your email address was changed. Use your new email address the next time you sign in.</p>
 		}
@@ -256,8 +259,27 @@ templ accountPage(accountID string, emailChanged, notificationFailed bool) {
 		}
 		<p class="mt-6 text-sm text-slate-500">Account ID: <code>{ accountID }</code></p>
 		<a class="mt-8 inline-flex w-full justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700" href="/account/email">Change email address</a>
+		<a class="mt-3 inline-flex w-full justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700" href="/account/password">Change password</a>
 		<form class="mt-3" method="post" action="/logout">
 			<button class="w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700" type="submit">Sign out</button>
 		</form>
+	}
+}
+
+templ passwordChangePage(accountID, message string, passwordMinimumLength int) {
+	@layout("Change your password") {
+		<h1 class="text-3xl font-semibold tracking-tight">Change your password</h1>
+		<p class="mt-3 text-slate-600 dark:text-slate-300">Enter your current password and choose a new one. This signs out your other Authling browser sessions.</p>
+		if message != "" {
+			<p role="alert" class="mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100">{ message }</p>
+		}
+		<form class="mt-8 space-y-5" method="post" action="/account/password">
+			<input class="hidden" type="text" name="username" value={ accountID } autocomplete="username" readonly/>
+			<label class="block"><span class="font-medium">Current password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="current_password" autocomplete="current-password" maxlength="1024" autofocus required/></label>
+			<label class="block"><span class="font-medium">New password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="new_password" autocomplete="new-password" minlength={ strconv.Itoa(passwordMinimumLength) } maxlength="1024" required/></label>
+			<label class="block"><span class="font-medium">Confirm new password</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3" type="password" name="new_password_confirmation" autocomplete="new-password" minlength={ strconv.Itoa(passwordMinimumLength) } maxlength="1024" required/></label>
+			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Change password</button>
+		</form>
+		<p class="mt-6 text-sm"><a class="font-semibold text-authling-700 underline dark:text-authling-200" href="/account">Return to your account</a>.</p>
 	}
 }

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -1246,7 +1246,7 @@ func accountCreatedPage(accountID string) templ.Component {
 	})
 }
 
-func accountPage(accountID string, emailChanged, notificationFailed bool) templ.Component {
+func accountPage(accountID string, passwordChanged, emailChanged, notificationFailed bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -1283,8 +1283,8 @@ func accountPage(accountID string, emailChanged, notificationFailed bool) templ.
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if emailChanged {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<p role=\"status\" class=\"mt-5 rounded-xl bg-green-50 p-4 text-green-900 dark:bg-green-950 dark:text-green-100\">Your email address was changed. Use your new email address the next time you sign in.</p>")
+			if passwordChanged {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<p role=\"status\" class=\"mt-5 rounded-xl bg-green-50 p-4 text-green-900 dark:bg-green-950 dark:text-green-100\">Your password was changed. Your other Authling browser sessions were signed out.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -1293,32 +1293,151 @@ func accountPage(accountID string, emailChanged, notificationFailed bool) templ.
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			if notificationFailed {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-amber-50 p-4 text-amber-900 dark:bg-amber-950 dark:text-amber-100\">We couldn’t send a security notice to your previous address. Your email address was still changed.</p>")
+			if emailChanged {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<p role=\"status\" class=\"mt-5 rounded-xl bg-green-50 p-4 text-green-900 dark:bg-green-950 dark:text-green-100\">Your email address was changed. Use your new email address the next time you sign in.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, " <p class=\"mt-6 text-sm text-slate-500\">Account ID: <code>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if notificationFailed {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-amber-50 p-4 text-amber-900 dark:bg-amber-950 dark:text-amber-100\">We couldn’t send a security notice to your previous address. Your email address was still changed.</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, " <p class=\"mt-6 text-sm text-slate-500\">Account ID: <code>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var62 string
 			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 257, Col: 70}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 260, Col: 70}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</code></p><a class=\"mt-8 inline-flex w-full justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" href=\"/account/email\">Change email address</a><form class=\"mt-3\" method=\"post\" action=\"/logout\"><button class=\"w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" type=\"submit\">Sign out</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</code></p><a class=\"mt-8 inline-flex w-full justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" href=\"/account/email\">Change email address</a> <a class=\"mt-3 inline-flex w-full justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" href=\"/account/password\">Change password</a><form class=\"mt-3\" method=\"post\" action=\"/logout\"><button class=\"w-full rounded-xl border border-slate-300 px-5 py-3 font-semibold dark:border-slate-700\" type=\"submit\">Sign out</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
 		templ_7745c5c3_Err = layout("Your Authling account").Render(templ.WithChildren(ctx, templ_7745c5c3_Var61), templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func passwordChangePage(accountID, message string, passwordMinimumLength int) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var63 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var63 == nil {
+			templ_7745c5c3_Var63 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Var64 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+			if !templ_7745c5c3_IsBuffer {
+				defer func() {
+					templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err == nil {
+						templ_7745c5c3_Err = templ_7745c5c3_BufErr
+					}
+				}()
+			}
+			ctx = templ.InitializeContext(ctx)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<h1 class=\"text-3xl font-semibold tracking-tight\">Change your password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Enter your current password and choose a new one. This signs out your other Authling browser sessions.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if message != "" {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<p role=\"alert\" class=\"mt-5 rounded-xl bg-red-50 p-4 text-red-800 dark:bg-red-950 dark:text-red-100\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var65 string
+				templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 274, Col: 113}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/account/password\"><input class=\"hidden\" type=\"text\" name=\"username\" value=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var66 string
+			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.ResolveAttributeValue(accountID)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 277, Col: 70}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var66)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\" autocomplete=\"username\" readonly> <label class=\"block\"><span class=\"font-medium\">Current password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"current_password\" autocomplete=\"current-password\" maxlength=\"1024\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">New password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"new_password\" autocomplete=\"new-password\" minlength=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var67 string
+			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 279, Col: 267}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var67)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "\" maxlength=\"1024\" required></label> <label class=\"block\"><span class=\"font-medium\">Confirm new password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"new_password_confirmation\" autocomplete=\"new-password\" minlength=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var68 string
+			templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 280, Col: 288}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var68)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Change password</button></form><p class=\"mt-6 text-sm\"><a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"/account\">Return to your account</a>.</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			return nil
+		})
+		templ_7745c5c3_Err = layout("Change your password").Render(templ.WithChildren(ctx, templ_7745c5c3_Var64), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -1336,7 +1336,7 @@ func accountPage(accountID string, passwordChanged, emailChanged, notificationFa
 	})
 }
 
-func passwordChangePage(accountID, message string, passwordMinimumLength int) templ.Component {
+func passwordChangePage(message string, passwordMinimumLength int) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -1392,46 +1392,33 @@ func passwordChangePage(accountID, message string, passwordMinimumLength int) te
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/account/password\"><input class=\"hidden\" type=\"text\" name=\"username\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/account/password\"><label class=\"block\"><span class=\"font-medium\">Current password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"current_password\" autocomplete=\"current-password\" maxlength=\"1024\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">New password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"new_password\" autocomplete=\"new-password\" minlength=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var66 string
-			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.ResolveAttributeValue(accountID)
+			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 277, Col: 70}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 278, Col: 267}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var66)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\" autocomplete=\"username\" readonly> <label class=\"block\"><span class=\"font-medium\">Current password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"current_password\" autocomplete=\"current-password\" maxlength=\"1024\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">New password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"new_password\" autocomplete=\"new-password\" minlength=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\" maxlength=\"1024\" required></label> <label class=\"block\"><span class=\"font-medium\">Confirm new password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"new_password_confirmation\" autocomplete=\"new-password\" minlength=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var67 string
 			templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 279, Col: 267}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 279, Col: 288}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var67)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "\" maxlength=\"1024\" required></label> <label class=\"block\"><span class=\"font-medium\">Confirm new password</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3\" type=\"password\" name=\"new_password_confirmation\" autocomplete=\"new-password\" minlength=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var68 string
-			templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 280, Col: 288}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var68)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Change password</button></form><p class=\"mt-6 text-sm\"><a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"/account\">Return to your account</a>.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "\" maxlength=\"1024\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Change password</button></form><p class=\"mt-6 text-sm\"><a class=\"font-semibold text-authling-700 underline dark:text-authling-200\" href=\"/account\">Return to your account</a>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/authling/internal/web/web.go
+++ b/authling/internal/web/web.go
@@ -298,7 +298,7 @@ func Handler(dependencies ...Dependencies) http.Handler {
 		render(w, r, http.StatusOK, accountPage(account.ID, passwordChanged, emailChanged, emailChanged && r.URL.Query().Get("email_notice_failed") == "1"))
 	})
 	mux.HandleFunc("GET /account/password", func(w http.ResponseWriter, r *http.Request) {
-		account, err := authenticatedAccount(r, deps)
+		_, err := authenticatedAccount(r, deps)
 		if errors.Is(err, sessions.ErrNotFound) {
 			clearSessionCookie(w, deps.SecureCookies)
 			redirect(w, r, "/login")
@@ -311,7 +311,7 @@ func Handler(dependencies ...Dependencies) http.Handler {
 			http.Error(w, "password change unavailable", http.StatusServiceUnavailable)
 			return
 		}
-		render(w, r, http.StatusOK, passwordChangePage(account.ID, "", deps.Accounts.PasswordMinimumLength()))
+		render(w, r, http.StatusOK, passwordChangePage("", deps.Accounts.PasswordMinimumLength()))
 	})
 	mux.HandleFunc("POST /account/password", func(w http.ResponseWriter, r *http.Request) {
 		if deps.Accounts == nil || deps.Authentication == nil || deps.Sessions == nil {
@@ -334,28 +334,28 @@ func Handler(dependencies ...Dependencies) http.Handler {
 			return
 		}
 		if err := r.ParseForm(); err != nil {
-			render(w, r, http.StatusBadRequest, passwordChangePage(account.ID, "Invalid form submission.", deps.Accounts.PasswordMinimumLength()))
+			render(w, r, http.StatusBadRequest, passwordChangePage("Invalid form submission.", deps.Accounts.PasswordMinimumLength()))
 			return
 		}
 		newPassword := r.FormValue("new_password")
 		if newPassword != r.FormValue("new_password_confirmation") {
-			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(account.ID, "New passwords do not match.", deps.Accounts.PasswordMinimumLength()))
+			render(w, r, http.StatusUnprocessableEntity, passwordChangePage("New passwords do not match.", deps.Accounts.PasswordMinimumLength()))
 			return
 		}
 		changed, err := deps.Authentication.ChangePassword(r.Context(), account.ID, r.FormValue("current_password"), newPassword)
 		switch {
 		case errors.Is(err, accounts.ErrInvalidCredentials):
-			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(account.ID, "The current password is incorrect.", deps.Accounts.PasswordMinimumLength()))
+			render(w, r, http.StatusUnprocessableEntity, passwordChangePage("The current password is incorrect.", deps.Accounts.PasswordMinimumLength()))
 			return
 		case errors.Is(err, accounts.ErrInvalidPassword), errors.Is(err, accounts.ErrPasswordUnchanged):
-			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(account.ID, err.Error(), deps.Accounts.PasswordMinimumLength()))
+			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(err.Error(), deps.Accounts.PasswordMinimumLength()))
 			return
 		case errors.Is(err, accounts.ErrCredentialChanged):
 			clearSessionCookie(w, deps.SecureCookies)
 			redirect(w, r, "/login")
 			return
 		case err != nil:
-			render(w, r, http.StatusServiceUnavailable, passwordChangePage(account.ID, "We couldn't change your password. Please try again later.", deps.Accounts.PasswordMinimumLength()))
+			render(w, r, http.StatusServiceUnavailable, passwordChangePage("We couldn't change your password. Please try again later.", deps.Accounts.PasswordMinimumLength()))
 			return
 		}
 		if err := establishSessionAtAuthenticationVersion(w, r, deps, changed.ID, changed.AuthenticationVersion); err != nil {

--- a/authling/internal/web/web.go
+++ b/authling/internal/web/web.go
@@ -294,7 +294,76 @@ func Handler(dependencies ...Dependencies) http.Handler {
 			return
 		}
 		emailChanged := r.URL.Query().Get("email_changed") == "1"
-		render(w, r, http.StatusOK, accountPage(account.ID, emailChanged, emailChanged && r.URL.Query().Get("email_notice_failed") == "1"))
+		passwordChanged := r.URL.Query().Get("password_changed") == "1"
+		render(w, r, http.StatusOK, accountPage(account.ID, passwordChanged, emailChanged, emailChanged && r.URL.Query().Get("email_notice_failed") == "1"))
+	})
+	mux.HandleFunc("GET /account/password", func(w http.ResponseWriter, r *http.Request) {
+		account, err := authenticatedAccount(r, deps)
+		if errors.Is(err, sessions.ErrNotFound) {
+			clearSessionCookie(w, deps.SecureCookies)
+			redirect(w, r, "/login")
+			return
+		} else if err != nil {
+			http.Error(w, "account unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if deps.Accounts == nil {
+			http.Error(w, "password change unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		render(w, r, http.StatusOK, passwordChangePage(account.ID, "", deps.Accounts.PasswordMinimumLength()))
+	})
+	mux.HandleFunc("POST /account/password", func(w http.ResponseWriter, r *http.Request) {
+		if deps.Accounts == nil || deps.Authentication == nil || deps.Sessions == nil {
+			http.Error(w, "password change unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !sameOrigin(r, publicOrigin) {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+		account, err := authenticatedAccount(r, deps)
+		if errors.Is(err, sessions.ErrNotFound) {
+			clearSessionCookie(w, deps.SecureCookies)
+			redirect(w, r, "/login")
+			return
+		}
+		if err != nil {
+			http.Error(w, "account unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			render(w, r, http.StatusBadRequest, passwordChangePage(account.ID, "Invalid form submission.", deps.Accounts.PasswordMinimumLength()))
+			return
+		}
+		newPassword := r.FormValue("new_password")
+		if newPassword != r.FormValue("new_password_confirmation") {
+			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(account.ID, "New passwords do not match.", deps.Accounts.PasswordMinimumLength()))
+			return
+		}
+		changed, err := deps.Authentication.ChangePassword(r.Context(), account.ID, r.FormValue("current_password"), newPassword)
+		switch {
+		case errors.Is(err, accounts.ErrInvalidCredentials):
+			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(account.ID, "The current password is incorrect.", deps.Accounts.PasswordMinimumLength()))
+			return
+		case errors.Is(err, accounts.ErrInvalidPassword), errors.Is(err, accounts.ErrPasswordUnchanged):
+			render(w, r, http.StatusUnprocessableEntity, passwordChangePage(account.ID, err.Error(), deps.Accounts.PasswordMinimumLength()))
+			return
+		case errors.Is(err, accounts.ErrCredentialChanged):
+			clearSessionCookie(w, deps.SecureCookies)
+			redirect(w, r, "/login")
+			return
+		case err != nil:
+			render(w, r, http.StatusServiceUnavailable, passwordChangePage(account.ID, "We couldn't change your password. Please try again later.", deps.Accounts.PasswordMinimumLength()))
+			return
+		}
+		if err := establishSessionAtAuthenticationVersion(w, r, deps, changed.ID, changed.AuthenticationVersion); err != nil {
+			clearSessionCookie(w, deps.SecureCookies)
+			http.Error(w, "password changed, but a new session could not be established", http.StatusServiceUnavailable)
+			return
+		}
+		redirect(w, r, "/account?password_changed=1")
 	})
 	mux.HandleFunc("GET /account/email", func(w http.ResponseWriter, r *http.Request) {
 		if _, err := authenticatedAccount(r, deps); errors.Is(err, sessions.ErrNotFound) {

--- a/authling/proto/authling/core/v1/event.proto
+++ b/authling/proto/authling/core/v1/event.proto
@@ -76,6 +76,20 @@ message PasswordChangedEvent {
   // The audit event that initiated this recovery-driven change. Historical
   // password changes written before request auditing leave this empty.
   string password_reset_request_event_id = 7;
+
+  // The protected credential event that was current when this change was
+  // authorized. Historical password changes leave this empty.
+  string prior_credential_event_id = 8;
+
+  // The ceremony that authorized this change. Historical password changes
+  // leave this unspecified.
+  PasswordChangeKind kind = 9;
+}
+
+enum PasswordChangeKind {
+  PASSWORD_CHANGE_KIND_UNSPECIFIED = 0;
+  PASSWORD_CHANGE_KIND_RECOVERY = 1;
+  PASSWORD_CHANGE_KIND_SIGNED_IN = 2;
 }
 
 // PasswordResetRequestedEvent records an accepted recovery request for an


### PR DESCRIPTION
## Summary

- add signed-in password change with current-password reauthentication,
  replacement confirmation, password-policy enforcement, and password-manager
  compatible form semantics
- persist additive, PII-free password-change ceremony and prior-credential
  lineage while preserving historical event replay compatibility
- invalidate older Authling browser sessions and establish the completing
  browser at the exact committed authentication generation
- fence password changes across account and email-registry projection
  boundaries so concurrent email changes cannot create unreplayable history
- document the behavior in FDR-008 and update Authling's runtime inventory,
  glossary, feature records, contributor guidance, and roadmap

## Security and compatibility

- current-password failures share Authling's HMAC-keyed distributed attempt
  budget and bounded Argon2 capacity; infrastructure failures do not consume
  that budget
- account-subject OCC permits unrelated audit events while rejecting stale
  password or email credentials
- persisted protobuf changes are additive; historical unspecified
  `PasswordChangedEvent` records remain accepted
- password change preserves the account ID, verified email, OIDC `sub`, issued
  OIDC tokens, and relying-party sessions

## Review findings addressed

- fenced the split `EmailChangedEvent` / `EmailClaimedEvent` projection window
  discovered during adversarial review
- bound completion to the exact replacement validated during reauthentication
- removed a misleading opaque account ID from password-manager username
  metadata

## Verification

- `cd authling && mise codegen`
- `cd authling && mise test`
- `cd authling && GOWORK=off mise x -- go test -race ./internal/accounts ./internal/authentication ./internal/app -run 'Password|OperationalFailure' -timeout 5m`
- `cd authling && mise build`
- `cd authling && mise test-e2e` (29 passed)
- `mise license-check`
- Chrome DevTools review at desktop and 375px widths, including successful
  completion and session continuity
- final adversarial review of exact HEAD
  `1d278f796a42dbd27f5c9eeed348fe3b6a7d4b8e`: clean

## Documentation

- [FDR-008: Signed-in Password Change](authling/docs/fdr/FDR-008-signed-in-password-change.md)
- [Authling runtime architecture](authling/docs/architecture/INDEX.md)
