### PR TITLE
fix(authling): disable 1Password for code inputs

### DIFF
--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -114,7 +114,7 @@ templ passwordResetCodePage(flow, message, oidcRequest string) {
 			if oidcRequest != "" {
 				<input type="hidden" name="oidc_request" value={ oidcRequest }/>
 			}
-			<label class="block"><span class="font-medium">Password reset code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></span></label>
+			<label class="block"><span class="font-medium">Password reset code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" data-1p-ignore="true" maxlength="6" autofocus required/></span></label>
 			<button class="button button-primary w-full" type="submit">Verify code</button>
 		</form>
 	}
@@ -170,7 +170,7 @@ templ emailChangeCodePage(flow, message, signedInAs string) {
 		}
 		<form class="mt-8 space-y-5" method="post" action="/account/email/verify">
 			<input type="hidden" name="flow" value={ flow }/>
-			<label class="block"><span class="font-medium">Email change code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></span></label>
+			<label class="block"><span class="font-medium">Email change code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" data-1p-ignore="true" maxlength="6" autofocus required/></span></label>
 			<button class="button button-primary w-full" type="submit">Verify code</button>
 		</form>
 	}
@@ -231,7 +231,7 @@ templ codePage(flow, message string) {
 		}
 		<form class="mt-8 space-y-5" method="post" action="/signup/verify">
 			<input type="hidden" name="flow" value={ flow }/>
-			<label class="block"><span class="font-medium">Verification code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" maxlength="6" autofocus required/></span></label>
+			<label class="block"><span class="font-medium">Verification code</span><span class="otp-code mt-2"><span class="otp-code-boxes" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class="otp-code-input" type="text" name="code" inputmode="numeric" pattern="[0-9]{6}" autocomplete="one-time-code" data-1p-ignore="true" maxlength="6" autofocus required/></span></label>
 			<button class="button button-primary w-full" type="submit">Verify email</button>
 		</form>
 	}

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -460,7 +460,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<label class=\"block\"><span class=\"font-medium\">Password reset code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></span></label> <button class=\"button button-primary w-full\" type=\"submit\">Verify code</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<label class=\"block\"><span class=\"font-medium\">Password reset code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" data-1p-ignore=\"true\" maxlength=\"6\" autofocus required></span></label> <button class=\"button button-primary w-full\" type=\"submit\">Verify code</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -792,7 +792,7 @@ func emailChangeCodePage(flow, message, signedInAs string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\"> <label class=\"block\"><span class=\"font-medium\">Email change code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></span></label> <button class=\"button button-primary w-full\" type=\"submit\">Verify code</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\"> <label class=\"block\"><span class=\"font-medium\">Email change code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" data-1p-ignore=\"true\" maxlength=\"6\" autofocus required></span></label> <button class=\"button button-primary w-full\" type=\"submit\">Verify code</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1114,7 +1114,7 @@ func codePage(flow, message string) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\"> <label class=\"block\"><span class=\"font-medium\">Verification code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" maxlength=\"6\" autofocus required></span></label> <button class=\"button button-primary w-full\" type=\"submit\">Verify email</button></form>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\"> <label class=\"block\"><span class=\"font-medium\">Verification code</span><span class=\"otp-code mt-2\"><span class=\"otp-code-boxes\" aria-hidden=\"true\"><span></span><span></span><span></span><span></span><span></span><span></span></span><input class=\"otp-code-input\" type=\"text\" name=\"code\" inputmode=\"numeric\" pattern=\"[0-9]{6}\" autocomplete=\"one-time-code\" data-1p-ignore=\"true\" maxlength=\"6\" autofocus required></span></label> <button class=\"button button-primary w-full\" type=\"submit\">Verify email</button></form>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/authling/internal/web/web_test.go
+++ b/authling/internal/web/web_test.go
@@ -1,11 +1,14 @@
 package web
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/a-h/templ"
 )
 
 func TestHandlerRendersHomePageWithoutScripts(t *testing.T) {
@@ -62,6 +65,29 @@ func TestPasswordResetPageRendersWithoutAccountDisclosure(t *testing.T) {
 	}
 	if strings.Contains(body, "account exists") || strings.Contains(body, "account not found") || strings.Contains(body, "<script") {
 		t.Fatalf("password reset page has disclosure or script content: %q", body)
+	}
+}
+
+func TestOneTimeCodeInputsDisableOnePassword(t *testing.T) {
+	tests := []struct {
+		name string
+		page templ.Component
+	}{
+		{name: "signup", page: codePage("flow", "")},
+		{name: "password reset", page: passwordResetCodePage("flow", "", "")},
+		{name: "email change", page: emailChangeCodePage("flow", "", "person@example.com")},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var body strings.Builder
+			if err := test.page.Render(context.Background(), &body); err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(body.String(), `autocomplete="one-time-code" data-1p-ignore="true"`) {
+				t.Fatalf("one-time code input does not opt out of 1Password: %q", body.String())
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Why

1Password's inline control can obscure the final cell in Authling's six-digit code inputs.

## What changed

Add 1Password's supported per-field opt-out to signup, password-reset, and email-change code inputs while preserving native one-time-code assistance, and cover all three renderers with a regression test.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise test` — passed in standalone `GOWORK=off` and repository-workspace modes.
- Chrome DevTools — completed signup through the code-entry page and confirmed autofocus, `autocomplete="one-time-code"`, `data-1p-ignore="true"`, and unchanged layout.
