### PR TITLE
fix(dev): isolate Pitchfork workspace services

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -22,7 +22,7 @@ archive = "mise dev-archive"
 run_mode = "concurrent"
 
 [scripts.run.dev]
-command = "exec mise dev"
+command = "exec tools/dev-supervisor.sh mise dev"
 available_in = [ "local" ]
 default = true
 icon = "git-fork"

--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ Conductor allocates ten ports to every local workspace. With base port
 - LiveKit: `https://livekit-<workspace>.localhost:42443`
 
 The daemons still bind only to their workspace's allocated ports: Chatto uses
-the base port and `+1`, Authling uses `+2`, LiveKit uses `+5` through `+7`, and
-Mailpit uses `+8` and `+9`. Pitchfork terminates trusted development HTTPS and
-proxies each hostname directly to the corresponding daemon's declared browser
-listener; no Caddy process or other adapter is involved. `mise dev` prints the
-browser URLs, starts the dependency group, then declares the HTTP listener when
-restarting the two multi-port daemons. Outside Conductor, the port layout falls
-back to base port `4000`.
+the base port for Vite, `+1` for its backend, and `+4` for embedded NATS;
+Authling uses `+2`; LiveKit uses `+5` through `+7`; and Mailpit uses `+8` and
+`+9`. Pitchfork terminates trusted development HTTPS and proxies each hostname
+directly to the corresponding daemon's declared browser listener; no Caddy
+process or other adapter is involved. `mise dev` prints the browser URLs,
+starts the dependency group, then declares the HTTP listener when restarting
+the two multi-port daemons. Outside Conductor, the port layout falls back to
+base port `4000`.
 
 Pitchfork derives each daemon namespace from the checkout directory name, so
 concurrent worktrees remain isolated. `mise dev` registers one workspace-named

--- a/docs/adr/ADR-075-native-pitchfork-development-stack.md
+++ b/docs/adr/ADR-075-native-pitchfork-development-stack.md
@@ -42,11 +42,12 @@ current worktree's daemon namespace.
 gitignored `.context/dev/port-base` file before starting Pitchfork. Daemons read
 that file instead of inheriting an environment variable from Pitchfork's
 machine-wide supervisor. Chatto's browser-facing Vite server uses the base
-port, its backend uses offset `+1`, and Authling uses `+2`. LiveKit uses offsets
-`+5` through `+7`; Mailpit SMTP and UI use `+8` and `+9`. The known layout also
-lets LiveKit address Chatto's webhook while Chatto addresses LiveKit without a
-cyclic Pitchfork dependency. Internal listener, SMTP, and webhook connections
-use plain-HTTP loopback where applicable. Pitchfork's own reverse proxy exposes
+port, its backend uses offset `+1`, its embedded NATS listener uses `+4`, and
+Authling uses `+2`. LiveKit uses offsets `+5` through `+7`; Mailpit SMTP and UI
+use `+8` and `+9`. The known layout also lets LiveKit address Chatto's webhook
+while Chatto addresses LiveKit without a cyclic Pitchfork dependency. Internal
+listener, SMTP, and webhook connections use plain-HTTP loopback where
+applicable. Pitchfork's own reverse proxy exposes
 Chatto, Authling, Mailpit, and LiveKit at workspace-specific HTTPS hostnames on
 port `42443`. Pitchfork generates and trusts the certificate and proxies each
 hostname directly to its daemon's declared HTTP listener; no adapter process is

--- a/pitchfork.toml
+++ b/pitchfork.toml
@@ -87,6 +87,7 @@ project_dir=$(cd .. && pwd -P)
 port_base=$(cat ../.context/dev/port-base)
 workspace_slug=$(cat ../.context/dev/workspace-slug)
 backend_port=$((port_base + 1))
+nats_port=$((port_base + 4))
 smtp_port=$((port_base + 8))
 data_root="$project_dir/.context/dev/$workspace_slug"
 mkdir -p internal/http_server/.client "$data_root/chatto/nats" "$data_root/chatto/search"
@@ -100,6 +101,7 @@ export CHATTO_AUTH_PROVIDERS_0_CLIENT_ID="https://chatto-$workspace_slug.localho
 export CHATTO_LIVEKIT_URL="wss://livekit-$workspace_slug.localhost:42443"
 export CHATTO_LIVEKIT_WEBHOOK_URL="http://localhost:$backend_port/webhooks/livekit"
 export CHATTO_NATS_EMBEDDED_DATA_DIR="$data_root/chatto/nats"
+export CHATTO_NATS_EMBEDDED_PORT="$nats_port"
 export CHATTO_SMTP_PORT="$smtp_port"
 exec ./bin/chatto-dev start
 """
@@ -123,7 +125,7 @@ env = {
   CHATTO_CORE_ASSETS_MAX_UPLOAD_SIZE = "25MB",
   CHATTO_CORE_ASSETS_CACHE_ENABLED = "true",
   CHATTO_CORE_ASSETS_CACHE_TTL = "7d",
-  CHATTO_AUTH_ACCOUNT_CREATION_POLICY = "invite_only",
+  CHATTO_AUTH_ACCOUNT_CREATION_POLICY = "open",
   CHATTO_AUTH_PROVIDERS_0_ID = "authling",
   CHATTO_AUTH_PROVIDERS_0_TYPE = "oidc",
   CHATTO_AUTH_PROVIDERS_0_LABEL = "Authling",


### PR DESCRIPTION
## Why

Concurrent Pitchfork workspaces could not start Chatto because every embedded NATS server inherited the fixed port `4555`, and first-time Authling sign-in was blocked by the invite-only development policy.

## What changed

- Allocate Chatto's embedded NATS listener at workspace port offset `+4`.
- Use the repository's dev supervisor for Conductor lifecycle cleanup.
- Allow open account creation in the local Pitchfork stack and document the corrected port layout.

## API compatibility

- No public API or protocol behaviour changed; these settings affect only the local development stack.

## Test plan

- `git diff --check origin/main...HEAD`
- `mise x -- pitchfork daemons`
- Started Porto and another Conductor workspace concurrently; both Chatto HTTPS endpoints returned HTTP 200, and Chrome DevTools loaded Porto's login page with Authling available.
- Ran `mise dev-archive` and confirmed Porto's supervised processes and proxy routes were removed.
