### PR TITLE
fix(authling): constrain persisted event identifiers

### DIFF
--- a/authling/docs/architecture/INDEX.md
+++ b/authling/docs/architecture/INDEX.md
@@ -95,6 +95,11 @@ authority to delete keys that an in-flight replica could still reference.
 
 Persisted records use the `authling.core.v1.Event` protobuf envelope:
 
+New envelope IDs are opaque random `evt_...` values. Encoding and replay
+accept historical single-token identifiers but reject whitespace, subject
+separators, and email-address punctuation; correlation fields use the same
+token-safe vocabulary.
+
 | Event | Subject | Aggregate | Contents |
 |-------|---------|-----------|----------|
 | `AccountCreatedEvent` | `authling.evt.account.{accountId}` | Account | Opaque account ID, envelope creation time, and encrypted local credential fields including the preferred username |

--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -361,6 +361,9 @@ func validate(event *corev1.Event) error {
 	if strings.TrimSpace(event.GetId()) == "" {
 		return fmt.Errorf("Authling event id is required")
 	}
+	if !validSubjectToken(event.GetId()) {
+		return fmt.Errorf("Authling event id is invalid")
+	}
 	if event.GetCreatedAt() == nil {
 		return fmt.Errorf("Authling event created_at is required")
 	}

--- a/authling/internal/evtstream/evtstream_test.go
+++ b/authling/internal/evtstream/evtstream_test.go
@@ -232,6 +232,48 @@ func TestDecodeRejectsMalformedEvents(t *testing.T) {
 	}
 }
 
+func TestEventIDValidationRejectsSensitiveOrUnsafeTokens(t *testing.T) {
+	for _, eventID := range []string{
+		"person@example.com",
+		"evt.with.dots",
+		"evt/with/slashes",
+		"evt with spaces",
+		"evt\nwith-newline",
+	} {
+		t.Run(eventID, func(t *testing.T) {
+			event := accountCreatedEvent(eventID)
+			if _, err := encode(event); err == nil || !strings.Contains(err.Error(), "event id is invalid") {
+				t.Fatalf("encode event ID %q error = %v, want invalid event ID", eventID, err)
+			} else if strings.Contains(err.Error(), eventID) {
+				t.Fatalf("encode error leaked rejected event ID %q: %v", eventID, err)
+			}
+			data, err := proto.Marshal(event)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Decode(data); err == nil || !strings.Contains(err.Error(), "event id is invalid") {
+				t.Fatalf("decode event ID %q error = %v, want invalid event ID", eventID, err)
+			} else if strings.Contains(err.Error(), eventID) {
+				t.Fatalf("decode error leaked rejected event ID %q: %v", eventID, err)
+			}
+		})
+	}
+}
+
+func TestEventIDValidationAllowsHistoricalSubjectSafeTokens(t *testing.T) {
+	for _, eventID := range []string{"evt_legacy", "evt-legacy", "LegacyEvent_123"} {
+		t.Run(eventID, func(t *testing.T) {
+			record, err := encode(accountCreatedEvent(eventID))
+			if err != nil {
+				t.Fatalf("encode historical event ID %q: %v", eventID, err)
+			}
+			if _, err := Decode(record.Data); err != nil {
+				t.Fatalf("decode historical event ID %q: %v", eventID, err)
+			}
+		})
+	}
+}
+
 func profileUpdatedEvent(eventID string) *corev1.Event {
 	return &corev1.Event{Id: eventID, CreatedAt: timestamppb.Now(), Event: &corev1.Event_ProfileUpdated{ProfileUpdated: &corev1.ProfileUpdatedEvent{
 		AccountId: "acc_test", UserKeyRef: "key_user", CredentialKeyRef: "key_credential", ProfileEnvelopeVersion: 1,

--- a/authling/internal/pb/authling/core/v1/event.pb.go
+++ b/authling/internal/pb/authling/core/v1/event.pb.go
@@ -77,7 +77,8 @@ func (PasswordChangeKind) EnumDescriptor() ([]byte, []int) {
 // be removed, renumbered, or reused.
 type Event struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Stable event identifier used for idempotent publication.
+	// Stable opaque event identifier used for idempotent publication and
+	// correlation. Values are restricted to one NATS-safe subject token.
 	Id string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
 	// Time at which the durable fact was created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`

--- a/authling/proto/authling/core/v1/event.proto
+++ b/authling/proto/authling/core/v1/event.proto
@@ -11,7 +11,8 @@ option go_package = "hmans.de/authling/internal/pb/authling/core/v1;corev1";
 // This message is a storage contract. Existing fields and oneof tags must not
 // be removed, renumbered, or reused.
 message Event {
-  // Stable event identifier used for idempotent publication.
+  // Stable opaque event identifier used for idempotent publication and
+  // correlation. Values are restricted to one NATS-safe subject token.
   string id = 1;
 
   // Time at which the durable fact was created.


### PR DESCRIPTION
## Summary

- require persisted Authling envelope IDs to use the same single-token-safe vocabulary as their correlation fields
- reject email-shaped, dotted, slash-delimited, whitespace, and control-character IDs on both encode and replay without echoing rejected values
- preserve historical identifiers that already consist only of letters, digits, underscores, or hyphens
- document the event-ID contract in the protobuf source and Authling runtime inventory, including regenerated Go output

## Stack

This is PR 2 of 2 and is stacked on [#2083](https://github.com/chattocorp/chatto/pull/2083). Merge the base PR first; GitHub can then retarget this PR to `main`.

## Verification

- `cd authling && mise codegen`
- `cd authling && mise test`
- `cd authling && mise build`
- `cd authling && mise test-e2e` (33 passed)
- `mise license-check`

## References

- [Authling ADR-001: Event-Sourced NATS Architecture](https://github.com/chattocorp/chatto/blob/main/authling/docs/adr/ADR-001-event-sourced-nats-architecture.md)
- [Authling persisted event schema](https://github.com/chattocorp/chatto/blob/main/authling/proto/authling/core/v1/event.proto)
- [Authling runtime architecture](https://github.com/chattocorp/chatto/blob/main/authling/docs/architecture/INDEX.md)
