### PR TITLE
chore(dev): add aggregate reset task

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -730,6 +730,10 @@ depends = ["setup-cli"]
 dir = "cli"
 run = ["rm chatto.toml", "go run . init"]
 
+[tasks.reset]
+description = "Reset the local development environment"
+run = [{ task = "reset-data" }]
+
 [tasks.reset-data]
 description = "Reset the development environment (NATS data etc.)"
 confirm = "Are you sure you want to reset the development environment? This will delete all data."


### PR DESCRIPTION
## Why

Developers need a conventional top-level reset command while retaining the focused data-reset task.

## What changed

- Added `mise reset` as an aggregate task that delegates to the existing `reset-data` task, preserving its confirmation and deletion behavior.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise tasks ls | rg '^reset(-data)?\b'` — passed; both tasks are registered.
- `mise -y reset` — passed; `reset-data` ran and removed the local data directory.
- `git diff --check origin/main...` — passed.
