### PR TITLE
feat(frontend): show inline message state markers

### DIFF
--- a/apps/frontend/e2e/message-editing.test.ts
+++ b/apps/frontend/e2e/message-editing.test.ts
@@ -242,7 +242,7 @@ test.describe('Message editing', () => {
     await roomPage.expectMessageVisible(editedMessage);
     await roomPage.expectMessageNotVisible(originalMessage);
 
-    // Verify "(edited)" indicator appears
+    // Verify the edit marker appears.
     const editedMsg = roomPage.getMessage(editedMessage);
     await editedMsg.expectEdited();
   });

--- a/apps/frontend/e2e/pages/MessageComponent.ts
+++ b/apps/frontend/e2e/pages/MessageComponent.ts
@@ -420,18 +420,14 @@ export class MessageComponent {
     });
   }
 
-  /**
-   * Assert that the message shows (edited) indicator.
-   */
+  /** Assert that the message shows the edit marker. */
   async expectEdited(): Promise<void> {
-    await expect(this.locator.getByText('(edited)')).toBeVisible();
+    await expect(this.locator.locator('.edited-marker')).toBeVisible();
   }
 
-  /**
-   * Assert that the message does NOT show (edited) indicator.
-   */
+  /** Assert that the message does not show the edit marker. */
   async expectNotEdited(): Promise<void> {
-    await expect(this.locator.getByText('(edited)')).not.toBeVisible();
+    await expect(this.locator.locator('.edited-marker')).not.toBeVisible();
   }
 
   /**

--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -397,7 +397,7 @@ test.describe('Message Threading', () => {
         await roomPage.threadReplyInput.fill(editedReply);
         await roomPage.threadReplyInput.press('Control+Enter');
 
-        // User B should see the new content and the (edited) marker.
+        // User B should see the new content and the edit marker.
         await expect(roomPage2.threadPane.getByText(editedReply)).toBeVisible({
           timeout: TIMEOUTS.REALTIME_EVENT
         });

--- a/apps/frontend/messages/ar/room.json
+++ b/apps/frontend/messages/ar/room.json
@@ -104,6 +104,8 @@
       "meta": {
         "pinned": "رسالة مثبّتة",
         "thread": "الموضوع",
+        "edited": "تم تعديل الرسالة",
+        "echoed_to_channel": "أُرسل أيضًا إلى القناة",
         "reply_count_one": "رد واحد",
         "reply_count_many": "{count} ردود",
         "follow_thread": "اتبع الموضوع",

--- a/apps/frontend/messages/cs-CZ/room.json
+++ b/apps/frontend/messages/cs-CZ/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Připnutá zpráva",
         "thread": "Závit",
+        "edited": "Zpráva upravena",
+        "echoed_to_channel": "Také odesláno do kanálu",
         "reply_count_one": "1 odpověď",
         "reply_count_many": "{count} odpovědí",
         "follow_thread": "Sledujte vlákno",

--- a/apps/frontend/messages/de-DE/room.json
+++ b/apps/frontend/messages/de-DE/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Angepinnte Nachricht",
         "thread": "Thread",
+        "edited": "Nachricht bearbeitet",
+        "echoed_to_channel": "Auch an den Kanal gesendet",
         "reply_count_one": "1 Antwort",
         "reply_count_many": "{count} Antworten",
         "follow_thread": "Thread folgen",

--- a/apps/frontend/messages/en-GB/room.json
+++ b/apps/frontend/messages/en-GB/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Pinned message",
         "thread": "Thread",
+        "edited": "Edited message",
+        "echoed_to_channel": "Also sent to channel",
         "reply_count_one": "1 reply",
         "reply_count_many": "{count} replies",
         "follow_thread": "Follow thread",

--- a/apps/frontend/messages/eo/room.json
+++ b/apps/frontend/messages/eo/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Alpinglita mesaĝo",
         "thread": "Fadeno",
+        "edited": "Redaktita mesaĝo",
+        "echoed_to_channel": "Ankaŭ sendita al la kanalo",
         "reply_count_one": "1 respondo",
         "reply_count_many": "{count} respondas",
         "follow_thread": "Sekvu fadenon",

--- a/apps/frontend/messages/es-419/room.json
+++ b/apps/frontend/messages/es-419/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Mensaje fijado",
         "thread": "Hilo",
+        "edited": "Mensaje editado",
+        "echoed_to_channel": "También enviado al canal",
         "reply_count_one": "1 respuesta",
         "reply_count_many": "{count} responde",
         "follow_thread": "Seguir hilo",

--- a/apps/frontend/messages/es-ES/room.json
+++ b/apps/frontend/messages/es-ES/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Mensaje fijado",
         "thread": "Hilo",
+        "edited": "Mensaje editado",
+        "echoed_to_channel": "También enviado al canal",
         "reply_count_one": "1 respuesta",
         "reply_count_many": "{count} responde",
         "follow_thread": "Seguir hilo",

--- a/apps/frontend/messages/et-EE/room.json
+++ b/apps/frontend/messages/et-EE/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Kinnitatud sõnum",
         "thread": "Niit",
+        "edited": "Muudetud sõnum",
+        "echoed_to_channel": "Saadetud ka kanalisse",
         "reply_count_one": "1 vastus",
         "reply_count_many": "{count} vastust",
         "follow_thread": "Jälgi lõime",

--- a/apps/frontend/messages/fr-CA/room.json
+++ b/apps/frontend/messages/fr-CA/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Message épinglé",
         "thread": "Sujet",
+        "edited": "Message modifié",
+        "echoed_to_channel": "Également envoyé au canal",
         "reply_count_one": "1 réponse",
         "reply_count_many": "Réponses de {count}",
         "follow_thread": "Suivre le fil de discussion",

--- a/apps/frontend/messages/fr-FR/room.json
+++ b/apps/frontend/messages/fr-FR/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Message épinglé",
         "thread": "Sujet",
+        "edited": "Message modifié",
+        "echoed_to_channel": "Également envoyé au canal",
         "reply_count_one": "1 réponse",
         "reply_count_many": "Réponses de {count}",
         "follow_thread": "Suivre le fil de discussion",

--- a/apps/frontend/messages/he-IL/room.json
+++ b/apps/frontend/messages/he-IL/room.json
@@ -101,6 +101,8 @@
       "meta": {
         "pinned": "הודעה מוצמדת",
         "thread": "שרשור",
+        "edited": "הודעה נערכה",
+        "echoed_to_channel": "נשלח גם לערוץ",
         "reply_count_one": "תשובה אחת",
         "reply_count_many": "{count} תשובות",
         "follow_thread": "עקוב אחר השרשור",

--- a/apps/frontend/messages/it-IT/room.json
+++ b/apps/frontend/messages/it-IT/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Messaggio fissato",
         "thread": "Filo",
+        "edited": "Messaggio modificato",
+        "echoed_to_channel": "Inviato anche al canale",
         "reply_count_one": "1 risposta",
         "reply_count_many": "{count} risponde",
         "follow_thread": "Segui il filo",

--- a/apps/frontend/messages/ja-JP/room.json
+++ b/apps/frontend/messages/ja-JP/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "ピン留めされたメッセージ",
         "thread": "スレッド",
+        "edited": "編集済みメッセージ",
+        "echoed_to_channel": "チャンネルにも送信済み",
         "reply_count_one": "1 件の返信",
         "reply_count_many": "{count} が返信します",
         "follow_thread": "スレッドをフォローする",

--- a/apps/frontend/messages/lv-LV/room.json
+++ b/apps/frontend/messages/lv-LV/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Piesprausta ziņa",
         "thread": "Pavediens",
+        "edited": "Rediģēts ziņojums",
+        "echoed_to_channel": "Nosūtīts arī uz kanālu",
         "reply_count_one": "1 atbilde",
         "reply_count_many": "{count} atbildes",
         "follow_thread": "Sekojiet pavedienam",

--- a/apps/frontend/messages/nb-NO/room.json
+++ b/apps/frontend/messages/nb-NO/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Festet melding",
         "thread": "Tråd",
+        "edited": "Redigert melding",
+        "echoed_to_channel": "Også sendt til kanalen",
         "reply_count_one": "1 svar",
         "reply_count_many": "{count} svarer",
         "follow_thread": "Følg tråden",

--- a/apps/frontend/messages/nl-BE/room.json
+++ b/apps/frontend/messages/nl-BE/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Vastgezet bericht",
         "thread": "Discussie",
+        "edited": "Bewerkt bericht",
+        "echoed_to_channel": "Ook naar kanaal verzonden",
         "reply_count_one": "1 antwoord",
         "reply_count_many": "{count} antwoordt",
         "follow_thread": "Volg draad",

--- a/apps/frontend/messages/nl-NL/room.json
+++ b/apps/frontend/messages/nl-NL/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Vastgezet bericht",
         "thread": "Discussie",
+        "edited": "Bewerkt bericht",
+        "echoed_to_channel": "Ook naar kanaal verzonden",
         "reply_count_one": "1 antwoord",
         "reply_count_many": "{count} antwoordt",
         "follow_thread": "Volg draad",

--- a/apps/frontend/messages/pl-PL/room.json
+++ b/apps/frontend/messages/pl-PL/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Przypięta wiadomość",
         "thread": "Wątek",
+        "edited": "Edytowana wiadomość",
+        "echoed_to_channel": "Wysłano również na kanał",
         "reply_count_one": "1 odpowiedź",
         "reply_count_many": "Odpowiedzi {count}",
         "follow_thread": "Obserwuj wątek",

--- a/apps/frontend/messages/pt-BR/room.json
+++ b/apps/frontend/messages/pt-BR/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Mensagem fixada",
         "thread": "Tópico",
+        "edited": "Mensagem editada",
+        "echoed_to_channel": "Também enviado para o canal",
         "reply_count_one": "1 resposta",
         "reply_count_many": "Respostas {count}",
         "follow_thread": "Seguir tópico",

--- a/apps/frontend/messages/pt-PT/room.json
+++ b/apps/frontend/messages/pt-PT/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Mensagem fixada",
         "thread": "Tópico",
+        "edited": "Mensagem editada",
+        "echoed_to_channel": "Também enviado para o canal",
         "reply_count_one": "1 resposta",
         "reply_count_many": "Respostas {count}",
         "follow_thread": "Seguir tópico",

--- a/apps/frontend/messages/ru-RU/room.json
+++ b/apps/frontend/messages/ru-RU/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Закреплённое сообщение",
         "thread": "Тема",
+        "edited": "Сообщение отредактировано",
+        "echoed_to_channel": "Также отправлено в канал",
         "reply_count_one": "1 ответ",
         "reply_count_many": "{count} отвечает",
         "follow_thread": "Следовать за темой",

--- a/apps/frontend/messages/sv-SE/room.json
+++ b/apps/frontend/messages/sv-SE/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Fäst meddelande",
         "thread": "Tråd",
+        "edited": "Redigerat meddelande",
+        "echoed_to_channel": "Även skickat till kanalen",
         "reply_count_one": "1 svar",
         "reply_count_many": "{count} svarar",
         "follow_thread": "Följ tråden",

--- a/apps/frontend/messages/tr-TR/room.json
+++ b/apps/frontend/messages/tr-TR/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Sabitlenmiş mesaj",
         "thread": "Konu",
+        "edited": "Düzenlenmiş ileti",
+        "echoed_to_channel": "Kanala da gönderildi",
         "reply_count_one": "1 yanıt",
         "reply_count_many": "{count} yanıtlar",
         "follow_thread": "Konuyu takip et",

--- a/apps/frontend/messages/uk-UA/room.json
+++ b/apps/frontend/messages/uk-UA/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "Закріплене повідомлення",
         "thread": "Тема",
+        "edited": "Повідомлення відредаговано",
+        "echoed_to_channel": "Також надіслано до каналу",
         "reply_count_one": "1 відповідь",
         "reply_count_many": "Відповіді {count}",
         "follow_thread": "Слідкуйте за темою",

--- a/apps/frontend/messages/zh-CN/room.json
+++ b/apps/frontend/messages/zh-CN/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "已置顶消息",
         "thread": "话题串",
+        "edited": "已编辑的消息",
+        "echoed_to_channel": "也已发送到频道",
         "reply_count_one": "1 条回复",
         "reply_count_many": "{count} 条回复",
         "follow_thread": "关注话题串",

--- a/apps/frontend/messages/zh-TW/room.json
+++ b/apps/frontend/messages/zh-TW/room.json
@@ -100,6 +100,8 @@
       "meta": {
         "pinned": "已釘選訊息",
         "thread": "討論串",
+        "edited": "已編輯的訊息",
+        "echoed_to_channel": "也已傳送至頻道",
         "reply_count_one": "1 則回覆",
         "reply_count_many": "{count} 則回覆",
         "follow_thread": "追蹤討論串",

--- a/apps/frontend/src/lib/components/MessageContent.svelte
+++ b/apps/frontend/src/lib/components/MessageContent.svelte
@@ -36,6 +36,7 @@
     members = [],
     roleHandles = [],
     edited = false,
+    echoedToChannel = false,
     viewerLogin,
     timestampSettings = fallbackTimestampSettings,
     timestampLocale,
@@ -45,6 +46,7 @@
     members?: RoomMember[];
     roleHandles?: string[];
     edited?: boolean;
+    echoedToChannel?: boolean;
     viewerLogin?: string;
     timestampSettings?: TimeFormatSettings;
     timestampLocale?: string;
@@ -77,23 +79,57 @@
     };
   });
 
-  function injectEditedMarker(html: string): string {
+  function injectMessageStateMarkers(
+    html: string,
+    { edited, echoedToChannel }: { edited: boolean; echoedToChannel: boolean }
+  ): string {
     const doc = parseTrustedMarkdownHtml(`<div>${html}</div>`);
     const root = doc.body.firstElementChild;
     if (!root) return html;
-    const badge = doc.createElement('span');
-    badge.className = 'edited-marker text-xs whitespace-nowrap text-muted/70';
-    badge.textContent = '(edited)';
+    const markers: HTMLElement[] = [];
+    if (edited) {
+      const badge = doc.createElement('span');
+      badge.className =
+        'edited-marker inline-block align-[-0.09em] leading-none whitespace-nowrap text-muted/70';
+      badge.setAttribute('role', 'img');
+      badge.setAttribute('aria-label', m('room.message.meta.edited'));
+      badge.setAttribute('title', m('room.message.meta.edited'));
+      const icon = doc.createElement('span');
+      icon.className = 'iconify icon-[uil--pen] text-[0.875em]';
+      icon.setAttribute('aria-hidden', 'true');
+      badge.appendChild(icon);
+      markers.push(badge);
+    }
+    if (echoedToChannel) {
+      const badge = doc.createElement('span');
+      badge.className =
+        'echoed-to-channel-marker inline-block align-[-0.09em] leading-none whitespace-nowrap text-muted/70';
+      badge.setAttribute('role', 'img');
+      badge.setAttribute('aria-label', m('room.message.meta.echoed_to_channel'));
+      badge.setAttribute('title', m('room.message.meta.echoed_to_channel'));
+      const icon = doc.createElement('span');
+      icon.className = 'iconify icon-[uil--megaphone] text-[0.875em]';
+      icon.setAttribute('aria-hidden', 'true');
+      badge.appendChild(icon);
+      markers.push(badge);
+    }
+    if (markers.length === 0) return html;
+
     // Only inline the marker into a trailing <p> so it flows with the last word.
     // For block-level last children (<pre>, <ul>, <blockquote>) fall back to a
     // separate trailing line so the marker doesn't get clipped or look misplaced.
     const last = root.lastElementChild;
     if (last && last.tagName === 'P') {
-      last.appendChild(doc.createTextNode(' '));
-      last.appendChild(badge);
+      for (const marker of markers) {
+        last.appendChild(doc.createTextNode(' '));
+        last.appendChild(marker);
+      }
     } else {
       const trailer = doc.createElement('p');
-      trailer.appendChild(badge);
+      for (const [index, marker] of markers.entries()) {
+        if (index > 0) trailer.appendChild(doc.createTextNode(' '));
+        trailer.appendChild(marker);
+      }
       root.appendChild(trailer);
     }
     return root.innerHTML;
@@ -105,6 +141,7 @@
     members: RoomMember[],
     roleHandles: string[],
     edited: boolean,
+    echoedToChannel: boolean,
     viewerLogin: string | undefined,
     timestampSettings: TimeFormatSettings,
     timestampLocale: string | undefined
@@ -116,7 +153,9 @@
       timestampSettings,
       timestampLocale ?? getLocale()
     );
-    return edited ? injectEditedMarker(withTimestamps) : withTimestamps;
+    return edited || echoedToChannel
+      ? injectMessageStateMarkers(withTimestamps, { edited, echoedToChannel })
+      : withTimestamps;
   }
 
   // Handle clicks on links (open in system browser) and mentions (trigger callback).
@@ -170,7 +209,16 @@
 </script>
 
 <div class="prose max-w-none min-w-0" dir="auto" role="presentation" onclick={handleContentClick}>
-  {#await render(body, members, roleHandles, edited, viewerLogin, timestampSettings, timestampLocale)}
+  {#await render(
+    body,
+    members,
+    roleHandles,
+    edited,
+    echoedToChannel,
+    viewerLogin,
+    timestampSettings,
+    timestampLocale
+  )}
     {body}
   {:then html}
     <MarkdownHtml {html} />

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -402,7 +402,7 @@ describe('MessageContent component', () => {
     expect(container.textContent).toContain('fsdfsd fsdffdsf');
   });
 
-  it('renders bold content followed immediately by text in edited messages', async () => {
+  it('appends an edited marker after inline message text', async () => {
     const { container } = render(MessageContent, {
       props: {
         body: 'fsdfsd **fsdf**fdsf',
@@ -412,7 +412,38 @@ describe('MessageContent component', () => {
 
     await expect.poll(() => q(container, 'strong')).toBeTruthy();
     expect(q(container, 'strong')?.textContent).toBe('fsdf');
-    expect(container.textContent).toContain('fsdfsd fsdffdsf (edited)');
+    const marker = q(container, '.edited-marker')!;
+    expect(marker.getAttribute('role')).toBe('img');
+    expect(marker.getAttribute('aria-label')).toBe('Edited message');
+    expect(marker.getAttribute('title')).toBe('Edited message');
+    expect(marker.querySelector('[class~="icon-[uil--pen]"]')).toBeTruthy();
+    expect(marker.classList).toContain('align-[-0.09em]');
+  });
+
+  it('appends an echoed-to-channel marker after inline message text', async () => {
+    const { container } = render(MessageContent, {
+      props: { body: 'Visible in the room', echoedToChannel: true }
+    });
+
+    await expect.poll(() => q(container, '.echoed-to-channel-marker')).toBeTruthy();
+    const marker = q(container, '.echoed-to-channel-marker')!;
+    expect(marker.getAttribute('role')).toBe('img');
+    expect(marker.getAttribute('aria-label')).toBe('Also sent to channel');
+    expect(marker.getAttribute('title')).toBe('Also sent to channel');
+    expect(marker.querySelector('[class~="icon-[uil--megaphone]"]')).toBeTruthy();
+    expect(marker.classList).toContain('align-[-0.09em]');
+    expect(marker.parentElement?.tagName).toBe('P');
+  });
+
+  it('places an echoed-to-channel marker in a trailing paragraph after block content', async () => {
+    const { container } = render(MessageContent, {
+      props: { body: '```\ncode\n```', echoedToChannel: true }
+    });
+
+    await expect.poll(() => q(container, '.echoed-to-channel-marker')).toBeTruthy();
+    const marker = q(container, '.echoed-to-channel-marker')!;
+    expect(marker.parentElement?.tagName).toBe('P');
+    expect(marker.parentElement?.previousElementSibling?.tagName).toBe('PRE');
   });
 
   it('renders message timestamp tokens as localized time elements', async () => {

--- a/apps/frontend/src/lib/components/messages/MessageView.svelte
+++ b/apps/frontend/src/lib/components/messages/MessageView.svelte
@@ -24,6 +24,7 @@ identity, body rendering, and row geometry consistent.
     body = null,
     deleted = false,
     edited = false,
+    echoedToChannel = false,
     viewerLogin,
     compact = false,
     avatarOffset = false,
@@ -61,6 +62,7 @@ identity, body rendering, and row geometry consistent.
     body?: string | null;
     deleted?: boolean;
     edited?: boolean;
+    echoedToChannel?: boolean;
     viewerLogin?: string;
     compact?: boolean;
     avatarOffset?: boolean;
@@ -203,6 +205,7 @@ identity, body rendering, and row geometry consistent.
             {members}
             {roleHandles}
             {edited}
+            {echoedToChannel}
             {viewerLogin}
             {timestampSettings}
             {timestampLocale}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte
@@ -245,6 +245,9 @@
     isRootMessage && ((messageEvent?.threadExists ?? false) || (messageEvent?.replyCount ?? 0) > 0)
   );
   const isInThreadPane = $derived(!!permalinkThreadRootEventId);
+  const isEchoedToChannel = $derived(
+    isInThreadPane && !isEcho && !!messageEvent?.channelEchoEventId
+  );
   const replyInRoomActionLabel = $derived(
     isEcho ? m('room.message.actions.reply_thread') : m('room.message.actions.reply')
   );
@@ -565,6 +568,7 @@
     body={msg.body}
     deleted={isDeleted}
     edited={isEdited}
+    echoedToChannel={isEchoedToChannel}
     viewerLogin={currentUser.user?.login}
     {compact}
     avatarOffset={!!replyPreview}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte.spec.ts
@@ -153,6 +153,33 @@ afterEach(() => {
 });
 
 describe('MessageEvent action model integration', () => {
+  it('shows an echoed-to-channel marker only for an echoed reply in the thread pane', async () => {
+    const reply = messageEvent({
+      id: 'thread-reply',
+      threadRootEventId: 'thread-root',
+      channelEchoEventId: 'echo-wrapper'
+    });
+    const rendered = render(MessageEventTestHarness, {
+      props: { event: reply, permalinkThreadRootEventId: 'thread-root' }
+    });
+
+    await expect.element(q(rendered.container, '.echoed-to-channel-marker')).toBeInTheDocument();
+
+    await rendered.rerender({
+      event: messageEvent({ id: 'thread-reply', threadRootEventId: 'thread-root' }),
+      permalinkThreadRootEventId: 'thread-root'
+    });
+    await expect.element(q(rendered.container, '.echoed-to-channel-marker')).not.toBeInTheDocument();
+
+    const echo = messageEvent({
+      id: 'echo-wrapper',
+      echoOfEventId: 'thread-reply',
+      echoFromThreadRootEventId: 'thread-root'
+    });
+    await rendered.rerender({ event: echo, permalinkThreadRootEventId: null });
+    await expect.element(q(rendered.container, '.echoed-to-channel-marker')).not.toBeInTheDocument();
+  });
+
   it('orders and constrains reply actions for each threading mode', async () => {
     const onOpenThread = vi.fn();
     const event = messageEvent({ threadExists: true });

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageViewActionTestSurface.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageViewActionTestSurface.svelte
@@ -4,6 +4,7 @@
   let {
     eventId,
     body,
+    echoedToChannel = false,
     oncontextmenu,
     onmousedown,
     onmouseup,
@@ -18,6 +19,7 @@
   }: {
     eventId: string;
     body?: string | null;
+    echoedToChannel?: boolean;
     oncontextmenu?: (event: MouseEvent) => void;
     onmousedown?: (event: MouseEvent) => void;
     onmouseup?: (event: MouseEvent) => void;
@@ -47,6 +49,9 @@
   {ontouchcancel}
 >
   <span data-testid="message-body" bind:this={bodyElement}>{body}</span>
+  {#if echoedToChannel}
+    <span class="echoed-to-channel-marker" role="img" aria-label="Also sent to channel"></span>
+  {/if}
   {@render afterBody?.()}
   {@render actions?.()}
 </div>

--- a/docs/fdr/FDR-003-thread-reply-echo.md
+++ b/docs/fdr/FDR-003-thread-reply-echo.md
@@ -1,7 +1,7 @@
 # FDR-003: Thread Reply Echo
 
 **Status:** Active
-**Last reviewed:** 2026-08-22
+**Last reviewed:** 2026-08-25
 
 ## Overview
 
@@ -12,6 +12,7 @@ When posting a reply inside a thread, the user can optionally "also send to chan
 - The thread pane composer shows an "Also send to channel" checkbox when the user has the right permission.
 - Ticking the checkbox and sending the reply produces two visible artifacts: the reply inside the thread pane, and a copy of the same message in the room timeline.
 - The checkbox resets to unchecked after each successful send.
+- A thread reply with an echo shows a megaphone icon after its text. The icon is not a control. It updates when the echo is added or removed.
 - The echo in the room timeline shows a "Thread" indicator below the body; clicking it opens the thread.
 - If the original reply was attributed to a specific message, the echo shows the same reply-attribution byline. Clicking the byline on the echo opens the thread and highlights the referenced message inside it.
 - Editing or deleting the original reply automatically affects the echo too — edit/delete events target the original reply, and read models apply the change to the linked echo.

--- a/docs/fdr/FDR-004-message-editing-and-deletion.md
+++ b/docs/fdr/FDR-004-message-editing-and-deletion.md
@@ -1,7 +1,7 @@
 # FDR-004: Message Editing & Deletion
 
 **Status:** Active
-**Last reviewed:** 2026-08-22
+**Last reviewed:** 2026-08-25
 
 ## Overview
 
@@ -12,6 +12,7 @@ Authors can edit and delete their own messages; users with `message.manage` can 
 - Authors can edit their own messages within a 3-hour window from posting time. After the window closes, only moderators can edit. The window value is queryable via `Server.messageEditWindowSeconds` so the frontend can show countdown timers and disable the edit affordance at exactly the right moment.
 - Only the message body text can be edited. Attachments aren't editable as text but can be removed individually.
 - Edited message bodies are capped at the same 10,000-byte limit as newly posted message bodies.
+- Edited messages show a pen icon after their text. The icon is not a control.
 - Deletions remove the message body and all attachments and initially replace the rendered message with a "[Message deleted]" placeholder.
 - Attachment bytes are deleted only when the durable asset owner is the exact message being changed; a duplicate reference left by an older vulnerable server is removed without damaging the owning message.
 - A deleted-message placeholder disappears after one hour when the message has no current attachments or link preview, reactions, or replies in its thread.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -12,8 +12,8 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 |---|---------|--------|---------------|
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-08-21 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-08-22 |
-| [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-08-22 |
-| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-22 |
+| [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-08-25 |
+| [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-25 |
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-08-20 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-08-20 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-08-19 |


### PR DESCRIPTION
## Why

Thread replies that were also sent to the room had no indication in the thread, and the text-only edited marker added visual noise.

## What changed

- Add aligned, accessible megaphone and pen markers after message text for echoed and edited messages.
- Update all complete frontend catalogs, browser test helpers, and FDRs for the visible state markers.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: unchanged.

Newer client → older server: unchanged.

Capability discovery or minimum client/server version: not applicable.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/components/MessageContent.svelte.spec.ts 'src/routes/chat/[serverId]/[roomId]/MessageEvent.svelte.spec.ts'` — passed (84 tests).
- `mise lint-frontend` — passed with 0 Svelte errors or warnings.
- `mise build-frontend` — passed, including bundle checks.
