### PR TITLE
refactor(events): extract shared TypedEventLog adapter

### DIFF
--- a/authling/internal/evtstream/evtstream.go
+++ b/authling/internal/evtstream/evtstream.go
@@ -27,12 +27,22 @@ func IssuerSubject() string { return issuerSubject }
 
 // IssuerTail returns the singleton issuer aggregate's current OCC token.
 func (p *Publisher) IssuerTail(ctx context.Context) (uint64, error) {
-	return p.log.LastSubjectSeq(ctx, issuerSubject)
+	return p.LastSubjectSeq(ctx, issuerSubject)
 }
 
-// Publisher validates and appends Authling events through the shared event log.
+// Publisher validates and appends Authling events through the shared event
+// log. The embedded framework typed log supplies the mechanical encode and
+// publish mapping; this type adds only Authling's subjects, validation, and
+// aggregate-command methods.
 type Publisher struct {
-	log *events.EncodedEventLog
+	events.TypedEventLog[*corev1.Event]
+}
+
+// NewPublisher constructs an Authling protobuf publisher.
+func NewPublisher(log *events.EncodedEventLog) *Publisher {
+	return &Publisher{
+		TypedEventLog: *events.NewTypedEventLog(log, encode, decodeEventData),
+	}
 }
 
 // AccountRegistrySubject is the PII-free serialization point for local email
@@ -42,7 +52,7 @@ func AccountRegistrySubject() string { return accountRegistrySubject }
 
 // AccountRegistryTail returns the current OCC token for local account claims.
 func (p *Publisher) AccountRegistryTail(ctx context.Context) (uint64, error) {
-	return p.log.LastSubjectSeq(ctx, accountRegistrySubject)
+	return p.LastSubjectSeq(ctx, accountRegistrySubject)
 }
 
 // AccountTail returns the current OCC token for one account aggregate.
@@ -51,7 +61,7 @@ func (p *Publisher) AccountTail(ctx context.Context, accountID string) (uint64, 
 	if err != nil {
 		return 0, err
 	}
-	return p.log.LastSubjectSeq(ctx, subject)
+	return p.LastSubjectSeq(ctx, subject)
 }
 
 // AppendRegisteredAccount commits a local account against a previously read
@@ -66,17 +76,9 @@ func (p *Publisher) AppendRegisteredAccount(ctx context.Context, accountEvent, c
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	accountRecord, err := encode(accountEvent)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	claimRecord, err := encode(claimEvent)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequences, err := p.log.AppendBatch(ctx, []events.EncodedBatchEntry{
-		{Subject: accountSubject, Record: accountRecord, ExpectedSeq: 0, HasOCC: true},
-		{Subject: accountRegistrySubject, Record: claimRecord, ExpectedSeq: expectedRegistry, HasOCC: true},
+	sequences, err := p.AppendBatch(ctx, []events.TypedBatchEntry[*corev1.Event]{
+		{Subject: accountSubject, Event: accountEvent, ExpectedSeq: 0, HasOCC: true},
+		{Subject: accountRegistrySubject, Event: claimEvent, ExpectedSeq: expectedRegistry, HasOCC: true},
 	})
 	if err != nil {
 		return events.StreamPosition{}, err
@@ -84,9 +86,14 @@ func (p *Publisher) AppendRegisteredAccount(ctx context.Context, accountEvent, c
 	return events.SubjectPosition(accountRegistrySubject, sequences[1]), nil
 }
 
-// NewPublisher constructs an Authling protobuf publisher.
-func NewPublisher(log *events.EncodedEventLog) *Publisher {
-	return &Publisher{log: log}
+// appendAtPosition publishes one event at an explicitly observed aggregate
+// tail and reports its position on that aggregate.
+func (p *Publisher) appendAtPosition(ctx context.Context, subject string, event *corev1.Event, expectedTail uint64) (events.StreamPosition, error) {
+	sequence, err := p.AppendAt(ctx, subject, event, expectedTail)
+	if err != nil {
+		return events.StreamPosition{}, err
+	}
+	return events.SubjectPosition(subject, sequence), nil
 }
 
 // AppendAccountCreated creates a new account aggregate at expected sequence
@@ -103,15 +110,8 @@ func (p *Publisher) AppendAccountCreated(
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, 0)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, 0)
+
 }
 
 // AppendPasswordChanged replaces a credential at an explicitly observed
@@ -129,15 +129,8 @@ func (p *Publisher) AppendPasswordChanged(
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, expectedTail)
+
 }
 
 // AppendProfileUpdated replaces profile hints at an explicitly observed
@@ -151,15 +144,8 @@ func (p *Publisher) AppendProfileUpdated(ctx context.Context, event *corev1.Even
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, expectedTail)
+
 }
 
 // AppendPasswordResetRequested records an accepted recovery request at an
@@ -177,15 +163,8 @@ func (p *Publisher) AppendPasswordResetRequested(
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, expectedTail)
+
 }
 
 // AppendEmailChangeRequested records successful reauthentication for an email
@@ -203,15 +182,8 @@ func (p *Publisher) AppendEmailChangeRequested(
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, expectedTail)
+
 }
 
 // AppendEmailChanged atomically stages an encrypted replacement address on the
@@ -230,17 +202,9 @@ func (p *Publisher) AppendEmailChanged(
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	changeRecord, err := encode(changeEvent)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	claimRecord, err := encode(claimEvent)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequences, err := p.log.AppendBatch(ctx, []events.EncodedBatchEntry{
-		{Subject: accountSubject, Record: changeRecord, ExpectedSeq: expectedAccount, HasOCC: true},
-		{Subject: accountRegistrySubject, Record: claimRecord, ExpectedSeq: expectedRegistry, HasOCC: true},
+	sequences, err := p.AppendBatch(ctx, []events.TypedBatchEntry[*corev1.Event]{
+		{Subject: accountSubject, Event: changeEvent, ExpectedSeq: expectedAccount, HasOCC: true},
+		{Subject: accountRegistrySubject, Event: claimEvent, ExpectedSeq: expectedRegistry, HasOCC: true},
 	})
 	if err != nil {
 		return events.StreamPosition{}, err
@@ -259,15 +223,8 @@ func (p *Publisher) AppendOIDCGrantAuthorized(ctx context.Context, event *corev1
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, expectedTail)
+
 }
 
 // AppendOIDCGrantRevoked records revocation of an active OIDC grant at an
@@ -281,15 +238,8 @@ func (p *Publisher) AppendOIDCGrantRevoked(ctx context.Context, event *corev1.Ev
 	if err != nil {
 		return events.StreamPosition{}, err
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, subject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(subject, sequence), nil
+	return p.appendAtPosition(ctx, subject, event, expectedTail)
+
 }
 
 // AppendIssuerEstablished creates the singleton issuer aggregate.
@@ -297,15 +247,7 @@ func (p *Publisher) AppendIssuerEstablished(ctx context.Context, event *corev1.E
 	if event.GetIssuerEstablished() == nil {
 		return events.StreamPosition{}, fmt.Errorf("append issuer established: event payload is not issuer_established")
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, issuerSubject, record, 0)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(issuerSubject, sequence), nil
+	return p.appendAtPosition(ctx, issuerSubject, event, 0)
 }
 
 // AppendIssuerLifecycle records a signing-key transition at an explicitly
@@ -320,15 +262,7 @@ func (p *Publisher) AppendIssuerLifecycle(ctx context.Context, event *corev1.Eve
 	default:
 		return events.StreamPosition{}, fmt.Errorf("append issuer lifecycle: event payload is not a signing-key lifecycle event")
 	}
-	record, err := encode(event)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	sequence, err := p.log.AppendAt(ctx, issuerSubject, record, expectedTail)
-	if err != nil {
-		return events.StreamPosition{}, err
-	}
-	return events.SubjectPosition(issuerSubject, sequence), nil
+	return p.appendAtPosition(ctx, issuerSubject, event, expectedTail)
 }
 
 // Decode validates and decodes one persisted Authling event.
@@ -341,6 +275,16 @@ func Decode(data []byte) (events.DecodedEvent[*corev1.Event], error) {
 		return events.DecodedEvent[*corev1.Event]{}, err
 	}
 	return events.DecodedEvent[*corev1.Event]{Event: &event, ID: event.GetId()}, nil
+}
+
+// decodeEventData decodes an opaque record payload for typed subject reads;
+// persisted records were validated when they were published.
+func decodeEventData(data []byte) (*corev1.Event, error) {
+	var event corev1.Event
+	if err := proto.Unmarshal(data, &event); err != nil {
+		return nil, fmt.Errorf("decode Authling event: %w", err)
+	}
+	return &event, nil
 }
 
 func encode(event *corev1.Event) (events.EncodedRecord, error) {

--- a/cli/internal/evtstream/publisher.go
+++ b/cli/internal/evtstream/publisher.go
@@ -31,185 +31,37 @@ import (
 // well-formed before encoding.
 var ErrInvalidEvent = errors.New("invalid event")
 
-// Publisher is Chatto's typed adapter over the byte-oriented event log. It
-// validates and protobuf-encodes core events while EncodedEventLog owns NATS
-// OCC, atomic publication, stream positions, and encoded reads.
-type Publisher struct {
-	log *events.EncodedEventLog
-}
-
 const (
 	subjectEventsPageSize     = 500
 	subjectEventsPageMaxBytes = 16 * 1024 * 1024
 )
 
+// Publisher is Chatto's typed adapter over the byte-oriented event log. It
+// validates and protobuf-encodes core events while EncodedEventLog owns NATS
+// OCC, atomic publication, stream positions, and encoded reads.
+//
+// The embedded framework typed log supplies the mechanical encode/decode,
+// batch, mutation, and paged-read mapping plus untyped log reads; this type
+// adds only Chatto's envelope codec and EVT-specific convenience reads.
+type Publisher struct {
+	events.TypedEventLog[*corev1.Event]
+}
+
 // NewPublisher constructs a Chatto event publisher bound to a stream.
 func NewPublisher(js jetstream.JetStream, stream jetstream.Stream, logger events.Logger) *Publisher {
-	return &Publisher{log: events.NewEncodedEventLog(js, stream, logger)}
-}
-
-// StreamUsage returns the current message and byte totals for the bound stream.
-func (p *Publisher) StreamUsage(ctx context.Context) (messages, bytes uint64, err error) {
-	return p.log.StreamUsage(ctx)
-}
-
-// Append validates, encodes, and publishes an event using the subject's current
-// tail as its OCC token.
-func (p *Publisher) Append(ctx context.Context, subject string, event *corev1.Event) (uint64, error) {
-	record, err := encodeEvent(event)
-	if err != nil {
-		return 0, err
+	log := events.NewEncodedEventLog(js, stream, logger)
+	return &Publisher{
+		TypedEventLog: *events.NewTypedEventLog(log, encodeEvent, decodeEventData),
 	}
-	return p.log.Append(ctx, subject, record)
-}
-
-// AppendEventually retries OCC conflicts with the exact same encoded event.
-// Use it only when the event's semantics are safe after an intervening write.
-func (p *Publisher) AppendEventually(
-	ctx context.Context,
-	subject string,
-	event *corev1.Event,
-) (uint64, error) {
-	record, err := encodeEvent(event)
-	if err != nil {
-		return 0, err
-	}
-	return p.log.AppendEventually(ctx, subject, record)
-}
-
-// AppendAt publishes an event with a caller-supplied expected last sequence
-// for subject.
-func (p *Publisher) AppendAt(
-	ctx context.Context,
-	subject string,
-	event *corev1.Event,
-	expectedSeq uint64,
-) (uint64, error) {
-	record, err := encodeEvent(event)
-	if err != nil {
-		return 0, err
-	}
-	return p.log.AppendAt(ctx, subject, record, expectedSeq)
-}
-
-// AppendAtFilter publishes to subject with OCC against a possibly wildcarded
-// subject filter.
-func (p *Publisher) AppendAtFilter(
-	ctx context.Context,
-	subject string,
-	event *corev1.Event,
-	filter string,
-	expectedFilterSeq uint64,
-) (uint64, error) {
-	record, err := encodeEvent(event)
-	if err != nil {
-		return 0, err
-	}
-	return p.log.AppendAtFilter(ctx, subject, record, filter, expectedFilterSeq)
 }
 
 // BatchEntry is one Chatto event in an atomic publish batch. At least one entry
 // must carry a per-subject, wildcard-filter, or whole-stream OCC guard.
-type BatchEntry struct {
-	Subject           string
-	Event             *corev1.Event
-	ExpectedSeq       uint64
-	FilterSubject     string
-	HasOCC            bool
-	ExpectedStreamSeq uint64
-	HasStreamOCC      bool
-}
-
-// AppendBatch validates and encodes every event before atomically publishing
-// the resulting opaque records. Either all records land adjacently or none do.
-func (p *Publisher) AppendBatch(ctx context.Context, entries []BatchEntry) ([]uint64, error) {
-	if len(entries) == 0 {
-		return nil, nil
-	}
-	hasOCC := false
-	for i, entry := range entries {
-		if err := validateEvent(entry.Event); err != nil {
-			return nil, fmt.Errorf("batch entry %d: %w", i, err)
-		}
-		hasOCC = hasOCC || entry.HasOCC || entry.HasStreamOCC
-	}
-	if !hasOCC {
-		return nil, events.ErrMissingOCC
-	}
-
-	encoded := make([]events.EncodedBatchEntry, len(entries))
-	for i, entry := range entries {
-		record, err := encodeEvent(entry.Event)
-		if err != nil {
-			return nil, fmt.Errorf("batch entry %d: %w", i, err)
-		}
-		encoded[i] = events.EncodedBatchEntry{
-			Subject:           entry.Subject,
-			Record:            record,
-			ExpectedSeq:       entry.ExpectedSeq,
-			FilterSubject:     entry.FilterSubject,
-			HasOCC:            entry.HasOCC,
-			ExpectedStreamSeq: entry.ExpectedStreamSeq,
-			HasStreamOCC:      entry.HasStreamOCC,
-		}
-	}
-	return p.log.AppendBatch(ctx, encoded)
-}
+type BatchEntry = events.TypedBatchEntry[*corev1.Event]
 
 // MutationEntry is one typed Chatto event selected by a mutation decision.
 // The shared event framework applies OCC from the chosen boundary.
-type MutationEntry struct {
-	Subject string
-	Event   *corev1.Event
-}
-
-// ExecuteMutation captures the selected boundary, reruns decide after OCC
-// conflicts, and atomically publishes the returned events. Returning no
-// entries is a successful no-op.
-func (p *Publisher) ExecuteMutation(
-	ctx context.Context,
-	boundary events.MutationBoundary,
-	decide func(context.Context, events.MutationAttempt) ([]MutationEntry, error),
-) (events.MutationResult, error) {
-	if decide == nil {
-		return events.MutationResult{}, events.ErrInvalidMutationDecision
-	}
-	return p.log.ExecuteMutation(ctx, boundary, func(ctx context.Context, attempt events.MutationAttempt) ([]events.EncodedMutationEntry, error) {
-		entries, err := decide(ctx, attempt)
-		if err != nil {
-			return nil, err
-		}
-		encoded := make([]events.EncodedMutationEntry, len(entries))
-		for i, entry := range entries {
-			record, err := encodeEvent(entry.Event)
-			if err != nil {
-				return nil, fmt.Errorf("mutation entry %d: %w", i, err)
-			}
-			encoded[i] = events.EncodedMutationEntry{Subject: entry.Subject, Record: record}
-		}
-		return encoded, nil
-	})
-}
-
-// LastStreamSeq returns the current last sequence of EVT.
-func (p *Publisher) LastStreamSeq(ctx context.Context) (uint64, error) {
-	return p.log.LastStreamSeq(ctx)
-}
-
-// LastSubjectSeq returns the stream's current last sequence for an exact
-// subject or wildcard subject filter.
-func (p *Publisher) LastSubjectSeq(ctx context.Context, subjectOrFilter string) (uint64, error) {
-	return p.log.LastSubjectSeq(ctx, subjectOrFilter)
-}
-
-// LastSubjectPosition returns the stream's current position for an exact
-// subject or wildcard subject filter.
-func (p *Publisher) LastSubjectPosition(
-	ctx context.Context,
-	subjectOrFilter string,
-) (events.StreamPosition, error) {
-	return p.log.LastSubjectPosition(ctx, subjectOrFilter)
-}
+type MutationEntry = events.TypedMutationEntry[*corev1.Event]
 
 // SubjectEvents returns decoded events on a subject in stream order.
 func (p *Publisher) SubjectEvents(
@@ -229,11 +81,11 @@ func (p *Publisher) SubjectEventsAfter(
 	if err != nil {
 		return nil, lastSeq, err
 	}
-	events := make([]*corev1.Event, 0, len(subjectEvents))
+	decoded := make([]*corev1.Event, 0, len(subjectEvents))
 	for _, subjectEvent := range subjectEvents {
-		events = append(events, subjectEvent.Event)
+		decoded = append(decoded, subjectEvent.Event)
 	}
-	return events, lastSeq, nil
+	return decoded, lastSeq, nil
 }
 
 // SubjectEvent preserves the durable subject and stream sequence alongside a
@@ -251,27 +103,13 @@ func (p *Publisher) SubjectEventsWithSubjectsAfter(
 	subject string,
 	afterSeq uint64,
 ) ([]*SubjectEvent, uint64, error) {
-	var events []*SubjectEvent
-	var lastSeq uint64
-	for {
-		page, err := p.log.SubjectRecordsAfterPage(ctx, subject, afterSeq, subjectEventsPageSize, subjectEventsPageMaxBytes)
-		if err != nil {
-			return nil, lastSeq, err
-		}
-		for _, record := range page.Records {
-			var event corev1.Event
-			if err := proto.Unmarshal(record.Data, &event); err != nil {
-				return nil, 0, fmt.Errorf("unmarshal event at seq %d: %w", record.Sequence, err)
-			}
-			events = append(events, &SubjectEvent{Subject: record.Subject, Sequence: record.Sequence, Event: &event})
-		}
-		if page.LastSequence > lastSeq {
-			lastSeq = page.LastSequence
-		}
-		if !page.More || len(page.Records) == 0 {
-			break
-		}
-		afterSeq = page.LastSequence
+	records, lastSeq, err := p.TypedEventLog.SubjectEventsWithSubjectsAfter(ctx, subject, afterSeq, subjectEventsPageSize, subjectEventsPageMaxBytes)
+	if err != nil {
+		return nil, lastSeq, err
+	}
+	events := make([]*SubjectEvent, 0, len(records))
+	for _, record := range records {
+		events = append(events, &SubjectEvent{Subject: record.Subject, Sequence: record.Sequence, Event: record.Event})
 	}
 	return events, lastSeq, nil
 }
@@ -301,6 +139,14 @@ func encodeEvent(event *corev1.Event) (events.EncodedRecord, error) {
 		return events.EncodedRecord{}, fmt.Errorf("marshal event: %w", err)
 	}
 	return events.EncodedRecord{ID: event.GetId(), Data: data}, nil
+}
+
+func decodeEventData(data []byte) (*corev1.Event, error) {
+	var event corev1.Event
+	if err := proto.Unmarshal(data, &event); err != nil {
+		return nil, err
+	}
+	return &event, nil
 }
 
 func validateEvent(event *corev1.Event) error {

--- a/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
+++ b/docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-07-30
 
-**Updated:** 2026-08-19
+**Updated:** 2026-08-27
 
 ## Context
 
@@ -78,6 +78,15 @@ application-owned stream enables per-message TTL, but semantic expiry remains
 application policy enforced by projections and APIs. Atomic batches report a
 typed duplicate-ID failure so an application can fall back to idempotent
 single-record appends without losing a committed prefix.
+
+`TypedEventLog[E]` is the shared mechanical adapter over that boundary,
+extracted once Chatto and Authling had duplicated the same encode, batch,
+mutation, and paged-read plumbing in their per-application publishers. It maps
+one application event type through application-supplied encoder and decoder
+functions; applications keep their envelope codecs, subjects, semantic
+validation, aggregate command methods, and composition. This extraction
+follows the two-consumer rule above rather than a desire to shorten one
+application's wiring.
 
 The framework is configured with a concrete JetStream stream; it does not
 assume that an application has only one event log or that the log is named

--- a/pkg/events/typed_event_log.go
+++ b/pkg/events/typed_event_log.go
@@ -1,0 +1,211 @@
+package events
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// ErrNoTypedDecoder is returned when typed subject reads are requested from a
+// TypedEventLog constructed without a decoder.
+var ErrNoTypedDecoder = errors.New("typed event log has no decoder")
+
+// TypedEventEncoder turns one application event into an opaque event-log
+// record before publication. The application owns validation, stable record
+// IDs, wire encoding, and every storage policy expressed by the record.
+type TypedEventEncoder[E any] func(E) (EncodedRecord, error)
+
+// TypedEventDecoder turns one opaque event-log record payload back into its
+// application event for typed subject reads. It must reject records that the
+// application cannot interpret rather than guessing.
+type TypedEventDecoder[E any] func([]byte) (E, error)
+
+// TypedSubjectRecord pairs one decoded application event with its matched
+// durable subject and stream sequence.
+type TypedSubjectRecord[E any] struct {
+	Subject  string
+	Sequence uint64
+	Event    E
+}
+
+// TypedBatchEntry is one application event in an atomic publish batch. At
+// least one entry must carry a per-subject, wildcard-filter, or whole-stream
+// OCC guard; the underlying EncodedEventLog enforces that invariant.
+type TypedBatchEntry[E any] struct {
+	Subject           string
+	Event             E
+	ExpectedSeq       uint64
+	FilterSubject     string
+	HasOCC            bool
+	ExpectedStreamSeq uint64
+	HasStreamOCC      bool
+}
+
+// TypedMutationEntry is one typed application event selected by a mutation
+// decision. The shared event framework applies OCC from the chosen boundary.
+type TypedMutationEntry[E any] struct {
+	Subject string
+	Event   E
+}
+
+// TypedEventLog adapts the envelope-neutral byte-oriented event log to one
+// application event type E through an application-supplied encoder. It owns
+// only the mechanical encode, decode, and batch/mutation mapping; applications
+// keep their subjects, semantic validation, envelope policy, and composition.
+//
+// Embedding an *EncodedEventLog means untyped log reads such as LastSubjectSeq,
+// LastSubjectPosition, StreamUsage, and SubjectRecordsAfterPage remain
+// available on the typed value.
+type TypedEventLog[E any] struct {
+	*EncodedEventLog
+
+	encode TypedEventEncoder[E]
+	decode TypedEventDecoder[E]
+}
+
+// NewTypedEventLog binds a typed adapter to an already constructed encoded
+// event log. Encode must be non-nil; it is applied to every published event.
+// Decode may be nil when the application only publishes through this log, but
+// typed subject reads then return an error.
+func NewTypedEventLog[E any](log *EncodedEventLog, encode TypedEventEncoder[E], decode TypedEventDecoder[E]) *TypedEventLog[E] {
+	return &TypedEventLog[E]{EncodedEventLog: log, encode: encode, decode: decode}
+}
+
+// Append validates, encodes, and publishes an event using the subject's
+// current tail as its OCC token.
+func (t *TypedEventLog[E]) Append(ctx context.Context, subject string, event E) (uint64, error) {
+	record, err := t.encode(event)
+	if err != nil {
+		return 0, err
+	}
+	return t.EncodedEventLog.Append(ctx, subject, record)
+}
+
+// AppendEventually retries OCC conflicts with the exact same encoded event.
+// Use it only when the event's semantics are safe after an intervening write.
+func (t *TypedEventLog[E]) AppendEventually(ctx context.Context, subject string, event E) (uint64, error) {
+	record, err := t.encode(event)
+	if err != nil {
+		return 0, err
+	}
+	return t.EncodedEventLog.AppendEventually(ctx, subject, record)
+}
+
+// AppendAt publishes an event with a caller-supplied expected last sequence
+// for subject.
+func (t *TypedEventLog[E]) AppendAt(ctx context.Context, subject string, event E, expectedSeq uint64) (uint64, error) {
+	record, err := t.encode(event)
+	if err != nil {
+		return 0, err
+	}
+	return t.EncodedEventLog.AppendAt(ctx, subject, record, expectedSeq)
+}
+
+// AppendAtFilter publishes to subject with OCC against a possibly wildcarded
+// subject filter.
+func (t *TypedEventLog[E]) AppendAtFilter(
+	ctx context.Context,
+	subject string,
+	event E,
+	filter string,
+	expectedFilterSeq uint64,
+) (uint64, error) {
+	record, err := t.encode(event)
+	if err != nil {
+		return 0, err
+	}
+	return t.EncodedEventLog.AppendAtFilter(ctx, subject, record, filter, expectedFilterSeq)
+}
+
+// AppendBatch encodes every event before atomically publishing the resulting
+// opaque records. Either all records land adjacently or none do.
+func (t *TypedEventLog[E]) AppendBatch(ctx context.Context, entries []TypedBatchEntry[E]) ([]uint64, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	encoded := make([]EncodedBatchEntry, len(entries))
+	for i, entry := range entries {
+		record, err := t.encode(entry.Event)
+		if err != nil {
+			return nil, fmt.Errorf("batch entry %d: %w", i, err)
+		}
+		encoded[i] = EncodedBatchEntry{
+			Subject:           entry.Subject,
+			Record:            record,
+			ExpectedSeq:       entry.ExpectedSeq,
+			FilterSubject:     entry.FilterSubject,
+			HasOCC:            entry.HasOCC,
+			ExpectedStreamSeq: entry.ExpectedStreamSeq,
+			HasStreamOCC:      entry.HasStreamOCC,
+		}
+	}
+	return t.EncodedEventLog.AppendBatch(ctx, encoded)
+}
+
+// ExecuteMutation captures the selected boundary, reruns decide after OCC
+// conflicts, and atomically publishes the returned events. Returning no
+// entries is a successful no-op.
+func (t *TypedEventLog[E]) ExecuteMutation(
+	ctx context.Context,
+	boundary MutationBoundary,
+	decide func(context.Context, MutationAttempt) ([]TypedMutationEntry[E], error),
+) (MutationResult, error) {
+	if decide == nil {
+		return MutationResult{}, ErrInvalidMutationDecision
+	}
+	return t.EncodedEventLog.ExecuteMutation(ctx, boundary, func(ctx context.Context, attempt MutationAttempt) ([]EncodedMutationEntry, error) {
+		entries, err := decide(ctx, attempt)
+		if err != nil {
+			return nil, err
+		}
+		encoded := make([]EncodedMutationEntry, len(entries))
+		for i, entry := range entries {
+			record, err := t.encode(entry.Event)
+			if err != nil {
+				return nil, fmt.Errorf("mutation entry %d: %w", i, err)
+			}
+			encoded[i] = EncodedMutationEntry{Subject: entry.Subject, Record: record}
+		}
+		return encoded, nil
+	})
+}
+
+// SubjectEventsWithSubjectsAfter decodes all records matching subject with a
+// stream sequence greater than afterSeq while preserving each record's matched
+// durable subject and sequence. maxRecords bounds every page;
+// maxBytes bounds page payload bytes when positive, mirroring
+// SubjectRecordsAfterPage.
+func (t *TypedEventLog[E]) SubjectEventsWithSubjectsAfter(
+	ctx context.Context,
+	subject string,
+	afterSeq uint64,
+	maxRecords int,
+	maxBytes int,
+) ([]TypedSubjectRecord[E], uint64, error) {
+	if t.decode == nil {
+		return nil, 0, ErrNoTypedDecoder
+	}
+	var decodedEvents []TypedSubjectRecord[E]
+	var lastSeq uint64
+	for {
+		page, err := t.EncodedEventLog.SubjectRecordsAfterPage(ctx, subject, afterSeq, maxRecords, maxBytes)
+		if err != nil {
+			return nil, lastSeq, err
+		}
+		for _, record := range page.Records {
+			event, err := t.decode(record.Data)
+			if err != nil {
+				return nil, 0, fmt.Errorf("decode record at seq %d: %w", record.Sequence, err)
+			}
+			decodedEvents = append(decodedEvents, TypedSubjectRecord[E]{Subject: record.Subject, Sequence: record.Sequence, Event: event})
+		}
+		if page.LastSequence > lastSeq {
+			lastSeq = page.LastSequence
+		}
+		if !page.More || len(page.Records) == 0 {
+			break
+		}
+		afterSeq = page.LastSequence
+	}
+	return decodedEvents, lastSeq, nil
+}

--- a/pkg/events/typed_event_log_test.go
+++ b/pkg/events/typed_event_log_test.go
@@ -1,0 +1,90 @@
+package events_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	. "hmans.de/chatto/pkg/events"
+)
+
+// typedTestEvent is a minimal application event for exercising the typed
+// adapter with a non-protobuf envelope.
+type typedTestEvent struct {
+	ID      string
+	Payload []byte
+}
+
+func encodeTypedTestEvent(event typedTestEvent) (EncodedRecord, error) {
+	if event.ID == "" {
+		return EncodedRecord{}, errors.New("id required")
+	}
+	return EncodedRecord{ID: event.ID, Data: bytes.Clone(event.Payload)}, nil
+}
+
+func decodeTypedTestEvent(data []byte) (typedTestEvent, error) {
+	return typedTestEvent{ID: "decoded", Payload: bytes.Clone(data)}, nil
+}
+
+func TestTypedEventLogEncodesAndDecodesThroughEncodedLog(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	subject := "evt.typed.record.created"
+
+	eventLog := NewEncodedEventLog(js, stream, testLogger())
+	typed := NewTypedEventLog(
+		eventLog,
+		encodeTypedTestEvent,
+		func(data []byte) (typedTestEvent, error) {
+			return typedTestEvent{ID: "typed-1", Payload: bytes.Clone(data)}, nil
+		},
+	)
+
+	seq, err := typed.AppendAt(ctx, subject, typedTestEvent{ID: "typed-1", Payload: []byte{0x01, 0x02}}, 0)
+	if err != nil {
+		t.Fatalf("AppendAt: %v", err)
+	}
+
+	records, lastSeq, err := typed.SubjectEventsWithSubjectsAfter(ctx, subject, 0, 100, 0)
+	if err != nil {
+		t.Fatalf("SubjectEventsWithSubjectsAfter: %v", err)
+	}
+	if len(records) != 1 || lastSeq != seq {
+		t.Fatalf("records=%d lastSeq=%d, want 1 and %d", len(records), lastSeq, seq)
+	}
+	if records[0].Subject != subject || records[0].Sequence != seq || records[0].Event.ID != "typed-1" || !bytes.Equal(records[0].Event.Payload, []byte{0x01, 0x02}) {
+		t.Fatalf("record = %+v", records[0])
+	}
+}
+
+var errBadTypedEvent = errors.New("typed encoder rejects empty payload")
+
+func TestTypedEventLogWrapsBatchEntryEncodeErrors(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	rejectingEncoder := func(event typedTestEvent) (EncodedRecord, error) {
+		if len(event.Payload) == 0 {
+			return EncodedRecord{}, errBadTypedEvent
+		}
+		return encodeTypedTestEvent(event)
+	}
+	typed := NewTypedEventLog(NewEncodedEventLog(js, stream, testLogger()), rejectingEncoder, decodeTypedTestEvent)
+
+	_, err := typed.AppendBatch(ctx, []TypedBatchEntry[typedTestEvent]{
+		{Subject: "evt.typed.batch.first", Event: typedTestEvent{ID: "first", Payload: []byte{0x00}}, HasOCC: true},
+		{Subject: "evt.typed.batch.second", Event: typedTestEvent{ID: "second"}},
+	})
+	if !errors.Is(err, errBadTypedEvent) {
+		t.Fatalf("AppendBatch error = %v, want wrapped errBadTypedEvent", err)
+	}
+}
+
+func TestTypedEventLogRequiresDecoderForSubjectReads(t *testing.T) {
+	js, stream := setupTestStream(t)
+	ctx := testContext(t)
+	typed := NewTypedEventLog[typedTestEvent](NewEncodedEventLog(js, stream, testLogger()), encodeTypedTestEvent, nil)
+
+	if _, _, err := typed.SubjectEventsWithSubjectsAfter(ctx, "evt.typed.none", 0, 10, 0); !errors.Is(err, ErrNoTypedDecoder) {
+		t.Fatalf("read without decoder = %v, want ErrNoTypedDecoder", err)
+	}
+}


### PR DESCRIPTION
## Why

Chatto's and Authling's typed event publishers duplicated the same mechanical plumbing over `EncodedEventLog` — encode dispatch, atomic batch mapping, mutation-decision mapping, and the paged subject-read decode loop — that had to be kept in sync by hand. This is ADR-056's two-consumer extraction case: Authling is the first concrete second application.

## What changed

- Added `events.TypedEventLog[E]` to the shared framework: it embeds `*EncodedEventLog`, maps one application event type through application-supplied encoder/decoder functions, and owns only mechanical encode/batch/mutation/paged-read glue.
- Chatto's `evtstream.Publisher` and Authling's `evtstream.Publisher` now embed the typed log; both keep their envelope codecs (including Authling's deterministic marshal), subjects, semantic validation, and aggregate command methods.
- Chatto `BatchEntry`/`MutationEntry` became type aliases over the framework types so all ~100 call sites are unchanged; every exported signature is identical.
- Authling's repetitive Append* command bodies collapsed onto a shared `appendAtPosition` helper; its two cross-aggregate atomic batches moved to typed batch entries with unchanged OCC guards.
- ADR-056 updated to record the extraction rationale. Persisted event bytes, subjects, OCC headers, stream positions, and public APIs are unchanged.

## API compatibility

- No public API or protocol behaviour changed.
- The `pkg/events` module remains pre-1.0; this is an additive framework surface.

Older client → newer server:

Newer client → older server:

Capability discovery or minimum client/server version:

## Test plan

- `mise test-events` (GOWORK=off) — passes; new portable tests cover typed append/read round-trip, batch encode-error wrapping, and missing-decoder rejection.
- `mise license-check` — REUSE 3.3 compliant.
- `mise test-cli` — full backend suite passes.
- `(cd authling && mise test)` — full suite passes, including GOWORK=off builds.
