### PR TITLE
chore: configure OpenCode MCP servers

### DIFF
--- a/.opencode/opencode.json
+++ b/.opencode/opencode.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "chrome-devtools": {
+      "type": "local",
+      "command": ["npx", "-y", "chrome-devtools-mcp@latest", "--headless", "--isolated"],
+      "enabled": true
+    },
+    "svelte": {
+      "type": "remote",
+      "url": "https://mcp.svelte.dev/mcp",
+      "enabled": true
+    },
+    "mdn": {
+      "type": "remote",
+      "url": "https://mcp.mdn.mozilla.net/",
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
## Why

Conductor agents using OpenCode had no MCP configuration, so project-standard tooling (Chrome DevTools verification, Svelte docs/autofixer, MDN lookup) was unavailable to them.

## What changed

Adds `.opencode/opencode.json` configuring three MCP servers — `chrome-devtools` (local, headless + isolated), `svelte` (remote), and `mdn` (remote) — mirroring the existing Claude-style `.mcp.json`.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- Config matches the shape published at https://opencode.ai/config.json; loaded by restarting the agent session.