### PR TITLE
fix(frontend): log auth/session degradation events with console.warn

### DIFF
--- a/apps/frontend/src/lib/auth/currentUser.svelte.ts
+++ b/apps/frontend/src/lib/auth/currentUser.svelte.ts
@@ -76,7 +76,7 @@ export class CurrentUserState {
     if (this.#isLoggingOut) return;
 
     if (!this.#cookieAuth) {
-      console.log('Remote server auth failure — marking reauthentication required');
+      console.warn('Remote server auth failure — marking reauthentication required');
       this.#onAuthenticationRequired?.();
       this.loading = false;
       return;

--- a/apps/frontend/src/routes/chat/ChatRoot.svelte
+++ b/apps/frontend/src/routes/chat/ChatRoot.svelte
@@ -139,7 +139,7 @@
     // Handle session terminated events from server (logout from another tab/device, admin boot).
     useSessionTerminated(
       (reason) => {
-        console.log('Session terminated by server:', reason);
+        console.warn('Session terminated by server:', reason);
         if (isExplicitSignOutRedirectInProgress()) return;
         clearTerminatedOriginSession();
       },


### PR DESCRIPTION
## Summary
- Promote two auth-relevant diagnostic logs from `console.log` to `console.warn` so they surface under default devtools filtering, consistent with all neighboring degraded-state logging:
  - `ChatRoot.svelte`: session terminated by server (remote logout / admin boot)
  - `currentUser.svelte.ts`: remote server auth failure marking reauthentication required

No behavior change; log-level alignment only.
