### PR TITLE
refactor(cli): consolidate effect-consumer wiring into evtstream

### DIFF
--- a/cli/internal/core/asset_cleanup.go
+++ b/cli/internal/core/asset_cleanup.go
@@ -12,23 +12,18 @@ import (
 )
 
 func (s *AssetModel) configureCleanup(ctx context.Context, stream jetstream.Stream) error {
-	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:            assetCleanupConsumerName,
-		Durable:         assetCleanupConsumerName,
-		Description:     "Shared durable queue for Chatto asset deletion",
-		DeliverPolicy:   jetstream.DeliverAllPolicy,
-		AckPolicy:       jetstream.AckExplicitPolicy,
-		AckWait:         assetCleanupAckWait,
-		MaxDeliver:      -1,
-		FilterSubject:   evtstream.AssetEventTypeFilter(evtstream.EventAssetDeleted),
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   assetCleanupMaxPending,
-		MaxRequestBatch: assetCleanupMaxPending,
+	consumer, err := evtstream.CreateEffectConsumer(ctx, stream, evtstream.EffectConsumerConfig{
+		Name:           assetCleanupConsumerName,
+		Description:    "Shared durable queue for Chatto asset deletion",
+		FilterSubjects: []string{evtstream.AssetEventTypeFilter(evtstream.EventAssetDeleted)},
+		AckWait:        assetCleanupAckWait,
+		MaxAckPending:  assetCleanupMaxPending,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
 	if err != nil {
 		return fmt.Errorf("create asset cleanup consumer: %w", err)
 	}
-	worker, err := events.NewDurableWorker(consumer, s.processCleanupDelivery, events.DurableWorkerOptions{
+	worker, err := evtstream.NewEffectWorker(consumer, s.processCleanupDelivery, evtstream.EffectWorkerOptions{
 		MaxConcurrent:     assetCleanupMaxPending,
 		RetryDelay:        assetCleanupRetryDelay,
 		AckTimeout:        assetCleanupAckTimeout,

--- a/cli/internal/core/call_model.go
+++ b/cli/internal/core/call_model.go
@@ -137,23 +137,18 @@ func NewCallModel(
 }
 
 func (s *CallModel) configureKeyCleanup(ctx context.Context, stream jetstream.Stream) error {
-	consumer, err := stream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:            callKeyCleanupConsumerName,
-		Durable:         callKeyCleanupConsumerName,
-		Description:     "Shared durable queue for ended Chatto call-key deletion",
-		DeliverPolicy:   jetstream.DeliverAllPolicy,
-		AckPolicy:       jetstream.AckExplicitPolicy,
-		AckWait:         callKeyCleanupAckWait,
-		MaxDeliver:      -1,
-		FilterSubject:   evtstream.RoomEventTypeFilter(evtstream.EventCallEnded),
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   callKeyCleanupMaxPending,
-		MaxRequestBatch: callKeyCleanupMaxPending,
+	consumer, err := evtstream.CreateEffectConsumer(ctx, stream, evtstream.EffectConsumerConfig{
+		Name:           callKeyCleanupConsumerName,
+		Description:    "Shared durable queue for ended Chatto call-key deletion",
+		FilterSubjects: []string{evtstream.RoomEventTypeFilter(evtstream.EventCallEnded)},
+		AckWait:        callKeyCleanupAckWait,
+		MaxAckPending:  callKeyCleanupMaxPending,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
 	if err != nil {
 		return fmt.Errorf("create call-key cleanup consumer: %w", err)
 	}
-	worker, err := events.NewDurableWorker(consumer, s.processKeyCleanupDelivery, events.DurableWorkerOptions{
+	worker, err := evtstream.NewEffectWorker(consumer, s.processKeyCleanupDelivery, evtstream.EffectWorkerOptions{
 		MaxConcurrent:     callKeyCleanupMaxPending,
 		RetryDelay:        callKeyCleanupRetryDelay,
 		AckTimeout:        callKeyCleanupAckTimeout,

--- a/cli/internal/core/notification_alert_delivery.go
+++ b/cli/internal/core/notification_alert_delivery.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 
+	"hmans.de/chatto/internal/evtstream"
 	"hmans.de/chatto/internal/notificationstream"
 	corev1 "hmans.de/chatto/internal/pb/chatto/core/v1"
 	"hmans.de/chatto/pkg/events"
@@ -56,18 +57,13 @@ func (c *ChattoCore) SetNotificationAlertHandler(handler func(context.Context, *
 }
 
 func (d *notificationAlertDelivery) initialize(ctx context.Context) error {
-	consumer, err := d.core.storage.notificationStream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:            notificationAlertConsumerName,
-		Durable:         notificationAlertConsumerName,
-		Description:     "Shared durable worker for Chatto notification alerts",
-		DeliverPolicy:   jetstream.DeliverAllPolicy,
-		AckPolicy:       jetstream.AckExplicitPolicy,
-		AckWait:         notificationAlertAckWait,
-		MaxDeliver:      -1,
-		FilterSubject:   notificationstream.SignalledSubject,
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   notificationAlertMaxPending,
-		MaxRequestBatch: notificationAlertMaxPending,
+	consumer, err := evtstream.CreateEffectConsumer(ctx, d.core.storage.notificationStream, evtstream.EffectConsumerConfig{
+		Name:           notificationAlertConsumerName,
+		Description:    "Shared durable worker for Chatto notification alerts",
+		FilterSubjects: []string{notificationstream.SignalledSubject},
+		AckWait:        notificationAlertAckWait,
+		MaxAckPending:  notificationAlertMaxPending,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
 	if err != nil {
 		return fmt.Errorf("create notification alert consumer: %w", err)
@@ -80,9 +76,8 @@ func (d *notificationAlertDelivery) run(ctx context.Context) error {
 	if err := d.core.notificationOccurrences.WaitReady(ctx); err != nil {
 		return fmt.Errorf("wait for notification projection before alert delivery: %w", err)
 	}
-	worker, err := events.NewDurableWorker(d.consumer, d.processDelivery, events.DurableWorkerOptions{
+	worker, err := evtstream.NewEffectWorker(d.consumer, d.processDelivery, evtstream.EffectWorkerOptions{
 		MaxConcurrent:     notificationAlertMaxPending,
-		FetchMaxWait:      time.Second,
 		RetryDelay:        notificationAlertRetryDelay,
 		AckTimeout:        notificationAlertAckTimeout,
 		HeartbeatInterval: notificationAlertHeartbeat,

--- a/cli/internal/core/notification_materializer.go
+++ b/cli/internal/core/notification_materializer.go
@@ -108,8 +108,7 @@ func (m *NotificationMaterializer) Run(ctx context.Context) error {
 		AckTimeout:        notificationWorkerAckTimeout,
 		HeartbeatInterval: notificationWorkerHeartbeat,
 		Logger:            m.core.logger.WithPrefix("NotificationWorker"),
-	},
-	)
+	})
 	if err != nil {
 		return fmt.Errorf("configure notification worker: %w", err)
 	}

--- a/cli/internal/core/notification_materializer.go
+++ b/cli/internal/core/notification_materializer.go
@@ -102,17 +102,13 @@ func (m *NotificationMaterializer) Run(ctx context.Context) error {
 		return fmt.Errorf("wait for notification projection before worker: %w", err)
 	}
 
-	worker, err := events.NewDurableWorker(
-		m.consumer,
-		m.processDelivery,
-		events.DurableWorkerOptions{
-			MaxConcurrent:     notificationWorkerMaxPending,
-			FetchMaxWait:      time.Second,
-			RetryDelay:        notificationWorkerRetryDelay,
-			AckTimeout:        notificationWorkerAckTimeout,
-			HeartbeatInterval: notificationWorkerHeartbeat,
-			Logger:            m.core.logger.WithPrefix("NotificationWorker"),
-		},
+	worker, err := evtstream.NewEffectWorker(m.consumer, m.processDelivery, evtstream.EffectWorkerOptions{
+		MaxConcurrent:     notificationWorkerMaxPending,
+		RetryDelay:        notificationWorkerRetryDelay,
+		AckTimeout:        notificationWorkerAckTimeout,
+		HeartbeatInterval: notificationWorkerHeartbeat,
+		Logger:            m.core.logger.WithPrefix("NotificationWorker"),
+	},
 	)
 	if err != nil {
 		return fmt.Errorf("configure notification worker: %w", err)
@@ -338,21 +334,16 @@ func (m *NotificationMaterializer) createConsumer(ctx context.Context) (jetstrea
 	} else if !errors.Is(err, jetstream.ErrConsumerNotFound) {
 		return nil, fmt.Errorf("read notification materializer consumer: %w", err)
 	}
-	consumer, err := m.core.storage.serverEvtStream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:        notificationWorkerConsumerName,
-		Durable:     notificationWorkerConsumerName,
-		Description: "Shared durable worker for Chatto notification materialization",
-		// Notification derivation starts with Notifications 2.0. Beginning at
-		// the consumer's creation boundary avoids manufacturing occurrences for
-		// the server's pre-upgrade message history on first rollout.
-		DeliverPolicy:   jetstream.DeliverNewPolicy,
-		AckPolicy:       jetstream.AckExplicitPolicy,
-		AckWait:         notificationWorkerAckWait,
-		MaxDeliver:      -1,
-		FilterSubjects:  filterSubjects,
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   notificationWorkerMaxPending,
-		MaxRequestBatch: notificationWorkerMaxPending,
+	// Notification derivation starts with Notifications 2.0. DeliverNew
+	// begins at the consumer's creation boundary and avoids manufacturing
+	// occurrences for the server's pre-upgrade message history on rollout.
+	consumer, err := evtstream.CreateEffectConsumer(ctx, m.core.storage.serverEvtStream, evtstream.EffectConsumerConfig{
+		Name:           notificationWorkerConsumerName,
+		Description:    "Shared durable worker for Chatto notification materialization",
+		FilterSubjects: filterSubjects,
+		AckWait:        notificationWorkerAckWait,
+		MaxAckPending:  notificationWorkerMaxPending,
+		DeliverPolicy:  jetstream.DeliverNewPolicy,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create notification materializer consumer: %w", err)

--- a/cli/internal/core/push_subscription_cleanup.go
+++ b/cli/internal/core/push_subscription_cleanup.go
@@ -54,31 +54,22 @@ func newPushSubscriptionCleanupModel(
 	reconcileLease *lease.Lease,
 	logger *log.Logger,
 ) (*pushSubscriptionCleanupModel, error) {
-	consumer, err := core.storage.serverEvtStream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:            pushSubscriptionCleanupConsumerName,
-		Durable:         pushSubscriptionCleanupConsumerName,
-		Description:     "Shared durable worker for Chatto user push-subscription cleanup",
-		DeliverPolicy:   jetstream.DeliverAllPolicy,
-		AckPolicy:       jetstream.AckExplicitPolicy,
-		AckWait:         pushSubscriptionCleanupConsumerAckWait,
-		MaxDeliver:      -1,
-		FilterSubject:   evtstream.UserEventTypeFilter(evtstream.EventUserAccountDeleted),
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   pushSubscriptionCleanupMaxPending,
-		MaxRequestBatch: pushSubscriptionCleanupMaxPending,
+	consumer, err := evtstream.CreateEffectConsumer(ctx, core.storage.serverEvtStream, evtstream.EffectConsumerConfig{
+		Name:           pushSubscriptionCleanupConsumerName,
+		Description:    "Shared durable worker for Chatto user push-subscription cleanup",
+		FilterSubjects: []string{evtstream.UserEventTypeFilter(evtstream.EventUserAccountDeleted)},
+		AckWait:        pushSubscriptionCleanupConsumerAckWait,
+		MaxAckPending:  pushSubscriptionCleanupMaxPending,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("create user push-subscription cleanup consumer: %w", err)
-	}
 	model := &pushSubscriptionCleanupModel{
 		core:           core,
 		reconcileLease: reconcileLease,
 		logger:         logger,
 		deleteAllFn:    core.DeleteAllUserPushSubscriptions,
 	}
-	model.worker, err = events.NewDurableWorker(consumer, model.processDelivery, events.DurableWorkerOptions{
+	model.worker, err = evtstream.NewEffectWorker(consumer, model.processDelivery, evtstream.EffectWorkerOptions{
 		MaxConcurrent:     pushSubscriptionCleanupMaxPending,
-		FetchMaxWait:      time.Second,
 		RetryDelay:        pushSubscriptionCleanupRetryDelay,
 		AckTimeout:        pushSubscriptionCleanupAcknowledgeTimeout,
 		HeartbeatInterval: pushSubscriptionCleanupDeliveryHeartbeat,

--- a/cli/internal/core/push_subscription_cleanup.go
+++ b/cli/internal/core/push_subscription_cleanup.go
@@ -62,6 +62,9 @@ func newPushSubscriptionCleanupModel(
 		MaxAckPending:  pushSubscriptionCleanupMaxPending,
 		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("create user push-subscription cleanup consumer: %w", err)
+	}
 	model := &pushSubscriptionCleanupModel{
 		core:           core,
 		reconcileLease: reconcileLease,

--- a/cli/internal/core/user_key_shredding.go
+++ b/cli/internal/core/user_key_shredding.go
@@ -52,6 +52,9 @@ func newUserKeyShreddingModel(ctx context.Context, core *ChattoCore, logger *log
 		MaxAckPending:  userKeyShreddingMaxPending,
 		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
+	if err != nil {
+		return nil, fmt.Errorf("create user-key shredding consumer: %w", err)
+	}
 	m := &UserKeyShreddingModel{
 		core:               core,
 		appendRequestAtFn:  core.EventPublisher.AppendAtFilter,

--- a/cli/internal/core/user_key_shredding.go
+++ b/cli/internal/core/user_key_shredding.go
@@ -44,22 +44,14 @@ type UserKeyShreddingModel struct {
 }
 
 func newUserKeyShreddingModel(ctx context.Context, core *ChattoCore, logger *log.Logger) (*UserKeyShreddingModel, error) {
-	consumer, err := core.storage.serverEvtStream.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:            userKeyShreddingConsumerName,
-		Durable:         userKeyShreddingConsumerName,
-		Description:     "Shared durable queue for Chatto user-key shredding",
-		DeliverPolicy:   jetstream.DeliverAllPolicy,
-		AckPolicy:       jetstream.AckExplicitPolicy,
-		AckWait:         userKeyShreddingConsumerAckWait,
-		MaxDeliver:      -1,
-		FilterSubject:   evtstream.UserEventTypeFilter(evtstream.EventUserKeyShreddingRequested),
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   userKeyShreddingMaxPending,
-		MaxRequestBatch: userKeyShreddingMaxPending,
+	consumer, err := evtstream.CreateEffectConsumer(ctx, core.storage.serverEvtStream, evtstream.EffectConsumerConfig{
+		Name:           userKeyShreddingConsumerName,
+		Description:    "Shared durable queue for Chatto user-key shredding",
+		FilterSubjects: []string{evtstream.UserEventTypeFilter(evtstream.EventUserKeyShreddingRequested)},
+		AckWait:        userKeyShreddingConsumerAckWait,
+		MaxAckPending:  userKeyShreddingMaxPending,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("create user-key shredding consumer: %w", err)
-	}
 	m := &UserKeyShreddingModel{
 		core:               core,
 		appendRequestAtFn:  core.EventPublisher.AppendAtFilter,
@@ -67,9 +59,8 @@ func newUserKeyShreddingModel(ctx context.Context, core *ChattoCore, logger *log
 		shredWrappingKeyFn: core.encryption.keyWrapper.ShredKey,
 	}
 	m.appendOnceFn = m.appendOnce
-	m.worker, err = events.NewDurableWorker(consumer, m.processDelivery, events.DurableWorkerOptions{
+	m.worker, err = evtstream.NewEffectWorker(consumer, m.processDelivery, evtstream.EffectWorkerOptions{
 		MaxConcurrent:     userKeyShreddingMaxPending,
-		FetchMaxWait:      time.Second,
 		RetryDelay:        userKeyShreddingRetryDelay,
 		AckTimeout:        userKeyShreddingAcknowledgeTimeout,
 		HeartbeatInterval: userKeyShreddingDeliveryHeartbeat,

--- a/cli/internal/evtstream/effects.go
+++ b/cli/internal/evtstream/effects.go
@@ -1,0 +1,127 @@
+// Shared mechanics for application-owned durable effect consumers.
+//
+// ADR-069 keeps every durable consumer's identity, rollout, and retirement an
+// application decision; this file only collapses the identical JetStream
+// consumer-creation and durable-worker-option rituals that previously repeated
+// at each effect site. Policy values remain per-site constants supplied by the
+// caller.
+package evtstream
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/pkg/events"
+)
+
+// EffectConsumerConfig describes one durable effect consumer's persisted
+// contract: its name and description, the event subjects it consumes, and its
+// delivery policy. Name, filter subjects, and policy are deployment-wide
+// resource decisions; changing them requires ADR-069's staged migration.
+type EffectConsumerConfig struct {
+	// Name is the durable consumer name (also used as Durable).
+	Name string
+	// Description is stored on the consumer for operator visibility.
+	Description string
+	// FilterSubjects lists one or more consumed subjects or wildcard filters.
+	FilterSubjects []string
+	// AckWait bounds unacknowledged redelivery for each delivery.
+	AckWait time.Duration
+	// MaxAckPending bounds outstanding deliveries and in-flight handler
+	// concurrency: the same value feeds MaxAckPending, MaxRequestBatch, and
+	// the worker's MaxConcurrent, matching every existing effect site.
+	MaxAckPending int
+	// DeliverPolicy selects where a new consumer starts reading the stream:
+	// DeliverAllPolicy replays retained history; DeliverNewPolicy starts at
+	// the creation boundary.
+	DeliverPolicy jetstream.DeliverPolicy
+}
+
+func (c EffectConsumerConfig) validate() error {
+	if c.Name == "" {
+		return fmt.Errorf("effect consumer name is required")
+	}
+	if len(c.FilterSubjects) == 0 {
+		return fmt.Errorf("effect consumer %s needs at least one filter subject", c.Name)
+	}
+	for _, subject := range c.FilterSubjects {
+		if subject == "" {
+			return fmt.Errorf("effect consumer %s has an empty filter subject", c.Name)
+		}
+	}
+	if c.AckWait <= 0 {
+		return fmt.Errorf("effect consumer %s ack wait must be positive", c.Name)
+	}
+	if c.MaxAckPending <= 0 {
+		return fmt.Errorf("effect consumer %s max ack pending must be positive", c.Name)
+	}
+	return nil
+}
+
+// CreateEffectConsumer creates or updates one durable effect consumer with
+// Chatto's standard effect policies: explicit acknowledgement, unlimited
+// redelivery, instant replay, and request batches bounded by MaxAckPending.
+//
+// A single filter subject is persisted via the singular Config.FilterSubject
+// field so the stored consumer config stays byte-compatible with consumers
+// that predate this helper; multi-subject consumers use FilterSubjects.
+func CreateEffectConsumer(ctx context.Context, stream jetstream.Stream, config EffectConsumerConfig) (jetstream.Consumer, error) {
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+	consumerConfig := jetstream.ConsumerConfig{
+		Name:            config.Name,
+		Durable:         config.Name,
+		Description:     config.Description,
+		DeliverPolicy:   config.DeliverPolicy,
+		AckPolicy:       jetstream.AckExplicitPolicy,
+		AckWait:         config.AckWait,
+		MaxDeliver:      -1,
+		ReplayPolicy:    jetstream.ReplayInstantPolicy,
+		MaxAckPending:   config.MaxAckPending,
+		MaxRequestBatch: config.MaxAckPending,
+	}
+	if len(config.FilterSubjects) == 1 {
+		consumerConfig.FilterSubject = config.FilterSubjects[0]
+	} else {
+		consumerConfig.FilterSubjects = config.FilterSubjects
+	}
+	consumer, err := stream.CreateOrUpdateConsumer(ctx, consumerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create effect consumer %s: %w", config.Name, err)
+	}
+	return consumer, nil
+}
+
+// EffectWorkerOptions holds the process-local execution knobs for one effect
+// worker. They are deliberately narrower than events.DurableWorkerOptions:
+// FetchMaxWait stays unset so the framework default applies, which is what
+// every effect site already used.
+type EffectWorkerOptions struct {
+	// MaxConcurrent bounds simultaneously executing handlers. Feed it the
+	// same EffectConsumerConfig.MaxAckPending used to create the consumer.
+	MaxConcurrent int
+	// RetryDelay waits before retrying after a failed delivery.
+	RetryDelay time.Duration
+	// AckTimeout fails handlers whose acknowledgement confirmation exceeds it.
+	AckTimeout time.Duration
+	// HeartbeatInterval bounds progress heartbeats to JetStream during pulls.
+	HeartbeatInterval time.Duration
+	// Logger receives delivery-failure diagnostics; errors must stay PII-free.
+	Logger events.Logger
+}
+
+// NewEffectWorker builds a durable worker over an application-owned effect
+// consumer using Chatto's standard effect execution options.
+func NewEffectWorker(consumer jetstream.Consumer, handle events.DurableDeliveryHandler, options EffectWorkerOptions) (*events.DurableWorker, error) {
+	return events.NewDurableWorker(consumer, handle, events.DurableWorkerOptions{
+		MaxConcurrent:     options.MaxConcurrent,
+		RetryDelay:        options.RetryDelay,
+		AckTimeout:        options.AckTimeout,
+		HeartbeatInterval: options.HeartbeatInterval,
+		Logger:            options.Logger,
+	})
+}

--- a/cli/internal/evtstream/effects_test.go
+++ b/cli/internal/evtstream/effects_test.go
@@ -115,6 +115,70 @@ func TestCreateEffectConsumerSupportsCreationBoundaryStart(t *testing.T) {
 	}
 }
 
+// TestCreateEffectConsumerUpdatePathStable re-applies identical configs to an
+// existing consumer, covering both filter-field representations. CreateOrUpdate
+// must not flip a historical singular-filter consumer to plural representation
+// (or vice versa) when an upgraded binary reproduces its contract.
+func TestCreateEffectConsumerUpdatePathStable(t *testing.T) {
+	ctx, stream := newEffectTestStream(t)
+
+	singular := EffectConsumerConfig{
+		Name:           "update-singular",
+		Description:    "update path",
+		FilterSubjects: []string{"evt.room.*.message_posted"},
+		AckWait:        time.Minute,
+		MaxAckPending:  2,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	}
+	if _, err := CreateEffectConsumer(ctx, stream, singular); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		consumer, err := stream.Consumer(ctx, "update-singular")
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := consumer.Info(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Config.FilterSubject != "evt.room.*.message_posted" || len(info.Config.FilterSubjects) != 0 {
+			t.Fatalf("pass %d: singular consumer drifted: %+v", i, info.Config)
+		}
+		if _, err := CreateEffectConsumer(ctx, stream, singular); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	plural := EffectConsumerConfig{
+		Name:           "update-plural",
+		Description:    "update path",
+		FilterSubjects: []string{"evt.room.*.message_posted", "evt.room.*.message_edited"},
+		AckWait:        time.Minute,
+		MaxAckPending:  2,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	}
+	if _, err := CreateEffectConsumer(ctx, stream, plural); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 2; i++ {
+		consumer, err := stream.Consumer(ctx, "update-plural")
+		if err != nil {
+			t.Fatal(err)
+		}
+		info, err := consumer.Info(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(info.Config.FilterSubjects) != 2 || info.Config.FilterSubject != "" {
+			t.Fatalf("pass %d: plural consumer drifted: %+v", i, info.Config)
+		}
+		if _, err := CreateEffectConsumer(ctx, stream, plural); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestCreateEffectConsumerRejectsInvalidContracts(t *testing.T) {
 	ctx, stream := newEffectTestStream(t)
 
@@ -137,6 +201,10 @@ func TestCreateEffectConsumerRejectsInvalidContracts(t *testing.T) {
 		{
 			name:   "zero max ack pending",
 			config: EffectConsumerConfig{Name: "nomaxpending", FilterSubjects: []string{"evt.x"}, AckWait: time.Minute, DeliverPolicy: jetstream.DeliverAllPolicy},
+		},
+		{
+			name:   "empty filter subject entry",
+			config: EffectConsumerConfig{Name: "emptysubject", FilterSubjects: []string{"evt.x", ""}, AckWait: time.Minute, MaxAckPending: 1, DeliverPolicy: jetstream.DeliverAllPolicy},
 		},
 	}
 	for _, tc := range cases {

--- a/cli/internal/evtstream/effects_test.go
+++ b/cli/internal/evtstream/effects_test.go
@@ -1,0 +1,189 @@
+package evtstream
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+
+	"hmans.de/chatto/internal/testutil"
+	"hmans.de/chatto/pkg/events"
+)
+
+// nopLogger satisfies events.Logger for worker-construction tests.
+type nopLogger struct{}
+
+func (nopLogger) Debug(interface{}, ...interface{}) {}
+func (nopLogger) Info(interface{}, ...interface{})  {}
+func (nopLogger) Warn(interface{}, ...interface{})  {}
+func (nopLogger) Error(interface{}, ...interface{}) {}
+
+func newEffectTestStream(t *testing.T) (context.Context, jetstream.Stream) {
+	t.Helper()
+	_, nc := testutil.StartNATS(t)
+	js, err := jetstream.New(nc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+	stream, err := js.CreateStream(ctx, jetstream.StreamConfig{
+		Name:     "EVT_EFFECT_TEST",
+		Subjects: []string{"evt.>", "notifications.>"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ctx, stream
+}
+
+func TestCreateEffectConsumerAppliesStandardEffectPolicies(t *testing.T) {
+	ctx, stream := newEffectTestStream(t)
+
+	consumer, err := CreateEffectConsumer(ctx, stream, EffectConsumerConfig{
+		Name:           "test-effect",
+		Description:    "unit contract check",
+		FilterSubjects: []string{"evt.room.*.message_posted", "evt.room.*.message_edited"},
+		AckWait:        2 * time.Minute,
+		MaxAckPending:  16,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := info.Config
+	if config.Name != "test-effect" || config.Durable != "test-effect" {
+		t.Fatalf("consumer name = %q durable = %q", config.Name, config.Durable)
+	}
+	if config.Description != "unit contract check" {
+		t.Fatalf("description = %q", config.Description)
+	}
+	// Two subjects must persist via the plural field.
+	if len(config.FilterSubjects) != 2 || config.FilterSubjects[0] != "evt.room.*.message_posted" || config.FilterSubjects[1] != "evt.room.*.message_edited" || config.FilterSubject != "" {
+		t.Fatalf("filter subjects = %q / %q", config.FilterSubject, config.FilterSubjects)
+	}
+	if config.DeliverPolicy != jetstream.DeliverAllPolicy {
+		t.Fatalf("deliver policy = %v", config.DeliverPolicy)
+	}
+	if config.AckPolicy != jetstream.AckExplicitPolicy {
+		t.Fatalf("ack policy = %v", config.AckPolicy)
+	}
+	if config.MaxDeliver != -1 {
+		t.Fatalf("max deliver = %d, want unlimited redelivery", config.MaxDeliver)
+	}
+	if config.ReplayPolicy != jetstream.ReplayInstantPolicy {
+		t.Fatalf("replay policy = %v", config.ReplayPolicy)
+	}
+	if config.AckWait != 2*time.Minute {
+		t.Fatalf("ack wait = %v", config.AckWait)
+	}
+	if config.MaxAckPending != 16 || config.MaxRequestBatch != 16 {
+		t.Fatalf("max ack pending = %d max request batch = %d", config.MaxAckPending, config.MaxRequestBatch)
+	}
+}
+
+func TestCreateEffectConsumerSupportsCreationBoundaryStart(t *testing.T) {
+	ctx, stream := newEffectTestStream(t)
+
+	consumer, err := CreateEffectConsumer(ctx, stream, EffectConsumerConfig{
+		Name:           "test-effect-new",
+		Description:    "creation-boundary consumer",
+		FilterSubjects: []string{"notifications.signalled"},
+		AckWait:        time.Minute,
+		MaxAckPending:  1,
+		DeliverPolicy:  jetstream.DeliverNewPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := consumer.Info(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Config.DeliverPolicy != jetstream.DeliverNewPolicy {
+		t.Fatalf("deliver policy = %v, want creation-boundary start", info.Config.DeliverPolicy)
+	}
+	// A single filter subject must persist via the singular field, matching
+	// the historical single-subject effect consumers.
+	if info.Config.FilterSubject != "notifications.signalled" || len(info.Config.FilterSubjects) != 0 {
+		t.Fatalf("filter subject = %q subjects = %v", info.Config.FilterSubject, info.Config.FilterSubjects)
+	}
+}
+
+func TestCreateEffectConsumerRejectsInvalidContracts(t *testing.T) {
+	ctx, stream := newEffectTestStream(t)
+
+	cases := []struct {
+		name   string
+		config EffectConsumerConfig
+	}{
+		{
+			name:   "missing name",
+			config: EffectConsumerConfig{FilterSubjects: []string{"evt.x"}, AckWait: time.Minute, MaxAckPending: 1, DeliverPolicy: jetstream.DeliverAllPolicy},
+		},
+		{
+			name:   "no filter subjects",
+			config: EffectConsumerConfig{Name: "nofilter", AckWait: time.Minute, MaxAckPending: 1, DeliverPolicy: jetstream.DeliverAllPolicy},
+		},
+		{
+			name:   "empty ack wait",
+			config: EffectConsumerConfig{Name: "noackwait", FilterSubjects: []string{"evt.x"}, MaxAckPending: 1, DeliverPolicy: jetstream.DeliverAllPolicy},
+		},
+		{
+			name:   "zero max ack pending",
+			config: EffectConsumerConfig{Name: "nomaxpending", FilterSubjects: []string{"evt.x"}, AckWait: time.Minute, DeliverPolicy: jetstream.DeliverAllPolicy},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := CreateEffectConsumer(ctx, stream, tc.config); err == nil {
+				t.Fatalf("CreateEffectConsumer(%s) succeeded, want contract error", tc.name)
+			}
+		})
+	}
+}
+
+func TestEffectWorkerOptionsPreserveDeliveryKnobs(t *testing.T) {
+	ctx, stream := newEffectTestStream(t)
+
+	consumer, err := CreateEffectConsumer(ctx, stream, EffectConsumerConfig{
+		Name:           "test-worker-options",
+		Description:    "worker option passthrough",
+		FilterSubjects: []string{"evt.room.*.message_posted"},
+		AckWait:        time.Minute,
+		MaxAckPending:  4,
+		DeliverPolicy:  jetstream.DeliverAllPolicy,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	worker, err := NewEffectWorker(consumer, func(context.Context, events.DurableDelivery) error { return nil }, EffectWorkerOptions{
+		MaxConcurrent:     4,
+		RetryDelay:        30 * time.Second,
+		AckTimeout:        5 * time.Second,
+		HeartbeatInterval: 30 * time.Second,
+		Logger:            nopLogger{},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	opts := worker.Options()
+	if opts.MaxConcurrent != 4 {
+		t.Fatalf("max concurrent = %d", opts.MaxConcurrent)
+	}
+	// NewEffectWorker leaves FetchMaxWait unset; DurableWorker construction
+	// resolves zero to its own default, which must remain one second to match
+	// every historical effect site.
+	if opts.FetchMaxWait != time.Second {
+		t.Fatalf("resolved fetch max wait = %v, want framework default %v", opts.FetchMaxWait, time.Second)
+	}
+	if opts.RetryDelay != 30*time.Second || opts.AckTimeout != 5*time.Second || opts.HeartbeatInterval != 30*time.Second {
+		t.Fatalf("delivery knobs = %+v", opts)
+	}
+}

--- a/cli/internal/video/unit.go
+++ b/cli/internal/video/unit.go
@@ -80,14 +80,13 @@ func (Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 
 	workerCtx, stopWorker := context.WithCancel(ctx)
 	workerDone := make(chan error, 1)
-	worker, err := events.NewDurableWorker(
+	worker, err := evtstream.NewEffectWorker(
 		consumer,
 		func(ctx context.Context, delivery events.DurableDelivery) error {
 			return processDelivery(ctx, delivery, runtime, processor, env.Logger)
 		},
-		events.DurableWorkerOptions{
+		evtstream.EffectWorkerOptions{
 			MaxConcurrent:     env.Config.AssetProcessing.MaxConcurrentJobsOrDefault(),
-			FetchMaxWait:      time.Second,
 			RetryDelay:        retryDelay,
 			AckTimeout:        acknowledgeTimeout,
 			HeartbeatInterval: deliveryHeartbeat,
@@ -135,21 +134,16 @@ func createConsumer(ctx context.Context, js jetstream.JetStream) (jetstream.Cons
 	if err != nil {
 		return nil, fmt.Errorf("open EVT stream: %w", err)
 	}
-	consumer, err := evt.CreateOrUpdateConsumer(ctx, jetstream.ConsumerConfig{
-		Name:          consumerName,
-		Durable:       consumerName,
-		Description:   "Shared durable queue for Chatto asset-processing workers",
-		DeliverPolicy: jetstream.DeliverAllPolicy,
-		AckPolicy:     jetstream.AckExplicitPolicy,
-		AckWait:       consumerAckWait,
-		MaxDeliver:    -1,
+	consumer, err := evtstream.CreateEffectConsumer(ctx, evt, evtstream.EffectConsumerConfig{
+		Name:        consumerName,
+		Description: "Shared durable queue for Chatto asset-processing workers",
 		FilterSubjects: []string{
 			evtstream.AssetEventTypeFilter(evtstream.EventAssetProcessingStarted),
 			evtstream.RoomEventTypeFilter(evtstream.EventAssetProcessingStarted),
 		},
-		ReplayPolicy:    jetstream.ReplayInstantPolicy,
-		MaxAckPending:   consumerMaxPending,
-		MaxRequestBatch: consumerMaxPending,
+		AckWait:       consumerAckWait,
+		MaxAckPending: consumerMaxPending,
+		DeliverPolicy: jetstream.DeliverAllPolicy,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create asset-processing consumer: %w", err)

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -103,10 +103,9 @@ func TerminateDelivery(reason string, err error) error {
 	return &terminateDeliveryError{err: err, reason: reason}
 }
 
-// Options returns the effective options this worker was configured with.
-// Zero-valued durations reflect deferred-to-default settings; call it before
-// Run. It exists so applications can assert their own option-mapping helpers
-// pass delivery knobs through unchanged.
+// Options returns the worker's effective, default-resolved options as fixed
+// at construction. It exists so applications can assert their own
+// option-mapping helpers pass delivery knobs through unchanged.
 func (w *DurableWorker) Options() DurableWorkerOptions {
 	return w.opts
 }

--- a/pkg/events/durable_worker.go
+++ b/pkg/events/durable_worker.go
@@ -103,8 +103,17 @@ func TerminateDelivery(reason string, err error) error {
 	return &terminateDeliveryError{err: err, reason: reason}
 }
 
-// NewDurableWorker validates and constructs a worker. It does not create or
-// modify the supplied consumer.
+// Options returns the effective options this worker was configured with.
+// Zero-valued durations reflect deferred-to-default settings; call it before
+// Run. It exists so applications can assert their own option-mapping helpers
+// pass delivery knobs through unchanged.
+func (w *DurableWorker) Options() DurableWorkerOptions {
+	return w.opts
+}
+
+// NewDurableWorker validates and constructs a worker. It applies framework
+// defaults for unset options but does not create or modify the supplied
+// consumer.
 func NewDurableWorker(
 	consumer jetstream.Consumer,
 	handle DurableDeliveryHandler,


### PR DESCRIPTION
## Why

Seven durable effect-consumer sites each repeated the same JetStream consumer-creation ritual (standard effect policies, `MaxAckPending` mirrored into `MaxRequestBatch`) and the same `DurableWorkerOptions` shape, with per-site timing constants that had to be wired identically by hand every time.

## What changed

- Added `evtstream.CreateEffectConsumer` / `evtstream.NewEffectWorker`, collapsing the shared mechanics; per ADR-069 and the cli agent rules, every site still owns its name, description, filter subjects, ack wait, pending bound, delivery policy, and handler.
- Migrated all seven sites: call-key cleanup, user-key shredding, push-subscription cleanup, asset cleanup, notification alerts, notification materializer, video asset processing. `MaxConcurrent == MaxAckPending == MaxRequestBatch` is now one value passed once per site.
- Faithfulness notes: single-filter consumers persist via singular `FilterSubject` for byte-compatible storage (an existing contract test caught this regression mid-implementation); `FetchMaxWait` is deliberately unexposed since every site used the framework's 1s default; the materializer keeps its pre-existence filter-contract check and DeliverNew creation boundary.
- Added `events.DurableWorker.Options()` so applications can assert their option-mapping helpers pass delivery knobs through unchanged; extended effect tests covering config parity, contract validation, and update-path representation stability.

No delivery semantics changed: ack policies, redelivery bounds, concurrency caps, retry/ack timeout/heartbeat values are all preserved exactly.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server:

Newer client → older server:

Capability discovery or minimum client/server version:

## Test plan

- New `effects_test.go`: consumer-config equality (both deliver policies), singular/plural filter persistence incl. update-path stability, contract validation, worker option passthrough.
- `go test ./internal/core ./internal/video ./internal/evtstream` — pass (~150s core suite).
- `mise test-cli` (incl. test_endpoints) — pass; `mise test-events` — pass; license check clean.
