### PR TITLE
fix(authling): fence credential audit events

### DIFF
--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -95,6 +95,11 @@ authority to delete keys that an in-flight replica could still reference.
 
 Persisted records use the `authling.core.v1.Event` protobuf envelope:
 
+New envelope IDs are opaque random `evt_...` values. Encoding and replay
+accept historical single-token identifiers but reject whitespace, subject
+separators, and email-address punctuation; correlation fields use the same
+token-safe vocabulary.
+
 | Event | Subject | Aggregate | Contents |
 |-------|---------|-----------|----------|
 | `AccountCreatedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account ID, envelope creation time, and encrypted local credential fields including the preferred username |

--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -136,7 +136,10 @@ model retains a bounded set of email-change requests per account
 so replay can require the exact reauthentication audit chain without retaining
 abandoned request IDs without bound. An email-change account event stages its
 encrypted replacement; the adjacent correlated registry event swaps the active
-digest and credential and advances the authentication version. Local
+digest and credential and advances the authentication version. Before a
+credential-generation-bound password or request-audit command evaluates its
+precondition, the account service captures and waits for both the account and
+registry tails and rejects a staged replacement that is not active yet. Local
 authentication, signed-in password change, and email-change reauthentication
 share distributed attempt limits and bounded Argon2 capacity. They resolve and
 decrypt a verifier only for one bounded Argon2id comparison; absent login

--- a/authling/internal/accounts/accounts.go
+++ b/authling/internal/accounts/accounts.go
@@ -173,6 +173,9 @@ type Projection struct {
 	profiles       map[string]protectedProfile
 	vault          *keyvault.Vault
 	indexKey       []byte
+	// beforeEmailClaimApply is a test-only synchronization seam for holding
+	// the ordered projector between an atomic email change's two messages.
+	beforeEmailClaimApply func()
 }
 
 // NewProjection creates the protected account projection.
@@ -402,6 +405,12 @@ func (p *Projection) Apply(event *corev1.Event, sequence uint64) error {
 		if claim == nil {
 			return fmt.Errorf("unsupported account event")
 		}
+		p.RLock()
+		beforeApply := p.beforeEmailClaimApply
+		p.RUnlock()
+		if beforeApply != nil {
+			beforeApply()
+		}
 		p.Lock()
 		defer p.Unlock()
 		pending, ok := p.pendingEmails[claim.GetAccountId()]
@@ -556,12 +565,12 @@ func (p *Projection) credentialForAccount(accountID string) (protectedCredential
 	return credential, ok
 }
 
-// credentialForPasswordMutation rejects the interval in which an atomic email
+// credentialForIdentityMutation rejects the interval in which an atomic email
 // change has staged its account event but its adjacent registry claim has not
-// yet activated the new credential. Appending against the old credential in
-// that interval would create an event that fails ordered replay after the
-// registry claim advances the credential generation.
-func (p *Projection) credentialForPasswordMutation(accountID string) (protectedCredential, bool) {
+// yet activated the new credential. Credential-bound commands must not append
+// against the old credential in that interval because ordered replay would
+// reject the event after the registry claim advances the generation.
+func (p *Projection) credentialForIdentityMutation(accountID string) (protectedCredential, bool) {
 	p.RLock()
 	defer p.RUnlock()
 	if pending, ok := p.pendingEmails[accountID]; ok && pending.replaces {
@@ -1029,7 +1038,7 @@ func (s *Service) ChangePassword(ctx context.Context, target PasswordChangeTarge
 	if err != nil {
 		return Account{}, err
 	}
-	tail, credential, err := s.passwordCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+	tail, credential, err := s.identityCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
 	if err != nil {
 		return Account{}, err
 	}
@@ -1059,7 +1068,7 @@ func (s *Service) ChangePassword(ctx context.Context, target PasswordChangeTarge
 	for range 5 {
 		position, err := s.publisher.AppendPasswordChanged(ctx, event, tail)
 		if errors.Is(err, events.ErrConflict) {
-			tail, _, err = s.passwordCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+			tail, _, err = s.identityCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
 			if err != nil {
 				return Account{}, err
 			}
@@ -1126,20 +1135,9 @@ func (s *Service) RecordEmailChangeRequested(ctx context.Context, target EmailCh
 		AccountId: target.AccountID, CredentialEventId: target.CredentialEventID,
 	}}}
 	for range 5 {
-		tail, err := s.publisher.AccountTail(ctx, target.AccountID)
+		tail, _, err := s.identityCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
 		if err != nil {
-			return EmailChangeTarget{}, fmt.Errorf("read email-change account tail: %w", err)
-		}
-		subject, err := evtstream.AccountSubject(target.AccountID)
-		if err != nil {
-			return EmailChangeTarget{}, ErrCredentialChanged
-		}
-		if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
-			return EmailChangeTarget{}, fmt.Errorf("wait for email-change account: %w", err)
-		}
-		current, ok := s.handle.Projection().credentialForAccount(target.AccountID)
-		if !ok || current.eventID != target.CredentialEventID {
-			return EmailChangeTarget{}, ErrCredentialChanged
+			return EmailChangeTarget{}, err
 		}
 		position, err := s.publisher.AppendEmailChangeRequested(ctx, event, tail)
 		if errors.Is(err, events.ErrConflict) {
@@ -1275,25 +1273,21 @@ func (s *Service) RecordPasswordResetRequested(ctx context.Context, email string
 		if !ok {
 			return PasswordResetTarget{}, false, nil
 		}
-		accountID := target.AccountID
-		tail, err := s.publisher.AccountTail(ctx, accountID)
+		tail, _, err := s.identityCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+		if errors.Is(err, ErrCredentialChanged) {
+			continue
+		}
 		if err != nil {
-			return PasswordResetTarget{}, false, fmt.Errorf("read password reset account tail: %w", err)
+			return PasswordResetTarget{}, false, err
 		}
-		subject, err := evtstream.AccountSubject(accountID)
-		if err != nil {
-			return PasswordResetTarget{}, false, fmt.Errorf("resolve password reset account subject: %w", err)
-		}
-		if err := s.handle.Projector().WaitFor(ctx, events.SubjectPosition(subject, tail)); err != nil {
-			return PasswordResetTarget{}, false, fmt.Errorf("wait for password reset account: %w", err)
-		}
-		target, ok = s.handle.Projection().passwordResetTarget(email)
+		current, ok := s.handle.Projection().passwordResetTarget(email)
 		if !ok {
 			return PasswordResetTarget{}, false, nil
 		}
-		if target.AccountID != accountID {
+		if current.AccountID != target.AccountID || current.CredentialEventID != target.CredentialEventID {
 			continue
 		}
+		target = current
 		event := &corev1.Event{Id: eventID, CreatedAt: createdAt, Event: &corev1.Event_PasswordResetRequested{PasswordResetRequested: &corev1.PasswordResetRequestedEvent{
 			AccountId: target.AccountID, CredentialEventId: target.CredentialEventID,
 		}}}
@@ -1382,10 +1376,16 @@ func (s *Service) ResetPassword(ctx context.Context, target PasswordResetTarget,
 }
 
 func (s *Service) passwordResetCredentialAtTail(ctx context.Context, target PasswordResetTarget) (uint64, protectedCredential, error) {
-	return s.passwordCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
+	return s.identityCredentialAtTail(ctx, target.AccountID, target.CredentialEventID)
 }
 
-func (s *Service) passwordCredentialAtTail(ctx context.Context, accountID, credentialEventID string) (uint64, protectedCredential, error) {
+// identityCredentialAtTail captures both subjects that can advance a local
+// credential, waits until the projection has crossed both boundaries, and then
+// verifies the caller's credential generation. Capturing the registry tail is
+// essential because an email change is stored as an adjacent cross-subject
+// batch whose account event stages the credential and whose registry event
+// activates it.
+func (s *Service) identityCredentialAtTail(ctx context.Context, accountID, credentialEventID string) (uint64, protectedCredential, error) {
 	tail, err := s.publisher.AccountTail(ctx, accountID)
 	if err != nil {
 		return 0, protectedCredential{}, fmt.Errorf("read account tail: %w", err)
@@ -1409,7 +1409,7 @@ func (s *Service) passwordCredentialAtTail(ctx context.Context, accountID, crede
 			return 0, protectedCredential{}, fmt.Errorf("wait for account registry credential: %w", err)
 		}
 	}
-	credential, ok := s.handle.Projection().credentialForPasswordMutation(accountID)
+	credential, ok := s.handle.Projection().credentialForIdentityMutation(accountID)
 	if !ok || credential.eventID != credentialEventID {
 		return 0, protectedCredential{}, ErrCredentialChanged
 	}

--- a/authling/internal/accounts/accounts_interleaving_test.go
+++ b/authling/internal/accounts/accounts_interleaving_test.go
@@ -1,0 +1,183 @@
+package accounts
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"hmans.de/authling/internal/config"
+	"hmans.de/authling/internal/evtstream"
+	"hmans.de/authling/internal/keyvault"
+	"hmans.de/authling/internal/logging"
+	"hmans.de/authling/internal/natsruntime"
+	"hmans.de/authling/internal/storage"
+	"hmans.de/chatto/pkg/events"
+)
+
+func TestCredentialBoundAuditRequestsWaitForEmailClaim(t *testing.T) {
+	ctx := accountTestContext(t)
+	connection, err := natsruntime.Open(ctx, config.NATSConfig{
+		Embedded: config.EmbeddedNATSConfig{Enabled: true, DataDir: t.TempDir()},
+	})
+	if err != nil {
+		t.Fatalf("open NATS: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := connection.Close(); err != nil {
+			t.Errorf("close NATS: %v", err)
+		}
+	})
+	js, stream, err := storage.Open(ctx, connection.NATS, 1)
+	if err != nil {
+		t.Fatalf("open event storage: %v", err)
+	}
+	stores, err := storage.OpenStores(ctx, js, 1)
+	if err != nil {
+		t.Fatalf("open stores: %v", err)
+	}
+	vault := keyvault.New(stores.Keys)
+	indexKey, err := vault.WorkflowKey(ctx)
+	if err != nil {
+		t.Fatalf("open workflow key: %v", err)
+	}
+	defer clear(indexKey)
+	logger := logging.Events{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))}
+	publisher := evtstream.NewPublisher(events.NewEncodedEventLog(js, stream, logger))
+	projection := NewProjection(vault, indexKey)
+	handle := events.NewDecodedProjectionHandle(js, stream, projection, evtstream.Decode, logger)
+	service, err := NewService(ctx, publisher, handle, vault, 12)
+	if err != nil {
+		t.Fatalf("create account service: %v", err)
+	}
+	runCancel, runErrors := runAccountTestProjector(t, handle.Projector())
+
+	const (
+		oldEmail = "before@example.com"
+		newEmail = "after@example.com"
+		password = "a deliberately long test password"
+	)
+	account, err := service.CreateLocal(ctx, oldEmail, password)
+	if err != nil {
+		t.Fatalf("create local account: %v", err)
+	}
+	target, err := service.PrepareEmailChange(ctx, account.ID, password, newEmail)
+	if err != nil {
+		t.Fatalf("prepare email change: %v", err)
+	}
+	target, err = service.RecordEmailChangeRequested(ctx, target)
+	if err != nil {
+		t.Fatalf("record initial email-change request: %v", err)
+	}
+
+	claimStarted := make(chan struct{})
+	releaseClaim := make(chan struct{})
+	projection.Lock()
+	projection.beforeEmailClaimApply = func() {
+		close(claimStarted)
+		<-releaseClaim
+	}
+	projection.Unlock()
+	changeErrors := make(chan error, 1)
+	go func() {
+		_, err := service.ChangeEmail(ctx, target, newEmail)
+		changeErrors <- err
+	}()
+	select {
+	case <-claimStarted:
+	case <-ctx.Done():
+		t.Fatalf("wait for staged email change: %v", ctx.Err())
+	}
+
+	stagedTail, err := publisher.AccountTail(ctx, account.ID)
+	if err != nil {
+		t.Fatalf("read staged account tail: %v", err)
+	}
+	assertNoAuditAppend := func(name string, command func(context.Context) error) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			commandCtx, cancel := context.WithTimeout(t.Context(), 150*time.Millisecond)
+			defer cancel()
+			if err := command(commandCtx); !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("command error = %v, want context deadline while registry apply is blocked", err)
+			}
+			tail, err := publisher.AccountTail(accountTestContext(t), account.ID)
+			if err != nil {
+				t.Fatalf("read account tail: %v", err)
+			}
+			if tail != stagedTail {
+				t.Fatalf("account tail = %d, want staged email-change tail %d; audit event committed inside split batch", tail, stagedTail)
+			}
+		})
+	}
+	assertNoAuditAppend("email change request", func(commandCtx context.Context) error {
+		_, err := service.RecordEmailChangeRequested(commandCtx, EmailChangeTarget{
+			AccountID: account.ID, CredentialEventID: target.CredentialEventID,
+		})
+		return err
+	})
+	assertNoAuditAppend("password reset request", func(commandCtx context.Context) error {
+		_, _, err := service.RecordPasswordResetRequested(commandCtx, oldEmail)
+		return err
+	})
+
+	close(releaseClaim)
+	select {
+	case err := <-changeErrors:
+		if err != nil {
+			t.Fatalf("complete email change: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatalf("wait for email change: %v", ctx.Err())
+	}
+	if err := handle.Projector().Err(); err != nil {
+		t.Fatalf("live projection failed after interleaving: %v", err)
+	}
+	if _, ok, err := service.RecordPasswordResetRequested(ctx, newEmail); err != nil || !ok {
+		t.Fatalf("record request against activated credential: ok=%v err=%v", ok, err)
+	}
+
+	stopAccountTestProjector(t, runCancel, runErrors)
+	replayed := NewProjection(vault, indexKey)
+	replayHandle := events.NewDecodedProjectionHandle(js, stream, replayed, evtstream.Decode, logger)
+	replayCancel, replayErrors := runAccountTestProjector(t, replayHandle.Projector())
+	if !replayed.HasEmail(newEmail) || replayed.HasEmail(oldEmail) {
+		t.Fatalf("cold replay email registry: old=%v new=%v", replayed.HasEmail(oldEmail), replayed.HasEmail(newEmail))
+	}
+	stopAccountTestProjector(t, replayCancel, replayErrors)
+}
+
+func runAccountTestProjector(t *testing.T, projector *events.Projector) (context.CancelFunc, <-chan error) {
+	t.Helper()
+	runContext, cancel := context.WithCancel(context.Background())
+	runErrors := make(chan error, 1)
+	go func() { runErrors <- projector.Run(runContext) }()
+	if err := projector.WaitForStartup(accountTestContext(t)); err != nil {
+		cancel()
+		<-runErrors
+		t.Fatalf("wait for projector startup: %v", err)
+	}
+	return cancel, runErrors
+}
+
+func stopAccountTestProjector(t *testing.T, cancel context.CancelFunc, runErrors <-chan error) {
+	t.Helper()
+	cancel()
+	select {
+	case err := <-runErrors:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("projector shutdown error = %v, want context cancellation", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("projector did not stop")
+	}
+}
+
+func accountTestContext(t *testing.T) context.Context {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}

--- a/authling/internal/accounts/accounts_test.go
+++ b/authling/internal/accounts/accounts_test.go
@@ -113,7 +113,7 @@ func TestEmailReplacementClaimRequiresCorrelationButHistoricalCreationDoesNot(t 
 	}
 }
 
-func TestPasswordMutationRejectsTheSplitEmailChangeBatch(t *testing.T) {
+func TestIdentityMutationRejectsTheSplitEmailChangeBatch(t *testing.T) {
 	projection := NewProjection(nil, []byte("index key"))
 	projection.credentials = map[string]protectedCredential{"acc_example": {
 		accountID: "acc_example", eventID: "evt_prior", userKeyRef: "key_user", credentialKeyRef: "key_credential",
@@ -122,12 +122,12 @@ func TestPasswordMutationRejectsTheSplitEmailChangeBatch(t *testing.T) {
 		eventID: "evt_email_change", replaces: true,
 		credential: protectedCredential{accountID: "acc_example", eventID: "evt_email_change"},
 	}}
-	if credential, ok := projection.credentialForPasswordMutation("acc_example"); ok {
-		t.Fatalf("password mutation observed staged email-change credential: %+v", credential)
+	if credential, ok := projection.credentialForIdentityMutation("acc_example"); ok {
+		t.Fatalf("identity mutation observed staged email-change credential: %+v", credential)
 	}
 	delete(projection.pendingEmails, "acc_example")
-	if credential, ok := projection.credentialForPasswordMutation("acc_example"); !ok || credential.eventID != "evt_prior" {
-		t.Fatalf("password mutation credential after registry claim = %+v, %v", credential, ok)
+	if credential, ok := projection.credentialForIdentityMutation("acc_example"); !ok || credential.eventID != "evt_prior" {
+		t.Fatalf("identity mutation credential after registry claim = %+v, %v", credential, ok)
 	}
 }
 

--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -361,6 +361,9 @@ func validate(event *corev1.Event) error {
 	if strings.TrimSpace(event.GetId()) == "" {
 		return fmt.Errorf("Authling event id is required")
 	}
+	if !validSubjectToken(event.GetId()) {
+		return fmt.Errorf("Authling event id is invalid")
+	}
 	if event.GetCreatedAt() == nil {
 		return fmt.Errorf("Authling event created_at is required")
 	}

--- a/authling/internal/evtstream/evtstream_test.go
+++ b/authling/internal/evtstream/evtstream_test.go
@@ -232,6 +232,48 @@ func TestDecodeRejectsMalformedEvents(t *testing.T) {
 	}
 }
 
+func TestEventIDValidationRejectsSensitiveOrUnsafeTokens(t *testing.T) {
+	for _, eventID := range []string{
+		"person@example.com",
+		"evt.with.dots",
+		"evt/with/slashes",
+		"evt with spaces",
+		"evt\nwith-newline",
+	} {
+		t.Run(eventID, func(t *testing.T) {
+			event := accountCreatedEvent(eventID)
+			if _, err := encode(event); err == nil || !strings.Contains(err.Error(), "event id is invalid") {
+				t.Fatalf("encode event ID %q error = %v, want invalid event ID", eventID, err)
+			} else if strings.Contains(err.Error(), eventID) {
+				t.Fatalf("encode error leaked rejected event ID %q: %v", eventID, err)
+			}
+			data, err := proto.Marshal(event)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "event id is invalid") {
+				t.Fatalf("decode event ID %q error = %v, want invalid event ID", eventID, err)
+			} else if strings.Contains(err.Error(), eventID) {
+				t.Fatalf("decode error leaked rejected event ID %q: %v", eventID, err)
+			}
+		})
+	}
+}
+
+func TestEventIDValidationAllowsHistoricalSubjectSafeTokens(t *testing.T) {
+	for _, eventID := range []string{"evt_legacy", "evt-legacy", "LegacyEvent_123"} {
+		t.Run(eventID, func(t *testing.T) {
+			record, err := encode(accountCreatedEvent(eventID))
+			if err != nil {
+				t.Fatalf("encode historical event ID %q: %v", eventID, err)
+			}
+			if _, err := Decode(record.Data); err != nil {
+				t.Fatalf("decode historical event ID %q: %v", eventID, err)
+			}
+		})
+	}
+}
+
 func profileUpdatedEvent(eventID string) *corev1.Event {
 	return &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_ProfileUpdated{ProfileUpdated: &corev1.ProfileUpdatedEvent{
 		AccountId: "acc_test", UserKeyRef: "key_user", CredentialKeyRef: "key_credential", ProfileEnvelopeVersion: 1,

--- a/authling/internal/pb/authling/core/v1/event.pb.go
+++ b/authling/internal/pb/authling/core/v1/event.pb.go
@@ -77,7 +77,8 @@ func (PasswordChangeKind) EnumDescriptor() ([]byte, []int) {
 // be removed, renumbered, or reused.
 type Event struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Stable event identifier used for idempotent publication.
+	// Stable opaque event identifier used for idempotent publication and
+	// correlation. Values are restricted to one NATS-safe subject token.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Time at which the durable fact was created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`

--- a/authling/proto/authling/core/v1/event.proto
+++ b/authling/proto/authling/core/v1/event.proto
@@ -11,7 +11,8 @@ option go_package = "hmans.de/authling/internal/pb/authling/core/v1;corev1";
 // This message is a storage contract. Existing fields and oneof tags must not
 // be removed, renumbered, or reused.
 message Event {
-  // Stable event identifier used for idempotent publication.
+  // Stable opaque event identifier used for idempotent publication and
+  // correlation. Values are restricted to one NATS-safe subject token.
   string id = 1;
 
   // Time at which the durable fact was created.


### PR DESCRIPTION
## Summary

- capture and wait for both the account and account-registry projection boundaries before credential-bound request audits evaluate their preconditions
- reuse the same split-batch guard for password changes, password resets, and email-change request audits
- cover the exact account-event/registry-claim interleaving and prove both live projection and cold replay remain healthy
- document the cross-subject credential fence in Authling's runtime inventory

## Stack

This is PR 1 of 2 and is based on `main`. [#2084](https://github.com/chattocorp/chatto/pull/2084) hardens persisted Authling event identifiers on top.

## Verification

- `cd authling && mise test`
- `cd authling && mise build`
- `cd authling && mise test-e2e` (33 passed)
- `mise license-check`

## References

- [Authling ADR-001: Event-Sourced NATS Architecture](https://github.com/chattocorp/chatto/blob/main/authling/docs/adr/ADR-001-event-sourced-nats-architecture.md)
- [Authling FDR-006: Password Reset](https://github.com/chattocorp/chatto/blob/main/authling/docs/fdr/FDR-006-password-reset.md)
- [Authling FDR-007: Verified Email Change](https://github.com/chattocorp/chatto/blob/main/authling/docs/fdr/FDR-007-verified-email-change.md)
- [Authling runtime architecture](https://github.com/chattocorp/chatto/blob/main/authling/docs/architecture/INDEX.md)
