### PR TITLE
feat(authling): split verification codes into boxes

### DIFF
--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -96,7 +96,7 @@ templ passwordResetCodePage(flow, message, oidcRequest string) {
 			if oidcRequest != "" {
 				<input type="hidden" name="oidc_request" value={ oidcRequest }/>
 			}
-			<label class="block"><span class="font-medium">Password reset code</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></label>
+			<label class="block"><span class="font-medium">Password reset code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></span></label>
 			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Verify code</button>
 		</form>
 	}
@@ -152,7 +152,7 @@ templ emailChangeCodePage(flow, message string) {
 		}
 		<form class="mt-8 space-y-5" method="post" action="/account/email/verify">
 			<input type="hidden" name="flow" value={ flow }/>
-			<label class="block"><span class="font-medium">Email change code</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></label>
+			<label class="block"><span class="font-medium">Email change code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></span></label>
 			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Verify code</button>
 		</form>
 	}
@@ -213,7 +213,7 @@ templ codePage(flow, message string) {
 		}
 		<form class="mt-8 space-y-5" method="post" action="/signup/verify">
 			<input type="hidden" name="flow" value={ flow }/>
-			<label class="block"><span class="font-medium">Verification code</span><input class="mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" required/></label>
+			<label class="block"><span class="font-medium">Verification code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></span></label>
 			<button class="w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white" type="submit">Verify email</button>
 		</form>
 	}

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -409,7 +409,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<label class=\"block\"><span class=\"font-medium\">Password reset code</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify code</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<label class=\"block\"><span class=\"font-medium\">Password reset code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></span></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify code</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -741,7 +741,7 @@ func emailChangeCodePage(flow, message string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\"> <label class=\"block\"><span class=\"font-medium\">Email change code</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify code</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "\"> <label class=\"block\"><span class=\"font-medium\">Email change code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></span></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify code</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1063,7 +1063,7 @@ func codePage(flow, message string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\"> <label class=\"block\"><span class=\"font-medium\">Verification code</span><input class=\"mt-2 w-full rounded-xl border border-slate-300 bg-transparent px-4 py-3 font-mono tracking-[0.4em]\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" required></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify email</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\"> <label class=\"block\"><span class=\"font-medium\">Verification code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></span></label> <button class=\"w-full rounded-xl bg-authling-600 px-5 py-3 font-semibold text-white\" type=\"submit\">Verify email</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/authling/web/src/app.css
+++ b/authling/web/src/app.css
@@ -25,3 +25,45 @@
     @apply bg-slate-50 text-slate-900 antialiased dark:bg-slate-950 dark:text-slate-100;
   }
 }
+
+@layer components {
+  .otp-code {
+    --otp-cell-size: clamp(1.8rem, 9vw, 3.5rem);
+    --otp-gap: clamp(0.25rem, 1.5vw, 0.75rem);
+
+    @apply relative block max-w-full;
+    width: calc(var(--otp-cell-size) * 6 + var(--otp-gap) * 5);
+    height: var(--otp-cell-size);
+  }
+
+  .otp-code-boxes {
+    @apply grid h-full;
+    grid-template-columns: repeat(6, var(--otp-cell-size));
+    gap: var(--otp-gap);
+  }
+
+  .otp-code-boxes > span {
+    @apply border border-slate-300 bg-transparent transition-colors dark:border-slate-700;
+    border-radius: clamp(0.5rem, 2vw, 0.75rem);
+  }
+
+  .otp-code:focus-within .otp-code-boxes > span {
+    @apply border-authling-500 ring-2 ring-authling-500/25;
+  }
+
+  .otp-code-input {
+    @apply absolute inset-0 h-full border-0 bg-transparent font-mono font-semibold text-slate-900 shadow-none outline-none dark:text-slate-100;
+    box-sizing: border-box;
+    width: calc(100% + var(--otp-gap) + (var(--otp-cell-size) - 1ch) / 2);
+    padding: 0 0 0 calc((var(--otp-cell-size) - 1ch) / 2);
+    font-size: clamp(1.25rem, 5vw, 1.5rem);
+    line-height: var(--otp-cell-size);
+    letter-spacing: calc(var(--otp-cell-size) + var(--otp-gap) - 1ch);
+    caret-color: var(--color-authling-500);
+    clip-path: inset(0 calc(var(--otp-gap) + (var(--otp-cell-size) - 1ch) / 2) 0 0);
+  }
+
+  .otp-code-input:focus {
+    @apply border-0 ring-0 outline-none;
+  }
+}


### PR DESCRIPTION
## Why

Six-digit verification codes used a single wide field that did not match the familiar segmented OTP pattern.

## What changed

- Present signup, password-reset, and email-change codes as six responsive boxes while retaining one native input for paste, OTP autofill, and accessibility.
- Add focused, light/dark, desktop, and narrow-mobile styling without introducing client-side scripting.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `cd authling && mise test` — passed standalone and repository-workspace Go suites.
- `pnpm run check:e2e` plus targeted signup, password-reset, and email-change Playwright tests — type-check passed; all 7 tests passed.
- Chrome DevTools — verified six-digit entry, focus treatment, light/dark themes, desktop and 320 px mobile layouts, and no console errors.
