### PR TITLE
feat(frontend): remove implicit auto-away presence

### DIFF
--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -215,6 +215,11 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ## Smaller fixes you'll appreciate
 
+### Privacy and presence
+
+- Presence no longer changes to Away because of input inactivity or tab visibility. You
+  control Online, Away, Do Not Disturb, and Look offline directly.
+
 ### Messages, media, and calls
 
 - Empty direct-message conversations stay hidden from the other participant until the first

--- a/apps/frontend/messages/ar/settings.json
+++ b/apps/frontend/messages/ar/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "الحضور: {status}",
         "title": "التواجد",
-        "auto": "على الانترنت",
+        "online": "على الانترنت",
         "away": "بعيدًا",
         "do_not_disturb": "عدم الإزعاج",
         "offline": "غير متصل",

--- a/apps/frontend/messages/cs-CZ/settings.json
+++ b/apps/frontend/messages/cs-CZ/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Přítomnost: {status}",
         "title": "Přítomnost",
-        "auto": "Online",
+        "online": "Online",
         "away": "Pryč",
         "do_not_disturb": "Nerušit",
         "offline": "Offline",

--- a/apps/frontend/messages/de-DE/settings.json
+++ b/apps/frontend/messages/de-DE/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Präsenz: {status}",
         "title": "Präsenz",
-        "auto": "Online",
+        "online": "Online",
         "away": "Abwesend",
         "do_not_disturb": "Nicht stören",
         "offline": "Offline",

--- a/apps/frontend/messages/en-GB/settings.json
+++ b/apps/frontend/messages/en-GB/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Presence: {status}",
         "title": "Presence",
-        "auto": "Online",
+        "online": "Online",
         "away": "Away",
         "do_not_disturb": "Do Not Disturb",
         "offline": "Offline",

--- a/apps/frontend/messages/eo/settings.json
+++ b/apps/frontend/messages/eo/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Ĉeesto: {status}",
         "title": "Ĉeesto",
-        "auto": "Rete",
+        "online": "Rete",
         "away": "For",
         "do_not_disturb": "Ne ĝenu",
         "offline": "Senrete",

--- a/apps/frontend/messages/es-419/settings.json
+++ b/apps/frontend/messages/es-419/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Presencia: {status}",
         "title": "Presencia",
-        "auto": "En línea",
+        "online": "En línea",
         "away": "Ausente",
         "do_not_disturb": "No molestar",
         "offline": "Sin conexión",

--- a/apps/frontend/messages/es-ES/settings.json
+++ b/apps/frontend/messages/es-ES/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Presencia: {status}",
         "title": "Presencia",
-        "auto": "En línea",
+        "online": "En línea",
         "away": "Ausente",
         "do_not_disturb": "No molestar",
         "offline": "Sin conexión",

--- a/apps/frontend/messages/et-EE/settings.json
+++ b/apps/frontend/messages/et-EE/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Kohalolek: {status}",
         "title": "Kohalolek",
-        "auto": "Internetis",
+        "online": "Internetis",
         "away": "Eemal",
         "do_not_disturb": "Mitte segada",
         "offline": "Võrguühenduseta",

--- a/apps/frontend/messages/fr-CA/settings.json
+++ b/apps/frontend/messages/fr-CA/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Présence : {status}",
         "title": "Présence",
-        "auto": "En ligne",
+        "online": "En ligne",
         "away": "Absent",
         "do_not_disturb": "Ne pas déranger",
         "offline": "Hors ligne",

--- a/apps/frontend/messages/fr-FR/settings.json
+++ b/apps/frontend/messages/fr-FR/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Présence : {status}",
         "title": "Présence",
-        "auto": "En ligne",
+        "online": "En ligne",
         "away": "Absent",
         "do_not_disturb": "Ne pas déranger",
         "offline": "Hors ligne",

--- a/apps/frontend/messages/he-IL/settings.json
+++ b/apps/frontend/messages/he-IL/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "נוכחות: {status}",
         "title": "נוכחות",
-        "auto": "באינטרנט",
+        "online": "באינטרנט",
         "away": "לא נמצא/ת",
         "do_not_disturb": "נא לא להפריע",
         "offline": "במצב לא מקוון",

--- a/apps/frontend/messages/it-IT/settings.json
+++ b/apps/frontend/messages/it-IT/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Presenza: {status}",
         "title": "Presenza",
-        "auto": "In linea",
+        "online": "In linea",
         "away": "Via",
         "do_not_disturb": "Non disturbare",
         "offline": "Non in linea",

--- a/apps/frontend/messages/ja-JP/settings.json
+++ b/apps/frontend/messages/ja-JP/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "プレゼンス: {status}",
         "title": "プレゼンス",
-        "auto": "オンライン",
+        "online": "オンライン",
         "away": "離れています",
         "do_not_disturb": "邪魔しないでください",
         "offline": "オフライン",

--- a/apps/frontend/messages/lv-LV/settings.json
+++ b/apps/frontend/messages/lv-LV/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Klātbūtne: {status}",
         "title": "Klātbūtne",
-        "auto": "Tiešsaistē",
+        "online": "Tiešsaistē",
         "away": "Prom",
         "do_not_disturb": "Netraucēt",
         "offline": "Bezsaistē",

--- a/apps/frontend/messages/nb-NO/settings.json
+++ b/apps/frontend/messages/nb-NO/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Tilstedeværelse: {status}",
         "title": "Tilstedeværelse",
-        "auto": "På nett",
+        "online": "På nett",
         "away": "Borte",
         "do_not_disturb": "Ikke forstyrr",
         "offline": "Frakoblet",

--- a/apps/frontend/messages/nl-BE/settings.json
+++ b/apps/frontend/messages/nl-BE/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Aanwezigheid: {status}",
         "title": "Aanwezigheid",
-        "auto": "Online",
+        "online": "Online",
         "away": "Weg",
         "do_not_disturb": "Niet storen",
         "offline": "Offline",

--- a/apps/frontend/messages/nl-NL/settings.json
+++ b/apps/frontend/messages/nl-NL/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Aanwezigheid: {status}",
         "title": "Aanwezigheid",
-        "auto": "Online",
+        "online": "Online",
         "away": "Weg",
         "do_not_disturb": "Niet storen",
         "offline": "Offline",

--- a/apps/frontend/messages/pl-PL/settings.json
+++ b/apps/frontend/messages/pl-PL/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Obecność: {status}",
         "title": "Obecność",
-        "auto": "Online",
+        "online": "Online",
         "away": "Nieobecny",
         "do_not_disturb": "Nie przeszkadzać",
         "offline": "Nieaktywny",

--- a/apps/frontend/messages/pt-BR/settings.json
+++ b/apps/frontend/messages/pt-BR/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Presença: {status}",
         "title": "Presença",
-        "auto": "On-line",
+        "online": "On-line",
         "away": "Ausente",
         "do_not_disturb": "Não perturbe",
         "offline": "Off-line",

--- a/apps/frontend/messages/pt-PT/settings.json
+++ b/apps/frontend/messages/pt-PT/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Presenças: {status}",
         "title": "Presença",
-        "auto": "On-line",
+        "online": "On-line",
         "away": "Ausente",
         "do_not_disturb": "Não incomodar",
         "offline": "Offline",

--- a/apps/frontend/messages/ru-RU/settings.json
+++ b/apps/frontend/messages/ru-RU/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Присутствие: {status}",
         "title": "Присутствие",
-        "auto": "Онлайн",
+        "online": "Онлайн",
         "away": "В гостях",
         "do_not_disturb": "Не беспокоить",
         "offline": "Оффлайн",

--- a/apps/frontend/messages/sv-SE/settings.json
+++ b/apps/frontend/messages/sv-SE/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Närvaro: {status}",
         "title": "Närvaro",
-        "auto": "Online",
+        "online": "Online",
         "away": "Borta",
         "do_not_disturb": "Stör ej",
         "offline": "Offline",

--- a/apps/frontend/messages/tr-TR/settings.json
+++ b/apps/frontend/messages/tr-TR/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Mevcudiyet: {status}",
         "title": "Mevcudiyet",
-        "auto": "Çevrimiçi",
+        "online": "Çevrimiçi",
         "away": "uzakta",
         "do_not_disturb": "Rahatsız Etmeyin",
         "offline": "Çevrimdışı",

--- a/apps/frontend/messages/uk-UA/settings.json
+++ b/apps/frontend/messages/uk-UA/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "Присутність: {status}",
         "title": "Присутність",
-        "auto": "Онлайн",
+        "online": "Онлайн",
         "away": "В гостях",
         "do_not_disturb": "Не турбувати",
         "offline": "Офлайн",

--- a/apps/frontend/messages/zh-CN/settings.json
+++ b/apps/frontend/messages/zh-CN/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "在线状态：{status}",
         "title": "在线状态",
-        "auto": "在线",
+        "online": "在线",
         "away": "离开",
         "do_not_disturb": "请勿打扰",
         "offline": "离线",

--- a/apps/frontend/messages/zh-TW/settings.json
+++ b/apps/frontend/messages/zh-TW/settings.json
@@ -104,7 +104,7 @@
       "presence": {
         "button": "上線狀態：{status}",
         "title": "上線狀態",
-        "auto": "上線",
+        "online": "上線",
         "away": "離開",
         "do_not_disturb": "請勿打擾",
         "offline": "離線",

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -87,7 +87,7 @@ sidebar. Shows the avatar with presence and the live display name.
   const compactCallActiveButtonClass = 'btn-success btn-compact';
   const compactCallDangerButtonClass = 'btn-danger btn-compact';
   const useSheetDialog = prefersTouchActions() && !supportsHoverActions();
-  const presenceModes: PresenceMode[] = ['auto', 'away', 'doNotDisturb', 'invisible'];
+  const presenceModes: PresenceMode[] = ['online', 'away', 'doNotDisturb', 'invisible'];
   const currentPresence = $derived.by(() => {
     if (!activeServerUser) return PresenceStatus.OFFLINE;
     return presenceCache.get(
@@ -117,7 +117,7 @@ sidebar. Shows the avatar with presence and the live display name.
       case 'invisible':
         return m('settings.profile.presence.invisible');
       default:
-        return m('settings.profile.presence.auto');
+        return m('settings.profile.presence.online');
     }
   }
 
@@ -130,7 +130,7 @@ sidebar. Shows the avatar with presence and the live display name.
       case PresenceStatus.OFFLINE:
         return m('settings.profile.presence.offline');
       default:
-        return m('settings.profile.presence.auto');
+        return m('settings.profile.presence.online');
     }
   }
 

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -158,7 +158,7 @@ describe('CurrentUserBar', () => {
       hasVerifiedEmail: true,
       settings: null
     };
-    presencePreference.mode = 'auto';
+    presencePreference.mode = 'online';
     presencePreference.effectiveStatus = PresenceStatus.ONLINE;
     voiceCallState.connected = false;
     voiceCallState.roomId = null;

--- a/apps/frontend/src/lib/presenceTracking.spec.ts
+++ b/apps/frontend/src/lib/presenceTracking.spec.ts
@@ -60,7 +60,6 @@ describe('initPresenceTracking', () => {
 				storage.delete(key);
 			})
 		});
-		vi.stubGlobal('document', {});
 		vi.stubGlobal('window', {
 			addEventListener: windowTarget.addEventListener.bind(windowTarget),
 			removeEventListener: windowTarget.removeEventListener.bind(windowTarget),
@@ -173,7 +172,7 @@ describe('initPresenceTracking', () => {
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.OFFLINE);
 	});
 
-	it('follows another tab switching between explicit modes', () => {
+	it('follows another tab switching between explicit modes without rewriting shared state', () => {
 		startTracking();
 
 		dispatchStorageMode('away');
@@ -187,5 +186,13 @@ describe('initPresenceTracking', () => {
 		expect(sentUserSelectedFlags().at(-1)).toBe(true);
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
 		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.ONLINE);
+
+		// Applying another tab's mode must not rewrite the shared storage value;
+		// identical writes can surface as spurious storage events in other tabs.
+		const localSetItem = vi.mocked(localStorage.setItem);
+		const modeWrites = localSetItem.mock.calls.filter(
+			([key]) => key === __presenceTrackingTest.PRESENCE_MODE_STORAGE_KEY
+		);
+		expect(modeWrites).toHaveLength(0);
 	});
 });

--- a/apps/frontend/src/lib/presenceTracking.spec.ts
+++ b/apps/frontend/src/lib/presenceTracking.spec.ts
@@ -14,19 +14,9 @@ const mocks = vi.hoisted(() => ({
 	updatePresence: vi.fn()
 }));
 
-let documentTarget: EventTarget;
 let windowTarget: EventTarget;
-let visibilityState: DocumentVisibilityState;
 let cleanup: (() => void) | null;
 let onStatusChange: Mock<PresenceStatusHandler>;
-
-function dispatchDocumentEvent(type: string) {
-	documentTarget.dispatchEvent(new Event(type));
-}
-
-function dispatchWindowEvent(type: string) {
-	windowTarget.dispatchEvent(new Event(type));
-}
 
 function dispatchStorageMode(mode: string) {
 	const event = new Event('storage') as StorageEvent;
@@ -35,11 +25,6 @@ function dispatchStorageMode(mode: string) {
 		newValue: { value: mode }
 	});
 	windowTarget.dispatchEvent(event);
-}
-
-function setVisibility(next: DocumentVisibilityState) {
-	visibilityState = next;
-	dispatchDocumentEvent('visibilitychange');
 }
 
 function startTracking() {
@@ -62,9 +47,7 @@ describe('initPresenceTracking', () => {
 	beforeEach(() => {
 		vi.useFakeTimers({ now: 0 });
 		mocks.updatePresence = vi.fn<UpdatePresence>((status) => Promise.resolve(status));
-		documentTarget = new EventTarget();
 		windowTarget = new EventTarget();
-		visibilityState = 'visible';
 		cleanup = null;
 
 		const storage = new Map<string, string>();
@@ -77,14 +60,7 @@ describe('initPresenceTracking', () => {
 				storage.delete(key);
 			})
 		});
-		vi.stubGlobal('document', {
-			addEventListener: documentTarget.addEventListener.bind(documentTarget),
-			removeEventListener: documentTarget.removeEventListener.bind(documentTarget),
-			dispatchEvent: documentTarget.dispatchEvent.bind(documentTarget),
-			get visibilityState() {
-				return visibilityState;
-			}
-		});
+		vi.stubGlobal('document', {});
 		vi.stubGlobal('window', {
 			addEventListener: windowTarget.addEventListener.bind(windowTarget),
 			removeEventListener: windowTarget.removeEventListener.bind(windowTarget),
@@ -98,31 +74,66 @@ describe('initPresenceTracking', () => {
 		vi.useRealTimers();
 	});
 
-	it('reports online immediately and does not report away while activity continues', () => {
+	it('reports online as the default explicit status', () => {
 		startTracking();
 
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
+		expect(sentUserSelectedFlags()).toEqual([true]);
+	});
 
-		vi.advanceTimersByTime(4 * 60 * 1000 + 59 * 1000);
-		dispatchDocumentEvent('pointermove');
-		vi.advanceTimersByTime(4 * 60 * 1000 + 59 * 1000);
+	it('reports away only when the user explicitly selects it and never returns automatically', () => {
+		startTracking();
 
-		expect(sentStatuses()).not.toContain(APIPresenceStatus.AWAY);
-		expect(onStatusChange).not.toHaveBeenCalledWith(PresenceStatus.AWAY);
+		setPresenceMode('away');
+
+		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
+
+		vi.advanceTimersByTime(10 * 60 * 1000);
+
+		// The idle/hidden detectors are gone; only the 30s refresh keeps away alive.
+		const statuses = sentStatuses();
+		for (const status of statuses.slice(1)) {
+			expect(status).toBe(APIPresenceStatus.AWAY);
+		}
+		// The initial online report plus the explicit away transition; activity
+		// never returns the status to Online.
+		expect(onStatusChange.mock.calls.flat().filter((s) => s === PresenceStatus.ONLINE)).toHaveLength(
+			1
+		);
+	});
+
+	it('normalizes a legacy stored auto mode to explicit online', () => {
+		localStorage.setItem(__presenceTrackingTest.PRESENCE_MODE_STORAGE_KEY, 'auto');
+
+		startTracking();
+
+		expect(presencePreference.mode).toBe('online');
+		expect(localStorage.getItem(__presenceTrackingTest.PRESENCE_MODE_STORAGE_KEY)).toBe('online');
+		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
+	});
+
+	it('refreshes the chosen status so server-side presence TTLs do not expire', () => {
+		startTracking();
+		setPresenceMode('doNotDisturb');
+
+		vi.advanceTimersByTime(30_000);
+
+		expect(sentStatuses()).toEqual([
+			APIPresenceStatus.ONLINE,
+			APIPresenceStatus.DO_NOT_DISTURB,
+			APIPresenceStatus.DO_NOT_DISTURB
+		]);
+		expect(sentUserSelectedFlags()).toEqual([true, true, true]);
 	});
 
 	it('reconciles local status to the server-accepted presence', async () => {
-		mocks.updatePresence.mockImplementation((status, userSelected) =>
-			Promise.resolve(
-				status === APIPresenceStatus.ONLINE && !userSelected
-					? APIPresenceStatus.DO_NOT_DISTURB
-					: status
-			)
+		mocks.updatePresence.mockImplementationOnce(() =>
+			Promise.resolve(APIPresenceStatus.DO_NOT_DISTURB)
 		);
 
 		startTracking();
 
-		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
 
 		await Promise.resolve();
@@ -136,103 +147,20 @@ describe('initPresenceTracking', () => {
 			APIPresenceStatus.ONLINE,
 			APIPresenceStatus.DO_NOT_DISTURB
 		]);
-		expect(sentUserSelectedFlags()).toEqual([false, false]);
 	});
 
-	it('returns online when broad activity resumes after idle', () => {
-		startTracking();
-
-		vi.advanceTimersByTime(5 * 60 * 1000);
-		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
-
-		dispatchDocumentEvent('pointermove');
-
-		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.ONLINE);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
-	});
-
-	it('reports away after the hidden delay and returns online when visible again in auto mode', () => {
-		startTracking();
-
-		setVisibility('hidden');
-		vi.advanceTimersByTime(9_999);
-		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
-
-		vi.advanceTimersByTime(1);
-		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE, APIPresenceStatus.AWAY]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
-
-		setVisibility('visible');
-
-		expect(sentStatuses()).toEqual([
-			APIPresenceStatus.ONLINE,
-			APIPresenceStatus.AWAY,
-			APIPresenceStatus.ONLINE
-		]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
-	});
-
-	it('does not auto-return from explicit away on activity', () => {
-		startTracking();
-		setPresenceMode('away');
-
-		dispatchDocumentEvent('pointermove');
-		dispatchWindowEvent('focus');
-		vi.advanceTimersByTime(5 * 60 * 1000);
-
-		expect(sentStatuses()).toContain(APIPresenceStatus.AWAY);
-		expect(sentStatuses().slice(1)).not.toContain(APIPresenceStatus.ONLINE);
-		expect(sentUserSelectedFlags().at(1)).toBe(true);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
-	});
-
-	it('returns online when another tab clears explicit away while this tab is hidden', () => {
-		startTracking();
-		setVisibility('hidden');
-		vi.advanceTimersByTime(10_000);
-		dispatchStorageMode('away');
-
-		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.AWAY);
-
-		dispatchStorageMode('auto');
-
-		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.ONLINE);
-		expect(sentUserSelectedFlags().at(-1)).toBe(true);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
-		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.ONLINE);
-	});
-
-	it('keeps do not disturb through activity and refreshes it', () => {
-		startTracking();
-		setPresenceMode('doNotDisturb');
-
-		dispatchDocumentEvent('pointermove');
-		vi.advanceTimersByTime(30_000);
-
-		expect(sentStatuses()).toEqual([
-			APIPresenceStatus.ONLINE,
-			APIPresenceStatus.DO_NOT_DISTURB,
-			APIPresenceStatus.DO_NOT_DISTURB
-		]);
-		expect(sentUserSelectedFlags()).toEqual([false, true, true]);
-		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.DO_NOT_DISTURB);
-	});
-
-	it('does not update presence while invisible and returns online when automatic mode resumes', () => {
+	it('does not update presence while invisible and resumes when online is selected again', () => {
 		startTracking();
 		setPresenceMode('invisible');
 		vi.advanceTimersByTime(60_000);
-		dispatchDocumentEvent('pointermove');
 
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE]);
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.OFFLINE);
 
-		setPresenceMode('auto');
+		setPresenceMode('online');
 
 		expect(sentStatuses()).toEqual([APIPresenceStatus.ONLINE, APIPresenceStatus.ONLINE]);
-		expect(sentUserSelectedFlags()).toEqual([false, true]);
+		expect(sentUserSelectedFlags()).toEqual([true, true]);
 	});
 
 	it('starts without reporting presence when look offline was persisted', () => {
@@ -243,5 +171,21 @@ describe('initPresenceTracking', () => {
 
 		expect(sentStatuses()).toEqual([]);
 		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.OFFLINE);
+	});
+
+	it('follows another tab switching between explicit modes', () => {
+		startTracking();
+
+		dispatchStorageMode('away');
+
+		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.AWAY);
+		expect(presencePreference.mode).toBe('away');
+
+		dispatchStorageMode('online');
+
+		expect(sentStatuses().at(-1)).toBe(APIPresenceStatus.ONLINE);
+		expect(sentUserSelectedFlags().at(-1)).toBe(true);
+		expect(onStatusChange).toHaveBeenLastCalledWith(PresenceStatus.ONLINE);
+		expect(presencePreference.effectiveStatus).toBe(PresenceStatus.ONLINE);
 	});
 });

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -45,6 +45,10 @@ function modeToExplicitStatus(mode: PresenceMode): PresenceStatus {
 	}
 }
 
+function isPresenceMode(value: unknown): value is PresenceMode {
+	return value === 'online' || value === 'away' || value === 'doNotDisturb' || value === 'invisible';
+}
+
 /**
  * Reads the stored presence mode. Legacy stored values such as 'auto'
  * (removed implicit idle-away mode) normalize to the explicit 'online' mode.
@@ -52,15 +56,7 @@ function modeToExplicitStatus(mode: PresenceMode): PresenceStatus {
 function readStoredMode(): PresenceMode {
 	if (typeof localStorage === 'undefined') return 'online';
 	const stored = localStorage.getItem(PRESENCE_MODE_STORAGE_KEY);
-	if (
-		stored === 'online' ||
-		stored === 'away' ||
-		stored === 'doNotDisturb' ||
-		stored === 'invisible'
-	) {
-		return stored;
-	}
-	return 'online';
+	return isPresenceMode(stored) ? stored : 'online';
 }
 
 function storeMode(mode: PresenceMode) {
@@ -78,16 +74,7 @@ function storeMode(mode: PresenceMode) {
 function normalizeStoredMode(mode: PresenceMode) {
 	if (typeof localStorage === 'undefined') return;
 	const stored = localStorage.getItem(PRESENCE_MODE_STORAGE_KEY);
-	if (
-		stored === null ||
-		stored === 'online' ||
-		stored === 'away' ||
-		stored === 'doNotDisturb' ||
-		stored === 'invisible'
-	) {
-		return;
-	}
-	storeMode(mode);
+	if (stored !== null && !isPresenceMode(stored)) storeMode(mode);
 }
 
 export function setPresenceMode(mode: PresenceMode) {
@@ -112,7 +99,9 @@ export function initPresenceTracking(
 	let currentMode = readStoredMode();
 	let currentVisibleStatus: PresenceStatus | null = null;
 	let refreshTimer: ReturnType<typeof setInterval> | null = null;
-	let reportRevision = 0;
+	// Latest-request sequence. Out-of-order report responses must not let a
+	// stale accepted status overwrite a newer explicit choice.
+	let lastRequestSeq = 0;
 
 	presencePreference.mode = currentMode;
 	normalizeStoredMode(currentMode);
@@ -122,20 +111,19 @@ export function initPresenceTracking(
 		onStatusChange?.(status);
 	}
 
-	function applyAcceptedStatus(accepted: APIPresenceStatus, revision: number) {
-		if (revision !== reportRevision || currentMode === 'invisible') return;
-		const acceptedStatus = apiStatusToPresenceStatus(accepted);
-		currentVisibleStatus = acceptedStatus;
-		if (presencePreference.effectiveStatus !== acceptedStatus) {
-			emitLocalStatus(acceptedStatus);
-		}
-	}
-
-	function sendPresenceReport(status: PresenceStatus, revision: number) {
+	function sendPresenceReport(status: PresenceStatus) {
+		const requestSeq = ++lastRequestSeq;
 		for (const reporter of getReporters()) {
 			reporter
 				.updatePresence(presenceStatusToAPIStatus(status), true)
-				.then((accepted) => applyAcceptedStatus(accepted, revision))
+				.then((accepted) => {
+					if (requestSeq !== lastRequestSeq || currentMode === 'invisible') return;
+					const acceptedStatus = apiStatusToPresenceStatus(accepted);
+					currentVisibleStatus = acceptedStatus;
+					if (presencePreference.effectiveStatus !== acceptedStatus) {
+						emitLocalStatus(acceptedStatus);
+					}
+				})
 				.catch(() => {});
 		}
 	}
@@ -151,7 +139,7 @@ export function initPresenceTracking(
 		if (refreshTimer) return;
 		refreshTimer = setInterval(() => {
 			if (currentVisibleStatus === null) return;
-			sendPresenceReport(currentVisibleStatus, ++reportRevision);
+			sendPresenceReport(currentVisibleStatus);
 		}, PRESENCE_REFRESH_MS);
 	}
 
@@ -160,9 +148,9 @@ export function initPresenceTracking(
 		presencePreference.mode = mode;
 		if (persist) storeMode(mode);
 
-		const revision = ++reportRevision;
 		if (mode === 'invisible') {
 			clearRefreshTimer();
+			lastRequestSeq++;
 			currentVisibleStatus = null;
 			emitLocalStatus(PresenceStatus.OFFLINE);
 			return;
@@ -171,22 +159,15 @@ export function initPresenceTracking(
 		const explicitStatus = modeToExplicitStatus(mode);
 		currentVisibleStatus = explicitStatus;
 		emitLocalStatus(explicitStatus);
-		sendPresenceReport(explicitStatus, revision);
+		sendPresenceReport(explicitStatus);
 		ensureRefreshTimer();
 	}
 
 	applyModeFromUI = (mode) => applyMode(mode, true);
 
 	function onStorage(event: StorageEvent) {
-		if (event.key !== PRESENCE_MODE_STORAGE_KEY || event.newValue === null) return;
-		if (
-			event.newValue === 'online' ||
-			event.newValue === 'away' ||
-			event.newValue === 'doNotDisturb' ||
-			event.newValue === 'invisible'
-		) {
-			applyMode(event.newValue);
-		}
+		if (event.key !== PRESENCE_MODE_STORAGE_KEY || !isPresenceMode(event.newValue)) return;
+		applyMode(event.newValue);
 	}
 
 	window.addEventListener('storage', onStorage);

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -68,6 +68,28 @@ function storeMode(mode: PresenceMode) {
 	localStorage.setItem(PRESENCE_MODE_STORAGE_KEY, mode);
 }
 
+/**
+ * Rewrites the stored mode only when it holds a legacy or invalid value
+ * (for example the retired 'auto' mode) so all tabs converge on explicit
+ * modes. Never rewrites a valid or missing stored value: identical setItem
+ * calls can surface as cross-tab storage events and needlessly re-apply
+ * the same mode elsewhere.
+ */
+function normalizeStoredMode(mode: PresenceMode) {
+	if (typeof localStorage === 'undefined') return;
+	const stored = localStorage.getItem(PRESENCE_MODE_STORAGE_KEY);
+	if (
+		stored === null ||
+		stored === 'online' ||
+		stored === 'away' ||
+		stored === 'doNotDisturb' ||
+		stored === 'invisible'
+	) {
+		return;
+	}
+	storeMode(mode);
+}
+
 export function setPresenceMode(mode: PresenceMode) {
 	storeMode(mode);
 	presencePreference.mode = mode;
@@ -93,8 +115,7 @@ export function initPresenceTracking(
 	let reportRevision = 0;
 
 	presencePreference.mode = currentMode;
-	// Normalize legacy stored values such as 'auto' to 'online'.
-	storeMode(currentMode);
+	normalizeStoredMode(currentMode);
 
 	function emitLocalStatus(status: PresenceStatus) {
 		presencePreference.effectiveStatus = status;
@@ -134,10 +155,10 @@ export function initPresenceTracking(
 		}, PRESENCE_REFRESH_MS);
 	}
 
-	function applyMode(mode: PresenceMode, persist = false, syncedFromStorage = false) {
+	function applyMode(mode: PresenceMode, persist = false) {
 		currentMode = mode;
 		presencePreference.mode = mode;
-		if (persist || syncedFromStorage) storeMode(mode);
+		if (persist) storeMode(mode);
 
 		const revision = ++reportRevision;
 		if (mode === 'invisible') {
@@ -164,7 +185,7 @@ export function initPresenceTracking(
 			event.newValue === 'doNotDisturb' ||
 			event.newValue === 'invisible'
 		) {
-			applyMode(event.newValue, false, true);
+			applyMode(event.newValue);
 		}
 	}
 

--- a/apps/frontend/src/lib/presenceTracking.ts
+++ b/apps/frontend/src/lib/presenceTracking.ts
@@ -2,13 +2,8 @@ import { APIPresenceStatus, type PresenceAPI } from '$lib/api-client/presence';
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 import { presencePreference, type PresenceMode } from '$lib/state/presencePreference.svelte';
 
-const IDLE_TIMEOUT_MS = 5 * 60 * 1000;
-const HIDDEN_DELAY_MS = 10_000;
-const NOISY_ACTIVITY_THROTTLE_MS = 1_000;
 const PRESENCE_REFRESH_MS = 30_000;
 const PRESENCE_MODE_STORAGE_KEY = 'chatto.presence.mode';
-
-type ActivityState = 'active' | 'idle' | 'hidden';
 
 export type PresenceReporter = Pick<PresenceAPI, 'updatePresence'>;
 
@@ -37,7 +32,7 @@ function presenceStatusToAPIStatus(status: PresenceStatus): APIPresenceStatus {
 	}
 }
 
-function modeToExplicitStatus(mode: PresenceMode): PresenceStatus | null {
+function modeToExplicitStatus(mode: PresenceMode): PresenceStatus {
 	switch (mode) {
 		case 'away':
 			return PresenceStatus.AWAY;
@@ -46,22 +41,26 @@ function modeToExplicitStatus(mode: PresenceMode): PresenceStatus | null {
 		case 'invisible':
 			return PresenceStatus.OFFLINE;
 		default:
-			return null;
+			return PresenceStatus.ONLINE;
 	}
 }
 
+/**
+ * Reads the stored presence mode. Legacy stored values such as 'auto'
+ * (removed implicit idle-away mode) normalize to the explicit 'online' mode.
+ */
 function readStoredMode(): PresenceMode {
-	if (typeof localStorage === 'undefined') return 'auto';
+	if (typeof localStorage === 'undefined') return 'online';
 	const stored = localStorage.getItem(PRESENCE_MODE_STORAGE_KEY);
 	if (
-		stored === 'auto' ||
+		stored === 'online' ||
 		stored === 'away' ||
 		stored === 'doNotDisturb' ||
 		stored === 'invisible'
 	) {
 		return stored;
 	}
-	return 'auto';
+	return 'online';
 }
 
 function storeMode(mode: PresenceMode) {
@@ -75,6 +74,12 @@ export function setPresenceMode(mode: PresenceMode) {
 	applyModeFromUI?.(mode);
 }
 
+/**
+ * Reports an explicit, user-selected presence status to all connected servers.
+ * There is no automatic status: the client never switches modes on its own,
+ * it only refreshes the currently chosen explicit status so server-side
+ * presence TTLs do not expire.
+ */
 export function initPresenceTracking(
 	getReporters: () => PresenceReporter[],
 	onStatusChange?: (status: PresenceStatus) => void
@@ -83,15 +88,13 @@ export function initPresenceTracking(
 	initialized = true;
 
 	let currentMode = readStoredMode();
-	let currentState: ActivityState = document.visibilityState === 'hidden' ? 'hidden' : 'active';
 	let currentVisibleStatus: PresenceStatus | null = null;
-	let idleTimer: ReturnType<typeof setTimeout> | null = null;
-	let hiddenTimer: ReturnType<typeof setTimeout> | null = null;
 	let refreshTimer: ReturnType<typeof setInterval> | null = null;
-	let lastTimerResetAt = 0;
 	let reportRevision = 0;
 
 	presencePreference.mode = currentMode;
+	// Normalize legacy stored values such as 'auto' to 'online'.
+	storeMode(currentMode);
 
 	function emitLocalStatus(status: PresenceStatus) {
 		presencePreference.effectiveStatus = status;
@@ -107,20 +110,13 @@ export function initPresenceTracking(
 		}
 	}
 
-	function sendPresenceReport(status: PresenceStatus, userSelected: boolean, revision: number) {
+	function sendPresenceReport(status: PresenceStatus, revision: number) {
 		for (const reporter of getReporters()) {
 			reporter
-				.updatePresence(presenceStatusToAPIStatus(status), userSelected)
+				.updatePresence(presenceStatusToAPIStatus(status), true)
 				.then((accepted) => applyAcceptedStatus(accepted, revision))
 				.catch(() => {});
 		}
-	}
-
-	function reportStatus(status: PresenceStatus, userSelected = false) {
-		const revision = ++reportRevision;
-		currentVisibleStatus = status;
-		emitLocalStatus(status);
-		sendPresenceReport(status, userSelected, revision);
 	}
 
 	function clearRefreshTimer() {
@@ -133,109 +129,37 @@ export function initPresenceTracking(
 	function ensureRefreshTimer() {
 		if (refreshTimer) return;
 		refreshTimer = setInterval(() => {
-			if (currentMode === 'invisible' || currentVisibleStatus === null) return;
-			const userSelected = currentMode !== 'auto';
-			sendPresenceReport(currentVisibleStatus, userSelected, ++reportRevision);
+			if (currentVisibleStatus === null) return;
+			sendPresenceReport(currentVisibleStatus, ++reportRevision);
 		}, PRESENCE_REFRESH_MS);
-	}
-
-	function resetIdleTimer() {
-		if (idleTimer) clearTimeout(idleTimer);
-		lastTimerResetAt = Date.now();
-		idleTimer = setTimeout(() => transition('idle'), IDLE_TIMEOUT_MS);
-	}
-
-	function statusForAutoState(state: ActivityState): PresenceStatus {
-		return state === 'active' ? PresenceStatus.ONLINE : PresenceStatus.AWAY;
 	}
 
 	function applyMode(mode: PresenceMode, persist = false, syncedFromStorage = false) {
 		currentMode = mode;
 		presencePreference.mode = mode;
-		if (persist) storeMode(mode);
+		if (persist || syncedFromStorage) storeMode(mode);
 
+		const revision = ++reportRevision;
 		if (mode === 'invisible') {
 			clearRefreshTimer();
-			reportRevision++;
 			currentVisibleStatus = null;
 			emitLocalStatus(PresenceStatus.OFFLINE);
 			return;
 		}
 
-		if (mode === 'auto') {
-			currentState = document.visibilityState === 'hidden' ? 'hidden' : 'active';
-			const userSelected = persist || syncedFromStorage;
-			reportStatus(
-				userSelected ? PresenceStatus.ONLINE : statusForAutoState(currentState),
-				userSelected
-			);
-			ensureRefreshTimer();
-			resetIdleTimer();
-			return;
-		}
-
 		const explicitStatus = modeToExplicitStatus(mode);
-		reportStatus(explicitStatus ?? statusForAutoState(currentState), true);
+		currentVisibleStatus = explicitStatus;
+		emitLocalStatus(explicitStatus);
+		sendPresenceReport(explicitStatus, revision);
 		ensureRefreshTimer();
 	}
 
 	applyModeFromUI = (mode) => applyMode(mode, true);
 
-	function transition(newState: ActivityState) {
-		if (newState === currentState) return;
-		currentState = newState;
-		if (currentMode !== 'auto') return;
-		reportStatus(statusForAutoState(newState));
-		if (newState === 'active') resetIdleTimer();
-	}
-
-	function onActivity(noisy = false) {
-		if (currentMode !== 'auto') return;
-
-		if (currentState !== 'active') {
-			transition('active');
-			return;
-		}
-
-		if (!noisy || Date.now() - lastTimerResetAt >= NOISY_ACTIVITY_THROTTLE_MS) {
-			resetIdleTimer();
-		}
-	}
-
-	function onQuietActivity() {
-		onActivity(false);
-	}
-
-	function onNoisyActivity() {
-		onActivity(true);
-	}
-
-	const quietActivityEvents = ['pointerdown', 'keydown', 'touchstart'] as const;
-	const noisyActivityEvents = ['pointermove', 'wheel', 'scroll'] as const;
-
-	for (const event of quietActivityEvents) {
-		document.addEventListener(event, onQuietActivity, { passive: true });
-	}
-	for (const event of noisyActivityEvents) {
-		document.addEventListener(event, onNoisyActivity, { passive: true });
-	}
-
-	function onVisibilityChange() {
-		if (document.visibilityState === 'hidden') {
-			hiddenTimer = setTimeout(() => transition('hidden'), HIDDEN_DELAY_MS);
-		} else {
-			if (hiddenTimer) {
-				clearTimeout(hiddenTimer);
-				hiddenTimer = null;
-			}
-			transition('active');
-		}
-	}
-
 	function onStorage(event: StorageEvent) {
 		if (event.key !== PRESENCE_MODE_STORAGE_KEY || event.newValue === null) return;
 		if (
-			event.newValue === 'auto' ||
+			event.newValue === 'online' ||
 			event.newValue === 'away' ||
 			event.newValue === 'doNotDisturb' ||
 			event.newValue === 'invisible'
@@ -244,25 +168,12 @@ export function initPresenceTracking(
 		}
 	}
 
-	document.addEventListener('visibilitychange', onVisibilityChange);
-	window.addEventListener('focus', onQuietActivity);
 	window.addEventListener('storage', onStorage);
 
-	resetIdleTimer();
 	applyMode(currentMode);
 
 	return () => {
-		for (const event of quietActivityEvents) {
-			document.removeEventListener(event, onQuietActivity);
-		}
-		for (const event of noisyActivityEvents) {
-			document.removeEventListener(event, onNoisyActivity);
-		}
-		document.removeEventListener('visibilitychange', onVisibilityChange);
-		window.removeEventListener('focus', onQuietActivity);
 		window.removeEventListener('storage', onStorage);
-		if (idleTimer) clearTimeout(idleTimer);
-		if (hiddenTimer) clearTimeout(hiddenTimer);
 		clearRefreshTimer();
 		if (applyModeFromUI) applyModeFromUI = null;
 		initialized = false;

--- a/apps/frontend/src/lib/state/presencePreference.svelte.ts
+++ b/apps/frontend/src/lib/state/presencePreference.svelte.ts
@@ -1,9 +1,13 @@
 import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 
-export type PresenceMode = 'auto' | 'away' | 'doNotDisturb' | 'invisible';
+/**
+ * Presence modes are always explicit user choices; there is no automatic
+ * idle-away mode. The default is the explicit 'online' mode.
+ */
+export type PresenceMode = 'online' | 'away' | 'doNotDisturb' | 'invisible';
 
 class PresencePreference {
-  mode = $state<PresenceMode>('auto');
+  mode = $state<PresenceMode>('online');
   effectiveStatus = $state<PresenceStatus>(PresenceStatus.ONLINE);
 }
 

--- a/apps/frontend/src/routes/chat/ChatRoot.svelte
+++ b/apps/frontend/src/routes/chat/ChatRoot.svelte
@@ -168,7 +168,8 @@
     });
   }
 
-  // Initialize presence tracking (idle detection → AWAY, active → ONLINE).
+  // Initialize presence tracking (reports the user's explicit status choice
+  // and refreshes it so server-side presence TTLs do not expire).
   // This works across all instances, not just origin.
   const stopPresenceTracking = initPresenceTracking(
     () =>

--- a/docs/fdr/FDR-011-user-presence.md
+++ b/docs/fdr/FDR-011-user-presence.md
@@ -10,8 +10,8 @@ Every user has a presence status visible to others as a colored dot on their ava
 ## Behavior
 
 - Current clients refresh their own presence through `MyAccountService.UpdatePresence` on the ConnectRPC API.
-- Every status is an explicit user choice. The default mode is Online; users choose Online, Away, Do Not Disturb, or "Look offline" themselves.
-- The client never transitions between statuses on its own. There is no idle detection and no automatic away; a removed earlier version flipped users to Away after inactivity, but that implicit behavior was withdrawn because it misreported availability without user consent.
+- The client starts in Online mode unless the user previously chose another mode. Users can choose Online, Away, Do Not Disturb, or "Look offline".
+- The client does not use input activity or tab visibility to change the selected mode. It does not set Away automatically.
 - Users can set Do Not Disturb for their current live server presence. While DND is active, new notifications are still recorded for that user, but notification sounds and web push are suppressed (see FDR-012). Presence state is not persisted as server-side user/account state.
 - Explicit Away and Do Not Disturb are marked as manually selected in the live presence record. Updates that are not manually selected do not overwrite that manual state; an explicit Online selection clears it.
 - Users can choose "Look offline" locally. The client does not report an Offline status; it stops reporting presence so the existing presence record expires normally while messages and other realtime updates continue working.
@@ -37,12 +37,14 @@ Every user has a presence status visible to others as a colored dot on their ava
 ### 3. User-level live status with heartbeat-driven deduplication
 
 **Decision:** Presence is stored in `MEMORY_CACHE` as `presence.{userId}`. A per-process PresenceHub watches these keys and emits live events only when the user-level status changes. Current clients write `ONLINE`, `AWAY`, or `DO_NOT_DISTURB` through `MyAccountService.UpdatePresence`; `OFFLINE` is not an accepted update value. The live record carries whether the status was manually selected so reports that are not manually selected cannot clear explicit Away/DND.
-**Why:** Presence is a current-state hint, not durable account history, but explicit availability choices should not be defeated by another writer. Closing a tab does not actively write Offline, so another open tab can keep presence alive after the manual TTL expires.
+**Why:** Presence is a current-state hint, not durable account history, but a non-manual report must not replace an explicit availability choice. Closing a tab does not actively write Offline, so another open tab can keep presence alive after the manual TTL expires.
 **Tradeoff:** "Look offline" remains client-local: another active browser/device can still keep the user visible because the invisible client deliberately does not tell the server about that privacy choice.
 
-### 4. All statuses are explicit; there is no automatic away
+### 4. Presence mode changes require a user choice
 
-**Decision:** The client does not change presence modes on its own. An earlier version ran two automatic triggers (5 minutes of input inactivity, OR 10 seconds of tab hidden) that switched users to Away and back. That implicit behavior is removed: Away, Do Not Disturb, Online, and "Look offline" are all deliberate user choices, and the client only refreshes the chosen status so server-side TTLs do not expire.
+**Decision:** The client does not change the selected presence mode because of input inactivity or tab visibility. Online, Away, Do Not Disturb, and "Look offline" are selectable modes. Offline remains an inferred server state.
+**Why:** Input activity and tab visibility are not reliable measures of availability. They can expose whether a user interacts with or views Chatto, and they can show a status that the user did not choose. Explicit mode changes keep this information under the user's control.
+**Tradeoff:** A client can continue to show Online while its user is away. The status changes only when the user selects another mode or all clients stop refreshing presence and the live record expires.
 
 ### 5. DND is live user state
 

--- a/docs/fdr/FDR-011-user-presence.md
+++ b/docs/fdr/FDR-011-user-presence.md
@@ -1,7 +1,7 @@
 # FDR-011: User Presence
 
 **Status:** Active
-**Last reviewed:** 2026-08-19
+**Last reviewed:** 2026-08-27
 
 ## Overview
 
@@ -10,12 +10,10 @@ Every user has a presence status visible to others as a colored dot on their ava
 ## Behavior
 
 - Current clients refresh their own presence through `MyAccountService.UpdatePresence` on the ConnectRPC API.
-- In automatic mode, users start Online. After 5 minutes without keyboard/mouse/touch input, the client transitions to Away.
-- If the browser tab is hidden for 10 seconds, the client also transitions to Away (debounced to avoid flashing during quick tab switches).
-- Any interaction returns the user to Online only while automatic mode is active.
-- Users can explicitly set Away. Explicit Away does not auto-return to Online on activity.
+- Every status is an explicit user choice. The default mode is Online; users choose Online, Away, Do Not Disturb, or "Look offline" themselves.
+- The client never transitions between statuses on its own. There is no idle detection and no automatic away; a removed earlier version flipped users to Away after inactivity, but that implicit behavior was withdrawn because it misreported availability without user consent.
 - Users can set Do Not Disturb for their current live server presence. While DND is active, new notifications are still recorded for that user, but notification sounds and web push are suppressed (see FDR-012). Presence state is not persisted as server-side user/account state.
-- Explicit Away and Do Not Disturb are marked as manually selected in the live presence record. Automatic Online/Away reports from other clients do not overwrite that manual state; an explicit Online selection clears it.
+- Explicit Away and Do Not Disturb are marked as manually selected in the live presence record. Updates that are not manually selected do not overwrite that manual state; an explicit Online selection clears it.
 - Users can choose "Look offline" locally. The client does not report an Offline status; it stops reporting presence so the existing presence record expires normally while messages and other realtime updates continue working.
 - Disconnecting (closing the tab, network drop) does not send an active Offline signal. After 60 seconds without a heartbeat refresh, the presence entry expires and the user appears Offline.
 - The presence dot updates across the UI as other users' statuses change, in real time.
@@ -38,15 +36,13 @@ Every user has a presence status visible to others as a colored dot on their ava
 
 ### 3. User-level live status with heartbeat-driven deduplication
 
-**Decision:** Presence is stored in `MEMORY_CACHE` as `presence.{userId}`. A per-process PresenceHub watches these keys and emits live events only when the user-level status changes. Current clients write `ONLINE`, `AWAY`, or `DO_NOT_DISTURB` through `MyAccountService.UpdatePresence`; `OFFLINE` is not an accepted update value. The live record carries whether the status was manually selected so automatic updates from other clients cannot clear explicit Away/DND.
-**Why:** Presence is a current-state hint, not durable account history, but explicit availability choices should not be defeated by another idle detector. Closing a tab does not actively write Offline, so another open tab can keep automatic presence alive after the manual TTL expires.
+**Decision:** Presence is stored in `MEMORY_CACHE` as `presence.{userId}`. A per-process PresenceHub watches these keys and emits live events only when the user-level status changes. Current clients write `ONLINE`, `AWAY`, or `DO_NOT_DISTURB` through `MyAccountService.UpdatePresence`; `OFFLINE` is not an accepted update value. The live record carries whether the status was manually selected so reports that are not manually selected cannot clear explicit Away/DND.
+**Why:** Presence is a current-state hint, not durable account history, but explicit availability choices should not be defeated by another writer. Closing a tab does not actively write Offline, so another open tab can keep presence alive after the manual TTL expires.
 **Tradeoff:** "Look offline" remains client-local: another active browser/device can still keep the user visible because the invisible client deliberately does not tell the server about that privacy choice.
 
-### 4. Auto-away has two triggers (idle + tab hidden)
+### 4. All statuses are explicit; there is no automatic away
 
-**Decision:** Automatic mode has two independent triggers that transition to Away: 5 minutes of input inactivity, OR 10 seconds of tab hidden.
-**Why:** Idle-only would miss the very common "switched tabs" case. Tab-hidden-only would mark people as away the moment they alt-tab to look at something. Combining both covers the realistic away cases.
-**Tradeoff:** Some false positives — a user actively listening in another window is technically "away" by our model. Acceptable for the use case.
+**Decision:** The client does not change presence modes on its own. An earlier version ran two automatic triggers (5 minutes of input inactivity, OR 10 seconds of tab hidden) that switched users to Away and back. That implicit behavior is removed: Away, Do Not Disturb, Online, and "Look offline" are all deliberate user choices, and the client only refreshes the chosen status so server-side TTLs do not expire.
 
 ### 5. DND is live user state
 
@@ -62,7 +58,7 @@ Every user has a presence status visible to others as a colored dot on their ava
 
 ### 7. Per-server tracking, with frontend coordination across servers
 
-**Decision:** Each connected Chatto server tracks its own presence. The frontend's auto-away detector broadcasts the new status to all connected servers in parallel.
+**Decision:** Each connected Chatto server tracks its own presence. The frontend reports the chosen explicit status to all connected servers in parallel.
 **Why:** Servers are independent and shouldn't have to coordinate among themselves — that would require cross-server discovery and trust. The client is already connected to all of them and can coordinate cheaply. See ADR-025.
 **Tradeoff:** A user signed in from two different devices to the same server may have competing presence writers; the latest write wins until TTL expiry.
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -20,7 +20,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-08-25 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-15 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-08-25 |
-| [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-08-19 |
+| [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-08-27 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Experimental | 2026-08-27 |
 | [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-08-26 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |


### PR DESCRIPTION
## Why

Automatic Away used input inactivity and tab visibility as proxies for user availability. These signals are not reliable, can disclose whether a user interacts with or views Chatto, and can publish a status that the user did not choose. Presence mode changes should remain under the user's control.

## What changed

- Replaced the automatic presence preference with explicit Online, Away, Do Not Disturb, and Look offline choices.
- Removed input-idle and hidden-tab transitions, timers, and listeners. The client now refreshes only the selected mode.
- Normalized the legacy stored `auto` preference to Online.
- Updated the presence tests, menu, and localization catalogs.
- Updated FDR-011 and the 0.5 release notes with the privacy rationale. Offline remains an inferred server state after all clients stop refreshing presence.
- Left the backend and public API unchanged.

## Compatibility

- No protobuf, ConnectRPC, persisted-event, or server behavior changed.
- Existing stored `auto` client preferences migrate locally to Online without user action.
- No deployment migration or coordinated rollout is required.

## Test plan

- `mise lint-frontend` — passed with no Svelte errors or warnings.
- `mise test-frontend` — passed for the full frontend suite.
- `mise x -- pnpm exec playwright test e2e/presence-indicators.test.ts --retries=0` from `apps/frontend` — 11 tests passed.
- `mise run --force build-frontend` — passed, including bundle-size checks.
- `mise x -- pnpm --filter docs-website build` — passed; 71 pages built.
- Chrome DevTools verification — confirmed the four explicit menu choices, Away persistence after reload, and no console errors.

Closes #2027.
