### PR TITLE
fix(dev): clean up archived workspace processes

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -26,6 +26,7 @@ url = "https://docs.$CONDUCTOR_WORKSPACE_NAME.localhost:42444"
 
 [scripts]
 setup = "mise trust && mise install && mise setup && (cd authling && mise trust && mise install && mise deps)"
+archive = "exec tools/stop-workspace-dev.sh"
 run_mode = "concurrent"
 
 [scripts.run.dev]

--- a/docs/adr/ADR-078-portless-native-development-stack.md
+++ b/docs/adr/ADR-078-portless-native-development-stack.md
@@ -30,6 +30,11 @@ tasks. The existing `tools/dev-supervisor.sh` process-group wrapper forwards
 Conductor lifecycle signals and reaps the complete child tree. Stopping
 `mise dev` is the single lifecycle operation for the stack.
 
+During archive, Conductor runs `tools/stop-workspace-dev.sh`. The script records
+the workspace process tree before it sends `TERM`, then sends `KILL` to any
+recorded process that remains after the grace period. This prevents stale
+workspace ports when normal shutdown cannot complete.
+
 Portless replaces Pitchfork only as the HTTPS routing layer. Each
 browser-facing task runs its process through the mise-pinned Portless CLI. The
 tasks use Portless's direct named mode to expose Chatto, Authling,
@@ -78,8 +83,9 @@ artifacts while removing Pitchfork.
 
 - A failure in a persistent development-daemon supervisor can no longer block
   every worktree because no such supervisor owns the application processes.
-- `mise dev` and its process tree are the single lifecycle boundary; no archive
-  cleanup task or persistent route registry mutation is required.
+- `mise dev` and its process tree are the normal lifecycle boundary. Archive
+  cleanup is required to remove a tree that does not stop normally. No
+  persistent route registry mutation is required.
 - Concurrent workspaces keep separate listener ports, state, HTTPS origins,
   and Portless child registrations while sharing Portless's lightweight HTTPS
   proxy.

--- a/tools/dev-supervisor_test.sh
+++ b/tools/dev-supervisor_test.sh
@@ -8,6 +8,7 @@ repository_root="$(cd "$(dirname "$0")/.." && pwd)"
 supervisor_pid=""
 descendants=""
 all_test_pids=""
+archive_workspace=""
 
 descendants_of() {
 	local root_pid="$1"
@@ -38,6 +39,9 @@ is_live() {
 cleanup() {
 	if [[ -n "$all_test_pids" ]]; then
 		kill -KILL $all_test_pids 2>/dev/null || true
+	fi
+	if [[ -n "$archive_workspace" ]]; then
+		rm -rf "$archive_workspace"
 	fi
 }
 trap cleanup EXIT
@@ -100,6 +104,52 @@ assert_signal_cleanup() {
 assert_signal_cleanup HUP
 assert_signal_cleanup TERM
 assert_signal_cleanup INT
+
+# The archive fallback must kill the recorded child tree even if the supervisor
+# cannot run its TERM trap.
+archive_workspace="$(mktemp -d)"
+archive_workspace="$(cd "$archive_workspace" && pwd -P)"
+mkdir -p "$archive_workspace/tools"
+cp "$repository_root/tools/dev-supervisor.sh" "$archive_workspace/tools/dev-supervisor.sh"
+chmod +x "$archive_workspace/tools/dev-supervisor.sh"
+perl -e '$SIG{HUP} = $SIG{INT} = $SIG{TERM} = "DEFAULT"; exec @ARGV' \
+	"$archive_workspace/tools/dev-supervisor.sh" \
+	bash -c 'trap "" HUP INT TERM; sleep 300 & sleep 300 & wait' &
+supervisor_pid=$!
+all_test_pids+=" $supervisor_pid"
+for _ in {1..100}; do
+	descendants="$(descendants_of "$supervisor_pid")"
+	if [[ "$(wc -w <<<"$descendants" | tr -d ' ')" -ge 3 ]]; then
+		break
+	fi
+	sleep 0.02
+done
+all_test_pids+=" $descendants"
+if [[ "$(wc -w <<<"$descendants" | tr -d ' ')" -lt 3 ]]; then
+	echo "archive cleanup test did not create the expected process tree" >&2
+	exit 1
+fi
+kill -STOP "$supervisor_pid"
+CONDUCTOR_WORKSPACE_PATH="$archive_workspace" "$repository_root/tools/stop-workspace-dev.sh"
+for _ in {1..20}; do
+	still_live=false
+	for pid in "$supervisor_pid" $descendants; do
+		if is_live "$pid"; then
+			still_live=true
+			break
+		fi
+	done
+	if [[ "$still_live" == false ]]; then
+		break
+	fi
+	sleep 0.02
+done
+if [[ "$still_live" == true ]]; then
+	echo "workspace archive cleanup left the development process tree running" >&2
+	exit 1
+fi
+rm -rf "$archive_workspace"
+archive_workspace=""
 
 natural_exit_directory="$(mktemp -d)"
 grandchild_file="$natural_exit_directory/grandchild.pid"

--- a/tools/stop-workspace-dev.sh
+++ b/tools/stop-workspace-dev.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 ChattoCorp GmbH
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+set -euo pipefail
+
+workspace_path="${CONDUCTOR_WORKSPACE_PATH:-$PWD}"
+workspace_path="$(cd "$workspace_path" && pwd -P)"
+supervisor_path="$workspace_path/tools/dev-supervisor.sh"
+supervisor_pids=()
+workspace_pids=()
+
+descendants_of() {
+	local root_pid="$1"
+	ps -A -o pid=,ppid= | awk -v root_pid="$root_pid" '
+		{ parent[$1] = $2 }
+		END {
+			for (pid in parent) {
+				ancestor = pid
+				while (ancestor in parent && parent[ancestor] != 0) {
+					if (parent[ancestor] == root_pid) {
+						print pid
+						break
+					}
+					ancestor = parent[ancestor]
+				}
+			}
+		}
+	'
+}
+
+while read -r pid command; do
+	if [[ "$command" == *"$supervisor_path"* ]]; then
+		supervisor_pids+=("$pid")
+	fi
+done < <(ps -A -o pid= -o command=)
+
+if (( ${#supervisor_pids[@]} == 0 )); then
+	exit 0
+fi
+
+workspace_pids=("${supervisor_pids[@]}")
+for pid in "${supervisor_pids[@]}"; do
+	while read -r descendant_pid; do
+		workspace_pids+=("$descendant_pid")
+	done < <(descendants_of "$pid")
+done
+
+kill -TERM "${supervisor_pids[@]}" 2>/dev/null || true
+
+# The supervisor normally terminates this tree itself.
+for _ in {1..10}; do
+	live=false
+	for pid in "${workspace_pids[@]}"; do
+		if kill -0 "$pid" 2>/dev/null; then
+			live=true
+			break
+		fi
+	done
+	if [[ "$live" == false ]]; then
+		exit 0
+	fi
+	sleep 0.05
+done
+
+# The pre-TERM snapshot remains valid after children are reparented.
+kill -KILL "${workspace_pids[@]}" 2>/dev/null || true


### PR DESCRIPTION
## Why

Archived Conductor workspaces can leave development processes alive and block their allocated ports for later workspaces.

## What changed

- Add an archive hook that stops the workspace-specific development supervisor.
- Capture its process tree before shutdown and force-stop any remaining recorded process after the grace period.
- Correct ADR-078 and add focused fallback coverage.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise test-cli`
- `mise license-check`
- `git diff --check`
