### PR TITLE
feat(frontend): frame preference forms

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -226,6 +226,10 @@ generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
 - Management routes live under `/chat/[serverId]/manage/`: server-scoped pages
   under `manage/server/`, rooms under `manage/rooms/`, and room groups under
   `manage/room-groups/`.
+- Server Configuration, server-scoped User Preferences, and App Preferences
+  share the standard pane-page composition. Put their content in `PaneContent`
+  and frame each page-level form or control group with a titled, padded `Panel`;
+  use `FormSection` only to subdivide one panel, never instead of its frame.
 - SvelteKit reuses resource pages when only a route parameter changes. Fence
   async loads and saves by both resource ID and load generation so late
   responses cannot update the next resource's form state.

--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -123,6 +123,25 @@ them merely because the page header already names the overall feature: the
 page title answers “where am I?”, while panel titles answer “what is in this
 section?”.
 
+### Settings And Preferences
+
+Server Configuration, server-scoped User Preferences, and App Preferences use
+the same page structure. Their different data scopes affect navigation and
+state ownership, not the visual treatment of their forms.
+
+- Put settings content in `PaneContent`; do not reproduce its scrolling,
+  padding, or width classes on a route-local wrapper.
+- Frame every page-level form or independently meaningful control group with a
+  titled, padded `Panel`. Keep its validation, status, and actions inside the
+  same panel.
+- Let the panel span the content column. Apply `max-w-*` to the fields or form
+  inside it when a shorter line length improves usability, not to the panel
+  shell itself.
+- Use `FormSection` only to subdivide a single panel whose controls submit or
+  operate as one group. It is not a substitute for the page-level panel frame.
+- Stack independent settings panels with the standard `gap-6`, and never nest
+  one `Panel` inside another.
+
 ## Semantic Color Language
 
 Use semantic tokens instead of Tailwind palette colors for application chrome.

--- a/apps/frontend/e2e/server-flows.test.ts
+++ b/apps/frontend/e2e/server-flows.test.ts
@@ -84,7 +84,9 @@ test.describe('Landing Page', () => {
         expect(viewer.user?.profile?.id).toBeTruthy();
 
         await freshPage.goto(routes.settings);
-        await expect(freshPage.getByRole('heading', { name: 'Profile' })).toBeVisible();
+        await expect(
+          freshPage.getByRole('heading', { name: 'Profile', level: 1 })
+        ).toBeVisible();
         await expect(freshPage).not.toHaveURL(routes.login);
       },
       { baseURL: serverURL }

--- a/apps/frontend/e2e/session-expiration.test.ts
+++ b/apps/frontend/e2e/session-expiration.test.ts
@@ -133,7 +133,7 @@ test.describe('Session Expiration Handling', () => {
 
     // Navigate to a deep route and wait for full client-side initialization
     await gotoAndWaitForHydration(page, routes.settings);
-    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Profile', level: 1 })).toBeVisible();
 
     // Clear credentials and reload the protected route
     await clearCredentialsAndReloadProtectedRoute(page);
@@ -155,7 +155,7 @@ test.describe('Session Expiration Handling', () => {
 
     // Navigate to a specific route and wait for full client-side initialization
     await gotoAndWaitForHydration(page, routes.settings);
-    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Profile', level: 1 })).toBeVisible();
 
     // Clear credentials and reload the protected route
     await clearCredentialsAndReloadProtectedRoute(page);
@@ -183,7 +183,7 @@ test.describe('Session Expiration Handling', () => {
 
     // Navigate to a specific route and wait for full client-side initialization
     await gotoAndWaitForHydration(page, routes.settings);
-    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Profile', level: 1 })).toBeVisible();
 
     // Clear credentials and reload the protected route
     await clearCredentialsAndReloadProtectedRoute(page);
@@ -223,7 +223,7 @@ test.describe('Session Expiration Handling', () => {
     // Navigate to a deep route (this should refresh the cookie)
     await page.goto(routes.settings);
     await page.waitForURL(routes.settings);
-    await expect(page.getByRole('heading', { name: 'Profile' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Profile', level: 1 })).toBeVisible();
 
     // Get updated cookie
     const updatedCookies = await page.context().cookies();

--- a/apps/frontend/e2e/user-settings.test.ts
+++ b/apps/frontend/e2e/user-settings.test.ts
@@ -204,7 +204,7 @@ test.describe('App and User Preferences', () => {
   test('can set timezone and save', async ({ page }) => {
     await createAndLoginTestUser(page);
     await page.goto(routes.settingsPreferences);
-    await expect(page.getByRole('heading', { name: 'Time & region' })).toBeVisible({
+    await expect(page.getByRole('heading', { name: 'Time & region', level: 1 })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });
 
@@ -232,7 +232,7 @@ test.describe('App and User Preferences', () => {
   test('can set time format to 24-hour and save', async ({ page }) => {
     await createAndLoginTestUser(page);
     await page.goto(routes.settingsPreferences);
-    await expect(page.getByRole('heading', { name: 'Time & region' })).toBeVisible({
+    await expect(page.getByRole('heading', { name: 'Time & region', level: 1 })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });
 
@@ -270,7 +270,7 @@ test.describe('App and User Preferences', () => {
   test('can clear timezone back to browser default', async ({ page }) => {
     await createAndLoginTestUser(page);
     await page.goto(routes.settingsPreferences);
-    await expect(page.getByRole('heading', { name: 'Time & region' })).toBeVisible({
+    await expect(page.getByRole('heading', { name: 'Time & region', level: 1 })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });
 
@@ -308,7 +308,7 @@ test.describe('App and User Preferences', () => {
   test('shows validation error for invalid timezone', async ({ page }) => {
     await createAndLoginTestUser(page);
     await page.goto(routes.settingsPreferences);
-    await expect(page.getByRole('heading', { name: 'Time & region' })).toBeVisible({
+    await expect(page.getByRole('heading', { name: 'Time & region', level: 1 })).toBeVisible({
       timeout: TIMEOUTS.UI_STANDARD
     });
 

--- a/apps/frontend/src/lib/components/settings/NotificationPolicySettings.svelte
+++ b/apps/frontend/src/lib/components/settings/NotificationPolicySettings.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { FormSection, Hint } from '$lib/ui';
+  import { Panel } from '$lib/components/admin';
+  import { Hint } from '$lib/ui';
   import { m } from '$lib/i18n/messages';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import {
@@ -116,45 +117,50 @@
   </label>
 {/snippet}
 
-<FormSection title={m('settings.notifications.policy.title')} maxWidth="max-w-2xl" bordered>
-  <p class="mb-3 text-sm text-muted">{m('settings.notifications.policy.description')}</p>
-  <select
-    class="mb-3 input w-full text-sm"
-    aria-label={m('settings.notifications.policy.title')}
-    value={selectedRoomId}
-    disabled={savingField !== null}
-    onchange={(event) => {
-      selectedRoomId = event.currentTarget.value;
-    }}
-  >
-    <option value="">{serverScope.store.serverInfo.name}</option>
-    {#each policyRooms as room (room.id)}
-      <option value={room.id}>#{room.name}</option>
-    {/each}
-  </select>
-  {#if error}<Hint tone="danger">{error}</Hint>{/if}
-  {#if loading}
-    <p class="py-3 text-sm text-muted">{m('common.loading')}</p>
-  {:else if policy}
-    <div class="flex flex-col divide-y divide-border rounded-lg border border-border">
-      {@render policyRow(
-        'directMessages',
-        m('settings.notifications.policy.reason.direct_message')
-      )}
-      {@render policyRow(
-        'directMentions',
-        m('settings.notifications.policy.reason.direct_mention')
-      )}
-      {@render policyRow('replies', m('settings.notifications.policy.reason.reply'))}
-      {@render policyRow('roleMentions', m('settings.notifications.policy.reason.role_mention'))}
-      {@render policyRow('hereMentions', m('settings.notifications.policy.reason.here'))}
-      {@render policyRow('allMentions', m('settings.notifications.policy.reason.all'))}
-      {@render policyRow(
-        'followedThreads',
-        m('settings.notifications.policy.reason.followed_thread')
-      )}
-      {@render policyRow('followedRooms', m('settings.notifications.policy.reason.followed_room'))}
-      {@render policyRow('reactions', m('settings.notifications.policy.reason.reaction'))}
-    </div>
-  {/if}
-</FormSection>
+<Panel title={m('settings.notifications.policy.title')} icon="iconify icon-[uil--sliders-v-alt]">
+  <div class="max-w-2xl">
+    <p class="mb-3 text-sm text-muted">{m('settings.notifications.policy.description')}</p>
+    <select
+      class="mb-3 input w-full text-sm"
+      aria-label={m('settings.notifications.policy.title')}
+      value={selectedRoomId}
+      disabled={savingField !== null}
+      onchange={(event) => {
+        selectedRoomId = event.currentTarget.value;
+      }}
+    >
+      <option value="">{serverScope.store.serverInfo.name}</option>
+      {#each policyRooms as room (room.id)}
+        <option value={room.id}>#{room.name}</option>
+      {/each}
+    </select>
+    {#if error}<Hint tone="danger">{error}</Hint>{/if}
+    {#if loading}
+      <p class="py-3 text-sm text-muted">{m('common.loading')}</p>
+    {:else if policy}
+      <div class="flex flex-col divide-y divide-border rounded-lg border border-border">
+        {@render policyRow(
+          'directMessages',
+          m('settings.notifications.policy.reason.direct_message')
+        )}
+        {@render policyRow(
+          'directMentions',
+          m('settings.notifications.policy.reason.direct_mention')
+        )}
+        {@render policyRow('replies', m('settings.notifications.policy.reason.reply'))}
+        {@render policyRow('roleMentions', m('settings.notifications.policy.reason.role_mention'))}
+        {@render policyRow('hereMentions', m('settings.notifications.policy.reason.here'))}
+        {@render policyRow('allMentions', m('settings.notifications.policy.reason.all'))}
+        {@render policyRow(
+          'followedThreads',
+          m('settings.notifications.policy.reason.followed_thread')
+        )}
+        {@render policyRow(
+          'followedRooms',
+          m('settings.notifications.policy.reason.followed_room')
+        )}
+        {@render policyRow('reactions', m('settings.notifications.policy.reason.reaction'))}
+      </div>
+    {/if}
+  </div>
+</Panel>

--- a/apps/frontend/src/lib/demos/SettingsPage.stories.svelte
+++ b/apps/frontend/src/lib/demos/SettingsPage.stories.svelte
@@ -10,9 +10,11 @@
 </script>
 
 <script lang="ts">
+  import { Panel } from '$lib/components/admin';
   import FormSection from '$lib/ui/FormSection.svelte';
   import Hint from '$lib/ui/Hint.svelte';
-  import Divider from '$lib/ui/Divider.svelte';
+  import PaneContent from '$lib/ui/PaneContent.svelte';
+  import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { TextInput, TextArea, Select, Checkbox, Button } from '$lib/ui/form';
 
   let name = $state('Open Source Hangout');
@@ -32,86 +34,89 @@
 </script>
 
 <Story name="Space settings" asChild>
-  <div class="mx-auto max-w-2xl p-6">
-    <header class="mb-6">
-      <h1 class="text-2xl font-bold">Space settings</h1>
-      <p class="text-sm text-muted">Configure how this space appears and who can join.</p>
-    </header>
+  <div class="pane-page h-[48rem] bg-background">
+    <PaneHeader
+      title="Space settings"
+      subtitle="Configure how this space appears and who can join."
+    />
 
-    <Hint tone="info" icon="icon-[uil--info-circle]">
-      Changes here apply immediately to all members of this space.
-    </Hint>
+    <PaneContent>
+      <div class="flex flex-col gap-6">
+        <Hint tone="info" icon="icon-[uil--info-circle]">
+          Changes here apply immediately to all members of this space.
+        </Hint>
 
-    <form class="mt-6 flex flex-col gap-6" onsubmit={handleSubmit}>
-      <FormSection title="General">
-        <div class="flex flex-col gap-4">
-          <TextInput
-            id="space-name"
-            label="Space name"
-            bind:value={name}
-            required
-            description="Shown in the sidebar and on the discovery page."
-          />
-          <TextArea
-            id="space-description"
-            label="Description"
-            bind:value={description}
-            rows={3}
-            maxlength={200}
-            description="A short summary shown on the space card."
-          />
-        </div>
-      </FormSection>
+        <form onsubmit={handleSubmit}>
+          <Panel title="Space details" icon="iconify icon-[uil--edit]">
+            <div class="flex max-w-2xl flex-col gap-6">
+              <FormSection title="General">
+                <div class="flex flex-col gap-4">
+                  <TextInput
+                    id="space-name"
+                    label="Space name"
+                    bind:value={name}
+                    required
+                    description="Shown in the sidebar and on the discovery page."
+                  />
+                  <TextArea
+                    id="space-description"
+                    label="Description"
+                    bind:value={description}
+                    rows={3}
+                    maxlength={200}
+                    description="A short summary shown on the space card."
+                  />
+                </div>
+              </FormSection>
 
-      <Divider />
+              <FormSection title="Access" bordered>
+                <div class="flex flex-col gap-4">
+                  <Select
+                    id="visibility"
+                    label="Visibility"
+                    bind:value={visibility}
+                    options={[
+                      { value: 'public', label: 'Public — anyone can join' },
+                      { value: 'invite', label: 'Invite only' },
+                      { value: 'private', label: 'Private — hidden from listings' }
+                    ]}
+                  />
+                  <Checkbox
+                    id="allow-guests"
+                    bind:checked={allowGuests}
+                    label="Allow unauthenticated guests to read public rooms"
+                    description="Guests can read but not post."
+                  />
+                </div>
+              </FormSection>
 
-      <FormSection title="Access">
-        <div class="flex flex-col gap-4">
-          <Select
-            id="visibility"
-            label="Visibility"
-            bind:value={visibility}
-            options={[
-              { value: 'public', label: 'Public — anyone can join' },
-              { value: 'invite', label: 'Invite only' },
-              { value: 'private', label: 'Private — hidden from listings' }
-            ]}
-          />
-          <Checkbox
-            id="allow-guests"
-            bind:checked={allowGuests}
-            label="Allow unauthenticated guests to read public rooms"
-            description="Guests can read but not post."
-          />
-        </div>
-      </FormSection>
+              <FormSection title="Retention" bordered>
+                <Select
+                  id="retention"
+                  label="Message retention"
+                  bind:value={messageRetention}
+                  options={[
+                    { value: 'forever', label: 'Keep forever' },
+                    { value: '90', label: 'Delete after 90 days' },
+                    { value: '30', label: 'Delete after 30 days' },
+                    { value: '7', label: 'Delete after 7 days' }
+                  ]}
+                  description="Older messages are removed automatically. Affects all rooms."
+                />
+              </FormSection>
 
-      <Divider />
+              <div class="flex justify-end gap-2 border-t border-border pt-5">
+                <Button type="button" variant="secondary">Cancel</Button>
+                <Button type="submit" loading={saving} loadingText="Saving...">Save changes</Button>
+              </div>
+            </div>
+          </Panel>
+        </form>
 
-      <FormSection title="Retention">
-        <Select
-          id="retention"
-          label="Message retention"
-          bind:value={messageRetention}
-          options={[
-            { value: 'forever', label: 'Keep forever' },
-            { value: '90', label: 'Delete after 90 days' },
-            { value: '30', label: 'Delete after 30 days' },
-            { value: '7', label: 'Delete after 7 days' }
-          ]}
-          description="Older messages are removed automatically. Affects all rooms."
-        />
-      </FormSection>
-
-      <Divider />
-
-      <div class="flex items-center justify-between">
-        <Button variant="danger">Delete space</Button>
-        <div class="flex gap-2">
-          <Button variant="secondary">Cancel</Button>
-          <Button type="submit" loading={saving} loadingText="Saving...">Save changes</Button>
-        </div>
+        <Panel title="Danger zone" icon="iconify icon-[uil--exclamation-triangle]">
+          <Button variant="danger">Delete space</Button>
+        </Panel>
       </div>
-    </form>
+    </PaneContent>
   </div>
 </Story>

--- a/apps/frontend/src/lib/ui/FormSection.stories.svelte
+++ b/apps/frontend/src/lib/ui/FormSection.stories.svelte
@@ -3,9 +3,9 @@
   import FormSection from './FormSection.svelte';
 
   const componentDescription = `
-    Use FormSection to group related fields inside settings pages and modal-like forms. Prefer
-    vertical rhythm over nested cards, and use the bordered option only when adjacent sections need
-    stronger separation.
+		Use FormSection to subdivide one settings Panel or modal-like form. It does not replace the
+		page-level Panel frame. Prefer vertical rhythm over nested cards, and use the bordered option
+		only when adjacent sections need stronger separation.
   `.trim();
 
   const { Story } = defineMeta({
@@ -21,6 +21,7 @@
 </script>
 
 <script lang="ts">
+  import { Panel } from '$lib/components/admin';
   import { Checkbox, Form, TextArea, TextInput } from './form';
 
   let name = $state('Open Source Hangout');
@@ -31,37 +32,41 @@
 
 <Story name="Single section" asChild>
   <div class="bg-background p-6">
-    <Form onsubmit={() => {}} maxWidth="max-w-xl">
-      <FormSection title="General">
-        <div class="flex flex-col gap-4">
-          <TextInput id="fs-name" label="Space name" bind:value={name} required />
-          <TextArea id="fs-description" label="Description" bind:value={description} rows={2} />
-        </div>
-      </FormSection>
-    </Form>
+    <Panel title="Profile settings">
+      <Form onsubmit={() => {}} maxWidth="max-w-xl">
+        <FormSection title="Identity">
+          <div class="flex flex-col gap-4">
+            <TextInput id="fs-name" label="Space name" bind:value={name} required />
+            <TextArea id="fs-description" label="Description" bind:value={description} rows={2} />
+          </div>
+        </FormSection>
+      </Form>
+    </Panel>
   </div>
 </Story>
 
 <Story name="Multiple sections" asChild>
   <div class="bg-background p-6">
-    <Form onsubmit={() => {}} maxWidth="max-w-xl" spacing="spacious">
-      <FormSection title="General">
-        <div class="flex flex-col gap-4">
-          <TextInput id="fs2-name" label="Space name" bind:value={name} required />
-          <TextArea id="fs2-description" label="Description" bind:value={description} rows={2} />
-        </div>
-      </FormSection>
+    <Panel title="Space settings">
+      <Form onsubmit={() => {}} maxWidth="max-w-xl" spacing="spacious">
+        <FormSection title="General">
+          <div class="flex flex-col gap-4">
+            <TextInput id="fs2-name" label="Space name" bind:value={name} required />
+            <TextArea id="fs2-description" label="Description" bind:value={description} rows={2} />
+          </div>
+        </FormSection>
 
-      <FormSection title="Access" bordered>
-        <div class="flex flex-col gap-3">
-          <Checkbox id="fs2-guests" label="Allow guest accounts" bind:checked={allowGuests} />
-          <Checkbox
-            id="fs2-approval"
-            label="Require admin approval to join"
-            bind:checked={requireApproval}
-          />
-        </div>
-      </FormSection>
-    </Form>
+        <FormSection title="Access" bordered>
+          <div class="flex flex-col gap-3">
+            <Checkbox id="fs2-guests" label="Allow guest accounts" bind:checked={allowGuests} />
+            <Checkbox
+              id="fs2-approval"
+              label="Require admin approval to join"
+              bind:checked={requireApproval}
+            />
+          </div>
+        </FormSection>
+      </Form>
+    </Panel>
   </div>
 </Story>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -2,7 +2,7 @@
   import { createAccountAPI } from '$lib/api-client/account';
   import { m } from '$lib/i18n/messages';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { PaneHeader } from '$lib/ui';
+  import { PaneContent, PaneHeader } from '$lib/ui';
   import AvatarSettings from './AvatarSettings.svelte';
   import ProfileDetailsSettings from './ProfileDetailsSettings.svelte';
 
@@ -19,7 +19,9 @@
   showMobileNav
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <AvatarSettings getAccountAPI={accountAPI} />
-  <ProfileDetailsSettings getAccountAPI={accountAPI} />
-</div>
+<PaneContent>
+  <div class="flex flex-col gap-6">
+    <AvatarSettings getAccountAPI={accountAPI} />
+    <ProfileDetailsSettings getAccountAPI={accountAPI} />
+  </div>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/AvatarSettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/AvatarSettings.svelte
@@ -3,8 +3,8 @@
   import type { AccountAPI } from '$lib/api-client/account';
   import DropZoneOverlay from '$lib/attachments/DropZoneOverlay.svelte';
   import { dropZone } from '$lib/attachments/dropZone.svelte';
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
-  import { FormSection } from '$lib/ui';
   import { Button } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast';
   import { getAvatarInitials } from '$lib/utils/initials';
@@ -106,9 +106,9 @@
   }
 </script>
 
-<FormSection title={m('settings.profile.avatar.title')} maxWidth="max-w-md">
+<Panel title={m('settings.profile.avatar.title')} icon="iconify icon-[uil--image]">
   <div
-    class="relative flex items-start gap-6"
+    class="relative flex max-w-md items-start gap-6"
     data-testid="avatar-drop-zone"
     {@attach avatarDropZone}
   >
@@ -171,4 +171,4 @@
       </div>
     </div>
   </div>
-</FormSection>
+</Panel>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import type { AccountAPI } from '$lib/api-client/account';
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
   import { Dialog, Hint } from '$lib/ui';
   import { Button, Form, TextInput } from '$lib/ui/form';
@@ -133,43 +134,45 @@
   }
 </script>
 
-<Form onsubmit={handleSubmit} maxWidth="max-w-md" bordered {error}>
-  <TextInput
-    label={m('settings.profile.display_name.label')}
-    bind:value={displayName}
-    placeholder={m('settings.profile.display_name.placeholder')}
-    disabled={isSaving}
-    oninput={clearMessages}
-  />
+<Panel title={m('settings.profile.title')} icon="iconify icon-[uil--user]">
+  <Form onsubmit={handleSubmit} maxWidth="max-w-md" {error}>
+    <TextInput
+      label={m('settings.profile.display_name.label')}
+      bind:value={displayName}
+      placeholder={m('settings.profile.display_name.placeholder')}
+      disabled={isSaving}
+      oninput={clearMessages}
+    />
 
-  <TextInput
-    label={m('settings.profile.username.label')}
-    bind:value={login}
-    placeholder={m('settings.profile.username.placeholder')}
-    disabled={isSaving || !canChangeLogin}
-    testid="settings-username"
-    oninput={clearMessages}
-  />
+    <TextInput
+      label={m('settings.profile.username.label')}
+      bind:value={login}
+      placeholder={m('settings.profile.username.placeholder')}
+      disabled={isSaving || !canChangeLogin}
+      testid="settings-username"
+      oninput={clearMessages}
+    />
 
-  {#if !canChangeLogin}
-    <p class="text-sm text-muted">
-      {m('settings.profile.username.cooldown_notice', {
-        remaining: formatCooldownRemaining(cooldownRemaining)
-      })}
-    </p>
-  {/if}
+    {#if !canChangeLogin}
+      <p class="text-sm text-muted">
+        {m('settings.profile.username.cooldown_notice', {
+          remaining: formatCooldownRemaining(cooldownRemaining)
+        })}
+      </p>
+    {/if}
 
-  {#if successMessage}
-    <Hint tone="success">{successMessage}</Hint>
-  {/if}
+    {#if successMessage}
+      <Hint tone="success">{successMessage}</Hint>
+    {/if}
 
-  {#snippet footer()}
-    <Button type="submit" disabled={!isModified || isSaving} loading={isSaving}>
-      <span class="iconify icon-[uil--check]"></span>
-      {m('settings.profile.save_button')}
-    </Button>
-  {/snippet}
-</Form>
+    {#snippet footer()}
+      <Button type="submit" disabled={!isModified || isSaving} loading={isSaving}>
+        <span class="iconify icon-[uil--check]"></span>
+        {m('settings.profile.save_button')}
+      </Button>
+    {/snippet}
+  </Form>
+</Panel>
 
 <Dialog
   bind:visible={showLoginConfirm}

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { createAccountAPI } from '$lib/api-client/account';
+  import { Panel } from '$lib/components/admin';
   import { serverIdToSegment } from '$lib/navigation';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { FormSection, PaneHeader } from '$lib/ui';
+  import { PaneContent, PaneHeader } from '$lib/ui';
   import { m } from '$lib/i18n/messages';
   import DeleteAccountSection from './DeleteAccountSection.svelte';
   import ExternalIdentitySettings from './ExternalIdentitySettings.svelte';
@@ -28,28 +29,30 @@
   showMobileNav
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <FormSection title={m('settings.account.info_title')} maxWidth="max-w-md">
-    <dl class="flex flex-col gap-3 text-sm">
-      <div class="flex items-center justify-between">
-        <dt class="text-muted">{m('admin.members.user_id')}</dt>
-        <dd class="font-mono">{currentUser.user?.id}</dd>
-      </div>
-      <div class="flex items-center justify-between">
-        <dt class="text-muted">{m('settings.account.username')}</dt>
-        <dd class="font-mono">{currentUser.user?.login}</dd>
-      </div>
-      <div class="flex items-center justify-between">
-        <dt class="text-muted">{m('settings.account.display_name')}</dt>
-        <dd>{currentUser.user?.displayName}</dd>
-      </div>
-    </dl>
-  </FormSection>
+<PaneContent>
+  <div class="flex flex-col gap-6">
+    <Panel title={m('settings.account.info_title')} icon="iconify icon-[uil--info-circle]">
+      <dl class="flex max-w-md flex-col gap-3 text-sm">
+        <div class="flex items-center justify-between">
+          <dt class="text-muted">{m('admin.members.user_id')}</dt>
+          <dd class="font-mono">{currentUser.user?.id}</dd>
+        </div>
+        <div class="flex items-center justify-between">
+          <dt class="text-muted">{m('settings.account.username')}</dt>
+          <dd class="font-mono">{currentUser.user?.login}</dd>
+        </div>
+        <div class="flex items-center justify-between">
+          <dt class="text-muted">{m('settings.account.display_name')}</dt>
+          <dd>{currentUser.user?.displayName}</dd>
+        </div>
+      </dl>
+    </Panel>
 
-  <PasswordSettings {currentUser} getAccountAPI={accountAPI} />
-  <ExternalIdentitySettings {currentUser} {accountSettingsPath} />
-  <DeleteAccountSection
-    canDeleteAccount={currentUser.user?.viewerCanDeleteAccount ?? false}
-    getAccountAPI={accountAPI}
-  />
-</div>
+    <PasswordSettings {currentUser} getAccountAPI={accountAPI} />
+    <ExternalIdentitySettings {currentUser} {accountSettingsPath} />
+    <DeleteAccountSection
+      canDeleteAccount={currentUser.user?.viewerCanDeleteAccount ?? false}
+      getAccountAPI={accountAPI}
+    />
+  </div>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/DeleteAccountSection.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/DeleteAccountSection.svelte
@@ -2,6 +2,7 @@
   import type { AccountAPI } from '$lib/api-client/account';
   import { csrfFetch } from '$lib/auth/csrf';
   import { notifyLogout } from '$lib/auth/sessionChannel';
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { Dialog, Hint } from '$lib/ui';
@@ -67,15 +68,16 @@
 </script>
 
 {#if canDeleteAccount}
-  <div class="max-w-md border-t border-border pt-6">
-    <h3 class="mb-2 text-sm font-semibold text-danger">{m('settings.account.danger_title')}</h3>
-    <p class="mb-4 text-sm text-muted">
-      {m('settings.account.danger_description')}
-    </p>
-    <Button variant="danger" onclick={openDeleteModal}>
-      {m('settings.account.delete_button')}
-    </Button>
-  </div>
+  <Panel title={m('settings.account.danger_title')} icon="iconify icon-[uil--exclamation-triangle]">
+    <div class="max-w-md">
+      <p class="mb-4 text-sm text-muted">
+        {m('settings.account.danger_description')}
+      </p>
+      <Button variant="danger" onclick={openDeleteModal}>
+        {m('settings.account.delete_button')}
+      </Button>
+    </div>
+  </Panel>
 {/if}
 
 <Dialog

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/ExternalIdentitySettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/ExternalIdentitySettings.svelte
@@ -15,6 +15,7 @@
     type ExternalIdentityProviderInfo,
     type LinkedExternalIdentityInfo
   } from '$lib/api-client/externalIdentities';
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
   import { registerServerQueryCacheRemovalListener } from '$lib/query/cacheRegistry';
   import { queryClient } from '$lib/query/client';
@@ -22,7 +23,7 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
-  import { ConfirmDialog, Dialog, FormSection, Hint } from '$lib/ui';
+  import { ConfirmDialog, Dialog, Hint } from '$lib/ui';
   import { Button, FormError, TextInput } from '$lib/ui/form';
 
   let {
@@ -363,8 +364,8 @@
   }
 </script>
 
-<FormSection title={m('settings.account.sso.title')} maxWidth="max-w-md">
-  <div class="flex flex-col gap-4">
+<Panel title={m('settings.account.sso.title')} icon="iconify icon-[uil--link]">
+  <div class="flex max-w-md flex-col gap-4">
     {#if loading}
       <p class="text-sm text-muted">{m('settings.account.sso.loading')}</p>
     {:else}
@@ -448,7 +449,7 @@
       {/if}
     {/if}
   </div>
-</FormSection>
+</Panel>
 
 {#if disconnectTarget}
   <ConfirmDialog

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/PasswordSettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/PasswordSettings.svelte
@@ -2,8 +2,8 @@
   import { Code, ConnectError } from '@connectrpc/connect';
   import type { AccountAPI } from '$lib/api-client/account';
   import type { CurrentUserState } from '$lib/auth/currentUser.svelte';
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
-  import { FormSection } from '$lib/ui';
   import { Button, FormError, TextInput, validate, z } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast/toastState.svelte';
 
@@ -91,8 +91,8 @@
   }
 </script>
 
-<FormSection title={m('settings.account.password.title')} maxWidth="max-w-md">
-  <form class="flex flex-col gap-4" onsubmit={handleUpdatePassword}>
+<Panel title={m('settings.account.password.title')} icon="iconify icon-[uil--key-skeleton]">
+  <form class="flex max-w-md flex-col gap-4" onsubmit={handleUpdatePassword}>
     <p class="text-sm text-muted">
       {hasPassword
         ? m('settings.account.password.change_description')
@@ -146,4 +146,4 @@
       </Button>
     </div>
   </form>
-</FormSection>
+</Panel>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/account.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/account.page.svelte.spec.ts
@@ -47,9 +47,10 @@ describe('Account settings page', () => {
   });
 
   it('shows the current user ID in account information', async () => {
-    const { getByText } = render(AccountPage);
+    const { container, getByText } = render(AccountPage);
     await settle();
 
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(3);
     await expect.element(getByText('User ID')).toBeVisible();
     await expect.element(getByText('U123abcetc.')).toBeVisible();
   });

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
+  import { Panel } from '$lib/components/admin';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { ChoiceRow, PaneHeader, Hint, FormSection } from '$lib/ui';
+  import { ChoiceRow, Hint, PaneContent, PaneHeader } from '$lib/ui';
   import { Button, RangeField } from '$lib/ui/form';
   import NotificationPolicySettings from '$lib/components/settings/NotificationPolicySettings.svelte';
   import { getServerNotificationPreferences } from '$lib/state/serverNotificationPreferences.svelte';
@@ -271,234 +272,233 @@
   showMobileNav
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <NotificationPolicySettings />
+<PaneContent>
+  <div class="flex flex-col gap-6">
+    <NotificationPolicySettings />
 
-  <!-- Push Notifications Section (only show if enabled on server) -->
-  {#if showPushControls}
-    <div class="max-w-lg">
-      <h3 class="mb-4 text-sm font-semibold text-muted">
-        {m('settings.notifications.push.title')}
-      </h3>
-
-      {#if needsIosHomeScreen}
-        <Hint tone="info">
-          <div>
-            <p class="font-medium">{m('settings.notifications.push.ios_home_screen_title')}</p>
-            <p class="mt-1 text-sm text-muted">
-              {m('settings.notifications.push.ios_home_screen_description')}
-            </p>
-          </div>
-        </Hint>
-      {:else if !pushSupported}
-        <div class="surface-box px-4 py-3 text-sm text-muted">
-          {m('settings.notifications.push.not_supported')}
-        </div>
-      {:else if pushError}
-        <div class="mb-3">
-          <Hint tone="danger">{pushError}</Hint>
-        </div>
-      {/if}
-
-      {#if pushSupported}
-        {#if pushPermission === 'denied'}
-          <div class="rounded-lg border border-warning/60 bg-warning/10 px-4 py-3">
-            <p class="font-medium text-warning">
-              {m('settings.notifications.push.blocked_title')}
-            </p>
-            <p class="mt-1 text-sm text-muted">
-              {m('settings.notifications.push.blocked_description')}
-            </p>
-          </div>
-        {:else if pushSubscribed}
-          <div class="flex flex-col gap-3">
-            <Hint tone="success">
+    <!-- Push Notifications Section (only show if enabled on server) -->
+    {#if showPushControls}
+      <Panel title={m('settings.notifications.push.title')} icon="iconify icon-[uil--bell]">
+        <div class="max-w-lg">
+          {#if needsIosHomeScreen}
+            <Hint tone="info">
               <div>
-                <p class="font-medium">{m('settings.notifications.push.enabled_title')}</p>
+                <p class="font-medium">{m('settings.notifications.push.ios_home_screen_title')}</p>
                 <p class="mt-1 text-sm text-muted">
-                  {m('settings.notifications.push.enabled_description')}
+                  {m('settings.notifications.push.ios_home_screen_description')}
                 </p>
               </div>
             </Hint>
-            <div class="flex items-center gap-3">
-              <Button
-                variant="secondary"
-                size="sm"
-                onclick={handleTestPush}
-                disabled={pushTestLoading}
-                loading={pushTestLoading}
-                loadingText={m('settings.notifications.push.testing')}
-              >
-                {m('settings.notifications.push.test_button')}
-              </Button>
-              {#if pushTestStatus === 'sent'}
-                <span class="text-sm text-success" role="status">
-                  {m('settings.notifications.push.test_sent')}
-                </span>
-              {:else if pushTestStatus === 'failed'}
-                <span class="text-sm text-danger" role="alert">
-                  {m('settings.notifications.push.test_failed')}
-                </span>
-              {/if}
+          {:else if !pushSupported}
+            <div class="surface-box px-4 py-3 text-sm text-muted">
+              {m('settings.notifications.push.not_supported')}
             </div>
-          </div>
-        {:else}
-          <div class="flex items-center justify-between surface-box px-4 py-3">
-            <div>
-              <p class="font-medium">{m('settings.notifications.push.enable_title')}</p>
-              <p class="mt-1 text-sm text-muted">
-                {m('settings.notifications.push.enable_description')}
-              </p>
+          {:else if pushError}
+            <div class="mb-3">
+              <Hint tone="danger">{pushError}</Hint>
             </div>
-            <Button
-              variant="action"
-              size="sm"
-              onclick={handleEnablePush}
-              disabled={pushLoading}
-              loading={pushLoading}
-              loadingText={m('settings.notifications.push.enabling')}
-            >
-              {m('settings.notifications.push.enable_button')}
-            </Button>
-          </div>
-        {/if}
-      {/if}
-    </div>
-  {/if}
+          {/if}
 
-  <!-- Notification Sound Section -->
-  <div class="max-w-lg">
-    <h3 class="mb-4 text-sm font-semibold text-muted">
-      {m('settings.notifications.sound.title')}
-    </h3>
-
-    <div class="flex flex-col gap-4">
-      {#each soundCategories as category (category)}
-        {@const sounds = getSoundsForCategory(category)}
-        <div>
-          <h4 class="mb-2 text-xs font-medium tracking-wide text-muted uppercase">
-            {soundCategoryLabel(category)}
-          </h4>
-          <div
-            class="flex flex-col gap-1"
-            role="radiogroup"
-            aria-label={soundCategoryLabel(category)}
-          >
-            {#each sounds as sound (sound.id)}
-              {@const isSelected = notificationPreferences.notificationSound === sound.id}
-              <ChoiceRow
-                label={soundNameLabel(sound.id)}
-                selected={isSelected}
-                onclick={() => selectSound(sound.id)}
-              />
-            {/each}
-          </div>
+          {#if pushSupported}
+            {#if pushPermission === 'denied'}
+              <div class="rounded-lg border border-warning/60 bg-warning/10 px-4 py-3">
+                <p class="font-medium text-warning">
+                  {m('settings.notifications.push.blocked_title')}
+                </p>
+                <p class="mt-1 text-sm text-muted">
+                  {m('settings.notifications.push.blocked_description')}
+                </p>
+              </div>
+            {:else if pushSubscribed}
+              <div class="flex flex-col gap-3">
+                <Hint tone="success">
+                  <div>
+                    <p class="font-medium">{m('settings.notifications.push.enabled_title')}</p>
+                    <p class="mt-1 text-sm text-muted">
+                      {m('settings.notifications.push.enabled_description')}
+                    </p>
+                  </div>
+                </Hint>
+                <div class="flex items-center gap-3">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onclick={handleTestPush}
+                    disabled={pushTestLoading}
+                    loading={pushTestLoading}
+                    loadingText={m('settings.notifications.push.testing')}
+                  >
+                    {m('settings.notifications.push.test_button')}
+                  </Button>
+                  {#if pushTestStatus === 'sent'}
+                    <span class="text-sm text-success" role="status">
+                      {m('settings.notifications.push.test_sent')}
+                    </span>
+                  {:else if pushTestStatus === 'failed'}
+                    <span class="text-sm text-danger" role="alert">
+                      {m('settings.notifications.push.test_failed')}
+                    </span>
+                  {/if}
+                </div>
+              </div>
+            {:else}
+              <div class="flex items-center justify-between surface-box px-4 py-3">
+                <div>
+                  <p class="font-medium">{m('settings.notifications.push.enable_title')}</p>
+                  <p class="mt-1 text-sm text-muted">
+                    {m('settings.notifications.push.enable_description')}
+                  </p>
+                </div>
+                <Button
+                  variant="action"
+                  size="sm"
+                  onclick={handleEnablePush}
+                  disabled={pushLoading}
+                  loading={pushLoading}
+                  loadingText={m('settings.notifications.push.enabling')}
+                >
+                  {m('settings.notifications.push.enable_button')}
+                </Button>
+              </div>
+            {/if}
+          {/if}
         </div>
-      {/each}
-    </div>
+      </Panel>
+    {/if}
+
+    <!-- Notification Sound Section -->
+    <Panel title={m('settings.notifications.sound.title')} icon="iconify icon-[uil--volume]">
+      <div class="flex max-w-lg flex-col gap-4">
+        {#each soundCategories as category (category)}
+          {@const sounds = getSoundsForCategory(category)}
+          <div>
+            <h4 class="mb-2 text-xs font-medium tracking-wide text-muted uppercase">
+              {soundCategoryLabel(category)}
+            </h4>
+            <div
+              class="flex flex-col gap-1"
+              role="radiogroup"
+              aria-label={soundCategoryLabel(category)}
+            >
+              {#each sounds as sound (sound.id)}
+                {@const isSelected = notificationPreferences.notificationSound === sound.id}
+                <ChoiceRow
+                  label={soundNameLabel(sound.id)}
+                  selected={isSelected}
+                  onclick={() => selectSound(sound.id)}
+                />
+              {/each}
+            </div>
+          </div>
+        {/each}
+      </div>
+    </Panel>
+
+    <Panel
+      title={m('settings.notifications.sound.shape_title')}
+      icon="iconify icon-[uil--sliders-v-alt]"
+    >
+      {#snippet actions()}
+        <Button
+          variant="secondary"
+          size="sm"
+          onclick={previewSelectedSound}
+          disabled={notificationPreferences.notificationSound === 'silent'}
+        >
+          {m('settings.notifications.sound.preview')}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={() => notificationPreferences.resetNotificationSoundFilters()}
+        >
+          {m('settings.notifications.sound.reset')}
+        </Button>
+      {/snippet}
+
+      <div class="flex max-w-lg flex-col gap-2">
+        <RangeField
+          id="notification-volume-filter"
+          testid="notification-volume-filter"
+          label={m('settings.notifications.sound.volume')}
+          icon="icon-[uil--volume]"
+          min={0}
+          max={2}
+          step={0.05}
+          value={notificationPreferences.notificationSoundFilters.volume}
+          displayValue={formatVolume(notificationPreferences.notificationSoundFilters.volume)}
+          oninput={(event) => updateSoundFilter('volume', event)}
+          onchange={previewSelectedSound}
+        />
+
+        <RangeField
+          id="notification-high-pass-filter"
+          testid="notification-high-pass-filter"
+          label={m('settings.notifications.sound.tinny')}
+          icon="icon-[uil--bolt]"
+          min={20}
+          max={2000}
+          step={10}
+          value={notificationPreferences.notificationSoundFilters.highPassHz}
+          displayValue={formatTinny(notificationPreferences.notificationSoundFilters.highPassHz)}
+          oninput={(event) => updateSoundFilter('highPassHz', event)}
+          onchange={previewSelectedSound}
+        />
+
+        <RangeField
+          id="notification-low-pass-filter"
+          testid="notification-low-pass-filter"
+          label={m('settings.notifications.sound.muffled')}
+          icon="icon-[uil--volume-mute]"
+          min={0}
+          max={100}
+          value={muffledAmountFromLowPassHz(
+            notificationPreferences.notificationSoundFilters.lowPassHz
+          )}
+          displayValue={formatMuffled(notificationPreferences.notificationSoundFilters.lowPassHz)}
+          oninput={updateMuffledFilter}
+          onchange={previewSelectedSound}
+        />
+
+        <RangeField
+          id="notification-echo-filter"
+          testid="notification-echo-filter"
+          label={m('settings.notifications.sound.echo')}
+          icon="icon-[uil--redo]"
+          min={0}
+          max={100}
+          value={notificationPreferences.notificationSoundFilters.echo}
+          displayValue={formatEffect(notificationPreferences.notificationSoundFilters.echo)}
+          oninput={(event) => updateSoundFilter('echo', event)}
+          onchange={previewSelectedSound}
+        />
+
+        <RangeField
+          id="notification-reverb-filter"
+          testid="notification-reverb-filter"
+          label={m('settings.notifications.sound.reverb')}
+          icon="icon-[uil--cloud]"
+          min={0}
+          max={100}
+          value={notificationPreferences.notificationSoundFilters.reverb}
+          displayValue={formatEffect(notificationPreferences.notificationSoundFilters.reverb)}
+          oninput={(event) => updateSoundFilter('reverb', event)}
+          onchange={previewSelectedSound}
+        />
+
+        <RangeField
+          id="notification-crunch-filter"
+          testid="notification-crunch-filter"
+          label={m('settings.notifications.sound.crunch')}
+          icon="icon-[uil--fire]"
+          min={0}
+          max={100}
+          value={notificationPreferences.notificationSoundFilters.crunch}
+          displayValue={formatEffect(notificationPreferences.notificationSoundFilters.crunch)}
+          oninput={(event) => updateSoundFilter('crunch', event)}
+          onchange={previewSelectedSound}
+        />
+      </div>
+    </Panel>
   </div>
-
-  <FormSection title={m('settings.notifications.sound.shape_title')} maxWidth="max-w-lg" bordered>
-    {#snippet actions()}
-      <Button
-        variant="secondary"
-        size="sm"
-        onclick={previewSelectedSound}
-        disabled={notificationPreferences.notificationSound === 'silent'}
-      >
-        {m('settings.notifications.sound.preview')}
-      </Button>
-      <Button
-        variant="ghost"
-        size="sm"
-        onclick={() => notificationPreferences.resetNotificationSoundFilters()}
-      >
-        {m('settings.notifications.sound.reset')}
-      </Button>
-    {/snippet}
-
-    <div class="flex flex-col gap-2">
-      <RangeField
-        id="notification-volume-filter"
-        testid="notification-volume-filter"
-        label={m('settings.notifications.sound.volume')}
-        icon="icon-[uil--volume]"
-        min={0}
-        max={2}
-        step={0.05}
-        value={notificationPreferences.notificationSoundFilters.volume}
-        displayValue={formatVolume(notificationPreferences.notificationSoundFilters.volume)}
-        oninput={(event) => updateSoundFilter('volume', event)}
-        onchange={previewSelectedSound}
-      />
-
-      <RangeField
-        id="notification-high-pass-filter"
-        testid="notification-high-pass-filter"
-        label={m('settings.notifications.sound.tinny')}
-        icon="icon-[uil--bolt]"
-        min={20}
-        max={2000}
-        step={10}
-        value={notificationPreferences.notificationSoundFilters.highPassHz}
-        displayValue={formatTinny(notificationPreferences.notificationSoundFilters.highPassHz)}
-        oninput={(event) => updateSoundFilter('highPassHz', event)}
-        onchange={previewSelectedSound}
-      />
-
-      <RangeField
-        id="notification-low-pass-filter"
-        testid="notification-low-pass-filter"
-        label={m('settings.notifications.sound.muffled')}
-        icon="icon-[uil--volume-mute]"
-        min={0}
-        max={100}
-        value={muffledAmountFromLowPassHz(
-          notificationPreferences.notificationSoundFilters.lowPassHz
-        )}
-        displayValue={formatMuffled(notificationPreferences.notificationSoundFilters.lowPassHz)}
-        oninput={updateMuffledFilter}
-        onchange={previewSelectedSound}
-      />
-
-      <RangeField
-        id="notification-echo-filter"
-        testid="notification-echo-filter"
-        label={m('settings.notifications.sound.echo')}
-        icon="icon-[uil--redo]"
-        min={0}
-        max={100}
-        value={notificationPreferences.notificationSoundFilters.echo}
-        displayValue={formatEffect(notificationPreferences.notificationSoundFilters.echo)}
-        oninput={(event) => updateSoundFilter('echo', event)}
-        onchange={previewSelectedSound}
-      />
-
-      <RangeField
-        id="notification-reverb-filter"
-        testid="notification-reverb-filter"
-        label={m('settings.notifications.sound.reverb')}
-        icon="icon-[uil--cloud]"
-        min={0}
-        max={100}
-        value={notificationPreferences.notificationSoundFilters.reverb}
-        displayValue={formatEffect(notificationPreferences.notificationSoundFilters.reverb)}
-        oninput={(event) => updateSoundFilter('reverb', event)}
-        onchange={previewSelectedSound}
-      />
-
-      <RangeField
-        id="notification-crunch-filter"
-        testid="notification-crunch-filter"
-        label={m('settings.notifications.sound.crunch')}
-        icon="icon-[uil--fire]"
-        min={0}
-        max={100}
-        value={notificationPreferences.notificationSoundFilters.crunch}
-        displayValue={formatEffect(notificationPreferences.notificationSoundFilters.crunch)}
-        oninput={(event) => updateSoundFilter('crunch', event)}
-        onchange={previewSelectedSound}
-      />
-    </div>
-  </FormSection>
-</div>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/notifications/notifications.page.svelte.spec.ts
@@ -177,6 +177,7 @@ describe('Notification settings page', () => {
     const { container } = render(NotificationsPage);
     await settle();
 
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(3);
     const softPopButton = buttonWithText(container, 'Soft Pop');
     softPopButton.click();
     flushSync();

--- a/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/preferences/+page.svelte
@@ -3,8 +3,9 @@
   import { getLocale } from '$lib/i18n/runtime';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { createAccountAPI } from '$lib/api-client/account';
+  import { Panel } from '$lib/components/admin';
   import { TimeFormat } from '@chatto/api-types/api/v1/viewer_pb';
-  import { ChoiceRow, PaneHeader, FormSection } from '$lib/ui';
+  import { ChoiceRow, FormSection, PaneContent, PaneHeader } from '$lib/ui';
   import { Button, Combobox, FormError } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast';
   import { formatMessageTime, hour12ForTimeFormat } from '$lib/utils/formatTime';
@@ -142,69 +143,70 @@
   showMobileNav
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <!-- Timezone -->
-  <FormSection title={m('settings.preferences.timezone.title')} maxWidth="max-w-md">
-    <Combobox
-      id="timezone"
-      testid="timezone-input"
-      label={m('settings.preferences.timezone.title')}
-      labelHidden
-      description={m('settings.preferences.timezone.description')}
-      error={timezoneError}
-      items={displayedTimezones}
-      getValue={(timezone) => timezone}
-      getLabel={(timezone) => timezone}
-      placeholder={m('settings.preferences.timezone.browser_default')}
-      clearLabel={m('settings.preferences.timezone.clear')}
-      allowFreeform={false}
-      disabled={!settingsInitialized}
-      bind:value={selectedTimezone}
-      bind:text={timezoneSearch}
-      ontextchange={handleTimezoneTextChange}
-    />
-
-    {#if selectedTimezoneTime}
-      <p class="mt-1 text-sm text-muted">
-        {m('settings.preferences.timezone.current_time', { time: selectedTimezoneTime })}
-      </p>
-    {/if}
-  </FormSection>
-
-  <!-- Time Format -->
-  <FormSection title={m('settings.preferences.time_format.title')} maxWidth="max-w-md" bordered>
-    <div
-      class="flex flex-col gap-2"
-      role="radiogroup"
-      aria-label={m('settings.preferences.time_format.title')}
-    >
-      {#each timeFormatOptions as option (option.value)}
-        {@const isSelected = selectedTimeFormat === option.value}
-        <ChoiceRow
-          label={option.label}
-          description={option.description}
-          selected={isSelected}
+<PaneContent>
+  <Panel title={m('settings.preferences.title')} icon="iconify icon-[uil--clock-three]">
+    <div class="flex max-w-md flex-col gap-6">
+      <FormSection title={m('settings.preferences.timezone.title')}>
+        <Combobox
+          id="timezone"
+          testid="timezone-input"
+          label={m('settings.preferences.timezone.title')}
+          labelHidden
+          description={m('settings.preferences.timezone.description')}
+          error={timezoneError}
+          items={displayedTimezones}
+          getValue={(timezone) => timezone}
+          getLabel={(timezone) => timezone}
+          placeholder={m('settings.preferences.timezone.browser_default')}
+          clearLabel={m('settings.preferences.timezone.clear')}
+          allowFreeform={false}
           disabled={!settingsInitialized}
-          onclick={() => (selectedTimeFormat = option.value)}
+          bind:value={selectedTimezone}
+          bind:text={timezoneSearch}
+          ontextchange={handleTimezoneTextChange}
         />
-      {/each}
-    </div>
-  </FormSection>
 
-  <!-- Save -->
-  {#if error}
-    <div class="max-w-md">
-      <FormError {error} />
-    </div>
-  {/if}
+        {#if selectedTimezoneTime}
+          <p class="mt-1 text-sm text-muted">
+            {m('settings.preferences.timezone.current_time', {
+              time: selectedTimezoneTime
+            })}
+          </p>
+        {/if}
+      </FormSection>
 
-  <div class="flex max-w-md gap-2">
-    <Button
-      onclick={handleSave}
-      disabled={!isModified || isSaving || !!timezoneError}
-      loading={isSaving}
-    >
-      {m('settings.preferences.save_button')}
-    </Button>
-  </div>
-</div>
+      <FormSection title={m('settings.preferences.time_format.title')} bordered>
+        <div
+          class="flex flex-col gap-2"
+          role="radiogroup"
+          aria-label={m('settings.preferences.time_format.title')}
+        >
+          {#each timeFormatOptions as option (option.value)}
+            {@const isSelected = selectedTimeFormat === option.value}
+            <ChoiceRow
+              label={option.label}
+              description={option.description}
+              selected={isSelected}
+              disabled={!settingsInitialized}
+              onclick={() => (selectedTimeFormat = option.value)}
+            />
+          {/each}
+        </div>
+      </FormSection>
+
+      {#if error}
+        <FormError {error} />
+      {/if}
+
+      <div class="flex gap-2">
+        <Button
+          onclick={handleSave}
+          disabled={!isModified || isSaving || !!timezoneError}
+          loading={isSaving}
+        >
+          {m('settings.preferences.save_button')}
+        </Button>
+      </div>
+    </div>
+  </Panel>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/preferences/preferences.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/preferences/preferences.page.svelte.spec.ts
@@ -64,6 +64,7 @@ describe('Time and region settings page', () => {
 
     const timezoneInput = q(container, '[data-testid="timezone-input"]') as HTMLInputElement;
     const saveButton = buttonWithText(container, 'Save');
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(1);
     await expect.element(timezoneInput).toHaveValue('');
     await expect.element(timezoneInput).toBeDisabled();
     await expect.element(buttonWithText(container, '24-hour')).toBeDisabled();

--- a/apps/frontend/src/routes/chat/[serverId]/settings/profile.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/profile.page.svelte.spec.ts
@@ -113,6 +113,7 @@ describe('Profile settings page', () => {
     const usernameInput = q(container, '[data-testid="settings-username"]') as HTMLInputElement;
     const saveButton = q(container, 'button[type="submit"]') as HTMLButtonElement;
 
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(2);
     await expect.element(displayNameInput).toHaveValue('Alice');
     await expect.element(usernameInput).toHaveValue('alice');
     await expect.element(saveButton).toBeDisabled();

--- a/apps/frontend/src/routes/chat/preferences/+page.svelte
+++ b/apps/frontend/src/routes/chat/preferences/+page.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
   import { userPreferences, type DisplayTheme } from '$lib/state/userPreferences.svelte';
-  import { ChoiceRow, FormSection, PageTitle, PaneHeader } from '$lib/ui';
+  import { ChoiceRow, PageTitle, PaneContent, PaneHeader } from '$lib/ui';
 
   const themeOptions = $derived([
     {
@@ -32,22 +33,24 @@
   subtitle={m('settings.app_preferences.subtitle')}
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <FormSection title={m('settings.preferences.theme.title')} maxWidth="max-w-md">
-    <p class="mb-3 text-sm text-muted">{m('settings.preferences.browser_scope')}</p>
-    <div
-      class="flex flex-col gap-2"
-      role="radiogroup"
-      aria-label={m('settings.preferences.theme.title')}
-    >
-      {#each themeOptions as option (option.value)}
-        <ChoiceRow
-          label={option.label}
-          description={option.description}
-          selected={userPreferences.displayTheme === option.value}
-          onclick={() => (userPreferences.displayTheme = option.value)}
-        />
-      {/each}
+<PaneContent>
+  <Panel title={m('settings.preferences.theme.title')} icon="iconify icon-[uil--palette]">
+    <div class="max-w-md">
+      <p class="mb-3 text-sm text-muted">{m('settings.preferences.browser_scope')}</p>
+      <div
+        class="flex flex-col gap-2"
+        role="radiogroup"
+        aria-label={m('settings.preferences.theme.title')}
+      >
+        {#each themeOptions as option (option.value)}
+          <ChoiceRow
+            label={option.label}
+            description={option.description}
+            selected={userPreferences.displayTheme === option.value}
+            onclick={() => (userPreferences.displayTheme = option.value)}
+          />
+        {/each}
+      </div>
     </div>
-  </FormSection>
-</div>
+  </Panel>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/preferences/appearance.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/preferences/appearance.page.svelte.spec.ts
@@ -20,6 +20,7 @@ describe('App Preferences appearance page', () => {
     const { container } = render(AppearancePage);
     await settle();
 
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(1);
     expect(container.textContent).toContain('Appearance');
     expect(container.textContent).toContain(
       'Choices for this app that apply across all your registered servers'

--- a/apps/frontend/src/routes/chat/preferences/composer/+page.svelte
+++ b/apps/frontend/src/routes/chat/preferences/composer/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
   import {
     userPreferences,
     type ComposerEditorKind,
     type ComposerSendMode
   } from '$lib/state/userPreferences.svelte';
-  import { ChoiceRow, FormSection, PageTitle, PaneHeader } from '$lib/ui';
+  import { ChoiceRow, PageTitle, PaneContent, PaneHeader } from '$lib/ui';
 
   const editorOptions = $derived([
     {
@@ -40,40 +41,46 @@
   subtitle={m('settings.app_preferences.subtitle')}
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <FormSection title={m('settings.preferences.editor.title')} maxWidth="max-w-md">
-    <p class="mb-3 text-sm text-muted">{m('settings.preferences.browser_scope')}</p>
-    <div
-      class="flex flex-col gap-2"
-      role="radiogroup"
-      aria-label={m('settings.preferences.editor.title')}
-    >
-      {#each editorOptions as option (option.value)}
-        <ChoiceRow
-          label={option.label}
-          description={option.description}
-          selected={userPreferences.composerEditor === option.value}
-          onclick={() => (userPreferences.composerEditor = option.value)}
-        />
-      {/each}
-    </div>
-  </FormSection>
+<PaneContent>
+  <div class="flex flex-col gap-6">
+    <Panel title={m('settings.preferences.editor.title')} icon="iconify icon-[uil--edit]">
+      <div class="max-w-md">
+        <p class="mb-3 text-sm text-muted">{m('settings.preferences.browser_scope')}</p>
+        <div
+          class="flex flex-col gap-2"
+          role="radiogroup"
+          aria-label={m('settings.preferences.editor.title')}
+        >
+          {#each editorOptions as option (option.value)}
+            <ChoiceRow
+              label={option.label}
+              description={option.description}
+              selected={userPreferences.composerEditor === option.value}
+              onclick={() => (userPreferences.composerEditor = option.value)}
+            />
+          {/each}
+        </div>
+      </div>
+    </Panel>
 
-  <FormSection title={m('settings.preferences.send_mode.title')} maxWidth="max-w-md" bordered>
-    <p class="mb-3 text-sm text-muted">{m('settings.preferences.browser_scope')}</p>
-    <div
-      class="flex flex-col gap-2"
-      role="radiogroup"
-      aria-label={m('settings.preferences.send_mode.title')}
-    >
-      {#each sendModeOptions as option (option.value)}
-        <ChoiceRow
-          label={option.label}
-          description={option.description}
-          selected={userPreferences.composerSendMode === option.value}
-          onclick={() => (userPreferences.composerSendMode = option.value)}
-        />
-      {/each}
-    </div>
-  </FormSection>
-</div>
+    <Panel title={m('settings.preferences.send_mode.title')} icon="iconify icon-[uil--message]">
+      <div class="max-w-md">
+        <p class="mb-3 text-sm text-muted">{m('settings.preferences.browser_scope')}</p>
+        <div
+          class="flex flex-col gap-2"
+          role="radiogroup"
+          aria-label={m('settings.preferences.send_mode.title')}
+        >
+          {#each sendModeOptions as option (option.value)}
+            <ChoiceRow
+              label={option.label}
+              description={option.description}
+              selected={userPreferences.composerSendMode === option.value}
+              onclick={() => (userPreferences.composerSendMode = option.value)}
+            />
+          {/each}
+        </div>
+      </div>
+    </Panel>
+  </div>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/preferences/composer/composer.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/preferences/composer/composer.page.svelte.spec.ts
@@ -21,6 +21,7 @@ describe('App Preferences composer page', () => {
     const { container, getByRole } = render(ComposerPage);
     await settle();
 
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(2);
     const editorChoices = Array.from(
       container.querySelectorAll<HTMLButtonElement>('[aria-label="Message editor"] [role="radio"]')
     );

--- a/apps/frontend/src/routes/chat/preferences/language/+page.svelte
+++ b/apps/frontend/src/routes/chat/preferences/language/+page.svelte
@@ -1,8 +1,9 @@
 <script lang="ts">
+  import { Panel } from '$lib/components/admin';
   import { m } from '$lib/i18n/messages';
   import { localeDisplayName, selectableLocales } from '$lib/i18n/locales';
   import { getLocale, setLocale, type Locale } from '$lib/i18n/runtime';
-  import { ChoiceRow, FormSection, PageTitle, PaneHeader } from '$lib/ui';
+  import { ChoiceRow, PageTitle, PaneContent, PaneHeader } from '$lib/ui';
 
   const activeLocale = $derived(getLocale());
   const languageOptions = $derived(
@@ -24,10 +25,10 @@
   subtitle={m('settings.preferences.language.description')}
 />
 
-<div class="flex flex-col gap-6 overflow-y-auto p-6">
-  <FormSection title={m('settings.preferences.language.title')} maxWidth="max-w-md">
+<PaneContent>
+  <Panel title={m('settings.preferences.language.title')} icon="iconify icon-[uil--language]">
     <div
-      class="flex flex-col gap-2"
+      class="flex max-w-md flex-col gap-2"
       role="radiogroup"
       aria-label={m('settings.preferences.language.title')}
     >
@@ -39,5 +40,5 @@
         />
       {/each}
     </div>
-  </FormSection>
-</div>
+  </Panel>
+</PaneContent>

--- a/apps/frontend/src/routes/chat/preferences/language/language.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/preferences/language/language.page.svelte.spec.ts
@@ -21,9 +21,10 @@ describe('App Preferences language page', () => {
   });
 
   it('changes and persists the app language', async () => {
-    const { getByRole } = render(LanguagePage);
+    const { container, getByRole } = render(LanguagePage);
     await settle();
 
+    expect(container.querySelectorAll('.panel-shell')).toHaveLength(1);
     await getByRole('radio', { name: 'German (Germany)' }).click();
     await vi.waitFor(() => {
       expect(document.documentElement.lang).toBe('de-DE');


### PR DESCRIPTION
## Why

App and server-specific preference forms lacked the shared framed hierarchy used throughout Server Configuration, making adjacent settings surfaces feel inconsistent.

## What changed

- Wrapped App Preferences and User Preferences control groups in titled `Panel` frames inside `PaneContent`.
- Updated regression coverage, Storybook examples, frontend instructions, and design-system guidance to codify the pattern.

## API compatibility

No public API or protocol behavior changed; older client → newer server and newer client → older server are unchanged, with no capability-discovery or minimum-version impact.

## Test plan

- `mise lint-frontend`
- Focused Vitest page suite (7 files, 30 tests)
- Targeted Playwright E2E suite (3 files, 36 tests)
- `mise x -- pnpm run build:storybook`
- `mise build-frontend`
- Chrome DevTools checks in light/dark and desktop/narrow layouts
