### PR TITLE
docs: tighten local development guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ repository once it no longer needs frequent atomic changes with the shared
 
 ## Local Development Stack
 
-The root `mise dev` task runs the services needed for regular development as
-native processes: the Chatto backend and Vite frontend, Authling, Mailpit, and
-LiveKit. [Portless](https://portless.sh/) gives each browser-facing process a
-stable, worktree-aware HTTPS URL. The Portless-backed mise tasks pin it as an
-isolated npm tool and run it with Node.js 24 without changing the Node.js 22
-version used by the rest of the repository.
+Run the local Chatto backend and Vite frontend, Authling, Mailpit, and LiveKit:
 
 ```sh
 mise trust
@@ -42,60 +37,41 @@ mise setup
 mise dev
 ```
 
-`mise dev` starts all five processes in one supervised process group and
-prefixes their combined output. Vite reloads frontend source changes itself;
-restart `mise dev` after changing Chatto or Authling Go code. The shared API
-types and Lingua packages are built once by `mise setup` instead of running
-permanent package watchers. Chatto and Authling keep separate embedded-NATS
-state: Chatto uses the worktree-local `cli/data/`, while Authling
-uses `.context/dev-portless/<workspace>/nested/authling/` because its issuer is
-bound to the workspace hostname.
+`mise dev` runs the services in one supervised process group. Vite reloads
+frontend changes. Restart it after you change Chatto or Authling Go code.
+`mise setup` builds the shared API types and Lingua packages.
 
-The useful browser endpoints use the Conductor workspace name on the shared
-Portless development proxy port `42444`:
+[Portless](https://portless.sh/) provides HTTPS routes for browser-facing
+services. In Conductor, replace `<workspace>` with the workspace name:
 
 - Chatto: `https://chatto.<workspace>.localhost:42444`
 - Authling: `https://authling.<workspace>.localhost:42444`
 - Mailpit: `https://mailpit.<workspace>.localhost:42444`
 - LiveKit: `https://livekit.<workspace>.localhost:42444`
 
-Conductor still allocates ten ports to every local workspace. With base port
-`$CONDUCTOR_PORT`, the processes bind only to their allocated loopback ports:
-Chatto uses
-the base port for Vite, `+1` for its backend, and `+4` for embedded NATS;
-Authling uses `+2`; LiveKit uses `+5` through `+7`; and Mailpit uses `+8` and
-`+9`. Portless terminates trusted development HTTPS and proxies each worktree
-hostname to the corresponding listener. Outside Conductor, the listener layout
-falls back to base port `4000`.
+Outside Conductor, Portless uses the `local` route suffix. Services listen on
+loopback ports from base port `4000` (or `$CONDUCTOR_PORT` in Conductor).
 
 Create an Authling account, read its verification code in Mailpit, then choose
-**Authling** on Chatto's login screen. Chatto asks for a username on the first
-login because Authling's initial OIDC profile intentionally shares only its
-stable account ID. The development issuer uses CIMD and has no pre-registered
-conventional OIDC client. The stack also bootstraps Chatto owner `alice` and
-member `bob`; both use the development-only password `foobar123`.
+**Authling** on the Chatto login screen. Chatto asks for a username at first
+login. The stack also creates Chatto owner `alice` and member `bob`; both use
+the development-only password `foobar123`.
 
-Authling is configured as an ordinary OIDC provider for the development Chatto
-server. Chatto's server catalogue, login tokens, and cached user details stay
-on the current device; Authling stores identity-provider state only.
+Chatto uses Authling as its development OIDC provider. Chatto data is in
+`cli/data/`; Authling identity data is in
+`.context/dev-portless/<workspace>/nested/authling/`.
 
-The checked-in credentials and bootstrap accounts are for local development
-only. Stop the attached run command to stop the workspace's processes and
-unregister its Portless routes. Remove `cli/data/` while the stack is stopped to
-delete Chatto's local data. Remove
-`.context/dev-portless/<workspace>/nested/authling/` to delete that workspace's
-Authling identity and establish a fresh issuer on the next start. Changing the
-Conductor workspace name changes the HTTPS issuer and selects a fresh Authling
-state namespace. Portless generates and trusts a development CA on its first run. If
-the non-interactive run cannot request macOS authorization, run
-`mise x node@24 npm:portless@0.15.5 -- portless trust` once in an
-interactive terminal. The services' internal listener and webhook
-connections remain on plain-HTTP loopback. This is not a production deployment
-example.
+These credentials and accounts are for local development only. Stop `mise dev`
+to stop the services and unregister the routes. With the stack stopped, remove
+either data directory to reset that service. A new Conductor workspace name
+also creates a new Authling issuer and state directory.
 
-State from the former plain-HTTP, unnamespaced development setup is not reused
-by this HTTPS setup and may be removed from `.context/dev/authling/` and
-`.context/dev/chatto/` when it is no longer needed.
+Portless creates and trusts a development CA on its first run. If macOS cannot
+show its authorization prompt, run this command once in an interactive terminal:
+
+```sh
+mise x node@24 npm:portless@0.15.5 -- portless trust
+```
 
 ## License
 


### PR DESCRIPTION
## Why

The local development section in the README was difficult to scan because it contained implementation detail that developers do not need for routine setup.

## What changed

- Condensed setup, service, route, login, reset, and Portless trust guidance.
- Removed detailed internal port mappings, legacy-state guidance, and implementation explanations while retaining the commands and operational instructions developers need.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `git diff --check`
