### PR TITLE
feat(frontend): add composer formatting shortcuts

### DIFF
--- a/apps/frontend/src/lib/components/composer/MarkdownEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/MarkdownEditor.svelte
@@ -36,6 +36,7 @@ the same API as the visual editor while keeping the stored Markdown visible.
   import { codeFenceHighlighting } from './codeFenceHighlighting';
   import type {
     ComposerEditorApi,
+    ComposerFormattingCommand,
     ComposerEditorProps,
     ComposerFormattingState,
     ComposerIndentState
@@ -63,6 +64,25 @@ the same API as the visual editor while keeping the stored Markdown visible.
   const escapeWithTabFocus = (editorView: EditorView): boolean => {
     simplifySelection(editorView);
     return temporarilySetTabFocusMode(editorView);
+  };
+
+  const toggleSourceFormatting = (
+    editorView: EditorView,
+    command: ComposerFormattingCommand
+  ): boolean => {
+    const main = editorView.state.selection.main;
+    const result = applySourceFormatting(
+      editorView.state.doc.toString(),
+      { anchor: main.anchor, head: main.head },
+      command
+    );
+    editorView.dispatch({
+      changes: { from: 0, to: editorView.state.doc.length, insert: result.text },
+      selection: EditorSelection.single(result.anchor, result.head),
+      scrollIntoView: true
+    });
+    editorView.focus();
+    return true;
   };
 
   const markdownHighlightStyle = HighlightStyle.define([
@@ -192,6 +212,15 @@ the same API as the visual editor while keeping the stored Markdown visible.
           history(),
           drawSelection(),
           keymap.of([
+            { key: 'Mod-b', run: (view) => toggleSourceFormatting(view, 'bold') },
+            { key: 'Mod-i', run: (view) => toggleSourceFormatting(view, 'italic') },
+            {
+              key: '`',
+              run: (view) =>
+                view.state.selection.main.empty
+                  ? false
+                  : toggleSourceFormatting(view, 'inlineCode')
+            },
             { key: 'Escape', run: escapeWithTabFocus },
             indentWithTab,
             ...historyKeymap,
@@ -201,7 +230,7 @@ the same API as the visual editor while keeping the stored Markdown visible.
             base: commonmarkLanguage,
             extensions: [Table, Autolink],
             completeHTMLTags: false,
-            pasteURLAsLink: false
+            pasteURLAsLink: true
           }),
           syntaxHighlighting(markdownHighlightStyle),
           codeFenceHighlighting,
@@ -284,18 +313,7 @@ the same API as the visual editor while keeping the stored Markdown visible.
       },
       toggleFormatting: (command) => {
         if (destroyed) return;
-        const main = editorView.state.selection.main;
-        const result = applySourceFormatting(
-          editorView.state.doc.toString(),
-          { anchor: main.anchor, head: main.head },
-          command
-        );
-        editorView.dispatch({
-          changes: { from: 0, to: editorView.state.doc.length, insert: result.text },
-          selection: EditorSelection.single(result.anchor, result.head),
-          scrollIntoView: true
-        });
-        editorView.focus();
+        toggleSourceFormatting(editorView, command);
       },
       adjustIndent: (direction) => {
         if (destroyed) return false;

--- a/apps/frontend/src/lib/components/composer/MarkdownEditor.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MarkdownEditor.svelte.spec.ts
@@ -20,6 +20,36 @@ async function renderEditor(props: Record<string, unknown> = {}) {
   return rendered;
 }
 
+function dispatchEditorKey(target: Element, key: string, options: KeyboardEventInit = {}) {
+  target.dispatchEvent(
+    new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true, ...options })
+  );
+}
+
+function selectCurrentLine(target: Element) {
+  dispatchEditorKey(target, 'Home', { shiftKey: true });
+}
+
+function pressPrimaryModifierKey(target: Element, key: string) {
+  dispatchEditorKey(
+    target,
+    key,
+    navigator.platform.startsWith('Mac') ? { metaKey: true } : { ctrlKey: true }
+  );
+}
+
+function pasteText(target: Element, text: string) {
+  const dataTransfer = new DataTransfer();
+  dataTransfer.setData('text/plain', text);
+  target.dispatchEvent(
+    new ClipboardEvent('paste', {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: dataTransfer
+    })
+  );
+}
+
 describe('MarkdownEditor', () => {
   it('synchronizes its accessible name, placeholder, and disabled state', async () => {
     const rendered = await renderEditor();
@@ -65,6 +95,68 @@ describe('MarkdownEditor', () => {
     api.toggleFormatting('bulletList');
     expect(api.getText()).toBe('- first');
     expect(formatting.at(-1)?.bulletList).toBe(true);
+  });
+
+  it('toggles bold and italic with the platform modifier shortcuts', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    await renderEditor({ onReady: (api: ComposerEditorApi) => readyApis.push(api) });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+    const textbox = page.getByRole('textbox', { name: 'Write Markdown' }).element();
+
+    api.setContent('bold');
+    api.focus();
+    selectCurrentLine(textbox);
+    pressPrimaryModifierKey(textbox, 'b');
+    await vi.waitFor(() => expect(api.getText()).toBe('**bold**'));
+
+    api.setContent('italic');
+    api.focus();
+    selectCurrentLine(textbox);
+    pressPrimaryModifierKey(textbox, 'i');
+    await vi.waitFor(() => expect(api.getText()).toBe('*italic*'));
+  });
+
+  it('wraps selected text in inline-code markers when backtick is pressed', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    await renderEditor({ onReady: (api: ComposerEditorApi) => readyApis.push(api) });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+    const textbox = page.getByRole('textbox', { name: 'Write Markdown' }).element();
+
+    api.setContent('moo');
+    api.focus();
+    selectCurrentLine(textbox);
+    dispatchEditorKey(textbox, '`');
+
+    await vi.waitFor(() => expect(api.getText()).toBe('`moo`'));
+
+    api.setContent('moo');
+    api.focus();
+    await userEvent.keyboard('`');
+    await vi.waitFor(() => expect(api.getText()).toBe('moo`'));
+  });
+
+  it('turns selected text into a Markdown link when a URL is pasted over it', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    const onPaste = vi.fn(() => false);
+    await renderEditor({
+      onReady: (api: ComposerEditorApi) => readyApis.push(api),
+      onPaste
+    });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+    const textbox = page.getByRole('textbox', { name: 'Write Markdown' }).element();
+
+    api.setContent('Chatto docs');
+    api.focus();
+    selectCurrentLine(textbox);
+    pasteText(textbox, 'https://chatto.dev/docs');
+
+    await vi.waitFor(() =>
+      expect(api.getText()).toBe('[Chatto docs](https://chatto.dev/docs)')
+    );
+    expect(onPaste).toHaveBeenCalledOnce();
   });
 
   it('performs Markdown list continuation through its normal Enter API', async () => {

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
@@ -1,9 +1,20 @@
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 import { render } from 'vitest-browser-svelte';
 import { describe, expect, it, vi } from 'vitest';
 import '../../../app.css';
 import TipTapEditor from './TipTapEditor.svelte';
 import type { ComposerEditorApi } from './editorTypes';
+
+function selectEditorContents(editor: Element) {
+  editor.dispatchEvent(
+    new KeyboardEvent('keydown', {
+      key: 'a',
+      bubbles: true,
+      cancelable: true,
+      ...(navigator.platform.startsWith('Mac') ? { metaKey: true } : { ctrlKey: true })
+    })
+  );
+}
 
 describe('TipTapEditor accessibility', () => {
   it('keeps its accessible name synchronized with the placeholder', async () => {
@@ -18,6 +29,34 @@ describe('TipTapEditor accessibility', () => {
 });
 
 describe('TipTapEditor wrapping', () => {
+  it('formats selected text as inline code when backtick is pressed', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    const { container } = render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onReady: (api: ComposerEditorApi) => readyApis.push(api)
+      }
+    });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+    const editor = page.getByRole('textbox', { name: 'Write a message' }).element();
+
+    api.setContent('moo');
+    api.focus();
+    selectEditorContents(editor);
+    editor.dispatchEvent(
+      new KeyboardEvent('keydown', { key: '`', bubbles: true, cancelable: true })
+    );
+
+    await vi.waitFor(() => expect(container.querySelector('code')?.textContent).toBe('moo'));
+
+    api.setContent('moo');
+    api.focus();
+    await userEvent.keyboard('`');
+    await vi.waitFor(() => expect(editor.textContent).toBe('moo`'));
+    expect(container.querySelector('code')).toBeNull();
+  });
+
   it('performs the normal structural Enter action through its API', async () => {
     const readyApis: ComposerEditorApi[] = [];
     const onKeyDown = vi.fn(() => true);

--- a/apps/frontend/src/lib/components/composer/extensions.spec.ts
+++ b/apps/frontend/src/lib/components/composer/extensions.spec.ts
@@ -10,6 +10,7 @@ describe('createComposerExtensions', () => {
       'link',
       'markdown',
       'codeBlock',
+      'selectedTextInlineCodeShortcut',
       'markdownLinkInputRule',
       'completedMarkdownCodeFence',
       'markdownListMarkerAfterHardBreak',

--- a/apps/frontend/src/lib/components/composer/extensions.ts
+++ b/apps/frontend/src/lib/components/composer/extensions.ts
@@ -36,6 +36,17 @@ export const ComposerCodeBlockLowlight = CodeBlockLowlight.extend({
 
 export const ComposerLink = Link.extend({ inclusive: false });
 
+const SelectedTextInlineCodeShortcut = Extension.create({
+  name: 'selectedTextInlineCodeShortcut',
+
+  addKeyboardShortcuts() {
+    return {
+      '`': () =>
+        this.editor.state.selection.empty ? false : this.editor.commands.toggleCode()
+    };
+  }
+});
+
 function paragraphTextWithLineBreaks(node: ProseMirrorNode) {
   return node.textBetween(0, node.content.size, '\n', '\n');
 }
@@ -344,6 +355,7 @@ export function createComposerExtensions(placeholder: string) {
       }
     }),
     ComposerCodeBlockLowlight.configure({ lowlight }),
+    SelectedTextInlineCodeShortcut.configure(),
     MarkdownLinkInputRule.configure(),
     CompletedMarkdownCodeFence.configure(),
     MarkdownListMarkerAfterHardBreak.configure(),


### PR DESCRIPTION
## Why

The Markdown composer needs the familiar formatting interactions available in the visual composer so users can format text without reaching for the toolbar.

## What changed

- Added Cmd/Ctrl-B and Cmd/Ctrl-I source-formatting shortcuts to the Markdown composer.
- Pasting a URL over selected Markdown text now creates a Markdown link.
- Pressing backtick with selected text now applies inline code in both the Markdown and visual composers, while a collapsed selection still types a literal backtick.
- Added browser-component coverage for shortcuts, URL paste, inline-code selection, and ordinary backtick input.
- Updated the complete composer extension-set expectation for the inline-code shortcut extension.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise lint-frontend` — passed with zero errors and warnings.
- Focused MarkdownEditor and TipTapEditor browser-component suites — 19 tests passed.
- Focused composer extension suite — 2 tests passed.
- `mise test-cli` — passed, including the previously timed-out HTTP-server asset test.
- Chrome DevTools — verified all interactions in both live composers with no console errors.
