### PR TITLE
fix(api)!: prevent bots from starting DMs

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -67,6 +67,13 @@ continues to authorize DM reads. New clients treat a missing `message.read`
 room-permission row from an older server as unsupported and keep the former
 membership-based channel-room navigation behavior.
 
+Chatto 0.5 also denies `RoomService.StartDM` to bot callers. This rule applies
+when the requested DM already exists. A human must start the DM, after which
+the bot can interact through its normal permissions. A bot integration that
+used `StartDM` must stop that call and use its room state or realtime events.
+During a mixed-replica rollout, an older replica can still accept the call.
+Upgrade all replicas before you depend on this boundary.
+
 This breaking realtime migration does not retire the `chatto.api.v1`
 ConnectRPC namespace. It remains Chatto's resource-oriented public integrations
 API. Do not replace explicit resource reads, pagination, mutation responses, or

--- a/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
@@ -54,6 +54,16 @@ owner must have the same effective grant at that scope. DM membership
 authorizes the bot to read that DM. Posting remains a separate `message.post`
 or `message.post-in-thread` decision.
 
+## Direct messages
+
+A bot cannot start a DM. This rule also prevents a bot from using
+`RoomService.StartDM` to get a self-DM or an existing DM. A permission grant
+cannot change the rule.
+
+A human can start a DM that includes the bot. DM membership then lets the bot
+read the complete DM. Grant `message.post` if the bot must send messages in
+that DM. The owner must also have `message.post`.
+
 ## Authenticate requests
 
 Send the key as an HTTP bearer credential to the same public API used by other

--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -73,7 +73,7 @@ Room-relevant permissions such as `message.read`, `message.post`, `message.attac
 | Permission                | Meaning                                                                                                                                                                         |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `message.read`            | Read channel-room message and thread content, attachments, message search results, typing indicators, and message-derived activity. Channel-room membership is also required. DM membership authorizes DM reads. Fresh servers allow this for `everyone`; existing servers are never backfilled. |
-| `message.post`            | Post root messages and start DMs. Explicitly establishing a channel-room root as a thread also requires `message.post-in-thread`.                                              |
+| `message.post`            | Post root messages. A human with this permission can also start DMs. A bot cannot start a DM. Explicitly establishing a channel-room root as a thread also requires `message.post-in-thread`. |
 | `message.post-in-thread`  | Post messages inside channel-room threads and, together with `message.post`, explicitly establish a root as a thread.                                                          |
 | `message.attach`          | Attach files to new messages. Fresh servers allow this for `everyone`; existing servers upgraded from older versions may need an operator grant if uploads should stay enabled. |
 | `message.manage`          | Edit or delete other users' messages. Authors can edit/delete their own messages without this permission.                                                                       |
@@ -191,6 +191,11 @@ DMs use the same permission names where they make sense, but private conversatio
 Each participant can read the complete DM. `message.read` grants and denials do
 not change DM access. Owners cannot read or moderate a DM that they are not
 part of.
+
+Only a human can start a DM. A bot cannot use `RoomService.StartDM`, even when
+it has `message.post` or the DM already exists. A human must start the DM. The
+bot can then use `message.post` and other applicable message permissions in
+that DM.
 
 ## Where to configure permissions
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -236,8 +236,10 @@ Result of joining all joinable rooms in one room group.
 
 ### StartDM
 
-Starts or fetches a direct-message room for the current user and the
-requested participant set. The caller must be allowed to start DMs.
+Starts or fetches a direct-message room for the current human user and the
+requested participant set. The caller must have message.post. A valid
+request from a bot receives PERMISSION_DENIED and cannot use this RPC to
+fetch an existing DM.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/StartDM
@@ -247,7 +249,9 @@ POST /api/connect/chatto.api.v1.RoomService/StartDM
 
 #### Input: StartDMRequest
 
-Request to start or fetch a direct-message room.
+Request to start or fetch a direct-message room for a human caller. A valid
+request from a bot receives PERMISSION_DENIED, including when the room
+already exists.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -136,6 +136,11 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   continues to authorize DM reads. Upgrade every replica before you rely on a
   channel-room deny or missing grant because older replicas enforce membership
   only.
+- Bot integrations must not call `RoomService.StartDM`. Chatto 0.5 denies this
+  operation to every bot, including when the DM already exists. A human must
+  start the DM before the bot can read or post in it. Upgrade every replica
+  before you depend on this boundary because an older replica can still accept
+  the call.
 - Remove `webserver.allowed_origins` and `webserver.oauth_redirect_origins` (or their
   environment-variable equivalents) from server configuration; those settings no longer
   exist. The 0.5 OAuth flow requires a CIMD or built-in `client_id`, so upgrade clients and

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1811,8 +1811,10 @@ Result of joining all joinable rooms in one room group.
 
 ### StartDM
 
-Starts or fetches a direct-message room for the current user and the
-requested participant set. The caller must be allowed to start DMs.
+Starts or fetches a direct-message room for the current human user and the
+requested participant set. The caller must have message.post. A valid
+request from a bot receives PERMISSION_DENIED and cannot use this RPC to
+fetch an existing DM.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/StartDM
@@ -1822,7 +1824,9 @@ POST /api/connect/chatto.api.v1.RoomService/StartDM
 
 #### Input: StartDMRequest
 
-Request to start or fetch a direct-message room.
+Request to start or fetch a direct-message room for a human caller. A valid
+request from a bot receives PERMISSION_DENIED, including when the room
+already exists.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/frontend/e2e/bots.test.ts
+++ b/apps/frontend/e2e/bots.test.ts
@@ -13,6 +13,18 @@ interface ListRoomsResponse {
   rooms?: Array<{ room?: { id?: string } }>;
 }
 
+interface ListBotsResponse {
+  bots?: Array<{ user?: { id?: string; login?: string } }>;
+}
+
+interface ViewerResponse {
+  user?: { profile?: { id?: string } };
+}
+
+interface StartDMResponse {
+  room?: { id?: string };
+}
+
 interface CreatedUserResponse {
   id?: string;
 }
@@ -53,25 +65,23 @@ async function captureShowOnceBotKey(page: Page): Promise<string> {
   return apiKey;
 }
 
-async function getRoomAsBot(
+async function callAsBot(
   serverURL: string,
   apiKey: string,
-  roomId: string
+  procedure: string,
+  body: Record<string, unknown>
 ): Promise<BotAPIResult> {
   // Use Node's fetch rather than page.request so the admin's browser cookies
   // cannot supply ambient authority and Playwright never records the key.
-  const response = await fetch(
-    new URL('/api/connect/chatto.api.v1.RoomDirectoryService/GetRoom', serverURL),
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiKey}`,
-        'Connect-Protocol-Version': '1',
-        'Content-Type': 'application/json'
-      },
-      body: JSON.stringify({ roomId })
-    }
-  );
+  const response = await fetch(new URL(`/api/connect/${procedure}`, serverURL), {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Connect-Protocol-Version': '1',
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify(body)
+  });
 
   let code: string | undefined;
   try {
@@ -86,6 +96,14 @@ async function getRoomAsBot(
   }
 
   return { status: response.status, ...(code ? { code } : {}) };
+}
+
+async function getRoomAsBot(
+  serverURL: string,
+  apiKey: string,
+  roomId: string
+): Promise<BotAPIResult> {
+  return callAsBot(serverURL, apiKey, 'chatto.api.v1.RoomDirectoryService/GetRoom', { roomId });
 }
 
 async function createHumanOwner(
@@ -145,6 +163,16 @@ test.describe('Bot account lifecycle', () => {
       page.getByRole('heading', { name: botDisplayName, exact: true, level: 1 })
     ).toBeVisible();
 
+    const listedBots = await connectPost<ListBotsResponse>(
+      page,
+      'chatto.api.v1.BotService/ListBots'
+    );
+    const botId = listedBots.bots?.find((bot) => bot.user?.login === botLogin)?.user?.id;
+    if (!botId) throw new Error('The new bot was not present in the bot directory');
+    const viewer = await connectPost<ViewerResponse>(page, 'chatto.api.v1.ViewerService/GetViewer');
+    const adminId = viewer.user?.profile?.id;
+    if (!adminId) throw new Error('The viewer response did not contain the admin user ID');
+
     await expect(getRoomAsBot(serverURL, originalKey, roomId)).resolves.toEqual({
       status: 403,
       code: 'permission_denied'
@@ -167,6 +195,47 @@ test.describe('Bot account lifecycle', () => {
     ).toBeVisible();
 
     await expect(getRoomAsBot(serverURL, originalKey, roomId)).resolves.toEqual({ status: 200 });
+
+    await permissionFilter.fill('message.post');
+    const disabledMessagePost = page.getByRole('button', {
+      name: 'message.post is Disabled for bot at Server',
+      exact: true
+    });
+    await expect(disabledMessagePost).toBeEnabled();
+    await disabledMessagePost.click();
+    await expect(
+      page.getByRole('button', {
+        name: 'message.post is Enabled for bot at Server',
+        exact: true
+      })
+    ).toBeVisible();
+
+    const startedDM = await connectPost<StartDMResponse>(
+      page,
+      'chatto.api.v1.RoomService/StartDM',
+      { participantIds: [botId] }
+    );
+    const dmRoomId = startedDM.room?.id;
+    if (!dmRoomId) throw new Error('The human-started bot DM did not return a room ID');
+
+    // A direct message.post grant lets the bot interact in an existing DM,
+    // but it cannot invoke StartDM even to retrieve that same DM or itself.
+    await expect(
+      callAsBot(serverURL, originalKey, 'chatto.api.v1.RoomService/StartDM', {
+        participantIds: [adminId]
+      })
+    ).resolves.toEqual({ status: 403, code: 'permission_denied' });
+    await expect(
+      callAsBot(serverURL, originalKey, 'chatto.api.v1.RoomService/StartDM', {
+        participantIds: []
+      })
+    ).resolves.toEqual({ status: 403, code: 'permission_denied' });
+    await expect(
+      callAsBot(serverURL, originalKey, 'chatto.api.v1.MessageService/CreateMessage', {
+        roomId: dmRoomId,
+        body: 'Bot reply in a human-started DM'
+      })
+    ).resolves.toEqual({ status: 200 });
 
     await page.getByRole('button', { name: 'Reassign owner', exact: true }).click();
     const reassignDialog = page.getByRole('dialog', { name: 'Reassign owner' });

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -258,6 +258,10 @@ authorization, live events, backup/restore, and backend tests.
   get moderation visibility into DM contents.
 - DM membership is the complete DM content-read boundary. `message.read`
   applies only to channel rooms. Do not add a second DM read gate.
+- A bot must never start or fetch a DM through `RoomService.StartDM`, even when
+  it has `message.post` or the DM already exists. A human must start the DM.
+  After that, the bot can read it through membership and can use its normal
+  message permissions inside it.
 - Permission strings use exactly `{object}.{verb}` with hyphenated verbs:
   `room.ban-member`, `message.post-in-thread`, `admin.view-users`.
 - Add permissions in Go first, regenerate frontend mirrors, and test scope and

--- a/cli/internal/connectapi/bots_test.go
+++ b/cli/internal/connectapi/bots_test.go
@@ -92,6 +92,9 @@ func TestBotServiceLifecycleAndCanonicalPermissionMatrix(t *testing.T) {
 	if apiCapabilityGranted(viewer.Msg.GetCapabilities().GetGrants(), viewerCapabilityAdminView) {
 		t.Fatal("bot unexpectedly granted admin.view capability")
 	}
+	if apiCapabilityGranted(viewer.Msg.GetCapabilities().GetGrants(), viewerCapabilityDMStart) {
+		t.Fatal("bot unexpectedly granted dm.start capability")
+	}
 
 	rotated, err := service.RotateBotApiKey(ctx, connect.NewRequest(&apiv1.RotateBotApiKeyRequest{BotUserId: bot.GetUser().GetId()}))
 	if err != nil || rotated.Msg.GetApiKey() == "" || rotated.Msg.GetApiKey() == created.Msg.GetApiKey() {

--- a/cli/internal/connectapi/room_services_test.go
+++ b/cli/internal/connectapi/room_services_test.go
@@ -510,6 +510,38 @@ func TestRoomServiceStartDM(t *testing.T) {
 	})); connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("StartDM denied user code = %v, want permission denied", connect.CodeOf(err))
 	}
+
+	bot, err := env.core.CreateBot(env.ctx, env.viewer.GetId(), "connect_dm_start_bot", "Connect DM Start Bot")
+	if err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+	if err := env.core.SetUserPermissionState(env.ctx, env.viewer.GetId(), bot.User.GetId(), core.PermissionTargetScope{Kind: core.MatrixScopeServer}, core.PermMessagePost, core.PermissionStateAllow); err != nil {
+		t.Fatalf("grant bot message.post: %v", err)
+	}
+	dmWithBot, err := env.rooms.StartDM(ctx, connect.NewRequest(&apiv1.StartDMRequest{
+		ParticipantIds: []string{bot.User.GetId()},
+	}))
+	if err != nil {
+		t.Fatalf("human StartDM with bot: %v", err)
+	}
+	botCtx := withCaller(env.ctx, bot.User)
+	for name, participantIDs := range map[string][]string{
+		"self":     nil,
+		"existing": {env.viewer.GetId()},
+	} {
+		t.Run("bot cannot start "+name+" DM", func(t *testing.T) {
+			if _, err := env.rooms.StartDM(botCtx, connect.NewRequest(&apiv1.StartDMRequest{
+				ParticipantIds: participantIDs,
+			})); connect.CodeOf(err) != connect.CodePermissionDenied {
+				t.Fatalf("bot StartDM code = %v, want permission denied", connect.CodeOf(err))
+			}
+		})
+	}
+	if _, err := env.messages.CreateMessage(botCtx, connect.NewRequest(&apiv1.CreateMessageRequest{
+		RoomId: dmWithBot.Msg.GetRoom().GetId(), Body: "bot reply in human-started DM",
+	})); err != nil {
+		t.Fatalf("bot CreateMessage in human-started DM: %v", err)
+	}
 }
 
 func TestRoomServiceRejectsDMRooms(t *testing.T) {

--- a/cli/internal/core/bots_test.go
+++ b/cli/internal/core/bots_test.go
@@ -532,6 +532,83 @@ func TestBotDMReadUsesMembershipInsteadOfDelegatedMessageRead(t *testing.T) {
 	}
 }
 
+func TestBotCannotStartDMButCanParticipateInHumanStartedDM(t *testing.T) {
+	c, _ := setupTestCore(t)
+	ctx := testContext(t)
+	owner, err := c.CreateUser(ctx, SystemActorID, "dm-start-owner", "DM Start Owner", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser owner: %v", err)
+	}
+	bot, err := c.CreateBot(ctx, owner.GetId(), "dm_start_bot", "DM Start Bot")
+	if err != nil {
+		t.Fatalf("CreateBot: %v", err)
+	}
+	participant, err := c.CreateUser(ctx, SystemActorID, "dm-start-participant", "DM Start Participant", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser participant: %v", err)
+	}
+	other, err := c.CreateUser(ctx, SystemActorID, "dm-start-other", "DM Start Other", "password123")
+	if err != nil {
+		t.Fatalf("CreateUser other: %v", err)
+	}
+	if allowed, err := c.CanStartDM(ctx, bot.User.GetId()); err != nil || allowed {
+		t.Fatalf("bot CanStartDM without message.post = %v, %v; want false, nil", allowed, err)
+	}
+	if err := c.SetUserPermissionState(ctx, owner.GetId(), bot.User.GetId(), PermissionTargetScope{Kind: MatrixScopeServer}, PermMessagePost, PermissionStateAllow); err != nil {
+		t.Fatalf("grant bot message.post: %v", err)
+	}
+	if allowed, err := c.CanStartDM(ctx, bot.User.GetId()); err != nil || allowed {
+		t.Fatalf("bot CanStartDM with message.post = %v, %v; want false, nil", allowed, err)
+	}
+	if allowed, err := c.CanStartDM(ctx, "missing-dm-actor"); allowed || !errors.Is(err, ErrNotFound) {
+		t.Fatalf("missing actor CanStartDM = %v, %v; want false, ErrNotFound", allowed, err)
+	}
+	for name, participantIDs := range map[string][]string{
+		"self":  nil,
+		"human": {participant.GetId()},
+		"group": {participant.GetId(), other.GetId()},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, _, err := c.RoomCommands().StartDM(ctx, RoomStartDMInput{
+				ActorID: bot.User.GetId(), ParticipantIDs: participantIDs,
+			}); !errors.Is(err, ErrPermissionDenied) {
+				t.Fatalf("bot StartDM error = %v, want ErrPermissionDenied", err)
+			}
+			roomID := DMRoomID(ensureInList(participantIDs, bot.User.GetId()))
+			if _, err := c.GetRoom(ctx, KindDM, roomID); err == nil {
+				t.Fatal("bot StartDM created a DM despite the account-kind invariant")
+			}
+		})
+	}
+
+	dm, created, err := c.RoomCommands().StartDM(ctx, RoomStartDMInput{
+		ActorID: participant.GetId(), ParticipantIDs: []string{bot.User.GetId()},
+	})
+	if err != nil {
+		t.Fatalf("human StartDM with bot: %v", err)
+	}
+	if !created {
+		t.Fatal("human StartDM with bot did not create the DM")
+	}
+	if _, _, err := c.RoomCommands().StartDM(ctx, RoomStartDMInput{
+		ActorID: bot.User.GetId(), ParticipantIDs: []string{participant.GetId()},
+	}); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("bot StartDM for existing DM error = %v, want ErrPermissionDenied", err)
+	}
+	reply, err := c.Messages().PostMessage(ctx, MessagePostInput{
+		ActorID: bot.User.GetId(), RoomID: dm.GetId(), Body: "bot reply in human-started DM",
+	})
+	if err != nil {
+		t.Fatalf("bot PostMessage in human-started DM: %v", err)
+	}
+	if reply.Event == nil {
+		t.Fatal("bot PostMessage returned no event")
+	}
+	if _, err := c.RoomTimelineReads().GetMessage(ctx, participant.GetId(), dm.GetId(), reply.Event.GetId()); err != nil {
+		t.Fatalf("human GetMessage for bot reply: %v", err)
+	}
+}
+
 func TestCanonicalUserPermissionManagementUsesBotAuthorization(t *testing.T) {
 	c, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/core/can.go
+++ b/cli/internal/core/can.go
@@ -79,11 +79,20 @@ func (c *ChattoCore) CanManageBots(ctx context.Context, userID string) (bool, er
 	return c.HasServerPermission(ctx, userID, PermBotManage)
 }
 
-// CanStartDM checks if a user can start DM conversations. DMs are allowed by
-// default for authenticated users, but an applicable server-scope
-// message.post deny still blocks the action. This keeps global suspension
-// roles effective without requiring a default server-scope message.post allow.
+// CanStartDM checks if a human user can start DM conversations. Bot accounts
+// can never start or fetch DMs through the creation operation, regardless of
+// their permissions. DMs are allowed by default for active human users, but an
+// applicable server-scope message.post deny still blocks the action. This
+// keeps global suspension roles effective without requiring a default
+// server-scope message.post allow.
 func (c *ChattoCore) CanStartDM(ctx context.Context, userID string) (bool, error) {
+	isBot, _, accountExists := c.userModel.isBotAndOwner(userID)
+	if !accountExists {
+		return false, ErrNotFound
+	}
+	if isBot {
+		return false, nil
+	}
 	decision, err := c.ResolveUserPermission(ctx, userID, KindDM, "", PermMessagePost)
 	if err != nil {
 		return false, err

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
@@ -114,8 +114,10 @@ type RoomServiceClient interface {
 	// Joins every unarchived room in a group that the current user can join.
 	// Already-joined and non-joinable rooms are skipped.
 	JoinRoomGroup(context.Context, *connect.Request[v1.JoinRoomGroupRequest]) (*connect.Response[v1.JoinRoomGroupResponse], error)
-	// Starts or fetches a direct-message room for the current user and the
-	// requested participant set. The caller must be allowed to start DMs.
+	// Starts or fetches a direct-message room for the current human user and the
+	// requested participant set. The caller must have message.post. A valid
+	// request from a bot receives PERMISSION_DENIED and cannot use this RPC to
+	// fetch an existing DM.
 	StartDM(context.Context, *connect.Request[v1.StartDMRequest]) (*connect.Response[v1.StartDMResponse], error)
 	// Leaves the room as the current user. Direct-message and universal rooms
 	// cannot be left.
@@ -509,8 +511,10 @@ type RoomServiceHandler interface {
 	// Joins every unarchived room in a group that the current user can join.
 	// Already-joined and non-joinable rooms are skipped.
 	JoinRoomGroup(context.Context, *connect.Request[v1.JoinRoomGroupRequest]) (*connect.Response[v1.JoinRoomGroupResponse], error)
-	// Starts or fetches a direct-message room for the current user and the
-	// requested participant set. The caller must be allowed to start DMs.
+	// Starts or fetches a direct-message room for the current human user and the
+	// requested participant set. The caller must have message.post. A valid
+	// request from a bot receives PERMISSION_DENIED and cannot use this RPC to
+	// fetch an existing DM.
 	StartDM(context.Context, *connect.Request[v1.StartDMRequest]) (*connect.Response[v1.StartDMResponse], error)
 	// Leaves the room as the current user. Direct-message and universal rooms
 	// cannot be left.

--- a/cli/internal/pb/chatto/api/v1/rooms.pb.go
+++ b/cli/internal/pb/chatto/api/v1/rooms.pb.go
@@ -904,7 +904,9 @@ func (x *JoinRoomGroupResponse) GetJoinedRoomIds() []string {
 	return nil
 }
 
-// Request to start or fetch a direct-message room.
+// Request to start or fetch a direct-message room for a human caller. A valid
+// request from a bot receives PERMISSION_DENIED, including when the room
+// already exists.
 type StartDMRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Other participants to include in the direct-message room. The current user

--- a/docs/adr/ADR-037-dm-access-via-membership.md
+++ b/docs/adr/ADR-037-dm-access-via-membership.md
@@ -20,7 +20,10 @@ Remove both DM-specific permission strings as product and authorization concepts
 - Reading a DM is allowed by room membership alone.
 - Listing DMs returns the DM rooms the caller participates in.
 - Live DM events are filtered by room membership, the same as channel-room events.
-- Starting a DM and sending root messages in DM rooms are gated by `message.post`.
+- A human can start a DM when `message.post` allows it. A bot cannot start or
+  fetch a DM through `RoomService.StartDM`, regardless of its permissions or
+  owner. All participants need `message.post` to send root messages in an
+  existing DM.
 - DMs do not support threads. This is a room-kind invariant enforced by the
   message operation model and low-level Core write path, not an RBAC decision.
   Flat reply attribution remains available in DMs.
@@ -31,6 +34,8 @@ This decision does not make DMs globally visible. It removes the redundant read 
 ## Consequences
 
 - Operators can still stop DM abuse by revoking `message.post`, suspending the user, or removing the account.
+- A human must start every DM that includes a bot. After that, membership
+  authorizes bot reads and the bot's normal permissions authorize interactions.
 - Users do not lose read access to conversations they are already part of because an operator toggled a broad server permission.
 - The authorization model becomes easier to explain: membership answers "can read this room?", while `message.*` permissions answer "can perform this messaging capability?"
 - Effective owners still resolve every permission through the owner override,

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -16,7 +16,8 @@ Chatto controls who can do what through role-based access control. Every authent
 - Permissions gate capabilities and channel-room message access. Channel-room
   membership is necessary for message reads, and `message.read` supplies the
   explicit read authority. DM membership authorizes DM reads. `message.post`
-  separately gates starting DMs and sending root messages.
+  separately gates root-message posting and lets human users start DMs. Bot
+  accounts cannot start DMs regardless of their permissions.
 - Server admins can drag-and-drop to reorder custom roles. System role positions are fixed for ordering consistency.
 - Custom role display names are limited to 80 bytes; descriptions are limited to 500 bytes.
 - Owners are always granted all permissions. An effective owner has the durable `owner` role; verified users listed in `owners.emails` in `chatto.toml` are materialized into that role at boot or through retryable durable work after verification.
@@ -104,7 +105,11 @@ The full permission catalog is in `cli/internal/core/permission.go`. Key permiss
   Existing servers are not backfilled or reconciled, so operators must add any
   wanted grants during upgrade. DM membership authorizes DM reads without this
   permission.
-- `message.post` — post root messages in rooms and start DMs. Fresh servers grant this to `everyone` at server scope; fresh announcement rooms replace that baseline with a room-level `everyone` deny and a room-level `admin` allow. Moderators and other named roles need their own room-level posting grant.
+- `message.post` — post root messages in rooms and let human users start DMs.
+  Bot accounts cannot start DMs. Fresh servers grant this permission to
+  `everyone` at server scope. Fresh announcement rooms replace that baseline
+  with a room-level `everyone` deny and a room-level `admin` allow. Moderators
+  and other named roles need their own room-level posting grant.
 - `message.attach` — attach files to new messages. Fresh servers grant this to `everyone` at server scope; existing servers are not automatically backfilled after upgrade, so operators may need to grant it manually if uploads should remain enabled.
 - `room.manage` — edit/configure/delete channel rooms.
 - `room.ban-member` — ban members from channel rooms. DM membership is not managed through this permission.

--- a/docs/fdr/FDR-007-direct-messages.md
+++ b/docs/fdr/FDR-007-direct-messages.md
@@ -121,4 +121,4 @@ viewer's effective permissions.
 ## Related
 
 - **ADRs:** ADR-033 (event-sourced state), ADR-034 (single event stream), ADR-037 (DM access via membership), ADR-076 (deterministic notification occurrences), ADR-077 (persistent notification list), ADR-080 (explicit message-read permissions)
-- **FDRs:** FDR-001 (Roles & Permissions), FDR-002 (Replies & Threads), FDR-012 (Notifications), FDR-039 (Message Access & Interactions)
+- **FDRs:** FDR-001 (Roles & Permissions), FDR-002 (Replies & Threads), FDR-012 (Notifications), FDR-038 (Bot Accounts), FDR-039 (Message Access & Interactions)

--- a/docs/fdr/FDR-007-direct-messages.md
+++ b/docs/fdr/FDR-007-direct-messages.md
@@ -5,13 +5,22 @@
 
 ## Overview
 
-Users can start a private, one-to-one conversation with anyone they can see in a server. They can also start a self-DM for personal notes. DMs are rooms with `kind: dm`: they use the same message, reaction, attachment, notification, unread, and live-delivery machinery as channel rooms, while applying a smaller DM-specific creation and privacy policy. Each Chatto server has its own DM scope; there is currently no cross-server "unified DM inbox".
+Human users can start a private, one-to-one conversation with anyone they can
+see in a server. They can also start a self-DM for personal notes. DMs are
+rooms with `kind: dm`. They use the same message, reaction, attachment,
+notification, unread, and live-delivery machinery as channel rooms. They also
+have a smaller DM-specific creation and privacy policy. Each Chatto server has
+its own DM scope. Chatto does not have a cross-server DM inbox.
 
 ## Behavior
 
 - A DM is started from user context menus inside the chat UI (member list clicks, @mention clicks, message author clicks).
 - Starting a DM with another user navigates to the resulting two-person DM room. If that conversation already exists, the user lands in it rather than creating a duplicate.
-- Users can start a DM with themselves. The product does not let users create group DMs, even though the underlying room model and public API can represent a larger fixed participant set.
+- Human users can start a DM with themselves. The product does not let users create group DMs, even though the underlying room model and public API can represent a larger fixed participant set.
+- A bot cannot call `RoomService.StartDM`. This rule applies to self-DMs, new
+  DMs, group DMs, and DMs that already exist. A human must start a DM that
+  includes a bot. The bot can then read the DM through membership and use its
+  normal message permissions in the DM.
 - Starting a DM creates the durable room and participant memberships immediately so the complete composer is available, but the empty conversation stays out of every participant's navigation until its first message is sent.
 - The bundled web client starts DMs through ConnectRPC `RoomService.StartDM`, which delegates to the shared core DM model.
 - DM rooms appear in the per-server room sidebar with their participants' names and avatars rather than a room name.
@@ -21,7 +30,8 @@ Users can start a private, one-to-one conversation with anyone they can see in a
 - Inside a DM room, the room extras sidebar is available but starts closed and does not show the Members panel. The current Files panel and future non-member panels are shared, while channel-style moderation actions such as banning/removing room members remain unavailable.
 - A user can read a DM only when they are a participant. `message.read` does
   not apply to DMs, and there is no `dm.*` read permission.
-- Operators can prevent a user from starting new DMs or sending messages in existing DMs by revoking `message.post`.
+- Operators can prevent a human user from starting DMs, or any user from
+  sending messages in existing DMs, by revoking `message.post`.
 - Operators cannot ban or remove participants from an existing DM room. Channel member bans are a `room.ban-member` action and are rejected for DMs.
 - Inside a DM room, ordinary message-related features apply: posting, flat reply attribution, reactions, edits, deletes, mentions, and attachments.
 - DMs do not support threads. The client does not offer thread actions, and the server rejects attempts to create or extend a DM thread even for owners. Thread data written by older versions remains readable but read-only.
@@ -38,9 +48,10 @@ Users can start a private, one-to-one conversation with anyone they can see in a
 ### 2. Membership authorizes DM reads
 
 **Decision:** DM membership authorizes complete DM reads for humans and bots.
-`message.read` grants and denials do not change DM access. Starting DMs and
-posting messages in them use `message.post`. Reply attribution does not change
-that permission, and thread posting does not apply to DMs.
+`message.read` grants and denials do not change DM access. A human needs
+`message.post` to start a DM. All users need `message.post` to post messages in
+an existing DM. Reply attribution does not change that permission, and thread
+posting does not apply to DMs.
 **Why:** Membership is the fixed private participant boundary. Chatto has no
 permission UI for one DM, and hiding a DM from its participant is surprising.
 See ADR-037 and ADR-080.
@@ -86,9 +97,20 @@ message. Self-DMs do not notify their author, and ordinary DMs default to Alert.
 **Why:** Early creation keeps routing, permissions, attachments, previews, and the ordinary room composer simple while avoiding an unsolicited empty conversation in another participant's UI.
 **Tradeoff:** Empty DM rooms remain in durable history and authorized client state even though they are absent from navigation. This small amount of latent state avoids a separate draft-conversation model and disappears automatically from presentation after replay.
 
+### 8. Only humans can start DMs
+
+**Decision:** A bot cannot call `RoomService.StartDM`. No permission or owner
+override can change this rule. A human must start a DM that includes a bot.
+**Why:** A bot must not create an unsolicited private conversation. A bot does
+not need the start operation to participate after a human creates the DM.
+**Tradeoff:** A bot cannot use the idempotent start operation to get the room
+for an existing DM. It must learn the room from its normal room state or
+realtime events.
+
 ## Permissions
 
-- `message.post` — start DMs and send messages in DM rooms.
+- `message.post` — let a human start DMs, and let a human or bot send messages
+  in existing DM rooms.
 - `message.react` — add and remove reactions in DM rooms.
 
 DMs have no `dm.*` permissions. Membership authorizes reads. Message-action and

--- a/docs/fdr/FDR-038-bot-accounts.md
+++ b/docs/fdr/FDR-038-bot-accounts.md
@@ -51,6 +51,10 @@ exercise more authority than its human owner currently possesses.
 - Channel-room membership does not give a bot message content. The bot needs an
   explicit `message.read` grant, bounded by the same permission on its owner.
   DM membership authorizes the bot to read that DM.
+- A bot cannot start or fetch a DM through `RoomService.StartDM`, even if it
+  has `message.post` or the DM already exists. A human must start a DM that
+  includes the bot. The bot can then interact in that DM through its normal
+  message permissions.
 - Bot permissions are granted explicitly at their applicable server, room
   group, or room scope. The bot's effective permission is allowed only when
   both the bot's allowlist and its owner's current effective permissions allow
@@ -207,6 +211,18 @@ across existing and future surfaces.
 **Tradeoff:** Older clients that do not understand the additive bot marker will
 render a bot like an ordinary user until they are upgraded.
 
+### 9. Bots cannot start DMs
+
+**Decision:** Bot account kind always denies `RoomService.StartDM`. This rule
+applies before RBAC and has no owner override. A human can start a DM with a
+bot, after which DM membership and normal message permissions apply.
+**Why:** An automation credential must not create an unsolicited private
+conversation. The account-kind rule is visible and cannot be enabled by an
+incorrect permission grant.
+**Tradeoff:** A bot cannot use the idempotent start operation to get an
+existing DM. It must use the room state that Chatto sends after a human starts
+the DM.
+
 ## Permissions
 
 - `bot.create` — create bot accounts and become their owner.
@@ -249,6 +265,10 @@ override, but bots themselves cannot exercise bot-management operations.
   bot. A binary predating the ownership event cannot project the new owner, so
   rolling back after ownership writes requires a binary that understands the
   event.
+- Chatto 0.5 denies `RoomService.StartDM` to bot callers. This behavior is a
+  breaking authorization change for an integration that used this RPC. During
+  a mixed-replica rollout, an older replica can still accept the call. Upgrade
+  all replicas before you depend on this boundary.
 
 ## Related
 

--- a/docs/fdr/FDR-038-bot-accounts.md
+++ b/docs/fdr/FDR-038-bot-accounts.md
@@ -277,9 +277,10 @@ override, but bots themselves cannot exercise bot-management operations.
   with owner override), ADR-045 (public API stability tiers), ADR-046 (typed
   runtime credentials), ADR-052 (subject-specific RBAC), ADR-080 (explicit
   message-read permissions)
-- **FDRs:** FDR-001 (Roles & Permissions), FDR-018 (Account Lifecycle), FDR-022
-  (User Profile), FDR-023 (Authentication & Sessions), FDR-025 (User Search &
-  Member Directory), FDR-039 (Message Access & Interactions)
+- **FDRs:** FDR-001 (Roles & Permissions), FDR-007 (Direct Messages), FDR-018
+  (Account Lifecycle), FDR-022 (User Profile), FDR-023 (Authentication &
+  Sessions), FDR-025 (User Search & Member Directory), FDR-039 (Message Access
+  & Interactions)
 
 ## Open Questions
 

--- a/packages/api-types/src/chatto/api/v1/rooms_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_connect.ts
@@ -95,8 +95,10 @@ export const RoomService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Starts or fetches a direct-message room for the current user and the
-     * requested participant set. The caller must be allowed to start DMs.
+     * Starts or fetches a direct-message room for the current human user and the
+     * requested participant set. The caller must have message.post. A valid
+     * request from a bot receives PERMISSION_DENIED and cannot use this RPC to
+     * fetch an existing DM.
      *
      * @generated from rpc chatto.api.v1.RoomService.StartDM
      */

--- a/packages/api-types/src/chatto/api/v1/rooms_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_pb.ts
@@ -785,7 +785,9 @@ export class JoinRoomGroupResponse extends Message<JoinRoomGroupResponse> {
 }
 
 /**
- * Request to start or fetch a direct-message room.
+ * Request to start or fetch a direct-message room for a human caller. A valid
+ * request from a bot receives PERMISSION_DENIED, including when the room
+ * already exists.
  *
  * @generated from message chatto.api.v1.StartDMRequest
  */

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -164,7 +164,9 @@ message JoinRoomGroupResponse {
   repeated string joined_room_ids = 1;
 }
 
-// Request to start or fetch a direct-message room.
+// Request to start or fetch a direct-message room for a human caller. A valid
+// request from a bot receives PERMISSION_DENIED, including when the room
+// already exists.
 message StartDMRequest {
   // Other participants to include in the direct-message room. The current user
   // is always included by the server. An empty list creates or fetches the
@@ -420,8 +422,10 @@ service RoomService {
   // Joins every unarchived room in a group that the current user can join.
   // Already-joined and non-joinable rooms are skipped.
   rpc JoinRoomGroup(JoinRoomGroupRequest) returns (JoinRoomGroupResponse);
-  // Starts or fetches a direct-message room for the current user and the
-  // requested participant set. The caller must be allowed to start DMs.
+  // Starts or fetches a direct-message room for the current human user and the
+  // requested participant set. The caller must have message.post. A valid
+  // request from a bot receives PERMISSION_DENIED and cannot use this RPC to
+  // fetch an existing DM.
   rpc StartDM(StartDMRequest) returns (StartDMResponse);
   // Leaves the room as the current user. Direct-message and universal rooms
   // cannot be left.


### PR DESCRIPTION
## Why

A bot must not create an unsolicited private conversation. A direct or owner-derived permission must not bypass that account boundary. Humans must remain able to start DMs with bots, and bots must remain able to participate after that human action.

## What changed

- deny `RoomService.StartDM` to every bot account before RBAC can authorize it
- keep human-created bot DMs readable through membership and usable through the bot's normal message permissions
- expose `dm.start` as unavailable to bot viewers and cover the invariant through Core, ConnectRPC, and bearer-key E2E tests
- update the public RPC comments, generated API reference, FDRs, ADR, integration guidance, permissions guide, and 0.5.0 upgrade notes

## API compatibility

This is a breaking authorization change to the experimental `chatto.api.v1.RoomService.StartDM` API.

- Older bot client → newer server: a valid `StartDM` call receives `PERMISSION_DENIED`, including when the requested DM already exists. The integration must stop making this call and consume normal room state or realtime events after a human starts the DM.
- Newer client → older server: request and response shapes are unchanged, so the client remains wire-compatible. An older server can still accept a bot `StartDM` call and does not enforce the boundary.
- Human clients are unchanged. The existing `dm.start` viewer capability is false for bots; this PR adds no capability-discovery field.

Operators must upgrade all replicas before they depend on this security boundary. The change adds no protobuf field, persisted event, or migration. Public comments, generated clients, generated API reference pages, integration guidance, and 0.5.0 upgrade notes document the behavior.

## Test plan

- `mise test-cli`
- `mise test-frontend`
- `mise lint`
- `mise test-e2e` (663 passed; two unrelated timing tests passed on retry and were reported as flaky)
- focused Core and ConnectRPC bot-DM tests
- focused `e2e/bots.test.ts` bearer-key test without retries
- `mise codegen-proto`
- docs website production build
- `mise license-check`
- public API Buf breaking check against `origin/main`

Repository-wide and `rooms.proto`-scoped Buf lint are not green at the current base because of existing enum, `go_package`, and RPC request/response naming violations. This PR does not add a lint violation.

## Decisions and tracking

- [FDR-007: Direct Messages](https://github.com/chattocorp/chatto/blob/5f6f837d985f5b67bc1eac383f2cf43132f15154/docs/fdr/FDR-007-direct-messages.md)
- [FDR-038: Bot Accounts](https://github.com/chattocorp/chatto/blob/5f6f837d985f5b67bc1eac383f2cf43132f15154/docs/fdr/FDR-038-bot-accounts.md)
- [ADR-037: DM Access via Membership](https://github.com/chattocorp/chatto/blob/5f6f837d985f5b67bc1eac383f2cf43132f15154/docs/adr/ADR-037-dm-access-via-membership.md)
- Part of #2089.
