### PR TITLE
feat(notifications)!: replace Notifications 1.0 with persistent notifications

### DIFF
--- a/apps/frontend/src/lib/state/server/notifications.spec.ts
+++ b/apps/frontend/src/lib/state/server/notifications.spec.ts
@@ -448,6 +448,38 @@ describe('NotificationStore', () => {
     expect(api.listNotificationOccurrences).toHaveBeenCalledWith(50, 50);
   });
 
+  it('retains authoritative first-page pagination metadata', () => {
+    const store = new NotificationStore(makeAPI());
+    const first = notificationPage(page([mention('first')], 75));
+    first.consumedCount = 50;
+    first.hasMore = true;
+
+    store.replaceOccurrenceProjection(first);
+
+    expect(store.consumedCount).toBe(50);
+    expect(store.totalCount).toBe(75);
+    expect(store.hasMore).toBe(true);
+  });
+
+  it('appends an older page and advances its retained raw offset', async () => {
+    const api = makeAPI();
+    const older = notificationPage(page([mention('older')], 2));
+    older.consumedCount = 1;
+    api.listNotificationOccurrences.mockResolvedValueOnce(older);
+    const store = new NotificationStore(api);
+    const first = notificationPage(page([mention('first')], 2));
+    first.consumedCount = 1;
+    first.hasMore = true;
+    store.replaceOccurrenceProjection(first);
+
+    await store.fetchPage(1);
+
+    expect(store.occurrences.map(({ id }) => id)).toEqual(['first', 'older']);
+    expect(store.consumedCount).toBe(2);
+    expect(store.totalCount).toBe(2);
+    expect(store.hasMore).toBe(false);
+  });
+
   it('retries an in-flight page response invalidated by a projection reset', async () => {
     const response = deferred<NotificationOccurrencePage>();
     const api = makeAPI();
@@ -460,7 +492,9 @@ describe('NotificationStore', () => {
 
     await expect(fetch).resolves.toMatchObject({ occurrences: [] });
     expect(store.occurrences).toEqual([]);
-    expect(store.resetVersion).toBe(1);
+    expect(store.consumedCount).toBe(0);
+    expect(store.totalCount).toBe(0);
+    expect(store.hasMore).toBe(false);
   });
 
   it('retries an in-flight room lookup invalidated by a projection reset', async () => {

--- a/apps/frontend/src/lib/state/server/notifications.svelte.ts
+++ b/apps/frontend/src/lib/state/server/notifications.svelte.ts
@@ -72,14 +72,17 @@ export class NotificationStore {
   #failedMutationReconciliation: Promise<void> | undefined;
   #firstPageRequest: Promise<NotificationOccurrencePage> | undefined;
   occurrences = $state.raw<NotificationOccurrenceItem[]>([]);
+  /** Raw server rows consumed by the retained occurrence page. */
+  consumedCount = $state(0);
+  /** Exact visible occurrence total reported with the retained page. */
+  totalCount = $state(0);
+  /** Whether the retained page has older server rows available. */
+  hasMore = $state(false);
   unreadNotificationCount = $state(0);
   importantUnreadNotificationCount = $state(0);
   roomUnreadCounts = $state.raw<Record<string, number>>({});
   roomImportantUnreadCounts = $state.raw<Record<string, number>>({});
   nextExpiryAt = $state<string | null>(null);
-  /** Advances only for realtime invalidations, including changes made in another session. */
-  viewInvalidationVersion = $state(0);
-  resetVersion = $state(0);
   readonly revokedRoomIds = new SvelteSet<string>();
   /** Users whose copied profile data must not be rendered from stale notification pages. */
   readonly scrubbedUserIds = new SvelteSet<string>();
@@ -127,6 +130,9 @@ export class NotificationStore {
       0
     );
     this.occurrences = occurrences;
+    this.consumedCount = page.consumedCount ?? page.occurrences.length;
+    this.totalCount = page.totalCount;
+    this.hasMore = page.hasMore && this.consumedCount > 0;
     this.unreadNotificationCount = Math.max(0, page.unreadCount - revokedUnreadCount);
     this.importantUnreadNotificationCount = Math.max(
       0,
@@ -146,10 +152,6 @@ export class NotificationStore {
     this.error = null;
   }
 
-  invalidateViews(): void {
-    this.viewInvalidationVersion++;
-  }
-
   /** Invalidate projection-owned state while a compacted reset hydrates. */
   resetProjectionState(): void {
     this.#fetchGeneration++;
@@ -158,6 +160,9 @@ export class NotificationStore {
     this.#pendingReadById.clear();
     this.#pendingReadRequestById.clear();
     this.occurrences = [];
+    this.consumedCount = 0;
+    this.totalCount = 0;
+    this.hasMore = false;
     this.unreadNotificationCount = 0;
     this.importantUnreadNotificationCount = 0;
     this.roomUnreadCounts = {};
@@ -169,8 +174,6 @@ export class NotificationStore {
     // a later snapshot frame never arrives.
     this.hasLoaded = true;
     this.error = null;
-    this.resetVersion++;
-    this.invalidateViews();
   }
 
   /** Remove copied profile data for an account deleted from the projection. */
@@ -182,7 +185,6 @@ export class NotificationStore {
     if (occurrences.some((occurrence, index) => occurrence !== this.occurrences[index])) {
       this.occurrences = occurrences;
     }
-    this.invalidateViews();
   }
 
   /** Drop notification payloads for a room at an authorization boundary. */
@@ -212,6 +214,8 @@ export class NotificationStore {
           occurrence.room?.id === roomId
       ).length;
     this.occurrences = this.occurrences.filter((occurrence) => occurrence.room?.id !== roomId);
+    this.consumedCount = this.occurrences.length;
+    this.totalCount = Math.max(this.occurrences.length, this.totalCount - roomOccurrenceIds.size);
 
     if (removedUnreadOccurrences > 0) {
       this.unreadNotificationCount = Math.max(
@@ -228,14 +232,12 @@ export class NotificationStore {
     this.roomUnreadCounts = withoutRecordKey(this.roomUnreadCounts, roomId);
     this.roomImportantUnreadCounts = withoutRecordKey(this.roomImportantUnreadCounts, roomId);
     this.nextExpiryAt = earliestNotificationOccurrenceExpiry(this.occurrences);
-    this.invalidateViews();
   }
 
   /** Re-open a room only after an explicit positive membership projection. */
   restoreRoom(roomId: string): void {
     if (!this.revokedRoomIds.delete(roomId)) return;
     this.#authoritativeGeneration++;
-    this.invalidateViews();
   }
 
   /**
@@ -421,6 +423,10 @@ export class NotificationStore {
     if (offset === 0) this.replaceOccurrenceProjection(safePage);
     else {
       this.occurrences = mergeNotificationOccurrences(this.occurrences, safePage.occurrences);
+      const consumedCount = safePage.consumedCount ?? safePage.occurrences.length;
+      this.consumedCount = Math.max(this.consumedCount, offset + consumedCount);
+      this.totalCount = safePage.totalCount;
+      this.hasMore = safePage.hasMore && consumedCount > 0;
     }
     return safePage;
   }
@@ -455,6 +461,8 @@ export class NotificationStore {
     this.#fetchGeneration++;
     this.loading = false;
     this.occurrences = this.occurrences.filter((occurrence) => !removedIds.has(occurrence.id));
+    this.consumedCount = Math.max(0, this.consumedCount - removedOccurrences.length);
+    this.totalCount = Math.max(0, this.totalCount - removedOccurrences.length);
     const removedUnreadCount =
       knownCounts?.unread ?? removedOccurrences.filter((occurrence) => occurrence.unread).length;
     const removedImportantUnreadCount =
@@ -505,6 +513,9 @@ export class NotificationStore {
     this.#pendingDeletionById.clear();
     this.loading = false;
     this.occurrences = [];
+    this.consumedCount = 0;
+    this.totalCount = 0;
+    this.hasMore = false;
     this.unreadNotificationCount = 0;
     this.importantUnreadNotificationCount = 0;
     this.roomUnreadCounts = {};
@@ -757,7 +768,6 @@ export class NotificationStore {
         continue;
       }
       this.replaceOccurrenceProjection(page);
-      this.invalidateViews();
       return;
     }
   }

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -550,7 +550,6 @@ export class ServerStateStore {
             this.notifications.replaceOccurrenceProjection(
               mapNotificationOccurrencePage(replacement.occurrences)
             );
-            this.notifications.invalidateViews();
           }
           break;
         }

--- a/apps/frontend/src/routes/chat/notifications/+page.svelte
+++ b/apps/frontend/src/routes/chat/notifications/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { untrack } from 'svelte';
   import { SvelteMap, SvelteSet } from 'svelte/reactivity';
   import { EmptyState, PaneHeader } from '$lib/ui';
   import { Button } from '$lib/ui/form';
@@ -53,16 +52,24 @@
 
   const activeLocale = $derived(getLocale());
   const appUi = getAppUiState();
-  let groups = $state.raw<ServerGroup[]>(notificationGroupsFromProjection());
-  let loading = $state(!notificationProjectionHasLoaded());
+  const hydrationAttempts = new SvelteSet<string>();
+  const optimisticallyDismissedOccurrenceIds = new SvelteSet<string>();
+  const groups = $derived.by(notificationGroupsFromProjection);
+  const pagination = $derived.by(notificationPaginationFromProjection);
+  const loading = $derived(!notificationProjectionHasLoaded());
   let loadingMore = $state(false);
-  let pageError = $state(false);
+  let loadMoreError = $state(false);
   let dismissingAll = $state(false);
-  let loadGeneration = 0;
-  let pagination = $state.raw<PaginationSource[]>([]);
   const pendingMutationKeys = new SvelteSet<string>();
   const hasPendingMutation = $derived(pendingMutationKeys.size > 0);
   const hasMore = $derived(pagination.some((source) => source.hasMore));
+  const pageError = $derived(
+    loadMoreError ||
+      serverRegistry.servers.some((instance) => {
+        const stores = serverRegistry.getStore(instance.id);
+        return stores.isAuthenticated && stores.notifications.error !== null;
+      })
+  );
   const showServerHostname = $derived(
     serverRegistry.servers.filter(
       (instance) => serverRegistry.getStore(instance.id).isAuthenticated
@@ -82,207 +89,59 @@
     return sorted.filter((item) => item.group.latestAt >= newestUnloadedBoundary!);
   });
   const dateSections = $derived.by(() => groupNotificationsByDate(visibleGroups));
-  const notificationViewInvalidations = $derived(
-    serverRegistry.servers
-      .map((instance) => serverRegistry.getStore(instance.id).notifications.viewInvalidationVersion)
-      .join(':')
-  );
-  const notificationPrivacyBoundaries = $derived(
-    serverRegistry.servers
-      .map((instance) => {
-        const notifications = serverRegistry.getStore(instance.id).notifications;
-        const rooms = [...notifications.revokedRoomIds].sort().join(',');
-        const users = [...notifications.scrubbedUserIds].sort().join(',');
-        return `${rooms}|${users}`;
-      })
-      .join(':')
-  );
-  const notificationResetVersions = $derived(
-    serverRegistry.servers
-      .map((instance) => serverRegistry.getStore(instance.id).notifications.resetVersion)
-      .join(':')
-  );
-  let observedResetVersions = '';
-  let hasObservedResetVersions = false;
-  $effect(() => {
-    const currentResetVersions = notificationResetVersions;
-    if (!hasObservedResetVersions) {
-      observedResetVersions = currentResetVersions;
-      hasObservedResetVersions = true;
-      return;
-    }
-    if (currentResetVersions === observedResetVersions) return;
-    observedResetVersions = currentResetVersions;
-    // A compacted projection reset invalidates every hydrated page row.
-    groups = [];
-    pagination = [];
-  });
-  $effect(() => {
-    void notificationPrivacyBoundaries;
-    // Authorization loss and account deletion are privacy boundaries. Scrub
-    // local paginated payloads immediately instead of waiting for a reload.
-    groups = untrack(() =>
-      groups.flatMap((item) => {
-        const occurrences = visibleOccurrencesForServer(item.serverId, item.group.occurrences);
-        if (occurrences.length === 0) return [];
-        return groupNotificationOccurrences(occurrences).map((group) => ({ ...item, group }));
-      })
-    );
-  });
-  $effect(() => {
-    void notificationViewInvalidations;
-    // Initial projection hydration and one logical mutation can emit several
-    // adjacent invalidations. Coalesce them into one authoritative list read
-    // per authenticated server.
-    const timer = setTimeout(() => void loadNotifications(), 50);
-    return () => clearTimeout(timer);
-  });
 
-  // Reconcile the list at its earliest expiry as well as on live invalidations.
+  // Realtime normally hydrates this retained store before the route is opened.
+  // Fetch only genuinely missing projections as a transport fallback.
   $effect(() => {
-    if (groups.length === 0) return;
-    const expiry = groups.reduce<number | null>((earliest, item) => {
-      if (!item.group.nextExpiryAt) return earliest;
-      const value = new Date(item.group.nextExpiryAt).getTime() + 50;
-      return earliest === null || value < earliest ? value : earliest;
-    }, null);
-    if (expiry === null) return;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const schedule = () => {
-      const remaining = expiry - Date.now();
-      if (remaining <= 0) {
-        void loadNotifications();
-        return;
+    for (const instance of serverRegistry.servers) {
+      const stores = serverRegistry.getStore(instance.id);
+      if (
+        !stores.isAuthenticated ||
+        stores.notifications.hasLoaded ||
+        hydrationAttempts.has(instance.id)
+      ) {
+        continue;
       }
-      timer = setTimeout(schedule, Math.min(remaining, 2_147_483_647));
-    };
-    schedule();
-    return () => {
-      if (timer) clearTimeout(timer);
-    };
+      hydrationAttempts.add(instance.id);
+      void stores.notifications.fetch();
+    }
   });
 
-  async function loadNotifications() {
-    const generation = ++loadGeneration;
-    loading = true;
-    loadingMore = false;
+  // A privacy boundary can remove every renderable row from a raw page. Keep
+  // advancing until content is visible or the authoritative page is exhausted.
+  $effect(() => {
+    if (!loading && groups.length === 0 && hasMore && !loadingMore && !pageError) {
+      void loadMore();
+    }
+  });
+
+  async function retryNotifications() {
+    loadMoreError = false;
     const requests = serverRegistry.servers.flatMap((instance) => {
       const stores = serverRegistry.getStore(instance.id);
-      if (!stores.isAuthenticated) return [];
-      return [
-        {
-          serverId: instance.id,
-          request: (async () => {
-            const page = await stores.notifications.fetchPage();
-            let hostname: string;
-            try {
-              hostname = new URL(instance.url).hostname;
-            } catch {
-              hostname = instance.url;
-            }
-            return {
-              serverId: instance.id,
-              page,
-              groups: groupNotificationOccurrences(
-                visibleOccurrencesForServer(instance.id, page.occurrences)
-              ).map((group): ServerGroup => ({
-                serverId: instance.id,
-                serverHostname: hostname,
-                timeFormatSettings: timeFormatSettingsFor(stores.currentUser.user?.settings),
-                group
-              }))
-            };
-          })()
-        }
-      ];
-    });
-    const results = await Promise.allSettled(requests.map(({ request }) => request));
-    if (generation !== loadGeneration) return;
-    const refreshedServerIds = new SvelteSet(
-      results.flatMap((result) => (result.status === 'fulfilled' ? [result.value.serverId] : []))
-    );
-    groups = [
-      ...groups.filter((item) => !refreshedServerIds.has(item.serverId)),
-      ...results.flatMap((result) => (result.status === 'fulfilled' ? result.value.groups : []))
-    ].sort(compareGroups);
-    pagination = results.flatMap((result, index): PaginationSource[] => {
-      if (result.status !== 'fulfilled') {
-        return [
-          {
-            serverId: requests[index].serverId,
-            offset: 0,
-            hasMore: true
-          }
-        ];
+      if (
+        !stores.isAuthenticated ||
+        (stores.notifications.hasLoaded && stores.notifications.error === null)
+      ) {
+        return [];
       }
-      return [
-        {
-          serverId: result.value.serverId,
-          offset: result.value.page.consumedCount ?? result.value.page.occurrences.length,
-          hasMore: result.value.page.hasMore
-        }
-      ];
+      hydrationAttempts.add(instance.id);
+      return [stores.notifications.fetch()];
     });
-    pageError = results.some((result) => result.status === 'rejected');
-    loading = false;
-    if (groups.length === 0 && hasMore && !pageError) void loadMore();
+    await Promise.allSettled(requests);
   }
 
   async function loadMore() {
     if (loading || loadingMore || !hasMore) return;
-    const generation = loadGeneration;
     loadingMore = true;
-    pageError = false;
+    loadMoreError = false;
     const pending = pagination.filter((source) => source.hasMore);
     const results = await Promise.allSettled(
-      pending.map(async (source) => {
-        const stores = serverRegistry.getStore(source.serverId);
-        const page = await stores.notifications.fetchPage(source.offset);
-        let hostname: string;
-        const instance = serverRegistry.servers.find(({ id }) => id === source.serverId);
-        try {
-          hostname = new URL(instance?.url ?? '').hostname;
-        } catch {
-          hostname = instance?.url ?? source.serverId;
-        }
-        return {
-          serverId: source.serverId,
-          page,
-          groups: groupNotificationOccurrences(
-            visibleOccurrencesForServer(source.serverId, page.occurrences)
-          ).map((group): ServerGroup => ({
-            serverId: source.serverId,
-            serverHostname: hostname,
-            timeFormatSettings: timeFormatSettingsFor(stores.currentUser.user?.settings),
-            group
-          }))
-        };
-      })
+      pending.map((source) =>
+        serverRegistry.getStore(source.serverId).notifications.fetchPage(source.offset)
+      )
     );
-    if (generation !== loadGeneration) {
-      loadingMore = false;
-      return;
-    }
-    groups = mergeServerGroups(
-      groups,
-      results.flatMap((result) => (result.status === 'fulfilled' ? result.value.groups : []))
-    );
-    pagination = pagination.map((source) => {
-      const result = results.find(
-        (candidate) =>
-          candidate.status === 'fulfilled' && candidate.value.serverId === source.serverId
-      );
-      if (!result || result.status !== 'fulfilled') return source;
-      return {
-        ...source,
-        offset:
-          source.offset + (result.value.page.consumedCount ?? result.value.page.occurrences.length),
-        hasMore:
-          result.value.page.hasMore &&
-          (result.value.page.consumedCount ?? result.value.page.occurrences.length) > 0
-      };
-    });
-    pageError = results.some((result) => result.status === 'rejected');
+    loadMoreError = results.some((result) => result.status === 'rejected');
     loadingMore = false;
     if (groups.length === 0 && hasMore && !pageError) void loadMore();
   }
@@ -329,7 +188,9 @@
           hostname = instance.url;
         }
         return groupNotificationOccurrences(
-          visibleOccurrencesForServer(instance.id, stores.notifications.occurrences)
+          visibleOccurrencesForServer(instance.id, stores.notifications.occurrences).filter(
+            (occurrence) => !optimisticallyDismissedOccurrenceIds.has(occurrence.id)
+          )
         ).map((group): ServerGroup => ({
           serverId: instance.id,
           serverHostname: hostname,
@@ -338,6 +199,20 @@
         }));
       })
       .sort(compareGroups);
+  }
+
+  function notificationPaginationFromProjection(): PaginationSource[] {
+    return serverRegistry.servers.flatMap((instance) => {
+      const stores = serverRegistry.getStore(instance.id);
+      if (!stores.isAuthenticated) return [];
+      return [
+        {
+          serverId: instance.id,
+          offset: stores.notifications.consumedCount,
+          hasMore: stores.notifications.hasMore
+        }
+      ];
+    });
   }
 
   function notificationProjectionHasLoaded(): boolean {
@@ -351,27 +226,6 @@
     const byTime = b.group.latestAt.localeCompare(a.group.latestAt);
     if (byTime !== 0) return byTime;
     return mutationKey(a).localeCompare(mutationKey(b));
-  }
-
-  function mergeServerGroups(current: ServerGroup[], incoming: ServerGroup[]): ServerGroup[] {
-    const metadata = new SvelteMap<string, Omit<ServerGroup, 'group'>>();
-    const occurrences = new SvelteMap<string, NotificationOccurrenceItem[]>();
-    for (const item of [...current, ...incoming]) {
-      metadata.set(item.serverId, item);
-      const existing = occurrences.get(item.serverId) ?? [];
-      occurrences.set(item.serverId, [
-        ...existing,
-        ...item.group.occurrences.filter(
-          (occurrence) => !existing.some((candidate) => candidate.id === occurrence.id)
-        )
-      ]);
-    }
-    return [...occurrences.entries()]
-      .flatMap(([serverId, items]) => {
-        const server = metadata.get(serverId)!;
-        return groupNotificationOccurrences(items).map((group) => ({ ...server, group }));
-      })
-      .sort(compareGroups);
   }
 
   function groupNotificationsByDate(items: ServerGroup[]): NotificationDateSection[] {
@@ -533,12 +387,9 @@
     if (pendingMutationKeys.has(key)) return;
     setMutationPending(key, true);
     const store = serverRegistry.getStore(item.serverId).notifications;
-    groups = groups.filter((candidate) => rowKey(candidate) !== rowKey(item));
-    pagination = pagination.map((source) =>
-      source.serverId === item.serverId
-        ? { ...source, offset: Math.max(0, source.offset - item.group.occurrences.length) }
-        : source
-    );
+    for (const occurrence of item.group.occurrences) {
+      optimisticallyDismissedOccurrenceIds.add(occurrence.id);
+    }
     try {
       await store.deleteOccurrences(
         item.group.occurrences.map((occurrence) => occurrence.id),
@@ -563,8 +414,11 @@
   async function dismissAll() {
     if (dismissingAll || hasPendingMutation || groups.length === 0) return;
     dismissingAll = true;
-    groups = [];
-    pagination = pagination.map((source) => ({ ...source, offset: 0, hasMore: false }));
+    for (const item of groups) {
+      for (const occurrence of item.group.occurrences) {
+        optimisticallyDismissedOccurrenceIds.add(occurrence.id);
+      }
+    }
 
     const serverIds = serverRegistry.servers.flatMap((instance) => {
       const store = serverRegistry.getStore(instance.id);
@@ -579,7 +433,6 @@
       results.flatMap((result, index) => (result.status === 'rejected' ? [serverIds[index]!] : []))
     );
     if (failedServerIds.size > 0) {
-      pageError = true;
       toast.error(m('common.error.network'));
     }
     dismissingAll = false;
@@ -611,7 +464,7 @@
   <div class="flex flex-1 flex-col overflow-y-auto">
     {#if pageError && groups.length === 0}
       <EmptyState icon="icon-[uil--exclamation-triangle]" title={m('common.error.network')}>
-        <Button variant="secondary" label={m('common.retry')} onclick={loadNotifications}
+        <Button variant="secondary" label={m('common.retry')} onclick={retryNotifications}
           >{m('common.retry')}</Button
         >
       </EmptyState>

--- a/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
@@ -41,12 +41,15 @@ const { mocks } = vi.hoisted(() => ({
         }
       },
       notifications: {
-        viewInvalidationVersion: 0,
-        resetVersion: 0,
         revokedRoomIds: new Set<string>(),
         scrubbedUserIds: new Set<string>(),
         occurrences: [] as NotificationOccurrenceItem[],
+        consumedCount: 0,
+        totalCount: 0,
+        hasMore: false,
         hasLoaded: false,
+        error: null as string | null,
+        fetch: vi.fn(),
         fetchPage: vi.fn(),
         markOccurrenceRead: vi.fn().mockResolvedValue(undefined),
         deleteOccurrences: vi.fn().mockResolvedValue(undefined),
@@ -109,18 +112,29 @@ function page(
   };
 }
 
+function retainProjection(
+  occurrences: NotificationOccurrenceItem[] = [mocks.occurrence as NotificationOccurrenceItem],
+  hasMore = false,
+  consumedCount = occurrences.length
+) {
+  mocks.store.notifications.occurrences = occurrences;
+  mocks.store.notifications.consumedCount = consumedCount;
+  mocks.store.notifications.totalCount = occurrences.length;
+  mocks.store.notifications.hasMore = hasMore;
+  mocks.store.notifications.hasLoaded = true;
+  mocks.store.notifications.error = null;
+}
+
 describe('notifications page', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     toast.clear();
     await loadLocaleMessages('en-GB');
     setReactiveLocale('en-GB');
-    mocks.store.notifications.viewInvalidationVersion = 0;
-    mocks.store.notifications.resetVersion = 0;
     mocks.store.notifications.revokedRoomIds.clear();
     mocks.store.notifications.scrubbedUserIds.clear();
-    mocks.store.notifications.occurrences = [];
-    mocks.store.notifications.hasLoaded = false;
+    retainProjection();
+    mocks.store.notifications.fetch.mockResolvedValue(undefined);
     mocks.store.notifications.fetchPage.mockResolvedValue(page());
     mocks.store.notifications.deleteOccurrences.mockResolvedValue(undefined);
     mocks.store.notifications.deleteAllOccurrences.mockResolvedValue(undefined);
@@ -188,7 +202,7 @@ describe('notifications page', () => {
       room: null,
       eventId: ''
     } as NotificationOccurrenceItem;
-    mocks.store.notifications.fetchPage.mockResolvedValue(page([unsupported]));
+    retainProjection([unsupported]);
 
     const { container } = render(NotificationsPage);
     const row = await vi.waitFor(() => {
@@ -220,16 +234,14 @@ describe('notifications page', () => {
       unread: false,
       createdAt: new Date(Date.now() - 60_000).toISOString()
     };
-    mocks.store.notifications.fetchPage.mockResolvedValue(
-      page([mocks.occurrence as NotificationOccurrenceItem, readOccurrence])
-    );
+    retainProjection([mocks.occurrence as NotificationOccurrenceItem, readOccurrence]);
 
     const { container } = render(NotificationsPage);
     await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
     });
 
-    expect(mocks.store.notifications.fetchPage).toHaveBeenCalledTimes(1);
+    expect(mocks.store.notifications.fetchPage).not.toHaveBeenCalled();
     const readRow = q(container, '[data-notification-state="read"]') as HTMLElement;
     const unreadRow = q(container, '[data-notification-state="unread"]') as HTMLElement;
     const readTarget = q(readRow, ':scope > button') as HTMLButtonElement;
@@ -245,36 +257,50 @@ describe('notifications page', () => {
     expect(unreadContent.querySelectorAll(':scope > *')).toHaveLength(2);
   });
 
-  it('renders the retained occurrence projection immediately while refreshing', async () => {
-    let resolveRefresh: ((value: ReturnType<typeof page>) => void) | undefined;
-    mocks.store.notifications.occurrences = [mocks.occurrence as NotificationOccurrenceItem];
-    mocks.store.notifications.hasLoaded = true;
-    mocks.store.notifications.fetchPage.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveRefresh = resolve;
-        })
-    );
-
+  it('renders a retained occurrence projection without refetching it', async () => {
     const rendered = render(NotificationsPage);
     expect(rendered.container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(
       1
     );
     expect(rendered.container.textContent).not.toContain('Loading');
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(mocks.store.notifications.fetch).not.toHaveBeenCalled();
+    expect(mocks.store.notifications.fetchPage).not.toHaveBeenCalled();
+    rendered.unmount();
+  });
 
-    resolveRefresh?.(page());
-    await vi.waitFor(() => expect(mocks.store.notifications.fetchPage).toHaveBeenCalledTimes(1));
+  it('renders a retained empty projection without flashing or refetching', async () => {
+    retainProjection([]);
+
+    const rendered = render(NotificationsPage);
+    expect(rendered.container.textContent).toContain('No notifications');
+    expect(rendered.container.textContent).not.toContain('Loading');
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    expect(mocks.store.notifications.fetch).not.toHaveBeenCalled();
+    expect(mocks.store.notifications.fetchPage).not.toHaveBeenCalled();
+    expect(rendered.container.textContent).toContain('No notifications');
     rendered.unmount();
   });
 
   it('keeps initial hydration visually quiet', async () => {
+    const originalStore = mocks.store.notifications;
     let resolveRefresh: ((value: ReturnType<typeof page>) => void) | undefined;
-    mocks.store.notifications.fetchPage.mockImplementation(
-      () =>
-        new Promise((resolve) => {
-          resolveRefresh = resolve;
-        })
-    );
+    const api = {
+      listNotificationOccurrences: vi.fn(
+        () =>
+          new Promise<ReturnType<typeof page>>((resolve) => {
+            resolveRefresh = resolve;
+          })
+      ),
+      markNotificationRead: vi.fn(),
+      batchDeleteNotificationOccurrences: vi.fn(),
+      deleteAllNotificationOccurrences: vi.fn(),
+      getNotificationPolicy: vi.fn(),
+      updateNotificationPolicy: vi.fn()
+    };
+    const notificationStore = new NotificationStore(api as never);
+    (mocks.store as { notifications: unknown }).notifications = notificationStore;
 
     const rendered = render(NotificationsPage);
     expect(rendered.container.textContent).not.toContain('Loading');
@@ -288,6 +314,7 @@ describe('notifications page', () => {
       ).toHaveLength(1);
     });
     rendered.unmount();
+    (mocks.store as { notifications: unknown }).notifications = originalStore;
   });
 
   it('renders a full-sentence summary and omits the single-occurrence counter', async () => {
@@ -305,7 +332,7 @@ describe('notifications page', () => {
       actor,
       signalKind: NotificationSignalKind.FOLLOWED_THREAD
     };
-    mocks.store.notifications.fetchPage.mockResolvedValue(page([occurrence]));
+    retainProjection([occurrence]);
 
     const { container } = render(NotificationsPage);
     const row = await vi.waitFor(() => {
@@ -340,9 +367,10 @@ describe('notifications page', () => {
       attentionLevel: NotificationAttentionLevel.AMBIENT,
       reactionEmoji: emoji
     });
-    mocks.store.notifications.fetchPage.mockResolvedValue(
-      page([reaction('reaction-alice', alice, 'thumbsup'), reaction('reaction-bob', bob, 'heart')])
-    );
+    retainProjection([
+      reaction('reaction-alice', alice, 'thumbsup'),
+      reaction('reaction-bob', bob, 'heart')
+    ]);
 
     const { container } = render(NotificationsPage);
     const row = await vi.waitFor(() => {
@@ -371,18 +399,16 @@ describe('notifications page', () => {
       presenceStatus: 1,
       customStatus: null
     };
-    mocks.store.notifications.fetchPage.mockResolvedValue(
-      page([
-        {
-          ...mocks.occurrence,
-          id: 'reaction-bob',
-          actor: bob,
-          signalKind: NotificationSignalKind.REACTION,
-          attentionLevel: NotificationAttentionLevel.AMBIENT,
-          reactionEmoji: 'heart'
-        }
-      ])
-    );
+    retainProjection([
+      {
+        ...mocks.occurrence,
+        id: 'reaction-bob',
+        actor: bob,
+        signalKind: NotificationSignalKind.REACTION,
+        attentionLevel: NotificationAttentionLevel.AMBIENT,
+        reactionEmoji: 'heart'
+      }
+    ]);
 
     const { container } = render(NotificationsPage);
     const row = await vi.waitFor(() => {
@@ -405,30 +431,28 @@ describe('notifications page', () => {
       presenceStatus: 1,
       customStatus: null
     };
-    mocks.store.notifications.fetchPage.mockResolvedValue(
-      page([
-        {
-          ...mocks.occurrence,
-          id: 'reaction-alice',
-          createdAt: '2026-08-19T12:00:00.000Z',
-          actor: alice,
-          eventId: 'reacted-to-message',
-          signalKind: NotificationSignalKind.REACTION,
-          attentionLevel: NotificationAttentionLevel.AMBIENT,
-          reactionEmoji: 'thumbsup'
-        },
-        {
-          ...mocks.occurrence,
-          id: 'reaction-deleted',
-          createdAt: '2026-08-19T12:01:00.000Z',
-          actor: null,
-          eventId: 'reacted-to-message',
-          signalKind: NotificationSignalKind.REACTION,
-          attentionLevel: NotificationAttentionLevel.AMBIENT,
-          reactionEmoji: 'heart'
-        }
-      ] as NotificationOccurrenceItem[])
-    );
+    retainProjection([
+      {
+        ...mocks.occurrence,
+        id: 'reaction-alice',
+        createdAt: '2026-08-19T12:00:00.000Z',
+        actor: alice,
+        eventId: 'reacted-to-message',
+        signalKind: NotificationSignalKind.REACTION,
+        attentionLevel: NotificationAttentionLevel.AMBIENT,
+        reactionEmoji: 'thumbsup'
+      },
+      {
+        ...mocks.occurrence,
+        id: 'reaction-deleted',
+        createdAt: '2026-08-19T12:01:00.000Z',
+        actor: null,
+        eventId: 'reacted-to-message',
+        signalKind: NotificationSignalKind.REACTION,
+        attentionLevel: NotificationAttentionLevel.AMBIENT,
+        reactionEmoji: 'heart'
+      }
+    ] as NotificationOccurrenceItem[]);
 
     const { container } = render(NotificationsPage);
     const row = await vi.waitFor(() => {
@@ -448,7 +472,13 @@ describe('notifications page', () => {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        fetchPage: vi.fn().mockRejectedValue(new Error('remote offline'))
+        occurrences: [],
+        consumedCount: 0,
+        totalCount: 0,
+        hasMore: false,
+        hasLoaded: false,
+        error: 'remote offline',
+        fetch: vi.fn().mockResolvedValue(undefined)
       }
     };
     mocks.servers.push({ id: 'remote', url: 'https://remote.example.test' });
@@ -466,12 +496,11 @@ describe('notifications page', () => {
 
   it('does not render a stale notification page for a room behind a privacy boundary', async () => {
     mocks.store.notifications.revokedRoomIds.add('room-1');
-    mocks.store.notifications.fetchPage.mockResolvedValue(page());
 
     const { container } = render(NotificationsPage);
 
     await vi.waitFor(() => {
-      expect(mocks.store.notifications.fetchPage).toHaveBeenCalled();
+      expect(mocks.store.notifications.fetchPage).not.toHaveBeenCalled();
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(0);
     });
   });
@@ -555,23 +584,18 @@ describe('notifications page', () => {
     }
   });
 
-  it('keeps mounted rows while a realtime refresh waits for an optimistic mutation', async () => {
+  it('applies an authoritative realtime replacement without a list request', async () => {
     const originalStore = mocks.store.notifications;
-    let resolveMutation: ((value: NotificationOccurrenceItem) => void) | undefined;
     const api = {
-      listNotificationOccurrences: vi.fn().mockResolvedValue(page()),
-      markNotificationRead: vi.fn().mockImplementation(
-        () =>
-          new Promise<NotificationOccurrenceItem>((resolve) => {
-            resolveMutation = resolve;
-          })
-      ),
+      listNotificationOccurrences: vi.fn(),
+      markNotificationRead: vi.fn(),
       batchDeleteNotificationOccurrences: vi.fn(),
       deleteAllNotificationOccurrences: vi.fn(),
       getNotificationPolicy: vi.fn(),
       updateNotificationPolicy: vi.fn()
     };
     const notificationStore = new NotificationStore(api as never);
+    notificationStore.replaceOccurrenceProjection(page());
     (mocks.store as { notifications: unknown }).notifications = notificationStore;
     const rendered = render(NotificationsPage);
     try {
@@ -581,51 +605,31 @@ describe('notifications page', () => {
         ).toHaveLength(1);
       });
 
-      const marking = notificationStore.markRead('mention-1');
-      notificationStore.invalidateViews();
-      await new Promise((resolve) => setTimeout(resolve, 80));
-
-      expect(api.listNotificationOccurrences).toHaveBeenCalledTimes(1);
-      expect(
-        rendered.container.querySelectorAll('[data-testid="notification-group"]')
-      ).toHaveLength(1);
-
-      resolveMutation?.(mocks.occurrence as NotificationOccurrenceItem);
-      await expect(marking).resolves.toBe(true);
-      await vi.waitFor(() => expect(api.listNotificationOccurrences).toHaveBeenCalledTimes(2));
+      notificationStore.replaceOccurrenceProjection(page([]));
+      await vi.waitFor(() => {
+        expect(
+          rendered.container.querySelectorAll('[data-testid="notification-group"]')
+        ).toHaveLength(0);
+      });
+      expect(api.listNotificationOccurrences).not.toHaveBeenCalled();
     } finally {
       rendered.unmount();
       (mocks.store as { notifications: unknown }).notifications = originalStore;
     }
   });
 
-  it('retries a mounted refresh invalidated by a mutation that starts in flight', async () => {
+  it('updates mounted rows after quiet reconciliation', async () => {
     const originalStore = mocks.store.notifications;
-    let resolveRefresh: ((value: ReturnType<typeof page>) => void) | undefined;
-    let resolveMutation: ((value: NotificationOccurrenceItem) => void) | undefined;
     const api = {
-      listNotificationOccurrences: vi
-        .fn()
-        .mockResolvedValueOnce(page())
-        .mockImplementationOnce(
-          () =>
-            new Promise<ReturnType<typeof page>>((resolve) => {
-              resolveRefresh = resolve;
-            })
-        )
-        .mockResolvedValue(page([])),
-      markNotificationRead: vi.fn().mockImplementation(
-        () =>
-          new Promise<NotificationOccurrenceItem>((resolve) => {
-            resolveMutation = resolve;
-          })
-      ),
+      listNotificationOccurrences: vi.fn().mockResolvedValue(page([])),
+      markNotificationRead: vi.fn(),
       batchDeleteNotificationOccurrences: vi.fn(),
       deleteAllNotificationOccurrences: vi.fn(),
       getNotificationPolicy: vi.fn(),
       updateNotificationPolicy: vi.fn()
     };
     const notificationStore = new NotificationStore(api as never);
+    notificationStore.replaceOccurrenceProjection(page());
     (mocks.store as { notifications: unknown }).notifications = notificationStore;
     const rendered = render(NotificationsPage);
     try {
@@ -635,25 +639,13 @@ describe('notifications page', () => {
         ).toHaveLength(1);
       });
 
-      notificationStore.invalidateViews();
-      await vi.waitFor(() => expect(api.listNotificationOccurrences).toHaveBeenCalledTimes(2));
-      const marking = notificationStore.markRead('mention-1');
-      resolveRefresh?.(page());
-      await new Promise((resolve) => setTimeout(resolve, 20));
-
-      expect(rendered.container.textContent).not.toContain('Network error');
-      expect(
-        rendered.container.querySelectorAll('[data-testid="notification-group"]')
-      ).toHaveLength(1);
-
-      resolveMutation?.(mocks.occurrence as NotificationOccurrenceItem);
-      await expect(marking).resolves.toBe(true);
-      await vi.waitFor(() => expect(api.listNotificationOccurrences).toHaveBeenCalledTimes(3));
+      await notificationStore.reconcile();
       await vi.waitFor(() => {
         expect(
           rendered.container.querySelectorAll('[data-testid="notification-group"]')
         ).toHaveLength(0);
       });
+      expect(api.listNotificationOccurrences).toHaveBeenCalledTimes(1);
     } finally {
       rendered.unmount();
       (mocks.store as { notifications: unknown }).notifications = originalStore;
@@ -691,17 +683,15 @@ describe('notifications page', () => {
     mocks.store.notifications.deleteOccurrences.mockImplementation(
       () => new Promise<void>((resolve) => (resolveMutation = resolve))
     );
-    mocks.store.notifications.fetchPage.mockResolvedValue(
-      page([
-        mocks.occurrence as NotificationOccurrenceItem,
-        {
-          ...mocks.occurrence,
-          id: 'mention-2',
-          eventId: 'event-2',
-          createdAt: new Date(Date.now() - 1_000).toISOString()
-        }
-      ])
-    );
+    retainProjection([
+      mocks.occurrence as NotificationOccurrenceItem,
+      {
+        ...mocks.occurrence,
+        id: 'mention-2',
+        eventId: 'event-2',
+        createdAt: new Date(Date.now() - 1_000).toISOString()
+      }
+    ]);
 
     const { container } = render(NotificationsPage);
     const deleteButton = await vi.waitFor(() => {
@@ -737,7 +727,7 @@ describe('notifications page', () => {
       timezone: 'Pacific/Auckland',
       timeFormat: TimeFormat.TIME_FORMAT_24_HOUR
     };
-    mocks.store.notifications.fetchPage.mockResolvedValue(page(occurrences));
+    retainProjection(occurrences);
 
     const { container } = render(NotificationsPage);
     const headings = await vi.waitFor(() => {
@@ -768,9 +758,12 @@ describe('notifications page', () => {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        fetchPage: vi
-          .fn()
-          .mockResolvedValue(page([{ ...mocks.occurrence, id: 'remote-notification' }])),
+        occurrences: [{ ...mocks.occurrence, id: 'remote-notification' }],
+        consumedCount: 1,
+        totalCount: 1,
+        hasMore: false,
+        hasLoaded: true,
+        error: null,
         deleteAllOccurrences: vi.fn(() => new Promise<void>((resolve) => (resolveRemote = resolve)))
       }
     };
@@ -801,9 +794,12 @@ describe('notifications page', () => {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        fetchPage: vi
-          .fn()
-          .mockResolvedValue(page([{ ...mocks.occurrence, id: 'remote-notification' }])),
+        occurrences: [{ ...mocks.occurrence, id: 'remote-notification' }],
+        consumedCount: 1,
+        totalCount: 1,
+        hasMore: false,
+        hasLoaded: true,
+        error: null,
         deleteAllOccurrences: vi.fn().mockRejectedValue(new Error('remote offline'))
       }
     };
@@ -833,9 +829,12 @@ describe('notifications page', () => {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        fetchPage: vi
-          .fn()
-          .mockResolvedValue(page([{ ...mocks.occurrence, id: 'remote-notification' }])),
+        occurrences: [{ ...mocks.occurrence, id: 'remote-notification' }],
+        consumedCount: 1,
+        totalCount: 1,
+        hasMore: false,
+        hasLoaded: true,
+        error: null,
         deleteAllOccurrences: vi.fn().mockResolvedValue(undefined)
       }
     };
@@ -858,6 +857,7 @@ describe('notifications page', () => {
   });
 
   it('loads the next page from each server independently', async () => {
+    const originalStore = mocks.store.notifications;
     let intersectionCallback: IntersectionObserverCallback | undefined;
     vi.stubGlobal(
       'IntersectionObserver',
@@ -876,50 +876,85 @@ describe('notifications page', () => {
         thresholds = [];
       }
     );
-    mocks.store.notifications.fetchPage.mockImplementation((offset = 0) => {
-      const occurrence = {
-        ...mocks.occurrence,
-        id: `notification-${offset}`,
-        createdAt: `2026-08-11T12:0${offset}:00Z`
-      };
-      return Promise.resolve(page([occurrence], offset === 0));
-    });
+    const api = {
+      listNotificationOccurrences: vi.fn((_limit: number, offset = 0) => {
+        const occurrence = {
+          ...mocks.occurrence,
+          id: `notification-${offset}`,
+          createdAt: `2026-08-11T12:0${offset}:00Z`
+        };
+        return Promise.resolve(page([occurrence], false));
+      }),
+      markNotificationRead: vi.fn(),
+      batchDeleteNotificationOccurrences: vi.fn(),
+      deleteAllNotificationOccurrences: vi.fn(),
+      getNotificationPolicy: vi.fn(),
+      updateNotificationPolicy: vi.fn()
+    };
+    const notificationStore = new NotificationStore(api as never);
+    const firstOccurrence = {
+      ...mocks.occurrence,
+      id: 'notification-0',
+      createdAt: '2026-08-11T12:00:00Z'
+    } as NotificationOccurrenceItem;
+    notificationStore.replaceOccurrenceProjection(page([firstOccurrence], true));
+    const fetchPage = vi.spyOn(notificationStore, 'fetchPage');
+    (mocks.store as { notifications: unknown }).notifications = notificationStore;
 
-    const { container } = render(NotificationsPage);
-    await vi.waitFor(() => {
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
-    });
-    intersectionCallback?.(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver
-    );
-    await vi.waitFor(() => {
-      expect(mocks.store.notifications.fetchPage).toHaveBeenCalledWith(1);
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
-    });
+    const { container, unmount } = render(NotificationsPage);
+    try {
+      await vi.waitFor(() => {
+        expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
+      });
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
+      );
+      await vi.waitFor(() => {
+        expect(fetchPage).toHaveBeenCalledWith(1);
+        expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
+      });
+    } finally {
+      unmount();
+      (mocks.store as { notifications: unknown }).notifications = originalStore;
+    }
   });
 
   it('continues past an empty privacy-filtered page using its raw consumed offset', async () => {
-    mocks.store.notifications.fetchPage.mockImplementation((offset = 0) => {
-      if (offset === 0) {
-        return Promise.resolve({ ...page([], true), consumedCount: 50 });
-      }
-      return Promise.resolve(
-        offset === 50
-          ? { ...page([mocks.occurrence as NotificationOccurrenceItem]), consumedCount: 1 }
-          : page([])
-      );
-    });
+    const originalStore = mocks.store.notifications;
+    const api = {
+      listNotificationOccurrences: vi.fn((_limit: number, offset = 0) => {
+        return Promise.resolve(
+          offset === 50
+            ? { ...page([mocks.occurrence as NotificationOccurrenceItem]), consumedCount: 1 }
+            : page([])
+        );
+      }),
+      markNotificationRead: vi.fn(),
+      batchDeleteNotificationOccurrences: vi.fn(),
+      deleteAllNotificationOccurrences: vi.fn(),
+      getNotificationPolicy: vi.fn(),
+      updateNotificationPolicy: vi.fn()
+    };
+    const notificationStore = new NotificationStore(api as never);
+    notificationStore.replaceOccurrenceProjection({ ...page([], true), consumedCount: 50 });
+    const fetchPage = vi.spyOn(notificationStore, 'fetchPage');
+    (mocks.store as { notifications: unknown }).notifications = notificationStore;
 
-    const { container } = render(NotificationsPage);
-
-    await vi.waitFor(() => {
-      expect(mocks.store.notifications.fetchPage).toHaveBeenCalledWith(50);
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
-    });
+    const { container, unmount } = render(NotificationsPage);
+    try {
+      await vi.waitFor(() => {
+        expect(fetchPage).toHaveBeenCalledWith(50);
+        expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
+      });
+    } finally {
+      unmount();
+      (mocks.store as { notifications: unknown }).notifications = originalStore;
+    }
   });
 
   it('consolidates one direct-message group across loaded pages and dismisses every member', async () => {
+    const originalStore = mocks.store.notifications;
     let intersectionCallback: IntersectionObserverCallback | undefined;
     let resolveSecondPage: (() => void) | undefined;
     vi.stubGlobal(
@@ -939,51 +974,70 @@ describe('notifications page', () => {
         thresholds = [];
       }
     );
-    mocks.store.notifications.fetchPage.mockImplementation(async (offset = 0) => {
-      const occurrence = {
+    const occurrenceAt = (offset: number) =>
+      ({
         ...mocks.occurrence,
         id: `dm-${offset}`,
         eventId: `dm-event-${offset}`,
         threadRootId: null,
         signalKind: NotificationSignalKind.DIRECT_MESSAGE,
         createdAt: new Date(Date.UTC(2026, 7, 11, 12, 0, offset)).toISOString()
-      };
-      if (offset === 1) {
-        await new Promise<void>((resolve) => {
-          resolveSecondPage = resolve;
-        });
-      }
-      return page([occurrence], offset === 0);
-    });
+      }) as NotificationOccurrenceItem;
+    const api = {
+      listNotificationOccurrences: vi.fn(async (_limit: number, offset = 0) => {
+        if (offset === 1) {
+          await new Promise<void>((resolve) => {
+            resolveSecondPage = resolve;
+          });
+        }
+        return page([occurrenceAt(offset)], false);
+      }),
+      markNotificationRead: vi.fn(),
+      batchDeleteNotificationOccurrences: vi.fn().mockResolvedValue(0),
+      deleteAllNotificationOccurrences: vi.fn(),
+      getNotificationPolicy: vi.fn(),
+      updateNotificationPolicy: vi.fn()
+    };
+    const notificationStore = new NotificationStore(api as never);
+    notificationStore.replaceOccurrenceProjection(page([occurrenceAt(0)], true));
+    const fetchPage = vi.spyOn(notificationStore, 'fetchPage');
+    const deleteOccurrences = vi.spyOn(notificationStore, 'deleteOccurrences');
+    (mocks.store as { notifications: unknown }).notifications = notificationStore;
 
-    const { container } = render(NotificationsPage);
-    await vi.waitFor(() => {
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
-    });
-    intersectionCallback?.(
-      [{ isIntersecting: true } as IntersectionObserverEntry],
-      {} as IntersectionObserver
-    );
-    await vi.waitFor(() => {
-      expect(mocks.store.notifications.fetchPage).toHaveBeenCalledWith(1);
-      expect(resolveSecondPage).toEqual(expect.any(Function));
-      expect(q(container, '.selectable-list')?.getAttribute('aria-busy')).toBe('true');
-      expect(container.textContent).not.toContain('Loading');
-    });
-    resolveSecondPage!();
-    await vi.waitFor(() => {
-      expect(container.textContent).not.toContain('Loading');
-      expect(q(container, '.selectable-list')?.getAttribute('aria-busy')).toBe('false');
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
-    });
-
-    (q(container, 'button[aria-label="Delete"]') as HTMLButtonElement).click();
-    await vi.waitFor(() => {
-      expect(mocks.store.notifications.deleteOccurrences).toHaveBeenCalledWith(
-        expect.arrayContaining(['dm-0', 'dm-1']),
-        { unread: 2, importantUnread: 2, roomId: 'room-1' }
+    const { container, unmount } = render(NotificationsPage);
+    try {
+      await vi.waitFor(() => {
+        expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
+      });
+      intersectionCallback?.(
+        [{ isIntersecting: true } as IntersectionObserverEntry],
+        {} as IntersectionObserver
       );
-    });
-    expect(mocks.store.notifications.deleteOccurrences.mock.calls[0]?.[0]).toHaveLength(2);
+      await vi.waitFor(() => {
+        expect(fetchPage).toHaveBeenCalledWith(1);
+        expect(resolveSecondPage).toEqual(expect.any(Function));
+        expect(q(container, '.selectable-list')?.getAttribute('aria-busy')).toBe('true');
+        expect(container.textContent).not.toContain('Loading');
+      });
+      resolveSecondPage!();
+      await vi.waitFor(() => {
+        expect(container.textContent).not.toContain('Loading');
+        expect(q(container, '.selectable-list')?.getAttribute('aria-busy')).toBe('false');
+        expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
+      });
+
+      (q(container, 'button[aria-label="Delete"]') as HTMLButtonElement).click();
+      await vi.waitFor(() => {
+        expect(deleteOccurrences).toHaveBeenCalledWith(expect.arrayContaining(['dm-0', 'dm-1']), {
+          unread: 2,
+          importantUnread: 2,
+          roomId: 'room-1'
+        });
+      });
+      expect(deleteOccurrences.mock.calls[0]?.[0]).toHaveLength(2);
+    } finally {
+      unmount();
+      (mocks.store as { notifications: unknown }).notifications = originalStore;
+    }
   });
 });


### PR DESCRIPTION
## Why

Notifications 1.0 conflates attention, handling, deletion, grouping, and
interruptive delivery. Its server-owned groups lose exact jump targets and
produce misleading unread counts. Notifications 2.0 makes every source signal
individually addressable while leaving presentation grouping to the client.

Closes #1556.

## What changed

### Product and public API

- Replaced Notifications 1.0 with exact, 90-day notification occurrences for
  DMs, direct/role/`@here`/`@all` mentions, replies, followed room/thread
  activity, and reactions.
- Added rich `NotificationSignal` oneof variants. Signal-specific data and the
  exact destination travel together. Policy uses explicit optional fields for
  Chatto's finite built-in signal classes instead of a second enum mirroring
  the signal oneof. Delivery modes are named for their actual effect: Off,
  Silent, or Alert.
- Added resource-oriented list/get/batch-get, mark-read, exact/batch delete,
  dismiss-all, and server/room policy RPCs. Sparse field-mask updates set or
  clear several overrides atomically without replacing unrelated fields. Read
  notifications remain visible until dismissed and cannot be marked unread.
- Realtime replacements carry exact occurrences and authoritative total, room,
  and Important unread counts without exposing JetStream coordinates.
- Kept presentation grouping in the client. DMs and reactions consolidate for
  display while occurrences retain independent identities, unread counts,
  deletion, and jump targets. Presentation attention remains independent:
  reactions are Ambient; mentions, replies, and DMs are Important.
- Kept Notifications as a routed page with chronological date separators,
  optimistic dismissal, localized full-sentence summaries, no message previews,
  and subdued styling for read rows.

### Storage and processing

- Added the backed-up, file-backed, S2-compressed, replicated `NOTIFICATIONS`
  stream with four fixed low-cardinality subjects:
  `notifications.signalled`, `.read`, `.removed`, and `.alert_resolved`.
- Application state expires exactly 90 days after source activity. Per-record
  JetStream TTL and stream `MaxAge` retain physical data for a further 24-hour
  cleanup grace; projections enforce semantic expiry independently of broker
  cleanup timing.
- A durable framework worker consumes EVT domain facts directly. At the exact
  decision boundary it reconstructs recipients, policy, thread-follow state,
  visibility, and reply state, then writes deterministic notification lifecycle
  facts in bounded atomic batches before double-acking EVT. Duplicate-ID retries
  fall back to idempotent per-record appends while retaining any committed
  prefix for projection, invalidation, and exact mutation accounting.
  High-fanout sources use one projection wait, watcher-indexed visibility and
  presence state, and one flushed set of coalesced recipient invalidations.
  Redelivery is idempotent and there is no notification queue or runtime-state
  handoff.
- The `NOTIFICATIONS` projection materializes the current occurrence resources.
  Its snapshots cannot advance beyond the worker's acknowledged EVT floor, so
  restore cannot skip source facts whose notification output was not durably
  written.
- The durable alert worker consumes `notifications.signalled`, waits for the
  occurrence projection, fences the source materializer, and revalidates the
  deadline, unread state, preference, DND, subscription, authorization, and
  target visibility immediately before push delivery. One
  `NotificationAlertResolved` fact records the first terminal outcome.
- Account deletion now treats Web Push credential erasure as a recoverable
  consequence of the existing `UserAccountDeletedEvent`. A dedicated shared
  durable worker retries strict owner-first cleanup. The permanent deletion
  fact fences registration, while a renewable lease leader performs
  startup/periodic reconciliation without a fixed whole-pass deadline, scanning
  current subscription and owner state once to erase late writes and repair
  orphaned records. This adds no new EVT fact or runtime deletion marker.
- Explicit dismissal appends an anti-recreation removal fact, then retryably
  secure-deletes the content-bearing signal. The removal carries its private
  signal coordinate, and cleanup-only tombstone state survives through the
  physical grace so cold replay and restore cannot lose retryability. Automatic
  expiry needs no event: reads, timers, startup replay, and snapshot restore
  enforce the immutable application deadline.
- Room/thread read boundaries are written before occurrence read facts so late
  materialization cannot recreate unread work. One process-wide filtered KV
  watcher indexes read and visibility boundaries; local writes wait for their
  exact watched revision. Every replica performs one startup/recovery repair,
  then reconciles only the affected user/room/thread scope when a read boundary
  changes. Notification expiry and secure-delete maintenance run once per
  minute rather than rescanning global state on lifecycle traffic.
- Visibility-loss handling covers membership, universal-room changes,
  room-group layout, bans, account deletion, and `room.join` RBAC without adding
  authorization-fence facts to EVT.
- Backups capture the EVT/worker boundary before notification lifecycle state.
  A source is therefore either represented in `NOTIFICATIONS` or replayable by
  the restored durable worker.

### Framework and documentation

- Extended `events.EncodedEventLog` with validated per-record TTL support for
  single and atomic-batch appends, including a typed duplicate-batch error so
  callers can fall back to idempotent single appends when JetStream rejects an
  atomic retry containing an already-seen message ID. Single-record mutation
  results also expose duplicate acknowledgements, keeping concurrent delete
  result counts exact.
- Generalized projection registration and snapshot binding so projections can
  be backed by independent event streams and identities.
- Added documented headless Svelte `Interval` and `Deadline` lifecycle
  components, then declared notification reconciliation and semantic-expiry
  scheduling through them per authenticated server. Interactive Storybook
  examples demonstrate conditional mounting, cleanup, absolute deadlines, and
  rescheduling.
- Documented the reusable protobuf-design rule: use explicit fields for finite,
  product-defined concepts; reserve keyed rows for dynamic/extensible keyspaces;
  and treat an enum that merely mirrors a `oneof` as a design smell.
- Updated ADR-075, ADR-076, FDR-012, FDR-013, FDR-018, the glossary, runtime
  architecture inventory, ConnectRPC reference, operations guide, and 0.5.0
  release notes.

## Compatibility and rollout

This is an intentional breaking replacement of the experimental pre-1.0
`chatto.api.v1` Notifications 1.0 integration API and its realtime projection
operation. Notification lifecycle semantics also change; persisted EVT changes
remain additive. Integrations must regenerate clients. Notifications 1.0
records and coarse preferences are not migrated; an upgraded server starts
with an empty notification list and the new defaults.

- **Older client → newer server:** Notifications 1.0 RPCs and the old realtime
  replacement operation are unavailable. The old notification client is not
  compatible and must be upgraded with the server.
- **Newer client → older server:** Notifications 2.0 RPCs and its realtime
  replacement operation are unavailable. The bundled client already treats
  Chatto 0.5.0 as its minimum supported server release; no Notifications 2.0
  fallback to a 0.4.x server is provided.
- **Version boundary:** This is a required 0.5.0 client/server release boundary,
  not an optional server capability. The realtime protocol remains version 2;
  unknown projection operations continue to fail closed rather than advancing
  a resume cursor across state the client did not understand.

Released Notifications 1.0 realtime field numbers and names remain reserved.
The final Notifications 2.0 schema does not preserve compatibility with
unreleased intermediate drafts from this feature branch. Persisted EVT changes
are additive and existing message events remain decodable.

New `NotificationSignal` oneof branches are wire-additive after release;
unsupported variants are preserved and exhaustive APIs fail safely instead of
guessing their visibility or deleting them. New top-level notification
lifecycle variants require a readers-first rollout.

## Verification

- `mise codegen-proto`
- `mise test-cli`
- `mise test-frontend` — 1,670 client tests, 1,181 server tests, 187 Storybook tests, and
  five performance tests passed before the lifecycle-story follow-up
- complete Storybook suite after the lifecycle-story follow-up — 189 passed
- `mise test-e2e -- notification-policy.test.ts` — 2 passed
- `mise test-e2e` — 646 passed; six unrelated cases recovered on retry; all
  notification scenarios passed
- `mise test-events` — standalone and workspace modes
- `(cd authling && mise test)` — standalone and workspace modes
- `mise x -- go test -race ./internal/notificationstream`
- race-enabled push cleanup tests covering partial failure, redelivery,
  account-deletion fencing, orphan repair, and late registration
- focused notification projection, API, realtime, push, and stream tests
- notification policy/settings/page Playwright slice — 39 passed after the
  final storage/concurrency repairs
- exact notification Playwright suite — 36 passed after the final review fixes
- internal/storage Buf compatibility gate
- `mise license-check`
- `git diff --check`
- Chrome DevTools inspection of `/chat/notifications` and notification policy
  settings, including server/room reads and set/clear writes; no console
  warnings or errors


