### PR TITLE
feat(frontend): suppress previews for angle-bracket links

### DIFF
--- a/apps/docs-website/src/content/docs/getting-started/message-formatting.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/message-formatting.mdx
@@ -57,3 +57,13 @@ Chatto formats:
 ```
 
 Chatto displays source HTML, horizontal rules, reference-style links, and setext headings as literal text. Markdown image syntax does not embed remote images; upload an attachment instead. Label a fenced code block with a supported language, such as `js`, `go`, or `ruby`, to highlight its programming syntax while composing and after sending.
+
+## Prevent a link preview
+
+Put a complete HTTP or HTTPS URL in angle brackets to keep the link clickable without a preview attachment:
+
+```md
+<https://example.com>
+```
+
+You can use this syntax in the Markdown editor and the visual editor. If the message contains a later URL without angle brackets, Chatto can use that URL for the preview instead.

--- a/apps/docs-website/src/content/docs/getting-started/message-formatting.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/message-formatting.mdx
@@ -67,3 +67,4 @@ Put a complete HTTP or HTTPS URL in angle brackets to keep the link clickable wi
 ```
 
 You can use this syntax in the Markdown editor and the visual editor. If the message contains a later URL without angle brackets, Chatto can use that URL for the preview instead.
+Chatto also prevents the preview if you omit the closing angle bracket.

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -764,6 +764,45 @@ describe('MessageComposer', () => {
     });
   });
 
+  describe('angle-bracket link preview suppression', () => {
+    it('suppresses previews and posts the autolink from the visual editor', async () => {
+      const body = '<https://example.com/visual>';
+      const { container, roomId } = renderMessageComposer({ roomId: 'visual-autolink' });
+      const editor = await findEditor(container);
+
+      await typeEditorLiteralText(editor, body);
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      expect(fetchLinkPreviewConnectMock).not.toHaveBeenCalled();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body,
+        linkPreviewToken: null
+      });
+    });
+
+    it('suppresses previews and posts the autolink from the Markdown editor', async () => {
+      userPreferences.composerEditor = 'markdown';
+      const body = '<https://example.com/markdown>';
+      const { container, roomId } = renderMessageComposer({ roomId: 'markdown-autolink' });
+      const editor = await findEditor(container);
+
+      await typeEditorKeys(editor, body);
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      expect(fetchLinkPreviewConnectMock).not.toHaveBeenCalled();
+      (q(container, 'button[aria-label="Send message"]') as HTMLButtonElement).click();
+      await vi.waitFor(() => expect(mutationMock).toHaveBeenCalledOnce());
+      expect(mutationMock.mock.calls[0][1].input).toMatchObject({
+        roomId,
+        body,
+        linkPreviewToken: null
+      });
+    });
+  });
+
   describe('Slow Mode', () => {
     it('shows ready, waiting, and bypassed status', async () => {
       const ready = renderMessageComposer({ roomId: 'room-ready', slowModeSeconds: 30 });

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -766,7 +766,7 @@ describe('MessageComposer', () => {
 
   describe('angle-bracket link preview suppression', () => {
     it('suppresses previews and posts the autolink from the visual editor', async () => {
-      const body = '<https://example.com/visual>';
+      const body = '<https://example.com/visual';
       const { container, roomId } = renderMessageComposer({ roomId: 'visual-autolink' });
       const editor = await findEditor(container);
 
@@ -785,7 +785,7 @@ describe('MessageComposer', () => {
 
     it('suppresses previews and posts the autolink from the Markdown editor', async () => {
       userPreferences.composerEditor = 'markdown';
-      const body = '<https://example.com/markdown>';
+      const body = '<https://example.com/markdown';
       const { container, roomId } = renderMessageComposer({ roomId: 'markdown-autolink' });
       const editor = await findEditor(container);
 

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -35,6 +35,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     createClipboardContent,
     getSerializedMarkdown,
     hasDefaultEmptyDocument,
+    isHttpMarkdownAutolink,
     prepareMarkdownForEditor
   } from './markdown';
   import { normalizeQuoteInsertionContent } from './quotes';
@@ -486,7 +487,18 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
               if (onPaste?.(event)) return true;
 
               const text = event.clipboardData?.getData('text/plain');
+              const normalizedText = text?.replace(/\r\n?/g, '\n');
               const html = event.clipboardData?.getData('text/html');
+              if (
+                normalizedText &&
+                isHttpMarkdownAutolink(normalizedText) &&
+                !editor?.isActive('codeBlock')
+              ) {
+                editor?.commands.insertContent(prepareMarkdownForEditor(normalizedText), {
+                  contentType: 'markdown'
+                });
+                return true;
+              }
               if (!text || !html || editor?.isActive('codeBlock')) return false;
 
               // Prefer and Markdown-parse the textual representation when the clipboard also

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
@@ -203,6 +203,45 @@ describe('TipTapEditor Markdown autolinks', () => {
     await expect.element(editor).toHaveTextContent('https://example.com/story');
   });
 
+  it('preserves a typed autolink when the closing angle bracket is missing', async () => {
+    const updates: string[] = [];
+    render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onUpdate: (markdown: string) => updates.push(markdown)
+      }
+    });
+    const editor = page.getByRole('textbox', { name: 'Write a message' });
+
+    await userEvent.click(editor);
+    await userEvent.type(editor, '<https://example.com/unclosed');
+
+    await vi.waitFor(() => expect(updates.at(-1)).toBe('<https://example.com/unclosed'));
+  });
+
+  it('preserves a restored autolink with no closing angle bracket', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    const updates: string[] = [];
+    const { container } = render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onReady: (api: ComposerEditorApi) => readyApis.push(api),
+        onUpdate: (markdown: string) => updates.push(markdown)
+      }
+    });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+
+    api.setContent('<https://example.com/unclosed');
+    api.focus('end');
+    api.insertText(' after');
+
+    await vi.waitFor(() => expect(updates.at(-1)).toBe('<https://example.com/unclosed after'));
+    expect(container.querySelector('a')?.getAttribute('href')).toBe(
+      'https://example.com/unclosed'
+    );
+  });
+
   it('preserves an angle-bracket URL pasted into the visual editor', async () => {
     const updates: string[] = [];
     render(TipTapEditor, {

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
@@ -164,3 +164,91 @@ describe('TipTapEditor wrapping', () => {
     expect(getComputedStyle(item, '::before').textAlign).toBe('end');
   });
 });
+
+describe('TipTapEditor Markdown autolinks', () => {
+  it('preserves a restored angle-bracket autolink after a later edit', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    const updates: string[] = [];
+    render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onReady: (api: ComposerEditorApi) => readyApis.push(api),
+        onUpdate: (markdown: string) => updates.push(markdown)
+      }
+    });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+
+    api.setContent('<https://example.com/?a=1&b=2>');
+    api.focus('end');
+    api.insertText(' after');
+
+    await vi.waitFor(() => expect(updates.at(-1)).toBe('<https://example.com/?a=1&b=2> after'));
+  });
+
+  it('converts a typed angle-bracket URL into a preserved Markdown autolink', async () => {
+    const updates: string[] = [];
+    render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onUpdate: (markdown: string) => updates.push(markdown)
+      }
+    });
+    const editor = page.getByRole('textbox', { name: 'Write a message' });
+
+    await userEvent.click(editor);
+    await userEvent.type(editor, '<https://example.com/story>');
+
+    await vi.waitFor(() => expect(updates.at(-1)).toBe('<https://example.com/story>'));
+    await expect.element(editor).toHaveTextContent('https://example.com/story');
+  });
+
+  it('preserves an angle-bracket URL pasted into the visual editor', async () => {
+    const updates: string[] = [];
+    render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onUpdate: (markdown: string) => updates.push(markdown)
+      }
+    });
+    const editor = page.getByRole('textbox', { name: 'Write a message' }).element();
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', '<https://example.com/pasted>');
+
+    editor.dispatchEvent(
+      new ClipboardEvent('paste', {
+        bubbles: true,
+        cancelable: true,
+        clipboardData: dataTransfer
+      })
+    );
+
+    await vi.waitFor(() => expect(updates.at(-1)).toBe('<https://example.com/pasted>'));
+    expect(editor.querySelector('a')?.getAttribute('href')).toBe('https://example.com/pasted');
+  });
+
+  it('uses a regular Markdown link after its destination changes', async () => {
+    const readyApis: ComposerEditorApi[] = [];
+    const updates: string[] = [];
+    render(TipTapEditor, {
+      props: {
+        placeholder: 'Write a message',
+        onReady: (api: ComposerEditorApi) => readyApis.push(api),
+        onUpdate: (markdown: string) => updates.push(markdown)
+      }
+    });
+    await vi.waitFor(() => expect(readyApis).toHaveLength(1));
+    const api = readyApis[0]!;
+
+    api.setContent('<https://example.com/original>');
+    api.focus('end');
+    const linkInput = page.getByRole('textbox', { name: 'Link URL' });
+    await expect.element(linkInput).toBeVisible();
+    await userEvent.fill(linkInput, 'https://example.com/changed');
+    await userEvent.tab();
+
+    await vi.waitFor(() =>
+      expect(updates.at(-1)).toBe('[https://example.com/original](https://example.com/changed)')
+    );
+  });
+});

--- a/apps/frontend/src/lib/components/composer/extensions.spec.ts
+++ b/apps/frontend/src/lib/components/composer/extensions.spec.ts
@@ -12,6 +12,8 @@ describe('createComposerExtensions', () => {
       'codeBlock',
       'selectedTextInlineCodeShortcut',
       'markdownLinkInputRule',
+      'markdownAutolinkInputRule',
+      'normalizeMarkdownAutolinks',
       'completedMarkdownCodeFence',
       'markdownListMarkerAfterHardBreak',
       'trailingParagraphAfterCodeBlock',

--- a/apps/frontend/src/lib/components/composer/extensions.ts
+++ b/apps/frontend/src/lib/components/composer/extensions.ts
@@ -43,6 +43,8 @@ export const ComposerCodeBlockLowlight = CodeBlockLowlight.extend({
 });
 
 const markdownAutolinkAttribute = 'markdownAutolink';
+const closedMarkdownAutolink = 'closed';
+const unclosedMarkdownAutolink = 'unclosed';
 
 function isMarkdownAutolinkToken(token: MarkdownToken): boolean {
   const raw = token.raw ?? '';
@@ -66,7 +68,7 @@ export const ComposerLink = Link.extend({
     return helpers.applyMark('link', helpers.parseInline(token.tokens ?? []), {
       href: token.href,
       title: token.title || null,
-      [markdownAutolinkAttribute]: isMarkdownAutolinkToken(token)
+      [markdownAutolinkAttribute]: isMarkdownAutolinkToken(token) ? closedMarkdownAutolink : false
     });
   },
 
@@ -75,9 +77,11 @@ export const ComposerLink = Link.extend({
     const title = node.attrs?.title ?? '';
     const text = helpers.renderChildren(node);
 
-    if (node.attrs?.[markdownAutolinkAttribute] && !title) {
+    if (node.attrs?.[markdownAutolinkAttribute] === closedMarkdownAutolink && !title) {
       return `<${text}>`;
     }
+
+    if (node.attrs?.[markdownAutolinkAttribute] === unclosedMarkdownAutolink && !title) return text;
 
     return title ? `[${text}](${href} "${title}")` : `[${text}](${href})`;
   }
@@ -250,7 +254,7 @@ export const MarkdownAutolinkInputRule = Extension.create({
           tr.addMark(
             from,
             from + href.length,
-            linkType.create({ href, [markdownAutolinkAttribute]: true })
+            linkType.create({ href, [markdownAutolinkAttribute]: closedMarkdownAutolink })
           );
           tr.removeStoredMark(linkType);
         }
@@ -275,25 +279,48 @@ export const NormalizeMarkdownAutolinks = Extension.create({
           const tr = newState.tr;
           let changed = false;
 
+          const hasUnescapedOpeningAngleBefore = (position: number) => {
+            const textBefore = newState.doc.textBetween(Math.max(0, position - 64), position);
+            if (!textBefore.endsWith('<')) return false;
+
+            let precedingBackslashes = 0;
+            for (
+              let index = textBefore.length - 2;
+              index >= 0 && textBefore[index] === '\\';
+              index -= 1
+            ) {
+              precedingBackslashes += 1;
+            }
+            return precedingBackslashes % 2 === 0;
+          };
+
           newState.doc.descendants((node, position) => {
             if (!node.isText) return;
 
-            const autolink = node.marks.find(
-              (mark) => mark.type === linkType && mark.attrs[markdownAutolinkAttribute]
-            );
-            if (!autolink) return;
+            const link = node.marks.find((mark) => mark.type === linkType);
+            if (!link) return;
 
-            const isUnmodifiedAutolink =
-              node.text === autolink.attrs.href && node.marks.length === 1;
-            if (isUnmodifiedAutolink) return;
+            const currentAutolink = link.attrs[markdownAutolinkAttribute];
+            const isPlainURLLink =
+              node.text === link.attrs.href && node.marks.length === 1 && !link.attrs.title;
+            let nextAutolink:
+              false | typeof closedMarkdownAutolink | typeof unclosedMarkdownAutolink = false;
 
-            tr.removeMark(position, position + node.nodeSize, autolink);
+            if (currentAutolink === closedMarkdownAutolink && isPlainURLLink) {
+              nextAutolink = closedMarkdownAutolink;
+            } else if (isPlainURLLink && hasUnescapedOpeningAngleBefore(position)) {
+              nextAutolink = unclosedMarkdownAutolink;
+            }
+
+            if (currentAutolink === nextAutolink) return;
+
+            tr.removeMark(position, position + node.nodeSize, link);
             tr.addMark(
               position,
               position + node.nodeSize,
               linkType.create({
-                ...autolink.attrs,
-                [markdownAutolinkAttribute]: false
+                ...link.attrs,
+                [markdownAutolinkAttribute]: nextAutolink
               })
             );
             changed = true;

--- a/apps/frontend/src/lib/components/composer/extensions.ts
+++ b/apps/frontend/src/lib/components/composer/extensions.ts
@@ -1,4 +1,11 @@
-import { Extension, InputRule, mergeAttributes } from '@tiptap/core';
+import {
+  Extension,
+  InputRule,
+  mergeAttributes,
+  type MarkdownParseHelpers,
+  type MarkdownRendererHelpers,
+  type MarkdownToken
+} from '@tiptap/core';
 import type { Node as ProseMirrorNode, Schema } from '@tiptap/pm/model';
 import { Plugin, PluginKey, TextSelection } from '@tiptap/pm/state';
 import StarterKit from '@tiptap/starter-kit';
@@ -7,9 +14,10 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import { Markdown } from '@tiptap/markdown';
 import Placeholder from '@tiptap/extension-placeholder';
 import { lowlight } from '$lib/codeHighlighting';
-import { isDefaultEmptyDocument } from './markdown';
+import { isDefaultEmptyDocument, isHttpMarkdownAutolink } from './markdown';
 
 const markdownLinkInputRegex = /(^|\s)\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)$/;
+const markdownAutolinkInputRegex = /(^|\s)<(https?:\/\/[^\s<>]+)>$/i;
 const codeFenceLineRegex = /^```([\w-]+)?$/;
 const markdownBulletListLineRegex = /^[ \t]{0,3}[-+*]\s(.*)$/;
 const markdownOrderedListLineRegex = /^[ \t]{0,3}(\d{1,9})[.)]\s(.*)$/;
@@ -34,15 +42,53 @@ export const ComposerCodeBlockLowlight = CodeBlockLowlight.extend({
   }
 });
 
-export const ComposerLink = Link.extend({ inclusive: false });
+const markdownAutolinkAttribute = 'markdownAutolink';
+
+function isMarkdownAutolinkToken(token: MarkdownToken): boolean {
+  const raw = token.raw ?? '';
+  return isHttpMarkdownAutolink(raw) && raw.slice(1, -1) === (token.href ?? '');
+}
+
+export const ComposerLink = Link.extend({
+  inclusive: false,
+
+  addAttributes() {
+    return {
+      ...this.parent?.(),
+      [markdownAutolinkAttribute]: {
+        default: false,
+        rendered: false
+      }
+    };
+  },
+
+  parseMarkdown(token: MarkdownToken, helpers: MarkdownParseHelpers) {
+    return helpers.applyMark('link', helpers.parseInline(token.tokens ?? []), {
+      href: token.href,
+      title: token.title || null,
+      [markdownAutolinkAttribute]: isMarkdownAutolinkToken(token)
+    });
+  },
+
+  renderMarkdown(node, helpers: MarkdownRendererHelpers) {
+    const href = node.attrs?.href ?? '';
+    const title = node.attrs?.title ?? '';
+    const text = helpers.renderChildren(node);
+
+    if (node.attrs?.[markdownAutolinkAttribute] && !title) {
+      return `<${text}>`;
+    }
+
+    return title ? `[${text}](${href} "${title}")` : `[${text}](${href})`;
+  }
+});
 
 const SelectedTextInlineCodeShortcut = Extension.create({
   name: 'selectedTextInlineCodeShortcut',
 
   addKeyboardShortcuts() {
     return {
-      '`': () =>
-        this.editor.state.selection.empty ? false : this.editor.commands.toggleCode()
+      '`': () => (this.editor.state.selection.empty ? false : this.editor.commands.toggleCode())
     };
   }
 });
@@ -177,6 +223,83 @@ export const MarkdownLinkInputRule = Extension.create({
           tr.insertText(label, from);
           tr.addMark(from, from + label.length, linkType.create({ href }));
           tr.removeStoredMark(linkType);
+        }
+      })
+    ];
+  }
+});
+
+export const MarkdownAutolinkInputRule = Extension.create({
+  name: 'markdownAutolinkInputRule',
+
+  addInputRules() {
+    return [
+      new InputRule({
+        find: markdownAutolinkInputRegex,
+        handler: ({ state, range, match }) => {
+          const prefix = match[1] ?? '';
+          const href = match[2];
+          const linkType = state.schema.marks.link;
+          if (!href || !linkType) return null;
+
+          const from = range.from + prefix.length;
+          const tr = state.tr;
+
+          tr.delete(from, range.to);
+          tr.insertText(href, from);
+          tr.addMark(
+            from,
+            from + href.length,
+            linkType.create({ href, [markdownAutolinkAttribute]: true })
+          );
+          tr.removeStoredMark(linkType);
+        }
+      })
+    ];
+  }
+});
+
+export const NormalizeMarkdownAutolinks = Extension.create({
+  name: 'normalizeMarkdownAutolinks',
+
+  addProseMirrorPlugins() {
+    return [
+      new Plugin({
+        key: new PluginKey('normalizeMarkdownAutolinks'),
+        appendTransaction: (transactions, _oldState, newState) => {
+          if (!transactions.some((transaction) => transaction.docChanged)) return null;
+
+          const linkType = newState.schema.marks.link;
+          if (!linkType) return null;
+
+          const tr = newState.tr;
+          let changed = false;
+
+          newState.doc.descendants((node, position) => {
+            if (!node.isText) return;
+
+            const autolink = node.marks.find(
+              (mark) => mark.type === linkType && mark.attrs[markdownAutolinkAttribute]
+            );
+            if (!autolink) return;
+
+            const isUnmodifiedAutolink =
+              node.text === autolink.attrs.href && node.marks.length === 1;
+            if (isUnmodifiedAutolink) return;
+
+            tr.removeMark(position, position + node.nodeSize, autolink);
+            tr.addMark(
+              position,
+              position + node.nodeSize,
+              linkType.create({
+                ...autolink.attrs,
+                [markdownAutolinkAttribute]: false
+              })
+            );
+            changed = true;
+          });
+
+          return changed ? tr : null;
         }
       })
     ];
@@ -357,6 +480,8 @@ export function createComposerExtensions(placeholder: string) {
     ComposerCodeBlockLowlight.configure({ lowlight }),
     SelectedTextInlineCodeShortcut.configure(),
     MarkdownLinkInputRule.configure(),
+    MarkdownAutolinkInputRule.configure(),
+    NormalizeMarkdownAutolinks.configure(),
     CompletedMarkdownCodeFence.configure(),
     MarkdownListMarkerAfterHardBreak.configure(),
     TrailingParagraphAfterCodeBlock.configure(),

--- a/apps/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
@@ -18,7 +18,10 @@ describe('LinkPreviewState', () => {
     const fetchLinkPreview = vi.fn<FetchLinkPreview>();
     const state = new LinkPreviewState(() => apiWithFetch(fetchLinkPreview));
 
-    const cleanup = state.scheduleDetection('See http://localhost/chat/-/room_456/m/evt_123', false);
+    const cleanup = state.scheduleDetection(
+      'See http://localhost/chat/-/room_456/m/evt_123',
+      false
+    );
     await vi.advanceTimersByTimeAsync(500);
     cleanup();
 
@@ -36,6 +39,7 @@ describe('LinkPreviewState', () => {
       '\\`https://example.com\\`',
       '```\nhttps://example.com\n```',
       '> https://example.com',
+      '<https://example.com>',
       'mail user@example.com',
       'ftp://example.com/file'
     ]) {
@@ -65,11 +69,15 @@ describe('LinkPreviewState', () => {
     });
     const state = new LinkPreviewState(() => apiWithFetch(fetchLinkPreview));
 
-    const cleanup = state.scheduleDetection(`Look ${url}`, false);
+    const cleanup = state.scheduleDetection(
+      `<https://suppressed.example/story> Look ${url}`,
+      false
+    );
     await vi.advanceTimersByTimeAsync(500);
     await vi.waitFor(() => expect(fetchLinkPreview).toHaveBeenCalledOnce());
     cleanup();
 
+    expect(fetchLinkPreview).toHaveBeenCalledWith(url);
     expect(state.buildToken()).toBe('cht_LPpreviewtoken');
   });
 

--- a/apps/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/linkPreviews.svelte.spec.ts
@@ -40,6 +40,7 @@ describe('LinkPreviewState', () => {
       '```\nhttps://example.com\n```',
       '> https://example.com',
       '<https://example.com>',
+      '<https://example.com',
       'mail user@example.com',
       'ftp://example.com/file'
     ]) {

--- a/apps/frontend/src/lib/components/composer/markdown.spec.ts
+++ b/apps/frontend/src/lib/components/composer/markdown.spec.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest';
 import { Schema } from '@tiptap/pm/model';
-import { buildQuoteContent, createClipboardContent, prepareMarkdownForEditor } from './markdown';
+import {
+  buildQuoteContent,
+  createClipboardContent,
+  isHttpMarkdownAutolink,
+  prepareMarkdownForEditor
+} from './markdown';
+
+describe('isHttpMarkdownAutolink', () => {
+  it('accepts only complete angle-bracket HTTP(S) URLs', () => {
+    expect(isHttpMarkdownAutolink('<https://example.com/story>')).toBe(true);
+    expect(isHttpMarkdownAutolink('<HTTP://example.com/story>')).toBe(true);
+    expect(isHttpMarkdownAutolink('<example.com>')).toBe(false);
+    expect(isHttpMarkdownAutolink('<https://example.com/story')).toBe(false);
+    expect(isHttpMarkdownAutolink('See <https://example.com/story>')).toBe(false);
+  });
+});
 
 describe('prepareMarkdownForEditor', () => {
   it('escapes HTML-looking prose without changing link destinations', () => {

--- a/apps/frontend/src/lib/components/composer/markdown.ts
+++ b/apps/frontend/src/lib/components/composer/markdown.ts
@@ -4,6 +4,11 @@ import type { SelectedQuoteBlock } from '$lib/state/room';
 
 const markdownLinkPasteRegex = /\[([^\]\n]+)\]\((https?:\/\/[^\s)]+)\)/g;
 
+/** Return whether text is one complete HTTP(S) Markdown autolink. */
+export function isHttpMarkdownAutolink(text: string): boolean {
+  return /^<https?:\/\/[^\s<>]+>$/i.test(text);
+}
+
 export function isDefaultEmptyDocument(doc: ProseMirrorNode): boolean {
   if (doc.childCount !== 1) return false;
   const firstChild = doc.firstChild;

--- a/apps/frontend/src/lib/linkPreview.spec.ts
+++ b/apps/frontend/src/lib/linkPreview.spec.ts
@@ -127,6 +127,20 @@ describe('extractURLs', () => {
       expect(extractURLs('<http://suppressed.example/story>')).toEqual([]);
     });
 
+    it('ignores HTTP(S) links after an unmatched opening angle bracket', () => {
+      expect(
+        extractURLs(
+          'Skip <https://suppressed.example/story and preview https://shown.example/story'
+        )
+      ).toEqual(['https://shown.example/story']);
+      expect(extractURLs('<http://suppressed.example/story')).toEqual([]);
+    });
+
+    it('does not suppress escaped or bare-domain unmatched angle syntax', () => {
+      expect(extractURLs('\\<https://example.com/story')).toEqual(['https://example.com/story']);
+      expect(extractURLs('<example.com')).toEqual(['https://example.com']);
+    });
+
     it('does not treat angle-wrapped bare domains as suppressed autolinks', () => {
       expect(extractURLs('<example.com>')).toEqual(['https://example.com']);
       expect(extractURLs('<www.example.com>')).toEqual(['https://www.example.com']);

--- a/apps/frontend/src/lib/linkPreview.spec.ts
+++ b/apps/frontend/src/lib/linkPreview.spec.ts
@@ -18,15 +18,11 @@ describe('extractURLs', () => {
     });
 
     it('strips trailing punctuation from protocol URLs', () => {
-      expect(extractURLs('See https://example.com/path!!')).toEqual([
-        'https://example.com/path'
-      ]);
+      expect(extractURLs('See https://example.com/path!!')).toEqual(['https://example.com/path']);
     });
 
     it('strips wrapper closing parentheses but keeps balanced URL parentheses', () => {
-      expect(extractURLs('See (https://example.com/path)')).toEqual([
-        'https://example.com/path'
-      ]);
+      expect(extractURLs('See (https://example.com/path)')).toEqual(['https://example.com/path']);
       expect(extractURLs('See https://example.com/path_(v1)')).toEqual([
         'https://example.com/path_(v1)'
       ]);
@@ -122,6 +118,20 @@ describe('extractURLs', () => {
   });
 
   describe('markdown boundaries', () => {
+    it('ignores angle-bracket autolinks and continues to the next URL', () => {
+      expect(
+        extractURLs(
+          'Skip <https://suppressed.example/story> and preview https://shown.example/story'
+        )
+      ).toEqual(['https://shown.example/story']);
+      expect(extractURLs('<http://suppressed.example/story>')).toEqual([]);
+    });
+
+    it('does not treat angle-wrapped bare domains as suppressed autolinks', () => {
+      expect(extractURLs('<example.com>')).toEqual(['https://example.com']);
+      expect(extractURLs('<www.example.com>')).toEqual(['https://www.example.com']);
+    });
+
     it('ignores URLs inside inline code', () => {
       expect(extractURLs('Run `curl https://example.com` first')).toEqual([]);
     });
@@ -168,19 +178,13 @@ describe('extractURLs', () => {
 
 describe('parseYouTubeVideoID', () => {
   it('extracts valid YouTube video IDs from supported URL forms', () => {
-    expect(parseYouTubeVideoID('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe(
-      'dQw4w9WgXcQ'
-    );
+    expect(parseYouTubeVideoID('https://www.youtube.com/watch?v=dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
     expect(parseYouTubeVideoID('https://www.youtube.com/watch?feature=share&v=dQw4w9WgXcQ')).toBe(
       'dQw4w9WgXcQ'
     );
-    expect(parseYouTubeVideoID('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe(
-      'dQw4w9WgXcQ'
-    );
+    expect(parseYouTubeVideoID('https://www.youtube.com/embed/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
     expect(parseYouTubeVideoID('https://youtu.be/dQw4w9WgXcQ?t=42')).toBe('dQw4w9WgXcQ');
-    expect(parseYouTubeVideoID('https://m.youtube.com/shorts/dQw4w9WgXcQ')).toBe(
-      'dQw4w9WgXcQ'
-    );
+    expect(parseYouTubeVideoID('https://m.youtube.com/shorts/dQw4w9WgXcQ')).toBe('dQw4w9WgXcQ');
   });
 
   it('rejects non-YouTube hosts and invalid video URL forms', () => {

--- a/apps/frontend/src/lib/linkPreview.ts
+++ b/apps/frontend/src/lib/linkPreview.ts
@@ -21,6 +21,17 @@ const markdown = new MarkdownIt({
 markdown.linkify.tlds(tlds);
 markdown.disable(['escape']);
 
+function endsWithUnescapedOpeningAngle(text: string): boolean {
+  if (!text.endsWith('<')) return false;
+
+  let precedingBackslashes = 0;
+  for (let index = text.length - 2; index >= 0 && text[index] === '\\'; index -= 1) {
+    precedingBackslashes += 1;
+  }
+
+  return precedingBackslashes % 2 === 0;
+}
+
 /**
  * Extracts unique URLs from text, including bare-domain URLs (e.g. www.hmans.dev).
  * Returns at most maxURLs URLs, in the order they appear.
@@ -74,7 +85,14 @@ export function extractURLs(text: string, maxURLs = 1): string[] {
       const href = child.attrGet('href');
       if (!href) continue;
 
-      const rawText = child.markup === 'linkify' ? (children[i + 1]?.content ?? '') : '';
+      const linkText = children[i + 1]?.content ?? '';
+      const hasUnclosedAutolinkPrefix =
+        endsWithUnescapedOpeningAngle(children[i - 1]?.content ?? '') &&
+        /^https?:\/\//i.test(linkText) &&
+        linkText === href;
+      if (hasUnclosedAutolinkPrefix) continue;
+
+      const rawText = child.markup === 'linkify' ? linkText : '';
       addURL(href, rawText);
     }
   }

--- a/apps/frontend/src/lib/linkPreview.ts
+++ b/apps/frontend/src/lib/linkPreview.ts
@@ -36,11 +36,7 @@ export function extractURLs(text: string, maxURLs = 1): string[] {
     if (result.length >= maxURLs) return;
 
     let url = rawUrl;
-    if (
-      rawText &&
-      !/^[a-z][a-z0-9+.-]*:/i.test(rawText) &&
-      /^http:\/\//i.test(url)
-    ) {
+    if (rawText && !/^[a-z][a-z0-9+.-]*:/i.test(rawText) && /^http:\/\//i.test(url)) {
       // linkify-it adds http:// to bare domains; upgrade those to https://.
       url = url.replace(/^http:\/\//i, 'https://');
     }
@@ -73,6 +69,7 @@ export function extractURLs(text: string, maxURLs = 1): string[] {
     for (let i = 0; i < children.length; i++) {
       const child = children[i];
       if (child.type !== 'link_open') continue;
+      if (child.markup === 'autolink') continue;
 
       const href = child.attrGet('href');
       if (!href) continue;

--- a/docs/fdr/FDR-009-link-previews.md
+++ b/docs/fdr/FDR-009-link-previews.md
@@ -12,7 +12,7 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 - The composer fetches a link preview as soon as the user has typed a complete eligible URL.
 - Only the first eligible URL in a message gets a preview. There is no multi-preview layout.
 - URLs inside code spans, code blocks, pre-formatted text, and blockquotes do not trigger link previews.
-- An HTTP or HTTPS link in angle brackets, such as `<https://example.com>`, stays clickable and does not trigger a link preview. This behavior works in both message editors. A later eligible URL can get the preview instead.
+- An HTTP or HTTPS link that starts with an angle bracket, such as `<https://example.com>`, stays clickable and does not trigger a link preview. The closing angle bracket is optional. This behavior works in both message editors. A later eligible URL can get the preview instead.
 - YouTube URLs get a specialized embed-ready card without scraping the page.
 - Supported public social-post URLs use a native Chatto card populated from provider data. The card can include the provider, author, post text, attached images, an embedded website card, and one quoted post with its own common media. Bluesky and Mastodon are supported providers. Mastodon content warnings and accepted quote posts use the same common fields; warned text and media stay concealed until the reader reveals them, and boosts show the original post without boost attribution. If structured post data is unavailable, the post falls back to a normal link preview.
 - A preview shows up in the composer with a dismiss button. Dismissing the preview prevents it from being attached to the sent message, and the dismissal is remembered for that URL during the composition session.

--- a/docs/fdr/FDR-009-link-previews.md
+++ b/docs/fdr/FDR-009-link-previews.md
@@ -1,7 +1,7 @@
 # FDR-009: Link Previews
 
 **Status:** Active
-**Last reviewed:** 2026-07-15
+**Last reviewed:** 2026-08-27
 
 ## Overview
 
@@ -9,9 +9,10 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 
 ## Behavior
 
-- The composer fetches a link preview as soon as the user has typed a complete URL.
-- Only the first URL in a message gets a preview. There is no multi-preview layout.
+- The composer fetches a link preview as soon as the user has typed a complete eligible URL.
+- Only the first eligible URL in a message gets a preview. There is no multi-preview layout.
 - URLs inside code spans, code blocks, pre-formatted text, and blockquotes do not trigger link previews.
+- An HTTP or HTTPS link in angle brackets, such as `<https://example.com>`, stays clickable and does not trigger a link preview. This behavior works in both message editors. A later eligible URL can get the preview instead.
 - YouTube URLs get a specialized embed-ready card without scraping the page.
 - Supported public social-post URLs use a native Chatto card populated from provider data. The card can include the provider, author, post text, attached images, an embedded website card, and one quoted post with its own common media. Bluesky and Mastodon are supported providers. Mastodon content warnings and accepted quote posts use the same common fields; warned text and media stay concealed until the reader reveals them, and boosts show the original post without boost attribution. If structured post data is unavailable, the post falls back to a normal link preview.
 - A preview shows up in the composer with a dismiss button. Dismissing the preview prevents it from being attached to the sent message, and the dismissal is remembered for that URL during the composition session.
@@ -30,7 +31,7 @@ When a message contains a URL, Chatto can attach a preview card with the page's 
 
 ### 2. One preview per message, first URL only
 
-**Decision:** Only the first URL in a message gets a preview card. Subsequent URLs render as plain links.
+**Decision:** Only the first eligible URL in a message gets a preview card. Subsequent URLs render as plain links.
 **Why:** Multi-preview layouts (Slack-style) blow up the message height and are usually visual clutter. One preview captures the most-likely-relevant link.
 **Tradeoff:** Messages that genuinely need to highlight several links can't. Authors can split into multiple messages.
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -18,7 +18,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-08-27 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-08-26 |
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-08-25 |
-| [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-07-15 |
+| [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-08-27 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-08-25 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-08-27 |
 | [FDR-012](FDR-012-notifications.md) | Notifications | Experimental | 2026-08-27 |


### PR DESCRIPTION
## Why

Users need a forgiving way to keep an HTTP(S) link clickable without attaching a preview card, including when they omit the closing angle bracket.

## What changed

- Exclude complete and unclosed angle-bracket HTTP(S) autolinks from preview candidates while allowing a later eligible URL.
- Preserve both forms through visual-editor typing, pasting, draft restoration, and editing; fall back to a regular Markdown link when the destination changes.
- Keep escaped brackets and angle-prefixed bare domains previewable, and document the behavior in FDR-009 and the public message-formatting guide.

## API compatibility

- No public API or protocol behaviour changed; older/newer client-server combinations, capability discovery, rollout, and migration are unaffected.

## Test plan

- `mise test-frontend`: 3,355 tests passed.
- `mise lint-frontend`: passed with zero Svelte errors or warnings.
- Documentation build: 71 pages passed; Svelte autofixer and `git diff --check` passed.
- Chrome DevTools: both editor modes preserve suppression; an unclosed visual-editor draft restored as a clickable link with no preview card or FetchLinkPreview request.