### PR TITLE
refactor(cli): deduplicate stream-incarnation identity logic

### DIFF
--- a/cli/internal/evtstream/identity.go
+++ b/cli/internal/evtstream/identity.go
@@ -1,39 +1,38 @@
 package evtstream
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/internal/streamidentity"
 )
 
 const (
 	// IdentityMetadataKey stores Chatto's durable EVT stream incarnation.
 	IdentityMetadataKey = "chatto.evt.incarnation"
-	identityPrefix      = "evt-incarnation-v1:"
 )
+
+// identityScheme owns the EVT stream's incarnation format: metadata key,
+// versioned prefix, digest domain, and error labels.
+var identityScheme = streamidentity.Identity{
+	MetadataKey: IdentityMetadataKey,
+	Prefix:      "evt-incarnation-v1:",
+	Domain:      "chatto/evt-incarnation/v1",
+	Label:       "EVT stream",
+}
 
 // NewIdentity deterministically derives Chatto's identity for one EVT stream
 // incarnation. created is used only when initializing missing metadata.
 func NewIdentity(created time.Time) (string, error) {
-	if created.IsZero() {
-		return "", fmt.Errorf("EVT stream creation time is required")
-	}
-	sum := sha256.Sum256([]byte("chatto/evt-incarnation/v1\x00" + created.UTC().Format(time.RFC3339Nano)))
-	return identityPrefix + hex.EncodeToString(sum[:16]), nil
+	return identityScheme.New(created)
 }
 
 // ValidIdentity reports whether identity has Chatto's versioned EVT
 // stream-incarnation format.
 func ValidIdentity(identity string) bool {
-	if len(identity) != len(identityPrefix)+32 || !strings.HasPrefix(identity, identityPrefix) {
-		return false
-	}
-	_, err := hex.DecodeString(identity[len(identityPrefix):])
-	return err == nil
+	return identityScheme.Valid(identity)
 }
 
 // Identity reads the durable Chatto EVT incarnation cached when the stream was
@@ -48,12 +47,5 @@ func Identity(stream jetstream.Stream) (string, error) {
 // IdentityFromInfo resolves and validates Chatto's EVT incarnation from one
 // StreamInfo snapshot so callers can bind it to the same sequence bounds.
 func IdentityFromInfo(info *jetstream.StreamInfo) (string, error) {
-	if info == nil {
-		return "", fmt.Errorf("EVT stream info is unavailable")
-	}
-	identity := info.Config.Metadata[IdentityMetadataKey]
-	if !ValidIdentity(identity) {
-		return "", fmt.Errorf("EVT stream identity is missing or invalid")
-	}
-	return identity, nil
+	return identityScheme.FromInfo(info)
 }

--- a/cli/internal/notificationstream/identity_test.go
+++ b/cli/internal/notificationstream/identity_test.go
@@ -1,0 +1,60 @@
+package notificationstream
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+func TestNewIdentityPreservesPersistedFormat(t *testing.T) {
+	created := time.Date(2026, time.July, 30, 12, 34, 56, 789, time.UTC)
+
+	first, err := NewIdentity(created)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := NewIdentity(created)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const want = "notifications-incarnation-v1:ecb00ffc639bb523e0a64b4dc034242d"
+	if first != want || second != want {
+		t.Fatalf("NewIdentity() = %q, %q; want persisted-compatible %q", first, second, want)
+	}
+	if !ValidIdentity(first) {
+		t.Fatalf("generated identity %q is invalid", first)
+	}
+}
+
+func TestValidIdentityRejectsMalformedValues(t *testing.T) {
+	for _, identity := range []string{
+		"",
+		"application-defined",
+		"notifications-incarnation-v1:",
+		"notifications-incarnation-v1:gggggggggggggggggggggggggggggggg",
+		"evt-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	} {
+		if ValidIdentity(identity) {
+			t.Errorf("ValidIdentity(%q) = true", identity)
+		}
+	}
+}
+
+func TestIdentityFromInfoReadsChattoMetadata(t *testing.T) {
+	const want = "notifications-incarnation-v1:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	info := &jetstream.StreamInfo{
+		Config: jetstream.StreamConfig{
+			Metadata: map[string]string{IdentityMetadataKey: want},
+		},
+	}
+
+	got, err := IdentityFromInfo(info)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("IdentityFromInfo() = %q, want %q", got, want)
+	}
+}

--- a/cli/internal/notificationstream/stream.go
+++ b/cli/internal/notificationstream/stream.go
@@ -4,17 +4,15 @@ package notificationstream
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
 
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
+	"hmans.de/chatto/internal/streamidentity"
 	"hmans.de/chatto/pkg/events"
 )
 
@@ -26,8 +24,16 @@ const (
 	AlertResolvedSubject = "notifications.alert_resolved"
 
 	IdentityMetadataKey = "chatto.notifications.incarnation"
-	identityPrefix      = "notifications-incarnation-v1:"
 )
+
+// identityScheme owns the NOTIFICATIONS stream's incarnation format: metadata
+// key, versioned prefix, digest domain, and error labels.
+var identityScheme = streamidentity.Identity{
+	MetadataKey: IdentityMetadataKey,
+	Prefix:      "notifications-incarnation-v1:",
+	Domain:      "chatto/notifications-incarnation/v1",
+	Label:       "NOTIFICATIONS stream",
+}
 
 // Subjects returns the complete, fixed subject set owned by NOTIFICATIONS.
 // Returning a fresh slice keeps callers from mutating the stream contract.
@@ -223,29 +229,21 @@ func decodeEvent(data []byte) (events.DecodedEvent[*corev1.NotificationEvent], e
 	return events.DecodedEvent[*corev1.NotificationEvent]{Event: &event, ID: event.GetId()}, nil
 }
 
+// NewIdentity deterministically derives Chatto's identity for one NOTIFICATIONS
+// stream incarnation. created is used only when initializing missing metadata.
 func NewIdentity(created time.Time) (string, error) {
-	if created.IsZero() {
-		return "", fmt.Errorf("NOTIFICATIONS stream creation time is required")
-	}
-	sum := sha256.Sum256([]byte("chatto/notifications-incarnation/v1\x00" + created.UTC().Format(time.RFC3339Nano)))
-	return identityPrefix + hex.EncodeToString(sum[:16]), nil
+	return identityScheme.New(created)
 }
 
+// ValidIdentity reports whether identity has Chatto's versioned NOTIFICATIONS
+// stream-incarnation format.
 func ValidIdentity(identity string) bool {
-	if len(identity) != len(identityPrefix)+32 || !strings.HasPrefix(identity, identityPrefix) {
-		return false
-	}
-	_, err := hex.DecodeString(identity[len(identityPrefix):])
-	return err == nil
+	return identityScheme.Valid(identity)
 }
 
+// IdentityFromInfo resolves and validates Chatto's NOTIFICATIONS incarnation
+// from one StreamInfo snapshot so callers can bind it to the same sequence
+// bounds.
 func IdentityFromInfo(info *jetstream.StreamInfo) (string, error) {
-	if info == nil {
-		return "", fmt.Errorf("NOTIFICATIONS stream info is unavailable")
-	}
-	identity := info.Config.Metadata[IdentityMetadataKey]
-	if !ValidIdentity(identity) {
-		return "", fmt.Errorf("NOTIFICATIONS stream identity is missing or invalid")
-	}
-	return identity, nil
+	return identityScheme.FromInfo(info)
 }

--- a/cli/internal/streamidentity/streamidentity.go
+++ b/cli/internal/streamidentity/streamidentity.go
@@ -1,0 +1,66 @@
+// Package streamidentity provides Chatto's versioned stream-incarnation
+// identity format, shared by the durable EVT stream and other incarnation-bound
+// streams such as NOTIFICATIONS.
+//
+// The identity is a prefixed, hex-encoded SHA-256 digest derived from the
+// stream's creation time. It is persisted in stream metadata so it survives
+// backup and restore, unlike StreamInfo.Created. Each stream declares its own
+// metadata key, prefix, and domain string; this package owns only the common
+// derivation, format validation, and lookup mechanics.
+package streamidentity
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+)
+
+// Identity describes one stream's incarnation scheme: where the identity is
+// cached in JetStream metadata, how the encoded value is recognized, and which
+// domain string feeds the digest. Values are immutable after definition.
+type Identity struct {
+	// MetadataKey is the stream-config metadata key that caches the identity.
+	MetadataKey string
+	// Prefix marks the identity format generation inside the encoded value.
+	Prefix string
+	// Domain names the identity inside the digest input, e.g. "chatto/evt-incarnation/v1".
+	Domain string
+	// Label is used verbatim in error messages, e.g. "EVT stream".
+	Label string
+}
+
+// New deterministically derives the stream identity for one incarnation.
+// created is used only when initializing missing metadata.
+func (i Identity) New(created time.Time) (string, error) {
+	if created.IsZero() {
+		return "", fmt.Errorf("%s creation time is required", i.Label)
+	}
+	sum := sha256.Sum256([]byte(i.Domain + "\x00" + created.UTC().Format(time.RFC3339Nano)))
+	return i.Prefix + hex.EncodeToString(sum[:16]), nil
+}
+
+// Valid reports whether identity has the expected versioned identity format.
+func (i Identity) Valid(identity string) bool {
+	if len(identity) != len(i.Prefix)+32 || !strings.HasPrefix(identity, i.Prefix) {
+		return false
+	}
+	_, err := hex.DecodeString(identity[len(i.Prefix):])
+	return err == nil
+}
+
+// FromInfo resolves and validates the identity from one StreamInfo snapshot so
+// callers can bind it to the same sequence bounds.
+func (i Identity) FromInfo(info *jetstream.StreamInfo) (string, error) {
+	if info == nil {
+		return "", fmt.Errorf("%s info is unavailable", i.Label)
+	}
+	identity := info.Config.Metadata[i.MetadataKey]
+	if !i.Valid(identity) {
+		return "", fmt.Errorf("%s identity is missing or invalid", i.Label)
+	}
+	return identity, nil
+}


### PR DESCRIPTION
## Why

`internal/evtstream` and `internal/notificationstream` each carried line-for-line identical stream-incarnation machinery — SHA-256 identity derivation, versioned-format validation, and stream-metadata lookup — differing only in metadata key, prefix string, and error labels. Duplicated cryptographic validation logic must stay in sync by hand, which is an avoidable drift risk.

## What changed

- Added a small application-level `cli/internal/streamidentity` helper whose `Identity` type owns the shared derivation, validation, and lookup mechanics.
- Reduced both packages to thin wrappers. Per `cli/AGENTS.md`, these mechanics stay at the application-composition layer rather than in the `pkg/events` framework.
- Persisted identity formats, metadata keys, digest domains, exported APIs, and error messages are byte-identical; callers needed no changes.
- Added a persisted-format parity test for NOTIFICATIONS identities (previously untested), including a fixed expected digest to fail loudly on any drift.

## API compatibility

- No public API or protocol behaviour changed.
- Persisted stream metadata values (incarnation identities) are unchanged.

Older client → newer server:

Newer client → older server:

Capability discovery or minimum client/server version:

## Test plan

- `go test ./internal/notificationstream ./internal/evtstream ./internal/core` — all pass.
- `go vet` on the changed packages — clean.
