### PR TITLE
fix(frontend): accept all uploadable composer drops

### DIFF
--- a/apps/frontend/src/lib/attachments/dropZone.svelte.spec.ts
+++ b/apps/frontend/src/lib/attachments/dropZone.svelte.spec.ts
@@ -113,15 +113,17 @@ describe('dropZone attachment', () => {
   });
 
   describe('drop & MIME filtering', () => {
-    it('forwards files matching the default image/* filter', () => {
+    it('accepts every file type by default', () => {
       const onDrop = vi.fn();
       attach({ onDrop });
 
       const png = file('a.png', 'image/png');
-      host.dispatchEvent(dragEvent('drop', { files: [png] }));
+      const pdf = file('doc.pdf', 'application/pdf');
+      const unknown = file('archive.custom', '');
+      host.dispatchEvent(dragEvent('drop', { files: [png, pdf, unknown] }));
 
       expect(onDrop).toHaveBeenCalledOnce();
-      expect(onDrop.mock.calls[0][0]).toEqual([png]);
+      expect(onDrop.mock.calls[0][0]).toEqual([png, pdf, unknown]);
     });
 
     it('drops files that do not match the accepted types', () => {

--- a/apps/frontend/src/lib/attachments/dropZone.svelte.ts
+++ b/apps/frontend/src/lib/attachments/dropZone.svelte.ts
@@ -6,7 +6,7 @@
  *
  * @param options.onDrop - Called with File[] when valid files are dropped
  * @param options.onDragStateChange - Called with boolean when drag enters/leaves
- * @param options.acceptedTypes - MIME types to accept (default: ['image/*'])
+ * @param options.acceptedTypes - MIME types to accept. Omit to accept all files.
  */
 export function dropZone(options: {
   onDrop: (files: File[]) => void;
@@ -14,7 +14,7 @@ export function dropZone(options: {
   acceptedTypes?: string[];
 }) {
   return (element: HTMLElement) => {
-    const acceptedTypes = options.acceptedTypes ?? ['image/*'];
+    const acceptedTypes = options.acceptedTypes;
 
     // Counter to handle nested elements triggering enter/leave
     let dragCounter = 0;
@@ -72,7 +72,9 @@ export function dropZone(options: {
       options.onDragStateChange?.(false);
 
       const files = Array.from(e.dataTransfer?.files ?? []);
-      const validFiles = files.filter((f) => matchesMimeType(f, acceptedTypes));
+      const validFiles = acceptedTypes
+        ? files.filter((file) => matchesMimeType(file, acceptedTypes))
+        : files;
 
       if (validFiles.length > 0) {
         options.onDrop(validFiles);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -514,7 +514,7 @@
     openFileMessage(messageEventId, threadRootEventId, closeMobile);
   }
 
-  // Drop zone state for drag-and-drop image uploads
+  // Drop zone state for drag-and-drop uploads
   let isDraggingFiles = $state(false);
   let composerApi = $state<MessageComposerApi | null>(null);
 
@@ -523,8 +523,7 @@
     room.roomData?.canPostMessage && room.roomData?.canAttach
       ? dropZone({
           onDrop: (files) => composerApi?.addFiles(files),
-          onDragStateChange: (dragging) => (isDraggingFiles = dragging),
-          acceptedTypes: ['image/*', 'video/*', 'audio/*']
+          onDragStateChange: (dragging) => (isDraggingFiles = dragging)
         })
       : undefined
   );

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -132,8 +132,7 @@
     canPostInThread && canAttach
       ? dropZone({
           onDrop: (files) => composerApi?.addFiles(files),
-          onDragStateChange: (dragging) => (isDraggingFiles = dragging),
-          acceptedTypes: ['image/*', 'video/*', 'audio/*']
+          onDragStateChange: (dragging) => (isDraggingFiles = dragging)
         })
       : undefined
   );


### PR DESCRIPTION
## Why

Dragging files into a composer should support the same file types as selecting them through the file picker.

## What changed

- Make unrestricted drop zones accept every file type by default, including files with missing MIME metadata.
- Let room and thread composers use that default while preserving explicit image-only filters for avatar and server-branding drop zones.
- Keep existing composer validation for server upload limits and disabled video uploads.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `pnpm vitest run src/lib/attachments/dropZone.svelte.spec.ts` — 14 tests passed.
- Svelte autofixer on the changed Svelte modules — no issues.
- Prettier check and `git diff --check` — passed.
