### PR TITLE
fix(frontend): simplify copy ID affordance

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -55,7 +55,7 @@ message search results:
 | Standard pane page                        | `PageTitle`, `PaneHeader`, `PaneContent`, and titled `Panel` sections      | Hand-rolled page widths, scrolling, and section cards        |
 | Pane title and toolbar                    | `PaneHeader` with `HeaderIconButton` actions                               | Textual primary actions in the pane header                   |
 | Inline icon action with standard hit area | `icon-action`                                                              | Repeating hit-area, hover, and pressed classes               |
-| Mini icon action directly beside a value  | `mini-icon-button`                                                         | Adding padding, a background fill, or press scaling          |
+| Mini icon action directly beside a value  | `mini-icon-action`                                                         | Adding padding, a background fill, or press scaling          |
 | Global app-header icon                    | `app-header-icon`                                                          | `icon-action` with compensating margins                      |
 | Durable content container                 | `Panel` or `panel-shell`                                                   | Ad hoc card borders, radius, and elevation                   |
 | Compact nested row                        | `surface-box`                                                              | A panel nested inside another panel                          |
@@ -295,7 +295,7 @@ matches the action.
   drag, resize, or text-selection behavior.
 - Respect `prefers-reduced-motion` for non-essential animation.
 - Keep interactive hit areas at least 40 by 40 pixels unless a dense desktop
-  toolbar has a documented non-overlapping exception. `mini-icon-button` is
+  toolbar has a documented non-overlapping exception. `mini-icon-action` is
   the narrow exception for a subordinate icon placed directly beside the text
   or value it acts on; do not use it for standalone or toolbar actions.
 

--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -54,7 +54,8 @@ message search results:
 | Floating menu or tooltip                  | `ContextMenu`, `HelpTooltip`, or `FloatingPopover`                         | Hand-written fixed positioning and z-index                   |
 | Standard pane page                        | `PageTitle`, `PaneHeader`, `PaneContent`, and titled `Panel` sections      | Hand-rolled page widths, scrolling, and section cards        |
 | Pane title and toolbar                    | `PaneHeader` with `HeaderIconButton` actions                               | Textual primary actions in the pane header                   |
-| Inline icon action                        | `icon-action`                                                              | Repeating hit-area, hover, and pressed classes               |
+| Inline icon action with standard hit area | `icon-action`                                                              | Repeating hit-area, hover, and pressed classes               |
+| Mini icon action directly beside a value  | `mini-icon-button`                                                         | Adding padding, a background fill, or press scaling          |
 | Global app-header icon                    | `app-header-icon`                                                          | `icon-action` with compensating margins                      |
 | Durable content container                 | `Panel` or `panel-shell`                                                   | Ad hoc card borders, radius, and elevation                   |
 | Compact nested row                        | `surface-box`                                                              | A panel nested inside another panel                          |
@@ -294,7 +295,9 @@ matches the action.
   drag, resize, or text-selection behavior.
 - Respect `prefers-reduced-motion` for non-essential animation.
 - Keep interactive hit areas at least 40 by 40 pixels unless a dense desktop
-  toolbar has a documented non-overlapping exception.
+  toolbar has a documented non-overlapping exception. `mini-icon-button` is
+  the narrow exception for a subordinate icon placed directly beside the text
+  or value it acts on; do not use it for standalone or toolbar actions.
 
 Chatto deliberately uses browser/platform text rendering. Do not add global
 font smoothing. Ordinary controls are solid rather than gradient-filled;

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -655,7 +655,7 @@
 /* Unframed icon-sized action for a subordinate command placed directly beside
  * the text or value it affects. Use icon-action for a standard hit area.
  */
-@utility mini-icon-button {
+@utility mini-icon-action {
   @apply inline-flex shrink-0 cursor-pointer text-muted transition-colors hover:text-text focus-visible:text-text;
 }
 

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -642,14 +642,21 @@
   @apply -m-2 flex h-11 w-11 cursor-pointer items-center justify-center rounded transition-[background-color,color,scale] hover:text-text active:scale-[0.96] active:bg-surface-emphasized;
 }
 
-/* Compact inline icon-only action for row/input affordances such as copy,
- * dismiss, and clear. Larger toolbar icons should use HeaderIconButton or
+/* Compact inline icon-only action for row/input affordances such as dismiss
+ * and clear. Larger toolbar icons should use HeaderIconButton or
  * pane-header-icon-button instead.
  */
 @utility icon-action {
   @apply inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] active:scale-[0.96];
   @apply hover:bg-surface-emphasized hover:text-text;
   @apply disabled:cursor-not-allowed disabled:opacity-50;
+}
+
+/* Unframed icon-sized action for a subordinate command placed directly beside
+ * the text or value it affects. Use icon-action for a standard hit area.
+ */
+@utility mini-icon-button {
+  @apply inline-flex shrink-0 cursor-pointer text-muted transition-colors hover:text-text focus-visible:text-text;
 }
 
 /* Hide scrollbar while maintaining scroll functionality */

--- a/apps/frontend/src/lib/components/admin/CopyId.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/CopyId.stories.svelte
@@ -29,7 +29,7 @@
     docs: {
       description: {
         story:
-          'The copy button uses the mini-icon-button treatment and stops row-click propagation.'
+          'The copy button uses the mini-icon-action treatment and stops row-click propagation.'
       }
     }
   }}

--- a/apps/frontend/src/lib/components/admin/CopyId.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/CopyId.stories.svelte
@@ -29,7 +29,7 @@
     docs: {
       description: {
         story:
-          'The copy button uses the compact inline icon-action treatment and stops row-click propagation.'
+          'The copy button uses the mini-icon-button treatment and stops row-click propagation.'
       }
     }
   }}

--- a/apps/frontend/src/lib/components/admin/CopyId.svelte
+++ b/apps/frontend/src/lib/components/admin/CopyId.svelte
@@ -16,7 +16,7 @@
   <button
     type="button"
     onclick={copy}
-    class="icon-action shrink-0"
+    class="mini-icon-button"
     title={m('common.copy_to_clipboard')}
   >
     <span class="iconify icon-[uil--copy] text-base leading-none"></span>

--- a/apps/frontend/src/lib/components/admin/CopyId.svelte
+++ b/apps/frontend/src/lib/components/admin/CopyId.svelte
@@ -16,7 +16,7 @@
   <button
     type="button"
     onclick={copy}
-    class="mini-icon-button"
+    class="mini-icon-action"
     title={m('common.copy_to_clipboard')}
   >
     <span class="iconify icon-[uil--copy] text-base leading-none"></span>

--- a/apps/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/apps/frontend/src/lib/ui/Utilities.stories.svelte
@@ -400,7 +400,7 @@
     docs: {
       description: {
         story:
-          '`mini-icon-button` is an unframed, icon-sized action that changes only text colour on hover and focus. Reserve it for a subordinate command directly beside the value it affects.'
+          '`mini-icon-action` is an unframed, icon-sized action that changes only text colour on hover and focus. Reserve it for a subordinate command directly beside the value it affects.'
       }
     }
   }}
@@ -411,7 +411,7 @@
     </p>
     <div class="inline-flex items-center gap-1.5 self-start surface-box p-3">
       <code class="text-xs">USR-7Q9M2N</code>
-      <button type="button" class="mini-icon-button" title="Copy to clipboard">
+      <button type="button" class="mini-icon-action" title="Copy to clipboard">
         <span class="iconify icon-[uil--copy]"></span>
       </button>
     </div>

--- a/apps/frontend/src/lib/ui/Utilities.stories.svelte
+++ b/apps/frontend/src/lib/ui/Utilities.stories.svelte
@@ -374,23 +374,45 @@
     docs: {
       description: {
         story:
-          '`icon-action` is the compact inline icon button for row/input affordances. Use HeaderIconButton for toolbar actions instead.'
+          '`icon-action` is the compact icon button with a standard hit area for row/input affordances. Use HeaderIconButton for toolbar actions instead.'
       }
     }
   }}
 >
   <div class="flex max-w-md flex-col gap-3">
     <p class="max-w-prose text-sm text-muted">
-      Use for low-emphasis actions that sit inside another element: copy an ID, clear a field,
-      dismiss a row.
+      Use for low-emphasis actions that sit inside another element and still need a standard hit
+      area, such as clearing a field or dismissing a row.
     </p>
     <div class="flex items-center gap-2 surface-box p-3">
-      <code class="text-xs">USR-7Q9M2N</code>
-      <button type="button" class="icon-action" title="Copy to clipboard">
-        <span class="iconify icon-[uil--copy]"></span>
-      </button>
+      <span class="text-muted">Active filter</span>
       <button type="button" class="ml-auto icon-action" title="Dismiss">
         <span class="iconify icon-[uil--times]"></span>
+      </button>
+    </div>
+  </div>
+</Story>
+
+<Story
+  name="mini icon button"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          '`mini-icon-button` is an unframed, icon-sized action that changes only text colour on hover and focus. Reserve it for a subordinate command directly beside the value it affects.'
+      }
+    }
+  }}
+>
+  <div class="flex max-w-md flex-col gap-3">
+    <p class="max-w-prose text-sm text-muted">
+      Use for a small secondary affordance whose associated value supplies the surrounding context.
+    </p>
+    <div class="inline-flex items-center gap-1.5 self-start surface-box p-3">
+      <code class="text-xs">USR-7Q9M2N</code>
+      <button type="button" class="mini-icon-button" title="Copy to clipboard">
+        <span class="iconify icon-[uil--copy]"></span>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## Why

The copy-to-clipboard icon beside opaque IDs used the full `icon-action` treatment, giving a subordinate control an oversized hover fill and press animation.

## What changed

- Add a reusable `mini-icon-action` utility that remains unframed and changes only text colour on hover or focus.
- Apply the utility to `CopyId` and document its narrow use beside an associated value.
- Update the design-system guidance and Storybook examples to distinguish mini icon actions from standard 40×40 icon actions.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- `mise x -- pnpm exec vitest --run --project=storybook src/lib/components/admin/CopyId.stories.svelte src/lib/ui/Utilities.stories.svelte` — 2 files and 11 tests passed.
- Chrome DevTools — verified the Storybook control remains transparent, has no press transform, and changes only text colour on hover.
