### PR TITLE
feat(frontend): add context-menu copy actions

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -270,6 +270,10 @@ in the component explaining why Tailwind or a semantic utility is insufficient.
 Menus, compact chat hover bars, media overlays, and icon toolbars use their
 context-specific primitive.
 
+Context-menu action groups use sibling `menu-section` surfaces. Let the
+`ContextMenu` gap separate those surfaces; never draw a hairline divider inside
+a `menu-section`, because it conflicts with the standard surface-gap separator.
+
 The supported variants are `action`, `neutral`, `secondary`, `ghost`,
 `warning`, `danger`, and `danger-secondary`. Use the variant whose meaning
 matches the action.

--- a/apps/frontend/messages/ar/chat.json
+++ b/apps/frontend/messages/ar/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "الملف الشخصي للمستخدم",
-      "send_message": "أرسل رسالة"
+      "send_message": "أرسل رسالة",
+      "copy_user_id": "نسخ معرّف المستخدم"
     },
     "server_gutter": {
       "add_server": "إضافة خادم",

--- a/apps/frontend/messages/ar/room_list.json
+++ b/apps/frontend/messages/ar/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "ضع علامة كمقروءة",
     "remove_server": "إزالة الخادم",
     "leave_room": "مغادرة الغرفة",
+    "copy_room_id": "نسخ معرّف الغرفة",
+    "copy_server_hostname": "نسخ اسم مضيف الخادم",
     "room_settings": "إعدادات الغرفة",
     "group_settings": "إعدادات {group}",
     "server_actions": "إجراءات {server}",

--- a/apps/frontend/messages/cs-CZ/chat.json
+++ b/apps/frontend/messages/cs-CZ/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Uživatelský profil",
-      "send_message": "Odeslat zprávu"
+      "send_message": "Odeslat zprávu",
+      "copy_user_id": "Zkopírovat ID uživatele"
     },
     "server_gutter": {
       "add_server": "Přidat server",

--- a/apps/frontend/messages/cs-CZ/room_list.json
+++ b/apps/frontend/messages/cs-CZ/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Označit jako přečtené",
     "remove_server": "Odebrat server",
     "leave_room": "Opusťte místnost",
+    "copy_room_id": "Zkopírovat ID místnosti",
+    "copy_server_hostname": "Zkopírovat název hostitele serveru",
     "room_settings": "Nastavení místnosti",
     "group_settings": "Nastavení pro {group}",
     "server_actions": "Akce pro {server}",

--- a/apps/frontend/messages/de-DE/chat.json
+++ b/apps/frontend/messages/de-DE/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Benutzerprofil",
-      "send_message": "Nachricht senden"
+      "send_message": "Nachricht senden",
+      "copy_user_id": "Benutzer-ID kopieren"
     },
     "server_gutter": {
       "add_server": "Server hinzufügen",

--- a/apps/frontend/messages/de-DE/room_list.json
+++ b/apps/frontend/messages/de-DE/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Als gelesen markieren",
     "remove_server": "Server entfernen",
     "leave_room": "Raum verlassen",
+    "copy_room_id": "Raum-ID kopieren",
+    "copy_server_hostname": "Server-Hostnamen kopieren",
     "room_settings": "Raumeinstellungen",
     "group_settings": "Einstellungen für {group}",
     "server_actions": "Aktionen für {server}",

--- a/apps/frontend/messages/en-GB/chat.json
+++ b/apps/frontend/messages/en-GB/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "User profile",
-      "send_message": "Send Message"
+      "send_message": "Send Message",
+      "copy_user_id": "Copy User ID"
     },
     "server_gutter": {
       "add_server": "Add Server",

--- a/apps/frontend/messages/en-GB/room_list.json
+++ b/apps/frontend/messages/en-GB/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Mark as read",
     "remove_server": "Remove server",
     "leave_room": "Leave room",
+    "copy_room_id": "Copy Room ID",
+    "copy_server_hostname": "Copy Server Hostname",
     "room_settings": "Room settings",
     "group_settings": "Settings for {group}",
     "server_actions": "Actions for {server}",

--- a/apps/frontend/messages/eo/chat.json
+++ b/apps/frontend/messages/eo/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Profilo de uzanto",
-      "send_message": "Sendu Mesaĝon"
+      "send_message": "Sendu Mesaĝon",
+      "copy_user_id": "Kopii identigilon de uzanto"
     },
     "server_gutter": {
       "add_server": "Aldonu Servilon",

--- a/apps/frontend/messages/eo/room_list.json
+++ b/apps/frontend/messages/eo/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marki kiel legitan",
     "remove_server": "Forigi servilon",
     "leave_room": "Forlasi ĉambron",
+    "copy_room_id": "Kopii identigilon de ĉambro",
+    "copy_server_hostname": "Kopii la gastigantonomon de la servilo",
     "room_settings": "Agordoj de ĉambro",
     "group_settings": "Agordoj por {group}",
     "server_actions": "Agoj por {server}",

--- a/apps/frontend/messages/es-419/chat.json
+++ b/apps/frontend/messages/es-419/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Perfil de usuario",
-      "send_message": "Enviar Mensaje"
+      "send_message": "Enviar Mensaje",
+      "copy_user_id": "Copiar ID de usuario"
     },
     "server_gutter": {
       "add_server": "Agregar servidor",

--- a/apps/frontend/messages/es-419/room_list.json
+++ b/apps/frontend/messages/es-419/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marcar como leído",
     "remove_server": "Eliminar servidor",
     "leave_room": "Salir de la sala",
+    "copy_room_id": "Copiar ID de la sala",
+    "copy_server_hostname": "Copiar nombre de host del servidor",
     "room_settings": "Configuración de la sala",
     "group_settings": "Configuración de {group}",
     "server_actions": "Acciones para {server}",

--- a/apps/frontend/messages/es-ES/chat.json
+++ b/apps/frontend/messages/es-ES/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Perfil de usuario",
-      "send_message": "Enviar Mensaje"
+      "send_message": "Enviar Mensaje",
+      "copy_user_id": "Copiar ID de usuario"
     },
     "server_gutter": {
       "add_server": "Agregar servidor",

--- a/apps/frontend/messages/es-ES/room_list.json
+++ b/apps/frontend/messages/es-ES/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marcar como leído",
     "remove_server": "Eliminar servidor",
     "leave_room": "Salir de la sala",
+    "copy_room_id": "Copiar ID de la sala",
+    "copy_server_hostname": "Copiar nombre de host del servidor",
     "room_settings": "Configuración de la sala",
     "group_settings": "Configuración de {group}",
     "server_actions": "Acciones para {server}",

--- a/apps/frontend/messages/et-EE/chat.json
+++ b/apps/frontend/messages/et-EE/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Kasutajaprofiil",
-      "send_message": "Saada sõnum"
+      "send_message": "Saada sõnum",
+      "copy_user_id": "Kopeeri kasutaja ID"
     },
     "server_gutter": {
       "add_server": "Lisa server",

--- a/apps/frontend/messages/et-EE/room_list.json
+++ b/apps/frontend/messages/et-EE/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Märgi loetuks",
     "remove_server": "Eemalda server",
     "leave_room": "Jätke ruumi",
+    "copy_room_id": "Kopeeri ruumi ID",
+    "copy_server_hostname": "Kopeeri serveri hostinimi",
     "room_settings": "Ruumi seaded",
     "group_settings": "Seaded: {group}",
     "server_actions": "Toimingud: {server}",

--- a/apps/frontend/messages/fr-CA/chat.json
+++ b/apps/frontend/messages/fr-CA/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Profil de l'utilisateur",
-      "send_message": "Envoyer un message"
+      "send_message": "Envoyer un message",
+      "copy_user_id": "Copier l’identifiant de l’utilisateur"
     },
     "server_gutter": {
       "add_server": "Ajouter un serveur",

--- a/apps/frontend/messages/fr-CA/room_list.json
+++ b/apps/frontend/messages/fr-CA/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marquer comme lu",
     "remove_server": "Retirer le serveur",
     "leave_room": "Quitter le salon",
+    "copy_room_id": "Copier l’identifiant du salon",
+    "copy_server_hostname": "Copier le nom d’hôte du serveur",
     "room_settings": "Paramètres du salon",
     "group_settings": "Paramètres de {group}",
     "server_actions": "Actions pour {server}",

--- a/apps/frontend/messages/fr-FR/chat.json
+++ b/apps/frontend/messages/fr-FR/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Profil utilisateur",
-      "send_message": "Envoyer un message"
+      "send_message": "Envoyer un message",
+      "copy_user_id": "Copier l’identifiant de l’utilisateur"
     },
     "server_gutter": {
       "add_server": "Ajouter un serveur",

--- a/apps/frontend/messages/fr-FR/room_list.json
+++ b/apps/frontend/messages/fr-FR/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marquer comme lu",
     "remove_server": "Retirer le serveur",
     "leave_room": "Quitter le salon",
+    "copy_room_id": "Copier l’identifiant du salon",
+    "copy_server_hostname": "Copier le nom d’hôte du serveur",
     "room_settings": "Paramètres du salon",
     "group_settings": "Paramètres de {group}",
     "server_actions": "Actions pour {server}",

--- a/apps/frontend/messages/he-IL/chat.json
+++ b/apps/frontend/messages/he-IL/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "פרופיל משתמש",
-      "send_message": "שלח הודעה"
+      "send_message": "שלח הודעה",
+      "copy_user_id": "העתקת מזהה המשתמש"
     },
     "server_gutter": {
       "add_server": "הוסף שרת",

--- a/apps/frontend/messages/he-IL/room_list.json
+++ b/apps/frontend/messages/he-IL/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "סמן כנקראו",
     "remove_server": "הסר שרת",
     "leave_room": "עזוב את החדר",
+    "copy_room_id": "העתקת מזהה החדר",
+    "copy_server_hostname": "העתקת שם המארח של השרת",
     "room_settings": "הגדרות החדר",
     "group_settings": "הגדרות עבור {group}",
     "server_actions": "פעולות עבור {server}",

--- a/apps/frontend/messages/it-IT/chat.json
+++ b/apps/frontend/messages/it-IT/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Profilo utente",
-      "send_message": "Invia messaggio"
+      "send_message": "Invia messaggio",
+      "copy_user_id": "Copia ID utente"
     },
     "server_gutter": {
       "add_server": "Aggiungi server",

--- a/apps/frontend/messages/it-IT/room_list.json
+++ b/apps/frontend/messages/it-IT/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Segna come letto",
     "remove_server": "Rimuovi server",
     "leave_room": "Lascia spazio",
+    "copy_room_id": "Copia ID stanza",
+    "copy_server_hostname": "Copia nome host del server",
     "room_settings": "Impostazioni della stanza",
     "group_settings": "Impostazioni per {group}",
     "server_actions": "Azioni per {server}",

--- a/apps/frontend/messages/ja-JP/chat.json
+++ b/apps/frontend/messages/ja-JP/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "ユーザープロフィール",
-      "send_message": "メッセージを送信"
+      "send_message": "メッセージを送信",
+      "copy_user_id": "ユーザーIDをコピー"
     },
     "server_gutter": {
       "add_server": "サーバーの追加",

--- a/apps/frontend/messages/ja-JP/room_list.json
+++ b/apps/frontend/messages/ja-JP/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "既読にする",
     "remove_server": "サーバーを削除",
     "leave_room": "ルームから退出",
+    "copy_room_id": "ルームIDをコピー",
+    "copy_server_hostname": "サーバーのホスト名をコピー",
     "room_settings": "ルーム設定",
     "group_settings": "{group}の設定",
     "server_actions": "{server}のアクション",

--- a/apps/frontend/messages/lv-LV/chat.json
+++ b/apps/frontend/messages/lv-LV/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Lietotāja profils",
-      "send_message": "Nosūtīt ziņu"
+      "send_message": "Nosūtīt ziņu",
+      "copy_user_id": "Kopēt lietotāja ID"
     },
     "server_gutter": {
       "add_server": "Pievienot serveri",

--- a/apps/frontend/messages/lv-LV/room_list.json
+++ b/apps/frontend/messages/lv-LV/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Atzīmēt kā izlasītu",
     "remove_server": "Noņemt serveri",
     "leave_room": "Atstāj istabu",
+    "copy_room_id": "Kopēt telpas ID",
+    "copy_server_hostname": "Kopēt servera resursdatora nosaukumu",
     "room_settings": "Telpas iestatījumi",
     "group_settings": "Iestatījumi {group}",
     "server_actions": "Darbības {server}",

--- a/apps/frontend/messages/nb-NO/chat.json
+++ b/apps/frontend/messages/nb-NO/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Brukerprofil",
-      "send_message": "Send melding"
+      "send_message": "Send melding",
+      "copy_user_id": "Kopier bruker-ID"
     },
     "server_gutter": {
       "add_server": "Legg til server",

--- a/apps/frontend/messages/nb-NO/room_list.json
+++ b/apps/frontend/messages/nb-NO/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Merk som lest",
     "remove_server": "Fjern server",
     "leave_room": "Forlat rom",
+    "copy_room_id": "Kopier rom-ID",
+    "copy_server_hostname": "Kopier serverens vertsnavn",
     "room_settings": "Rominnstillinger",
     "group_settings": "Innstillinger for {group}",
     "server_actions": "Handlinger for {server}",

--- a/apps/frontend/messages/nl-BE/chat.json
+++ b/apps/frontend/messages/nl-BE/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Gebruikersprofiel",
-      "send_message": "Bericht verzenden"
+      "send_message": "Bericht verzenden",
+      "copy_user_id": "Gebruikers-ID kopiëren"
     },
     "server_gutter": {
       "add_server": "Server toevoegen",

--- a/apps/frontend/messages/nl-BE/room_list.json
+++ b/apps/frontend/messages/nl-BE/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Markeren als gelezen",
     "remove_server": "Server verwijderen",
     "leave_room": "Ruimte verlaten",
+    "copy_room_id": "Ruimte-ID kopiëren",
+    "copy_server_hostname": "Serverhostnaam kopiëren",
     "room_settings": "Ruimte-instellingen",
     "group_settings": "Instellingen voor {group}",
     "server_actions": "Acties voor {server}",

--- a/apps/frontend/messages/nl-NL/chat.json
+++ b/apps/frontend/messages/nl-NL/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Gebruikersprofiel",
-      "send_message": "Bericht verzenden"
+      "send_message": "Bericht verzenden",
+      "copy_user_id": "Gebruikers-ID kopiëren"
     },
     "server_gutter": {
       "add_server": "Server toevoegen",

--- a/apps/frontend/messages/nl-NL/room_list.json
+++ b/apps/frontend/messages/nl-NL/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Markeren als gelezen",
     "remove_server": "Server verwijderen",
     "leave_room": "Ruimte verlaten",
+    "copy_room_id": "Ruimte-ID kopiëren",
+    "copy_server_hostname": "Serverhostnaam kopiëren",
     "room_settings": "Ruimte-instellingen",
     "group_settings": "Instellingen voor {group}",
     "server_actions": "Acties voor {server}",

--- a/apps/frontend/messages/pl-PL/chat.json
+++ b/apps/frontend/messages/pl-PL/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Profil użytkownika",
-      "send_message": "Wyślij wiadomość"
+      "send_message": "Wyślij wiadomość",
+      "copy_user_id": "Kopiuj identyfikator użytkownika"
     },
     "server_gutter": {
       "add_server": "Dodaj serwer",

--- a/apps/frontend/messages/pl-PL/room_list.json
+++ b/apps/frontend/messages/pl-PL/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Oznacz jako przeczytane",
     "remove_server": "Usuń serwer",
     "leave_room": "Opuść pokój",
+    "copy_room_id": "Kopiuj identyfikator pokoju",
+    "copy_server_hostname": "Kopiuj nazwę hosta serwera",
     "room_settings": "Ustawienia pokoju",
     "group_settings": "Ustawienia dla {group}",
     "server_actions": "Działania dla {server}",

--- a/apps/frontend/messages/pt-BR/chat.json
+++ b/apps/frontend/messages/pt-BR/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Perfil do usuário",
-      "send_message": "Enviar mensagem"
+      "send_message": "Enviar mensagem",
+      "copy_user_id": "Copiar ID do usuário"
     },
     "server_gutter": {
       "add_server": "Adicionar servidor",

--- a/apps/frontend/messages/pt-BR/room_list.json
+++ b/apps/frontend/messages/pt-BR/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marcar como lido",
     "remove_server": "Remover servidor",
     "leave_room": "Sair da sala",
+    "copy_room_id": "Copiar ID da sala",
+    "copy_server_hostname": "Copiar nome do host do servidor",
     "room_settings": "Configurações da sala",
     "group_settings": "Configurações de {group}",
     "server_actions": "Ações para {server}",

--- a/apps/frontend/messages/pt-PT/chat.json
+++ b/apps/frontend/messages/pt-PT/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Perfil de utilizador",
-      "send_message": "Enviar mensagem"
+      "send_message": "Enviar mensagem",
+      "copy_user_id": "Copiar ID do utilizador"
     },
     "server_gutter": {
       "add_server": "Adicionar servidor",

--- a/apps/frontend/messages/pt-PT/room_list.json
+++ b/apps/frontend/messages/pt-PT/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Marcar como lido",
     "remove_server": "Remover servidor",
     "leave_room": "Sair da sala",
+    "copy_room_id": "Copiar ID da sala",
+    "copy_server_hostname": "Copiar nome do anfitrião do servidor",
     "room_settings": "Definições da sala",
     "group_settings": "Definições de {group}",
     "server_actions": "Ações para {server}",

--- a/apps/frontend/messages/ru-RU/chat.json
+++ b/apps/frontend/messages/ru-RU/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Профиль пользователя",
-      "send_message": "Отправить сообщение"
+      "send_message": "Отправить сообщение",
+      "copy_user_id": "Скопировать ID пользователя"
     },
     "server_gutter": {
       "add_server": "Добавить сервер",

--- a/apps/frontend/messages/ru-RU/room_list.json
+++ b/apps/frontend/messages/ru-RU/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Отметить как прочитанное",
     "remove_server": "Удалить сервер",
     "leave_room": "Покинуть комнату",
+    "copy_room_id": "Скопировать ID комнаты",
+    "copy_server_hostname": "Скопировать имя хоста сервера",
     "room_settings": "Настройки комнаты",
     "group_settings": "Настройки для {group}",
     "server_actions": "Действия для {server}",

--- a/apps/frontend/messages/sv-SE/chat.json
+++ b/apps/frontend/messages/sv-SE/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Användarprofil",
-      "send_message": "Skicka meddelande"
+      "send_message": "Skicka meddelande",
+      "copy_user_id": "Kopiera användar-ID"
     },
     "server_gutter": {
       "add_server": "Lägg till server",

--- a/apps/frontend/messages/sv-SE/room_list.json
+++ b/apps/frontend/messages/sv-SE/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Markera som läst",
     "remove_server": "Ta bort server",
     "leave_room": "Lämna rum",
+    "copy_room_id": "Kopiera rums-ID",
+    "copy_server_hostname": "Kopiera serverns värdnamn",
     "room_settings": "Rumsinställningar",
     "group_settings": "Inställningar för {group}",
     "server_actions": "Åtgärder för {server}",

--- a/apps/frontend/messages/tr-TR/chat.json
+++ b/apps/frontend/messages/tr-TR/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Kullanıcı profili",
-      "send_message": "Mesaj Gönder"
+      "send_message": "Mesaj Gönder",
+      "copy_user_id": "Kullanıcı kimliğini kopyala"
     },
     "server_gutter": {
       "add_server": "Sunucu Ekle",

--- a/apps/frontend/messages/tr-TR/room_list.json
+++ b/apps/frontend/messages/tr-TR/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Okundu olarak işaretle",
     "remove_server": "Sunucuyu kaldır",
     "leave_room": "Odadan ayrıl",
+    "copy_room_id": "Oda kimliğini kopyala",
+    "copy_server_hostname": "Sunucu ana bilgisayar adını kopyala",
     "room_settings": "Oda ayarları",
     "group_settings": "{group} ayarları",
     "server_actions": "{server} için eylemler",

--- a/apps/frontend/messages/uk-UA/chat.json
+++ b/apps/frontend/messages/uk-UA/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "Профіль користувача",
-      "send_message": "Надіслати повідомлення"
+      "send_message": "Надіслати повідомлення",
+      "copy_user_id": "Копіювати ID користувача"
     },
     "server_gutter": {
       "add_server": "Додати сервер",

--- a/apps/frontend/messages/uk-UA/room_list.json
+++ b/apps/frontend/messages/uk-UA/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "Позначити як прочитане",
     "remove_server": "Видалити сервер",
     "leave_room": "Залишити кімнату",
+    "copy_room_id": "Копіювати ID кімнати",
+    "copy_server_hostname": "Копіювати ім’я хоста сервера",
     "room_settings": "Налаштування кімнати",
     "group_settings": "Налаштування для {group}",
     "server_actions": "Дії для {server}",

--- a/apps/frontend/messages/zh-CN/chat.json
+++ b/apps/frontend/messages/zh-CN/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "用户个人资料",
-      "send_message": "发送消息"
+      "send_message": "发送消息",
+      "copy_user_id": "复制用户 ID"
     },
     "server_gutter": {
       "add_server": "添加服务器",

--- a/apps/frontend/messages/zh-CN/room_list.json
+++ b/apps/frontend/messages/zh-CN/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "标记为已读",
     "remove_server": "移除服务器",
     "leave_room": "离开聊天室",
+    "copy_room_id": "复制聊天室 ID",
+    "copy_server_hostname": "复制服务器主机名",
     "room_settings": "聊天室设置",
     "group_settings": "{group} 的设置",
     "server_actions": "{server} 的操作",

--- a/apps/frontend/messages/zh-TW/chat.json
+++ b/apps/frontend/messages/zh-TW/chat.json
@@ -39,7 +39,8 @@
     },
     "user_menu": {
       "profile": "使用者個人檔案",
-      "send_message": "傳送訊息"
+      "send_message": "傳送訊息",
+      "copy_user_id": "複製使用者 ID"
     },
     "server_gutter": {
       "add_server": "新增伺服器",

--- a/apps/frontend/messages/zh-TW/room_list.json
+++ b/apps/frontend/messages/zh-TW/room_list.json
@@ -15,6 +15,8 @@
     "mark_as_read": "標示為已讀",
     "remove_server": "移除伺服器",
     "leave_room": "離開聊天室",
+    "copy_room_id": "複製聊天室 ID",
+    "copy_server_hostname": "複製伺服器主機名稱",
     "room_settings": "聊天室設定",
     "group_settings": "{group} 的設定",
     "server_actions": "{server} 的操作",

--- a/apps/frontend/scripts/check-design-system.mjs
+++ b/apps/frontend/scripts/check-design-system.mjs
@@ -126,6 +126,20 @@ for (const file of await svelteFiles(sourceRoot)) {
       failures.push(`${path}:${line}: ${description} (${match[0].trim()})`);
     }
   }
+
+  for (const contextMenu of utilitySource.matchAll(/<ContextMenu\b[\s\S]*?<\/ContextMenu>/g)) {
+    const actionSeparator = contextMenu[0].match(
+      /(?:class\s*=\s*["'][^"']*\bborder-t\b[^"']*["']|role\s*=\s*["']separator["'])[\s\S]*?<(?:a|button)\b/
+    );
+    if (!actionSeparator) continue;
+
+    const line = utilitySource
+      .slice(0, (contextMenu.index ?? 0) + (actionSeparator.index ?? 0))
+      .split('\n').length;
+    failures.push(
+      `${path}:${line}: context-menu action groups must use sibling menu-section surfaces, not inline separators`
+    );
+  }
 }
 
 if (failures.length > 0) {

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -97,6 +97,16 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     void markNavigationRoomAsRead(activeServerId, room.id);
   }
 
+  async function handleCopyRoomId(roomId: string): Promise<void> {
+    roomContextMenu = null;
+    try {
+      await navigator.clipboard.writeText(roomId);
+      toast.success(m('common.copied_to_clipboard'));
+    } catch {
+      toast.error(m('common.error.generic'));
+    }
+  }
+
   function handleLeaveRoom(room: RoomsListItem): void {
     roomContextMenu = null;
     pushState('', {
@@ -551,5 +561,19 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       onConfigure={() => handleConfigureRoom(contextRoom)}
       onLeave={() => handleLeaveRoom(contextRoom)}
     />
+    <div class="menu-section">
+      <nav class="sidebar-nav">
+        <button
+          type="button"
+          class="sidebar-item"
+          onclick={() => void handleCopyRoomId(contextRoom.id)}
+          role="menuitem"
+          data-testid="copy-room-id"
+        >
+          <span class="iconify sidebar-icon icon-[uil--copy]" aria-hidden="true"></span>
+          {m('room_list.copy_room_id')}
+        </button>
+      </nav>
+    </div>
   </ContextMenu>
 {/if}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -5,12 +5,14 @@ import { q } from '$lib/test-utils';
 
 import { NotificationSignalKind } from '$lib/api-client/notifications';
 import type { RoomsListGroup } from '$lib/state/server/rooms.svelte';
+import { getToasts, toast } from '$lib/ui/toast';
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     activeCallRoomIds: new Set<string>(),
     projectedCallParticipants: new Map<string, unknown[]>(),
     unreadRoomIds: new Set<string>(),
+    writeClipboardText: vi.fn(),
     markNavigationRoomAsRead: vi.fn().mockResolvedValue(true),
     pushState: vi.fn(),
     goto: vi.fn(),
@@ -251,6 +253,7 @@ function setRoomUnread(roomId: string, hasUnread: boolean) {
 }
 
 beforeEach(() => {
+  toast.clear();
   localStorage.clear();
   sessionStorage.clear();
   mocks.activeCallRoomIds = new Set();
@@ -261,6 +264,11 @@ beforeEach(() => {
   mocks.store.navigation.currentUserId = 'me';
   setRooms();
   vi.clearAllMocks();
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: mocks.writeClipboardText },
+    configurable: true
+  });
+  mocks.writeClipboardText.mockResolvedValue(undefined);
   mocks.store.notifications.fetchRoomNotification.mockResolvedValue({
     ok: true,
     totalCount: 0,
@@ -381,11 +389,32 @@ describe('RoomList', () => {
     await expect.element(markRead ?? null).toBeInTheDocument();
     await expect.element(markRead ?? null).toBeEnabled();
     await expect.element(leave ?? null).toBeInTheDocument();
-    await expect.element(q(document.body, '[role="separator"]')).toBeInTheDocument();
+    expect(markRead?.closest('.menu-section')).not.toBe(leave?.closest('.menu-section'));
+    expect(q(document.body, '[role="separator"]')).toBeNull();
 
     markRead!.click();
 
     expect(mocks.markNavigationRoomAsRead).toHaveBeenCalledWith('origin', 'channel-1');
+  });
+
+  it('shows Copy Room ID as the final context-menu row and copies the ID', async () => {
+    const { container } = render(RoomList);
+    const row = q(container, '[href="/chat/-/channel-1"]') as HTMLAnchorElement;
+
+    row.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    await vi.waitFor(() =>
+      expect(document.querySelector('[data-testid="copy-room-id"]')).not.toBeNull()
+    );
+
+    const copyRoomId = q(document.body, '[data-testid="copy-room-id"]') as HTMLButtonElement;
+    await expect.element(copyRoomId).toHaveTextContent('Copy Room ID');
+    const menuItems = copyRoomId.closest('[role="menu"]')?.querySelectorAll('[role="menuitem"]');
+    expect(menuItems?.item((menuItems?.length ?? 0) - 1)).toBe(copyRoomId);
+
+    copyRoomId.click();
+
+    await vi.waitFor(() => expect(mocks.writeClipboardText).toHaveBeenCalledWith('channel-1'));
+    expect(getToasts().map((item) => item.message)).toContain('Copied to clipboard');
   });
 
   it('offers a join action for a visible non-member room', async () => {

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -112,6 +112,19 @@
     void markNavigationServerAsRead(serverId);
   }
 
+  async function handleCopyServerHostname(): Promise<void> {
+    const hostname = serverHost;
+    closeContextMenu();
+    if (!hostname) return;
+
+    try {
+      await navigator.clipboard.writeText(hostname);
+      toast.success(m('common.copied_to_clipboard'));
+    } catch {
+      toast.error(m('common.error.generic'));
+    }
+  }
+
   function handleRemoveServer(): void {
     closeContextMenu();
     pushState('', {
@@ -271,5 +284,21 @@
       onMarkRead={handleMarkServerRead}
       onLeave={handleRemoveServer}
     />
+    {#if serverHost}
+      <div class="menu-section">
+        <nav class="sidebar-nav">
+          <button
+            type="button"
+            class="sidebar-item"
+            onclick={() => void handleCopyServerHostname()}
+            role="menuitem"
+            data-testid="copy-server-hostname"
+          >
+            <span class="iconify sidebar-icon icon-[uil--copy]" aria-hidden="true"></span>
+            {m('room_list.copy_server_hostname')}
+          </button>
+        </nav>
+      </div>
+    {/if}
   </ContextMenu>
 {/if}

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -18,7 +18,9 @@ const { mocks } = vi.hoisted(() => {
       startRemoteReauthentication: vi.fn(),
       beginOriginReauthentication: vi.fn(),
       isOriginServer: vi.fn(() => false),
+      writeClipboardText: vi.fn(),
       toastError: vi.fn(),
+      toastSuccess: vi.fn(),
       appUi: {
         disableRoomCallWideFor: vi.fn()
       },
@@ -157,7 +159,7 @@ vi.mock('$lib/auth/reauth', () => ({
 }));
 
 vi.mock('$lib/ui/toast', () => ({
-  toast: { error: mocks.toastError }
+  toast: { error: mocks.toastError, success: mocks.toastSuccess }
 }));
 
 import ServerSidebarEntry from './ServerSidebarEntry.svelte';
@@ -216,7 +218,15 @@ describe('ServerSidebarEntry', () => {
     mocks.beginOriginReauthentication.mockReset();
     mocks.isOriginServer.mockReset();
     mocks.isOriginServer.mockReturnValue(false);
+    mocks.server.url = 'https://remote.example.com';
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mocks.writeClipboardText },
+      configurable: true
+    });
+    mocks.writeClipboardText.mockReset();
+    mocks.writeClipboardText.mockResolvedValue(undefined);
     mocks.toastError.mockReset();
+    mocks.toastSuccess.mockReset();
     mocks.appUi.disableRoomCallWideFor.mockClear();
     mocks.getAuthenticatedServerState.mockResolvedValue(serverState());
     mocks.getViewerStateViaConnect.mockResolvedValue(viewerState());
@@ -277,9 +287,14 @@ describe('ServerSidebarEntry', () => {
     const markRead = Array.from(document.querySelectorAll('button')).find(
       (button) => button.textContent?.trim() === 'Mark as read'
     );
+    const remove = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Remove server'
+    );
     await expect.element(markRead ?? null).toBeInTheDocument();
     await expect.element(markRead ?? null).toBeEnabled();
-    await expect.element(q(document.body, '[role="separator"]')).toBeInTheDocument();
+    await expect.element(remove ?? null).toBeInTheDocument();
+    expect(markRead?.closest('.menu-section')).not.toBe(remove?.closest('.menu-section'));
+    expect(q(document.body, '[role="separator"]')).toBeNull();
     markRead!.click();
 
     expect(mocks.markNavigationServerAsRead).toHaveBeenCalledWith('remote');
@@ -300,6 +315,44 @@ describe('ServerSidebarEntry', () => {
     await expect
       .element(q(document.body, '[role="menu"]'))
       .toHaveAttribute('aria-label', 'Actions for Loaded Remote');
+  });
+
+  it('shows Copy Server Hostname last and copies the displayed host', async () => {
+    mocks.server.url = 'https://remote.example.com:8443/chat';
+    const { container } = render(ServerSidebarEntry, {
+      props: { serverId: 'remote', currentUserId: 'user-1' }
+    });
+    const icon = q(container, '[data-testid="server-icon"]') as HTMLAnchorElement;
+
+    icon.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+    await vi.waitFor(() =>
+      expect(document.querySelector('[data-testid="copy-server-hostname"]')).not.toBeNull()
+    );
+
+    const copyHostname = q(
+      document.body,
+      '[data-testid="copy-server-hostname"]'
+    ) as HTMLButtonElement;
+    await expect.element(copyHostname).toHaveTextContent('Copy Server Hostname');
+    const menuItems = copyHostname
+      .closest('[role="menu"]')
+      ?.querySelectorAll('[role="menuitem"]');
+    expect(menuItems?.item((menuItems?.length ?? 0) - 1)).toBe(copyHostname);
+
+    const remove = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Remove server'
+    );
+    expect(remove?.closest('.menu-section')).not.toBe(copyHostname.closest('.menu-section'));
+
+    copyHostname.click();
+
+    await vi.waitFor(() =>
+      expect(mocks.writeClipboardText).toHaveBeenCalledWith('remote.example.com:8443')
+    );
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Copied to clipboard');
+    await vi.waitFor(() =>
+      expect(q(document.body, '[data-testid="copy-server-hostname"]')).toBeNull()
+    );
   });
 
   it('opens the remove-server confirmation for the selected server', async () => {

--- a/apps/frontend/src/lib/components/menus/NavigationContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/NavigationContextMenu.svelte
@@ -35,43 +35,46 @@ presentation-only.
   } = $props();
 </script>
 
-<div class="menu-section">
-  <nav class="sidebar-nav">
-    {#if kind === 'room' && !isRoomMember}
-      <button
-        type="button"
-        class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
-        onclick={onJoin}
-        disabled={!canJoin}
-        role="menuitem"
-      >
-        <span class="iconify sidebar-icon icon-[uil--sign-in-alt]" aria-hidden="true"></span>
-        {m('room.join.action')}
-      </button>
-    {:else if showMarkRead}
-      <button
-        type="button"
-        class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
-        onclick={onMarkRead}
-        disabled={!canMarkRead}
-        role="menuitem"
-      >
-        <span class="iconify sidebar-icon icon-[uil--check-circle]" aria-hidden="true"></span>
-        {m('room_list.mark_as_read')}
-      </button>
-    {/if}
-
-    {#if canConfigure && onConfigure}
-      <button type="button" class="sidebar-item" onclick={onConfigure} role="menuitem">
-        <span class="iconify sidebar-icon icon-[uil--setting]" aria-hidden="true"></span>
-        {m('room_list.room_settings')}
-      </button>
-    {/if}
-
-    {#if isRoomMember && canLeave}
-      {#if showMarkRead || (canConfigure && onConfigure)}
-        <div role="separator" class="mx-2 my-1 border-t border-text/10"></div>
+{#if (kind === 'room' && !isRoomMember) || showMarkRead || (canConfigure && onConfigure)}
+  <div class="menu-section">
+    <nav class="sidebar-nav">
+      {#if kind === 'room' && !isRoomMember}
+        <button
+          type="button"
+          class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
+          onclick={onJoin}
+          disabled={!canJoin}
+          role="menuitem"
+        >
+          <span class="iconify sidebar-icon icon-[uil--sign-in-alt]" aria-hidden="true"></span>
+          {m('room.join.action')}
+        </button>
+      {:else if showMarkRead}
+        <button
+          type="button"
+          class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
+          onclick={onMarkRead}
+          disabled={!canMarkRead}
+          role="menuitem"
+        >
+          <span class="iconify sidebar-icon icon-[uil--check-circle]" aria-hidden="true"></span>
+          {m('room_list.mark_as_read')}
+        </button>
       {/if}
+
+      {#if canConfigure && onConfigure}
+        <button type="button" class="sidebar-item" onclick={onConfigure} role="menuitem">
+          <span class="iconify sidebar-icon icon-[uil--setting]" aria-hidden="true"></span>
+          {m('room_list.room_settings')}
+        </button>
+      {/if}
+    </nav>
+  </div>
+{/if}
+
+{#if isRoomMember && canLeave}
+  <div class="menu-section">
+    <nav class="sidebar-nav">
       <button
         type="button"
         class="sidebar-item text-danger hover:text-danger"
@@ -87,6 +90,6 @@ presentation-only.
         ></span>
         {kind === 'server' ? m('room_list.remove_server') : m('room_list.leave_room')}
       </button>
-    {/if}
-  </nav>
-</div>
+    </nav>
+  </div>
+{/if}

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
@@ -30,6 +30,7 @@ ContextMenu, which handles both modes automatically.
     type CustomUserStatus
   } from '$lib/state/userProfiles.svelte';
   import { m } from '$lib/i18n/messages';
+  import { toast } from '$lib/ui/toast';
 
   let {
     user,
@@ -73,6 +74,17 @@ ContextMenu, which handles both modes automatically.
   function handleBanFromRoom() {
     onBanFromRoom?.();
   }
+
+  async function handleCopyUserId(): Promise<void> {
+    try {
+      const write = navigator.clipboard.writeText(user.id);
+      onClose?.();
+      await write;
+      toast.success(m('common.copied_to_clipboard'));
+    } catch {
+      toast.error(m('common.error.generic'));
+    }
+  }
 </script>
 
 <ContextMenu
@@ -84,18 +96,18 @@ ContextMenu, which handles both modes automatically.
   class="w-64"
   onclose={() => onClose?.()}
 >
-  <div class="rounded-md bg-background">
-    <div class="flex items-center gap-3 p-3">
-      <UserAvatar {user} size="md" />
-      <div class="min-w-0 flex-1">
-        <div class="truncate font-semibold">{displayName}</div>
-        <div class="truncate text-xs text-muted">@{getLiveLogin(user.id, user.login)}</div>
-        <UserCustomStatusBadge status={customStatus} showText class="mt-1 max-w-full" />
-      </div>
+  <div class="flex items-center gap-3 menu-section p-3">
+    <UserAvatar {user} size="md" />
+    <div class="min-w-0 flex-1">
+      <div class="truncate font-semibold">{displayName}</div>
+      <div class="truncate text-xs text-muted">@{getLiveLogin(user.id, user.login)}</div>
+      <UserCustomStatusBadge status={customStatus} showText class="mt-1 max-w-full" />
     </div>
+  </div>
 
-    {#if canSendMessage || canBanFromRoom}
-      <div class="border-t border-border p-1">
+  {#if canSendMessage || canBanFromRoom}
+    <div class="menu-section">
+      <nav class="sidebar-nav">
         {#if canSendMessage}
           <button type="button" class="sidebar-item" onclick={handleSendMessage}>
             {m('chat.user_menu.send_message')}
@@ -111,7 +123,20 @@ ContextMenu, which handles both modes automatically.
             {banningFromRoom ? m('admin.moderation.banning') : m('admin.moderation.ban_action')}
           </button>
         {/if}
-      </div>
-    {/if}
+      </nav>
+    </div>
+  {/if}
+
+  <div class="menu-section">
+    <nav class="sidebar-nav">
+      <button
+        type="button"
+        class="sidebar-item"
+        onclick={() => void handleCopyUserId()}
+        data-testid="copy-user-id"
+      >
+        {m('chat.user_menu.copy_user_id')}
+      </button>
+    </nav>
   </div>
 </ContextMenu>

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
@@ -1,8 +1,9 @@
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 
 import { q } from '$lib/test-utils';
+import { getToasts, toast } from '$lib/ui/toast';
 import UserContextMenu from './UserContextMenu.svelte';
 
 vi.mock('$lib/state/userProfiles.svelte', () => ({
@@ -28,6 +29,15 @@ const user = {
 };
 
 let originalShowPopover: typeof HTMLElement.prototype.showPopover;
+const writeClipboardText = vi.fn();
+
+function buttonWithText(container: HTMLElement, text: string): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === text
+    ) ?? null
+  );
+}
 
 function renderMenu(props: Record<string, unknown> = {}) {
   return render(UserContextMenu, {
@@ -49,6 +59,16 @@ beforeAll(() => {
 
 afterAll(() => {
   HTMLElement.prototype.showPopover = originalShowPopover;
+});
+
+beforeEach(() => {
+  toast.clear();
+  writeClipboardText.mockReset();
+  writeClipboardText.mockResolvedValue(undefined);
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: writeClipboardText },
+    configurable: true
+  });
 });
 
 describe('UserContextMenu', () => {
@@ -86,7 +106,41 @@ describe('UserContextMenu', () => {
     hidden.unmount();
 
     const visible = renderMenu({ canSendMessage: true });
-    await expect.element(q(visible.container, 'button')).toHaveTextContent('Send Message');
+    await expect.element(buttonWithText(visible.container, 'Send Message')).toBeInTheDocument();
+  });
+
+  it('separates the profile and actions with sibling menu surfaces', () => {
+    const { container } = renderMenu({ canSendMessage: true, canBanFromRoom: true });
+    const dialog = q(container, '[role="dialog"]')!;
+    const sections = dialog.querySelectorAll('.menu-section');
+
+    expect(sections).toHaveLength(3);
+    expect(sections[0]?.textContent).toContain('Alice Example');
+    expect(sections[1]?.textContent).toContain('Send Message');
+    expect(sections[1]?.textContent).toContain('Ban from room');
+    expect(sections[2]?.textContent).toContain('Copy User ID');
+    expect(sections[0]?.parentElement).toBe(sections[1]?.parentElement);
+    expect(sections[1]?.parentElement).toBe(sections[2]?.parentElement);
+    expect(dialog.querySelector('[class~="border-t"], [role="separator"]')).toBeNull();
+  });
+
+  it('shows Copy User ID last and copies the exact user ID', async () => {
+    const onClose = vi.fn();
+    const { container } = renderMenu({ onClose });
+    const copyUserId = q(container, '[data-testid="copy-user-id"]') as HTMLButtonElement;
+    const dialogButtons = q(container, '[role="dialog"]')?.querySelectorAll('button');
+
+    await expect.element(copyUserId).toHaveTextContent('Copy User ID');
+    expect(dialogButtons?.item((dialogButtons?.length ?? 0) - 1)).toBe(copyUserId);
+
+    copyUserId.click();
+
+    await vi.waitFor(() => expect(writeClipboardText).toHaveBeenCalledWith('user-1'));
+    expect(onClose).toHaveBeenCalledOnce();
+    expect(writeClipboardText.mock.invocationCallOrder[0]).toBeLessThan(
+      onClose.mock.invocationCallOrder[0]!
+    );
+    expect(getToasts().map((item) => item.message)).toContain('Copied to clipboard');
   });
 
   it('calls send and close callbacks when sending a message', () => {
@@ -94,7 +148,7 @@ describe('UserContextMenu', () => {
     const onClose = vi.fn();
     const { container } = renderMenu({ canSendMessage: true, onSendMessage, onClose });
 
-    (q(container, 'button') as HTMLButtonElement).click();
+    buttonWithText(container, 'Send Message')?.click();
 
     expect(onSendMessage).toHaveBeenCalledOnce();
     expect(onClose).toHaveBeenCalledOnce();

--- a/apps/frontend/src/lib/ui/ContextMenu.stories.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.stories.svelte
@@ -20,6 +20,7 @@
 <script lang="ts">
   let trigger: HTMLButtonElement;
   let open = $state(false);
+  let sheetOpen = $state(false);
   let anchor = $state<{ top: number; bottom: number; left: number } | null>(null);
 
   function openMenu() {
@@ -52,6 +53,43 @@
           <span class="sidebar-icon iconify icon-[uil--trash]"></span>
           Delete
         </button>
+      </div>
+    </ContextMenu>
+  {/if}
+</Story>
+
+<Story name="Touch sheet" asChild>
+  <button type="button" class="btn-action" onclick={() => (sheetOpen = true)}>Open sheet</button>
+
+  {#if sheetOpen}
+    <ContextMenu
+      presentation="sheet"
+      ariaLabel="Example touch actions"
+      onclose={() => (sheetOpen = false)}
+    >
+      <div class="menu-section">
+        <nav class="sidebar-nav">
+          <button type="button" class="sidebar-item" onclick={() => (sheetOpen = false)}>
+            <span class="iconify sidebar-icon icon-[uil--edit]" aria-hidden="true"></span>
+            Edit
+          </button>
+          <button type="button" class="sidebar-item" onclick={() => (sheetOpen = false)}>
+            <span class="iconify sidebar-icon icon-[uil--copy]" aria-hidden="true"></span>
+            Copy
+          </button>
+        </nav>
+      </div>
+      <div class="menu-section">
+        <nav class="sidebar-nav">
+          <button
+            type="button"
+            class="sidebar-item text-danger"
+            onclick={() => (sheetOpen = false)}
+          >
+            <span class="iconify sidebar-icon icon-[uil--trash]" aria-hidden="true"></span>
+            Delete
+          </button>
+        </nav>
       </div>
     </ContextMenu>
   {/if}

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte
@@ -76,11 +76,13 @@ ignored (the BottomSheet handles its own positioning).
 {#if useSheet}
   <BottomSheet bind:visible={sheetVisible} {ariaLabel} {onclose}>
     {#if role === 'menu'}
-      <div role="menu" aria-label={ariaLabel}>
+      <div class="flex flex-col gap-1" role="menu" aria-label={ariaLabel}>
         {@render children()}
       </div>
     {:else}
-      {@render children()}
+      <div class="flex flex-col gap-1">
+        {@render children()}
+      </div>
     {/if}
   </BottomSheet>
 {:else}

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte.spec.ts
@@ -140,6 +140,7 @@ describe('ContextMenu', () => {
       .element(q(container, 'dialog.bottom-sheet'))
       .toHaveAttribute('aria-label', 'Room actions');
     await expect.element(q(container, '[role="menu"]')).toHaveAttribute('aria-label', 'Room actions');
+    await expect.element(q(container, '[role="menu"]')).toHaveClass('flex', 'flex-col', 'gap-1');
     expect(container.textContent).toContain('Menu body');
   });
 });

--- a/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
+++ b/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md
@@ -1,7 +1,7 @@
 # FDR-017: Room Groups & Sidebar Layout
 
 **Status:** Active
-**Last reviewed:** 2026-08-13
+**Last reviewed:** 2026-08-22
 
 ## Overview
 
@@ -13,7 +13,7 @@ Channel rooms are organized into **room groups** — named, ordered containers t
 - Configured room groups, the alphabetical fallback used before a layout exists, and the Direct Messages section share the same sidebar heading, spacing, and collapse/expand interaction. This presentation does not make Direct Messages an operator-managed room group.
 - ConnectRPC `RoomDirectoryService.ListRoomGroups` exposes the same ordered sidebar structure for protobuf-first clients, filtering room entries to non-archived channel rooms visible to the viewer, preserving sidebar links, and reporting effective `room.create` and `room.manage` group capabilities in viewer state.
 - Joined channel rooms behave as normal navigation entries. Listable channel rooms the viewer has not joined yet are shown slightly faded; selecting a joinable room asks for confirmation before joining, while selecting a non-joinable room explains that access is not currently available.
-- Every visible room row exposes a context menu. Joined rooms offer unread and leave actions where applicable; non-member rooms offer Join, disabled when the viewer lacks `room.join`. Effective room `room.manage` holders also receive a settings action for channel rooms.
+- Every visible sidebar room row exposes a context menu with a final “Copy Room ID” action that writes the room's stable ID to the clipboard. Successful copies are confirmed; clipboard failures report an error. Joined rooms offer unread and leave actions where applicable; non-member rooms offer Join, disabled when the viewer lacks `room.join`. Effective room `room.manage` holders also receive a settings action for channel rooms.
 - Server-wide room managers can create and reorder groups from the room-layout overview. Its edit action opens the room group's resource page in the shared management area. Effective group `room.manage` holders can edit or delete that group, while either they or server-wide `role.manage` holders can configure its role permission matrix.
 - Group names are limited to 80 bytes; group descriptions are limited to 500 bytes.
 - Every channel room belongs to exactly one group. There's no "uncategorized" branch — room creation requires a group.

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,7 +1,7 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-08-21
+**Last reviewed:** 2026-08-22
 
 ## Overview
 
@@ -18,6 +18,7 @@ A human user's profile carries the public identity they present to the rest of t
 - **Custom status expiry** — users can optionally choose an expiry date and time. After that instant, projected reads and the web client hide the status automatically. Users can also clear it manually.
 - **Settings** — human accounts currently support timezone (IANA name, e.g., `Europe/Berlin`) and time format (browser default / 12-hour / 24-hour). Stored server-side so they sync across devices. If not set, the frontend uses the browser timezone and locale time-format default.
 - **Display theme** — users can choose System, Light, or Dark. System follows the browser or OS color-scheme preference. The choice is browser-local and applies immediately on that device.
+- **Profile menu** — opening a user's profile popup or touch sheet shows their public identity and any available message or moderation actions. A final “Copy User ID” action copies the stable user ID to the clipboard.
 - **Admin overrides** — operators with the right permissions can update other human users' profiles, bypass the login cooldown, clear the cooldown so the user can change again before the 30 days expire, and force-delete an avatar.
 - **Bot identity management** — a bot owner or human user with `bot.manage` can update a bot's login and display name through `BotService`. Bot API keys cannot edit identity, and bot avatar, custom-status, and personal-settings management are not supported in this slice.
 

--- a/docs/fdr/FDR-031-client-server-compatibility-discovery.md
+++ b/docs/fdr/FDR-031-client-server-compatibility-discovery.md
@@ -1,7 +1,7 @@
 # FDR-031: Client–Server Compatibility Discovery
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-02
+**Last reviewed:** 2026-08-21
 
 ## Overview
 
@@ -15,6 +15,9 @@ Chatto's pre-1.0 API remains experimental.
 
 - A registered server's context menu shows the software version reported by
   that server's latest discovery response.
+- A registered server's context menu or touch sheet shows its configured host
+  and provides a final action that copies that exact host, including a
+  non-default port, to the clipboard.
 - A warning marker appears when the server predates the oldest version
   supported by the current client. The 0.5 client classifies pre-0.5 servers as
   unsupported because they do not provide the required server-projection

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -26,12 +26,12 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-05-31 |
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-08-20 |
-| [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-07-20 |
+| [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-08-22 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-08-21 |
 | [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-08-19 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-07-14 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-08-11 |
-| [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-08-21 |
+| [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-08-22 |
 | [FDR-023](FDR-023-authentication-and-sessions.md) | Authentication & Sessions | Active | 2026-08-21 |
 | [FDR-024](FDR-024-permission-inspection-tool.md) | Permission Inspection Tool | Active | 2026-06-15 |
 | [FDR-025](FDR-025-user-search-and-member-directory.md) | User Search & Member Directory | Active | 2026-08-21 |
@@ -40,7 +40,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-028](FDR-028-operator-api-and-cli.md) | Operator API & CLI | Active | 2026-06-29 |
 | [FDR-029](FDR-029-chatto-shields.md) | Chatto Shields | Active | 2026-07-12 |
 | [FDR-030](FDR-030-inline-message-timestamps.md) | Inline Message Timestamps | Active | 2026-07-12 |
-| [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-07-30 |
+| [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-08-21 |
 | [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-07-19 |
 | [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-07-31 |
 | [FDR-034](FDR-034-chatto-desktop.md) | Chatto Desktop | Experimental | 2026-08-20 |


### PR DESCRIPTION
## Why

People need a quick, consistent way to copy stable room, user, and server identifiers from the places where those resources are already being inspected.

## What changed

- Adds final localized copy actions for room IDs, user IDs, and configured server hosts (including non-default ports), with success/error feedback and teardown-safe clipboard ordering.
- Standardizes floating and touch-sheet action groups on sibling menu surfaces, adds a design-system guard and Storybook touch-sheet example, and updates [FDR-017](https://github.com/chattocorp/chatto/blob/hmans/copy-room-id-menu/docs/fdr/FDR-017-room-groups-and-sidebar-layout.md), [FDR-022](https://github.com/chattocorp/chatto/blob/hmans/copy-room-id-menu/docs/fdr/FDR-022-user-profile.md), and [FDR-031](https://github.com/chattocorp/chatto/blob/hmans/copy-room-id-menu/docs/fdr/FDR-031-client-server-compatibility-discovery.md).

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- Affected Vitest component suites: 69/69 passed; `mise lint-frontend`: zero errors or warnings; `mise x -- pnpm --filter chatto-frontend build-storybook`: succeeded; Chrome DevTools verified desktop and touch layouts plus live room, server, and user copy behavior, including the user-ID regression.
