### PR TITLE
docs: adopt ASD-STE100 writing rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,35 @@ permission to reorganize unrelated product code.
 - The nearest applicable `AGENTS.md` owns path-specific guidance. Root rules
   still apply when nested guidance is more specific.
 
+## Simplified Technical English
+
+Use [ASD-STE100 Simplified Technical English, Issue 9
+(January 2025)](https://www.asd-ste100.org/assets/files/ASD-STE100_ISSUE9.pdf),
+including its controlled dictionary, for all new or changed documentation in
+this repository. This scope includes the docs website.
+
+Use canonical product, API, user-interface, and configuration terms as
+technical terms. For Chatto terms, use the canonical vocabulary in
+[`docs/GLOSSARY.md`](docs/GLOSSARY.md). Do not change code, commands, literal
+names, or quotations.
+
+Treat violations in unchanged text as migration work. Apply the standard to a
+full page when you make a substantial page edit. Claim formal conformance only
+after a full review against the standard and its dictionary.
+
+### Approved Exclusions
+
+These pages can use a conversational product voice and vocabulary that
+ASD-STE100 does not approve:
+
+- `apps/docs-website/src/content/docs/index.mdx` — product home page.
+- `apps/docs-website/src/content/docs/getting-started/introduction.mdx` —
+  narrative product introduction.
+
+ASD-STE100 still applies to technical instructions and safety information on an
+excluded page. Add an exclusion only with explicit user approval. Record its
+full path and reason here.
+
 ## Prime Directives
 
 - Prefer simple, clear changes over clever abstractions.

--- a/apps/docs-website/AGENTS.md
+++ b/apps/docs-website/AGENTS.md
@@ -29,6 +29,8 @@ Starlight.
 
 ## Style
 
+- Follow the ASD-STE100 rules and the approved exclusion list in the root
+  `AGENTS.md`. The root list is the only documentation exclusion list.
 - Be direct, concise, and confident.
 - Use second person, present tense.
 - Lead with the actionable fact, not background.

--- a/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/binary.mdx
@@ -1,60 +1,86 @@
 ---
 title: Standalone Binary
-description: How to deploy Chatto as a standalone binary.
+description: Deploy Chatto as one binary with embedded NATS.
 ---
 
 import {
-  Steps,
   Aside,
-  FileTree,
-  LinkCard,
   CardGrid,
+  LinkCard,
 } from "@astrojs/starlight/components";
 import ArchDiagram from "../../../../components/diagrams/BinaryDiagram.astro";
 
 <Aside type="caution">
-  While it is totally possible to host Chatto just using the binary (it will
-  even terminate TLS for you if you want!), it is heavily recommended to make
-  use of the provided Docker image through [Docker
-  Compose](/guides/deployment/docker-compose/), [Kubernetes](/guides/deployment/kubernetes/), or
-  another container runtime of your choice.
+  Use this deployment for a test environment or a small server that can accept
+  short downtime. For most production servers, use [Docker
+  Compose](/guides/deployment/docker-compose/) or a different container
+  runtime.
 </Aside>
 
-Chatto ships as a single binary with an embedded NATS server and built-in Let's Encrypt TLS. No reverse proxy, no external database — just one process serving everything. Alternatively, spin it up on any port and use your existing reverse proxy to wire things up and terminate TLS.
+The standalone binary includes embedded NATS and optional automatic TLS. It
+does not use an external database.
+
+You can use the automatic TLS function in Chatto. You can also put Chatto
+behind your reverse proxy.
 
 ## Architecture
 
 <ArchDiagram />
 
-The Chatto binary includes an embedded NATS server with JetStream for storage. It expects a `chatto.toml` configuration file (you can generate one using `chatto init`), and stores all data in a `./data/` directory.
+By default, `chatto run` starts an embedded NATS server with JetStream. Chatto
+reads `chatto.toml` from the current working directory. It stores embedded NATS
+data in `./data/` by default.
+
+<Aside type="caution">
+  Do not start more than one Chatto server process with one embedded data
+  directory. Use external NATS for a deployment with multiple processes.
+</Aside>
 
 ## Prerequisites
 
-- A server with Chatto installed. Use `brew install chattocorp/tap/chatto` on macOS or Linux with Homebrew, or download the Linux, macOS, or FreeBSD archive from [GitHub Releases](https://github.com/chattocorp/chatto/releases).
-- A domain pointing to your server (e.g., `chat.example.com`)
-- Firewall allowing inbound TCP 80 and 443
+Prepare these items:
 
-## Setup
+- A Linux, macOS, or FreeBSD host with Chatto installed.
+- A domain that points to the host, such as `chat.example.com`.
+- Persistent storage for the Chatto data directory.
+- Inbound TCP ports 80 and 443 when Chatto terminates TLS.
 
-Please refer to the [Quick Start](/getting-started/quick-start/) guide for details on initializing your `chatto.toml` configuration file.
+Install Chatto with Homebrew on macOS or Linux:
 
-For production use, please review the file and **at least**:
+```bash
+brew install chattocorp/tap/chatto
+```
 
-- configure SMTP credentials
-- set `webserver.url` to your public URL
-- review `webserver.tls` if you want Chatto to terminate TLS
+You can also download an archive from [GitHub
+Releases](https://github.com/chattocorp/chatto/releases).
 
-It is also strongly recommended that you:
+## Configure Chatto
 
-- review the `[core.assets.s3]` section if you want to use an external object store for uploaded files (optional, but recommended; you can enable this later if you wish)
-- choose whether to allow direct registration, and configure at least one tested SSO provider before setting `auth.direct_login = false`
-- review the `[push]` section if you want to support native push notifications
-- review the `[video]` section if you want to support video uploads
-- review the `[livekit]` section if you want to support voice and video calls (requires LiveKit)
+Use the [Quick Start](/getting-started/quick-start/) guide to generate
+`chatto.toml`.
 
-## Running as a systemd Service
+Before you use the configuration in production, do these steps:
 
-For production use on Linux, create a systemd unit to manage the process:
+- Set `webserver.url` to the public URL.
+- Add at least one verified email address to `owners.emails`.
+- Configure SMTP if Chatto must send registration or verification email.
+- Select automatic Chatto TLS or TLS in a reverse proxy.
+- Put `nats.embedded.data_dir` on persistent storage.
+- Select the permitted login methods.
+- Do a test of an external login provider before you set `auth.direct_login`
+  to `false`.
+
+Examine these optional sections for the specified features:
+
+- Use `[core.assets.s3]` for S3-compatible upload storage.
+- Use `[push]` for push notifications.
+- Use `[video]` and `[asset_processing]` for video uploads.
+- Use `[livekit]` for calls.
+
+## Run Chatto as a systemd Service
+
+On Linux, use systemd to start Chatto and restart it after a failure. Create
+this unit:
 
 ```ini
 # /etc/systemd/system/chatto.service
@@ -77,38 +103,44 @@ AmbientCapabilities=CAP_NET_BIND_SERVICE
 WantedBy=multi-user.target
 ```
 
+Make sure that the `chatto` user can read `chatto.toml` and write the data
+directory. Then, enable and start the service:
+
 ```bash
 sudo systemctl enable --now chatto
 ```
 
 <Aside type="tip">
-  Using `AmbientCapabilities=CAP_NET_BIND_SERVICE` in the unit file grants the
-  capability at runtime, so you don't need to `setcap` the binary separately.
-  This is the preferred approach when using systemd. You only need these when
-  running Chatto on a port lower than 1024.
+  `AmbientCapabilities=CAP_NET_BIND_SERVICE` lets Chatto bind to ports below
+  1024. Remove this line when Chatto listens only on ports that are 1024 or
+  higher.
 </Aside>
 
-## Adding Voice and Video Calls
+## Add Calls
 
-The standalone binary doesn't include LiveKit. To add voice and video calls, you have two options:
+The standalone binary does not include LiveKit. Select one of these methods to
+add calls:
 
-1. **Switch to Docker Compose** (recommended) — the [Docker Compose guide](/guides/deployment/docker-compose/) includes LiveKit out of the box.
-2. **Run LiveKit separately** — install and run a [LiveKit server](https://docs.livekit.io/home/self-hosting/local/) alongside Chatto, then configure the LiveKit environment variables.
+1. Use [Docker Compose](/guides/deployment/docker-compose/) with the included
+   LiveKit service.
+2. Run a separate [LiveKit
+   server](https://docs.livekit.io/home/self-hosting/local/). Then, configure
+   the LiveKit environment variables.
 
 <CardGrid>
   <LinkCard
     title="Docker Compose"
     href="/guides/deployment/docker-compose/"
-    description="Recommended production deployment with LiveKit and Caddy."
+    description="Use the recommended production deployment with LiveKit and Caddy."
   />
   <LinkCard
     title="Environment Variables"
     href="/reference/environment-variables/"
-    description="Full reference for all configuration options."
+    description="Examine the full Chatto configuration reference."
   />
   <LinkCard
     title="Backup & Restore"
     href="/guides/operations/backup-restore/"
-    description="How to back up and restore your Chatto data."
+    description="Create and restore Chatto data backups."
   />
 </CardGrid>

--- a/apps/docs-website/src/content/docs/guides/deployment/read-this-first.mdx
+++ b/apps/docs-website/src/content/docs/guides/deployment/read-this-first.mdx
@@ -1,66 +1,107 @@
 ---
 title: Read This First
-description: Choose a Chatto deployment path and make the important production decisions before you start.
+description: Select a Chatto deployment and make the primary production decisions before you start.
 ---
 
-import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
+import { CardGrid, LinkCard } from "@astrojs/starlight/components";
 
-Chatto ships in a compact, self-contained binary, and `chatto run` gives you a fully functional chat server. You can deploy Chatto that way, but most production servers benefit from a more explicit setup. This section helps you choose between the standalone binary, Docker Compose, and Kubernetes.
+Chatto ships as one compact binary. The `chatto run` command starts a Chatto
+server.
 
-## What You Should Know
+This guide helps you select the standalone binary, Docker Compose, or
+Kubernetes.
+
+## What You Must Know
 
 ### NATS and JetStream
 
-Chatto doesn't require a database like MySQL or PostgreSQL; instead, it uses **NATS**, a compact message broker that also ships with a built-in stream persistence engine. Chatto can run with an embedded NATS server, or you can point it at one you've set up yourself.
+Chatto does not use MySQL or PostgreSQL. Chatto uses NATS and JetStream to store
+durable event data and runtime data.
 
-The important thing to be aware of is that ultimately, **NATS persists its data into the filesystem**; if you have any plans for running more than a single Chatto process (you won't need it for performance, but you may want it for redundancy, high availability, or zero-downtime upgrades), you **must** choose the latter option. (Don't worry, NATS is just as easy to provision as Chatto, and most of our examples will show you how.)
+Chatto can start an embedded NATS server. Chatto can also connect to an
+external NATS server.
 
-If you don't care about redundancy and your users are fine with your chat server briefly becoming unavailable during upgrades, you can just use the embedded NATS server and not care about any of this stuff. (And yes, you can change your mind later!)
+Use external NATS when you run more than one Chatto server process. The
+external service lets all Chatto server processes use the same durable data.
+Use external NATS when high availability or updates without downtime are
+necessary.
+
+Embedded NATS stores its data in the local filesystem. Use it only for one
+Chatto server process. Your server will stop briefly when you update Chatto.
+Use the Chatto backup and restore commands to migrate between these
+configurations.
 
 ### File Uploads
 
-You can configure your Chatto server to allow users to attach files (images, videos, etc.) to messages. These files need to be stored somewhere; out of the box, **this is also done in NATS**.
+Chatto stores uploaded files in NATS Object Store by default. Use this
+configuration for a small server that stores a small quantity of uploaded data.
 
-But you can also **configure an external S3-compatible object storage** for Chatto to store your files in, and **we strongly recommend doing so for any but the smallest servers**. Chatto doesn't care if it's literally AWS S3 or some other provider's S3-compatible object storage or something you operate locally; it just needs to be compatible with the AWS S3 SDK.
+For most production servers, use an S3-compatible object store. The object
+store can be a hosted service or a service that you operate. It must be
+compatible with the AWS S3 SDK.
 
-### Users, PII and Data
+Read [Media & Attachments](/guides/infrastructure/media-attachments/) for the
+storage and processing configurations.
 
-Each Chatto server powers a single community with its own data, including user accounts. You get a series of choices in how users can join your server, from direct email-based registration to logging in through an external identity provider (eg. Google, GitHub, Discord, your own self-hosted IdP, and so on.)
+### User Accounts and Protected Data
 
-A user account on your server is 100% separate from the same person's account on other servers. This is by design (see ["Chatto is not a platform"](/getting-started/introduction/)). All user data -- their PII (Personally Identifiable Information, eg. email address, user name, display name etc.) as well as their message data is **encrypted at rest**, using per-user keys that get wiped when the user decides to delete their account. This also means that outside of manually restoring a deleted user's keys, deleted user accounts and data is **unrecoverable**.
+Each Chatto server has separate user accounts and community data. Users can
+register directly or use an external identity provider. An account on one
+Chatto server is not an account on a different server.
 
-Chatto ships with a simple built-in KMS (Key Management Service); support for external KMS is planned.
+Chatto encrypts message text and selected account fields before it writes them
+to durable storage. Chatto does not encrypt each record or uploaded asset.
 
-### Voice and Video Calls
+Read [Encryption at Rest and Data
+Erasure](/guides/operations/privacy-erasure/) for the full protection
+boundary. Chatto includes a built-in key management service (KMS). You cannot
+configure an external KMS currently.
 
-Chatto ships with full support for voice and video calls, including screen sharing. The actual calls are powered by **LiveKit** (Apache-2.0), which you need to deploy alongside Chatto. As with NATS, the deployment examples show the required wiring.
+### Calls
 
-## What You Should Decide Beforehand
+Chatto includes calls and screen sharing through LiveKit. Deploy LiveKit with
+Chatto to enable these features. Each deployment guide gives the necessary
+configuration.
 
-- **Public URL**: you'll want your server to be reachable by your users, so pick a domain or host name, eg. `chat.yourdomain.com`.
-- **TLS**: Internet-facing production servers should use HTTPS. Be ready to provision the required certificate. The deployment examples typically provision certificates automatically through Let's Encrypt.
-- **Embedded vs. External NATS**: make a decision on whether to go with Chatto's embedded NATS server, or point Chatto at a dedicated external NATS server. The former is the more convenient option, the latter sets you up better for future scaling. Again, our examples show you how to do this.
-- **Data Storage**: make a decision on where NATS should store its data. Outside of uploaded file blobs, you're not going to need huge amounts of space.
-- **File Storage**: decide on whether to use NATS for storing file uploads, or wire up an S3 compatible object storage.
-- **Admin Bootstrap**: Chatto's configuration allows you to specify the email addresses of users who should _always_ be server owners. This is a failsafe to prevent you from accidentally locking yourself out of your own server. Please be aware that the user is not automatically created for you; you still have to create your account either through the usual signup flow, or using the `chatto operator` command.
-- **SMTP**: Chatto will need to send emails for verifying email addresses and other planned features like email-based notification reminders. Please prepare a set of SMTP credentials to allow Chatto to send emails. (If you never want Chatto to verify emails or send reminders, you can skip this, but we strongly recommend that you don't.)
+## Make the Deployment Decisions
 
-## Pick a Deployment Path
+- **Public URL:** Select a domain, such as `chat.example.com`, that your users
+  can access.
+- **TLS:** Use HTTPS for an Internet-facing production server. Prepare a TLS
+  certificate or use a deployment that gets one automatically.
+- **NATS:** Use embedded NATS for one Chatto server process. Use external NATS
+  for multiple processes.
+- **Data storage:** Put the NATS data directory on durable storage. Monitor the
+  available disk space.
+- **File storage:** Use NATS Object Store when users upload a small quantity of
+  data. Use S3-compatible storage when users upload more data.
+- **Owner account:** Add each owner email address to `owners.emails`. Chatto
+  gives the owner role after a user verifies a matching address. This setting
+  does not create an account.
+- **Login methods:** Select direct registration, external login providers, or
+  the two methods. Do a test of an external provider before you set
+  `auth.direct_login` to `false`.
+- **SMTP:** Configure SMTP for direct registration, email verification, and
+  other email features. Do a test of the credentials before you invite users.
+- **Backups:** Select storage for data backups, key exports, and S3 assets. Do a
+  test of the restore procedure at regular intervals.
+
+## Select a Deployment
 
 <CardGrid>
   <LinkCard
     title="Standalone Binary"
     href="/guides/deployment/binary/"
-    description="Smallest setup for testing or simple VMs. Uses embedded NATS. Use for small/casual servers only."
+    description="Use one binary and embedded NATS for a test environment or a small server."
   />
   <LinkCard
     title="Docker Compose"
     href="/guides/deployment/docker-compose/"
-    description="Recommended for most self-hosted production servers. Includes Chatto, external NATS, Caddy, and LiveKit."
+    description="Use the recommended production setup with Chatto, external NATS, Caddy, and LiveKit."
   />
   <LinkCard
     title="Kubernetes"
     href="/guides/deployment/kubernetes/"
-    description="Supported deployment target for operators who can supply their own manifests and NATS setup."
+    description="Use Kubernetes when you can supply the manifests and the external NATS deployment."
   />
 </CardGrid>

--- a/docs/adr/ADR-022-nanoid-with-entity-prefixes.md
+++ b/docs/adr/ADR-022-nanoid-with-entity-prefixes.md
@@ -2,40 +2,72 @@
 
 **Date:** 2026-03-01
 
-**Updated:** 2026-08-19
+**Updated:** 2026-08-23
 
 ## Context
 
-Every entity in Chatto (users, spaces, rooms, events, assets, notifications) needs a unique identifier. The options include UUIDs (128-bit, standard but verbose), auto-incrementing integers (simple but leak ordering and count), and NanoID (compact, customizable alphabet, configurable entropy).
+Chatto gives each durable entity a unique identifier. Identifier formats have
+different costs.
 
-Additionally, when debugging production issues or reading logs, it's helpful to immediately know what *type* of entity an ID refers to without additional context.
+UUIDs are standard, but they contain 36 characters. Sequential integers are
+short, but they show creation order and approximate entity counts. NanoID can
+use a selected alphabet and length.
+
+Logs and diagnostic output can show an identifier without more context. A
+type prefix lets an operator identify the entity type immediately.
 
 ## Decision
 
-Use 14-character NanoIDs with an alphanumeric alphabet (~83.4 bits of entropy) prefixed by a single letter indicating the entity type:
+Use a 14-character NanoID body with an alphanumeric alphabet. This format gives
+approximately 83.4 bits of entropy.
 
-| Prefix | Entity |
-|--------|--------|
+Add one or more prefix characters that identify the entity type or token
+purpose. Chatto uses these prefixes for primary entity identifiers:
+
+| Prefix | Entity type |
+|--------|-------------|
 | `U` | User |
-| `S` | Space |
+| `S` | Legacy space |
 | `R` | Room |
+| `C` | Call |
+| `CP` | Call media publisher |
+| `G` | Room group |
+| `L` | Sidebar link |
 | `A` | Asset |
+| `I` | Invitation |
 | `E` | Event |
 | `N` | Legacy notification |
 
-Opaque tokens use two-letter prefixes: `PR` (password reset), `RG` (registration completion), and `AD` (account deletion). Email verification codes are six-digit numeric OTPs and do not use NanoID prefixes.
+Multi-character prefixes also identify opaque tokens. Current examples include
+password-reset (`PR`), registration-completion (`RG`), external-identity
+(`EC`, `EL`, `ELS`), and account-deletion (`AD`) tokens.
 
-DM room IDs are a special case: deterministic SHA-256 hex truncated to 14 characters, with no prefix (since they're computed from participant IDs, not randomly generated).
+Some credential formats add the `cht_` marker before the NanoID prefix. These
+formats include access tokens (`cht_AT`), link-preview tokens (`cht_LP`), and
+OAuth authorization codes (`cht_AC`).
 
-Notifications 2.0 is another deliberate exception. Exact occurrence IDs use a
-deterministic `ntf_` identifier derived from recipient, source event, and signal
-kind; notification lifecycle fact IDs use `nte_`. These IDs make retry and
-replay idempotent and are not NanoIDs. See ADR-076.
+Email verification codes use six numeric digits. They do not use a NanoID
+prefix.
+
+DM room identifiers are a special case. Chatto sorts the participant
+identifiers and calculates a SHA-256 hash. It uses the first 14 hexadecimal
+characters without a prefix.
+
+Notifications 2.0 uses deterministic identifiers. An occurrence identifier
+starts with `ntf_`, and a lifecycle event identifier starts with `nte_`.
+Deterministic identity makes retries and replay idempotent. See ADR-076.
 
 ## Consequences
 
-- **Self-describing IDs**: Seeing `U8kX2mP4qR7nYw` in a log immediately tells you it's a user. No need to cross-reference which table or bucket it came from.
-- **Compact**: 15 characters total (1 prefix + 14 NanoID) vs. 36 for a UUID. Matters for NATS subject paths where IDs are embedded in subjects.
-- **URL-safe**: The alphanumeric alphabet avoids characters that need URL encoding. IDs can appear in URLs, NATS subjects, and KV keys without escaping.
-- **Visual consistency with DM IDs**: The 14-character NanoID length matches the 14-character SHA-256 hex truncation used for DM room IDs, so all IDs have roughly the same visual footprint.
-- **Collision probability is acceptable**: At ~83.4 bits of entropy, the probability of collision is negligible for the expected scale (millions of entities, not billions).
+- **Visible entity type:** An operator can identify the entity type from most
+  identifiers without a second lookup.
+- **Compact format:** Most entity identifiers contain 15 characters. A UUID
+  contains 36 characters. Short identifiers keep NATS subjects short.
+- **URL-safe format:** URL encoding is not necessary for the alphanumeric
+  alphabet. Identifiers can occur in URLs, NATS subjects, and KV keys.
+- **Same length:** A DM room identifier has the same 14-character body
+  length as a NanoID.
+- **Small collision probability:** The selected entropy is sufficient at a
+  scale of millions of entities.
+- **Type disclosure:** The prefix shows the identifier type. An identifier is a
+  reference. It is not a secret.

--- a/docs/fdr/FDR-029-chatto-shields.md
+++ b/docs/fdr/FDR-029-chatto-shields.md
@@ -1,54 +1,95 @@
 # FDR-029: Chatto Shields
 
 **Status:** Active
-**Last reviewed:** 2026-07-12
+**Last reviewed:** 2026-08-23
 
 ## Overview
 
-Chatto Shields are opt-in public badges that self-hosted communities can embed in READMEs, project pages, and websites. They expose a small aggregate view of community size and current activity without requiring a Chatto session.
+Chatto Shields are optional public badges for self-hosted communities.
+Operators can put these badges in READMEs, project pages, and websites. A badge
+shows an aggregate account count or presence count without a Chatto session.
 
 ## Behavior
 
-- Operators enable shields explicitly with `[webserver.shields].enabled` or `CHATTO_WEBSERVER_SHIELDS_ENABLED`. Disabled servers return Not Found for shield URLs.
-- `/.well-known/chatto/shields/online.json` returns Shields.io endpoint-badge JSON for the number of users with any current live presence record. Online, Away, and Do Not Disturb all count because the badge answers "how many members are currently present," not which availability state each member selected.
-- `/.well-known/chatto/shields/registered.json` returns Shields.io endpoint-badge JSON for the number of verified accounts. Unverified accounts are excluded.
-- The matching `.png` URLs are convenience redirects to Shields.io's endpoint badge renderer, using the matching Chatto JSON endpoint as the data source.
-- Chatto controls the metric labels and colors returned by the JSON endpoints. The default `.png` redirect uses Shields.io's default rendering style.
-- Shield responses expose only aggregate counts. They do not expose user identities, per-status presence breakdowns, or per-user activity.
+- An operator enables shields with `webserver.shields.enabled` or
+  `CHATTO_WEBSERVER_SHIELDS_ENABLED`. Chatto returns Not Found for shield URLs
+  when shields are disabled.
+- `/.well-known/chatto/shields/online.json` returns Shields.io endpoint JSON.
+  It counts each user who has a current live presence record. Online, Away, and
+  Do Not Disturb all count. The badge measures presence, not the selected
+  availability state.
+- `/.well-known/chatto/shields/registered.json` returns Shields.io endpoint
+  JSON. It counts verified accounts and does not count unverified accounts.
+- The related `.png` URLs redirect to the Shields.io endpoint renderer. Each
+  redirect uses the related Chatto JSON endpoint as its data source.
+- Chatto supplies the metric labels and colors. Shields.io supplies the default
+  image style.
+- Shield responses show only aggregate counts. They do not show user
+  identities, individual presence states, or individual activity.
 
 ## Design Decisions
 
-### 1. Opt-in public counts
+### 1. Keep public counts optional
 
-**Decision:** Community shields are disabled by default and enabled only when the operator opts in.
-**Why:** Public READMEs and websites are unauthenticated, cacheable surfaces. Community size and live activity can be sensitive for private or small servers.
-**Tradeoff:** Operators must configure one extra setting before they can embed badges.
+**Decision:** Keep community shields disabled by default. An operator must
+enable them with an explicit setting.
 
-### 2. Well-known public namespace
+**Why:** Public READMEs and websites are unauthenticated and can be cached.
+Community size and live presence can be sensitive on private or small servers.
 
-**Decision:** Shields live under `/.well-known/chatto/shields/` rather than a top-level `/shields/` route.
-**Why:** Badge metadata is public, discovery-like server metadata. The well-known namespace keeps Chatto's root URL space from accumulating one-off integration paths.
-**Tradeoff:** The URLs are longer, so the docs provide copy-paste Markdown examples and the `.png` redirects hide the longer Shields.io URL.
+**Tradeoff:** Badge use requires one more setting.
 
-### 3. Shields.io endpoint JSON instead of local image rendering
+### 2. Use the well-known public namespace
 
-**Decision:** Chatto exposes Shields.io-compatible JSON and redirects the short `.png` URLs to Shields.io's hosted renderer.
-**Why:** The primary consumers are Markdown renderers, static websites, and social/project pages that expect polished image badges. Delegating visual rendering keeps Chatto from owning badge typography, rasterization, and style compatibility.
-**Tradeoff:** Rendering the `.png` badge depends on Shields.io being reachable by the viewer, and Shields.io must be able to fetch the public Chatto JSON endpoint. Operators who do not want this dependency can link to the JSON endpoint only or keep shields disabled.
+**Decision:** Put shields under `/.well-known/chatto/shields/`. Do not use a
+top-level `/shields/` route.
 
-### 4. Plain HTTP instead of ConnectRPC
+**Why:** Badge metadata is public discovery information. The well-known
+namespace prevents unrelated integration routes at the Chatto root URL.
 
-**Decision:** Shields use small public HTTP endpoints rather than a new ConnectRPC service, even though side-effect-free ConnectRPC methods can be served through GET.
-**Why:** Shields.io expects a root JSON document with its endpoint-badge schema. A ConnectRPC GET URL would require protobuf/codegen surface area and an awkward encoded `connect=v1&encoding=json&message=...` URL inside the Shields.io `url` parameter.
-**Tradeoff:** This remains a narrow non-ConnectRPC public surface. It is intentionally scoped to aggregate badge data and does not become a general metrics API.
+**Tradeoff:** The URLs are longer. The documentation supplies Markdown
+examples, and the `.png` redirects hide the longer Shields.io URL.
 
-### 5. Aggregate-only privacy boundary
+### 3. Let Shields.io render the image
 
-**Decision:** v1 exposes only the online and registered aggregate counts.
-**Why:** Aggregate badges satisfy the README use case while avoiding per-user identity, per-status presence, and richer operational telemetry on a public endpoint. Presence remains live runtime state; offline is still represented by absence.
-**Tradeoff:** The public badge cannot explain why a count changed or distinguish Online from Away or DND.
+**Decision:** Return Shields.io endpoint JSON. Redirect the short `.png` URLs
+to the hosted Shields.io renderer.
+
+**Why:** Markdown renderers, static websites, and project pages use image
+badges. Shields.io owns the badge typography, rasterization, and style
+compatibility.
+
+**Tradeoff:** The viewer must have access to Shields.io. Shields.io must also
+have access to the public Chatto JSON endpoint. An operator can use only the
+JSON endpoint or keep shields disabled.
+
+### 4. Use plain HTTP
+
+**Decision:** Use small public HTTP endpoints. Do not add a ConnectRPC service
+for shields.
+
+**Why:** Shields.io uses one JSON document with its endpoint schema. A
+ConnectRPC GET endpoint requires protobuf definitions and generated code. It
+also puts an encoded request in the Shields.io URL parameter.
+
+**Tradeoff:** This design adds narrow public HTTP endpoints that do not use
+ConnectRPC. The endpoints supply only badge counts and are not a general
+metrics API.
+
+### 5. Expose only aggregate data
+
+**Decision:** Expose only the online and registered aggregate counts in v1.
+
+**Why:** Aggregate badges satisfy the README use case. They do not expose user
+identity, individual presence state, or more operational data. Presence is live
+runtime state. When a user is offline, there is no presence record.
+
+**Tradeoff:** A badge cannot show the cause of a count change. It cannot
+distinguish Online from Away or Do Not Disturb.
 
 ## Related
 
-- **ADRs:** ADR-001 (NATS JetStream as Primary Data Store), ADR-036 (Persist Runtime State in RUNTIME_STATE)
-- **FDRs:** FDR-011 (User Presence), FDR-021 (Admin Dashboard & System Monitoring), FDR-023 (Authentication & Sessions)
+- **ADRs:** ADR-001 (NATS JetStream as Primary Data Store), ADR-036 (Persist
+  Runtime State in RUNTIME_STATE)
+- **FDRs:** FDR-011 (User Presence), FDR-021 (Admin Dashboard & System
+  Monitoring), FDR-023 (Authentication & Sessions)

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -38,7 +38,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-026](FDR-026-last-room-memory.md) | Last-Room Memory | Active | 2026-05-19 |
 | [FDR-027](FDR-027-pwa-and-service-worker.md) | PWA & Service Worker | Active | 2026-08-20 |
 | [FDR-028](FDR-028-operator-api-and-cli.md) | Operator API & CLI | Active | 2026-06-29 |
-| [FDR-029](FDR-029-chatto-shields.md) | Chatto Shields | Active | 2026-07-12 |
+| [FDR-029](FDR-029-chatto-shields.md) | Chatto Shields | Active | 2026-08-23 |
 | [FDR-030](FDR-030-inline-message-timestamps.md) | Inline Message Timestamps | Active | 2026-07-12 |
 | [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-08-21 |
 | [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-08-23 |


### PR DESCRIPTION
## Why

Chatto documentation does not have a shared controlled-language policy. This
makes user and maintainer documentation less consistent and harder to scan.

This PR adopts ASD-STE100 for new and changed repository documentation. It also
tests the policy on representative user guides and decision records before a
broader documentation review near the Chatto 0.5 release.

## What changed

- Add the repository-wide ASD-STE100 rule, the approved exclusion list, and a
  reference to the canonical Chatto [glossary](https://github.com/chattocorp/chatto/blob/hmans/add-asd-ste100-rules/docs/GLOSSARY.md).
- Point the docs website instructions at the root policy and exclusion list.
- Rewrite the deployment overview and standalone binary guide in Simplified
  Technical English. Clarify NATS topology, storage, encryption boundaries,
  owner bootstrap, login setup, backups, and LiveKit requirements.
- Rewrite [ADR-022](https://github.com/chattocorp/chatto/blob/hmans/add-asd-ste100-rules/docs/adr/ADR-022-nanoid-with-entity-prefixes.md)
  and [FDR-029](https://github.com/chattocorp/chatto/blob/hmans/add-asd-ste100-rules/docs/fdr/FDR-029-chatto-shields.md)
  as representative internal records. Update their current identifier and
  configuration details where the source had drifted.
- Keep the docs home page and narrative introduction as explicit product-voice
  exclusions. Technical instructions and safety information on those pages
  still use ASD-STE100.

## Compatibility and operations

- This is a documentation-only change.
- There is no runtime, public API, migration, rollout, or security impact.
- The broader docs website rewrite is intentionally deferred until the Chatto
  0.5 documentation review.

## Test plan

- `git diff --check` — passed.
- `(cd cli && mise x -- go test ./internal/core -run 'Test(New(User|Room|Asset|Event)ID|ID(Uniqueness|Characters))$')` — passed.
- `(cd cli && mise x -- go test ./internal/http_server -run '^TestShields')` — passed.
- `(cd apps/docs-website && mise x -- pnpm build)` — passed. Astro built all 70
  pages and the search index.
- Chrome DevTools — verified the deployment overview and standalone binary
  pages. Both pages loaded all resources and rendered their navigation,
  headings, links, callouts, diagrams, and code blocks.
- Manual ASD-STE100 review and local controlled-dictionary scan — completed.
