### PR TITLE
fix(frontend): move account settings to top

### DIFF
--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -47,6 +47,11 @@
 
   const userPreferenceNavItems = $derived([
     {
+      href: resolve('/chat/[serverId]/settings/account', { serverId: serverSegment }),
+      label: m('settings.nav.account'),
+      icon: 'iconify icon-[uil--setting]'
+    },
+    {
       href: resolve('/chat/[serverId]/settings', { serverId: serverSegment }),
       label: m('settings.nav.profile'),
       icon: 'iconify icon-[uil--user]'
@@ -60,11 +65,6 @@
       href: resolve('/chat/[serverId]/settings/notifications', { serverId: serverSegment }),
       label: m('settings.nav.notifications'),
       icon: 'iconify icon-[uil--bell]'
-    },
-    {
-      href: resolve('/chat/[serverId]/settings/account', { serverId: serverSegment }),
-      label: m('settings.nav.account'),
-      icon: 'iconify icon-[uil--setting]'
     }
   ]);
 


### PR DESCRIPTION
## Why

Account settings were last in the Your account navigation group, which made the account page less discoverable.

## What changed

- Put the existing Account navigation item first in the server settings group.
- Preserved its route, translated label, and icon.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/components/chat/Chrome.svelte` — no issues.
- `mise test-frontend` — passed.
- `git diff --check origin/main...HEAD` — passed.
- Chrome DevTools loaded the local app, but authenticated sidebar verification was unavailable without a local signed-in test account.
