### PR TITLE
test(frontend): cover bot account lifecycle

### DIFF
--- a/.agents/skills/fdr/SKILL.md
+++ b/.agents/skills/fdr/SKILL.md
@@ -157,7 +157,7 @@ For each FDR being audited, launch a dedicated Explore subagent that:
 
 1. **Reads the FDR** in full
 2. **Verifies each claim** against the codebase:
-   - Permission names — do the constants exist in `cli/internal/core/permissions.go`?
+   - Permission names — do the constants exist in `cli/internal/core/permission.go`?
    - Behavioral claims — does the code actually work this way?
    - Design Decisions — are the stated rationales still accurate? Has the implementation drifted?
    - Related ADRs/FDRs — do the cited records still exist and still apply?
@@ -180,7 +180,7 @@ Run audits in parallel via the Agent tool when auditing multiple FDRs.
 
 When auditing or creating an FDR, verify:
 
-- [ ] All permission strings exist in `cli/internal/core/permissions.go`
+- [ ] All permission strings exist in `cli/internal/core/permission.go`
 - [ ] Permission strings use hyphens, not underscores
 - [ ] User-facing behaviors match the code
 - [ ] Design Decisions still reflect the current implementation

--- a/apps/frontend/e2e/bots.test.ts
+++ b/apps/frontend/e2e/bots.test.ts
@@ -1,0 +1,176 @@
+import { expect, type Page } from '@playwright/test';
+import { connectPost } from './fixtures/connectHelpers';
+import { loginAsAdminAndUsePrimaryServer } from './fixtures/testUser';
+import * as routes from './routes';
+import { test } from './setup';
+
+interface BotAPIResult {
+  status: number;
+  code?: string;
+}
+
+interface ListRoomsResponse {
+  rooms?: Array<{ room?: { id?: string } }>;
+}
+
+const BOT_KEY_PATTERN = /^cht_BK_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
+const BOT_KEY_IN_TEXT_PATTERN = /cht_BK_[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g;
+
+// This test handles show-once bearer credentials in the DOM. Keep them out of
+// Playwright artifacts even when the test fails or retries. Playwright 1.62's
+// error-context snapshot is separate from the configured trace/screenshot
+// controls, so disable it explicitly for this test worker as well.
+process.env.PLAYWRIGHT_NO_COPY_PROMPT = '1';
+test.use({ trace: 'off', screenshot: 'off', video: 'off' });
+
+function redactBotKeys(value: string): string {
+  return value.replace(BOT_KEY_IN_TEXT_PATTERN, '[REDACTED]');
+}
+
+async function captureShowOnceBotKey(page: Page): Promise<string> {
+  const dialog = page.getByRole('dialog', { name: 'Save This API Key' });
+  const keyElement = dialog.locator('code');
+  await keyElement.waitFor({ state: 'visible' });
+  const apiKey = await keyElement.evaluate((element) => {
+    const value = element.textContent?.trim() ?? '';
+    // Playwright 1.62 writes an accessibility snapshot on failure even when
+    // trace and screenshots are off. Redact the live DOM before any later
+    // assertion or action can fail and trigger that snapshot.
+    element.textContent = '[REDACTED]';
+    return value;
+  });
+
+  await dialog.getByRole('button', { name: 'Got it', exact: true }).click();
+  await expect(dialog).toBeHidden();
+
+  if (!apiKey || !BOT_KEY_PATTERN.test(apiKey)) {
+    throw new Error('The show-once bot API key had an unexpected format');
+  }
+  return apiKey;
+}
+
+async function getRoomAsBot(
+  serverURL: string,
+  apiKey: string,
+  roomId: string
+): Promise<BotAPIResult> {
+  // Use Node's fetch rather than page.request so the admin's browser cookies
+  // cannot supply ambient authority and Playwright never records the key.
+  const response = await fetch(
+    new URL('/api/connect/chatto.api.v1.RoomDirectoryService/GetRoom', serverURL),
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Connect-Protocol-Version': '1',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ roomId })
+    }
+  );
+
+  let code: string | undefined;
+  try {
+    const payload: unknown = await response.json();
+    if (payload && typeof payload === 'object' && 'code' in payload) {
+      const candidate = (payload as { code?: unknown }).code;
+      if (typeof candidate === 'string') code = candidate;
+    }
+  } catch {
+    // Successful Connect responses and the status are sufficient for this
+    // lifecycle assertion even if an error proxy returns a non-JSON body.
+  }
+
+  return { status: response.status, ...(code ? { code } : {}) };
+}
+
+test.describe('Bot account lifecycle', () => {
+  // setup.ts gives every test its own server and removes that server's data
+  // directory during fixture teardown, including after an early failure.
+  test('create, authorise, rotate, and delete through Server Admin', async ({
+    page,
+    serverURL
+  }) => {
+    const browserErrors: string[] = [];
+    page.on('pageerror', (error) => browserErrors.push(redactBotKeys(error.message)));
+    page.on('console', (message) => {
+      if (message.type() === 'error') browserErrors.push(redactBotKeys(message.text()));
+    });
+
+    await loginAsAdminAndUsePrimaryServer(page);
+    const directory = await connectPost<ListRoomsResponse>(
+      page,
+      'chatto.api.v1.RoomDirectoryService/ListRooms'
+    );
+    const roomId = directory.rooms?.[0]?.room?.id;
+    if (!roomId) throw new Error('The bootstrap server did not expose a room for the bot test');
+
+    await page.goto(routes.serverAdminBots);
+    await expect(page.getByRole('heading', { name: 'Bots', exact: true })).toBeVisible();
+
+    const suffix = Date.now().toString(36);
+    const botLogin = `lifecycle_${suffix}_bot`;
+    const botDisplayName = `Lifecycle Bot ${suffix}`;
+
+    await page.getByRole('button', { name: 'Create Bot', exact: true }).click();
+    const createDialog = page.getByRole('dialog', { name: 'Create Bot Account' });
+    await createDialog.getByRole('textbox', { name: 'Username' }).fill(botLogin);
+    await createDialog.getByRole('textbox', { name: 'Display Name' }).fill(botDisplayName);
+    await createDialog.getByRole('button', { name: 'Create Bot', exact: true }).click();
+
+    const originalKey = await captureShowOnceBotKey(page);
+    await page.waitForURL(routes.patterns.anyAdminBot);
+    await expect(
+      page.getByRole('heading', { name: botDisplayName, exact: true, level: 1 })
+    ).toBeVisible();
+
+    await expect(getRoomAsBot(serverURL, originalKey, roomId)).resolves.toEqual({
+      status: 403,
+      code: 'permission_denied'
+    });
+
+    const permissionFilter = page.getByTestId('permission-filter');
+    await expect(permissionFilter).toBeVisible();
+    await permissionFilter.fill('room.list');
+    const disabledRoomList = page.getByRole('button', {
+      name: 'room.list is Disabled for bot at Server',
+      exact: true
+    });
+    await expect(disabledRoomList).toBeEnabled();
+    await disabledRoomList.click();
+    await expect(
+      page.getByRole('button', {
+        name: 'room.list is Enabled for bot at Server',
+        exact: true
+      })
+    ).toBeVisible();
+
+    await expect(getRoomAsBot(serverURL, originalKey, roomId)).resolves.toEqual({ status: 200 });
+
+    await page.getByRole('button', { name: 'Rotate Key', exact: true }).click();
+    const rotateDialog = page.getByRole('dialog', { name: 'Rotate API Key' });
+    await rotateDialog.getByRole('button', { name: 'Rotate Key', exact: true }).click();
+    const rotatedKey = await captureShowOnceBotKey(page);
+    if (rotatedKey === originalKey) {
+      throw new Error('Rotating the bot API key did not issue a new credential');
+    }
+
+    await expect(getRoomAsBot(serverURL, originalKey, roomId)).resolves.toEqual({
+      status: 401,
+      code: 'unauthenticated'
+    });
+    await expect(getRoomAsBot(serverURL, rotatedKey, roomId)).resolves.toEqual({ status: 200 });
+
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+    const deleteDialog = page.getByRole('dialog', { name: 'Delete Bot' });
+    await deleteDialog.getByRole('button', { name: 'Delete', exact: true }).click();
+    await page.waitForURL(routes.serverAdminBots);
+    await expect(page.getByText('Bot deleted', { exact: true })).toBeVisible();
+
+    await expect(getRoomAsBot(serverURL, rotatedKey, roomId)).resolves.toEqual({
+      status: 401,
+      code: 'unauthenticated'
+    });
+    expect(browserErrors, 'browser console and page errors').toEqual([]);
+  });
+});

--- a/apps/frontend/e2e/routes.ts
+++ b/apps/frontend/e2e/routes.ts
@@ -124,6 +124,8 @@ export const patterns = {
   anyThread: /\/chat\/-\/(?!manage\/)[a-zA-Z0-9]+\/[a-zA-Z0-9]+$/,
   /** Any admin user page: /chat/-/manage/server/members/{id} */
   anyAdminUser: /\/chat\/-\/manage\/server\/members\/[a-zA-Z0-9]+/,
+  /** Any bot-management page: /chat/-/manage/server/bots/{id} */
+  anyAdminBot: /\/chat\/-\/manage\/server\/bots\/[a-zA-Z0-9]+$/,
   /** Any non-admin chat route (home instance or instance-agnostic) */
   nonAdmin: /\/chat\/(?:-(?:\/(?!manage(?:\/|$))|$)|notifications)/,
   /** Chat root or any room (used after redirects) */

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -1,15 +1,15 @@
 # FDR-001: Roles & Permissions (RBAC)
 
 **Status:** Active
-**Last reviewed:** 2026-08-19
+**Last reviewed:** 2026-08-21
 
 ## Overview
 
-Chatto controls who can do what through role-based access control. Every authenticated user holds one or more roles; each role grants or denies specific permissions. Permissions can also be overridden per room-group and per room, giving operators fine-grained control without inventing parallel role systems.
+Chatto controls who can do what through role-based access control. Every authenticated human user holds one or more roles; each role grants or denies specific permissions. Permissions can also be overridden per room-group and per room, giving operators fine-grained control without inventing parallel role systems. Bot accounts are the deliberate exception: they use an explicit direct-permission allowlist bounded by their human owner's current authority (FDR-038).
 
 ## Behavior
 
-- Every authenticated user belongs to the implicit `everyone` role and may additionally hold one or more named roles.
+- Every authenticated human user belongs to the implicit `everyone` role and may additionally hold one or more named roles. Bots inherit neither `everyone` nor named-role permissions.
 - The system roles are `owner`, `admin`, `moderator`, `everyone`. Role position controls ordering/display and legacy event compatibility; it is not an authorization rank.
 - A role grants or denies named permissions like `message.post`, `room.create`, `admin.view-users`.
 - Permission grants/denies can be configured at three scopes: per-server, per room-group, and per room. Each direct user or named role contributes its nearest decision; denies win across those explicit subjects. The implicit `everyone` role supplies the scoped baseline, and an allow overrides its deny only at the same or a nearer scope.
@@ -39,7 +39,7 @@ Chatto controls who can do what through role-based access control. Every authent
 
 ### 2. Named subjects with an `everyone` baseline
 
-**Decision:** For non-owners, select the nearest room/group/server decision independently for the direct user and every explicitly assigned named role. Denies win across those decisions. Select `everyone`'s nearest decision as the scoped baseline; a direct-user or named-role allow overrides an `everyone` deny only at the same or a nearer scope. If nothing applies, the result is denied at the API boundary.
+**Decision:** For non-owner human users, select the nearest room/group/server decision independently for the direct user and every explicitly assigned named role. Denies win across those decisions. Select `everyone`'s nearest decision as the scoped baseline; a direct-user or named-role allow overrides an `everyone` deny only at the same or a nearer scope. If nothing applies, the result is denied at the API boundary. Bots instead use only explicit direct-user allows, further bounded by their owner's current effective permissions.
 **Why:** Operators can express an allowlist by denying the `everyone` baseline and granting a named role, while a named restriction role such as `suspended` still reliably denies. Role position remains irrelevant to authorization. See ADR-052.
 **Tradeoff:** An `everyone` deny can be overridden deliberately at its own scope or a nearer one. A restriction role's deny beats other subjects' grants, but a nearer allow configured on that same role replaces its broader deny. Direct-user decisions follow the same nearest-scope rule. ADR-052 records the compatibility audit.
 
@@ -104,4 +104,4 @@ The full permission catalog is in `cli/internal/core/permission.go`. Key permiss
 ## Related
 
 - **ADRs:** ADR-004 (authorization at API boundary), ADR-027 (instance/space consolidation), ADR-030 (space tier retirement), ADR-031 (room-group-centric ACL), ADR-033 (event-sourced state), ADR-035 (per-aggregate migration), ADR-037 (DM access via membership), ADR-040 (permission-only RBAC with owner override), ADR-052 (subject-specific RBAC with an everyone baseline), ADR-076 (notification occurrences), ADR-077 (persistent notification list)
-- **FDRs:** Every FDR that mentions a permission depends on this one; see also FDR-012 (Notifications).
+- **FDRs:** Every FDR that mentions a permission depends on this one; see also FDR-012 (Notifications) and FDR-038 (Bot Accounts).

--- a/docs/fdr/FDR-018-account-lifecycle.md
+++ b/docs/fdr/FDR-018-account-lifecycle.md
@@ -1,17 +1,17 @@
 # FDR-018: Account Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-08-19
+**Last reviewed:** 2026-08-21
 
 ## Overview
 
-This FDR covers the user account from registration through deletion: signup, email verification, account deletion, and the crypto-shredding model that makes deletion permanent and reliable. It does *not* cover authentication mechanics (login, sessions, tokens) — those live in FDR-023.
+This FDR covers human accounts from registration through deletion: signup, email verification, self-service account deletion, and the crypto-shredding model that makes deletion permanent and reliable. The same deletion and crypto-shredding mechanics also apply when a bot is deleted through its management API, as specified by FDR-038. Authentication mechanics (login, sessions, tokens) live in FDR-023.
 
 ## Behavior
 
 ### Registration
 
-- A user starts registration with an email address. Chatto returns the same generic response whether the address is available or already claimed, so the registration endpoint does not disclose existing accounts.
+- A human user starts registration with an email address. Chatto returns the same generic response whether the address is available or already claimed, so the registration endpoint does not disclose existing accounts.
 - Chatto sends a six-digit verification code to an available address. Verifying the code returns a short-lived completion token; it does not create an account.
 - The user then chooses a login and password. The login must pass uniqueness, format, and blocked-username checks, and the email is checked again in case it was claimed while the completion token was outstanding.
 - Successful completion creates the account with the email already verified. There is no partially registered or unverified account state in the direct-registration flow.
@@ -20,14 +20,14 @@ This FDR covers the user account from registration through deletion: signup, ema
 
 ### Email management
 
-- A user can have multiple verified email addresses on file.
+- A human user can have multiple verified email addresses on file. Bot accounts cannot have verified emails.
 - Adding a new email triggers a verification mail to the new address; the email is added in pending state until the code is confirmed.
 - A user can delete one of their verified emails as long as at least one verified email remains.
 - Email verification code issuance is recorded in the EVT audit log with a hashed email, expiry, and safe request metadata; the raw code is not recorded.
 
 ### Account deletion
 
-- The user requests deletion via Account Settings.
+- A human user requests their own deletion via Account Settings.
 - A two-step confirmation flow asks the user to type a confirmation string before the deletion executes.
 - Account deletion confirmation-token issuance is recorded in the EVT audit log with expiry and safe request metadata; the raw token is not recorded.
 - The account deletion confirmation token itself lives in `RUNTIME_STATE` under an HMAC-derived key with a 15-minute per-key TTL.
@@ -42,6 +42,7 @@ This FDR covers the user account from registration through deletion: signup, ema
 - Historical room join and leave facts remain stored, but timeline messages omit deleted users from membership activity. Grouped activity includes only visible actors, and the row is hidden when none remain.
 - New durable user events store login, display name, and verified email as encrypted PII payloads. Projections retain those encrypted envelopes, decrypt login/email transiently to derive in-memory lookup digests and decrypt fields for reads, and remove user-owned lookup entries when the account is crypto-shredded.
 - The login is freed up for re-use.
+- Bots cannot request their own deletion. Their owner or a human user with `bot.manage` deletes them through `BotService`; deleting a human owner also deletes every bot they own. Those paths use the same durable deletion and crypto-shredding behavior described above.
 
 ## Design Decisions
 
@@ -101,16 +102,16 @@ This FDR covers the user account from registration through deletion: signup, ema
 
 ## Permissions
 
-- Self: anyone authenticated can update their own profile (FDR-022), add or remove their own emails, and delete their own account.
+- Self: an authenticated human user can update their own profile (FDR-022), add or remove their own emails, and delete their own account.
 - `user.delete-any` — admin permission to delete other users' accounts.
-- `user.delete-self` — gates own-account deletion. Granted to `everyone` by default; operators can revoke to lock down self-deletion.
+- `user.delete-self` — gates a human user's own-account deletion. Granted to `everyone` by default; operators can revoke it to lock down self-deletion. Bots cannot exercise it even if an allow appears in their direct permission matrix.
 
 ## Related
 
 - **ADRs:** ADR-007 (per-user encryption with crypto-shredding), ADR-060
   (application-neutral data cryptography), ADR-069 (explicit durable consumer
   lifecycle), ADR-076 (notification occurrences), ADR-077 (persistent notification list)
-- **FDRs:** FDR-001 (Roles & Permissions), FDR-012 (Notifications), FDR-013 (Web Push Notifications), FDR-022 (User Profile), FDR-023 (Authentication & Sessions)
+- **FDRs:** FDR-001 (Roles & Permissions), FDR-012 (Notifications), FDR-013 (Web Push Notifications), FDR-022 (User Profile), FDR-023 (Authentication & Sessions), FDR-038 (Bot Accounts)
 
 ## Open Questions
 

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,24 +1,25 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-07-15
+**Last reviewed:** 2026-08-21
 
 ## Overview
 
-A user's profile carries the public identity they present to the rest of the server (login, display name, avatar, custom status) plus server-synced personal settings (timezone, time format). Most of the profile is self-editable; one field — the login — is throttled to discourage identity-confusion abuse, with an admin escape hatch for legitimate needs. Browser-local display preferences, such as theme, live outside the profile.
+A human user's profile carries the public identity they present to the rest of the server (login, display name, avatar, custom status) plus server-synced personal settings (timezone, time format). Most of the profile is self-editable; one field — the login — is throttled to discourage identity-confusion abuse, with an admin escape hatch for legitimate needs. Browser-local display preferences, such as theme, live outside the profile. Bot accounts expose the same public identity shape but currently support only managed login and display-name edits (FDR-038).
 
 ## Behavior
 
-- **Display name** — freely editable by the user. Shown in messages, member lists, mention autocomplete, etc.
-- **Login (username)** — editable by the user with a 30-day cooldown between changes. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
+- **Display name** — freely editable by a human user. Shown in messages, member lists, mention autocomplete, etc.
+- **Login (username)** — editable by a human user with a 30-day cooldown between changes. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
-- **Avatar** — users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
-- **Custom status** — users can set an emoji plus short text. The emoji is shown next to their name; the text is shown alongside it where space allows and as hover/accessible text in compact places.
+- **Avatar** — human users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
+- **Custom status** — human users can set an emoji plus short text. The emoji is shown next to their name; the text is shown alongside it where space allows and as hover/accessible text in compact places.
 - **Custom status templates** — the web client offers preset statuses for lunch, holiday/vacation, and sick leave plus a custom mode. Presets store reserved text tokens in the same free-form status text field so each client can render the label in its active locale. Custom mode stores the user's literal text.
 - **Custom status expiry** — users can optionally choose an expiry date and time. After that instant, projected reads and the web client hide the status automatically. Users can also clear it manually.
-- **Settings** — currently timezone (IANA name, e.g., `Europe/Berlin`) and time format (browser default / 12-hour / 24-hour). Stored server-side so they sync across devices. If not set, the frontend uses the browser timezone and locale time-format default.
+- **Settings** — human accounts currently support timezone (IANA name, e.g., `Europe/Berlin`) and time format (browser default / 12-hour / 24-hour). Stored server-side so they sync across devices. If not set, the frontend uses the browser timezone and locale time-format default.
 - **Display theme** — users can choose System, Light, or Dark. System follows the browser or OS color-scheme preference. The choice is browser-local and applies immediately on that device.
-- **Admin overrides** — operators with the right permissions can update other users' profiles, bypass the login cooldown, clear the cooldown so the user can change again before the 30 days expire, and force-delete an avatar.
+- **Admin overrides** — operators with the right permissions can update other human users' profiles, bypass the login cooldown, clear the cooldown so the user can change again before the 30 days expire, and force-delete an avatar.
+- **Bot identity management** — a bot owner or human user with `bot.manage` can update a bot's login and display name through `BotService`. Bot API keys cannot edit identity, and bot avatar, custom-status, and personal-settings management are not supported in this slice.
 
 ## Design Decisions
 
@@ -60,9 +61,9 @@ A user's profile carries the public identity they present to the rest of the ser
 
 ### 7. Cross-user edits gated by `user.manage-accounts`
 
-**Decision:** Admin updates to other users' profiles require `user.manage-accounts` for cross-user edits. Self-edits bypass that permission because they're privilege-neutral identity edits.
+**Decision:** Admin updates to other human users' profiles require `user.manage-accounts` for cross-user edits. Human self-edits bypass that permission because they're privilege-neutral identity edits. Bot login and display-name changes instead follow BotService ownership or `bot.manage` authorization and remain bounded to those two fields.
 **Why:** Chatto's simplified RBAC model is permission-based for everyone except effective owners, who are protected by the owner override rather than target-rank gates.
-**Tradeoff:** A user with `user.manage-accounts` can edit any target user's profile.
+**Tradeoff:** A user with `user.manage-accounts` can edit any target human user's profile, while bot identity management has a separate, deliberately narrower authority path.
 
 ### 8. Custom status is durable profile metadata, not presence
 
@@ -84,11 +85,12 @@ A user's profile carries the public identity they present to the rest of the ser
 
 ## Permissions
 
-- Self-edit (display name, avatar, custom status, settings, own login subject to cooldown) — no explicit permission; just authentication.
-- Cross-user edit — `user.manage-accounts`.
+- Human self-edit (display name, avatar, custom status, settings, own login subject to cooldown) — no explicit permission; just authentication.
+- Cross-human-user edit — `user.manage-accounts`.
 - Clear another user's login cooldown — same gate.
+- Bot login and display-name edit — bot ownership or `bot.manage`; bot avatar, custom-status, and personal-settings edits are not supported.
 
 ## Related
 
 - **ADRs:** ADR-007 (per-user encryption with crypto-shredding), ADR-021 (dual asset storage), ADR-065 (runtime JSON client internationalization)
-- **FDRs:** FDR-001 (Roles & Permissions), FDR-008 (File Attachments & Video Processing), FDR-011 (User Presence), FDR-018 (Account Lifecycle)
+- **FDRs:** FDR-001 (Roles & Permissions), FDR-008 (File Attachments & Video Processing), FDR-011 (User Presence), FDR-018 (Account Lifecycle), FDR-038 (Bot Accounts)

--- a/docs/fdr/FDR-025-user-search-and-member-directory.md
+++ b/docs/fdr/FDR-025-user-search-and-member-directory.md
@@ -1,11 +1,11 @@
 # FDR-025: User Search & Member Directory
 
 **Status:** Active
-**Last reviewed:** 2026-07-04
+**Last reviewed:** 2026-08-21
 
 ## Overview
 
-Any authenticated user can browse the server's member directory — a paginated list of all users on the server, with optional substring search. The directory powers general member-picking surfaces such as user comboboxes, quick switching, and @mention autocomplete. Admin member-management screens use the separate `AdminUserService` because they expose administrative fields and permissions.
+Any authenticated user can browse the server's member directory — a paginated list of all active human and bot accounts on the server, with optional substring search. The directory powers general member-picking surfaces such as user comboboxes, quick switching, and @mention autocomplete. Admin member-management screens use the separate `AdminUserService` because they expose administrative fields and permissions.
 
 ## Behavior
 
@@ -16,6 +16,7 @@ Any authenticated user can browse the server's member directory — a paginated 
 - Default page size is 20; the maximum is 500. Requests larger than 500 are silently clamped down.
 - Results are sorted by `createdAt` ascending (oldest member first). Users created before the timestamp field existed sort to the end, alphabetically by login.
 - Direct user lookups by stable user ID or login return the same public directory row shape as the directory and require authentication. Batch user hydration by stable user ID supports cache-miss loading without N+1 reads.
+- Directory and lookup rows expose the canonical `User.is_bot` marker. Clients render an accessible bot indicator so people can distinguish automation from human accounts.
 
 ## Design Decisions
 
@@ -47,7 +48,7 @@ Any authenticated user can browse the server's member directory — a paginated 
 
 **Decision:** No special permission required; any authenticated user can list members or look up a member by stable user ID.
 **Why:** Chatto's privacy model treats user identity (login, display name, avatar) as public to other members. Hiding members from members would be incongruent — they'd see each other in messages anyway. Operators who want a fully private member list would need a different feature.
-**Tradeoff:** Bot accounts or system users (if introduced) would surface in normal listings. The admin UI may still require admin permissions to reach its member-management page, but the underlying directory query remains available to authenticated users.
+**Tradeoff:** Bot accounts intentionally surface in normal listings. Integrations that need only human accounts must filter the canonical `is_bot` marker. The admin UI may still require admin permissions to reach its member-management page, but the underlying directory query remains available to authenticated users.
 
 ### 6. Implicit membership, no explicit member records
 
@@ -62,4 +63,4 @@ No explicit permission — authentication only.
 ## Related
 
 - **ADRs:** ADR-027 (instance/space consolidation)
-- **FDRs:** FDR-001 (Roles & Permissions), FDR-006 (@Mentions), FDR-021 (Admin Dashboard & System Monitoring), FDR-022 (User Profile)
+- **FDRs:** FDR-001 (Roles & Permissions), FDR-006 (@Mentions), FDR-021 (Admin Dashboard & System Monitoring), FDR-022 (User Profile), FDR-038 (Bot Accounts)

--- a/docs/fdr/FDR-038-bot-accounts.md
+++ b/docs/fdr/FDR-038-bot-accounts.md
@@ -15,8 +15,10 @@ exercise more authority than its human owner currently possesses.
 - A human user with `bot.create` can create a bot account and becomes its
   owner.
 - Server Admin's Bots page lists the bots visible to the caller and creates new
-  bots. Selecting a bot opens its own detail page for identity editing, key
-  rotation, deletion, metadata, and permissions.
+  bots. Selecting a bot opens its own detail page for login and display-name
+  editing, key rotation, deletion, metadata, and permissions. Bot avatar,
+  custom-status, and personal-settings management are not supported in this
+  slice.
 - On a fresh RBAC bootstrap, `everyone` receives `bot.create`, while `admin`
   and `owner` have `bot.manage`. The owner grant follows Chatto's normal
   effective-owner override rather than being stored as an editable permission
@@ -77,6 +79,8 @@ exercise more authority than its human owner currently possesses.
   sessions, OAuth access tokens, password-reset flows, or other human sign-in
   methods. A bot API key cannot change the bot's identity, ownership,
   permissions, or API key.
+- Bots cannot request their own deletion. Only their owner or a human user with
+  `bot.manage` can delete them through `BotService`.
 - Deleting a bot uses the normal account-deletion and crypto-shredding
   behavior. Deleting a human owner also deletes every bot they own and revokes
   those bots' API keys.
@@ -105,7 +109,9 @@ APIs as people without requiring parallel bot-only resource models. Separating
 authentication keeps an API credential from becoming an interactive login.
 **Tradeoff:** Account-security and credential-enrolment operations must enforce
 the account-kind boundary rather than treating every passwordless account as
-eligible for a password or external identity.
+eligible for a password or external identity. Bot profile management also
+needs a deliberately narrower surface than the human self-profile and
+cross-user administration APIs.
 
 ### 3. Explicit allowlist instead of normal role inheritance
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -10,7 +10,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
-| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-08-19 |
+| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-08-21 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-08-19 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-06-01 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-19 |
@@ -27,14 +27,14 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-08-20 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-07-20 |
-| [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-08-19 |
+| [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-08-21 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-08-19 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-07-14 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-08-11 |
-| [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-06-23 |
+| [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-08-21 |
 | [FDR-023](FDR-023-authentication-and-sessions.md) | Authentication & Sessions | Active | 2026-08-12 |
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-06-15 |
-| [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-05-19 |
+| [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-08-21 |
 | [FDR-026](FDR-026-last-room-memory.md) | Last-Room Memory | Active | 2026-05-19 |
 | [FDR-027](FDR-027-pwa-and-service-worker.md) | PWA & Service Worker | Active | 2026-08-20 |
 | [FDR-028](FDR-028-operator-api-and-cli.md) | Operator API & CLI | Active | 2026-06-29 |


### PR DESCRIPTION
## Why

Bot accounts need one regression test proving the complete operator workflow and its authentication boundaries, while the feature records need to distinguish human and bot account behaviour consistently.

## What changed

- Playwright coverage for creation, zero ambient authority, a minimal permission grant, API success, key rotation/revocation, and deletion/revocation
- Show-once key handling that keeps credentials out of Playwright, network, console, and failure artifacts
- Bot-specific corrections in [FDR-001](docs/fdr/FDR-001-roles-and-permissions.md), [FDR-018](docs/fdr/FDR-018-account-lifecycle.md), [FDR-022](docs/fdr/FDR-022-user-profile.md), [FDR-025](docs/fdr/FDR-025-user-search-and-member-directory.md), [FDR-038](docs/fdr/FDR-038-bot-accounts.md), and the FDR maintenance guidance

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: N/A

Newer client → older server: N/A

Capability discovery or minimum client/server version: unchanged

## Test plan

- `mise test-e2e -- bots.test.ts` — passed
- `mise lint-frontend` — passed with zero errors and warnings
- `mise license-check` — passed
- Prettier, ESLint, and `git diff --check` — passed
- Chrome DevTools — Bots page and create dialog verified with no browser errors
- Final Playwright artifact scan — no credential-shaped bot keys found

Closes #276.
