### PR TITLE
fix(realtime): defer retained timeline hydration

### DIFF
--- a/cli/internal/http_server/realtime_projection.go
+++ b/cli/internal/http_server/realtime_projection.go
@@ -812,11 +812,10 @@ func (s *HTTPServer) realtimeProjectionFrameForEventWithRooms(ctx context.Contex
 		if err := appendRoom(roomID); err != nil {
 			return nil, false, err
 		}
-		if payload.RoomMemberAdded.GetUserId() == viewerID {
-			if err := appendRoomTimeline(roomID); err != nil {
-				return nil, false, err
-			}
-		}
+		// AddMember publishes this audit fact before the authoritative
+		// UserJoinedRoom membership fact. The following fact waits for the
+		// membership projection and materialises a retained timeline, so doing
+		// it here can race authorization and close the realtime socket.
 	case *corev1.Event_RoomMemberRemoved:
 		roomID := payload.RoomMemberRemoved.GetRoomId()
 		if err := appendRoom(roomID); err != nil {


### PR DESCRIPTION
## Why

Newly admitted viewers could receive a preliminary room-membership audit event before the membership projection was ready. Realtime timeline hydration then failed authorization and closed the WebSocket.

## What changed

- Defer retained-room timeline hydration from `room_member_added` to the following authoritative `user_joined_room` event, which waits for the membership projection.
- Continue to materialize the room itself for the audit event.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- go test ./internal/http_server -run '^TestRealtimeWebSocketMaterializesRetainedRoomAfterViewerGainsAccess$' -count=50` — passed.
- `mise test-cli` — passed before this fix was split from the dialog-action branch.
