### PR TITLE
feat(frontend): submit dialog actions with Enter

### DIFF
--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -351,7 +351,7 @@ store owns only optimistic join/leave state.
   </p>
 
   <div class="flex items-center gap-3">
-    <Button variant="danger" onclick={confirmLeaveRoom}>{m('room.leave.action')}</Button>
+    <Button defaultAction variant="danger" onclick={confirmLeaveRoom}>{m('room.leave.action')}</Button>
     <Button variant="ghost" onclick={() => (leaveConfirmVisible = false)}>
       {m('common.cancel')}
     </Button>

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -316,7 +316,7 @@
         <Button variant="secondary" onclick={() => composer.postAsNewRoot()}>
           {m('composer.post_as_new_message')}
         </Button>
-        <Button variant="action" onclick={() => composer.postInRecentThread()}>
+        <Button defaultAction variant="action" onclick={() => composer.postInRecentThread()}>
           <span class="iconify icon-[uil--comment-alt-lines]"></span>
           {m('composer.continue_in_thread')}
         </Button>

--- a/apps/frontend/src/lib/components/rbac/DeleteRoleModal.svelte
+++ b/apps/frontend/src/lib/components/rbac/DeleteRoleModal.svelte
@@ -38,7 +38,7 @@
       <Button variant="secondary" onclick={handleClose} disabled={deleting}
         >{m('common.cancel')}</Button
       >
-      <Button variant="danger" onclick={onConfirm} disabled={deleting}>
+      <Button defaultAction variant="danger" onclick={onConfirm} disabled={deleting}>
         {deleting ? m('rbac.delete_role.deleting') : m('rbac.delete_role.action')}
       </Button>
     </div>

--- a/apps/frontend/src/lib/ui/Dialog.stories.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.stories.svelte
@@ -126,7 +126,7 @@
         <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
           Cancel
         </Button>
-        <Button onclick={() => (dialogWithFooterVisible = false)}>Confirm</Button>
+        <Button defaultAction onclick={() => (dialogWithFooterVisible = false)}>Confirm</Button>
       </div>
     {/snippet}
   </Dialog>

--- a/apps/frontend/src/lib/ui/Dialog.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.svelte
@@ -44,6 +44,10 @@
     lg: 'w-200 max-w-[90vw]'
   };
 
+  function getDefaultAction(node: ParentNode): HTMLButtonElement | null {
+    return node.querySelector<HTMLButtonElement>('button[data-dialog-default]:not([disabled])');
+  }
+
   function syncDialogVisibility(node: HTMLDialogElement) {
     dialogEl = node;
     if (visible) {
@@ -53,10 +57,10 @@
       // showModal() naturally focuses the first focusable element, which
       // for our layout is the Close (X) button in the header — not what
       // users expect. Move focus to the first form field, falling back
-      // to the form's submit button (so confirm-style dialogs get Enter
-      // wired to confirm, not close). Skipped on touch devices to avoid
-      // popping the on-screen keyboard. A field that already received
-      // focus via the native `autofocus` attribute is left alone.
+      // to the form's submit button or explicitly marked default action (so
+      // Enter confirms instead of closing). Skipped on touch devices to avoid
+      // popping the on-screen keyboard. A field that already received focus
+      // via the native `autofocus` attribute is left alone.
       if (shouldAutoFocus()) {
         queueMicrotask(() => {
           const fieldSelector =
@@ -67,7 +71,8 @@
           if (alreadyOnField) return;
           const target =
             node.querySelector<HTMLElement>(fieldSelector) ??
-            node.querySelector<HTMLElement>('button[type="submit"]:not([disabled])');
+            node.querySelector<HTMLElement>('button[type="submit"]:not([disabled])') ??
+            getDefaultAction(node);
           target?.focus();
         });
       }
@@ -91,11 +96,41 @@
       dialogEl?.close();
     }, 100);
   }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (
+      event.key !== 'Enter' ||
+      event.defaultPrevented ||
+      event.isComposing ||
+      event.repeat
+    ) {
+      return;
+    }
+
+    if (!dialogEl) return;
+    const defaultAction = getDefaultAction(dialogEl);
+    if (!defaultAction) return;
+
+    const target = event.target;
+    // Forms own Enter through native submission. Textareas use Enter for a
+    // new line, so neither should invoke a dialog-level default action.
+    if (
+      target instanceof HTMLTextAreaElement ||
+      (target instanceof Element &&
+        target.closest('form, button, a, select, [role="button"], [contenteditable="true"]'))
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    defaultAction.click();
+  }
 </script>
 
 <dialog
   {@attach syncDialogVisibility}
   onclose={handleNativeClose}
+  onkeydown={handleKeydown}
   oncancel={(e) => {
     // Always run our animated close path; never let the browser close the
     // dialog instantly without the fade-out.

--- a/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import Dialog from './Dialog.svelte';
@@ -168,6 +168,60 @@ describe('Dialog', () => {
 
       const closeButton = q(container, 'button[aria-label="Close"]');
       await expect.element(closeButton).toBeInTheDocument();
+    });
+  });
+
+  describe('default action', () => {
+    it('clicks the marked default action when Enter is pressed outside a form', () => {
+      const { container } = render(Dialog, {
+        props: {
+          visible: true,
+          children: testSnippet('<button data-dialog-default>Confirm</button>')
+        }
+      });
+
+      const defaultAction = vi.fn();
+      q(container, '[data-dialog-default]')?.addEventListener('click', defaultAction);
+
+      q(container, 'dialog')?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+
+      expect(defaultAction).toHaveBeenCalledOnce();
+    });
+
+    it('leaves Enter in a textarea alone', () => {
+      const { container } = render(Dialog, {
+        props: {
+          visible: true,
+          children: testSnippet(
+            '<div><textarea data-testid="message"></textarea><button data-dialog-default>Confirm</button></div>'
+          )
+        }
+      });
+
+      const defaultAction = vi.fn();
+      q(container, '[data-dialog-default]')?.addEventListener('click', defaultAction);
+
+      q(container, '[data-testid="message"]')?.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+      );
+
+      expect(defaultAction).not.toHaveBeenCalled();
+    });
+
+    it('does not click a disabled marked action', () => {
+      const { container } = render(Dialog, {
+        props: {
+          visible: true,
+          children: testSnippet('<button data-dialog-default disabled>Confirm</button>')
+        }
+      });
+
+      const defaultAction = vi.fn();
+      q(container, '[data-dialog-default]')?.addEventListener('click', defaultAction);
+
+      q(container, 'dialog')?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+
+      expect(defaultAction).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/frontend/src/lib/ui/form/Button.svelte
+++ b/apps/frontend/src/lib/ui/form/Button.svelte
@@ -9,6 +9,7 @@
     loading = false,
     disabled = false,
     fullWidth = false,
+    defaultAction = false,
     loadingText,
     href,
     onclick,
@@ -29,6 +30,8 @@
     loading?: boolean;
     disabled?: boolean;
     fullWidth?: boolean;
+    /** Marks this as its containing dialog's action for the Enter key. */
+    defaultAction?: boolean;
     loadingText?: string;
     /** When provided, renders as an <a> link instead of a <button> */
     href?: string;
@@ -90,6 +93,7 @@
     aria-disabled={disabled || loading || undefined}
     aria-label={label}
     {title}
+    data-dialog-default={defaultAction || undefined}
     tabindex={disabled || loading ? -1 : undefined}
     class={[
       variantClasses[variant],
@@ -108,6 +112,7 @@
     aria-busy={loading || undefined}
     aria-label={label}
     {title}
+    data-dialog-default={defaultAction || undefined}
     class={[variantClasses[variant], sizeClasses[size], fullWidth ? 'w-full' : '']}
   >
     {@render content()}

--- a/apps/frontend/src/routes/chat/SignOutDialog.svelte
+++ b/apps/frontend/src/routes/chat/SignOutDialog.svelte
@@ -85,6 +85,7 @@
     <div class="flex flex-wrap justify-end gap-2">
       <Button variant="secondary" onclick={onclose}>{m('common.cancel')}</Button>
       <Button
+        defaultAction
         variant="action"
         loading={signingOutCurrent}
         disabled={signingOutAll || !canSignOutCurrentServer}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/bots/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/bots/+page.svelte
@@ -349,7 +349,7 @@
       </Button>
     </div>
     <div class="flex justify-end">
-      <Button onclick={closeAPIKey}>{m('common.got_it')}</Button>
+      <Button defaultAction onclick={closeAPIKey}>{m('common.got_it')}</Button>
     </div>
   </div>
 </Dialog>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/bots/[botId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/bots/[botId]/+page.svelte
@@ -437,7 +437,7 @@
       </Button>
     </div>
     <div class="flex justify-end">
-      <Button onclick={closeAPIKey}>{m('common.got_it')}</Button>
+      <Button defaultAction onclick={closeAPIKey}>{m('common.got_it')}</Button>
     </div>
   </div>
 </Dialog>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
@@ -182,7 +182,7 @@
   <p class="mb-4 text-muted">{m('settings.profile.username.confirm_cooldown')}</p>
 
   <div class="flex items-center gap-3">
-    <Button onclick={confirmLoginChange}>
+    <Button defaultAction onclick={confirmLoginChange}>
       <span class="iconify icon-[uil--check]"></span>
       {m('settings.profile.username.confirm_button')}
     </Button>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/DeleteAccountSection.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/DeleteAccountSection.svelte
@@ -115,6 +115,7 @@
         {m('common.cancel')}
       </Button>
       <Button
+        defaultAction
         variant="danger"
         onclick={handleDeleteAccount}
         disabled={!canDelete || isDeleting}

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/ExternalIdentitySettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/ExternalIdentitySettings.svelte
@@ -525,7 +525,7 @@
       })}
     </Hint>
     <div class="flex justify-end">
-      <Button variant="secondary" onclick={closeDisconnectBlockedModal}>
+      <Button defaultAction variant="secondary" onclick={closeDisconnectBlockedModal}>
         {m('ui.close')}
       </Button>
     </div>


### PR DESCRIPTION
## Why

Users should be able to activate a dialog's primary action with Enter without accidentally triggering a secondary action or duplicate request.

## What changed

- Add `defaultAction` to the shared `Button` component and let `Dialog` locate that enabled action, focus it after opening, and activate it for Enter.
- Mark the primary actions in existing general dialogs, while preserving native form submission and leaving textareas, links, controls, and disabled or loading actions alone.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/ui/Dialog.svelte.spec.ts` — 21 passed.
- Chrome DevTools: opened the Dialog Storybook footer example and verified Enter activates Confirm and closes the dialog.
