### PR TITLE
fix(frontend): proxy OAuth token endpoint in development

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -264,6 +264,10 @@ export default defineConfig(async ({ command }) => {
           target: backendTarget,
           changeOrigin: true
         },
+        '/oauth/token': {
+          target: backendTarget,
+          changeOrigin: true
+        },
         '/api': {
           target: backendTarget,
           ws: true,


### PR DESCRIPTION
## Why

Bearer renewal failed during local development because Vite returned its HTML 404 page for `/oauth/token` instead of forwarding the request to Chatto.

## What changed

The Vite development proxy now forwards the exact `/oauth/token` route to the configured backend target while leaving frontend-owned `/oauth` routes unchanged.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unaffected.
- Newer client → older server: unaffected.
- Capability discovery or minimum client/server version: none.

## Test plan

- Chrome DevTools: verified that `POST /oauth/token` through the public Vite URL reaches Go and returns OAuth JSON `400 invalid_request` instead of Vite HTML `404`.
- `mise lint-frontend` — passed with 0 errors and 0 warnings.
- `git diff --check origin/main...HEAD` — passed.
