### PR TITLE
docs(agents): simplify instructions for ASD-STE100

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,12 +1,11 @@
 # Instructions for Agents
 
-Read this file first. It contains repo-wide rules that should not be hidden in
-path-specific guidance.
+Read this file first. It contains rules for the complete repository.
 
 ## Product Boundaries And Instruction Routing
 
-This repository contains two independent products plus an incubating shared
-framework boundary:
+This repository has two independent products and an incubating shared-framework
+boundary:
 
 - **Chatto** is the chat server, bundled client, CLI, and existing public
   protocols. Unless a path is explicitly Authling-owned or shared, existing
@@ -19,15 +18,13 @@ framework boundary:
   modules live under `pkg/events/`, `pkg/natsruntime/`, `pkg/datacrypto/`, and
   `pkg/appconfig/`.
 
-Authling's presence in this repository is explicitly temporary. It is being
-incubated here only while Authling provides the concrete second application
-needed to extract and harden the shared framework. Once that boundary is
-stable, Authling is intended to move to its own repository. Do not describe
-this repository as Authling's permanent home, and do not introduce coupling
-that would make the eventual extraction harder.
+Authling is in this repository temporarily. It provides the second application
+needed to extract and validate the shared framework. Move Authling to its own
+repository when the shared boundary is stable. Do not describe this repository
+as its permanent home. Do not add coupling that makes this move more difficult.
 
-Before changing files, classify the task as Chatto, Authling, shared-framework,
-or repository-wide work. Follow these routing rules:
+Before you change a file, classify the task as Chatto, Authling,
+shared-framework, or repository-wide work. Follow these routing rules:
 
 1. Any task that concerns Authling or changes anything under `authling/` must
    read [`authling/AGENTS.md`](authling/AGENTS.md) in full before acting. Do
@@ -71,9 +68,9 @@ or repository-wide work. Follow these routing rules:
    and shared-framework integration points. Optimize those exceptions for
    deletion or relocation when Authling leaves this repository.
 
-If a task crosses these boundaries, keep the product impacts explicit in code,
-tests, documentation, and the final report. Do not use a cross-product task as
-permission to reorganize unrelated product code.
+For a task that crosses these boundaries, state each product impact in code,
+tests, documentation, and the final report. Do not use a cross-product task to
+reorganize unrelated product code.
 
 ## Where Context Lives
 
@@ -113,11 +110,11 @@ permission to reorganize unrelated product code.
 
 ## Instruction Strength
 
-- **Must** and **never** mark requirements, safety boundaries, or invariants.
-- **Prefer** marks the default; depart from it only with a concrete reason.
-- **Consider** marks a review prompt rather than a required action.
-- The nearest applicable `AGENTS.md` owns path-specific guidance. Root rules
-  still apply when nested guidance is more specific.
+- **Must** and **never** mark requirements, safety boundaries, and invariants.
+- **Prefer** marks the default. Use another action only for a specific reason.
+- **Consider** marks a review prompt, not a required action.
+- The nearest applicable `AGENTS.md` controls path-specific guidance. Root
+  rules still apply when nested guidance is more specific.
 
 ## Simplified Technical English
 
@@ -131,14 +128,14 @@ technical terms. For Chatto terms, use the canonical vocabulary in
 [`docs/GLOSSARY.md`](docs/GLOSSARY.md). Do not change code, commands, literal
 names, or quotations.
 
-Treat violations in unchanged text as migration work. Apply the standard to a
-full page when you make a substantial page edit. Claim formal conformance only
-after a full review against the standard and its dictionary.
+Treat a violation in unchanged text as migration work. Apply the standard to a
+complete page when you make a substantial page edit. Claim formal conformance
+only after a complete review against the standard and its dictionary.
 
 ### Approved Exclusions
 
-These pages can use a conversational product voice and vocabulary that
-ASD-STE100 does not approve:
+These pages can use a conversational product voice and vocabulary outside
+ASD-STE100:
 
 - `apps/docs-website/src/content/docs/index.mdx` — product home page.
 - `apps/docs-website/src/content/docs/getting-started/introduction.mdx` —
@@ -150,12 +147,12 @@ full path and reason here.
 
 ## Prime Directives
 
-- Prefer simple, clear changes over clever abstractions.
-- Add concise code documentation for public APIs and for otherwise important
-  fields, functions, types, invariants, and lifecycle behavior that future
-  maintainers should not have to infer from call sites.
+- Prefer simple, clear changes to complex abstractions.
+- Add short code documentation for public APIs and important fields, functions,
+  types, invariants, and lifecycle behavior. Future maintainers must not have
+  to infer this information from call sites.
 - Keep tests and documentation up to date when changing behavior.
-- Run verification that would actually catch regressions in the area touched.
+- Run verification that can find regressions in the changed area.
 - Never claim full verification when only a partial signal was run.
 - Never silence lint, type, vet, or Svelte warnings as a routine fix. Fix the
   cause; discuss rare scoped exceptions before adding them.
@@ -171,10 +168,10 @@ full path and reason here.
   safely reset when validation fails. Explicit owner-only broker diagnostics
   and event-log inspection APIs are the sole exception: their operational
   purpose and fields must clearly identify the NATS/JetStream details exposed.
-- Treat optional operational telemetry as best-effort: its failure must not make
-  broader diagnostics unavailable. Preserve an explicit unavailable state across
-  API and UI boundaries instead of replacing unknown values with healthy-looking
-  zeroes, empty strings, or timestamps.
+- Treat optional operational telemetry as best effort. Its failure must not make
+  other diagnostics unavailable. Preserve an explicit unavailable state across
+  API and UI boundaries. Do not replace an unknown value with a zero, empty
+  string, or timestamp that appears healthy.
 - Chatto is public, self-hosted, pre-1.0 software with real user data and mixed
   versions in use. Follow ADR-045 and `proto/AGENTS.md` for public and persisted
   protocol compatibility. A breaking experimental API change requires explicit
@@ -183,7 +180,7 @@ full path and reason here.
 
 ## Tooling
 
-Tools are managed by `mise`; prefer tasks when available.
+`mise` manages tools. Prefer its tasks when they are available.
 
 Use Chrome DevTools MCP only to inspect and verify Chatto or Authling browser
 behavior. Do not use it for general web research or public documentation
@@ -208,7 +205,7 @@ mise codegen-proto
 Run Authling's unprefixed tasks from `authling/`; its nested `mise.toml` owns
 the Authling toolchain and workflow.
 
-For ad-hoc tool invocations, use `mise x -- ...` rather than assuming `go`,
+For an ad-hoc tool command, use `mise x -- ...`. Do not assume that `go`,
 `pnpm`, `node`, or related binaries are on `PATH`.
 
 When an agent needs the long-running development stack, launch `mise dev`; the

--- a/apps/desktop/AGENTS.md
+++ b/apps/desktop/AGENTS.md
@@ -1,9 +1,9 @@
 # Instructions for Agents Working in `apps/desktop/`
 
-This file covers the experimental desktop application and its native helpers.
+This file applies to the experimental desktop application and its native helpers.
 
 ## Testing
 
-- Native macOS helper behavior must have focused Swift tests wired into a macOS
-  CI step. Desktop JavaScript checks and production helper builds do not compile
+- Add focused Swift tests for native macOS helper behavior. Run the tests in a
+  macOS CI step. JavaScript checks and production helper builds do not compile
   Swift test targets.

--- a/apps/docs-website/AGENTS.md
+++ b/apps/docs-website/AGENTS.md
@@ -1,16 +1,15 @@
 # Instructions for Agents Working in `apps/docs-website/`
 
-The docs website is Chatto's public documentation site, built with Astro and
+The docs website is the public Chatto documentation site. It uses Astro and
 Starlight.
 
 ## Audience
 
-- Write for community members, server operators, administrators, and API
-  consumers.
-- Do not put maintainer workflow text in visible docs pages. Hidden source
-  comments are fine when useful.
-- The repository, binaries, and Docker images are public. Do not document private
-  repo or registry access steps.
+- Write for community members, server operators, administrators, and API users.
+- Do not put maintainer workflow text in visible pages. You can use hidden
+  source comments when they help.
+- The repository, binaries, and Docker images are public. Do not document
+  private repository or registry access.
 
 ## Keep Docs In Sync
 
@@ -23,19 +22,18 @@ Starlight.
 - New or changed user-facing features: update the relevant guide.
 - Changed config defaults or deployment semantics: update both reference and
   guide pages that mention them.
-- New pages usually need sidebar entries in `astro.config.mjs`.
-- Generated ConnectRPC reference pages must remain useful to API consumers, not
-  protobuf maintainers.
+- Add a sidebar entry in `astro.config.mjs` for a new page when needed.
+- Keep generated ConnectRPC reference pages useful to API users.
 
 ## Style
 
 - Follow the ASD-STE100 rules and the approved exclusion list in the root
   `AGENTS.md`. The root list is the only documentation exclusion list.
-- Be direct, concise, and confident.
-- Use second person, present tense.
-- Lead with the actionable fact, not background.
-- Prefer tables, short lists, and examples over long prose.
-- Show config examples before explaining them.
+- Use direct, short sentences.
+- Use the second person and present tense.
+- Give the action before background information.
+- Prefer tables, short lists, and examples to long text.
+- Show configuration examples before an explanation.
 - Use base readable text size; reserve smaller text for labels, badges, and
   metadata.
 
@@ -52,7 +50,7 @@ Starlight.
 
 ## Starlight
 
-Use built-in Starlight components where they make the page clearer:
+Use built-in Starlight components when they make the page clear:
 
 - `Steps` for setup/tutorial sequences.
 - `Aside` for `tip`, `note`, `caution`, and `danger` callouts.
@@ -60,13 +58,13 @@ Use built-in Starlight components where they make the page clearer:
 - `LinkCard` and `CardGrid` for cross-references.
 - `Tabs` and `TabItem` for alternatives such as TOML vs environment variables.
 
-Prefer linking to dedicated guides over repeating detailed instructions.
+Link to a dedicated guide instead of repeating detailed instructions.
 
 ## Diagrams
 
-- SVG architecture diagrams live in `src/assets/` and are imported raw with
-  `?raw` when animation is needed.
-- Support light/dark mode inside SVG styles.
-- Keep service box colors muted and connection/dot styling consistent with the
+- Put SVG architecture diagrams in `src/assets/`. Import them with `?raw` for
+  animation.
+- Support light and dark mode in SVG styles.
+- Use muted service-box colors. Keep connection and dot styles consistent with
   existing diagrams.
-- Use smooth `animateMotion` easing for moving dots; avoid linear motion.
+- Use smooth `animateMotion` easing for moving dots. Do not use linear motion.

--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -1,20 +1,21 @@
 # Instructions for Agents Working in `apps/frontend/`
 
 Frontend work uses SvelteKit, Svelte 5 runes, Tailwind 4, Lingua JSON i18n,
-generated protobuf clients, Vitest browser tests, Playwright e2e, and Storybook.
+generated protobuf clients, Vitest browser tests, Playwright end-to-end tests,
+and Storybook.
 
 ## Svelte Tooling
 
-- For Svelte questions or edits, use the Svelte docs/MCP workflow available to
-  the agent session.
-- When writing or editing `.svelte`, `.svelte.ts`, or `.svelte.js`, run the
-  Svelte autofixer before handing back code.
+- For Svelte questions or edits, use the available Svelte documentation and MCP
+  workflow.
+- When you write or edit `.svelte`, `.svelte.ts`, or `.svelte.js`, run the
+  Svelte autofixer before you return the code.
 - Do not generate a Svelte playground link for code written into this repo.
 
 ## Architecture
 
-- Prefer store classes and thin components. Data lifecycle belongs in stores;
-  components render state and call named store methods.
+- Prefer store classes and small components. Stores own the data lifecycle.
+  Components render state and call named store methods.
 - Server-scoped state belongs in `ServerStateStore` or related per-server
   stores under `src/lib/state/server/`.
 - Component-local `$state` is fine for UI-only state such as open/closed, hover,

--- a/authling/AGENTS.md
+++ b/authling/AGENTS.md
@@ -1,25 +1,23 @@
 # Instructions for Agents Working in `authling/`
 
-Read the repository-root [`AGENTS.md`](../AGENTS.md) first, then read this file
-in full before any Authling task. The root instructions require this explicit
-read because nested agent instructions and skills may not be discovered
-automatically.
+Read the root [`AGENTS.md`](../AGENTS.md) first. Then read this file completely
+before an Authling task. The root instructions require this step because an
+agent might not find nested instructions and skills automatically.
 
 ## Product Boundary
 
-Authling is an independent, self-hostable identity provider. It lives in the
-Chatto repository temporarily to make shared-framework extraction practical,
-not because it is part of the Chatto product. Once the shared boundary is
-stable enough for normal versioned consumption, Authling is intended to move
-to its own repository.
+Authling is an independent identity provider that users can host themselves.
+It is in the Chatto repository temporarily to make shared-framework extraction
+practical. It is not part of Chatto. Move it to its own repository when the
+shared boundary is stable for normal versioned use.
 
 - Authling has its own Go module, executable, configuration, HTTP surface,
   lifecycle, data model, documentation, version, changelog, and releases.
 - Authling is not a Chatto runtime unit, optional Chatto feature, or special
   kind of Chatto server.
 - The primary deployment model is a standalone Authling process. Keep future
-  process-level embedding possible through dependency-injected composition, but
-  do not build or couple to an embedding mode without a concrete requirement.
+  process-level embedding possible with dependency-injected composition. Do not
+  build or couple to an embedding mode without a specific requirement.
 - Authling always uses credentials for its own NATS account. It must never
   share a Chatto application's NATS account, even if both runtimes eventually
   occupy one operating-system process.
@@ -30,8 +28,8 @@ to its own repository.
 
 ## Current Product Direction
 
-- Start with standards-compliant OpenID Connect. Do not introduce a custom
-  identity protocol while OIDC satisfies the requirement.
+- Start with standards-compliant OpenID Connect. Do not add a custom identity
+  protocol when OIDC meets the requirement.
 - Chatto server operators explicitly choose which OIDC issuers they trust.
   Authling must not imply a global issuer or automatic trust.
 - Authling stores identity-provider state only: accounts, credentials, browser
@@ -120,7 +118,7 @@ repository skills as non-product infrastructure.
 
 - Treat Authling as security-critical infrastructure. Authentication,
   authorization, consent, redirect handling, issuer metadata, signing keys,
-  tokens, recovery, and account linking require explicit threat analysis and
+  tokens, recovery, and account linking need explicit threat analysis and
   adversarial tests.
 - Never log raw email addresses, login identifiers, provider subjects, tokens,
   authorization codes, passwords, recovery material, signing keys, raw IP
@@ -128,7 +126,7 @@ repository skills as non-product infrastructure.
 - Persist durable identity facts as events and short-lived credentials or
   workflow state as runtime state, once those stores exist. Do not infer
   Authling's exact subjects or resources from Chatto.
-- Default to least privilege and fail closed when identity, key, issuer, or
+- Use least privilege by default. Fail closed when identity, key, issuer, or
   authorization state is unavailable.
 
 ## Identity Events And Recovery
@@ -177,8 +175,8 @@ repository skills as non-product infrastructure.
   `version.go`, its changelog is `CHANGELOG.md`, and its tags use
   `authling/v<version>`. The slash follows Go's nested-module tag convention.
 - Authling releases are source-only during the initial scaffold. Add binary or
-  container artifact workflows only when there is an implemented runtime worth
-  distributing.
+  container artifact workflows only when an implemented runtime is ready to
+  distribute.
 - Authling releases are independent from Chatto releases. An Authling-only
   commit must not require a Chatto release.
 - Treat persisted identity data, signing-key references, issuer identifiers,
@@ -217,11 +215,11 @@ undeclared or unreleased cross-module dependencies cannot be hidden by
 `go.work`. Do not add Authling tasks to the repository-root `mise.toml`;
 Authling's task catalog must remain movable with the product.
 
-Run the lowest test layer that can catch the failure, but add integration and
+Run the lowest test layer that can find the failure. Add integration and
 protocol tests when behavior crosses HTTP, OIDC, NATS, JetStream, cryptographic,
 or process-lifecycle boundaries. Browser end-to-end tests use a dedicated
-Authling process, Mailpit process, port range, and temporary data directory per
-test; do not point them at development state or share a process across tests.
+Authling process, Mailpit process, port range, and temporary data directory for
+each test. Do not use development state or share a process between tests.
 Persisted-event and recovery changes require relevant malformed-event,
 historical replay or restart, OCC conflict, enumeration-resistance, and
 PII/recovery-material leakage tests. Regenerate and commit derived protobuf or

--- a/cli/AGENTS.md
+++ b/cli/AGENTS.md
@@ -1,25 +1,26 @@
 # Instructions for Agents Working in `cli/`
 
-This file covers backend code: Go services, ConnectRPC, NATS/JetStream,
-authorization, live events, backup/restore, and backend tests.
+This file applies to backend code: Go services, ConnectRPC, NATS/JetStream,
+authorization, live events, backup and restore, and backend tests.
 
 ## Non-Negotiables
 
-- Chatto is multi-replica software. Never rely on process-local serialization
-  for correctness.
+- Chatto can run in more than one replica. Never use process-local
+  serialization for correctness.
 - NATS JetStream/KV is the primary data store. Use JetStream OCC or KV
   `Create`/revision `Update` for uniqueness and cross-replica invariants.
 - Durable domain state belongs in `EVT`; latest-value runtime state belongs in
   `RUNTIME_STATE` only when it is truly runtime/latest-value state.
 - Services own their domain state and projections. Do not bypass service
-  boundaries to poke JetStream, KV, or projections from unrelated code.
+  boundaries to access JetStream, KV, or projections from unrelated code.
 - Call access is generation-bound. Use one call-state snapshot whenever an
   operation combines call identity and participants. For access credentials,
   capture the call ID and E2EE key reference from the same projected session,
   resolve that key reference, then revalidate both values before issuing
   access; fail or retry if the generation changed. Never assemble one response
   or credential from independent call-state reads.
-- Do not log PII. Use opaque IDs, counts, booleans, event names, and safe hashes.
+- Do not log PII. Use opaque IDs, counts, Boolean values, event names, and safe
+  hashes.
 - Projections must not retain decrypted PII when encrypted source fields can be
   retained and hydrated at read boundaries. Keep derived lookup state
   non-plaintext, and never turn KMS or decryption failures into apparent

--- a/pkg/appconfig/AGENTS.md
+++ b/pkg/appconfig/AGENTS.md
@@ -1,6 +1,6 @@
 # Instructions for Agents Working in `pkg/appconfig/`
 
-Read the repository-root [`AGENTS.md`](../../AGENTS.md),
+Read the root [`AGENTS.md`](../../AGENTS.md),
 [`cli/AGENTS.md`](../../cli/AGENTS.md), and
 [`authling/AGENTS.md`](../../authling/AGENTS.md) before changing this shared
 module. Also follow
@@ -8,7 +8,7 @@ module. Also follow
 
 ## Boundary
 
-- Keep production code application-neutral.
+- Keep production code independent of applications.
 - This module owns only TOML file selection and decoding followed by
   struct-tagged environment-variable overrides.
 - Applications own their configuration types, field and environment names,
@@ -19,8 +19,8 @@ module. Also follow
   side effect of framework work.
 - Do not import Chatto or Authling packages or encode either product's paths,
   prefixes, schemas, or policies.
-- The module is independently versioned but pre-1.0 and has no API stability
-  promise yet.
+- This module has an independent pre-1.0 version. It has no API stability
+  promise.
 - The complete module is licensed under Apache-2.0.
 
 ## Verification

--- a/pkg/datacrypto/AGENTS.md
+++ b/pkg/datacrypto/AGENTS.md
@@ -1,6 +1,6 @@
 # Instructions for Agents Working in `pkg/datacrypto/`
 
-Read the repository-root [`AGENTS.md`](../../AGENTS.md),
+Read the root [`AGENTS.md`](../../AGENTS.md),
 [`cli/AGENTS.md`](../../cli/AGENTS.md), and
 [`authling/AGENTS.md`](../../authling/AGENTS.md) before changing this shared
 module. Also follow
@@ -8,7 +8,7 @@ module. Also follow
 
 ## Boundary
 
-- Keep production code application-neutral.
+- Keep production code independent of applications.
 - This module owns only random 256-bit key generation, XChaCha20-Poly1305
   authenticated encryption, and authenticated wrapping of 256-bit keys.
 - Applications own associated-data construction and domain separation, key
@@ -16,8 +16,8 @@ module. Also follow
   integration, caching, rotation, and erasure policy.
 - Do not import Chatto or Authling packages or encode either product's
   identifiers, formats, or policies.
-- The module is independently versioned but pre-1.0 and has no API stability
-  promise yet.
+- This module has an independent pre-1.0 version. It has no API stability
+  promise.
 - The complete module is licensed under Apache-2.0. Keep its source, tests,
   documentation, and standalone license metadata inside that permissive
   boundary.

--- a/pkg/events/AGENTS.md
+++ b/pkg/events/AGENTS.md
@@ -1,6 +1,6 @@
 # Instructions for Agents Working in `pkg/events/`
 
-Read the repository-root [`AGENTS.md`](../../AGENTS.md),
+Read the root [`AGENTS.md`](../../AGENTS.md),
 [`cli/AGENTS.md`](../../cli/AGENTS.md), and
 [`authling/AGENTS.md`](../../authling/AGENTS.md) before changing this shared
 module. Also follow
@@ -12,21 +12,21 @@ durable worker resource ownership.
 
 ## Boundary
 
-- Keep production code envelope-neutral and application-neutral.
+- Keep production code neutral to envelopes and applications.
 - Production imports are limited to the Go standard library and
   `github.com/nats-io/nats.go`.
 - Do not import Chatto or Authling domain packages, protobuf envelopes,
   subjects, resource names, configuration, or lifecycle policy.
 - Tests may additionally use `github.com/nats-io/nats-server/v2`, but must not
   borrow product-specific test helpers.
-- Drive exported API changes from concrete external-package consumers. Do not
-  add generic surface only to shorten one application's wiring.
+- Base exported API changes on actual external-package users. Do not add a
+  general API only to make one application setup shorter.
 - `DurableWorker` executes an already configured consumer; it must not infer
   consumer ownership from process lifecycle or create, delete, retire, or
   garbage-collect application consumers. Persisted names, inactivity policy,
   rollout, and safe retirement remain application responsibilities.
-- The module is independently versioned but pre-1.0 and has no API stability
-  promise yet.
+- This module has an independent pre-1.0 version. It has no API stability
+  promise.
 - The complete module is licensed under Apache-2.0. Keep its source,
   tests, documentation, and standalone license metadata inside that
   permissive boundary.
@@ -34,9 +34,9 @@ durable worker resource ownership.
 ## Compatibility
 
 Framework refactors must preserve application-owned event bytes, subjects,
-headers, OCC guards, replay ordering, stream positions, and snapshot/checkpoint
-semantics unless the consuming applications explicitly coordinate a compatible
-change.
+headers, OCC guards, replay order, stream positions, and snapshot/checkpoint
+semantics. Change them only when all consuming applications coordinate a
+compatible change.
 
 ## Verification
 

--- a/pkg/natsruntime/AGENTS.md
+++ b/pkg/natsruntime/AGENTS.md
@@ -1,6 +1,6 @@
 # Instructions for Agents Working in `pkg/natsruntime/`
 
-Read the repository-root [`AGENTS.md`](../../AGENTS.md),
+Read the root [`AGENTS.md`](../../AGENTS.md),
 [`cli/AGENTS.md`](../../cli/AGENTS.md), and
 [`authling/AGENTS.md`](../../authling/AGENTS.md) before changing this shared
 module. Also follow
@@ -8,17 +8,17 @@ module. Also follow
 
 ## Boundary
 
-- Keep production code application-neutral.
+- Keep production code independent of applications.
 - This module owns only embedded NATS process lifecycle mechanics: creation,
   startup readiness, failure cleanup, in-process connection options, and
   shutdown.
 - Applications own their configuration schemas, defaults, listeners,
   authentication, monitoring, logging, storage paths, and deployment policy.
 - Do not import Chatto or Authling packages.
-- Keep the API thin over `nats-server`; do not mirror its complete options
-  surface in a second configuration model.
-- The module is independently versioned but pre-1.0 and has no API stability
-  promise yet.
+- Keep the API small over `nats-server`. Do not copy all its options into a
+  second configuration model.
+- This module has an independent pre-1.0 version. It has no API stability
+  promise.
 - The complete module is licensed under Apache-2.0. Keep its source,
   tests, documentation, and standalone license metadata inside that
   permissive boundary.

--- a/proto/AGENTS.md
+++ b/proto/AGENTS.md
@@ -1,7 +1,7 @@
 # Instructions for Agents Working in `proto/`
 
-Protobuf definitions feed persisted state, generated Go/TypeScript bindings,
-ConnectRPC services, and the public API reference.
+Protobuf definitions provide persisted state, generated Go and TypeScript
+bindings, ConnectRPC services, and the public API reference.
 
 ## Public API Protos
 
@@ -17,24 +17,24 @@ For public API packages:
   unauthenticated discovery/bootstrap ConnectRPC API consistency rules.
 - Follow [chatto/realtime/v1/AGENTS.md](chatto/realtime/v1/AGENTS.md) for the
   realtime WebSocket protobuf protocol.
-- Write comments for API consumers, not Chatto maintainers.
-- Every public service, RPC, message, enum, enum value, and important field
-  should have useful comments.
-- Explain what the call reads or changes, required IDs, pagination/cursor
-  semantics, login availability, and notable response behavior.
-- Keep field comments short enough for generated tables; put longer behavior
-  notes on messages or RPCs.
-- Do not include maintainer workflow text such as "run codegen" in comments that
-  render into public docs.
+- Write comments for API users, not Chatto maintainers.
+- Add useful comments to each public service, RPC, message, enum, enum value,
+  and important field.
+- Explain what a call reads or changes, required IDs, pagination or cursor
+  rules, login availability, and important response behavior.
+- Keep field comments short for generated tables. Put longer behavior notes on
+  messages or RPCs.
+- Do not put maintainer workflow text, such as "run codegen", in comments that
+  appear in public documentation.
 
 ## Compatibility
 
 - The public auth, discovery, integration, admin, and realtime `v1` packages
-  are experimental while Chatto is pre-1.0. Compatibility is preferred, not
-  guaranteed. Breaking changes require explicit user approval, an explicit
-  design benefit, a compatibility plan, generated-client/docs updates,
-  release-note guidance, and the `api-breaking-change` PR label. A release
-  milestone does not waive these requirements.
+  are experimental while Chatto is pre-1.0. Prefer compatibility. A breaking
+  change requires explicit user approval, a design benefit, a compatibility
+  plan, generated-client and documentation updates, release-note guidance, and
+  the `api-breaking-change` PR label. A release milestone does not remove these
+  requirements.
 - Except for projection-owned snapshot payloads described below, do not
   renumber fields that may be persisted or consumed by clients.
 - Except for projection-owned snapshot payloads, do not change a field type at
@@ -141,10 +141,10 @@ For public API packages:
 - Singular `Get*` methods return `NOT_FOUND` when absence is the error result.
   `BatchGet*` and list methods may omit missing or inaccessible resources, but
   document that behavior on the RPC.
-- Generated public docs and TypeScript bindings are part of the API surface.
-  When adding public RPCs, regenerate `@chatto/api-types` and docs in the same
-  change. Do not recreate a handwritten API-client package; bundled frontend
-  adapters belong under `apps/frontend/src/lib/api-client`.
+- Generated public documentation and TypeScript bindings are part of the API.
+  When you add a public RPC, regenerate `@chatto/api-types` and the
+  documentation in the same change. Do not create a handwritten API-client
+  package. Put bundled frontend adapters in `apps/frontend/src/lib/api-client`.
 
 ## Code Generation
 

--- a/proto/chatto/admin/v1/AGENTS.md
+++ b/proto/chatto/admin/v1/AGENTS.md
@@ -1,8 +1,8 @@
 # Instructions for Agents Working in `proto/chatto/admin/v1/`
 
-This directory defines the public `chatto.admin.v1` ConnectRPC surface for
-administrative operations. These APIs are public and generated for clients, but
-their names and docs should make the administrative scope obvious.
+This directory contains the public `chatto.admin.v1` ConnectRPC API for
+administrative operations. Clients can generate this API. Its names and
+documentation must make the administrative scope clear.
 
 ## API Surface
 
@@ -12,7 +12,7 @@ their names and docs should make the administrative scope obvious.
 - Reuse shared shapes from `chatto.api.v1` when the semantics are the same.
 - Do not reuse response-rich messages as request inputs when some fields are
   ignored. Add a request-only input message instead.
-- Keep authorization expectations explicit in service and RPC comments.
+- State authorization requirements in service and RPC comments.
 - Prefer service names that name the administrative resource directly. Do not
   keep a narrower name when the service owns broader admin behavior; for
   example, admin user/member management should be named around users when it
@@ -21,10 +21,10 @@ their names and docs should make the administrative scope obvious.
   mutations. The public `MyAccountService` owns current-caller self-service;
   admin user management belongs in an explicitly named admin service with
   permission-gated RPC comments.
-- Administrative services should be exhaustive for their resource and scope,
-  not limited to the current admin UI. If a normal admin client would expect
-  list, get, batch get, create, update, or delete behavior for the resource,
-  either provide it or document why that operation is intentionally absent.
+- Make administrative services complete for their resource and scope. Do not
+  limit them to the current admin UI. If an admin client would expect list, get,
+  batch get, create, update, or delete behavior, provide it or document why it
+  is not available.
 - Follow the CRUD-like naming pattern for ordinary admin resource APIs:
   `List<ResourcePlural>`, `Get<Resource>`, `BatchGet<ResourcePlural>`,
   `Create<Resource>`, `Update<Resource>`, and `Delete<Resource>`. Use domain
@@ -58,5 +58,5 @@ their names and docs should make the administrative scope obvious.
 - Follow the public API compatibility rules in `proto/AGENTS.md`.
 - The package split is about API clarity and generated-client scope, not about
   making admin routes private or unstable.
-- Breaking changes still need an explicit compatibility note and generated
-  client/docs updates.
+- A breaking change still needs an explicit compatibility note and updates to
+  generated clients and documentation.

--- a/proto/chatto/api/v1/AGENTS.md
+++ b/proto/chatto/api/v1/AGENTS.md
@@ -1,8 +1,8 @@
 # Instructions for Agents Working in `proto/chatto/api/v1/`
 
-This directory defines the public `chatto.api.v1` ConnectRPC surface. Treat
-these protos as the integration API first, even when the bundled frontend is the
-first consumer.
+This directory contains the public `chatto.api.v1` ConnectRPC API. Treat these
+protos as an integration API first, even when the bundled frontend is the first
+user.
 
 ## API Surface
 
@@ -16,8 +16,8 @@ first consumer.
   integrations.
 - If app-only API is added later, document why it is app-only and still keep it
   stable enough for mixed bundled client/server versions.
-- Prefer a broad, coherent base API over moving rough edges into a separate
-  namespace.
+- Prefer one broad, coherent base API. Do not move difficult behavior to a
+  separate namespace.
 - Prefer service names that make the resource and scope obvious to generated
   API consumers, even if that creates more services. Do not collapse unrelated
   resources into broad catch-all services just because they share a scope.
@@ -34,10 +34,10 @@ first consumer.
 - Once a service name carries the scope, use concise resource method names such
   as `ListMembers`, `GetMember`, and `BatchGetMembers` rather than repeating
   the scope in every RPC name.
-- Services should be exhaustive for their resource and scope, not limited to
-  the current frontend workflow. If a normal client would expect list, get,
-  batch get, create, update, or delete behavior for the resource, either provide
-  it or document why that operation is intentionally absent.
+- Make services complete for their resource and scope. Do not limit them to the
+  current frontend workflow. If a normal client would expect list, get, batch
+  get, create, update, or delete behavior, provide it or document why it is not
+  available.
 - Follow the CRUD-like naming pattern for ordinary resource APIs:
   `List<ResourcePlural>`, `Get<Resource>`, `BatchGet<ResourcePlural>`,
   `Create<Resource>`, `Update<Resource>`, and `Delete<Resource>`. Use domain
@@ -120,14 +120,14 @@ first consumer.
 ## Comments And Documentation
 
 - Write comments for API consumers, not Chatto maintainers.
-- Every public service, RPC, message, enum, enum value, and important field
-  should have useful comments.
-- Explain what the call reads or changes, required IDs, pagination/cursor
-  semantics, login availability, and notable response behavior.
-- Keep field comments short enough for generated tables; put longer behavior
-  notes on messages or RPCs.
-- Do not include maintainer workflow text such as "run codegen" in comments that
-  render into public docs.
+- Add useful comments to each public service, RPC, message, enum, enum value,
+  and important field.
+- Explain what the call reads or changes, required IDs, pagination or cursor
+  rules, login availability, and important response behavior.
+- Keep field comments short for generated tables. Put longer behavior notes on
+  messages or RPCs.
+- Do not put maintainer workflow text, such as "run codegen", in comments that
+  appear in public documentation.
 
 ## Compatibility
 
@@ -137,8 +137,8 @@ first consumer.
 - Removing a field requires both `reserved <tag>` and `reserved "<name>"`.
 - Renames are wire-safe but code-breaking; update generated consumers in the
   same change.
-- The project is pre-1.0, but public API breakage still needs an explicit plan
-  and PR compatibility note.
+- The project is pre-1.0. A public API break still needs an explicit plan and a
+  PR compatibility note.
 - Follow [ADR-045](../../../../docs/adr/ADR-045-public-api-stability-tiers.md)
   for integration API, bundled app API, and realtime protocol stability tiers.
 

--- a/proto/chatto/auth/v1/AGENTS.md
+++ b/proto/chatto/auth/v1/AGENTS.md
@@ -1,7 +1,7 @@
 # Instructions for Agents Working in `proto/chatto/auth/v1/`
 
-This directory defines public authentication and authorization-related
-ConnectRPC flows that are not ordinary authenticated account API calls.
+This directory contains public ConnectRPC authentication and authorization
+flows. These flows are not ordinary authenticated account API calls.
 
 ## API Surface
 
@@ -16,11 +16,11 @@ ConnectRPC flows that are not ordinary authenticated account API calls.
 
 ## Comments And Authorization
 
-- Every service and RPC comment must state whether the method is fully public,
-  requires a capability token, or requires an authenticated user.
-- Comments should describe caller-visible behavior and notable absence/error
-  semantics.
-- Avoid implementation workflow text in comments that render into public docs.
+- Each service and RPC comment must say if the method is public, needs a
+  capability token, or needs an authenticated user.
+- Describe behavior visible to the caller and important absence or error cases.
+- Do not put implementation workflow text in comments that appear in public
+  documentation.
 
 ## Reused Shapes
 
@@ -32,8 +32,8 @@ ConnectRPC flows that are not ordinary authenticated account API calls.
 ## Compatibility
 
 - Follow the public API compatibility rules in `proto/AGENTS.md`.
-- The project is pre-1.0, but package, service, and method path changes still
-  need an explicit plan and PR compatibility note.
+- The project is pre-1.0. Package, service, and method-path changes still need
+  an explicit plan and a PR compatibility note.
 
 ## Code Generation
 

--- a/proto/chatto/discovery/v1/AGENTS.md
+++ b/proto/chatto/discovery/v1/AGENTS.md
@@ -1,11 +1,11 @@
 # Instructions for Agents Working in `proto/chatto/discovery/v1/`
 
-This directory defines the public unauthenticated `chatto.discovery.v1`
-ConnectRPC surface.
+This directory contains the public unauthenticated `chatto.discovery.v1`
+ConnectRPC API.
 
 ## API Surface
 
-- Keep this package narrow: it is for pre-authentication bootstrap and
+- Keep this package small. Use it for pre-authentication bootstrap and
   discovery metadata.
 - Keep public auth/capability-token flows in `chatto.auth.v1`; do not put them
   here just because they intentionally do not require a normal user session.
@@ -17,11 +17,11 @@ ConnectRPC surface.
 
 ## Comments And Authorization
 
-- Every service and RPC comment must state whether the method is fully public or
-  requires a capability token.
-- Comments should describe caller-visible behavior and notable absence/error
-  semantics.
-- Avoid implementation workflow text in comments that render into public docs.
+- Each service and RPC comment must say if the method is public or needs a
+  capability token.
+- Describe behavior visible to the caller and important absence or error cases.
+- Do not put implementation workflow text in comments that appear in public
+  documentation.
 
 ## Reused Shapes
 
@@ -34,8 +34,8 @@ ConnectRPC surface.
 ## Compatibility
 
 - Follow the public API compatibility rules in `proto/AGENTS.md`.
-- The project is pre-1.0, but package, service, and method path changes still
-  need an explicit plan and PR compatibility note.
+- The project is pre-1.0. Package, service, and method-path changes still need
+  an explicit plan and a PR compatibility note.
 - Do not expose implementation-level feature or method support as public
   discovery capabilities. The bundled client keeps explicit minimum server
   versions for features it gates.

--- a/proto/chatto/realtime/v1/AGENTS.md
+++ b/proto/chatto/realtime/v1/AGENTS.md
@@ -1,7 +1,7 @@
 # Instructions for Agents Working in `proto/chatto/realtime/v1/`
 
-This directory defines the public `chatto.realtime.v1` protobuf WebSocket
-protocol used at `/api/realtime`.
+This directory contains the public `chatto.realtime.v1` protobuf WebSocket
+protocol at `/api/realtime`.
 
 ## API Surface
 
@@ -10,23 +10,23 @@ protocol used at `/api/realtime`.
 - Do not add unary ConnectRPC services here.
 - Prefer importing stable public enums/messages from `chatto.api.v1` over
   duplicating shared client-visible semantics.
-- Keep comments focused on wire behavior, connection lifecycle, authentication,
-  and reconnect/catch-up expectations.
+- In comments, describe wire behavior, connection lifecycle, authentication,
+  and reconnect or catch-up behavior.
 
 ## Compatibility
 
 - Follow the public API compatibility rules in `proto/AGENTS.md`.
-- Realtime compatibility includes protocol behavior, not just protobuf field
-  tags. New required client behavior must be negotiated through hello/capability
-  fields or a new protocol version.
+- Realtime compatibility includes protocol behavior and protobuf field tags.
+  Negotiate new required client behavior with hello/capability fields or a new
+  protocol version.
 - `chatto.realtime.v1` is the protobuf namespace; protocol version 2 is the
   only accepted handshake. Do not reintroduce protocol-v1 compatibility paths.
 - Resume cursors are encrypted, authenticated, and viewer-bound. They may use
   EVT coordinates internally but must never disclose NATS/JetStream identities,
   sequences, subjects, or other persistence details on the wire.
-- Resume cursors have a bounded public lifetime (currently 24 hours). Expired
-  cursors must converge through compacted current state, never through a
-  partially trusted replay position.
+- Resume cursors have a limited public lifetime (currently 24 hours). An
+  expired cursor must use compacted current state. Do not use a partly trusted
+  replay position.
 - A client must never advance its resume cursor across an undecodable frame,
   unknown top-level frame, or unknown projection operation. Protocol evolution must preserve that
   fail-closed invariant and provide an explicit negotiation/migration path for


### PR DESCRIPTION
## Why

Make repository instructions easier to read and apply in ASD-STE100 style.

## What changed

Reword all 16 `AGENTS.md` files with shorter, direct instructions while keeping product boundaries, security rules, compatibility requirements, and verification guidance.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `git diff --check`
- `mise lint`
