### PR TITLE
feat(authling): add durable OIDC authorization grants

### DIFF
--- a/authling/AGENTS.md
+++ b/authling/AGENTS.md
@@ -43,8 +43,9 @@ to its own repository.
 - The current experimental runtime persists and replays local accounts,
   exposes server-rendered verified-email signup, password login, browser
   sessions and session management, password reset, signed-in password change,
-  verified email change, and logout. It provides the narrow OpenID Connect
-  surface recorded in FDR-004. It has no public
+  verified email change, and logout. It provides durable exact-client OIDC
+  authorization grants and the narrow OpenID Connect surface recorded in
+  FDR-004 and FDR-010. It has no public
   account-management, application-data, document, or synchronization API. Do
   not document other planned identity-provider behavior as implemented.
 

--- a/authling/README.md
+++ b/authling/README.md
@@ -3,8 +3,9 @@
 Authling is a standalone, self-hostable OpenID Connect identity provider. Its
 experimental runtime currently provides verified-email signup, encrypted local
 credentials, password login and reset, verified email change, signed-in
-password change, revocable browser sessions, and a small Authorization Code
-OpenID Provider for conventional and CIMD clients. It also stores only
+password change, revocable browser sessions, durable OIDC authorization grants,
+and a small Authorization Code OpenID Provider for conventional and CIMD
+clients. It also stores only
 identity-provider state; application data and synchronization are outside its
 scope.
 
@@ -85,8 +86,8 @@ The development configuration serves Authling at <http://localhost:8080>, with
 signup at <http://localhost:8080/signup>, login at
 <http://localhost:8080/login>, and password reset at
 <http://localhost:8080/password-reset>. Signed-in accounts can change their
-verified email address or password and review or revoke other browser sessions
-from <http://localhost:8080/account>.
+verified email address or password, review or revoke other browser sessions,
+and manage authorized OIDC apps from <http://localhost:8080/account>.
 Mailpit receives SMTP on port 1025 and shows captured messages at
 <http://127.0.0.1:8025>. Set
 `AUTHLING_HTTP_BIND_ADDRESS` to override the Authling listener and
@@ -119,6 +120,12 @@ initial profile supports Authorization Code, requires `openid` and S256 PKCE
 for every client, signs ID tokens with RS256, and exposes a minimal UserInfo
 response containing only the account ID as `sub`. It exposes no
 application-data scopes.
+
+Explicit consent creates a durable authorization grant for the exact client
+ID and `openid` scope. Later covered requests skip repeated consent unless the
+client sends `prompt=consent`. The account page lists and revokes these grants.
+Revocation makes future requests ask again; it does not end already issued
+five-minute tokens or sessions held by the relying party.
 
 CIMD public clients use their HTTPS metadata-document URL directly as
 `client_id`; they need no Authling-side registration. Conventional consumers

--- a/authling/TODO.md
+++ b/authling/TODO.md
@@ -27,10 +27,11 @@ current runtime in `docs/architecture/`.
 
 ## OpenID Connect
 
-- [ ] Define relying-party grouping for consent across one or more OIDC clients
+- [ ] Define authenticated relying-party grouping and exact-client grant migration across one or more OIDC clients
 - [ ] Track CIMD Internet-Draft evolution and define compatibility policy before upgrading from draft-02
 - [ ] Design signing-key rotation and retirement
-- [ ] Add refresh-token, token-revocation, and RP-initiated logout behavior
+- [ ] Add rotating refresh tokens bound to durable authorization-grant generations
+- [ ] Add token-revocation and RP-initiated logout behavior
 - [ ] Define identity-claim release policies before adding further scopes and claims
 - [ ] Automate the official OpenID Provider conformance suite outside the fast Docker-free test path
 - [ ] Add version-skew fixtures for CIMD-aware Chatto consumers

--- a/authling/docs/GLOSSARY.md
+++ b/authling/docs/GLOSSARY.md
@@ -11,9 +11,9 @@ store, or a user's home server.
 
 **Account** — Authling's opaque aggregate for one user identity. Its account ID
 is the stable OpenID Connect subject (`sub`) exposed to authorized clients. A local
-account may have an encrypted, verified email/password credential and one or
-more independent browser sessions. Accounts do not yet have profile data or
-OIDC grants.
+account may have an encrypted, verified email/password credential, one or more
+independent browser sessions, and durable OIDC authorization grants. Accounts
+do not yet have profile data.
 
 **Local credential** — An Authling login method based on a verified normalized
 email address and an Argon2id password verifier. Both values are retained only
@@ -56,6 +56,17 @@ an identity migration, not an ordinary listener reconfiguration.
 **Relying party** — An application that asks Authling to authenticate an
 account through OpenID Connect. Its individual protocol identity is an OIDC
 client.
+
+**OIDC client** — One exact protocol identity identified by `client_id` and
+validated from Authling configuration or a CIMD document. Authling initially
+treats every client ID as a separate account-facing application; a future
+relying-party identity may deliberately group multiple clients.
+
+**Authorization grant** — A durable, account-owned authorization for one exact
+OIDC client and scope set. It lets a covered future request skip repeated
+consent and can be revoked independently of Authling browser sessions. Grant
+revocation does not enumerate or terminate already issued short-lived tokens
+or the relying party's own sessions.
 
 **Client ID Metadata Document (CIMD)** — An HTTPS JSON document whose URL is
 also a public OIDC client's identifier. Authling uses CIMD for automatic,

--- a/authling/docs/adr/ADR-004-cimd-native-openid-provider.md
+++ b/authling/docs/adr/ADR-004-cimd-native-openid-provider.md
@@ -69,9 +69,13 @@ event. Pending requests, authorization-code mappings, and access-token records
 are authenticated-encrypted in the expiring runtime-state bucket beneath
 HMAC-derived keys.
 
-Authling always asks for per-request consent. A signed-out browser resumes the
+Authling records explicit consent as a durable, account-owned authorization
+grant for one exact client ID and scope set. A covered later request may reuse
+that grant; `prompt=consent` always asks again. A signed-out browser resumes the
 request through its opaque server-side request ID after login. Client redirect
-URIs never become general-purpose return parameters.
+URIs never become general-purpose return parameters. Grant behavior and its
+future extension boundary are recorded in
+[FDR-010](../fdr/FDR-010-oidc-authorization-grants.md).
 
 ## Consequences
 

--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -103,6 +103,8 @@ Persisted records use the `authling.core.v1.Event` protobuf envelope:
 | `EmailChangeRequestedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account and reauthenticated credential-event IDs |
 | `EmailChangedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, credential-key, request, and prior-credential references plus the replacement encrypted email |
 | `EmailClaimedEvent` | `authling.evt.account-registry` | Account registry | Opaque account and optional staged credential-event IDs |
+| `OIDCGrantAuthorizedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, grant, and prior-authorization IDs; keyed exact-client digest; client display snapshot; granted scopes |
+| `OIDCGrantRevokedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account, grant, and active authorization-event IDs |
 | `IssuerEstablishedEvent` | `authling.evt.issuer` | Issuer singleton | Immutable issuer URL and opaque signing-key reference and ID |
 
 The account ID is restricted to one NATS-safe token. Structural account
@@ -142,6 +144,16 @@ stream position before returning the projected account.
 
 The account projection is currently cold-replay-only. It has no snapshot or
 local-checkpoint persistence.
+
+The authorization-grant projection consumes `authling.evt.account.*` and
+materializes active grants by account, exact client ID, and opaque grant ID. It
+validates account existence and the correlation chain for explicit renewal and
+revocation, retains ended grant IDs to prevent generation reuse, and serves
+only after startup replay. Grant commands synchronize to the account tail,
+publish with account-subject OCC, retry from refreshed state after conflicts,
+and wait for their committed position. The projection is cold-replay-only and
+contains client metadata and scopes but no account PII, tokens, codes, redirect
+URIs, or browser data.
 
 The browser-session inventory is a process-wide in-memory model over one
 filtered `session.*` watcher on `AUTHLING_RUNTIME_STATE`. It decrypts the latest
@@ -251,8 +263,17 @@ OpenID Connect mounts discovery at `/.well-known/openid-configuration` and its
 protocol endpoints below `/oauth/`. Authorization accepts only code flow,
 requires exactly the `openid` scope and S256 PKCE.
 Signed-out requests resume through an opaque server-side request ID after
-login; `GET` and same-origin `POST` `/oidc/consent` display and record
-per-request consent.
+login. `GET /oidc/consent` reuses a durable exact-client authorization grant
+when it covers the requested scopes, except when `prompt=consent` requires an
+explicit decision. Same-origin `POST /oidc/consent` records explicit approval
+before authorizing the expiring request or returns a denial to the validated
+client redirect.
+
+`GET /account` lists active OIDC grants separately from Authling browser
+sessions. Same-origin `POST /account/authorizations/revoke` authorizes the
+opaque grant ID under the current account and commits revocation. Revocation
+forces future authorization to ask again but does not terminate already issued
+five-minute tokens or relying-party sessions.
 
 Conventional clients resolve from configuration. Unconfigured HTTPS URL client
 IDs resolve through the bounded CIMD fetcher, which disables redirects and

--- a/authling/docs/fdr/FDR-004-openid-connect-provider.md
+++ b/authling/docs/fdr/FDR-004-openid-connect-provider.md
@@ -1,7 +1,7 @@
 # FDR-004: OpenID Connect Provider
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-14
+**Last reviewed:** 2026-08-21
 
 ## Overview
 
@@ -19,11 +19,13 @@ to the relying party with an Authorization Code.
 - Redirect URI matching is exact. Authorization errors are sent to a client
   only after that client and redirect have been validated.
 - A signed-out person is sent through local login and then resumes the pending
-  consent screen. The screen identifies the signed-in account and the client,
-  and explains that the stable account identifier will be shared.
-- Consent is requested for every authorization. Allowing binds the request to
-  the current account; denying returns `access_denied` and the original state
-  to the validated redirect URI.
+  consent decision. When consent is required, the screen identifies the
+  signed-in account and client and explains that the stable account identifier
+  will be shared.
+- Allowing creates or renews a durable exact-client authorization grant and
+  binds the request to the current account. Later requests covered by that
+  grant skip the consent screen unless they use `prompt=consent`. Denying
+  returns `access_denied` and the original state to the validated redirect URI.
 - The authorization code expires with its ten-minute request, is bound to the
   client, redirect, and PKCE verifier, and succeeds in at most one concurrent
   exchange.
@@ -69,6 +71,9 @@ permits link-local, multicast, or other special-use destinations.
   are resolved server-side and cannot carry an arbitrary return URL.
 - A storage conflict during approval or code claim fails the operation instead
   of creating two grants.
+- Grant creation and revocation use account-subject OCC and wait for the grant
+  projection. Revocation controls future consent reuse, not already issued
+  short-lived tokens or relying-party sessions.
 - Failure responses do not reveal client secrets, codes, tokens, account IDs,
   email addresses, or complete request URLs.
 
@@ -77,7 +82,7 @@ permits link-local, multicast, or other special-use destinations.
 - Only local password authentication and the `pwd` authentication-method
   reference exist.
 - Refresh tokens, token revocation, RP-initiated logout, further identity scopes and
-  claims, persistent consent, application grouping, key rotation, and official
+  claims, relying-party grouping, key rotation, and official
   conformance-suite automation are not implemented.
 - CIMD remains an Internet-Draft. Authling implements the reviewed draft-02
   profile and may need an explicit migration as the document evolves.
@@ -87,3 +92,4 @@ permits link-local, multicast, or other special-use destinations.
 - **ADR:** [ADR-004](../adr/ADR-004-cimd-native-openid-provider.md)
 - **Product boundary:** [ADR-007](../adr/ADR-007-limit-authling-to-identity-provider.md)
 - **Features:** [FDR-003](FDR-003-local-login-and-browser-sessions.md)
+- **Authorization grants:** [FDR-010](FDR-010-oidc-authorization-grants.md)

--- a/authling/docs/fdr/FDR-010-oidc-authorization-grants.md
+++ b/authling/docs/fdr/FDR-010-oidc-authorization-grants.md
@@ -1,0 +1,132 @@
+# FDR-010: OIDC Authorization Grants
+
+**Status:** Experimental
+**Last reviewed:** 2026-08-21
+
+## Overview
+
+Authling remembers an account's explicit authorization of an OIDC client.
+Later authorization requests for the same client and an already granted scope
+set can continue without showing the consent page again. A signed-in person can
+review and revoke these durable relationships under **Authorized apps**.
+
+These grants describe applications authorized through Authling. They are not
+Authling browser sessions and do not enumerate the relying party's own login
+sessions.
+
+## Behavior
+
+- The initial grant boundary is one exact OIDC `client_id`. Authling does not
+  infer that clients with similar names, redirect hosts, or CIMD hostnames are
+  the same relying party.
+- Explicitly allowing a consent request creates a durable grant for the
+  authenticated account, exact client, and granted scopes. The grant captures
+  the validated client name and display host used by the account UI.
+- A later request skips the consent page only when its exact client ID has an
+  active grant containing every requested scope. Authentication is still
+  required, and all ordinary client, redirect, request, and PKCE validation
+  still runs.
+- `prompt=consent` always displays consent. Allowing it renews the active grant
+  and records a new authorization fact without changing the active grant ID.
+- Denying a forced-consent request does not revoke an existing grant.
+- The account page lists active grants with their client name, display host,
+  and latest explicit authorization time. Same-origin POST is required to
+  revoke one.
+- Revocation affects future authorization decisions immediately after the
+  durable write. Existing relying-party sessions, authorization codes, ID
+  tokens, and five-minute access tokens are not enumerated or terminated and
+  remain subject to their own expiry and one-time-use rules.
+- Re-authorizing a revoked client creates a fresh grant ID. This separates the
+  new authorization generation from credentials that may later be bound to the
+  revoked generation.
+
+## Durable Model
+
+`OIDCGrantAuthorizedEvent` and `OIDCGrantRevokedEvent` are PII-free account
+aggregate facts in `AUTHLING_EVT`. They contain opaque account and grant IDs,
+a deployment-keyed digest of the exact client ID, the client metadata snapshot,
+scopes, and opaque event correlations. They contain no raw configured client
+ID or CIMD URL, account email, browser metadata, token, code, redirect URI, or
+submitted request URL.
+
+The authorization projection consumes `authling.evt.account.*`, rebuilds the
+active grant inventory in memory, and is disposable. Commands synchronize it
+to the current account tail, publish with account-subject OCC, re-evaluate
+after conflicts, and wait for the committed position before returning. Replay
+rejects renewals or revocations that reference another active authorization,
+grant IDs reused after revocation, and grants for absent accounts.
+
+The client metadata stored in a grant is a display snapshot, not the authority
+for future protocol requests. Every authorization request continues to resolve
+and validate the currently configured client or CIMD document. This avoids an
+outbound metadata fetch from the account page and prevents transient client
+resolution failures from hiding revocation controls.
+
+The new protobuf variants are additive storage fields, but binaries predating
+them reject the unknown Authling event payload during replay. Deploy this
+experimental feature as a coordinated Authling upgrade. Once either event has
+been written, do not roll a replica back to a version that predates FDR-010.
+
+## Security and Failure Behavior
+
+- A stale replica cannot reuse a revoked grant: consent-reuse decisions first
+  wait for the local projection to reach the authoritative account tail.
+- The opaque grant ID in a revocation form is not sufficient authority. The
+  server derives the account from the active Authling browser session and
+  resolves the grant under that account.
+- Cross-origin revocation is rejected. A missing, already revoked, or
+  cross-account grant has the same account-facing unavailable result.
+- If durable grant creation succeeds but the expiring authorization request
+  cannot be updated, retrying the request can continue from the committed
+  grant. Runtime protocol state never becomes the only record of consent.
+- Logs and errors do not include account IDs, client IDs, grant IDs, tokens,
+  authorization codes, or full request URLs.
+
+## Extension Notes
+
+### Refresh tokens
+
+Refresh tokens are the intended next OIDC feature because the durable grant is
+their revocation anchor. The implementation should:
+
+- bind every opaque refresh-token family to the account, exact client ID,
+  grant ID, and granted scopes;
+- verify that the grant ID is still active on every refresh and fail closed
+  when the authorization projection is unavailable;
+- rotate refresh tokens with single-use OCC so concurrent reuse has at most one
+  winner;
+- keep refresh-token credentials in encrypted runtime state rather than the
+  durable event log;
+- make grant revocation invalidate every refresh token in that grant
+  generation, while leaving already issued short-lived access and ID tokens to
+  expire; and
+- decide and document the `offline_access` request, consent, client-policy, and
+  discovery semantics before advertising the refresh-token grant type.
+
+Token revocation and RP-initiated logout remain separate protocol features.
+They may provide narrower ways to end credentials or relying-party sessions,
+but must not redefine account grant revocation implicitly.
+
+### Relying-party grouping
+
+A future relying-party identity may group multiple exact client IDs behind one
+account-facing application. Grouping must use explicit, authenticated metadata
+and a durable migration policy; matching names, redirect hosts, or hostname
+suffixes is not sufficient. Existing exact-client grants must remain valid and
+revocable during migration. The projection can later materialize grouped views
+without changing historical events, while a new event type should record any
+durable grouping or grant migration fact.
+
+### Additional scopes and metadata changes
+
+Future incremental authorization should compare requested scopes with the
+active set and show consent for newly requested access. It should define
+whether an explicit authorization replaces or unions scope sets. Client
+display-metadata refresh should remain separate from protocol client
+validation and must not let a changed document silently broaden a grant.
+
+## Related
+
+- **OIDC provider:** [FDR-004](FDR-004-openid-connect-provider.md)
+- **Browser sessions:** [FDR-009](FDR-009-browser-session-management.md)
+- **Architecture:** [ADR-001](../adr/ADR-001-event-sourced-nats-architecture.md), [ADR-004](../adr/ADR-004-cimd-native-openid-provider.md)

--- a/authling/docs/fdr/INDEX.md
+++ b/authling/docs/fdr/INDEX.md
@@ -17,3 +17,4 @@ record planned behavior as active functionality.
 | [FDR-007](FDR-007-verified-email-change.md) | Verified Email Change | Experimental | 2026-08-20 |
 | [FDR-008](FDR-008-signed-in-password-change.md) | Signed-in Password Change | Experimental | 2026-08-20 |
 | [FDR-009](FDR-009-browser-session-management.md) | Browser Session Management | Experimental | 2026-08-20 |
+| [FDR-010](FDR-010-oidc-authorization-grants.md) | OIDC Authorization Grants | Experimental | 2026-08-21 |

--- a/authling/e2e/oidc.test.ts
+++ b/authling/e2e/oidc.test.ts
@@ -86,6 +86,27 @@ test('completes a conventional OIDC Authorization Code flow', async ({ page, req
   expect(userinfo.status()).toBe(200);
   expect(await userinfo.json()).toEqual({ sub: accountID });
 
+  await page.goto(`${stack.baseURL}/account`);
+  const authorizedApps = page.getByRole('heading', { name: 'Authorized apps' }).locator('..');
+  await expect(authorizedApps.getByText('Authling E2E client')).toBeVisible();
+  await expect(authorizedApps.getByText('configured by this Authling operator', { exact: false })).toBeVisible();
+
+  await page.goto(authorize.toString());
+  await expect(page).toHaveURL(new RegExp(`^${escapeRegExp(stack.callbackURL)}\\?`));
+
+  const forcedConsent = new URL(authorize);
+  forcedConsent.searchParams.set('prompt', 'consent');
+  await page.goto(forcedConsent.toString());
+  await expect(page.getByRole('heading', { name: 'Authorize Authling E2E client?' })).toBeVisible();
+
+  await page.goto(`${stack.baseURL}/account`);
+  await authorizedApps.getByRole('button', { name: 'Revoke access' }).click();
+  await expect(page.getByText('The app’s authorization was revoked', { exact: false })).toBeVisible();
+  await expect(authorizedApps.getByText('You haven’t authorized any apps yet.')).toBeVisible();
+
+  await page.goto(authorize.toString());
+  await expect(page.getByRole('heading', { name: 'Authorize Authling E2E client?' })).toBeVisible();
+
   const reused = await request.post(`${stack.baseURL}/oauth/token`, {
     form: {
       grant_type: 'authorization_code', client_id: 'authling-e2e', redirect_uri: redirectURI,
@@ -95,6 +116,10 @@ test('completes a conventional OIDC Authorization Code flow', async ({ page, req
   expect(reused.status()).toBe(400);
   expect(await reused.json()).toMatchObject({ error: 'invalid_grant' });
 });
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 test('rejects authorization without S256 PKCE before starting consent', async ({ request, stack }) => {
   const response = await request.get(`${stack.baseURL}/oauth/authorize`, {

--- a/authling/e2e/security.test.ts
+++ b/authling/e2e/security.test.ts
@@ -29,6 +29,7 @@ for (const path of [
   '/account/email',
   '/account/email/verify',
   '/account/email/complete',
+  '/account/authorizations/revoke',
   '/account/sessions/revoke',
   '/account/sessions/revoke-others',
   '/oidc/consent'

--- a/authling/internal/accounts/accounts.go
+++ b/authling/internal/accounts/accounts.go
@@ -169,6 +169,11 @@ func (*Projection) Subjects() []string {
 
 // Apply adds one durable account fact to the in-memory registry.
 func (p *Projection) Apply(event *corev1.Event, sequence uint64) error {
+	if event.GetOidcGrantAuthorized() != nil || event.GetOidcGrantRevoked() != nil {
+		// Authorization grants share the account aggregate for ordering but are
+		// materialized by their own product projection.
+		return nil
+	}
 	if requested := event.GetPasswordResetRequested(); requested != nil {
 		p.Lock()
 		defer p.Unlock()

--- a/authling/internal/app/runtime.go
+++ b/authling/internal/app/runtime.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"hmans.de/authling/internal/accounts"
 	"hmans.de/authling/internal/authentication"
+	"hmans.de/authling/internal/authorizations"
 	"hmans.de/authling/internal/config"
 	"hmans.de/authling/internal/email"
 	"hmans.de/authling/internal/emailchange"
@@ -49,6 +50,8 @@ type Runtime struct {
 	Authentication *authentication.Service
 	// Sessions owns first-party browser session runtime state.
 	Sessions *sessions.Service
+	// Authorizations owns durable account grants to OIDC clients.
+	Authorizations *authorizations.Service
 	// OIDC provides standards-based identity to configured and CIMD clients.
 	OIDC *oidcprovider.Service
 }
@@ -116,6 +119,12 @@ func newRuntimeWithEmailChangeOptions(ctx context.Context, cfg config.Config, lo
 	issuerProjection := issuer.NewProjection()
 	issuerHandle := events.NewDecodedProjectionHandle(js, stream, issuerProjection, evtstream.Decode, logger)
 	issuerService := issuer.NewService(publisher, issuerHandle, vault, cfg.HTTP.PublicURLOrDefault())
+	authorizationProjection := authorizations.NewProjection()
+	authorizationHandle := events.NewDecodedProjectionHandle(js, stream, authorizationProjection, evtstream.Decode, logger)
+	authorizationService, err := authorizations.NewService(publisher, authorizationHandle, workflowKey)
+	if err != nil {
+		return closeOnError(fmt.Errorf("open authorization grant service: %w", err))
+	}
 	cimd, err := oidcprovider.NewCIMDResolver(
 		cfg.HTTP.PublicURLOrDefault(),
 		nil,
@@ -127,11 +136,11 @@ func newRuntimeWithEmailChangeOptions(ctx context.Context, cfg config.Config, lo
 	}
 	clients := oidcprovider.NewResolver(cfg, cimd)
 	oidcStorage := oidcprovider.NewStorage(stores.RuntimeState, js, workflowKey, clients, issuerService)
-	oidcService := oidcprovider.New(cfg, issuerService, oidcStorage)
+	oidcService := oidcprovider.New(cfg, issuerService, oidcStorage, authorizationService)
 	authenticationService := authentication.New(stores.RuntimeState, js, workflowKey, accountService)
 	return &Runtime{
 		connection:     connection,
-		projectors:     []*events.Projector{handle.Projector(), issuerHandle.Projector()},
+		projectors:     []*events.Projector{handle.Projector(), issuerHandle.Projector(), authorizationHandle.Projector()},
 		issuer:         issuerService,
 		Accounts:       accountService,
 		Registration:   registration.New(stores.RuntimeState, js, workflowKey, sender, accountService),
@@ -139,6 +148,7 @@ func newRuntimeWithEmailChangeOptions(ctx context.Context, cfg config.Config, lo
 		EmailChange:    emailchange.New(stores.RuntimeState, js, workflowKey, sender, accountService, authenticationService, emailChangeOptions...),
 		Authentication: authenticationService,
 		Sessions:       sessionService,
+		Authorizations: authorizationService,
 		OIDC:           oidcService,
 	}, nil
 }
@@ -218,6 +228,7 @@ func Serve(ctx context.Context, cfg config.Config, logger *slog.Logger) (serveEr
 			PasswordReset:     runtime.PasswordReset,
 			EmailChange:       runtime.EmailChange,
 			Sessions:          runtime.Sessions,
+			Authorizations:    runtime.Authorizations,
 			OIDC:              runtime.OIDC,
 			SecureCookies:     cfg.HTTP.SecureCookies(),
 			PublicURL:         cfg.HTTP.PublicURLOrDefault(),

--- a/authling/internal/app/runtime_test.go
+++ b/authling/internal/app/runtime_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/nats-io/nats.go/jetstream"
 	"hmans.de/authling/internal/accounts"
+	"hmans.de/authling/internal/authorizations"
 	"hmans.de/authling/internal/config"
 	"hmans.de/authling/internal/email"
 	"hmans.de/authling/internal/emailchange"
@@ -164,7 +165,7 @@ func TestOIDCAuthorizationCodeFlowAndSingleUseCode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	handler := web.Handler(web.Dependencies{Accounts: runtime.Accounts, Authentication: runtime.Authentication, Registration: runtime.Registration, Sessions: runtime.Sessions, OIDC: runtime.OIDC, PublicURL: cfg.HTTP.PublicURLOrDefault()})
+	handler := web.Handler(web.Dependencies{Accounts: runtime.Accounts, Authentication: runtime.Authentication, Registration: runtime.Registration, Sessions: runtime.Sessions, Authorizations: runtime.Authorizations, OIDC: runtime.OIDC, PublicURL: cfg.HTTP.PublicURLOrDefault()})
 
 	discovery := requestHandler(t, handler, http.MethodGet, "http://localhost:8080/.well-known/openid-configuration", "", nil)
 	if discovery.Code != http.StatusOK || !strings.Contains(discovery.Body.String(), `"issuer":"http://localhost:8080"`) {
@@ -230,6 +231,211 @@ func TestOIDCAuthorizationCodeFlowAndSingleUseCode(t *testing.T) {
 	}
 	if successes != 1 || rejected != 1 {
 		t.Fatalf("concurrent code redemption successes/rejections = %d/%d, want 1/1", successes, rejected)
+	}
+}
+
+func TestOIDCAuthorizationGrantsReuseConsentAndRevokeFutureAccess(t *testing.T) {
+	cfg := embeddedTestConfig(t)
+	cfg.HTTP = config.HTTPConfig{BindAddress: "127.0.0.1:8080", PublicURL: "http://localhost:8080"}
+	cfg.OIDC.Clients = []config.OIDCClientConfig{{ID: "test-client", Name: "Test Client", RedirectURIs: []string{"http://localhost:9999/callback"}}}
+	runtime, cancel, runErrors := startTestRuntime(t, cfg)
+	defer stopTestRuntime(t, runtime, cancel, runErrors)
+	account, err := runtime.Accounts.CreateLocal(testContext(t), "oidc@example.com", "a deliberately uncommon password")
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := web.Handler(web.Dependencies{
+		Accounts: runtime.Accounts, Authentication: runtime.Authentication, Sessions: runtime.Sessions,
+		Authorizations: runtime.Authorizations, OIDC: runtime.OIDC, PublicURL: cfg.HTTP.PublicURLOrDefault(),
+	})
+	login := requestHandler(t, handler, http.MethodPost, "/login", url.Values{
+		"email": {"oidc@example.com"}, "password": {"a deliberately uncommon password"},
+	}.Encode(), nil)
+	if login.Code != http.StatusSeeOther || len(login.Result().Cookies()) != 1 {
+		t.Fatalf("login status/cookies/body = %d %d %s", login.Code, len(login.Result().Cookies()), login.Body.String())
+	}
+	cookie := login.Result().Cookies()[0]
+
+	start := func(prompt string) string {
+		t.Helper()
+		query := url.Values{
+			"client_id": {"test-client"}, "redirect_uri": {"http://localhost:9999/callback"},
+			"response_type": {"code"}, "scope": {"openid"}, "state": {"state-value"},
+			"nonce": {"nonce-value"}, "code_challenge": {"7w_YNF9DSfIdPf_pRjSq646_kPr-2-o9NAl16JGghdM"},
+			"code_challenge_method": {"S256"},
+		}
+		if prompt != "" {
+			query.Set("prompt", prompt)
+		}
+		response := requestHandler(t, handler, http.MethodGet, "/oauth/authorize?"+query.Encode(), "", cookie)
+		location := response.Header().Get("Location")
+		if response.Code < 300 || response.Code >= 400 || !strings.HasPrefix(location, "/oidc/consent?id=") {
+			t.Fatalf("authorization start status/location/body = %d %q %s", response.Code, location, response.Body.String())
+		}
+		return location
+	}
+	finishCallback := func(target string) string {
+		t.Helper()
+		callback := requestHandler(t, handler, http.MethodGet, target, "", cookie)
+		redirect, err := url.Parse(callback.Header().Get("Location"))
+		if err != nil || redirect.Query().Get("code") == "" {
+			t.Fatalf("authorization callback status/location/body = %d %q %s", callback.Code, callback.Header().Get("Location"), callback.Body.String())
+		}
+		return redirect.Query().Get("code")
+	}
+
+	firstLocation := start("")
+	firstPage := requestHandler(t, handler, http.MethodGet, firstLocation, "", cookie)
+	if firstPage.Code != http.StatusOK || !strings.Contains(firstPage.Body.String(), "Authorize Test Client?") {
+		t.Fatalf("first consent status/body = %d %s", firstPage.Code, firstPage.Body.String())
+	}
+	firstURL, _ := url.Parse(firstLocation)
+	allow := requestHandler(t, handler, http.MethodPost, "/oidc/consent", url.Values{
+		"id": {firstURL.Query().Get("id")}, "decision": {"allow"},
+	}.Encode(), cookie)
+	if allow.Code != http.StatusSeeOther {
+		t.Fatalf("allow status/body = %d %s", allow.Code, allow.Body.String())
+	}
+	code := finishCallback(allow.Header().Get("Location"))
+	tokenResponse := redeemCode(t, handler, code, strings.Repeat("v", 43))
+	if tokenResponse.Code != http.StatusOK {
+		t.Fatalf("token status/body = %d %s", tokenResponse.Code, tokenResponse.Body.String())
+	}
+	var tokens struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.Unmarshal(tokenResponse.Body.Bytes(), &tokens); err != nil || tokens.AccessToken == "" {
+		t.Fatalf("decode token response: %v, %+v", err, tokens)
+	}
+
+	grants, err := runtime.Authorizations.List(testContext(t), account.ID)
+	if err != nil || len(grants) != 1 || grants[0].ClientName != "Test Client" {
+		t.Fatalf("active grants = %+v, %v", grants, err)
+	}
+	accountPage := requestHandler(t, handler, http.MethodGet, "/account", "", cookie)
+	if accountPage.Code != http.StatusOK || !strings.Contains(accountPage.Body.String(), "Authorized apps") || !strings.Contains(accountPage.Body.String(), "Test Client") {
+		t.Fatalf("account authorized apps status/body = %d %s", accountPage.Code, accountPage.Body.String())
+	}
+
+	repeat := requestHandler(t, handler, http.MethodGet, start(""), "", cookie)
+	if repeat.Code != http.StatusSeeOther || !strings.HasPrefix(repeat.Header().Get("Location"), "/oauth/authorize/callback?") {
+		t.Fatalf("repeat consent status/location/body = %d %q %s", repeat.Code, repeat.Header().Get("Location"), repeat.Body.String())
+	}
+	_ = finishCallback(repeat.Header().Get("Location"))
+
+	forced := requestHandler(t, handler, http.MethodGet, start("consent"), "", cookie)
+	if forced.Code != http.StatusOK || !strings.Contains(forced.Body.String(), "Authorize Test Client?") {
+		t.Fatalf("forced consent status/body = %d %s", forced.Code, forced.Body.String())
+	}
+
+	forgedRequest := httptest.NewRequest(http.MethodPost, "http://localhost:8080/account/authorizations/revoke", strings.NewReader(url.Values{"grant_id": {grants[0].ID}}.Encode()))
+	forgedRequest.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	forgedRequest.Header.Set("Origin", "https://evil.example")
+	forgedRequest.AddCookie(cookie)
+	forged := httptest.NewRecorder()
+	handler.ServeHTTP(forged, forgedRequest)
+	if forged.Code != http.StatusForbidden {
+		t.Fatalf("cross-origin grant revoke status = %d, want forbidden", forged.Code)
+	}
+	other, err := runtime.Accounts.Create(testContext(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.Authorizations.Revoke(testContext(t), other.ID, grants[0].ID); !errors.Is(err, authorizations.ErrNotFound) {
+		t.Fatalf("cross-account grant revoke error = %v, want not found", err)
+	}
+
+	revoke := requestHandler(t, handler, http.MethodPost, "/account/authorizations/revoke", url.Values{"grant_id": {grants[0].ID}}.Encode(), cookie)
+	if revoke.Code != http.StatusSeeOther || revoke.Header().Get("Location") != "/account?app_revoked=1" {
+		t.Fatalf("grant revoke status/location/body = %d %q %s", revoke.Code, revoke.Header().Get("Location"), revoke.Body.String())
+	}
+	if remaining, err := runtime.Authorizations.List(testContext(t), account.ID); err != nil || len(remaining) != 0 {
+		t.Fatalf("grants after revoke = %+v, %v", remaining, err)
+	}
+
+	userinfoRequest := httptest.NewRequest(http.MethodGet, "http://localhost:8080/oauth/userinfo", nil)
+	userinfoRequest.Header.Set("Authorization", "Bearer "+tokens.AccessToken)
+	userinfo := httptest.NewRecorder()
+	handler.ServeHTTP(userinfo, userinfoRequest)
+	if userinfo.Code != http.StatusOK || !strings.Contains(userinfo.Body.String(), `"sub":"`+account.ID+`"`) {
+		t.Fatalf("userinfo after grant revoke status/body = %d %s", userinfo.Code, userinfo.Body.String())
+	}
+	afterRevokeLocation := start("")
+	afterRevoke := requestHandler(t, handler, http.MethodGet, afterRevokeLocation, "", cookie)
+	if afterRevoke.Code != http.StatusOK || !strings.Contains(afterRevoke.Body.String(), "Authorize Test Client?") {
+		t.Fatalf("consent after revoke status/body = %d %s", afterRevoke.Code, afterRevoke.Body.String())
+	}
+	afterRevokeURL, _ := url.Parse(afterRevokeLocation)
+	reauthorize := requestHandler(t, handler, http.MethodPost, "/oidc/consent", url.Values{
+		"id": {afterRevokeURL.Query().Get("id")}, "decision": {"allow"},
+	}.Encode(), cookie)
+	if reauthorize.Code != http.StatusSeeOther {
+		t.Fatalf("reauthorization status/body = %d %s", reauthorize.Code, reauthorize.Body.String())
+	}
+	reauthorizedGrants, err := runtime.Authorizations.List(testContext(t), account.ID)
+	if err != nil || len(reauthorizedGrants) != 1 || reauthorizedGrants[0].ID == grants[0].ID {
+		t.Fatalf("reauthorized grants = %+v, %v; want a fresh generation", reauthorizedGrants, err)
+	}
+}
+
+func TestOIDCAuthorizationGrantsReplayAfterRestart(t *testing.T) {
+	cfg := embeddedTestConfig(t)
+	first, cancelFirst, firstErrors := startTestRuntime(t, cfg)
+	account, err := first.Accounts.Create(testContext(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	grant, err := first.Authorizations.Authorize(testContext(t), account.ID, authorizations.Client{
+		ID: "client-one", Name: "Client One", Host: "client.example",
+	}, []string{"openid"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	stopTestRuntime(t, first, cancelFirst, firstErrors)
+
+	restarted, cancelRestarted, restartedErrors := startTestRuntime(t, cfg)
+	defer stopTestRuntime(t, restarted, cancelRestarted, restartedErrors)
+	grants, err := restarted.Authorizations.List(testContext(t), account.ID)
+	if err != nil || len(grants) != 1 || grants[0].ID != grant.ID || grants[0].AuthorizationEventID != grant.AuthorizationEventID {
+		t.Fatalf("replayed grants = %+v, %v; want %+v", grants, err, grant)
+	}
+	if _, ok := restarted.Accounts.Get(account.ID); !ok {
+		t.Fatal("account projection failed to replay authorization events")
+	}
+}
+
+func TestConcurrentOIDCAuthorizationsShareOneGrantGeneration(t *testing.T) {
+	runtime, cancel, runErrors := startTestRuntime(t, embeddedTestConfig(t))
+	defer stopTestRuntime(t, runtime, cancel, runErrors)
+	account, err := runtime.Accounts.Create(testContext(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := authorizations.Client{ID: "client-one", Name: "Client One", Host: "client.example"}
+	start := make(chan struct{})
+	results := make(chan authorizations.Grant, 2)
+	errors := make(chan error, 2)
+	for range 2 {
+		go func() {
+			<-start
+			grant, err := runtime.Authorizations.Authorize(t.Context(), account.ID, client, []string{"openid"})
+			results <- grant
+			errors <- err
+		}()
+	}
+	close(start)
+	first, second := <-results, <-results
+	for range 2 {
+		if err := <-errors; err != nil {
+			t.Fatalf("concurrent authorization: %v", err)
+		}
+	}
+	if first.ID == "" || first.ID != second.ID {
+		t.Fatalf("concurrent grants = %+v and %+v", first, second)
+	}
+	grants, err := runtime.Authorizations.List(testContext(t), account.ID)
+	if err != nil || len(grants) != 1 || grants[0].ID != first.ID {
+		t.Fatalf("active grants after concurrent authorization = %+v, %v", grants, err)
 	}
 }
 

--- a/authling/internal/authorizations/authorizations.go
+++ b/authling/internal/authorizations/authorizations.go
@@ -1,0 +1,345 @@
+// Package authorizations owns durable OIDC authorization grants and their
+// account-facing projection.
+package authorizations
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"sort"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"hmans.de/authling/internal/evtstream"
+	"hmans.de/authling/internal/ids"
+	corev1 "hmans.de/authling/internal/pb/authling/core/v1"
+	"hmans.de/chatto/pkg/events"
+)
+
+// ErrNotFound indicates that an account or active authorization grant is not
+// available to the command.
+var ErrNotFound = errors.New("authorization grant not found")
+
+// Client is validated OIDC client metadata supplied to a grant command. ID is
+// reduced to a deployment-keyed digest before persistence; future relying-
+// party grouping may deliberately place more than one client behind a grant.
+type Client struct {
+	ID   string
+	Name string
+	Host string
+}
+
+// Grant is one active account-owned authorization for an exact OIDC client.
+type Grant struct {
+	ID                   string
+	AccountID            string
+	ClientName           string
+	ClientHost           string
+	Scopes               []string
+	AuthorizedAt         time.Time
+	AuthorizationEventID string
+	clientDigest         string
+}
+
+// Projection rebuilds active OIDC grants from account aggregate history.
+type Projection struct {
+	events.MemoryProjection
+	accounts map[string]struct{}
+	byClient map[string]map[string]Grant
+	byID     map[string]map[string]Grant
+	usedIDs  map[string]struct{}
+}
+
+// NewProjection creates an empty authorization-grant projection.
+func NewProjection() *Projection { return &Projection{} }
+
+// Subjects returns the account event family consumed by this projection.
+func (*Projection) Subjects() []string { return []string{evtstream.AccountSubjectFilter} }
+
+// Apply adds one durable account fact to the authorization-grant model.
+func (p *Projection) Apply(event *corev1.Event, _ uint64) error {
+	if created := event.GetAccountCreated(); created != nil {
+		p.Lock()
+		defer p.Unlock()
+		if p.accounts == nil {
+			p.accounts = make(map[string]struct{})
+		}
+		if _, exists := p.accounts[created.GetAccountId()]; exists {
+			return fmt.Errorf("authorization projection saw duplicate account creation")
+		}
+		p.accounts[created.GetAccountId()] = struct{}{}
+		return nil
+	}
+	if authorized := event.GetOidcGrantAuthorized(); authorized != nil {
+		grant := Grant{
+			ID:                   authorized.GetGrantId(),
+			AccountID:            authorized.GetAccountId(),
+			ClientName:           authorized.GetClientName(),
+			ClientHost:           authorized.GetClientHost(),
+			Scopes:               append([]string(nil), authorized.GetScopes()...),
+			AuthorizedAt:         event.GetCreatedAt().AsTime(),
+			AuthorizationEventID: event.GetId(),
+			clientDigest:         string(authorized.GetClientIdDigest()),
+		}
+		p.Lock()
+		defer p.Unlock()
+		if _, exists := p.accounts[grant.AccountID]; !exists {
+			return fmt.Errorf("OIDC grant authorization references an absent account")
+		}
+		if p.byClient == nil {
+			p.byClient = make(map[string]map[string]Grant)
+			p.byID = make(map[string]map[string]Grant)
+			p.usedIDs = make(map[string]struct{})
+		}
+		clients := p.byClient[grant.AccountID]
+		if clients == nil {
+			clients = make(map[string]Grant)
+			p.byClient[grant.AccountID] = clients
+		}
+		grants := p.byID[grant.AccountID]
+		if grants == nil {
+			grants = make(map[string]Grant)
+			p.byID[grant.AccountID] = grants
+		}
+		priorID := authorized.GetPriorAuthorizationEventId()
+		prior, active := clients[grant.clientDigest]
+		if priorID == "" {
+			if active {
+				return fmt.Errorf("new OIDC grant overlaps an active client grant")
+			}
+			if _, used := p.usedIDs[grant.ID]; used {
+				return fmt.Errorf("OIDC grant id was reused after its generation ended")
+			}
+		} else if !active || prior.ID != grant.ID || prior.AuthorizationEventID != priorID {
+			return fmt.Errorf("OIDC grant renewal references another active authorization")
+		}
+		if existing, exists := grants[grant.ID]; exists && existing.clientDigest != grant.clientDigest {
+			return fmt.Errorf("OIDC grant id references multiple clients")
+		}
+		p.usedIDs[grant.ID] = struct{}{}
+		clients[grant.clientDigest] = grant
+		grants[grant.ID] = grant
+		return nil
+	}
+	if revoked := event.GetOidcGrantRevoked(); revoked != nil {
+		p.Lock()
+		defer p.Unlock()
+		if _, exists := p.accounts[revoked.GetAccountId()]; !exists {
+			return fmt.Errorf("OIDC grant revocation references an absent account")
+		}
+		grant, exists := p.byID[revoked.GetAccountId()][revoked.GetGrantId()]
+		if !exists || grant.AuthorizationEventID != revoked.GetAuthorizationEventId() {
+			return fmt.Errorf("OIDC grant revocation references another active authorization")
+		}
+		delete(p.byID[grant.AccountID], grant.ID)
+		delete(p.byClient[grant.AccountID], grant.clientDigest)
+		return nil
+	}
+	// Other account events are historical facts owned by sibling projections.
+	return nil
+}
+
+func (p *Projection) hasAccount(accountID string) bool {
+	p.RLock()
+	defer p.RUnlock()
+	_, ok := p.accounts[accountID]
+	return ok
+}
+
+func (p *Projection) grantForClientDigest(accountID, clientDigest string) (Grant, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	grant, ok := p.byClient[accountID][clientDigest]
+	grant.Scopes = append([]string(nil), grant.Scopes...)
+	return grant, ok
+}
+
+func (p *Projection) grantByID(accountID, grantID string) (Grant, bool) {
+	p.RLock()
+	defer p.RUnlock()
+	grant, ok := p.byID[accountID][grantID]
+	grant.Scopes = append([]string(nil), grant.Scopes...)
+	return grant, ok
+}
+
+func (p *Projection) list(accountID string) []Grant {
+	p.RLock()
+	defer p.RUnlock()
+	grants := make([]Grant, 0, len(p.byID[accountID]))
+	for _, grant := range p.byID[accountID] {
+		grant.Scopes = append([]string(nil), grant.Scopes...)
+		grants = append(grants, grant)
+	}
+	sort.Slice(grants, func(i, j int) bool {
+		if grants[i].AuthorizedAt.Equal(grants[j].AuthorizedAt) {
+			return grants[i].ID < grants[j].ID
+		}
+		return grants[i].AuthorizedAt.After(grants[j].AuthorizedAt)
+	})
+	return grants
+}
+
+// Service validates grant commands, commits them with account OCC, and serves
+// read-your-writes grant decisions.
+type Service struct {
+	publisher *evtstream.Publisher
+	handle    events.ProjectionHandle[*Projection]
+	indexKey  []byte
+}
+
+// NewService constructs the OIDC authorization-grant boundary.
+func NewService(publisher *evtstream.Publisher, handle events.ProjectionHandle[*Projection], indexKey []byte) (*Service, error) {
+	if publisher == nil || handle.Projector() == nil || len(indexKey) != 32 {
+		return nil, fmt.Errorf("authorization grant dependencies are incomplete")
+	}
+	return &Service{publisher: publisher, handle: handle, indexKey: append([]byte(nil), indexKey...)}, nil
+}
+
+// Authorize records explicit consent. Re-consenting renews the current grant;
+// authorizing after revocation creates a new grant generation.
+func (s *Service) Authorize(ctx context.Context, accountID string, client Client, scopes []string) (Grant, error) {
+	if client.ID == "" {
+		return Grant{}, fmt.Errorf("OIDC client id is required")
+	}
+	clientDigest := s.clientDigest(client.ID)
+	for range 5 {
+		tail, err := s.syncAccount(ctx, accountID)
+		if err != nil {
+			return Grant{}, err
+		}
+		prior, active := s.handle.Projection().grantForClientDigest(accountID, clientDigest)
+		grantID := prior.ID
+		priorEventID := prior.AuthorizationEventID
+		if !active {
+			grantID, err = ids.New("grant")
+			if err != nil {
+				return Grant{}, err
+			}
+			priorEventID = ""
+		}
+		eventID, err := ids.New("evt")
+		if err != nil {
+			return Grant{}, err
+		}
+		event := &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_OidcGrantAuthorized{OidcGrantAuthorized: &corev1.OIDCGrantAuthorizedEvent{
+			AccountId: accountID, GrantId: grantID, ClientIdDigest: []byte(clientDigest), ClientName: client.Name, ClientHost: client.Host,
+			Scopes: append([]string(nil), scopes...), PriorAuthorizationEventId: priorEventID,
+		}}}
+		position, err := s.publisher.AppendOIDCGrantAuthorized(ctx, event, tail)
+		if errors.Is(err, events.ErrConflict) {
+			continue
+		}
+		if err != nil {
+			return Grant{}, fmt.Errorf("commit OIDC grant authorization: %w", err)
+		}
+		if err := s.handle.Projector().WaitFor(ctx, position); err != nil {
+			return Grant{}, fmt.Errorf("wait for OIDC grant authorization: %w", err)
+		}
+		grant, ok := s.handle.Projection().grantForClientDigest(accountID, clientDigest)
+		if !ok || grant.ID != grantID {
+			return Grant{}, fmt.Errorf("authorized OIDC grant is absent from projection")
+		}
+		return grant, nil
+	}
+	return Grant{}, fmt.Errorf("OIDC grant authorization conflict")
+}
+
+// Covers reports whether the active client grant contains every requested
+// scope after synchronizing to the account aggregate tail.
+func (s *Service) Covers(ctx context.Context, accountID, clientID string, scopes []string) (bool, error) {
+	if clientID == "" {
+		return false, fmt.Errorf("OIDC client id is required")
+	}
+	if _, err := s.syncAccount(ctx, accountID); err != nil {
+		return false, err
+	}
+	grant, ok := s.handle.Projection().grantForClientDigest(accountID, s.clientDigest(clientID))
+	if !ok {
+		return false, nil
+	}
+	have := make(map[string]struct{}, len(grant.Scopes))
+	for _, scope := range grant.Scopes {
+		have[scope] = struct{}{}
+	}
+	for _, scope := range scopes {
+		if _, ok := have[scope]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// List returns the account's active grants after synchronizing to its durable
+// tail.
+func (s *Service) List(ctx context.Context, accountID string) ([]Grant, error) {
+	if _, err := s.syncAccount(ctx, accountID); err != nil {
+		return nil, err
+	}
+	return s.handle.Projection().list(accountID), nil
+}
+
+// Revoke ends one active grant owned by accountID.
+func (s *Service) Revoke(ctx context.Context, accountID, grantID string) error {
+	for range 5 {
+		tail, err := s.syncAccount(ctx, accountID)
+		if err != nil {
+			return err
+		}
+		grant, ok := s.handle.Projection().grantByID(accountID, grantID)
+		if !ok {
+			return ErrNotFound
+		}
+		eventID, err := ids.New("evt")
+		if err != nil {
+			return err
+		}
+		event := &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_OidcGrantRevoked{OidcGrantRevoked: &corev1.OIDCGrantRevokedEvent{
+			AccountId: accountID, GrantId: grant.ID, AuthorizationEventId: grant.AuthorizationEventID,
+		}}}
+		position, err := s.publisher.AppendOIDCGrantRevoked(ctx, event, tail)
+		if errors.Is(err, events.ErrConflict) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("commit OIDC grant revocation: %w", err)
+		}
+		if err := s.handle.Projector().WaitFor(ctx, position); err != nil {
+			return fmt.Errorf("wait for OIDC grant revocation: %w", err)
+		}
+		if _, ok := s.handle.Projection().grantByID(accountID, grantID); ok {
+			return fmt.Errorf("revoked OIDC grant remains in projection")
+		}
+		return nil
+	}
+	return fmt.Errorf("OIDC grant revocation conflict")
+}
+
+func (s *Service) clientDigest(clientID string) string {
+	digest := hmac.New(sha256.New, s.indexKey)
+	_, _ = digest.Write([]byte("authling:oidc-client-index:v1\x00"))
+	_, _ = digest.Write([]byte(clientID))
+	return string(digest.Sum(nil))
+}
+
+func (s *Service) syncAccount(ctx context.Context, accountID string) (uint64, error) {
+	tail, err := s.publisher.AccountTail(ctx, accountID)
+	if err != nil {
+		return 0, fmt.Errorf("read account tail: %w", err)
+	}
+	if tail == 0 {
+		return 0, ErrNotFound
+	}
+	subject, err := evtstream.AccountSubject(accountID)
+	if err != nil {
+		return 0, ErrNotFound
+	}
+	if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
+		return 0, fmt.Errorf("wait for authorization grants: %w", err)
+	}
+	if !s.handle.Projection().hasAccount(accountID) {
+		return 0, ErrNotFound
+	}
+	return tail, nil
+}

--- a/authling/internal/authorizations/authorizations_test.go
+++ b/authling/internal/authorizations/authorizations_test.go
@@ -1,0 +1,65 @@
+package authorizations
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+	corev1 "hmans.de/authling/internal/pb/authling/core/v1"
+)
+
+func TestProjectionRejectsForkedAndReusedGrantHistory(t *testing.T) {
+	projection := NewProjection()
+	if err := projection.Apply(accountCreated("evt_account"), 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(grantAuthorized("evt_grant", "grant_one", ""), 2); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(grantAuthorized("evt_fork", "grant_one", "evt_other"), 3); err == nil || !strings.Contains(err.Error(), "another active authorization") {
+		t.Fatalf("forked renewal error = %v", err)
+	}
+	if err := projection.Apply(grantRevoked("evt_revoke", "grant_one", "evt_other"), 4); err == nil || !strings.Contains(err.Error(), "another active authorization") {
+		t.Fatalf("forked revocation error = %v", err)
+	}
+	if err := projection.Apply(grantRevoked("evt_revoke", "grant_one", "evt_grant"), 5); err != nil {
+		t.Fatal(err)
+	}
+	if err := projection.Apply(grantAuthorized("evt_reuse", "grant_one", ""), 6); err == nil || !strings.Contains(err.Error(), "reused after its generation ended") {
+		t.Fatalf("reused grant id error = %v", err)
+	}
+}
+
+func TestProjectionRejectsGrantForAbsentAccount(t *testing.T) {
+	projection := NewProjection()
+	if err := projection.Apply(grantAuthorized("evt_grant", "grant_one", ""), 1); err == nil || !strings.Contains(err.Error(), "absent account") {
+		t.Fatalf("absent-account grant error = %v", err)
+	}
+}
+
+func TestClientDigestIsDeploymentKeyed(t *testing.T) {
+	clientID := "https://client.example/metadata?tenant=private"
+	first := (&Service{indexKey: []byte("first deployment key")}).clientDigest(clientID)
+	second := (&Service{indexKey: []byte("second deployment key")}).clientDigest(clientID)
+	if len(first) != 32 || first == second || bytes.Contains([]byte(first), []byte(clientID)) {
+		t.Fatalf("client digests do not provide a keyed opaque index")
+	}
+}
+
+func accountCreated(eventID string) *corev1.Event {
+	return &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_AccountCreated{AccountCreated: &corev1.AccountCreatedEvent{AccountId: "acc_one"}}}
+}
+
+func grantAuthorized(eventID, grantID, priorEventID string) *corev1.Event {
+	return &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_OidcGrantAuthorized{OidcGrantAuthorized: &corev1.OIDCGrantAuthorizedEvent{
+		AccountId: "acc_one", GrantId: grantID, ClientIdDigest: make([]byte, 32), ClientName: "Client One", ClientHost: "client.example",
+		Scopes: []string{"openid"}, PriorAuthorizationEventId: priorEventID,
+	}}}
+}
+
+func grantRevoked(eventID, grantID, authorizationEventID string) *corev1.Event {
+	return &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_OidcGrantRevoked{OidcGrantRevoked: &corev1.OIDCGrantRevokedEvent{
+		AccountId: "acc_one", GrantId: grantID, AuthorizationEventId: authorizationEventID,
+	}}}
+}

--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -4,6 +4,7 @@ package evtstream
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -225,6 +226,50 @@ func (p *Publisher) AppendEmailChanged(
 	return events.SubjectPosition(accountRegistrySubject, sequences[1]), nil
 }
 
+// AppendOIDCGrantAuthorized records a new or explicitly renewed OIDC grant at
+// an observed account tail.
+func (p *Publisher) AppendOIDCGrantAuthorized(ctx context.Context, event *corev1.Event, expectedTail uint64) (events.StreamPosition, error) {
+	payload := event.GetOidcGrantAuthorized()
+	if payload == nil {
+		return events.StreamPosition{}, fmt.Errorf("append OIDC grant authorized: event payload is not oidc_grant_authorized")
+	}
+	subject, err := AccountSubject(payload.GetAccountId())
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	record, err := encode(event)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	return events.SubjectPosition(subject, sequence), nil
+}
+
+// AppendOIDCGrantRevoked records revocation of an active OIDC grant at an
+// observed account tail.
+func (p *Publisher) AppendOIDCGrantRevoked(ctx context.Context, event *corev1.Event, expectedTail uint64) (events.StreamPosition, error) {
+	payload := event.GetOidcGrantRevoked()
+	if payload == nil {
+		return events.StreamPosition{}, fmt.Errorf("append OIDC grant revoked: event payload is not oidc_grant_revoked")
+	}
+	subject, err := AccountSubject(payload.GetAccountId())
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	record, err := encode(event)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	return events.SubjectPosition(subject, sequence), nil
+}
+
 // AppendIssuerEstablished creates the singleton issuer aggregate.
 func (p *Publisher) AppendIssuerEstablished(ctx context.Context, event *corev1.Event) (events.StreamPosition, error) {
 	if event.GetIssuerEstablished() == nil {
@@ -336,6 +381,19 @@ func validate(event *corev1.Event) error {
 		if !validSubjectToken(credential.GetAccountId()) || credential.GetCredentialEnvelopeVersion() != 1 || !validSubjectToken(credential.GetUserKeyRef()) || !validSubjectToken(credential.GetCredentialKeyRef()) || len(credential.GetEmailNonce()) == 0 || len(credential.GetEmailCiphertext()) == 0 || !validSubjectToken(credential.GetEmailChangeRequestEventId()) || !validSubjectToken(credential.GetPriorCredentialEventId()) {
 			return fmt.Errorf("email credential envelope is incomplete or unsupported")
 		}
+	case *corev1.Event_OidcGrantAuthorized:
+		grant := payload.OidcGrantAuthorized
+		if !validSubjectToken(grant.GetAccountId()) || !validSubjectToken(grant.GetGrantId()) || len(grant.GetClientIdDigest()) != sha256.Size || strings.TrimSpace(grant.GetClientName()) == "" || len(grant.GetClientName()) > 256 || strings.TrimSpace(grant.GetClientHost()) == "" || len(grant.GetClientHost()) > 256 || !validScopes(grant.GetScopes()) {
+			return fmt.Errorf("OIDC grant authorization is incomplete or invalid")
+		}
+		if priorID := grant.GetPriorAuthorizationEventId(); priorID != "" && !validSubjectToken(priorID) {
+			return fmt.Errorf("OIDC grant prior authorization event id is invalid")
+		}
+	case *corev1.Event_OidcGrantRevoked:
+		grant := payload.OidcGrantRevoked
+		if !validSubjectToken(grant.GetAccountId()) || !validSubjectToken(grant.GetGrantId()) || !validSubjectToken(grant.GetAuthorizationEventId()) {
+			return fmt.Errorf("OIDC grant revocation is incomplete or invalid")
+		}
 	case *corev1.Event_IssuerEstablished:
 		if payload.IssuerEstablished.GetIssuer() == "" || payload.IssuerEstablished.GetSigningKeyRef() == "" || payload.IssuerEstablished.GetSigningKeyId() == "" {
 			return fmt.Errorf("issuer establishment is incomplete")
@@ -344,6 +402,23 @@ func validate(event *corev1.Event) error {
 		return fmt.Errorf("Authling event payload is required")
 	}
 	return nil
+}
+
+func validScopes(scopes []string) bool {
+	if len(scopes) == 0 || len(scopes) > 32 {
+		return false
+	}
+	seen := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		if scope == "" || len(scope) > 256 || strings.ContainsAny(scope, " \t\r\n") {
+			return false
+		}
+		if _, exists := seen[scope]; exists {
+			return false
+		}
+		seen[scope] = struct{}{}
+	}
+	return true
 }
 
 // AccountSubject returns the durable subject for one account aggregate.

--- a/authling/internal/evtstream/evtstream_test.go
+++ b/authling/internal/evtstream/evtstream_test.go
@@ -171,6 +171,26 @@ func TestDecodeRejectsMalformedEvents(t *testing.T) {
 	if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "signed-in password change correlation is invalid") {
 		t.Fatalf("decode uncorrelated signed-in password change error = %v", err)
 	}
+	malformedGrant := &corev1.Event{Id: "evt_grant", CreatedAt: timestamppb.Now(), Event: &corev1.Event_OidcGrantAuthorized{OidcGrantAuthorized: &corev1.OIDCGrantAuthorizedEvent{
+		AccountId: "acc_test", GrantId: "grant_test", ClientIdDigest: make([]byte, 32), ClientName: "Client", ClientHost: "client.example", Scopes: []string{"openid", "openid"},
+	}}}
+	data, err = proto.Marshal(malformedGrant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "OIDC grant authorization is incomplete or invalid") {
+		t.Fatalf("decode duplicate grant scopes error = %v", err)
+	}
+	malformedRevocation := &corev1.Event{Id: "evt_revoke", CreatedAt: timestamppb.Now(), Event: &corev1.Event_OidcGrantRevoked{OidcGrantRevoked: &corev1.OIDCGrantRevokedEvent{
+		AccountId: "acc_test", GrantId: "grant_test",
+	}}}
+	data, err = proto.Marshal(malformedRevocation)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "OIDC grant revocation is incomplete or invalid") {
+		t.Fatalf("decode uncorrelated grant revocation error = %v", err)
+	}
 }
 
 func TestAccountSubjectRejectsUnsafeTokens(t *testing.T) {

--- a/authling/internal/oidcprovider/provider.go
+++ b/authling/internal/oidcprovider/provider.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/cors"
 	liboidc "github.com/zitadel/oidc/v3/pkg/oidc"
 	"github.com/zitadel/oidc/v3/pkg/op"
+	"hmans.de/authling/internal/authorizations"
 	"hmans.de/authling/internal/config"
 	"hmans.de/authling/internal/issuer"
 )
@@ -22,6 +23,7 @@ import (
 type Service struct {
 	issuer  *issuer.Service
 	storage *Storage
+	grants  *authorizations.Service
 	cfg     config.Config
 
 	mu       sync.RWMutex
@@ -30,8 +32,8 @@ type Service struct {
 }
 
 // New constructs the provider boundary. Initialize must run after issuer initialization.
-func New(cfg config.Config, issuerService *issuer.Service, storage *Storage) *Service {
-	return &Service{cfg: cfg, issuer: issuerService, storage: storage}
+func New(cfg config.Config, issuerService *issuer.Service, storage *Storage, grants *authorizations.Service) *Service {
+	return &Service{cfg: cfg, issuer: issuerService, storage: storage, grants: grants}
 }
 
 // Initialize constructs the protocol engine using the durable issuer identity.
@@ -93,9 +95,49 @@ func (s *Service) Consent(ctx context.Context, id string) (ConsentRequest, error
 
 // Authorize approves a pending request for the authenticated account and returns the provider callback.
 func (s *Service) Authorize(ctx context.Context, id, accountID string) (string, error) {
+	consent, err := s.storage.Consent(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	if s.grants == nil {
+		return "", fmt.Errorf("OIDC authorization grants unavailable")
+	}
+	if _, err := s.grants.Authorize(ctx, accountID, authorizations.Client{
+		ID: consent.ClientID, Name: consent.ClientName, Host: consent.ClientHost,
+	}, consent.Scopes); err != nil {
+		return "", err
+	}
 	if err := s.storage.Authorize(ctx, id, accountID); err != nil {
 		return "", err
 	}
+	return s.callback(ctx, id)
+}
+
+// TryAuthorize approves a pending request from an existing durable grant.
+// prompt=consent always returns false so the browser sees explicit consent.
+func (s *Service) TryAuthorize(ctx context.Context, id, accountID string) (string, bool, error) {
+	consent, err := s.storage.Consent(ctx, id)
+	if err != nil {
+		return "", false, err
+	}
+	if consent.ForceConsent || s.grants == nil {
+		return "", false, nil
+	}
+	covered, err := s.grants.Covers(ctx, accountID, consent.ClientID, consent.Scopes)
+	if err != nil {
+		return "", false, err
+	}
+	if !covered {
+		return "", false, nil
+	}
+	if err := s.storage.Authorize(ctx, id, accountID); err != nil {
+		return "", false, err
+	}
+	target, err := s.callback(ctx, id)
+	return target, err == nil, err
+}
+
+func (s *Service) callback(ctx context.Context, id string) (string, error) {
 	s.mu.RLock()
 	provider := s.provider
 	s.mu.RUnlock()
@@ -199,7 +241,7 @@ func validateAuthorizeRequest(r *http.Request) error {
 		return fmt.Errorf("authorization query is too large")
 	}
 	query := r.URL.Query()
-	for _, name := range []string{"client_id", "redirect_uri", "response_type", "scope", "code_challenge", "code_challenge_method", "state", "nonce"} {
+	for _, name := range []string{"client_id", "redirect_uri", "response_type", "scope", "code_challenge", "code_challenge_method", "state", "nonce", "prompt"} {
 		if len(query[name]) > 1 {
 			return fmt.Errorf("duplicate parameter")
 		}

--- a/authling/internal/oidcprovider/storage.go
+++ b/authling/internal/oidcprovider/storage.go
@@ -51,6 +51,7 @@ type authRequestState struct {
 	ResponseMode  liboidc.ResponseMode        `json:"response_mode,omitempty"`
 	CodeChallenge string                      `json:"code_challenge"`
 	CodeMethod    liboidc.CodeChallengeMethod `json:"code_challenge_method"`
+	ForceConsent  bool                        `json:"force_consent,omitempty"`
 	Subject       string                      `json:"subject,omitempty"`
 	Authorized    bool                        `json:"authorized"`
 	AuthTime      time.Time                   `json:"auth_time,omitempty"`
@@ -94,8 +95,9 @@ type tokenState struct {
 
 // ConsentRequest contains the non-sensitive metadata shown to an authenticated user.
 type ConsentRequest struct {
-	ID, ClientName, ClientHost, RedirectOrigin string
-	Scopes                                     []string
+	ID, ClientID, ClientName, ClientHost, RedirectOrigin string
+	Scopes                                               []string
+	ForceConsent                                         bool
 }
 
 // Storage persists OIDC protocol state in Authling's encrypted runtime bucket.
@@ -128,6 +130,7 @@ func (s *Storage) CreateAuthRequest(ctx context.Context, request *liboidc.AuthRe
 		State: request.State, Nonce: request.Nonce, Scopes: append([]string(nil), request.Scopes...),
 		ResponseType: request.ResponseType, ResponseMode: request.ResponseMode,
 		CodeChallenge: request.CodeChallenge, CodeMethod: request.CodeChallengeMethod,
+		ForceConsent: len(request.Prompt) == 1 && request.Prompt[0] == liboidc.PromptConsent,
 	}
 	if err := s.create(ctx, s.requestKey(id), state, authRequestLifetime); err != nil {
 		return nil, err
@@ -208,9 +211,10 @@ func (s *Storage) Consent(ctx context.Context, id string) (ConsentRequest, error
 		return ConsentRequest{}, errOIDCStateNotFound
 	}
 	return ConsentRequest{
-		ID: state.ID, ClientName: state.ClientName, ClientHost: state.ClientHost,
+		ID: state.ID, ClientID: state.ClientID, ClientName: state.ClientName, ClientHost: state.ClientHost,
 		RedirectOrigin: redirectOrigin,
 		Scopes:         append([]string(nil), state.Scopes...),
+		ForceConsent:   state.ForceConsent,
 	}, nil
 }
 

--- a/authling/internal/pb/authling/core/v1/event.pb.go
+++ b/authling/internal/pb/authling/core/v1/event.pb.go
@@ -90,6 +90,8 @@ type Event struct {
 	//	*Event_PasswordResetRequested
 	//	*Event_EmailChangeRequested
 	//	*Event_EmailChanged
+	//	*Event_OidcGrantAuthorized
+	//	*Event_OidcGrantRevoked
 	Event         isEvent_Event `protobuf_oneof:"event"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -209,6 +211,24 @@ func (x *Event) GetEmailChanged() *EmailChangedEvent {
 	return nil
 }
 
+func (x *Event) GetOidcGrantAuthorized() *OIDCGrantAuthorizedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_OidcGrantAuthorized); ok {
+			return x.OidcGrantAuthorized
+		}
+	}
+	return nil
+}
+
+func (x *Event) GetOidcGrantRevoked() *OIDCGrantRevokedEvent {
+	if x != nil {
+		if x, ok := x.Event.(*Event_OidcGrantRevoked); ok {
+			return x.OidcGrantRevoked
+		}
+	}
+	return nil
+}
+
 type isEvent_Event interface {
 	isEvent_Event()
 }
@@ -241,6 +261,14 @@ type Event_EmailChanged struct {
 	EmailChanged *EmailChangedEvent `protobuf:"bytes,106,opt,name=email_changed,json=emailChanged,proto3,oneof"`
 }
 
+type Event_OidcGrantAuthorized struct {
+	OidcGrantAuthorized *OIDCGrantAuthorizedEvent `protobuf:"bytes,107,opt,name=oidc_grant_authorized,json=oidcGrantAuthorized,proto3,oneof"`
+}
+
+type Event_OidcGrantRevoked struct {
+	OidcGrantRevoked *OIDCGrantRevokedEvent `protobuf:"bytes,108,opt,name=oidc_grant_revoked,json=oidcGrantRevoked,proto3,oneof"`
+}
+
 func (*Event_AccountCreated) isEvent_Event() {}
 
 func (*Event_EmailClaimed) isEvent_Event() {}
@@ -254,6 +282,10 @@ func (*Event_PasswordResetRequested) isEvent_Event() {}
 func (*Event_EmailChangeRequested) isEvent_Event() {}
 
 func (*Event_EmailChanged) isEvent_Event() {}
+
+func (*Event_OidcGrantAuthorized) isEvent_Event() {}
+
+func (*Event_OidcGrantRevoked) isEvent_Event() {}
 
 // IssuerEstablishedEvent permanently binds one Authling deployment to its
 // externally visible OpenID Connect issuer and initial signing-key identity.
@@ -805,11 +837,171 @@ func (x *EmailChangedEvent) GetPriorCredentialEventId() string {
 	return ""
 }
 
+// OIDCGrantAuthorizedEvent records an account's authorization of one exact
+// OIDC client and scope set. Repeated explicit consent renews the active grant
+// by correlating it to the preceding authorization event.
+type OIDCGrantAuthorizedEvent struct {
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	AccountId string                 `protobuf:"bytes,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	GrantId   string                 `protobuf:"bytes,2,opt,name=grant_id,json=grantId,proto3" json:"grant_id,omitempty"`
+	// Deployment-keyed digest of the exact client ID. The raw configured ID or
+	// CIMD URL is not retained in durable account history.
+	ClientIdDigest []byte   `protobuf:"bytes,3,opt,name=client_id_digest,json=clientIdDigest,proto3" json:"client_id_digest,omitempty"`
+	ClientName     string   `protobuf:"bytes,4,opt,name=client_name,json=clientName,proto3" json:"client_name,omitempty"`
+	ClientHost     string   `protobuf:"bytes,5,opt,name=client_host,json=clientHost,proto3" json:"client_host,omitempty"`
+	Scopes         []string `protobuf:"bytes,6,rep,name=scopes,proto3" json:"scopes,omitempty"`
+	// Empty for a new grant. Renewals identify the active authorization event
+	// they replace so replay rejects stale or forked grant history.
+	PriorAuthorizationEventId string `protobuf:"bytes,7,opt,name=prior_authorization_event_id,json=priorAuthorizationEventId,proto3" json:"prior_authorization_event_id,omitempty"`
+	unknownFields             protoimpl.UnknownFields
+	sizeCache                 protoimpl.SizeCache
+}
+
+func (x *OIDCGrantAuthorizedEvent) Reset() {
+	*x = OIDCGrantAuthorizedEvent{}
+	mi := &file_authling_core_v1_event_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OIDCGrantAuthorizedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OIDCGrantAuthorizedEvent) ProtoMessage() {}
+
+func (x *OIDCGrantAuthorizedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_authling_core_v1_event_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OIDCGrantAuthorizedEvent.ProtoReflect.Descriptor instead.
+func (*OIDCGrantAuthorizedEvent) Descriptor() ([]byte, []int) {
+	return file_authling_core_v1_event_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetGrantId() string {
+	if x != nil {
+		return x.GrantId
+	}
+	return ""
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetClientIdDigest() []byte {
+	if x != nil {
+		return x.ClientIdDigest
+	}
+	return nil
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetClientName() string {
+	if x != nil {
+		return x.ClientName
+	}
+	return ""
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetClientHost() string {
+	if x != nil {
+		return x.ClientHost
+	}
+	return ""
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetScopes() []string {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
+func (x *OIDCGrantAuthorizedEvent) GetPriorAuthorizationEventId() string {
+	if x != nil {
+		return x.PriorAuthorizationEventId
+	}
+	return ""
+}
+
+// OIDCGrantRevokedEvent ends one active authorization-grant generation.
+type OIDCGrantRevokedEvent struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	AccountId            string                 `protobuf:"bytes,1,opt,name=account_id,json=accountId,proto3" json:"account_id,omitempty"`
+	GrantId              string                 `protobuf:"bytes,2,opt,name=grant_id,json=grantId,proto3" json:"grant_id,omitempty"`
+	AuthorizationEventId string                 `protobuf:"bytes,3,opt,name=authorization_event_id,json=authorizationEventId,proto3" json:"authorization_event_id,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *OIDCGrantRevokedEvent) Reset() {
+	*x = OIDCGrantRevokedEvent{}
+	mi := &file_authling_core_v1_event_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *OIDCGrantRevokedEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OIDCGrantRevokedEvent) ProtoMessage() {}
+
+func (x *OIDCGrantRevokedEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_authling_core_v1_event_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OIDCGrantRevokedEvent.ProtoReflect.Descriptor instead.
+func (*OIDCGrantRevokedEvent) Descriptor() ([]byte, []int) {
+	return file_authling_core_v1_event_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *OIDCGrantRevokedEvent) GetAccountId() string {
+	if x != nil {
+		return x.AccountId
+	}
+	return ""
+}
+
+func (x *OIDCGrantRevokedEvent) GetGrantId() string {
+	if x != nil {
+		return x.GrantId
+	}
+	return ""
+}
+
+func (x *OIDCGrantRevokedEvent) GetAuthorizationEventId() string {
+	if x != nil {
+		return x.AuthorizationEventId
+	}
+	return ""
+}
+
 var File_authling_core_v1_event_proto protoreflect.FileDescriptor
 
 const file_authling_core_v1_event_proto_rawDesc = "" +
 	"\n" +
-	"\x1cauthling/core/v1/event.proto\x12\x10authling.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc5\x05\n" +
+	"\x1cauthling/core/v1/event.proto\x12\x10authling.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x80\a\n" +
 	"\x05Event\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
@@ -820,7 +1012,9 @@ const file_authling_core_v1_event_proto_rawDesc = "" +
 	"\x10password_changed\x18g \x01(\v2&.authling.core.v1.PasswordChangedEventH\x00R\x0fpasswordChanged\x12i\n" +
 	"\x18password_reset_requested\x18h \x01(\v2-.authling.core.v1.PasswordResetRequestedEventH\x00R\x16passwordResetRequested\x12c\n" +
 	"\x16email_change_requested\x18i \x01(\v2+.authling.core.v1.EmailChangeRequestedEventH\x00R\x14emailChangeRequested\x12J\n" +
-	"\remail_changed\x18j \x01(\v2#.authling.core.v1.EmailChangedEventH\x00R\femailChangedB\a\n" +
+	"\remail_changed\x18j \x01(\v2#.authling.core.v1.EmailChangedEventH\x00R\femailChanged\x12`\n" +
+	"\x15oidc_grant_authorized\x18k \x01(\v2*.authling.core.v1.OIDCGrantAuthorizedEventH\x00R\x13oidcGrantAuthorized\x12W\n" +
+	"\x12oidc_grant_revoked\x18l \x01(\v2'.authling.core.v1.OIDCGrantRevokedEventH\x00R\x10oidcGrantRevokedB\a\n" +
 	"\x05event\"~\n" +
 	"\x16IssuerEstablishedEvent\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12&\n" +
@@ -873,7 +1067,23 @@ const file_authling_core_v1_event_proto_rawDesc = "" +
 	"emailNonce\x12)\n" +
 	"\x10email_ciphertext\x18\x06 \x01(\fR\x0femailCiphertext\x12@\n" +
 	"\x1demail_change_request_event_id\x18\a \x01(\tR\x19emailChangeRequestEventId\x129\n" +
-	"\x19prior_credential_event_id\x18\b \x01(\tR\x16priorCredentialEventId*\x81\x01\n" +
+	"\x19prior_credential_event_id\x18\b \x01(\tR\x16priorCredentialEventId\"\x99\x02\n" +
+	"\x18OIDCGrantAuthorizedEvent\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\tR\taccountId\x12\x19\n" +
+	"\bgrant_id\x18\x02 \x01(\tR\agrantId\x12(\n" +
+	"\x10client_id_digest\x18\x03 \x01(\fR\x0eclientIdDigest\x12\x1f\n" +
+	"\vclient_name\x18\x04 \x01(\tR\n" +
+	"clientName\x12\x1f\n" +
+	"\vclient_host\x18\x05 \x01(\tR\n" +
+	"clientHost\x12\x16\n" +
+	"\x06scopes\x18\x06 \x03(\tR\x06scopes\x12?\n" +
+	"\x1cprior_authorization_event_id\x18\a \x01(\tR\x19priorAuthorizationEventId\"\x87\x01\n" +
+	"\x15OIDCGrantRevokedEvent\x12\x1d\n" +
+	"\n" +
+	"account_id\x18\x01 \x01(\tR\taccountId\x12\x19\n" +
+	"\bgrant_id\x18\x02 \x01(\tR\agrantId\x124\n" +
+	"\x16authorization_event_id\x18\x03 \x01(\tR\x14authorizationEventId*\x81\x01\n" +
 	"\x12PasswordChangeKind\x12$\n" +
 	" PASSWORD_CHANGE_KIND_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dPASSWORD_CHANGE_KIND_RECOVERY\x10\x01\x12\"\n" +
@@ -892,7 +1102,7 @@ func file_authling_core_v1_event_proto_rawDescGZIP() []byte {
 }
 
 var file_authling_core_v1_event_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_authling_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_authling_core_v1_event_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_authling_core_v1_event_proto_goTypes = []any{
 	(PasswordChangeKind)(0),             // 0: authling.core.v1.PasswordChangeKind
 	(*Event)(nil),                       // 1: authling.core.v1.Event
@@ -903,23 +1113,27 @@ var file_authling_core_v1_event_proto_goTypes = []any{
 	(*PasswordResetRequestedEvent)(nil), // 6: authling.core.v1.PasswordResetRequestedEvent
 	(*EmailChangeRequestedEvent)(nil),   // 7: authling.core.v1.EmailChangeRequestedEvent
 	(*EmailChangedEvent)(nil),           // 8: authling.core.v1.EmailChangedEvent
-	(*timestamppb.Timestamp)(nil),       // 9: google.protobuf.Timestamp
+	(*OIDCGrantAuthorizedEvent)(nil),    // 9: authling.core.v1.OIDCGrantAuthorizedEvent
+	(*OIDCGrantRevokedEvent)(nil),       // 10: authling.core.v1.OIDCGrantRevokedEvent
+	(*timestamppb.Timestamp)(nil),       // 11: google.protobuf.Timestamp
 }
 var file_authling_core_v1_event_proto_depIdxs = []int32{
-	9, // 0: authling.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
-	4, // 1: authling.core.v1.Event.account_created:type_name -> authling.core.v1.AccountCreatedEvent
-	3, // 2: authling.core.v1.Event.email_claimed:type_name -> authling.core.v1.EmailClaimedEvent
-	2, // 3: authling.core.v1.Event.issuer_established:type_name -> authling.core.v1.IssuerEstablishedEvent
-	5, // 4: authling.core.v1.Event.password_changed:type_name -> authling.core.v1.PasswordChangedEvent
-	6, // 5: authling.core.v1.Event.password_reset_requested:type_name -> authling.core.v1.PasswordResetRequestedEvent
-	7, // 6: authling.core.v1.Event.email_change_requested:type_name -> authling.core.v1.EmailChangeRequestedEvent
-	8, // 7: authling.core.v1.Event.email_changed:type_name -> authling.core.v1.EmailChangedEvent
-	0, // 8: authling.core.v1.PasswordChangedEvent.kind:type_name -> authling.core.v1.PasswordChangeKind
-	9, // [9:9] is the sub-list for method output_type
-	9, // [9:9] is the sub-list for method input_type
-	9, // [9:9] is the sub-list for extension type_name
-	9, // [9:9] is the sub-list for extension extendee
-	0, // [0:9] is the sub-list for field type_name
+	11, // 0: authling.core.v1.Event.created_at:type_name -> google.protobuf.Timestamp
+	4,  // 1: authling.core.v1.Event.account_created:type_name -> authling.core.v1.AccountCreatedEvent
+	3,  // 2: authling.core.v1.Event.email_claimed:type_name -> authling.core.v1.EmailClaimedEvent
+	2,  // 3: authling.core.v1.Event.issuer_established:type_name -> authling.core.v1.IssuerEstablishedEvent
+	5,  // 4: authling.core.v1.Event.password_changed:type_name -> authling.core.v1.PasswordChangedEvent
+	6,  // 5: authling.core.v1.Event.password_reset_requested:type_name -> authling.core.v1.PasswordResetRequestedEvent
+	7,  // 6: authling.core.v1.Event.email_change_requested:type_name -> authling.core.v1.EmailChangeRequestedEvent
+	8,  // 7: authling.core.v1.Event.email_changed:type_name -> authling.core.v1.EmailChangedEvent
+	9,  // 8: authling.core.v1.Event.oidc_grant_authorized:type_name -> authling.core.v1.OIDCGrantAuthorizedEvent
+	10, // 9: authling.core.v1.Event.oidc_grant_revoked:type_name -> authling.core.v1.OIDCGrantRevokedEvent
+	0,  // 10: authling.core.v1.PasswordChangedEvent.kind:type_name -> authling.core.v1.PasswordChangeKind
+	11, // [11:11] is the sub-list for method output_type
+	11, // [11:11] is the sub-list for method input_type
+	11, // [11:11] is the sub-list for extension type_name
+	11, // [11:11] is the sub-list for extension extendee
+	0,  // [0:11] is the sub-list for field type_name
 }
 
 func init() { file_authling_core_v1_event_proto_init() }
@@ -935,6 +1149,8 @@ func file_authling_core_v1_event_proto_init() {
 		(*Event_PasswordResetRequested)(nil),
 		(*Event_EmailChangeRequested)(nil),
 		(*Event_EmailChanged)(nil),
+		(*Event_OidcGrantAuthorized)(nil),
+		(*Event_OidcGrantRevoked)(nil),
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -942,7 +1158,7 @@ func file_authling_core_v1_event_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_authling_core_v1_event_proto_rawDesc), len(file_authling_core_v1_event_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"strconv"
 	"time"
+	"hmans.de/authling/internal/authorizations"
 	"hmans.de/authling/internal/oidcprovider"
 	"hmans.de/authling/internal/sessions"
 )
@@ -261,7 +262,7 @@ templ accountCreatedPage(accountID string) {
 	}
 }
 
-templ accountPage(accountID, signedInAs string, browserSessions []sessions.BrowserSession, passwordChanged, emailChanged, notificationFailed, sessionRevoked, otherSessionsRevoked, sessionMissing bool) {
+templ accountPage(accountID, signedInAs string, browserSessions []sessions.BrowserSession, authorizationGrants []authorizations.Grant, passwordChanged, emailChanged, notificationFailed, sessionRevoked, otherSessionsRevoked, sessionMissing, appRevoked, appMissing bool) {
 	@layout("Your Authling account", signedInAs) {
 		<h1 class="text-3xl font-semibold tracking-tight">Your account</h1>
 		<p class="mt-3 text-slate-600 dark:text-slate-300">Your browser has an active Authling session.</p>
@@ -283,12 +284,43 @@ templ accountPage(accountID, signedInAs string, browserSessions []sessions.Brows
 		if sessionMissing {
 			<p role="status" class="notice notice-neutral">That browser session is no longer active.</p>
 		}
+		if appRevoked {
+			<p role="status" class="notice notice-success">The app’s authorization was revoked. It must ask for access again in a future authorization flow.</p>
+		}
+		if appMissing {
+			<p role="status" class="notice notice-neutral">That app is no longer authorized.</p>
+		}
 		<p class="mt-6 text-sm text-slate-500 dark:text-slate-400">Account ID: <code>{ accountID }</code></p>
 		<a class="button button-secondary mt-8 w-full" href="/account/email">Change email address</a>
 		<a class="button button-secondary mt-3 w-full" href="/account/password">Change password</a>
 		<form class="mt-3" method="post" action="/logout">
 			<button class="button button-secondary w-full" type="submit">Sign out</button>
 		</form>
+		<div class="mt-10 border-t border-slate-200 pt-8 dark:border-slate-800">
+			<h2 class="text-xl font-semibold tracking-tight">Authorized apps</h2>
+			<p class="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">Apps you allowed to know your stable Authling account identifier. Revoking an app makes it ask again next time; existing app sessions and issued tokens are not ended here.</p>
+			if len(authorizationGrants) == 0 {
+				<p class="mt-5 rounded-2xl border border-slate-200 p-4 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400">You haven’t authorized any apps yet.</p>
+			} else {
+				<div class="mt-5 space-y-3">
+					for _, grant := range authorizationGrants {
+						<div class="rounded-2xl border border-slate-200 p-4 dark:border-slate-700">
+							<div class="flex flex-col items-start gap-4 sm:flex-row sm:justify-between">
+								<div class="min-w-0">
+									<p class="font-semibold">{ grant.ClientName }</p>
+									<p class="mt-1 break-words text-sm text-slate-500 dark:text-slate-400">{ grant.ClientHost }</p>
+									<p class="mt-2 text-sm text-slate-500 dark:text-slate-400">Authorized { formatSessionTime(grant.AuthorizedAt) }</p>
+								</div>
+								<form class="w-full sm:w-auto" method="post" action="/account/authorizations/revoke">
+									<input type="hidden" name="grant_id" value={ grant.ID }/>
+									<button class="button button-danger button-compact w-full whitespace-nowrap sm:w-auto" type="submit">Revoke access</button>
+								</form>
+							</div>
+						</div>
+					}
+				</div>
+			}
+		</div>
 		<div class="mt-10 border-t border-slate-200 pt-8 dark:border-slate-800">
 			<h2 class="text-xl font-semibold tracking-tight">Browser sessions</h2>
 			<p class="mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300">Review where your account is signed in. Authling does not store browser names, IP addresses, or locations.</p>

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -9,6 +9,7 @@ import "github.com/a-h/templ"
 import templruntime "github.com/a-h/templ/runtime"
 
 import (
+	"hmans.de/authling/internal/authorizations"
 	"hmans.de/authling/internal/oidcprovider"
 	"hmans.de/authling/internal/sessions"
 	"net/url"
@@ -44,7 +45,7 @@ func layout(title, signedInAs string) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 18, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 19, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -62,7 +63,7 @@ func layout(title, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue("Signed in as " + signedInAs + ". View your account.")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 29, Col: 306}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 30, Col: 306}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 			if templ_7745c5c3_Err != nil {
@@ -75,7 +76,7 @@ func layout(title, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(signedInAs)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 32, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 33, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 			if templ_7745c5c3_Err != nil {
@@ -88,7 +89,7 @@ func layout(title, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(signedInAs)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 32, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 33, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -207,7 +208,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 65, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 66, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -230,7 +231,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 69, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 70, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 				if templ_7745c5c3_Err != nil {
@@ -248,7 +249,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(passwordResetURL(oidcRequest))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 75, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 76, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -320,7 +321,7 @@ func passwordResetPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 92, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 93, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -343,7 +344,7 @@ func passwordResetPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 96, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 97, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 				if templ_7745c5c3_Err != nil {
@@ -413,7 +414,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var19 string
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 110, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 111, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
@@ -431,7 +432,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 113, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 114, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 			if templ_7745c5c3_Err != nil {
@@ -449,7 +450,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var21 string
 				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 115, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 116, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 				if templ_7745c5c3_Err != nil {
@@ -514,7 +515,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 126, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 127, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -532,7 +533,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 				var templ_7745c5c3_Var25 string
 				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 128, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 129, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
@@ -550,7 +551,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 131, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 132, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 			if templ_7745c5c3_Err != nil {
@@ -568,7 +569,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 				var templ_7745c5c3_Var27 string
 				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 133, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 134, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 				if templ_7745c5c3_Err != nil {
@@ -586,7 +587,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 135, Col: 204}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 136, Col: 204}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 			if templ_7745c5c3_Err != nil {
@@ -698,7 +699,7 @@ func emailChangePage(message, signedInAs string) templ.Component {
 				var templ_7745c5c3_Var33 string
 				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 154, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 155, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
@@ -768,7 +769,7 @@ func emailChangeCodePage(flow, message, signedInAs string) templ.Component {
 				var templ_7745c5c3_Var36 string
 				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 169, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 170, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 				if templ_7745c5c3_Err != nil {
@@ -786,7 +787,7 @@ func emailChangeCodePage(flow, message, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var37 string
 			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 172, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 173, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
 			if templ_7745c5c3_Err != nil {
@@ -851,7 +852,7 @@ func emailChangeConfirmPage(flow, message, signedInAs string) templ.Component {
 				var templ_7745c5c3_Var40 string
 				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 184, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 185, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 				if templ_7745c5c3_Err != nil {
@@ -869,7 +870,7 @@ func emailChangeConfirmPage(flow, message, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var41 string
 			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 187, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 188, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
 			if templ_7745c5c3_Err != nil {
@@ -929,7 +930,7 @@ func consentPage(request oidcprovider.ConsentRequest, signedInAs string) templ.C
 			var templ_7745c5c3_Var44 string
 			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 195, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 196, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
@@ -942,7 +943,7 @@ func consentPage(request oidcprovider.ConsentRequest, signedInAs string) templ.C
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientHost)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 196, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 197, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -955,7 +956,7 @@ func consentPage(request oidcprovider.ConsentRequest, signedInAs string) templ.C
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(request.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 204, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 205, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
 			if templ_7745c5c3_Err != nil {
@@ -1020,7 +1021,7 @@ func signupPage(message string) templ.Component {
 				var templ_7745c5c3_Var49 string
 				templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 216, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 217, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 				if templ_7745c5c3_Err != nil {
@@ -1090,7 +1091,7 @@ func codePage(flow, message string) templ.Component {
 				var templ_7745c5c3_Var52 string
 				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 230, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 231, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 				if templ_7745c5c3_Err != nil {
@@ -1108,7 +1109,7 @@ func codePage(flow, message string) templ.Component {
 			var templ_7745c5c3_Var53 string
 			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 233, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 234, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var53)
 			if templ_7745c5c3_Err != nil {
@@ -1168,7 +1169,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var56 string
 			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 243, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 244, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 			if templ_7745c5c3_Err != nil {
@@ -1186,7 +1187,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 				var templ_7745c5c3_Var57 string
 				templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 245, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 246, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 				if templ_7745c5c3_Err != nil {
@@ -1204,7 +1205,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 248, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 249, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var58)
 			if templ_7745c5c3_Err != nil {
@@ -1217,7 +1218,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var59 string
 			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 249, Col: 200}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 250, Col: 200}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var59)
 			if templ_7745c5c3_Err != nil {
@@ -1277,7 +1278,7 @@ func accountCreatedPage(accountID string) templ.Component {
 			var templ_7745c5c3_Var62 string
 			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 259, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 260, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 			if templ_7745c5c3_Err != nil {
@@ -1297,7 +1298,7 @@ func accountCreatedPage(accountID string) templ.Component {
 	})
 }
 
-func accountPage(accountID, signedInAs string, browserSessions []sessions.BrowserSession, passwordChanged, emailChanged, notificationFailed, sessionRevoked, otherSessionsRevoked, sessionMissing bool) templ.Component {
+func accountPage(accountID, signedInAs string, browserSessions []sessions.BrowserSession, authorizationGrants []authorizations.Grant, passwordChanged, emailChanged, notificationFailed, sessionRevoked, otherSessionsRevoked, sessionMissing, appRevoked, appMissing bool) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -1390,112 +1391,209 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, " <p class=\"mt-6 text-sm text-slate-500 dark:text-slate-400\">Account ID: <code>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if appRevoked {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "<p role=\"status\" class=\"notice notice-success\">The app’s authorization was revoked. It must ask for access again in a future authorization flow.</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, " ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			if appMissing {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<p role=\"status\" class=\"notice notice-neutral\">That app is no longer authorized.</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, " <p class=\"mt-6 text-sm text-slate-500 dark:text-slate-400\">Account ID: <code>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var65 string
 			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 286, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 293, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</code></p><a class=\"button button-secondary mt-8 w-full\" href=\"/account/email\">Change email address</a> <a class=\"button button-secondary mt-3 w-full\" href=\"/account/password\">Change password</a><form class=\"mt-3\" method=\"post\" action=\"/logout\"><button class=\"button button-secondary w-full\" type=\"submit\">Sign out</button></form><div class=\"mt-10 border-t border-slate-200 pt-8 dark:border-slate-800\"><h2 class=\"text-xl font-semibold tracking-tight\">Browser sessions</h2><p class=\"mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300\">Review where your account is signed in. Authling does not store browser names, IP addresses, or locations.</p><div class=\"mt-5 space-y-3\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</code></p><a class=\"button button-secondary mt-8 w-full\" href=\"/account/email\">Change email address</a> <a class=\"button button-secondary mt-3 w-full\" href=\"/account/password\">Change password</a><form class=\"mt-3\" method=\"post\" action=\"/logout\"><button class=\"button button-secondary w-full\" type=\"submit\">Sign out</button></form><div class=\"mt-10 border-t border-slate-200 pt-8 dark:border-slate-800\"><h2 class=\"text-xl font-semibold tracking-tight\">Authorized apps</h2><p class=\"mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300\">Apps you allowed to know your stable Authling account identifier. Revoking an app makes it ask again next time; existing app sessions and issued tokens are not ended here.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			for _, browserSession := range browserSessions {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<div class=\"rounded-2xl border border-slate-200 p-4 dark:border-slate-700\"><div class=\"flex flex-col items-start gap-4 sm:flex-row sm:justify-between\"><div><div class=\"flex flex-wrap items-center gap-2\"><p class=\"font-semibold\">Browser session</p>")
+			if len(authorizationGrants) == 0 {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "<p class=\"mt-5 rounded-2xl border border-slate-200 p-4 text-sm text-slate-500 dark:border-slate-700 dark:text-slate-400\">You haven’t authorized any apps yet.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				if browserSession.Current {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<span class=\"rounded-full bg-authling-100 px-2.5 py-1 text-xs font-semibold text-authling-800 dark:bg-authling-950 dark:text-authling-100\">This browser</span>")
+			} else {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "<div class=\"mt-5 space-y-3\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				for _, grant := range authorizationGrants {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "<div class=\"rounded-2xl border border-slate-200 p-4 dark:border-slate-700\"><div class=\"flex flex-col items-start gap-4 sm:flex-row sm:justify-between\"><div class=\"min-w-0\"><p class=\"font-semibold\">")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</div><dl class=\"mt-2 space-y-1 text-sm text-slate-500 dark:text-slate-400\"><div><dt class=\"inline\">Started:</dt><dd class=\"ml-1 inline\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var66 string
-				templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.CreatedAt))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 307, Col: 115}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</dd></div><div><dt class=\"inline\">Last active:</dt><dd class=\"ml-1 inline\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var67 string
-				templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.LastSeenAt))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 308, Col: 120}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</dd></div><div><dt class=\"inline\">Expires:</dt><dd class=\"ml-1 inline\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var68 string
-				templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.ExpiresAt))
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 309, Col: 115}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "</dd></div></dl></div>")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				if !browserSession.Current {
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "<form class=\"w-full sm:w-auto\" method=\"post\" action=\"/account/sessions/revoke\"><input type=\"hidden\" name=\"session_id\" value=\"")
+					var templ_7745c5c3_Var66 string
+					templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(grant.ClientName)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 310, Col: 52}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "</p><p class=\"mt-1 break-words text-sm text-slate-500 dark:text-slate-400\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var67 string
+					templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(grant.ClientHost)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 311, Col: 98}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</p><p class=\"mt-2 text-sm text-slate-500 dark:text-slate-400\">Authorized ")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var68 string
+					templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(grant.AuthorizedAt))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 312, Col: 118}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</p></div><form class=\"w-full sm:w-auto\" method=\"post\" action=\"/account/authorizations/revoke\"><input type=\"hidden\" name=\"grant_id\" value=\"")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var69 string
-					templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.ResolveAttributeValue(browserSession.ID)
+					templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.ResolveAttributeValue(grant.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 314, Col: 73}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 315, Col: 62}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var69)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
-					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\"> <button class=\"button button-danger button-compact w-full whitespace-nowrap sm:w-auto\" type=\"submit\">Sign out</button></form>")
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "\"> <button class=\"button button-danger button-compact w-full whitespace-nowrap sm:w-auto\" type=\"submit\">Revoke access</button></form></div></div>")
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "</div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "</div><div class=\"mt-10 border-t border-slate-200 pt-8 dark:border-slate-800\"><h2 class=\"text-xl font-semibold tracking-tight\">Browser sessions</h2><p class=\"mt-2 text-sm leading-6 text-slate-600 dark:text-slate-300\">Review where your account is signed in. Authling does not store browser names, IP addresses, or locations.</p><div class=\"mt-5 space-y-3\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, browserSession := range browserSessions {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "<div class=\"rounded-2xl border border-slate-200 p-4 dark:border-slate-700\"><div class=\"flex flex-col items-start gap-4 sm:flex-row sm:justify-between\"><div><div class=\"flex flex-wrap items-center gap-2\"><p class=\"font-semibold\">Browser session</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if browserSession.Current {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "<span class=\"rounded-full bg-authling-100 px-2.5 py-1 text-xs font-semibold text-authling-800 dark:bg-authling-950 dark:text-authling-100\">This browser</span>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "</div><dl class=\"mt-2 space-y-1 text-sm text-slate-500 dark:text-slate-400\"><div><dt class=\"inline\">Started:</dt><dd class=\"ml-1 inline\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var70 string
+				templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.CreatedAt))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 339, Col: 115}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "</dd></div><div><dt class=\"inline\">Last active:</dt><dd class=\"ml-1 inline\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var71 string
+				templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.LastSeenAt))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 340, Col: 120}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "</dd></div><div><dt class=\"inline\">Expires:</dt><dd class=\"ml-1 inline\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var72 string
+				templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.ExpiresAt))
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 341, Col: 115}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "</dd></div></dl></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if !browserSession.Current {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "<form class=\"w-full sm:w-auto\" method=\"post\" action=\"/account/sessions/revoke\"><input type=\"hidden\" name=\"session_id\" value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var73 string
+					templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.ResolveAttributeValue(browserSession.ID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 346, Col: 73}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var73)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\"> <button class=\"button button-danger button-compact w-full whitespace-nowrap sm:w-auto\" type=\"submit\">Sign out</button></form>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "</div></div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if hasOtherBrowserSession(browserSessions) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "<form class=\"mt-4\" method=\"post\" action=\"/account/sessions/revoke-others\"><button class=\"button button-danger w-full\" type=\"submit\">Sign out all other browsers</button></form>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "<form class=\"mt-4\" method=\"post\" action=\"/account/sessions/revoke-others\"><button class=\"button button-danger w-full\" type=\"submit\">Sign out all other browsers</button></form>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1538,12 +1636,12 @@ func passwordChangePage(message string, passwordMinimumLength int, signedInAs st
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var70 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var70 == nil {
-			templ_7745c5c3_Var70 = templ.NopComponent
+		templ_7745c5c3_Var74 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var74 == nil {
+			templ_7745c5c3_Var74 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var71 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var75 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -1555,62 +1653,62 @@ func passwordChangePage(message string, passwordMinimumLength int, signedInAs st
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<h1 class=\"text-3xl font-semibold tracking-tight\">Change your password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Enter your current password and choose a new one. This signs out your other Authling browser sessions.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "<h1 class=\"text-3xl font-semibold tracking-tight\">Change your password</h1><p class=\"mt-3 text-slate-600 dark:text-slate-300\">Enter your current password and choose a new one. This signs out your other Authling browser sessions.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if message != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "<p role=\"alert\" class=\"notice notice-error\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, "<p role=\"alert\" class=\"notice notice-error\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var72 string
-				templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(message)
+				var templ_7745c5c3_Var76 string
+				templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 349, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 381, Col: 56}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "</p>")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 121, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/account/password\"><label class=\"block\"><span class=\"font-medium\">Current password</span><input class=\"form-control\" type=\"password\" name=\"current_password\" autocomplete=\"current-password\" maxlength=\"1024\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">New password</span><input class=\"form-control\" type=\"password\" name=\"new_password\" autocomplete=\"new-password\" minlength=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 122, " <form class=\"mt-8 space-y-5\" method=\"post\" action=\"/account/password\"><label class=\"block\"><span class=\"font-medium\">Current password</span><input class=\"form-control\" type=\"password\" name=\"current_password\" autocomplete=\"current-password\" maxlength=\"1024\" autofocus required></label> <label class=\"block\"><span class=\"font-medium\">New password</span><input class=\"form-control\" type=\"password\" name=\"new_password\" autocomplete=\"new-password\" minlength=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var73 string
-			templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
+			var templ_7745c5c3_Var77 string
+			templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 353, Col: 208}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 385, Col: 208}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var73)
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\" maxlength=\"1024\" required></label> <label class=\"block\"><span class=\"font-medium\">Confirm new password</span><input class=\"form-control\" type=\"password\" name=\"new_password_confirmation\" autocomplete=\"new-password\" minlength=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var77)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var74 string
-			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 354, Col: 229}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var74)
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 123, "\" maxlength=\"1024\" required></label> <label class=\"block\"><span class=\"font-medium\">Confirm new password</span><input class=\"form-control\" type=\"password\" name=\"new_password_confirmation\" autocomplete=\"new-password\" minlength=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\" maxlength=\"1024\" required></label> <button class=\"button button-primary w-full\" type=\"submit\">Change password</button></form><p class=\"mt-6 text-sm\"><a class=\"text-link\" href=\"/account\">Return to your account</a>.</p>")
+			var templ_7745c5c3_Var78 string
+			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 386, Col: 229}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var78)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 124, "\" maxlength=\"1024\" required></label> <button class=\"button button-primary w-full\" type=\"submit\">Change password</button></form><p class=\"mt-6 text-sm\"><a class=\"text-link\" href=\"/account\">Return to your account</a>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = layout("Change your password", signedInAs).Render(templ.WithChildren(ctx, templ_7745c5c3_Var71), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = layout("Change your password", signedInAs).Render(templ.WithChildren(ctx, templ_7745c5c3_Var75), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/authling/internal/web/web.go
+++ b/authling/internal/web/web.go
@@ -16,6 +16,7 @@ import (
 	"github.com/a-h/templ"
 	"hmans.de/authling/internal/accounts"
 	"hmans.de/authling/internal/authentication"
+	"hmans.de/authling/internal/authorizations"
 	"hmans.de/authling/internal/emailchange"
 	"hmans.de/authling/internal/oidcprovider"
 	"hmans.de/authling/internal/passwordreset"
@@ -42,6 +43,7 @@ type Dependencies struct {
 	PasswordReset  *passwordreset.Service
 	EmailChange    *emailchange.Service
 	Sessions       *sessions.Service
+	Authorizations *authorizations.Service
 	OIDC           *oidcprovider.Service
 	SecureCookies  bool
 	PublicURL      string
@@ -242,6 +244,13 @@ func Handler(dependencies ...Dependencies) http.Handler {
 			http.Error(w, "account unavailable", http.StatusServiceUnavailable)
 			return
 		}
+		if target, authorized, err := deps.OIDC.TryAuthorize(r.Context(), requestID, account.ID); err != nil {
+			http.Error(w, "authorization request unavailable", http.StatusServiceUnavailable)
+			return
+		} else if authorized {
+			redirect(w, r, target)
+			return
+		}
 		email, err := deps.Accounts.EmailAddress(r.Context(), account.ID)
 		if err != nil {
 			http.Error(w, "account unavailable", http.StatusServiceUnavailable)
@@ -313,19 +322,64 @@ func Handler(dependencies ...Dependencies) http.Handler {
 			http.Error(w, "browser sessions unavailable", http.StatusServiceUnavailable)
 			return
 		}
+		var authorizationGrants []authorizations.Grant
+		if deps.Authorizations != nil {
+			authorizationGrants, err = deps.Authorizations.List(r.Context(), account.ID)
+			if err != nil {
+				http.Error(w, "authorized apps unavailable", http.StatusServiceUnavailable)
+				return
+			}
+		}
 		emailChanged := r.URL.Query().Get("email_changed") == "1"
 		passwordChanged := r.URL.Query().Get("password_changed") == "1"
 		render(w, r, http.StatusOK, accountPage(
 			account.ID,
 			email,
 			browserSessions,
+			authorizationGrants,
 			passwordChanged,
 			emailChanged,
 			emailChanged && r.URL.Query().Get("email_notice_failed") == "1",
 			r.URL.Query().Get("session_revoked") == "1",
 			r.URL.Query().Get("other_sessions_revoked") == "1",
 			r.URL.Query().Get("session_missing") == "1",
+			r.URL.Query().Get("app_revoked") == "1",
+			r.URL.Query().Get("app_missing") == "1",
 		))
+	})
+	mux.HandleFunc("POST /account/authorizations/revoke", func(w http.ResponseWriter, r *http.Request) {
+		if deps.Authorizations == nil {
+			http.Error(w, "authorized app management unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if !sameOrigin(r, publicOrigin) {
+			http.Error(w, "cross-origin request rejected", http.StatusForbidden)
+			return
+		}
+		r.Body = http.MaxBytesReader(w, r.Body, 16<<10)
+		account, err := authenticatedAccount(r, deps)
+		if errors.Is(err, sessions.ErrNotFound) {
+			clearSessionCookie(w, deps.SecureCookies)
+			redirect(w, r, "/login")
+			return
+		}
+		if err != nil {
+			http.Error(w, "account unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		if err := r.ParseForm(); err != nil {
+			http.Error(w, "invalid form", http.StatusBadRequest)
+			return
+		}
+		err = deps.Authorizations.Revoke(r.Context(), account.ID, r.FormValue("grant_id"))
+		switch {
+		case errors.Is(err, authorizations.ErrNotFound):
+			redirect(w, r, "/account?app_missing=1")
+		case err != nil:
+			http.Error(w, "authorized app management unavailable", http.StatusServiceUnavailable)
+		default:
+			redirect(w, r, "/account?app_revoked=1")
+		}
 	})
 	mux.HandleFunc("POST /account/sessions/revoke", func(w http.ResponseWriter, r *http.Request) {
 		if deps.Sessions == nil {

--- a/authling/proto/authling/core/v1/event.proto
+++ b/authling/proto/authling/core/v1/event.proto
@@ -25,6 +25,8 @@ message Event {
     PasswordResetRequestedEvent password_reset_requested = 104;
     EmailChangeRequestedEvent email_change_requested = 105;
     EmailChangedEvent email_changed = 106;
+    OIDCGrantAuthorizedEvent oidc_grant_authorized = 107;
+    OIDCGrantRevokedEvent oidc_grant_revoked = 108;
   }
 }
 
@@ -118,4 +120,29 @@ message EmailChangedEvent {
   bytes email_ciphertext = 6;
   string email_change_request_event_id = 7;
   string prior_credential_event_id = 8;
+}
+
+// OIDCGrantAuthorizedEvent records an account's authorization of one exact
+// OIDC client and scope set. Repeated explicit consent renews the active grant
+// by correlating it to the preceding authorization event.
+message OIDCGrantAuthorizedEvent {
+  string account_id = 1;
+  string grant_id = 2;
+  // Deployment-keyed digest of the exact client ID. The raw configured ID or
+  // CIMD URL is not retained in durable account history.
+  bytes client_id_digest = 3;
+  string client_name = 4;
+  string client_host = 5;
+  repeated string scopes = 6;
+
+  // Empty for a new grant. Renewals identify the active authorization event
+  // they replace so replay rejects stale or forked grant history.
+  string prior_authorization_event_id = 7;
+}
+
+// OIDCGrantRevokedEvent ends one active authorization-grant generation.
+message OIDCGrantRevokedEvent {
+  string account_id = 1;
+  string grant_id = 2;
+  string authorization_event_id = 3;
 }


### PR DESCRIPTION
## Why

Authling should remember which exact OIDC clients an account has explicitly authorized, avoid redundant consent prompts, and let the account revoke future access.

## What changed

- Adds durable, account-owned authorization grants with keyed client identifiers, event-sourced OCC commands, replay validation, and an in-memory projection.
- Reuses covered grants during authorization unless `prompt=consent` is requested, and adds an **Authorized apps** account view with same-origin revocation.
- Documents behavior, security boundaries, mixed-version constraints, and the planned refresh-token and relying-party-grouping extensions in [FDR-010](authling/docs/fdr/FDR-010-oidc-authorization-grants.md).
- Adds unit, runtime, protocol, security-header, browser-flow, and generated protobuf/template coverage.

## API compatibility

- Behavioural change; temporal client/server impact described below.

Older client → newer server: Existing OIDC clients remain compatible; covered requests may now skip repeated consent, while `prompt=consent` preserves an explicit prompt.

Newer client → older server: No new client capability is required, but older Authling servers do not persist grants or expose account-level revocation.

Capability discovery or minimum client/server version: Discovery metadata is unchanged; once a new grant event is written, Authling binaries predating this event schema cannot replay that account history and must not be rolled back.

## Test plan

- `(cd authling && mise test)` — passed in standalone-module and workspace modes.
- `(cd authling && mise test-e2e)` — passed, 33 tests.
- `(cd authling && mise codegen-templates)` and `(cd authling && mise build-web)` — passed.
- Chrome DevTools review covered populated, empty, and revoked Authorized Apps states; the shared Revoke Access button resolves to `cursor: pointer`.
- `git diff --check` — passed.
