### PR TITLE
chore(dev): add Storybook and docs previews

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -16,6 +16,14 @@ url = "https://mailpit.$CONDUCTOR_WORKSPACE_NAME.localhost:42444"
 name = "LiveKit"
 url = "https://livekit.$CONDUCTOR_WORKSPACE_NAME.localhost:42444"
 
+[[preview_urls]]
+name = "Storybook"
+url = "https://storybook.$CONDUCTOR_WORKSPACE_NAME.localhost:42444"
+
+[[preview_urls]]
+name = "Docs website"
+url = "https://docs.$CONDUCTOR_WORKSPACE_NAME.localhost:42444"
+
 [scripts]
 setup = "mise trust && mise install && mise setup && (cd authling && mise trust && mise install && mise deps)"
 run_mode = "concurrent"
@@ -25,6 +33,16 @@ command = "exec mise dev"
 available_in = [ "local" ]
 default = true
 icon = "network"
+
+[scripts.run.storybook]
+command = "exec mise storybook"
+available_in = [ "local" ]
+icon = "component"
+
+[scripts.run.docs_website]
+command = "exec mise dev-docs-website"
+available_in = [ "local" ]
+icon = "book-open"
 
 [prompts]
 create_pr = "Create a full GitHub pull request for the current branch, not a draft PR."

--- a/docs/adr/ADR-078-portless-native-development-stack.md
+++ b/docs/adr/ADR-078-portless-native-development-stack.md
@@ -37,6 +37,13 @@ Mailpit, and LiveKit as `<service>.<workspace>.localhost` on shared proxy port
 `42444`.
 Portless owns a route for exactly as long as its child process runs.
 
+The standalone `mise storybook` and `mise dev-docs-website` tasks use the same
+proxy and expose `storybook.<workspace>.localhost` and
+`docs.<workspace>.localhost`, respectively. Portless assigns their loopback
+listener ports dynamically so both tasks can run alongside the regular stack
+without competing for its Conductor port block. Conductor provides separate run
+actions and preview links for both routes.
+
 The application listeners retain ADR-075's Conductor port layout. With
 `CONDUCTOR_PORT` as the base, Vite uses the base port, the Chatto backend uses
 `+1`, Authling uses `+2`, Chatto's embedded NATS uses `+4`, LiveKit uses `+5`
@@ -71,8 +78,9 @@ artifacts while removing Pitchfork.
 - Concurrent workspaces keep separate listener ports, state, HTTPS origins,
   and Portless child registrations while sharing Portless's lightweight HTTPS
   proxy.
-- Development URLs use the Conductor workspace name and port `42444`, allowing
-  `.conductor/settings.toml` to provide working preview links.
+- Development, Storybook, and docs website URLs use the Conductor workspace
+  name and port `42444`, allowing `.conductor/settings.toml` to provide working
+  preview links.
 - Developers may need to trust Portless's CA interactively on first use.
 - Backend and Authling changes temporarily require restarting the stack until
   a simpler watch-and-rebuild mechanism is selected.

--- a/mise.toml
+++ b/mise.toml
@@ -254,13 +254,20 @@ sources = [
 outputs = ["../apps/frontend/e2e/fixtures/bin/chatto-current"]
 
 [tasks.storybook]
-description = "Run the Storybook design-system catalog on the workspace port"
+description = "Run the Storybook design-system catalog with Portless"
 depends = ["setup-frontend", "build-api-types"]
 dir = "apps/frontend"
+tools = { node = "24", "npm:portless" = "0.15.5" }
 env = {
-  CHATTO_STORYBOOK_PORT = "{{env.CHATTO_STORYBOOK_PORT | default(value=env.CONDUCTOR_PORT | default(value='4000'))}}",
+  PORTLESS_PORT = "{{env.CHATTO_DEV_PROXY_PORT | default(value='42444')}}",
+  PORTLESS_HTTPS = "1",
+  PORTLESS_SYNC_HOSTS = "0",
+  CHATTO_DEV_ROUTE_SUFFIX = "{{env.CONDUCTOR_WORKSPACE_NAME | default(value='local')}}",
 }
-run = "exec pnpm exec storybook dev --host 127.0.0.1 --port \"$CHATTO_STORYBOOK_PORT\" --no-open"
+run = '''
+exec portless "storybook.$CHATTO_DEV_ROUTE_SUFFIX" -- \
+  sh -c 'exec pnpm exec storybook dev --host "$HOST" --port "$PORT" --no-open'
+'''
 
 [tasks.dev-backend]
 description = "Build and run the local development backend"
@@ -480,16 +487,20 @@ exec portless \
 '''
 
 [tasks.dev-docs-website]
-description = "Run the docs website development server with workspace-safe ports"
+description = "Run the docs website development server with Portless"
 depends = ["setup-frontend"]
 dir = "apps/docs-website"
-raw = true
-run = """
-workspace_port_base="${CONDUCTOR_PORT:-4000}"
-docs_website_port="${CHATTO_DOCS_WEBSITE_PORT:-$workspace_port_base}"
-
-exec pnpm astro dev --host 127.0.0.1 --port "$docs_website_port"
-"""
+tools = { node = "24", "npm:portless" = "0.15.5" }
+env = {
+  PORTLESS_PORT = "{{env.CHATTO_DEV_PROXY_PORT | default(value='42444')}}",
+  PORTLESS_HTTPS = "1",
+  PORTLESS_SYNC_HOSTS = "0",
+  CHATTO_DEV_ROUTE_SUFFIX = "{{env.CONDUCTOR_WORKSPACE_NAME | default(value='local')}}",
+}
+run = '''
+exec portless "docs.$CHATTO_DEV_ROUTE_SUFFIX" -- \
+  sh -c 'exec pnpm astro dev --host "$HOST" --port "$PORT"'
+'''
 
 [tasks.chatto]
 description = "Build and run the bundled Chatto CLI command with workspace-safe ports"


### PR DESCRIPTION
## Why

Conductor users need one-click, stable HTTPS previews for Storybook and the docs website that can run alongside the regular development stack.

## What changed

- Routes `mise storybook` and `mise dev-docs-website` through the pinned Portless toolchain with dynamically assigned loopback ports.
- Adds local-only Conductor run actions and preview URLs for both services, and updates ADR-078 with the expanded routing decision.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- Passed `git diff --check origin/main...`; mise discovered both tasks; both ran concurrently through their Portless routes and rendered successfully when loaded with Chrome DevTools MCP.
