### PR TITLE
fix(notifications): avoid authorization fence events

### DIFF
--- a/cli/internal/core/notification_policy.go
+++ b/cli/internal/core/notification_policy.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
@@ -13,7 +12,6 @@ import (
 
 	"hmans.de/chatto/internal/evtstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
-	"hmans.de/chatto/pkg/events"
 )
 
 // NotificationPolicyScopeKind identifies one supported notification-policy
@@ -314,13 +312,13 @@ func (s *NotificationPolicyModel) getScopedNotificationPolicyCurrent(ctx context
 	switch scope.Kind {
 	case NotificationPolicyScopeServer:
 	case NotificationPolicyScopeRoomGroup:
-		if _, err := s.prepareRoomGroupAccess(ctx, scope.ID); err != nil {
+		if err := s.checkRoomGroupAccess(ctx, scope.ID); err != nil {
 			return nil, err
 		}
 		group = s.core.configModel.notificationRoomGroupModes(actorID, scope.ID)
 		overrides = group
 	case NotificationPolicyScopeRoom:
-		if _, err := s.prepareRoomAccess(ctx, actorID, scope.ID); err != nil {
+		if err := s.checkRoomAccess(ctx, actorID, scope.ID); err != nil {
 			return nil, err
 		}
 		groupID := s.core.roomModel.roomGroupForRoom(scope.ID)
@@ -416,14 +414,9 @@ func (s *NotificationPolicyModel) UpdateScopedNotificationPolicy(ctx context.Con
 		return s.GetScopedNotificationPolicy(ctx, actorID, scope)
 	}
 
-	for attempt := 0; attempt < maxConfigUpdateRetries; attempt++ {
-		authorizationSeq, err := s.prepareScopedResourceAccess(ctx, actorID, scope)
-		if err != nil {
+	err := s.core.configModel.updateSubject(ctx, actorID, func(_ evtstream.Aggregate, _ string, _ uint64) ([]*corev1.Event, error) {
+		if err := s.checkScopedResourceAccess(ctx, actorID, scope); err != nil {
 			return nil, err
-		}
-		agg, filter, expectedSeq, err := s.core.configModel.prepareSubject(ctx, actorID)
-		if err != nil {
-			return nil, fmt.Errorf("prepare scoped notification policy: %w", err)
 		}
 		current := s.notificationModesForScope(actorID, scope)
 		next, err := applyNotificationDeliveryModesPatch(current, patch, mask)
@@ -431,50 +424,14 @@ func (s *NotificationPolicyModel) UpdateScopedNotificationPolicy(ctx context.Con
 			return nil, err
 		}
 		if proto.Equal(current, next) {
-			unchanged, err := s.core.configModel.subjectSequenceUnchanged(ctx, filter, expectedSeq)
-			if err != nil {
-				return nil, fmt.Errorf("revalidate room notification policy: %w", err)
-			}
-			if unchanged {
-				// Recheck access at the no-op linearization boundary. A no-op has
-				// no authorization-fenced append to perform this validation for us.
-				if _, err := s.prepareScopedResourceAccess(ctx, actorID, scope); err != nil {
-					return nil, err
-				}
-				return s.GetScopedNotificationPolicy(ctx, actorID, scope)
-			}
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
-			}
-			continue
+			return nil, nil
 		}
-		event := scopedNotificationPolicyChangedEvent(actorID, scope, next)
-		subject := agg.SubjectFor(event)
-		seqs, err := s.core.appendAuthorizationFencedBatch(ctx, actorID, []evtstream.BatchEntry{{
-			Subject: subject, Event: event, HasOCC: true, ExpectedSeq: expectedSeq, FilterSubject: filter,
-		}}, authorizationSeq)
-		if errors.Is(err, events.ErrConflict) {
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(time.Duration(1<<attempt) * time.Millisecond):
-			}
-			continue
-		}
-		if err != nil {
-			return nil, fmt.Errorf("update scoped notification policy: %w", err)
-		}
-		if len(seqs) == 0 {
-			return nil, errors.New("scoped notification policy committed no event")
-		}
-		if err := s.core.configModel.waitFor(ctx, events.SubjectPosition(subject, seqs[0])); err != nil {
-			return nil, fmt.Errorf("wait for scoped notification policy: %w", err)
-		}
-		return s.GetScopedNotificationPolicy(ctx, actorID, scope)
+		return []*corev1.Event{scopedNotificationPolicyChangedEvent(actorID, scope, next)}, nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("update scoped notification policy: %w", err)
 	}
-	return nil, ErrConfigConflict
+	return s.GetScopedNotificationPolicy(ctx, actorID, scope)
 }
 
 func validateNotificationPolicyScope(scope NotificationPolicyScope) error {
@@ -527,72 +484,68 @@ func scopedNotificationPolicyChangedEvent(actorID string, scope NotificationPoli
 	}})
 }
 
-func (s *NotificationPolicyModel) prepareScopedResourceAccess(ctx context.Context, actorID string, scope NotificationPolicyScope) (uint64, error) {
+func (s *NotificationPolicyModel) checkScopedResourceAccess(ctx context.Context, actorID string, scope NotificationPolicyScope) error {
 	if scope.Kind == NotificationPolicyScopeRoomGroup {
-		return s.prepareRoomGroupAccess(ctx, scope.ID)
+		return s.checkRoomGroupAccess(ctx, scope.ID)
 	}
-	return s.prepareRoomAccess(ctx, actorID, scope.ID)
+	return s.checkRoomAccess(ctx, actorID, scope.ID)
 }
 
-// prepareRoomGroupAccess captures the authorization fence shared by room-group
-// deletion, waits for the group aggregate, and confirms current existence.
-func (s *NotificationPolicyModel) prepareRoomGroupAccess(ctx context.Context, groupID string) (uint64, error) {
-	authorizationSeq, err := s.core.authorizationFenceSeq(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("capture notification policy room-group fence: %w", err)
-	}
+// checkRoomGroupAccess waits for the group aggregate and confirms current
+// existence. Policy changes use request-time scope validation because they can
+// change only the authenticated user's preferences; a preference that races a
+// group deletion is harmless and becomes inert.
+func (s *NotificationPolicyModel) checkRoomGroupAccess(ctx context.Context, groupID string) error {
 	position, err := s.core.EventPublisher.LastSubjectPosition(ctx, evtstream.GroupAggregate(groupID).AllEventsFilter())
 	if err != nil {
-		return 0, fmt.Errorf("capture notification policy room-group boundary: %w", err)
+		return fmt.Errorf("capture notification policy room-group boundary: %w", err)
 	}
 	if err := s.core.roomModel.waitForGroupLayout(ctx, position); err != nil {
-		return 0, fmt.Errorf("wait for notification policy room-group boundary: %w", err)
+		return fmt.Errorf("wait for notification policy room-group boundary: %w", err)
 	}
 	if _, err := s.core.GetRoomGroup(ctx, groupID); err != nil {
-		return 0, err
+		return err
 	}
-	return authorizationSeq, nil
+	return nil
 }
 
-// prepareRoomAccess returns the authorization-fence position that must remain
-// unchanged through a room-scoped policy write.
-func (s *NotificationPolicyModel) prepareRoomAccess(ctx context.Context, actorID, roomID string) (uint64, error) {
-	authorizationSeq, err := s.core.authorizationFenceSeq(ctx)
-	if err != nil {
-		return 0, fmt.Errorf("capture notification policy authorization fence: %w", err)
-	}
+// checkRoomAccess waits for the projections that define current effective room
+// membership, then confirms that the authenticated user is a member. Policy
+// changes use request-time membership semantics because they affect only that
+// user's preferences.
+func (s *NotificationPolicyModel) checkRoomAccess(ctx context.Context, actorID, roomID string) error {
 	roomPosition, err := s.core.EventPublisher.LastSubjectPosition(ctx, evtstream.RoomAggregate(roomID).AllEventsFilter())
 	if err != nil {
-		return 0, fmt.Errorf("capture notification policy room boundary: %w", err)
+		return fmt.Errorf("capture notification policy room boundary: %w", err)
 	}
 	groupPosition, err := s.core.EventPublisher.LastSubjectPosition(ctx, evtstream.GroupSubjectFilter())
 	if err != nil {
-		return 0, fmt.Errorf("capture notification policy group boundary: %w", err)
+		return fmt.Errorf("capture notification policy group boundary: %w", err)
 	}
 	rbacPosition, err := s.core.EventPublisher.LastSubjectPosition(ctx, evtstream.RBACSubjectFilter())
 	if err != nil {
-		return 0, fmt.Errorf("capture notification policy RBAC boundary: %w", err)
+		return fmt.Errorf("capture notification policy RBAC boundary: %w", err)
 	}
 	userPosition, err := s.core.EventPublisher.LastSubjectPosition(ctx, evtstream.UserAggregate(actorID).AllEventsFilter())
 	if err != nil {
-		return 0, fmt.Errorf("capture notification policy user boundary: %w", err)
+		return fmt.Errorf("capture notification policy user boundary: %w", err)
 	}
 	if err := s.core.roomModel.waitForDirectory(ctx, roomPosition); err != nil {
-		return 0, fmt.Errorf("wait for notification policy room boundary: %w", err)
+		return fmt.Errorf("wait for notification policy room boundary: %w", err)
 	}
 	if err := s.core.roomModel.waitForGroupLayout(ctx, groupPosition); err != nil {
-		return 0, fmt.Errorf("wait for notification policy group boundary: %w", err)
+		return fmt.Errorf("wait for notification policy group boundary: %w", err)
 	}
 	if err := s.core.rbacModel.waitFor(ctx, rbacPosition); err != nil {
-		return 0, fmt.Errorf("wait for notification policy RBAC boundary: %w", err)
+		return fmt.Errorf("wait for notification policy RBAC boundary: %w", err)
 	}
 	if err := s.core.userModel.waitForUsers(ctx, userPosition); err != nil {
-		return 0, fmt.Errorf("wait for notification policy user boundary: %w", err)
+		return fmt.Errorf("wait for notification policy user boundary: %w", err)
 	}
 	if err := s.requireRoomMember(ctx, actorID, roomID); err != nil {
-		return 0, err
+		return err
 	}
-	return authorizationSeq, nil
+	return nil
 }
 
 func (s *NotificationPolicyModel) requireRoomMember(ctx context.Context, actorID, roomID string) error {

--- a/cli/internal/core/notification_policy_test.go
+++ b/cli/internal/core/notification_policy_test.go
@@ -159,210 +159,75 @@ func TestGetNotificationPolicyWaitsForCurrentConfigProjection(t *testing.T) {
 	}
 }
 
-func TestSetRoomNotificationPolicyConflictsWithConcurrentMembershipLoss(t *testing.T) {
+func TestScopedNotificationPolicyUpdateRequiresCurrentScopeAccess(t *testing.T) {
 	chattoCore, _ := setupTestCore(t)
 	ctx := testContext(t)
-	user, err := chattoCore.CreateUser(ctx, SystemActorID, "policy-write-fence-user", "Policy Write Fence User", "password")
+	user, err := chattoCore.CreateUser(ctx, SystemActorID, "policy-access-user", "Policy Access User", "password")
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
-	room, err := chattoCore.CreateRoom(ctx, user.Id, KindChannel, "", "policy-write-fence-room", "")
+	other, err := chattoCore.CreateUser(ctx, SystemActorID, "policy-access-other", "Policy Access Other", "password")
+	if err != nil {
+		t.Fatalf("CreateUser other: %v", err)
+	}
+	room, err := chattoCore.CreateRoom(ctx, other.Id, KindChannel, "", "policy-access-room", "")
 	if err != nil {
 		t.Fatalf("CreateRoom: %v", err)
 	}
-	if _, err := chattoCore.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
-		t.Fatalf("JoinRoom: %v", err)
-	}
-	// Seed a config fact so replacing the config projector gives us a
-	// deterministic pause after room access has been checked but before append.
-	if _, err := chattoCore.NotificationPolicy().SetServerNotificationMode(ctx, user.Id,
-		notificationTestSignalReaction,
-		corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_PUSH_NOTIFICATION,
-	); err != nil {
-		t.Fatalf("SetServerNotificationMode: %v", err)
-	}
-	delayedConfig := evtstream.NewProjectionHandle(
-		chattoCore.js,
-		chattoCore.storage.serverEvtStream,
-		NewConfigProjection(),
-		testCoreLogger(),
-	)
-	chattoCore.configModel = NewConfigModel(chattoCore.EventPublisher, delayedConfig)
+	patch := &corev1.NotificationDeliveryModes{Reactions: corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_OFF.Enum()}
+	mask := &fieldmaskpb.FieldMask{Paths: []string{"reactions"}}
 
-	result := make(chan error, 1)
-	go func() {
-		_, err := chattoCore.NotificationPolicy().SetRoomNotificationMode(ctx, user.Id, room.Id,
-			notificationTestSignalReaction,
-			corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_OFF,
-		)
-		result <- err
-	}()
-	select {
-	case early := <-result:
-		t.Fatalf("SetRoomNotificationMode returned before delayed config projection started: %v", early)
-	case <-time.After(50 * time.Millisecond):
+	if _, err := chattoCore.NotificationPolicy().UpdateScopedNotificationPolicy(ctx, user.Id,
+		NotificationPolicyScope{Kind: NotificationPolicyScopeRoom, ID: room.Id}, patch, mask,
+	); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("room policy update error = %v, want ErrPermissionDenied", err)
 	}
-	if err := chattoCore.LeaveRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
-		t.Fatalf("LeaveRoom: %v", err)
-	}
-
-	runCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- delayedConfig.Projector().Run(runCtx) }()
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			t.Fatal("delayed config projector did not stop")
-		}
-	})
-	select {
-	case err := <-result:
-		if !errors.Is(err, ErrPermissionDenied) {
-			t.Fatalf("SetRoomNotificationMode after concurrent leave error = %v, want ErrPermissionDenied", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("SetRoomNotificationMode did not finish after config projection caught up")
-	}
-	if got := chattoCore.configModel.notificationRoomMode(user.Id, room.Id, notificationTestSignalReaction); got != corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_UNSPECIFIED {
-		t.Fatalf("room preference after rejected write = %v, want unspecified", got)
+	if _, err := chattoCore.NotificationPolicy().UpdateScopedNotificationPolicy(ctx, user.Id,
+		NotificationPolicyScope{Kind: NotificationPolicyScopeRoomGroup, ID: "missing-group"}, patch, mask,
+	); !errors.Is(err, ErrRoomGroupNotFound) {
+		t.Fatalf("room-group policy update error = %v, want ErrRoomGroupNotFound", err)
 	}
 }
 
-func TestSetRoomNotificationPolicyConflictsWithConcurrentRoomDeletion(t *testing.T) {
+func TestScopedNotificationPolicyUpdatesDoNotAdvanceAuthorizationFence(t *testing.T) {
 	chattoCore, _ := setupTestCore(t)
 	ctx := testContext(t)
-	user, err := chattoCore.CreateUser(ctx, SystemActorID, "policy-delete-fence-user", "Policy Delete Fence User", "password")
+	user, err := chattoCore.CreateUser(ctx, SystemActorID, "policy-no-fence-user", "Policy No Fence User", "password")
 	if err != nil {
 		t.Fatalf("CreateUser: %v", err)
 	}
-	room, err := chattoCore.CreateRoom(ctx, user.Id, KindChannel, "", "policy-delete-fence-room", "")
-	if err != nil {
-		t.Fatalf("CreateRoom: %v", err)
-	}
-	if _, err := chattoCore.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
-		t.Fatalf("JoinRoom: %v", err)
-	}
-	if _, err := chattoCore.NotificationPolicy().SetServerNotificationMode(ctx, user.Id,
-		notificationTestSignalReaction,
-		corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_PUSH_NOTIFICATION,
-	); err != nil {
-		t.Fatalf("SetServerNotificationMode: %v", err)
-	}
-	delayedConfig := evtstream.NewProjectionHandle(
-		chattoCore.js,
-		chattoCore.storage.serverEvtStream,
-		NewConfigProjection(),
-		testCoreLogger(),
-	)
-	chattoCore.configModel = NewConfigModel(chattoCore.EventPublisher, delayedConfig)
-
-	result := make(chan error, 1)
-	go func() {
-		_, err := chattoCore.NotificationPolicy().SetRoomNotificationMode(ctx, user.Id, room.Id,
-			notificationTestSignalReaction,
-			corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_OFF,
-		)
-		result <- err
-	}()
-	select {
-	case early := <-result:
-		t.Fatalf("SetRoomNotificationMode returned before delayed config projection started: %v", early)
-	case <-time.After(50 * time.Millisecond):
-	}
-	if err := chattoCore.DeleteRoom(ctx, user.Id, KindChannel, room.Id); err != nil {
-		t.Fatalf("DeleteRoom: %v", err)
-	}
-
-	runCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- delayedConfig.Projector().Run(runCtx) }()
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			t.Fatal("delayed config projector did not stop")
-		}
-	})
-	select {
-	case err := <-result:
-		if !errors.Is(err, ErrNotFound) {
-			t.Fatalf("SetRoomNotificationMode after concurrent deletion error = %v, want ErrNotFound", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("SetRoomNotificationMode did not finish after config projection caught up")
-	}
-	if got := chattoCore.configModel.notificationRoomMode(user.Id, room.Id, notificationTestSignalReaction); got != corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_UNSPECIFIED {
-		t.Fatalf("room preference after rejected write = %v, want unspecified", got)
-	}
-}
-
-func TestSetRoomGroupNotificationPolicyConflictsWithConcurrentGroupDeletion(t *testing.T) {
-	chattoCore, _ := setupTestCore(t)
-	ctx := testContext(t)
-	user, err := chattoCore.CreateUser(ctx, SystemActorID, "group-policy-delete-fence-user", "Group Policy Delete Fence User", "password")
-	if err != nil {
-		t.Fatalf("CreateUser: %v", err)
-	}
-	group, err := chattoCore.CreateRoomGroup(ctx, SystemActorID, "Group Policy Delete Fence", "")
+	group, err := chattoCore.CreateRoomGroup(ctx, SystemActorID, "Policy No Fence Group", "")
 	if err != nil {
 		t.Fatalf("CreateRoomGroup: %v", err)
 	}
-	if _, err := chattoCore.NotificationPolicy().SetServerNotificationMode(ctx, user.Id,
-		notificationTestSignalReaction,
-		corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_PUSH_NOTIFICATION,
-	); err != nil {
-		t.Fatalf("SetServerNotificationMode: %v", err)
+	room, err := chattoCore.CreateRoom(ctx, SystemActorID, KindChannel, group.Id, "policy-no-fence-room", "")
+	if err != nil {
+		t.Fatalf("CreateRoom: %v", err)
 	}
-	delayedConfig := evtstream.NewProjectionHandle(
-		chattoCore.js,
-		chattoCore.storage.serverEvtStream,
-		NewConfigProjection(),
-		testCoreLogger(),
-	)
-	chattoCore.configModel = NewConfigModel(chattoCore.EventPublisher, delayedConfig)
-
-	result := make(chan error, 1)
-	go func() {
-		_, err := chattoCore.NotificationPolicy().UpdateScopedNotificationPolicy(ctx, user.Id,
-			NotificationPolicyScope{Kind: NotificationPolicyScopeRoomGroup, ID: group.Id},
-			&corev1.NotificationDeliveryModes{Reactions: corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_OFF.Enum()},
-			&fieldmaskpb.FieldMask{Paths: []string{"reactions"}},
-		)
-		result <- err
-	}()
-	select {
-	case early := <-result:
-		t.Fatalf("group policy update returned before delayed config projection started: %v", early)
-	case <-time.After(50 * time.Millisecond):
-	}
-	if err := chattoCore.DeleteRoomGroup(ctx, SystemActorID, group.Id); err != nil {
-		t.Fatalf("DeleteRoomGroup: %v", err)
+	if _, err := chattoCore.JoinRoom(ctx, user.Id, KindChannel, user.Id, room.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
 	}
 
-	runCtx, cancel := context.WithCancel(context.Background())
-	done := make(chan error, 1)
-	go func() { done <- delayedConfig.Projector().Run(runCtx) }()
-	t.Cleanup(func() {
-		cancel()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			t.Fatal("delayed config projector did not stop")
-		}
-	})
-	select {
-	case err := <-result:
-		if !errors.Is(err, ErrRoomGroupNotFound) {
-			t.Fatalf("group policy update after concurrent deletion error = %v, want ErrRoomGroupNotFound", err)
-		}
-	case <-time.After(5 * time.Second):
-		t.Fatal("group policy update did not finish after config projection caught up")
+	before, err := chattoCore.authorizationFenceSeq(ctx)
+	if err != nil {
+		t.Fatalf("authorization fence before policy updates: %v", err)
 	}
-	if got := chattoCore.configModel.notificationRoomGroupModes(user.Id, group.Id).GetReactions(); got != corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_UNSPECIFIED {
-		t.Fatalf("group preference after rejected write = %v, want unspecified", got)
+	patch := &corev1.NotificationDeliveryModes{Reactions: corev1.NotificationDeliveryMode_NOTIFICATION_DELIVERY_MODE_OFF.Enum()}
+	mask := &fieldmaskpb.FieldMask{Paths: []string{"reactions"}}
+	for _, scope := range []NotificationPolicyScope{
+		{Kind: NotificationPolicyScopeRoomGroup, ID: group.Id},
+		{Kind: NotificationPolicyScopeRoom, ID: room.Id},
+	} {
+		if _, err := chattoCore.NotificationPolicy().UpdateScopedNotificationPolicy(ctx, user.Id, scope, patch, mask); err != nil {
+			t.Fatalf("UpdateScopedNotificationPolicy(%+v): %v", scope, err)
+		}
+	}
+	after, err := chattoCore.authorizationFenceSeq(ctx)
+	if err != nil {
+		t.Fatalf("authorization fence after policy updates: %v", err)
+	}
+	if after != before {
+		t.Fatalf("scoped notification policy updates advanced authorization fence: before=%d after=%d", before, after)
 	}
 }
 

--- a/cli/internal/core/room_membership.go
+++ b/cli/internal/core/room_membership.go
@@ -418,9 +418,9 @@ func (c *ChattoCore) appendRoomLeaveBatch(ctx context.Context, kind RoomKind, ro
 	}
 
 	// Leaving, removal, and ban are authorization-changing domain facts. Advance
-	// the existing generic fence in the same batch so an independently scoped
-	// mutation (for example a room notification preference) cannot commit from
-	// a membership decision that this leave has already invalidated.
+	// the existing generic fence in the same batch so a mutation with strict
+	// commit-time authorization (for example an authorized message edit) cannot
+	// commit from a membership decision that this leave has already invalidated.
 	seqs, err := c.appendAuthorizationFencedBatch(ctx, userID, entries, authorizationSeq)
 	if err != nil {
 		return fmt.Errorf("publish room leave batch: %w", err)

--- a/docs/fdr/FDR-012-notifications.md
+++ b/docs/fdr/FDR-012-notifications.md
@@ -147,6 +147,12 @@ notification decisions. Deleting a group leaves its saved user preferences
 inert. Group IDs are not reused, and deletion does not fan out cleanup writes
 to user configuration aggregates.
 
+Room-group and room policy writes validate scope access at request time and use
+OCC on the user's configuration aggregate. They do not advance the
+authorization fence. A concurrent membership loss, room deletion, or group
+deletion can leave a newly committed preference inert, but it cannot change
+another user's state or grant access to the deleted scope.
+
 ### 4. Source-time decisions are durable and replayable
 
 **Decision:** Notification recipients and effective source-time policy are


### PR DESCRIPTION
## Why

Room- and group-scoped notification preference changes currently append an empty authorization-fence fact, which adds EVT noise without protecting privileged state.

## What changed

Scoped policy writes now use the existing per-user configuration OCC and request-time scope validation, while concurrent scope loss can leave only an inert self-owned preference; regression tests cover access enforcement and prove that the authorization fence does not advance, and FDR-012 plus the room-leave comment document the boundary.

## API compatibility

No public API or protocol behaviour changed, and no rollout or migration action is required.

## Test plan

Focused core and ConnectRPC notification-policy tests, `mise test-cli`, `mise license-check`, and `git diff --check` all passed.
