### PR TITLE
feat(frontend): open created threads automatically

### DIFF
--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -62,6 +62,7 @@
     onReady,
     onTyping,
     onMessageSent,
+    onThreadCreated,
     onThreadMessageSent,
     onCancelReply,
     onEscape,
@@ -131,6 +132,7 @@
         if (event) optimisticPost = { roomId, createdAt: Date.parse(event.createdAt) };
         onMessageSent?.(event);
       },
+      onThreadCreated,
       onThreadMessageSent,
       onCancelReply,
       onEscape

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -3012,12 +3012,14 @@ describe('MessageComposer', () => {
       expect(roomStateMock.scrollState.requestScrollToBottom).toHaveBeenCalledOnce();
     });
 
-    it('posts a root as a thread without a separate navigation callback', async () => {
+    it('reports the root ID after a room-level post creates a thread', async () => {
       const onMessageSent = vi.fn();
+      const onThreadCreated = vi.fn();
       const { container, roomId } = renderMessageComposer({
         roomId: 'room_456',
         showCreateThread: true,
-        onMessageSent
+        onMessageSent,
+        onThreadCreated
       });
       const editor = await findEditor(container);
       const threadToggle = q(container, 'button[aria-label="Post as thread"]') as HTMLButtonElement;
@@ -3042,6 +3044,7 @@ describe('MessageComposer', () => {
       });
       await vi.waitFor(() => expect(onMessageSent).toHaveBeenCalledOnce());
       expect(onMessageSent).toHaveBeenCalledWith(expect.objectContaining({ id: 'msg_123' }));
+      expect(onThreadCreated).toHaveBeenCalledWith('msg_123');
       await expect.element(threadToggle).toHaveAttribute('aria-pressed', 'false');
     });
 

--- a/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
+++ b/apps/frontend/src/lib/components/composer/messageComposerState.svelte.ts
@@ -67,6 +67,8 @@ export type MessageComposerProps = {
   onReady?: (api: MessageComposerApi) => void;
   onTyping?: () => void;
   onMessageSent?: (event: TimelineEventView | null) => void;
+  /** Called after a room-level post successfully creates a thread. */
+  onThreadCreated?: (threadRootEventId: string) => void;
   onCancelReply?: () => void;
   onEscape?: () => void;
   showAlsoSendToChannel?: boolean;
@@ -98,7 +100,12 @@ type MessageComposerDependencies = {
   getOnReady: () => MessageComposerProps['onReady'];
   getCallbacks: () => Pick<
     MessageComposerProps,
-    'onTyping' | 'onMessageSent' | 'onThreadMessageSent' | 'onCancelReply' | 'onEscape'
+    | 'onTyping'
+    | 'onMessageSent'
+    | 'onThreadCreated'
+    | 'onThreadMessageSent'
+    | 'onCancelReply'
+    | 'onEscape'
   >;
   onPostError?: (error: unknown) => boolean;
   context: ComposerContext;
@@ -543,6 +550,9 @@ export class MessageComposerState {
         callbacks.onThreadMessageSent(post.threadRootEventId, event);
       } else {
         callbacks.onMessageSent?.(event);
+        if (post.createThread && event) {
+          callbacks.onThreadCreated?.(event.id);
+        }
       }
       this.#dependencies.context.scrollState?.requestScrollToBottom();
       callbacks.onCancelReply?.();

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -727,6 +727,7 @@
               void roomMessageStore.refreshCurrentWindow(null);
             }
           }}
+          onThreadCreated={(threadRootEventId) => openThread(threadRootEventId)}
           onThreadMessageSent={(threadRootEventId, event) => {
             typingIndicator?.resetDebounce();
             openThread(threadRootEventId, { highlightEventId: event?.id });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts
@@ -675,7 +675,7 @@ describe('Room local message echo', () => {
     expect(mocks.resetTypingDebounce).toHaveBeenCalledOnce();
   });
 
-  it('offers thread creation in channels and stays in the room after creating one', async () => {
+  it('opens a newly created thread after adding its root post to the room timeline', async () => {
     const { container } = render(Room, { props: { roomId: 'room-1' } });
 
     await expect
@@ -683,10 +683,10 @@ describe('Room local message echo', () => {
       .toHaveTextContent('true');
     (q(container, '[data-testid="emit-created-thread"]') as HTMLButtonElement).click();
 
-    expect(mocks.goto).not.toHaveBeenCalled();
     await expect
       .element(q(container, '[data-testid="room-event-ids"]'))
       .toHaveTextContent('msg-local');
+    expect(mocks.goto).toHaveBeenCalledWith('/chat/-/room-1/msg-local');
   });
 
   it('does not offer thread creation in DMs', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomLocalEchoMessageComposerMock.svelte
@@ -6,12 +6,14 @@
     inReplyTo,
     showCreateThread = false,
     createThreadRequired = false,
-    onMessageSent
+    onMessageSent,
+    onThreadCreated
   }: {
     inReplyTo?: string;
     showCreateThread?: boolean;
     createThreadRequired?: boolean;
     onMessageSent?: (event: TimelineEventView | null) => void;
+    onThreadCreated?: (threadRootEventId: string) => void;
   } = $props();
 
   const composerContext = getComposerContext();
@@ -71,7 +73,13 @@
   emit returned post
 </button>
 
-<button data-testid="emit-created-thread" onclick={() => onMessageSent?.(returnedPost)}>
+<button
+  data-testid="emit-created-thread"
+  onclick={() => {
+    onMessageSent?.(returnedPost);
+    onThreadCreated?.(returnedPost.id);
+  }}
+>
   emit created thread
 </button>
 


### PR DESCRIPTION
## Why

Posting a room-level message as a thread left people in the room timeline, so they had to open the newly created thread before they could continue the discussion.

## What changed

- Report the returned root event ID after a successful room-level post creates a thread.
- Ingest the root message, then navigate to its thread pane; the pane focuses its ready composer.
- Add composer and room-route coverage for the callback and navigation.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run 'src/lib/components/composer/MessageComposer.svelte.spec.ts'` — passed (156 tests).
- `mise x -- pnpm --filter chatto-frontend exec vitest --run 'src/routes/chat/[serverId]/[roomId]/Room.svelte.spec.ts'` — passed (38 tests).
