### PR TITLE
refactor(frontend): consolidate user-summary mapping

### DIFF
--- a/apps/frontend/src/lib/api-client/hooks.ts
+++ b/apps/frontend/src/lib/api-client/hooks.ts
@@ -1,11 +1,7 @@
-export type UserSummaryForCache = {
-  id: string;
-  login: string;
-  displayName: string;
-  deleted: boolean;
-  isBot?: boolean;
-  avatarUrl: string | null;
-};
+import type { UserSummary } from './userSummary.js';
+
+/** Cache-priming user snapshot; structurally the shared `UserSummary`. */
+export type UserSummaryForCache = UserSummary;
 
 export type ApiClientHooks = {
   onAuthenticationRequired?: (serverId: string) => void;

--- a/apps/frontend/src/lib/api-client/memberDirectory.ts
+++ b/apps/frontend/src/lib/api-client/memberDirectory.ts
@@ -8,26 +8,17 @@ import {
 import { UserService } from '@chatto/api-types/api/v1/member_directory_connect';
 import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
 import type { DirectoryMember as APIDirectoryMember } from '@chatto/api-types/api/v1/member_directory_pb';
-import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-import { presenceStatusOrOffline } from './enumDefaults.js';
-
+import {
+  mapUserPresenceView,
+  mapUserSummary,
+  type UserPresenceView,
+  type UserSummary
+} from './userSummary.js';
 export { presenceStatusOrOffline as apiPresenceStatus } from './enumDefaults.js';
 
 export type MemberDirectoryAPIConfig = ConnectAPIConfig;
 
-export type DirectoryMember = {
-  id: string;
-  login: string;
-  displayName: string;
-  deleted: boolean;
-  isBot?: boolean;
-  avatarUrl: string | null;
-  presenceStatus: PresenceStatus;
-  customStatus: {
-    emoji: string;
-    text: string;
-    expiresAt: string | null;
-  } | null;
+export type DirectoryMember = UserSummary & UserPresenceView & {
   roles: string[];
   createdAt: string | null;
 };
@@ -153,21 +144,15 @@ export type MemberDirectoryAPI = ReturnType<typeof createMemberDirectoryAPI>;
 
 export function mapDirectoryMember(member: APIDirectoryMember): DirectoryMember {
   const user = member.user;
+  // The directory contract renders a blank, offline member when the response
+  // omits the user instead of dropping the row, and never leaves `isBot`
+  // unset.
+  const summary: UserSummary = user
+    ? { ...mapUserSummary(user), isBot: user.isBot ?? false }
+    : { id: '', login: '', displayName: '', deleted: false, isBot: false, avatarUrl: null };
   return {
-    id: user?.id ?? '',
-    login: user?.login ?? '',
-    displayName: user?.displayName ?? '',
-    deleted: user?.deleted ?? false,
-    isBot: user?.isBot ?? false,
-    avatarUrl: user?.avatarUrl ?? null,
-    presenceStatus: presenceStatusOrOffline(user?.presenceStatus ?? PresenceStatus.UNSPECIFIED),
-    customStatus: user?.customStatus
-      ? {
-          emoji: user.customStatus.emoji,
-          text: user.customStatus.text,
-          expiresAt: user.customStatus.expiresAt?.toDate().toISOString() ?? null
-        }
-      : null,
+    ...summary,
+    ...mapUserPresenceView(user),
     roles: [...member.roles],
     createdAt: member.createdAt?.toDate().toISOString() ?? null
   };

--- a/apps/frontend/src/lib/api-client/notifications.ts
+++ b/apps/frontend/src/lib/api-client/notifications.ts
@@ -1,4 +1,4 @@
-import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import type { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { Empty } from '@bufbuild/protobuf';
 import { authHeaders, createChattoClient } from './connect.js';
 import {

--- a/apps/frontend/src/lib/api-client/notifications.ts
+++ b/apps/frontend/src/lib/api-client/notifications.ts
@@ -19,25 +19,20 @@ import {
   NotificationDeliveryMode
 } from '@chatto/api-types/api/v1/notifications_pb';
 import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
-import { presenceStatusOrOffline } from './enumDefaults.js';
+import { mapUserPresenceView, mapUserSummary, type UserSummary } from './userSummary.js';
 export type NotificationAPIConfig = {
   baseUrl: string;
   bearerToken: string | null;
   onAuthenticationRequired?: (serverId: string) => void;
 };
 
-export type NotificationActor = {
-  id: string;
-  login: string;
-  displayName: string;
-  deleted: boolean;
-  isBot?: boolean;
-  avatarUrl?: string | null;
+/** The acting user behind one notification occurrence. */
+export type NotificationActor = UserSummary & {
   presenceStatus: PresenceStatus;
   customStatus?: {
     emoji: string;
     text: string;
-    expiresAt?: string | null;
+    expiresAt: string | null;
   } | null;
 };
 
@@ -584,19 +579,7 @@ function notificationPresentationGroupKey(occurrence: NotificationOccurrenceItem
 function notificationActor(actor: APIUser | undefined): NotificationActor | null {
   if (!actor) return null;
   return {
-    id: actor.id,
-    login: actor.login,
-    displayName: actor.displayName,
-    deleted: actor.deleted,
-    isBot: actor.isBot,
-    avatarUrl: actor.avatarUrl ?? null,
-    presenceStatus: presenceStatusOrOffline(actor.presenceStatus),
-    customStatus: actor.customStatus
-      ? {
-          emoji: actor.customStatus.emoji,
-          text: actor.customStatus.text,
-          expiresAt: actor.customStatus.expiresAt?.toDate().toISOString() ?? null
-        }
-      : null
+    ...mapUserSummary(actor),
+    ...mapUserPresenceView(actor)
   };
 }

--- a/apps/frontend/src/lib/api-client/roomTimeline.ts
+++ b/apps/frontend/src/lib/api-client/roomTimeline.ts
@@ -184,8 +184,8 @@ async function batchTimelineUsers(
     const summaries = await createUserAPI(config).batchGetUsers(userIds);
     const users: Record<string, User> = {};
     for (const summary of summaries) {
-      // `UserSummary` is structurally the generated `User` shape the timeline
-      // view helpers read; normalize `avatarUrl` to keep the record uniform.
+      // The view helpers read generated `User` values; the only difference
+      // from a stored summary is `avatarUrl` (`string | undefined` vs `null`).
       users[summary.id] = {
         id: summary.id,
         login: summary.login,
@@ -228,11 +228,11 @@ function messageUserIds(messages: Message[]): string[] {
 }
 
 function primeTimelineUserIncludes(config: RoomTimelineAPIConfig, users: Record<string, User>) {
-	notifyUserSummaries(
-		config.serverId,
-		Object.values(users).map(mapUserSummary),
-		config.onUserSummaries
-	);
+  notifyUserSummaries(
+    config.serverId,
+    Object.values(users).map(mapUserSummary),
+    config.onUserSummaries
+  );
 }
 
 function emptyEventConnectionPage(): EventConnectionPage {

--- a/apps/frontend/src/lib/api-client/roomTimeline.ts
+++ b/apps/frontend/src/lib/api-client/roomTimeline.ts
@@ -14,6 +14,7 @@ import { MessageService } from '@chatto/api-types/api/v1/messages_connect';
 import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
 import { ThreadService } from '@chatto/api-types/api/v1/threads_connect';
 import { createUserAPI } from './users.js';
+import { mapUserSummary } from './userSummary.js';
 import { RoomTimelinePage } from '@chatto/api-types/api/v1/room_timeline_pb';
 import type { LinkPreview } from '@chatto/api-types/api/v1/link_previews_pb';
 import { MessageVideoProcessingStatus } from '@chatto/api-types/api/v1/message_types_pb';
@@ -183,6 +184,8 @@ async function batchTimelineUsers(
     const summaries = await createUserAPI(config).batchGetUsers(userIds);
     const users: Record<string, User> = {};
     for (const summary of summaries) {
+      // `UserSummary` is structurally the generated `User` shape the timeline
+      // view helpers read; normalize `avatarUrl` to keep the record uniform.
       users[summary.id] = {
         id: summary.id,
         login: summary.login,
@@ -192,7 +195,7 @@ async function batchTimelineUsers(
         avatarUrl: summary.avatarUrl ?? undefined
       } as User;
     }
-    primeTimelineUserIncludes(config, users);
+    notifyUserSummaries(config.serverId, summaries, config.onUserSummaries);
     return users;
   } catch {
     return {};
@@ -225,18 +228,11 @@ function messageUserIds(messages: Message[]): string[] {
 }
 
 function primeTimelineUserIncludes(config: RoomTimelineAPIConfig, users: Record<string, User>) {
-  notifyUserSummaries(
-    config.serverId,
-    Object.values(users).map((user) => ({
-      id: user.id,
-      login: user.login,
-      displayName: user.displayName,
-      deleted: user.deleted,
-      isBot: user.isBot,
-      avatarUrl: user.avatarUrl || null
-    })),
-    config.onUserSummaries
-  );
+	notifyUserSummaries(
+		config.serverId,
+		Object.values(users).map(mapUserSummary),
+		config.onUserSummaries
+	);
 }
 
 function emptyEventConnectionPage(): EventConnectionPage {

--- a/apps/frontend/src/lib/api-client/userSummary.spec.ts
+++ b/apps/frontend/src/lib/api-client/userSummary.spec.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import {
+  mapOptionalUserSummary,
+  mapUserPresenceView,
+  mapUserSummary
+} from './userSummary';
+
+function apiUser(overrides: Partial<APIUser> = {}): APIUser {
+  return {
+    id: 'U1',
+    login: 'alice',
+    displayName: 'Alice',
+    deleted: false,
+    isBot: false,
+    avatarUrl: '',
+    presenceStatus: PresenceStatus.ONLINE,
+    customStatus: undefined,
+    ...overrides
+  } as APIUser;
+}
+
+// Stand-in for a generated protobuf Timestamp in fixture data.
+function protoTimestamp(date: Date): unknown {
+  return { toDate: () => date };
+}
+
+describe('mapUserSummary', () => {
+  it('normalizes unset and empty avatar URLs to null', () => {
+    expect(mapUserSummary(apiUser({ avatarUrl: '' })).avatarUrl).toBeNull();
+    expect(mapUserSummary(apiUser({ avatarUrl: undefined })).avatarUrl).toBeNull();
+    expect(mapUserSummary(apiUser({ avatarUrl: '/assets/u1' })).avatarUrl).toBe('/assets/u1');
+  });
+});
+
+describe('mapOptionalUserSummary', () => {
+  it('returns null when the response omits the user', () => {
+    expect(mapOptionalUserSummary(undefined)).toBeNull();
+    expect(mapOptionalUserSummary(apiUser())?.id).toBe('U1');
+  });
+});
+
+describe('mapUserPresenceView', () => {
+  it('falls back to offline presence and null custom status', () => {
+    const view = mapUserPresenceView(undefined);
+    expect(view.presenceStatus).toBe(PresenceStatus.OFFLINE);
+    expect(view.customStatus).toBeNull();
+  });
+
+  it('converts custom status expiry timestamps to ISO strings', () => {
+    const expiresAt = new Date('2026-04-29T12:00:00Z');
+    const view = mapUserPresenceView({
+      ...apiUser(),
+      customStatus: {
+        emoji: 'coffee',
+        text: 'brewing',
+        expiresAt: protoTimestamp(expiresAt)
+      }
+    } as APIUser);
+    expect(view.customStatus).toEqual({
+      emoji: 'coffee',
+      text: 'brewing',
+      expiresAt: '2026-04-29T12:00:00.000Z'
+    });
+  });
+});

--- a/apps/frontend/src/lib/api-client/userSummary.ts
+++ b/apps/frontend/src/lib/api-client/userSummary.ts
@@ -1,0 +1,74 @@
+/**
+ * Shared mapping from the generated `User` protobuf message to the plain
+ * user-summary shape used across API client modules.
+ *
+ * This module is intentionally a leaf: it imports generated protobuf types
+ * only, so any api-client module can depend on it without shifting runtime
+ * chunk graphs. Every caller previously re-implemented these field maps by
+ * hand; this is now the single place that decides missing-value fallbacks
+ * (`avatarUrl` empty string becomes `null`) and presence/customStatus views.
+ */
+
+import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
+import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+import { presenceStatusOrOffline } from './enumDefaults.js';
+
+/** Lightweight identity snapshot of one user, safe to cache and prime stores with. */
+export type UserSummary = {
+  id: string;
+  login: string;
+  displayName: string;
+  deleted: boolean;
+  isBot?: boolean;
+  avatarUrl: string | null;
+};
+
+/**
+ * Map a generated user to its summary. Returns `undefined`-tolerant callers
+ * should guard before calling; see `mapOptionalUserSummary`.
+ */
+export function mapUserSummary(user: APIUser): UserSummary {
+  return {
+    id: user.id,
+    login: user.login,
+    displayName: user.displayName,
+    deleted: user.deleted,
+    isBot: user.isBot,
+    avatarUrl: user.avatarUrl || null
+  };
+}
+
+/**
+ * Map an optional generated user; `null` means the response omitted the user.
+ */
+export function mapOptionalUserSummary(user: APIUser | undefined): UserSummary | null {
+  return user ? mapUserSummary(user) : null;
+}
+
+/** Live-presence view of one user: normalized presence plus custom status. */
+export type UserPresenceView = {
+  presenceStatus: PresenceStatus;
+  customStatus: {
+    emoji: string;
+    text: string;
+    expiresAt: string | null;
+  } | null;
+};
+
+/**
+ * Map a generated user's presence and custom status for UI rendering.
+ * Unknown/unset presence falls back to offline; custom status timestamps are
+ * converted to ISO strings.
+ */
+export function mapUserPresenceView(user: APIUser | undefined): UserPresenceView {
+  return {
+    presenceStatus: presenceStatusOrOffline(user?.presenceStatus ?? PresenceStatus.UNSPECIFIED),
+    customStatus: user?.customStatus
+      ? {
+          emoji: user.customStatus.emoji,
+          text: user.customStatus.text,
+          expiresAt: user.customStatus.expiresAt?.toDate().toISOString() ?? null
+        }
+      : null
+  };
+}

--- a/apps/frontend/src/lib/api-client/userSummary.ts
+++ b/apps/frontend/src/lib/api-client/userSummary.ts
@@ -24,8 +24,12 @@ export type UserSummary = {
 };
 
 /**
- * Map a generated user to its summary. Returns `undefined`-tolerant callers
- * should guard before calling; see `mapOptionalUserSummary`.
+ * Map a generated user to its summary.
+ *
+ * Normalization contract: an unset or empty-string protobuf avatar URL maps
+ * to `null` (proto3 strings default to `''`, so "unset" and "empty" are the
+ * same fact). Callers that previously emitted `''` (`?? null`) now emit
+ * `null`; consumers treat both as no-avatar through truthiness checks.
  */
 export function mapUserSummary(user: APIUser): UserSummary {
   return {

--- a/apps/frontend/src/lib/api-client/users.ts
+++ b/apps/frontend/src/lib/api-client/users.ts
@@ -1,21 +1,14 @@
 import { authHeaders, createChattoClient } from './connect.js';
 import { UserService } from '@chatto/api-types/api/v1/member_directory_connect';
 import type { DirectoryMember as APIDirectoryMember } from '@chatto/api-types/api/v1/member_directory_pb';
-import type { User as APIUser } from '@chatto/api-types/api/v1/users_pb';
+
+export { mapUserSummary, mapOptionalUserSummary, type UserSummary } from './userSummary.js';
+import { mapUserSummary, type UserSummary } from './userSummary.js';
 
 export type UserAPIConfig = {
   baseUrl: string;
   bearerToken: string | null;
   onAuthenticationRequired?: (serverId: string) => void;
-};
-
-export type UserSummary = {
-  id: string;
-  login: string;
-  displayName: string;
-  deleted: boolean;
-  isBot?: boolean;
-  avatarUrl: string | null;
 };
 
 export function createUserAPI(config: UserAPIConfig) {
@@ -37,15 +30,4 @@ export type UserAPI = ReturnType<typeof createUserAPI>;
 
 export function mapDirectoryMemberUserSummary(member: APIDirectoryMember): UserSummary | null {
   return member.user ? mapUserSummary(member.user) : null;
-}
-
-export function mapUserSummary(user: APIUser): UserSummary {
-  return {
-    id: user.id,
-    login: user.login,
-    displayName: user.displayName,
-    deleted: user.deleted,
-    isBot: user.isBot,
-    avatarUrl: user.avatarUrl || null
-  };
 }

--- a/apps/frontend/src/lib/api-client/users.ts
+++ b/apps/frontend/src/lib/api-client/users.ts
@@ -3,7 +3,7 @@ import { UserService } from '@chatto/api-types/api/v1/member_directory_connect';
 import type { DirectoryMember as APIDirectoryMember } from '@chatto/api-types/api/v1/member_directory_pb';
 
 export { mapUserSummary, mapOptionalUserSummary, type UserSummary } from './userSummary.js';
-import { mapUserSummary, type UserSummary } from './userSummary.js';
+import { mapOptionalUserSummary, mapUserSummary, type UserSummary } from './userSummary.js';
 
 export type UserAPIConfig = {
   baseUrl: string;
@@ -29,5 +29,5 @@ export function createUserAPI(config: UserAPIConfig) {
 export type UserAPI = ReturnType<typeof createUserAPI>;
 
 export function mapDirectoryMemberUserSummary(member: APIDirectoryMember): UserSummary | null {
-  return member.user ? mapUserSummary(member.user) : null;
+  return mapOptionalUserSummary(member.user);
 }


### PR DESCRIPTION
## Why

Six api-client modules each rebuilt the same `{id, login, displayName, deleted, isBot, avatarUrl}` block from the generated `User` protobuf by hand, and memberDirectory and notifications duplicated the customStatus timestamp conversion verbatim. The copies had already drifted (`?? null` vs `|| null`, `isBot ?? false` on some surfaces only).

## What changed

- New leaf module `$lib/api-client/userSummary.ts`: `mapUserSummary`, `mapOptionalUserSummary`, and `mapUserPresenceView` (presence normalization + customStatus ISO conversion), plus the shared `UserSummary` type. It imports generated protobuf types only, so runtime chunk graphs stay put (verified by `mise build-frontend`).
- `UserSummaryForCache` is now an alias of `UserSummary`; `NotificationActor` and `DirectoryMember` build on the shared types; cache priming in roomTimeline maps through the shared mapper and primes straight from `batchGetUsers()` summaries.
- Directory-specific contracts are preserved explicitly: blank-member default row and `isBot` coercion to `false`.
- adminUsers keeps its own shapes where field subsets genuinely differ. One documented micro-delta: unset/empty-string avatar URLs now uniformly map to `null` on notification actors and directory members (consumers treat both as no-avatar via truthiness).

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server:

Newer client → older server:

Capability discovery or minimum client/server version:

## Test plan

- `mise test-frontend` — 140 files / 1277 tests pass, including a new spec pinning avatarUrl/presence/customStatus normalization.
- `pnpm check` (svelte-check) and `mise lint-frontend` — clean.
- `mise build-frontend` — production bundle-size checks pass (import graphs changed).
