### PR TITLE
feat(frontend): show server re-login status

### DIFF
--- a/apps/frontend/src/lib/ServerIcon.stories.svelte
+++ b/apps/frontend/src/lib/ServerIcon.stories.svelte
@@ -1,0 +1,54 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import ServerIcon from './ServerIcon.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Components/ServerIcon',
+    component: ServerIcon,
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: {
+          component:
+            'Server gutter icon with selection, notification, compatibility, and sign-in states.'
+        }
+      }
+    }
+  });
+
+  const home = { name: 'Home Server', logoUrl: null };
+  const remote = { name: 'Remote Server', logoUrl: null };
+  const legacy = { name: 'Legacy Server', logoUrl: null };
+</script>
+
+<Story name="Gutter states" asChild>
+  <div class="inline-flex flex-col gap-2 rounded-xl border border-border bg-background p-2">
+    <ServerIcon server={home} href="#home" title="Home Server" selected />
+    <ServerIcon
+      server={remote}
+      href="#remote"
+      title="Remote Server needs sign-in"
+      dimmed
+      reauthRequired
+    />
+    <ServerIcon
+      server={legacy}
+      href="#legacy"
+      title="Legacy Server — Server version is not supported"
+      dimmed
+      compatibilityWarning
+    />
+  </div>
+</Story>
+
+<Story name="Reauthentication required" asChild>
+  <div class="inline-flex rounded-xl border border-border bg-background p-2">
+    <ServerIcon
+      server={remote}
+      href="#remote"
+      title="Remote Server needs sign-in"
+      dimmed
+      reauthRequired
+    />
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ServerIcon.svelte
+++ b/apps/frontend/src/lib/ServerIcon.svelte
@@ -19,6 +19,7 @@
     contextMenuTrigger,
     title,
     dimmed = false,
+    reauthRequired = false,
     compatibilityWarning = false
   }: {
     /** Display data for the icon (server name + optional logo). */
@@ -42,6 +43,8 @@
     title?: string;
     /** Render as unavailable/degraded while keeping the icon in the gutter. */
     dimmed?: boolean;
+    /** Show that this server needs the user to sign in again. */
+    reauthRequired?: boolean;
     /** Show a non-interactive compatibility warning marker. */
     compatibilityWarning?: boolean;
   } = $props();
@@ -67,7 +70,15 @@
     {/if}
   </a>
 
-  {#if compatibilityWarning}
+  {#if reauthRequired}
+    <span
+      class="pointer-events-none absolute -top-1 -left-1 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-warning text-on-warning shadow-sm"
+      data-testid="server-reauth-required"
+      aria-hidden="true"
+    >
+      <span class="iconify text-xs icon-[uil--signin] rtl:-scale-x-100"></span>
+    </span>
+  {:else if compatibilityWarning}
     <span
       class="pointer-events-none absolute -top-1 -left-1 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-warning text-on-warning shadow-sm"
       data-testid="server-compatibility-warning"

--- a/apps/frontend/src/lib/ServerIcon.svelte
+++ b/apps/frontend/src/lib/ServerIcon.svelte
@@ -76,7 +76,7 @@
       data-testid="server-reauth-required"
       aria-hidden="true"
     >
-      <span class="iconify text-xs icon-[uil--signin] rtl:-scale-x-100"></span>
+      <span class="iconify text-xs icon-[uil--exclamation-circle]"></span>
     </span>
   {:else if compatibilityWarning}
     <span

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -220,6 +220,7 @@
   contextMenuTrigger={serverContextMenuTrigger}
   title={iconTitle}
   dimmed={iconDimmed}
+  reauthRequired={needsReauth}
   {compatibilityWarning}
 />
 

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -35,7 +35,7 @@ const { mocks } = vi.hoisted(() => {
         userLogin: 'alice',
         userDisplayName: 'Alice',
         userAvatarUrl: null,
-        reauthRequiredAt: null,
+        reauthRequiredAt: null as number | null,
         addedAt: 0
       },
       store: {
@@ -219,6 +219,7 @@ describe('ServerSidebarEntry', () => {
     mocks.isOriginServer.mockReset();
     mocks.isOriginServer.mockReturnValue(false);
     mocks.server.url = 'https://remote.example.com';
+    mocks.server.reauthRequiredAt = null;
     Object.defineProperty(navigator, 'clipboard', {
       value: { writeText: mocks.writeClipboardText },
       configurable: true
@@ -523,12 +524,38 @@ describe('ServerSidebarEntry', () => {
 
     await expect.element(icon).toHaveClass('opacity-40');
     await expect.element(icon).toHaveAttribute('title', 'Loaded Remote needs sign-in');
+    await expect
+      .element(q(container, '[data-testid="server-reauth-required"]'))
+      .not.toBeInTheDocument();
     icon.click();
 
     await vi.waitFor(() => {
       expect(mocks.startRemoteReauthentication).toHaveBeenCalledWith(mocks.server);
       expect(mocks.goto).not.toHaveBeenCalled();
     });
+  });
+
+  it('marks a server that requires reauthentication and prioritises it over compatibility', async () => {
+    mocks.server.reauthRequiredAt = 123;
+    mocks.store.isAuthenticated = false;
+    mocks.store.serverInfo.compatibility = {
+      status: 'unsupported',
+      reason: 'server-too-old'
+    };
+
+    const { container } = render(ServerSidebarEntry, {
+      props: { serverId: 'remote' }
+    });
+    const icon = q(container, '[data-testid="server-icon"]');
+
+    await expect.element(icon).toHaveAttribute('title', 'Loaded Remote needs sign-in');
+    await expect.element(icon).toHaveAttribute('aria-label', 'Loaded Remote needs sign-in');
+    await expect
+      .element(q(container, '[data-testid="server-reauth-required"]'))
+      .toBeInTheDocument();
+    await expect
+      .element(q(container, '[data-testid="server-compatibility-warning"]'))
+      .not.toBeInTheDocument();
   });
 
   it('uses the origin sign-in flow for an unauthenticated origin server', async () => {

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte.spec.ts
@@ -550,9 +550,11 @@ describe('ServerSidebarEntry', () => {
 
     await expect.element(icon).toHaveAttribute('title', 'Loaded Remote needs sign-in');
     await expect.element(icon).toHaveAttribute('aria-label', 'Loaded Remote needs sign-in');
-    await expect
-      .element(q(container, '[data-testid="server-reauth-required"]'))
-      .toBeInTheDocument();
+    const reauthMarker = q(container, '[data-testid="server-reauth-required"]');
+    await expect.element(reauthMarker).toBeInTheDocument();
+    expect(
+      reauthMarker?.querySelector('[class~="icon-[uil--exclamation-circle]"]')
+    ).not.toBeNull();
     await expect
       .element(q(container, '[data-testid="server-compatibility-warning"]'))
       .not.toBeInTheDocument();


### PR DESCRIPTION
## Why

The server gutter used the same dimmed icon for reauthentication and connection failures. Users could not see which inactive server needed them to sign in again.

## What changed

- Show a warning sign-in marker when a server has `reauthRequiredAt` set.
- Give reauthentication priority over the compatibility marker while preserving notification indicators.
- Keep the existing localized tooltip, accessible label, and click-to-sign-in behavior.
- Use the same exclamation-circle glyph as the compatibility marker.
- Add focused component tests and Storybook states.

This change does not modify authentication behavior, persisted formats, public APIs, rollout requirements, or operational behavior.

## Test plan

- Passed: `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/ServerSidebarEntry.svelte.spec.ts` (19 tests).
- Passed: `mise x -- pnpm --filter chatto-frontend exec vitest --run --project=storybook src/lib/ServerIcon.stories.svelte` (2 stories).
- Passed: `mise lint-frontend` with no Svelte errors, warnings, or ESLint findings.
- Passed: `mise license-check` with full REUSE 3.3 compliance.
- Passed: Svelte autofixer for all changed Svelte files.
- Reviewed with Chrome DevTools in light, dark, and accessibility-tree views.
