### PR TITLE
fix(authling): avoid caching failed JWKS responses

### DIFF
--- a/authling/internal/oidcprovider/provider.go
+++ b/authling/internal/oidcprovider/provider.go
@@ -207,11 +207,43 @@ func (s *Service) wrap(next http.Handler) http.Handler {
 			w.Header().Set("Cache-Control", "no-store")
 		}
 		if r.URL.Path == "/oauth/jwks" {
-			w.Header().Set("Cache-Control", "public, max-age=300")
+			response := &jwksResponseWriter{ResponseWriter: w}
+			next.ServeHTTP(response, r)
+			response.WriteHeader(http.StatusOK)
+			return
 		}
 		next.ServeHTTP(w, r)
 	})
 }
+
+// jwksResponseWriter decides cacheability when the downstream status becomes
+// known, preventing shared caches from retaining transient JWKS failures.
+type jwksResponseWriter struct {
+	http.ResponseWriter
+	wroteHeader bool
+}
+
+func (w *jwksResponseWriter) WriteHeader(statusCode int) {
+	if w.wroteHeader {
+		return
+	}
+	w.wroteHeader = true
+	if statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices {
+		w.Header().Set("Cache-Control", "public, max-age=300")
+	} else {
+		w.Header().Set("Cache-Control", "no-store")
+	}
+	w.ResponseWriter.WriteHeader(statusCode)
+}
+
+func (w *jwksResponseWriter) Write(body []byte) (int, error) {
+	w.WriteHeader(http.StatusOK)
+	return w.ResponseWriter.Write(body)
+}
+
+// Unwrap lets net/http recover optional capabilities from the underlying
+// response writer through http.ResponseController.
+func (w *jwksResponseWriter) Unwrap() http.ResponseWriter { return w.ResponseWriter }
 
 func (s *Service) serveDiscovery(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")

--- a/authling/internal/oidcprovider/provider_test.go
+++ b/authling/internal/oidcprovider/provider_test.go
@@ -61,6 +61,44 @@ func TestAccessTokenCryptoAcceptsLegacyTokensAndUsesStableKey(t *testing.T) {
 	}
 }
 
+func TestJWKSCacheControlDependsOnResponseStatus(t *testing.T) {
+	tests := []struct {
+		name       string
+		serve      http.HandlerFunc
+		wantStatus int
+		wantCache  string
+	}{
+		{
+			name: "successful response is public",
+			serve: func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(`{"keys":[]}`))
+			},
+			wantStatus: http.StatusOK,
+			wantCache:  "public, max-age=300",
+		},
+		{
+			name: "failed response is not stored",
+			serve: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Cache-Control", "public, max-age=300")
+				http.Error(w, "key vault unavailable", http.StatusInternalServerError)
+			},
+			wantStatus: http.StatusInternalServerError,
+			wantCache:  "no-store",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := (&Service{}).wrap(test.serve)
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, "https://auth.example/oauth/jwks", nil))
+			if response.Code != test.wantStatus || response.Header().Get("Cache-Control") != test.wantCache {
+				t.Fatalf("JWKS status/cache = %d %q, want %d %q", response.Code, response.Header().Get("Cache-Control"), test.wantStatus, test.wantCache)
+			}
+		})
+	}
+}
+
 func TestValidateAuthorizeRequestRequiresExactCodePKCEProfile(t *testing.T) {
 	valid := "https://auth.example/oauth/authorize?client_id=client&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&response_type=code&scope=openid&code_challenge=" + strings.Repeat("a", 43) + "&code_challenge_method=S256"
 	tests := []struct {


### PR DESCRIPTION
## Why

Authling currently marks JWKS responses as publicly cacheable before their status is known, allowing a shared cache to retain a transient key-vault failure for five minutes after recovery.

## What changed

JWKS middleware now applies `public, max-age=300` only to successful responses and overwrites unsuccessful responses with `no-store`, with regression coverage for both implicit success and downstream failure paths.

## API compatibility

- Behavioural change; temporal client/server impact described below.

Older clients against a newer server retain the existing successful JWKS behavior while failures become non-cacheable; newer clients need no special support from older servers, and no capability discovery or minimum version applies.

## Test plan

`GOWORK=off mise x -- go test -trimpath ./internal/oidcprovider`, `cd authling && mise test` in standalone-module and workspace modes, and `git diff --check` all pass.
