### PR TITLE
fix(authling): harden provider edge cases

### DIFF
--- a/authling/Dockerfile
+++ b/authling/Dockerfile
@@ -41,3 +41,4 @@ USER authling
 WORKDIR /data
 EXPOSE 8080
 ENTRYPOINT ["/authling"]
+CMD ["run"]

--- a/authling/README.md
+++ b/authling/README.md
@@ -118,8 +118,9 @@ binary; Node.js is not needed to run the resulting executable.
 Authling publishes discovery at `/.well-known/openid-configuration`. The
 initial profile supports Authorization Code, requires `openid` and S256 PKCE
 for every client, signs ID tokens with RS256, and exposes a minimal UserInfo
-response containing only the account ID as `sub`. It exposes no
-application-data scopes.
+response containing the account ID as `sub` plus non-empty
+`preferred_username` and `name` identity hints. It exposes no application-data
+scopes.
 
 Authling rotates its RS256 signing key automatically every 90 days. A new
 public key is published before use, and the preceding public key remains in

--- a/authling/e2e/oidc.test.ts
+++ b/authling/e2e/oidc.test.ts
@@ -129,11 +129,15 @@ function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-test('rejects authorization without S256 PKCE before starting consent', async ({ request, stack }) => {
+test('returns a missing-PKCE error to the validated client before consent', async ({ request, stack }) => {
+  const state = randomUUID();
   const response = await request.get(`${stack.baseURL}/oauth/authorize`, {
-    params: { client_id: 'authling-e2e', redirect_uri: stack.callbackURL, response_type: 'code', scope: 'openid' },
+    params: { client_id: 'authling-e2e', redirect_uri: stack.callbackURL, response_type: 'code', scope: 'openid', state },
     maxRedirects: 0
   });
-  expect(response.status()).toBe(400);
-  expect(await response.text()).toBe('invalid authorization request\n');
+  expect(response.status()).toBe(302);
+  const location = new URL(response.headers().location ?? '');
+  expect(`${location.origin}${location.pathname}`).toBe(stack.callbackURL);
+  expect(location.searchParams.get('error')).toBe('invalid_request');
+  expect(location.searchParams.get('state')).toBe(state);
 });

--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -373,7 +373,11 @@ func validate(event *corev1.Event) error {
 			return err
 		}
 		credential := payload.AccountCreated
-		hasCredential := credential.GetCredentialEnvelopeVersion() != 0 || credential.GetUserKeyRef() != "" || credential.GetCredentialKeyRef() != "" || len(credential.GetEmailNonce()) != 0 || len(credential.GetEmailCiphertext()) != 0 || len(credential.GetPasswordVerifierNonce()) != 0 || len(credential.GetPasswordVerifierCiphertext()) != 0
+		hasPreferredUsername := len(credential.GetPreferredUsernameNonce()) != 0 || len(credential.GetPreferredUsernameCiphertext()) != 0
+		if hasPreferredUsername && (len(credential.GetPreferredUsernameNonce()) == 0 || len(credential.GetPreferredUsernameCiphertext()) == 0) {
+			return fmt.Errorf("account preferred username envelope is incomplete")
+		}
+		hasCredential := credential.GetCredentialEnvelopeVersion() != 0 || credential.GetUserKeyRef() != "" || credential.GetCredentialKeyRef() != "" || len(credential.GetEmailNonce()) != 0 || len(credential.GetEmailCiphertext()) != 0 || len(credential.GetPasswordVerifierNonce()) != 0 || len(credential.GetPasswordVerifierCiphertext()) != 0 || hasPreferredUsername
 		if hasCredential {
 			if credential.GetCredentialEnvelopeVersion() != 1 || !validSubjectToken(credential.GetUserKeyRef()) || !validSubjectToken(credential.GetCredentialKeyRef()) || len(credential.GetEmailNonce()) == 0 || len(credential.GetEmailCiphertext()) == 0 || len(credential.GetPasswordVerifierNonce()) == 0 || len(credential.GetPasswordVerifierCiphertext()) == 0 {
 				return fmt.Errorf("account credential envelope is incomplete or unsupported")

--- a/authling/internal/evtstream/evtstream_test.go
+++ b/authling/internal/evtstream/evtstream_test.go
@@ -246,6 +246,62 @@ func TestAccountSubjectRejectsUnsafeTokens(t *testing.T) {
 	}
 }
 
+func TestDecodeRejectsPartialAccountCreatedCredentialEnvelopes(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*corev1.AccountCreatedEvent)
+	}{
+		{
+			name: "preferred username without credential",
+			mutate: func(event *corev1.AccountCreatedEvent) {
+				event.PreferredUsernameNonce = []byte("nonce")
+				event.PreferredUsernameCiphertext = []byte("ciphertext")
+			},
+		},
+		{
+			name: "partial preferred username",
+			mutate: func(event *corev1.AccountCreatedEvent) {
+				event.CredentialEnvelopeVersion = 1
+				event.UserKeyRef = "key_user"
+				event.CredentialKeyRef = "key_credential"
+				event.EmailNonce = []byte("nonce")
+				event.EmailCiphertext = []byte("ciphertext")
+				event.PasswordVerifierNonce = []byte("nonce")
+				event.PasswordVerifierCiphertext = []byte("ciphertext")
+				event.PreferredUsernameNonce = []byte("nonce")
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event := accountCreatedEvent("evt_created")
+			test.mutate(event.GetAccountCreated())
+			data, err := proto.Marshal(event)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Decode(data); err == nil {
+				t.Fatal("partial account credential envelope was accepted")
+			}
+		})
+	}
+}
+
+func TestAccountCreatedValidationAllowsHistoricalCredentialWithoutPreferredUsername(t *testing.T) {
+	event := accountCreatedEvent("evt_created")
+	credential := event.GetAccountCreated()
+	credential.CredentialEnvelopeVersion = 1
+	credential.UserKeyRef = "key_user"
+	credential.CredentialKeyRef = "key_credential"
+	credential.EmailNonce = []byte("nonce")
+	credential.EmailCiphertext = []byte("ciphertext")
+	credential.PasswordVerifierNonce = []byte("nonce")
+	credential.PasswordVerifierCiphertext = []byte("ciphertext")
+	if _, err := encode(event); err != nil {
+		t.Fatalf("historical credential without preferred username: %v", err)
+	}
+}
+
 func accountCreatedEvent(eventID string) *corev1.Event {
 	return &corev1.Event{
 		Id:        eventID,

--- a/authling/internal/oidcprovider/cimd.go
+++ b/authling/internal/oidcprovider/cimd.go
@@ -328,12 +328,25 @@ func blockedCIMDAddress(address netip.Addr) bool {
 	return false
 }
 
+// specialUsePrefixes complements netip's address classifications with the
+// IANA IPv4 and IPv6 special-purpose registries. CIMD fetches are an SSRF
+// boundary, so even globally reachable special-purpose assignments are denied.
+// Keep this list aligned with:
+// https://www.iana.org/assignments/iana-ipv4-special-registry
+// https://www.iana.org/assignments/iana-ipv6-special-registry
 var specialUsePrefixes = []netip.Prefix{
 	netip.MustParsePrefix("0.0.0.0/8"), netip.MustParsePrefix("100.64.0.0/10"),
 	netip.MustParsePrefix("192.0.0.0/24"), netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.31.196.0/24"), netip.MustParsePrefix("192.52.193.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"), netip.MustParsePrefix("192.175.48.0/24"),
 	netip.MustParsePrefix("198.18.0.0/15"), netip.MustParsePrefix("198.51.100.0/24"),
 	netip.MustParsePrefix("203.0.113.0/24"), netip.MustParsePrefix("240.0.0.0/4"),
-	netip.MustParsePrefix("2001:db8::/32"),
+	netip.MustParsePrefix("::ffff:0:0/96"), netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"), netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("100:0:0:1::/64"), netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"), netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("2620:4f:8000::/48"), netip.MustParsePrefix("3fff::/20"),
+	netip.MustParsePrefix("5f00::/16"),
 }
 
 func isLoopbackHost(host string) bool {

--- a/authling/internal/oidcprovider/provider.go
+++ b/authling/internal/oidcprovider/provider.go
@@ -182,6 +182,9 @@ func (s *Service) wrap(next http.Handler) http.Handler {
 		}
 		if r.URL.Path == "/oauth/authorize" {
 			if err := validateAuthorizeRequest(r); err != nil {
+				if s.redirectAuthorizationError(w, r, err) {
+					return
+				}
 				w.Header().Set("Cache-Control", "no-store")
 				http.Error(w, "invalid authorization request", http.StatusBadRequest)
 				return
@@ -214,6 +217,51 @@ func (s *Service) wrap(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+type authorizationRequestError struct {
+	code         string
+	redirectable bool
+}
+
+func (e *authorizationRequestError) Error() string { return "invalid authorization request" }
+
+// redirectAuthorizationError returns a protocol error only after the exact
+// client and redirect URI have been resolved. Unsafe or ambiguous requests stay
+// local so an attacker cannot turn Authling into an open redirector.
+func (s *Service) redirectAuthorizationError(w http.ResponseWriter, r *http.Request, requestErr *authorizationRequestError) bool {
+	if !requestErr.redirectable || s.storage == nil {
+		return false
+	}
+	query := r.URL.Query()
+	client, err := s.storage.GetClientByClientID(r.Context(), query.Get("client_id"))
+	if err != nil {
+		return false
+	}
+	redirectURI := query.Get("redirect_uri")
+	validRedirect := false
+	for _, candidate := range client.RedirectURIs() {
+		if candidate == redirectURI {
+			validRedirect = true
+			break
+		}
+	}
+	if !validRedirect {
+		return false
+	}
+	target, err := url.Parse(redirectURI)
+	if err != nil || target.Scheme == "" || target.Host == "" || target.Fragment != "" {
+		return false
+	}
+	parameters := target.Query()
+	parameters.Set("error", requestErr.code)
+	if state := query.Get("state"); state != "" {
+		parameters.Set("state", state)
+	}
+	target.RawQuery = parameters.Encode()
+	w.Header().Set("Cache-Control", "no-store")
+	http.Redirect(w, r, target.String(), http.StatusFound)
+	return true
 }
 
 // jwksResponseWriter decides cacheability when the downstream status becomes
@@ -285,38 +333,55 @@ func (s *Service) serveDiscovery(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-func validateAuthorizeRequest(r *http.Request) error {
+func validateAuthorizeRequest(r *http.Request) *authorizationRequestError {
+	localError := func() *authorizationRequestError {
+		return &authorizationRequestError{code: "invalid_request"}
+	}
+	clientError := func(code string) *authorizationRequestError {
+		return &authorizationRequestError{code: code, redirectable: true}
+	}
 	if r.Method != http.MethodGet {
-		return fmt.Errorf("authorization requires GET")
+		return localError()
 	}
 	if len(r.URL.RawQuery) > 8<<10 {
-		return fmt.Errorf("authorization query is too large")
+		return localError()
 	}
 	query := r.URL.Query()
-	for _, name := range []string{"client_id", "redirect_uri", "response_type", "scope", "code_challenge", "code_challenge_method", "state", "nonce", "prompt"} {
+	for _, name := range []string{"client_id", "redirect_uri", "response_type", "response_mode", "scope", "code_challenge", "code_challenge_method", "state", "nonce", "prompt"} {
 		if len(query[name]) > 1 {
-			return fmt.Errorf("duplicate parameter")
+			return localError()
 		}
 	}
-	if query.Get("client_id") == "" || query.Get("redirect_uri") == "" || query.Get("response_type") != string(liboidc.ResponseTypeCode) {
-		return fmt.Errorf("invalid request shape")
+	if query.Get("client_id") == "" || query.Get("redirect_uri") == "" {
+		return localError()
 	}
-	if len(query.Get("client_id")) > 2048 || len(query.Get("redirect_uri")) > 2048 || len(query.Get("state")) > 1024 || len(query.Get("nonce")) > 1024 {
-		return fmt.Errorf("authorization parameter is too large")
+	if len(query.Get("client_id")) > 2048 || len(query.Get("redirect_uri")) > 2048 || len(query.Get("state")) > 1024 {
+		return localError()
+	}
+	// The response mode determines how a protocol error can be returned. An
+	// unsupported value therefore has no safe client redirect representation.
+	if responseMode := query.Get("response_mode"); responseMode != "" && responseMode != string(liboidc.ResponseModeQuery) {
+		return localError()
+	}
+	if query.Get("response_type") != string(liboidc.ResponseTypeCode) {
+		return clientError("unauthorized_client")
 	}
 	if !validAuthorizeScopes(query.Get("scope")) {
-		return fmt.Errorf("unsupported scope")
+		return clientError("invalid_scope")
 	}
 	challenge := query.Get("code_challenge")
 	if !validPKCEValue(challenge) || query.Get("code_challenge_method") != string(liboidc.CodeChallengeMethodS256) {
-		return fmt.Errorf("S256 PKCE required")
+		return clientError("invalid_request")
 	}
 	prompts := strings.Fields(query.Get("prompt"))
 	if len(prompts) > 0 && !(len(prompts) == 1 && prompts[0] == liboidc.PromptConsent) {
-		return fmt.Errorf("unsupported prompt")
+		return clientError("invalid_request")
 	}
-	if query.Get("request") != "" || query.Has("max_age") || (query.Get("response_mode") != "" && query.Get("response_mode") != string(liboidc.ResponseModeQuery)) {
-		return fmt.Errorf("unsupported request mode")
+	if query.Get("request") != "" {
+		return clientError("request_not_supported")
+	}
+	if query.Has("max_age") || len(query.Get("nonce")) > 1024 {
+		return clientError("invalid_request")
 	}
 	return nil
 }

--- a/authling/internal/oidcprovider/provider_test.go
+++ b/authling/internal/oidcprovider/provider_test.go
@@ -282,6 +282,61 @@ func TestValidateAuthorizeRequestRejectsDuplicateSecurityParameters(t *testing.T
 	}
 }
 
+func TestAuthorizeValidationErrorsRedirectOnlyToValidatedClients(t *testing.T) {
+	valid := "https://auth.example/oauth/authorize?client_id=client&redirect_uri=https%3A%2F%2Fclient.example%2Fcallback&response_type=code&scope=openid&state=opaque-state&code_challenge=" + strings.Repeat("a", 43) + "&code_challenge_method=S256"
+	invalidScope := strings.ReplaceAll(valid, "scope=openid", "scope=openid%20email")
+	service := &Service{storage: &Storage{clients: &Resolver{configured: map[string]*Client{
+		"client": {IDValue: "client", Redirects: []string{"https://client.example/callback"}},
+	}}}}
+	tests := []struct {
+		name       string
+		raw        string
+		wantStatus int
+		wantError  string
+	}{
+		{name: "unsupported scope", raw: invalidScope, wantStatus: http.StatusFound, wantError: "invalid_scope"},
+		{name: "missing PKCE", raw: strings.ReplaceAll(valid, "&code_challenge="+strings.Repeat("a", 43), ""), wantStatus: http.StatusFound, wantError: "invalid_request"},
+		{name: "request object", raw: valid + "&request=opaque", wantStatus: http.StatusFound, wantError: "request_not_supported"},
+		{name: "unsupported response type", raw: strings.ReplaceAll(valid, "response_type=code", "response_type=token"), wantStatus: http.StatusFound, wantError: "unauthorized_client"},
+		{name: "unknown client", raw: strings.ReplaceAll(invalidScope, "client_id=client", "client_id=unknown"), wantStatus: http.StatusBadRequest},
+		{name: "unregistered redirect", raw: strings.ReplaceAll(invalidScope, "client.example%2Fcallback", "attacker.example%2Fcallback"), wantStatus: http.StatusBadRequest},
+		{name: "unsupported response mode", raw: valid + "&response_mode=form_post", wantStatus: http.StatusBadRequest},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			nextCalled := false
+			handler := service.wrap(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { nextCalled = true }))
+			response := httptest.NewRecorder()
+			handler.ServeHTTP(response, httptest.NewRequest(http.MethodGet, test.raw, nil))
+			if nextCalled {
+				t.Fatal("invalid authorization request reached the provider")
+			}
+			if response.Code != test.wantStatus || response.Header().Get("Cache-Control") != "no-store" {
+				t.Fatalf("status/cache = %d %q, want %d no-store", response.Code, response.Header().Get("Cache-Control"), test.wantStatus)
+			}
+			location, err := response.Result().Location()
+			if test.wantStatus != http.StatusFound {
+				if err == nil {
+					t.Fatalf("unsafe request redirected to %q", location)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parse error redirect: %v", err)
+			}
+			if got := location.Scheme + "://" + location.Host + location.Path; got != "https://client.example/callback" {
+				t.Fatalf("error redirect target = %q", got)
+			}
+			if got := location.Query().Get("error"); got != test.wantError {
+				t.Fatalf("error = %q, want %q", got, test.wantError)
+			}
+			if got := location.Query().Get("state"); got != "opaque-state" {
+				t.Fatalf("state = %q, want opaque-state", got)
+			}
+		})
+	}
+}
+
 func TestValidateCIMDEnforcesPublicCodeClientProfile(t *testing.T) {
 	identifier, err := validateClientIdentifierURL("https://client.example/oidc.json")
 	if err != nil {
@@ -321,9 +376,17 @@ func TestCIMDRejectsSpecialUseNetworksAndUnsafeIdentifiers(t *testing.T) {
 			t.Fatalf("unsafe client identifier %q was accepted", raw)
 		}
 	}
-	for _, raw := range []string{"127.0.0.1", "10.0.0.1", "100.64.0.1", "192.0.2.1", "198.51.100.1", "203.0.113.1", "224.0.0.1", "2001:db8::1"} {
+	for _, raw := range []string{
+		"127.0.0.1", "10.0.0.1", "100.64.0.1", "192.0.2.1", "192.31.196.1", "192.52.193.1", "192.88.99.1", "192.175.48.1", "198.51.100.1", "203.0.113.1", "224.0.0.1",
+		"::ffff:8.8.8.8", "64:ff9b::1", "64:ff9b:1::1", "100::1", "100:0:0:1::1", "2001::1", "2001:db8::1", "2002::1", "2620:4f:8000::1", "3fff::1", "5f00::1",
+	} {
 		if address := netip.MustParseAddr(raw); !blockedCIMDAddress(address) {
 			t.Fatalf("special-use address %s was accepted", address)
+		}
+	}
+	for _, raw := range []string{"8.8.8.8", "2606:4700:4700::1111"} {
+		if address := netip.MustParseAddr(raw); blockedCIMDAddress(address) {
+			t.Fatalf("ordinary public address %s was rejected", address)
 		}
 	}
 }

--- a/authling/internal/web/pages.templ
+++ b/authling/internal/web/pages.templ
@@ -17,6 +17,7 @@ templ layout(title, signedInAs string) {
 			<meta charset="utf-8"/>
 			<meta name="viewport" content="width=device-width, initial-scale=1"/>
 			<meta name="color-scheme" content="light dark"/>
+			<meta name="description" content="Authling is a self-hosted OpenID Connect identity provider."/>
 			<title>{ title }</title>
 			<link rel="stylesheet" href="/assets/app.css"/>
 		</head>
@@ -75,7 +76,7 @@ templ loginPage(message, oidcRequest string) {
 			<button class="button button-primary w-full" type="submit">Sign in</button>
 		</form>
 		<p class="mt-4 text-sm"><a class="text-link" href={ passwordResetURL(oidcRequest) }>Forgot your password?</a></p>
-		<p class="mt-6 text-sm text-slate-500">No account yet? <a class="text-link" href="/signup">Create one</a>.</p>
+		<p class="mt-6 text-sm text-slate-500 dark:text-slate-400">No account yet? <a class="text-link" href="/signup">Create one</a>.</p>
 	}
 }
 
@@ -100,7 +101,7 @@ templ passwordResetPage(message, oidcRequest string) {
 			<label class="block"><span class="font-medium">Email address</span><input class="form-control" type="email" name="email" autocomplete="email" autofocus required/></label>
 			<button class="button button-primary w-full" type="submit">Email me a reset code</button>
 		</form>
-		<p class="mt-6 text-sm text-slate-500"><a class="text-link" href="/login">Return to sign in</a>.</p>
+		<p class="mt-6 text-sm text-slate-500 dark:text-slate-400"><a class="text-link" href="/login">Return to sign in</a>.</p>
 	}
 }
 
@@ -387,7 +388,7 @@ templ profilePage(profile accounts.Profile, message, signedInAs string) {
 			<p role="alert" class="notice notice-error">{ message }</p>
 		}
 		<form class="mt-8 space-y-5" method="post" action="/account/profile">
-			<label class="block"><span class="font-medium">Preferred username</span><input class="form-control" type="text" name="preferred_username" autocomplete="username" minlength="2" maxlength="64" value={ profile.PreferredUsername } autofocus required/><span class="mt-2 block text-sm text-slate-500">This does not have to be unique.</span></label>
+			<label class="block"><span class="font-medium">Preferred username</span><input class="form-control" type="text" name="preferred_username" autocomplete="username" minlength="2" maxlength="64" value={ profile.PreferredUsername } autofocus required/><span class="mt-2 block text-sm text-slate-500 dark:text-slate-400">This does not have to be unique.</span></label>
 			<label class="block"><span class="font-medium">Full name</span><input class="form-control" type="text" name="full_name" autocomplete="name" maxlength="128" value={ profile.FullName }/></label>
 			<button class="button button-primary w-full" type="submit">Save profile</button>
 		</form>

--- a/authling/internal/web/pages_templ.go
+++ b/authling/internal/web/pages_templ.go
@@ -39,14 +39,14 @@ func layout(title, signedInAs string) templ.Component {
 			templ_7745c5c3_Var1 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><meta name=\"color-scheme\" content=\"light dark\"><title>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\"><meta name=\"viewport\" content=\"width=device-width, initial-scale=1\"><meta name=\"color-scheme\" content=\"light dark\"><meta name=\"description\" content=\"Authling is a self-hosted OpenID Connect identity provider.\"><title>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 20, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 21, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -64,7 +64,7 @@ func layout(title, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var3 string
 			templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.ResolveAttributeValue("Signed in as " + signedInAs + ". View your account.")
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 31, Col: 306}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 32, Col: 306}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var3)
 			if templ_7745c5c3_Err != nil {
@@ -77,7 +77,7 @@ func layout(title, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.ResolveAttributeValue(signedInAs)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 34, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 35, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var4)
 			if templ_7745c5c3_Err != nil {
@@ -90,7 +90,7 @@ func layout(title, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var5 string
 			templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(signedInAs)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 34, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 35, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 			if templ_7745c5c3_Err != nil {
@@ -209,7 +209,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 67, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 68, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -232,7 +232,7 @@ func loginPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var11 string
 				templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 71, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 72, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var11)
 				if templ_7745c5c3_Err != nil {
@@ -250,13 +250,13 @@ func loginPage(message, oidcRequest string) templ.Component {
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(passwordResetURL(oidcRequest))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 77, Col: 83}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 78, Col: 83}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">Forgot your password?</a></p><p class=\"mt-6 text-sm text-slate-500\">No account yet? <a class=\"text-link\" href=\"/signup\">Create one</a>.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "\">Forgot your password?</a></p><p class=\"mt-6 text-sm text-slate-500 dark:text-slate-400\">No account yet? <a class=\"text-link\" href=\"/signup\">Create one</a>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -322,7 +322,7 @@ func passwordResetPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 94, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 95, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -345,7 +345,7 @@ func passwordResetPage(message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var16 string
 				templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 98, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 99, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var16)
 				if templ_7745c5c3_Err != nil {
@@ -356,7 +356,7 @@ func passwordResetPage(message, oidcRequest string) templ.Component {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"form-control\" type=\"email\" name=\"email\" autocomplete=\"email\" autofocus required></label> <button class=\"button button-primary w-full\" type=\"submit\">Email me a reset code</button></form><p class=\"mt-6 text-sm text-slate-500\"><a class=\"text-link\" href=\"/login\">Return to sign in</a>.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "<label class=\"block\"><span class=\"font-medium\">Email address</span><input class=\"form-control\" type=\"email\" name=\"email\" autocomplete=\"email\" autofocus required></label> <button class=\"button button-primary w-full\" type=\"submit\">Email me a reset code</button></form><p class=\"mt-6 text-sm text-slate-500 dark:text-slate-400\"><a class=\"text-link\" href=\"/login\">Return to sign in</a>.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -415,7 +415,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var19 string
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 112, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 113, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
@@ -433,7 +433,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 			var templ_7745c5c3_Var20 string
 			templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 115, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 116, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var20)
 			if templ_7745c5c3_Err != nil {
@@ -451,7 +451,7 @@ func passwordResetCodePage(flow, message, oidcRequest string) templ.Component {
 				var templ_7745c5c3_Var21 string
 				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 117, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 118, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var21)
 				if templ_7745c5c3_Err != nil {
@@ -516,7 +516,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 128, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 129, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -534,7 +534,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 				var templ_7745c5c3_Var25 string
 				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 130, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 131, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 				if templ_7745c5c3_Err != nil {
@@ -552,7 +552,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 133, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 134, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var26)
 			if templ_7745c5c3_Err != nil {
@@ -570,7 +570,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 				var templ_7745c5c3_Var27 string
 				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.ResolveAttributeValue(oidcRequest)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 135, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 136, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var27)
 				if templ_7745c5c3_Err != nil {
@@ -588,7 +588,7 @@ func newPasswordPage(flow, message string, passwordMinimumLength int, oidcReques
 			var templ_7745c5c3_Var28 string
 			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 137, Col: 204}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 138, Col: 204}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var28)
 			if templ_7745c5c3_Err != nil {
@@ -700,7 +700,7 @@ func emailChangePage(message, signedInAs string) templ.Component {
 				var templ_7745c5c3_Var33 string
 				templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 156, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 157, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 				if templ_7745c5c3_Err != nil {
@@ -770,7 +770,7 @@ func emailChangeCodePage(flow, message, signedInAs string) templ.Component {
 				var templ_7745c5c3_Var36 string
 				templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 171, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 172, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
 				if templ_7745c5c3_Err != nil {
@@ -788,7 +788,7 @@ func emailChangeCodePage(flow, message, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var37 string
 			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 174, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 175, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var37)
 			if templ_7745c5c3_Err != nil {
@@ -853,7 +853,7 @@ func emailChangeConfirmPage(flow, message, signedInAs string) templ.Component {
 				var templ_7745c5c3_Var40 string
 				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 186, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 187, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 				if templ_7745c5c3_Err != nil {
@@ -871,7 +871,7 @@ func emailChangeConfirmPage(flow, message, signedInAs string) templ.Component {
 			var templ_7745c5c3_Var41 string
 			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 189, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 190, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var41)
 			if templ_7745c5c3_Err != nil {
@@ -931,7 +931,7 @@ func consentPage(request oidcprovider.ConsentRequest, signedInAs string) templ.C
 			var templ_7745c5c3_Var44 string
 			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 197, Col: 82}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 198, Col: 82}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 			if templ_7745c5c3_Err != nil {
@@ -944,7 +944,7 @@ func consentPage(request oidcprovider.ConsentRequest, signedInAs string) templ.C
 			var templ_7745c5c3_Var45 string
 			templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(request.ClientHost)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 198, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 199, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 			if templ_7745c5c3_Err != nil {
@@ -957,7 +957,7 @@ func consentPage(request oidcprovider.ConsentRequest, signedInAs string) templ.C
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.ResolveAttributeValue(request.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 206, Col: 52}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 207, Col: 52}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var46)
 			if templ_7745c5c3_Err != nil {
@@ -1022,7 +1022,7 @@ func signupPage(message string) templ.Component {
 				var templ_7745c5c3_Var49 string
 				templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 218, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 219, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 				if templ_7745c5c3_Err != nil {
@@ -1092,7 +1092,7 @@ func codePage(flow, message string) templ.Component {
 				var templ_7745c5c3_Var52 string
 				templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 232, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 233, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 				if templ_7745c5c3_Err != nil {
@@ -1110,7 +1110,7 @@ func codePage(flow, message string) templ.Component {
 			var templ_7745c5c3_Var53 string
 			templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 235, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 236, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var53)
 			if templ_7745c5c3_Err != nil {
@@ -1170,7 +1170,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var56 string
 			templ_7745c5c3_Var56, templ_7745c5c3_Err = templ.JoinStringErrs(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 245, Col: 103}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 246, Col: 103}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var56))
 			if templ_7745c5c3_Err != nil {
@@ -1188,7 +1188,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 				var templ_7745c5c3_Var57 string
 				templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 247, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 248, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 				if templ_7745c5c3_Err != nil {
@@ -1206,7 +1206,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.ResolveAttributeValue(flow)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 250, Col: 48}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 251, Col: 48}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var58)
 			if templ_7745c5c3_Err != nil {
@@ -1219,7 +1219,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var59 string
 			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 251, Col: 200}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 252, Col: 200}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var59)
 			if templ_7745c5c3_Err != nil {
@@ -1232,7 +1232,7 @@ func passwordPage(flow, message string, passwordMinimumLength int) templ.Compone
 			var templ_7745c5c3_Var60 string
 			templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 252, Col: 221}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 253, Col: 221}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var60)
 			if templ_7745c5c3_Err != nil {
@@ -1292,7 +1292,7 @@ func accountCreatedPage(accountID string) templ.Component {
 			var templ_7745c5c3_Var63 string
 			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 262, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 263, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
 			if templ_7745c5c3_Err != nil {
@@ -1442,7 +1442,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 			var templ_7745c5c3_Var66 string
 			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(accountID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 298, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 299, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 			if templ_7745c5c3_Err != nil {
@@ -1470,7 +1470,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 					var templ_7745c5c3_Var67 string
 					templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(grant.ClientName)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 316, Col: 52}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 317, Col: 52}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 					if templ_7745c5c3_Err != nil {
@@ -1483,7 +1483,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 					var templ_7745c5c3_Var68 string
 					templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(grant.ClientHost)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 317, Col: 98}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 318, Col: 98}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
 					if templ_7745c5c3_Err != nil {
@@ -1496,7 +1496,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 					var templ_7745c5c3_Var69 string
 					templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(grant.AuthorizedAt))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 318, Col: 118}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 319, Col: 118}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 					if templ_7745c5c3_Err != nil {
@@ -1509,7 +1509,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 					var templ_7745c5c3_Var70 string
 					templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.ResolveAttributeValue(grant.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 321, Col: 62}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 322, Col: 62}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var70)
 					if templ_7745c5c3_Err != nil {
@@ -1547,7 +1547,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 				var templ_7745c5c3_Var71 string
 				templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.CreatedAt))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 345, Col: 115}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 346, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 				if templ_7745c5c3_Err != nil {
@@ -1560,7 +1560,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 				var templ_7745c5c3_Var72 string
 				templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.LastSeenAt))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 346, Col: 120}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 347, Col: 120}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 				if templ_7745c5c3_Err != nil {
@@ -1573,7 +1573,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 				var templ_7745c5c3_Var73 string
 				templ_7745c5c3_Var73, templ_7745c5c3_Err = templ.JoinStringErrs(formatSessionTime(browserSession.ExpiresAt))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 347, Col: 115}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 348, Col: 115}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var73))
 				if templ_7745c5c3_Err != nil {
@@ -1591,7 +1591,7 @@ func accountPage(accountID, signedInAs string, browserSessions []sessions.Browse
 					var templ_7745c5c3_Var74 string
 					templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.ResolveAttributeValue(browserSession.ID)
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 352, Col: 73}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 353, Col: 73}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var74)
 					if templ_7745c5c3_Err != nil {
@@ -1689,7 +1689,7 @@ func profilePage(profile accounts.Profile, message, signedInAs string) templ.Com
 				var templ_7745c5c3_Var77 string
 				templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 387, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 388, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 				if templ_7745c5c3_Err != nil {
@@ -1707,20 +1707,20 @@ func profilePage(profile accounts.Profile, message, signedInAs string) templ.Com
 			var templ_7745c5c3_Var78 string
 			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.ResolveAttributeValue(profile.PreferredUsername)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 390, Col: 227}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 391, Col: 227}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var78)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 126, "\" autofocus required><span class=\"mt-2 block text-sm text-slate-500\">This does not have to be unique.</span></label> <label class=\"block\"><span class=\"font-medium\">Full name</span><input class=\"form-control\" type=\"text\" name=\"full_name\" autocomplete=\"name\" maxlength=\"128\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 126, "\" autofocus required><span class=\"mt-2 block text-sm text-slate-500 dark:text-slate-400\">This does not have to be unique.</span></label> <label class=\"block\"><span class=\"font-medium\">Full name</span><input class=\"form-control\" type=\"text\" name=\"full_name\" autocomplete=\"name\" maxlength=\"128\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var79 string
 			templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.ResolveAttributeValue(profile.FullName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 391, Col: 183}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 392, Col: 183}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var79)
 			if templ_7745c5c3_Err != nil {
@@ -1785,7 +1785,7 @@ func passwordChangePage(message string, passwordMinimumLength int, signedInAs st
 				var templ_7745c5c3_Var82 string
 				templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(message)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 403, Col: 56}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 404, Col: 56}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 				if templ_7745c5c3_Err != nil {
@@ -1803,7 +1803,7 @@ func passwordChangePage(message string, passwordMinimumLength int, signedInAs st
 			var templ_7745c5c3_Var83 string
 			templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 407, Col: 208}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 408, Col: 208}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var83)
 			if templ_7745c5c3_Err != nil {
@@ -1816,7 +1816,7 @@ func passwordChangePage(message string, passwordMinimumLength int, signedInAs st
 			var templ_7745c5c3_Var84 string
 			templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.ResolveAttributeValue(strconv.Itoa(passwordMinimumLength))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 408, Col: 229}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/pages.templ`, Line: 409, Col: 229}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var84)
 			if templ_7745c5c3_Err != nil {

--- a/authling/internal/web/web_test.go
+++ b/authling/internal/web/web_test.go
@@ -24,6 +24,9 @@ func TestHandlerRendersHomePageWithoutScripts(t *testing.T) {
 	if !strings.Contains(body, "Identity, under your control.") {
 		t.Fatalf("body does not contain the Authling heading: %q", body)
 	}
+	if !strings.Contains(body, `<meta name="description" content="Authling is a self-hosted OpenID Connect identity provider."`) {
+		t.Fatalf("body does not contain the Authling description: %q", body)
+	}
 	if strings.Contains(body, "<script") {
 		t.Fatalf("body unexpectedly contains a script: %q", body)
 	}


### PR DESCRIPTION
## Summary

- complete Authling's CIMD SSRF denylist for current IANA IPv4 and IPv6 special-purpose ranges
- return strict-profile OIDC authorization errors only through an exact, validated client redirect while preserving `state`
- reject partial preferred-username data in persisted account-creation events without breaking historical credential events
- make the Authling container start the service by default and align the README with the claims Authling emits
- add document metadata and complete dark-mode helper-text contrast coverage; the favicon remains intentionally unchanged

## Compatibility and security

- no protobuf fields, event tags, subjects, storage coordinates, or public success responses change
- historical local-account events that predate `preferred_username` remain valid
- invalid clients, ambiguous requests, unregistered redirects, and unsupported response modes continue to fail locally
- valid clients now receive standard error and `state` parameters for unsupported scopes, PKCE, prompts, request objects, and response types

This aligns the implementation with [Authling FDR-004](authling/docs/fdr/FDR-004-openid-connect-provider.md) and [Authling ADR-004](authling/docs/adr/ADR-004-cimd-native-openid-provider.md).

## Verification

- `cd authling && mise test`
- `cd authling && mise test-e2e` (33 passed)
- `cd authling && GOWORK=off mise x -- go test -race -trimpath ./...`
- `cd authling && mise x -- go vet ./...`
- `cd authling && mise x -- buf lint`
- `cd authling && mise x -- buf breaking --against '../.git#branch=main,subdir=authling'`
- `mise license-check`
- production Dockerfile build and final image configuration inspection
- Chrome DevTools mobile Lighthouse audit: Accessibility 100, Best Practices 100, SEO 100, Agentic Browsing 100
