### PR TITLE
refactor(proto)!: relocate live-only user payloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - "release-[0-9]*"
+      - 'release-[0-9]*'
   pull_request:
     types:
       - opened
@@ -193,6 +193,7 @@ jobs:
       - name: Check storage, internal, and Operator protobuf breaking changes
         run: |
           base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
+          mise x -- node --test tools/check-storage-proto-breaking.test.mjs
           mise x -- node tools/check-storage-proto-breaking.mjs \
             "../.git#branch=origin/${base_ref},subdir=proto"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - 'release-[0-9]*'
+      - "release-[0-9]*"
   pull_request:
     types:
       - opened
@@ -193,16 +193,8 @@ jobs:
       - name: Check storage, internal, and Operator protobuf breaking changes
         run: |
           base_ref="${GITHUB_BASE_REF:-${GITHUB_REF_NAME}}"
-          cd proto
-          mise x -- buf breaking . --against "../.git#branch=origin/${base_ref},subdir=proto" \
-            --exclude-imports \
-            --exclude-path chatto/auth/v1 \
-            --exclude-path chatto/discovery/v1 \
-            --exclude-path chatto/api/v1 \
-            --exclude-path chatto/admin/v1 \
-            --exclude-path chatto/realtime/v1 \
-            --exclude-path chatto/core/v1/live_events.proto \
-            --exclude-path chatto/core/v1/projection_snapshots.proto
+          mise x -- node tools/check-storage-proto-breaking.mjs \
+            "../.git#branch=origin/${base_ref},subdir=proto"
 
       - name: Check projection snapshot schema contracts
         working-directory: cli

--- a/cli/internal/core/user_preferences.go
+++ b/cli/internal/core/user_preferences.go
@@ -124,7 +124,7 @@ func (c *ChattoCore) UpdateUserSettings(ctx context.Context, userID string, inpu
 	}
 
 	c.logger.Info("Updated user settings", "user_id", userID)
-	c.publishServerUserPreferencesUpdatedEvent(ctx, userID, settings)
+	c.publishServerUserPreferencesSync(ctx, userID, settings)
 	if timezoneChanged {
 		c.publishUserProfileUpdate(ctx, userID)
 	}
@@ -132,9 +132,9 @@ func (c *ChattoCore) UpdateUserSettings(ctx context.Context, userID string, inpu
 	return settings, nil
 }
 
-// publishServerUserPreferencesUpdatedEvent publishes a live event when preferences change.
-// User-scoped: only delivered to the user who changed their preferences.
-func (c *ChattoCore) publishServerUserPreferencesUpdatedEvent(ctx context.Context, userID string, settings *corev1.ServerUserPreferences) {
+// publishServerUserPreferencesSync publishes a transient signal for the user
+// whose preferences changed.
+func (c *ChattoCore) publishServerUserPreferencesSync(ctx context.Context, userID string, settings *corev1.ServerUserPreferences) {
 	tz := ""
 	if settings.Timezone != nil {
 		tz = *settings.Timezone
@@ -142,7 +142,7 @@ func (c *ChattoCore) publishServerUserPreferencesUpdatedEvent(ctx context.Contex
 
 	event := newLiveEvent(userID, &corev1.LiveEvent{
 		Event: &corev1.LiveEvent_ServerUserPreferencesUpdated{
-			ServerUserPreferencesUpdated: &corev1.ServerUserPreferencesUpdatedEvent{
+			ServerUserPreferencesUpdated: &corev1.ServerUserPreferencesSyncEvent{
 				Timezone:   tz,
 				TimeFormat: settings.TimeFormat,
 			},

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -333,11 +333,10 @@ func (c *ChattoCore) createUserWithOptions(ctx context.Context, actorID string, 
 		}
 	}
 
-	// Create and publish audit event (best-effort)
-	// UserCreated goes to INSTANCE stream
+	// Publish a best-effort transient signal for the new public user.
 	event := newLiveEvent(eventActorID, &corev1.LiveEvent{
 		Event: &corev1.LiveEvent_UserCreated{
-			UserCreated: &corev1.UserCreatedEvent{
+			UserCreated: &corev1.UserCreatedSyncEvent{
 				UserId:      userID,
 				Login:       login,
 				DisplayName: displayName,

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -114,7 +114,7 @@ func TestChattoCore_CreateUserLiveEventUsesProvidedActorID(t *testing.T) {
 	}
 	created := live.GetUserCreated()
 	if created == nil {
-		t.Fatalf("expected UserCreatedEvent, got %T", live.Event)
+		t.Fatalf("expected UserCreatedSyncEvent, got %T", live.Event)
 	}
 	if created.GetUserId() != user.GetId() {
 		t.Fatalf("created live user_id = %q, want %q", created.GetUserId(), user.GetId())

--- a/cli/internal/http_server/realtime_test.go
+++ b/cli/internal/http_server/realtime_test.go
@@ -646,7 +646,7 @@ func TestRealtimeTransientMapperRejectsProjectionOwnedLiveEvents(t *testing.T) {
 		{"room read", &corev1.LiveEvent{Event: &corev1.LiveEvent_RoomMarkedAsRead{RoomMarkedAsRead: &corev1.RoomMarkedAsReadEvent{RoomId: "R1"}}}},
 		{"server updated", &corev1.LiveEvent{Event: &corev1.LiveEvent_ServerUpdated{ServerUpdated: &corev1.ServerUpdatedEvent{}}}},
 		{"profile updated", &corev1.LiveEvent{Event: &corev1.LiveEvent_UserProfileUpdated{UserProfileUpdated: &corev1.UserProfileSyncEvent{UserId: "U1"}}}},
-		{"preferences updated", &corev1.LiveEvent{Event: &corev1.LiveEvent_ServerUserPreferencesUpdated{ServerUserPreferencesUpdated: &corev1.ServerUserPreferencesUpdatedEvent{}}}},
+		{"preferences updated", &corev1.LiveEvent{Event: &corev1.LiveEvent_ServerUserPreferencesUpdated{ServerUserPreferencesUpdated: &corev1.ServerUserPreferencesSyncEvent{}}}},
 		{"room groups updated", &corev1.LiveEvent{Event: &corev1.LiveEvent_RoomGroupsUpdated{RoomGroupsUpdated: &corev1.RoomGroupsUpdatedEvent{}}}},
 		{"member deleted", &corev1.LiveEvent{Event: &corev1.LiveEvent_ServerMemberDeleted{ServerMemberDeleted: &corev1.ServerMemberDeletedEvent{UserId: "U1"}}}},
 	}

--- a/cli/internal/pb/chatto/core/v1/live_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/live_events.pb.go
@@ -40,7 +40,6 @@ type LiveEvent struct {
 	// Types that are valid to be assigned to Event:
 	//
 	//	*LiveEvent_UserCreated
-	//	*LiveEvent_UserDeleted
 	//	*LiveEvent_UserProfileUpdated
 	//	*LiveEvent_ServerUserPreferencesUpdated
 	//	*LiveEvent_ThreadFollowChanged
@@ -123,16 +122,6 @@ func (x *LiveEvent) GetUserCreated() *UserCreatedSyncEvent {
 	if x != nil {
 		if x, ok := x.Event.(*LiveEvent_UserCreated); ok {
 			return x.UserCreated
-		}
-	}
-	return nil
-}
-
-// Deprecated: Marked as deprecated in chatto/core/v1/live_events.proto.
-func (x *LiveEvent) GetUserDeleted() *UserDeletedEvent {
-	if x != nil {
-		if x, ok := x.Event.(*LiveEvent_UserDeleted); ok {
-			return x.UserDeleted
 		}
 	}
 	return nil
@@ -282,15 +271,6 @@ type LiveEvent_UserCreated struct {
 	UserCreated *UserCreatedSyncEvent `protobuf:"bytes,20,opt,name=user_created,json=userCreated,proto3,oneof"`
 }
 
-type LiveEvent_UserDeleted struct {
-	// Deprecated. Account deletion no longer publishes this transient signal;
-	// clients receive session_terminated for the deleted user's own sessions and
-	// server_member_deleted for server-wide invalidation.
-	//
-	// Deprecated: Marked as deprecated in chatto/core/v1/live_events.proto.
-	UserDeleted *UserDeletedEvent `protobuf:"bytes,21,opt,name=user_deleted,json=userDeleted,proto3,oneof"`
-}
-
 type LiveEvent_UserProfileUpdated struct {
 	// Transient current-profile snapshot derived after a durable profile change.
 	UserProfileUpdated *UserProfileSyncEvent `protobuf:"bytes,22,opt,name=user_profile_updated,json=userProfileUpdated,proto3,oneof"`
@@ -361,8 +341,6 @@ type LiveEvent_SessionTerminated struct {
 }
 
 func (*LiveEvent_UserCreated) isLiveEvent_Event() {}
-
-func (*LiveEvent_UserDeleted) isLiveEvent_Event() {}
 
 func (*LiveEvent_UserProfileUpdated) isLiveEvent_Event() {}
 
@@ -1197,14 +1175,13 @@ var File_chatto_core_v1_live_events_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_live_events_proto_rawDesc = "" +
 	"\n" +
-	" chatto/core/v1/live_events.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a chatto/core/v1/room_events.proto\x1a chatto/core/v1/user_events.proto\x1a%chatto/core/v1/user_preferences.proto\"\x92\x0f\n" +
+	" chatto/core/v1/live_events.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a chatto/core/v1/room_events.proto\x1a%chatto/core/v1/user_preferences.proto\"\xdb\x0e\n" +
 	"\tLiveEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
 	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x19\n" +
 	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12I\n" +
-	"\fuser_created\x18\x14 \x01(\v2$.chatto.core.v1.UserCreatedSyncEventH\x00R\vuserCreated\x12I\n" +
-	"\fuser_deleted\x18\x15 \x01(\v2 .chatto.core.v1.UserDeletedEventB\x02\x18\x01H\x00R\vuserDeleted\x12X\n" +
+	"\fuser_created\x18\x14 \x01(\v2$.chatto.core.v1.UserCreatedSyncEventH\x00R\vuserCreated\x12X\n" +
 	"\x14user_profile_updated\x18\x16 \x01(\v2$.chatto.core.v1.UserProfileSyncEventH\x00R\x12userProfileUpdated\x12w\n" +
 	"\x1fserver_user_preferences_updated\x18\x17 \x01(\v2..chatto.core.v1.ServerUserPreferencesSyncEventH\x00R\x1cserverUserPreferencesUpdated\x12^\n" +
 	"\x15thread_follow_changed\x18\x19 \x01(\v2(.chatto.core.v1.ThreadFollowChangedEventH\x00R\x13threadFollowChanged\x12^\n" +
@@ -1222,7 +1199,7 @@ const file_chatto_core_v1_live_events_proto_rawDesc = "" +
 	"\x13room_groups_updated\x18Z \x01(\v2&.chatto.core.v1.RoomGroupsUpdatedEventH\x00R\x11roomGroupsUpdated\x12W\n" +
 	"\x12session_terminated\x18d \x01(\v2&.chatto.core.v1.SessionTerminatedEventH\x00R\x11sessionTerminatedB\a\n" +
 	"\x05eventJ\x04\b\n" +
-	"\x10\vJ\x04\b\x18\x10\x19J\x04\b)\x10*J\x04\b2\x103J\x04\b3\x104J\x04\bF\x10GJ\x04\bG\x10HR\x0econfig_updatedR\x1anotification_level_changedR\x1avideo_processing_completedR\x14mention_notificationR\x1fnew_direct_message_notificationR\x14notification_createdR\x16notification_dismissed\"\x10\n" +
+	"\x10\vJ\x04\b\x15\x10\x16J\x04\b\x18\x10\x19J\x04\b)\x10*J\x04\b2\x103J\x04\b3\x104J\x04\bF\x10GJ\x04\bG\x10HR\x0econfig_updatedR\x1anotification_level_changedR\x1avideo_processing_completedR\x14mention_notificationR\x1fnew_direct_message_notificationR\x14notification_createdR\x16notification_dismissedR\fuser_deleted\"\x10\n" +
 	"\x0eHeartbeatEvent\"h\n" +
 	"\x14UserCreatedSyncEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
@@ -1304,37 +1281,35 @@ var file_chatto_core_v1_live_events_proto_goTypes = []any{
 	(*RoomGroupsUpdatedEvent)(nil),                  // 13: chatto.core.v1.RoomGroupsUpdatedEvent
 	(*SessionTerminatedEvent)(nil),                  // 14: chatto.core.v1.SessionTerminatedEvent
 	(*timestamppb.Timestamp)(nil),                   // 15: google.protobuf.Timestamp
-	(*UserDeletedEvent)(nil),                        // 16: chatto.core.v1.UserDeletedEvent
-	(*ServerMemberDeletedEvent)(nil),                // 17: chatto.core.v1.ServerMemberDeletedEvent
-	(*CallParticipantJoinedEvent)(nil),              // 18: chatto.core.v1.CallParticipantJoinedEvent
-	(*CallParticipantLeftEvent)(nil),                // 19: chatto.core.v1.CallParticipantLeftEvent
-	(TimeFormat)(0),                                 // 20: chatto.core.v1.TimeFormat
+	(*ServerMemberDeletedEvent)(nil),                // 16: chatto.core.v1.ServerMemberDeletedEvent
+	(*CallParticipantJoinedEvent)(nil),              // 17: chatto.core.v1.CallParticipantJoinedEvent
+	(*CallParticipantLeftEvent)(nil),                // 18: chatto.core.v1.CallParticipantLeftEvent
+	(TimeFormat)(0),                                 // 19: chatto.core.v1.TimeFormat
 }
 var file_chatto_core_v1_live_events_proto_depIdxs = []int32{
 	15, // 0: chatto.core.v1.LiveEvent.created_at:type_name -> google.protobuf.Timestamp
 	2,  // 1: chatto.core.v1.LiveEvent.user_created:type_name -> chatto.core.v1.UserCreatedSyncEvent
-	16, // 2: chatto.core.v1.LiveEvent.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
-	3,  // 3: chatto.core.v1.LiveEvent.user_profile_updated:type_name -> chatto.core.v1.UserProfileSyncEvent
-	4,  // 4: chatto.core.v1.LiveEvent.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesSyncEvent
-	9,  // 5: chatto.core.v1.LiveEvent.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
-	17, // 6: chatto.core.v1.LiveEvent.server_member_deleted:type_name -> chatto.core.v1.ServerMemberDeletedEvent
-	5,  // 7: chatto.core.v1.LiveEvent.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
-	6,  // 8: chatto.core.v1.LiveEvent.user_typing:type_name -> chatto.core.v1.UserTypingEvent
-	7,  // 9: chatto.core.v1.LiveEvent.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
-	18, // 10: chatto.core.v1.LiveEvent.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
-	19, // 11: chatto.core.v1.LiveEvent.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
-	8,  // 12: chatto.core.v1.LiveEvent.notification_occurrences_invalidated:type_name -> chatto.core.v1.NotificationOccurrencesInvalidatedEvent
-	11, // 13: chatto.core.v1.LiveEvent.notification_unread_changed:type_name -> chatto.core.v1.NotificationUnreadChangedEvent
-	10, // 14: chatto.core.v1.LiveEvent.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
-	12, // 15: chatto.core.v1.LiveEvent.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
-	13, // 16: chatto.core.v1.LiveEvent.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
-	14, // 17: chatto.core.v1.LiveEvent.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
-	20, // 18: chatto.core.v1.ServerUserPreferencesSyncEvent.time_format:type_name -> chatto.core.v1.TimeFormat
-	19, // [19:19] is the sub-list for method output_type
-	19, // [19:19] is the sub-list for method input_type
-	19, // [19:19] is the sub-list for extension type_name
-	19, // [19:19] is the sub-list for extension extendee
-	0,  // [0:19] is the sub-list for field type_name
+	3,  // 2: chatto.core.v1.LiveEvent.user_profile_updated:type_name -> chatto.core.v1.UserProfileSyncEvent
+	4,  // 3: chatto.core.v1.LiveEvent.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesSyncEvent
+	9,  // 4: chatto.core.v1.LiveEvent.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
+	16, // 5: chatto.core.v1.LiveEvent.server_member_deleted:type_name -> chatto.core.v1.ServerMemberDeletedEvent
+	5,  // 6: chatto.core.v1.LiveEvent.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
+	6,  // 7: chatto.core.v1.LiveEvent.user_typing:type_name -> chatto.core.v1.UserTypingEvent
+	7,  // 8: chatto.core.v1.LiveEvent.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
+	17, // 9: chatto.core.v1.LiveEvent.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
+	18, // 10: chatto.core.v1.LiveEvent.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
+	8,  // 11: chatto.core.v1.LiveEvent.notification_occurrences_invalidated:type_name -> chatto.core.v1.NotificationOccurrencesInvalidatedEvent
+	11, // 12: chatto.core.v1.LiveEvent.notification_unread_changed:type_name -> chatto.core.v1.NotificationUnreadChangedEvent
+	10, // 13: chatto.core.v1.LiveEvent.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
+	12, // 14: chatto.core.v1.LiveEvent.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
+	13, // 15: chatto.core.v1.LiveEvent.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
+	14, // 16: chatto.core.v1.LiveEvent.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
+	19, // 17: chatto.core.v1.ServerUserPreferencesSyncEvent.time_format:type_name -> chatto.core.v1.TimeFormat
+	18, // [18:18] is the sub-list for method output_type
+	18, // [18:18] is the sub-list for method input_type
+	18, // [18:18] is the sub-list for extension type_name
+	18, // [18:18] is the sub-list for extension extendee
+	0,  // [0:18] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_live_events_proto_init() }
@@ -1343,11 +1318,9 @@ func file_chatto_core_v1_live_events_proto_init() {
 		return
 	}
 	file_chatto_core_v1_room_events_proto_init()
-	file_chatto_core_v1_user_events_proto_init()
 	file_chatto_core_v1_user_preferences_proto_init()
 	file_chatto_core_v1_live_events_proto_msgTypes[0].OneofWrappers = []any{
 		(*LiveEvent_UserCreated)(nil),
-		(*LiveEvent_UserDeleted)(nil),
 		(*LiveEvent_UserProfileUpdated)(nil),
 		(*LiveEvent_ServerUserPreferencesUpdated)(nil),
 		(*LiveEvent_ThreadFollowChanged)(nil),

--- a/cli/internal/pb/chatto/core/v1/live_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/live_events.pb.go
@@ -119,7 +119,7 @@ func (x *LiveEvent) GetEvent() isLiveEvent_Event {
 	return nil
 }
 
-func (x *LiveEvent) GetUserCreated() *UserCreatedEvent {
+func (x *LiveEvent) GetUserCreated() *UserCreatedSyncEvent {
 	if x != nil {
 		if x, ok := x.Event.(*LiveEvent_UserCreated); ok {
 			return x.UserCreated
@@ -147,7 +147,7 @@ func (x *LiveEvent) GetUserProfileUpdated() *UserProfileSyncEvent {
 	return nil
 }
 
-func (x *LiveEvent) GetServerUserPreferencesUpdated() *ServerUserPreferencesUpdatedEvent {
+func (x *LiveEvent) GetServerUserPreferencesUpdated() *ServerUserPreferencesSyncEvent {
 	if x != nil {
 		if x, ok := x.Event.(*LiveEvent_ServerUserPreferencesUpdated); ok {
 			return x.ServerUserPreferencesUpdated
@@ -279,7 +279,7 @@ type isLiveEvent_Event interface {
 
 type LiveEvent_UserCreated struct {
 	// ----- User lifecycle / preferences -----
-	UserCreated *UserCreatedEvent `protobuf:"bytes,20,opt,name=user_created,json=userCreated,proto3,oneof"`
+	UserCreated *UserCreatedSyncEvent `protobuf:"bytes,20,opt,name=user_created,json=userCreated,proto3,oneof"`
 }
 
 type LiveEvent_UserDeleted struct {
@@ -297,7 +297,7 @@ type LiveEvent_UserProfileUpdated struct {
 }
 
 type LiveEvent_ServerUserPreferencesUpdated struct {
-	ServerUserPreferencesUpdated *ServerUserPreferencesUpdatedEvent `protobuf:"bytes,23,opt,name=server_user_preferences_updated,json=serverUserPreferencesUpdated,proto3,oneof"`
+	ServerUserPreferencesUpdated *ServerUserPreferencesSyncEvent `protobuf:"bytes,23,opt,name=server_user_preferences_updated,json=serverUserPreferencesUpdated,proto3,oneof"`
 }
 
 type LiveEvent_ThreadFollowChanged struct {
@@ -434,6 +434,67 @@ func (*HeartbeatEvent) Descriptor() ([]byte, []int) {
 	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{1}
 }
 
+// UserCreatedSyncEvent reports a newly created public user profile.
+type UserCreatedSyncEvent struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
+	Login         string                 `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
+	DisplayName   string                 `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *UserCreatedSyncEvent) Reset() {
+	*x = UserCreatedSyncEvent{}
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[2]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *UserCreatedSyncEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UserCreatedSyncEvent) ProtoMessage() {}
+
+func (x *UserCreatedSyncEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[2]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UserCreatedSyncEvent.ProtoReflect.Descriptor instead.
+func (*UserCreatedSyncEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{2}
+}
+
+func (x *UserCreatedSyncEvent) GetUserId() string {
+	if x != nil {
+		return x.UserId
+	}
+	return ""
+}
+
+func (x *UserCreatedSyncEvent) GetLogin() string {
+	if x != nil {
+		return x.Login
+	}
+	return ""
+}
+
+func (x *UserCreatedSyncEvent) GetDisplayName() string {
+	if x != nil {
+		return x.DisplayName
+	}
+	return ""
+}
+
 // UserProfileSyncEvent is a transient, projection-derived live snapshot. It
 // is published after a public profile field changes and is never stored in EVT.
 // Durable user events remain the authoritative profile facts.
@@ -455,7 +516,7 @@ type UserProfileSyncEvent struct {
 
 func (x *UserProfileSyncEvent) Reset() {
 	*x = UserProfileSyncEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[2]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -467,7 +528,7 @@ func (x *UserProfileSyncEvent) String() string {
 func (*UserProfileSyncEvent) ProtoMessage() {}
 
 func (x *UserProfileSyncEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[2]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -480,7 +541,7 @@ func (x *UserProfileSyncEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserProfileSyncEvent.ProtoReflect.Descriptor instead.
 func (*UserProfileSyncEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{2}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *UserProfileSyncEvent) GetUserId() string {
@@ -525,6 +586,62 @@ func (x *UserProfileSyncEvent) GetTimezone() string {
 	return ""
 }
 
+// ServerUserPreferencesSyncEvent reports updated user display preferences for
+// synchronization between the user's active clients.
+type ServerUserPreferencesSyncEvent struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// IANA time zone name. An empty value selects the browser default.
+	Timezone string `protobuf:"bytes,1,opt,name=timezone,proto3" json:"timezone,omitempty"`
+	// Preferred time display format.
+	TimeFormat    TimeFormat `protobuf:"varint,2,opt,name=time_format,json=timeFormat,proto3,enum=chatto.core.v1.TimeFormat" json:"time_format,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ServerUserPreferencesSyncEvent) Reset() {
+	*x = ServerUserPreferencesSyncEvent{}
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ServerUserPreferencesSyncEvent) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ServerUserPreferencesSyncEvent) ProtoMessage() {}
+
+func (x *ServerUserPreferencesSyncEvent) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ServerUserPreferencesSyncEvent.ProtoReflect.Descriptor instead.
+func (*ServerUserPreferencesSyncEvent) Descriptor() ([]byte, []int) {
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ServerUserPreferencesSyncEvent) GetTimezone() string {
+	if x != nil {
+		return x.Timezone
+	}
+	return ""
+}
+
+func (x *ServerUserPreferencesSyncEvent) GetTimeFormat() TimeFormat {
+	if x != nil {
+		return x.TimeFormat
+	}
+	return TimeFormat_TIME_FORMAT_UNSPECIFIED
+}
+
 type ServerUpdatedEvent struct {
 	state       protoimpl.MessageState `protogen:"open.v1"`
 	ServerId    string                 `protobuf:"bytes,1,opt,name=server_id,json=serverId,proto3" json:"server_id,omitempty"`
@@ -540,7 +657,7 @@ type ServerUpdatedEvent struct {
 
 func (x *ServerUpdatedEvent) Reset() {
 	*x = ServerUpdatedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -552,7 +669,7 @@ func (x *ServerUpdatedEvent) String() string {
 func (*ServerUpdatedEvent) ProtoMessage() {}
 
 func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[3]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -565,7 +682,7 @@ func (x *ServerUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*ServerUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{3}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *ServerUpdatedEvent) GetServerId() string {
@@ -619,7 +736,7 @@ type UserTypingEvent struct {
 
 func (x *UserTypingEvent) Reset() {
 	*x = UserTypingEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -631,7 +748,7 @@ func (x *UserTypingEvent) String() string {
 func (*UserTypingEvent) ProtoMessage() {}
 
 func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -644,7 +761,7 @@ func (x *UserTypingEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserTypingEvent.ProtoReflect.Descriptor instead.
 func (*UserTypingEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{4}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *UserTypingEvent) GetRoomId() string {
@@ -675,7 +792,7 @@ type PresenceChangedEvent struct {
 
 func (x *PresenceChangedEvent) Reset() {
 	*x = PresenceChangedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -687,7 +804,7 @@ func (x *PresenceChangedEvent) String() string {
 func (*PresenceChangedEvent) ProtoMessage() {}
 
 func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -700,7 +817,7 @@ func (x *PresenceChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PresenceChangedEvent.ProtoReflect.Descriptor instead.
 func (*PresenceChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{5}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *PresenceChangedEvent) GetStatus() string {
@@ -726,7 +843,7 @@ type NotificationOccurrencesInvalidatedEvent struct {
 
 func (x *NotificationOccurrencesInvalidatedEvent) Reset() {
 	*x = NotificationOccurrencesInvalidatedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -738,7 +855,7 @@ func (x *NotificationOccurrencesInvalidatedEvent) String() string {
 func (*NotificationOccurrencesInvalidatedEvent) ProtoMessage() {}
 
 func (x *NotificationOccurrencesInvalidatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -751,7 +868,7 @@ func (x *NotificationOccurrencesInvalidatedEvent) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use NotificationOccurrencesInvalidatedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationOccurrencesInvalidatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{6}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *NotificationOccurrencesInvalidatedEvent) GetAlertCandidateNotificationId() string {
@@ -785,7 +902,7 @@ type ThreadFollowChangedEvent struct {
 
 func (x *ThreadFollowChangedEvent) Reset() {
 	*x = ThreadFollowChangedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -797,7 +914,7 @@ func (x *ThreadFollowChangedEvent) String() string {
 func (*ThreadFollowChangedEvent) ProtoMessage() {}
 
 func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -810,7 +927,7 @@ func (x *ThreadFollowChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ThreadFollowChangedEvent.ProtoReflect.Descriptor instead.
 func (*ThreadFollowChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{7}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ThreadFollowChangedEvent) GetRoomId() string {
@@ -846,7 +963,7 @@ type RoomMarkedAsReadEvent struct {
 
 func (x *RoomMarkedAsReadEvent) Reset() {
 	*x = RoomMarkedAsReadEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -858,7 +975,7 @@ func (x *RoomMarkedAsReadEvent) String() string {
 func (*RoomMarkedAsReadEvent) ProtoMessage() {}
 
 func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -871,7 +988,7 @@ func (x *RoomMarkedAsReadEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomMarkedAsReadEvent.ProtoReflect.Descriptor instead.
 func (*RoomMarkedAsReadEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{8}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *RoomMarkedAsReadEvent) GetRoomId() string {
@@ -896,7 +1013,7 @@ type NotificationUnreadChangedEvent struct {
 
 func (x *NotificationUnreadChangedEvent) Reset() {
 	*x = NotificationUnreadChangedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -908,7 +1025,7 @@ func (x *NotificationUnreadChangedEvent) String() string {
 func (*NotificationUnreadChangedEvent) ProtoMessage() {}
 
 func (x *NotificationUnreadChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -921,7 +1038,7 @@ func (x *NotificationUnreadChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use NotificationUnreadChangedEvent.ProtoReflect.Descriptor instead.
 func (*NotificationUnreadChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{9}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *NotificationUnreadChangedEvent) GetRoomId() string {
@@ -953,7 +1070,7 @@ type MentionStatusClearedEvent struct {
 
 func (x *MentionStatusClearedEvent) Reset() {
 	*x = MentionStatusClearedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -965,7 +1082,7 @@ func (x *MentionStatusClearedEvent) String() string {
 func (*MentionStatusClearedEvent) ProtoMessage() {}
 
 func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -978,7 +1095,7 @@ func (x *MentionStatusClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MentionStatusClearedEvent.ProtoReflect.Descriptor instead.
 func (*MentionStatusClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{10}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *MentionStatusClearedEvent) GetRoomId() string {
@@ -999,7 +1116,7 @@ type RoomGroupsUpdatedEvent struct {
 
 func (x *RoomGroupsUpdatedEvent) Reset() {
 	*x = RoomGroupsUpdatedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1011,7 +1128,7 @@ func (x *RoomGroupsUpdatedEvent) String() string {
 func (*RoomGroupsUpdatedEvent) ProtoMessage() {}
 
 func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1024,7 +1141,7 @@ func (x *RoomGroupsUpdatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RoomGroupsUpdatedEvent.ProtoReflect.Descriptor instead.
 func (*RoomGroupsUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{11}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{13}
 }
 
 // Notifies a user that their session has been terminated.
@@ -1041,7 +1158,7 @@ type SessionTerminatedEvent struct {
 
 func (x *SessionTerminatedEvent) Reset() {
 	*x = SessionTerminatedEvent{}
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1053,7 +1170,7 @@ func (x *SessionTerminatedEvent) String() string {
 func (*SessionTerminatedEvent) ProtoMessage() {}
 
 func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_live_events_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_live_events_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1066,7 +1183,7 @@ func (x *SessionTerminatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionTerminatedEvent.ProtoReflect.Descriptor instead.
 func (*SessionTerminatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{12}
+	return file_chatto_core_v1_live_events_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *SessionTerminatedEvent) GetReason() string {
@@ -1080,16 +1197,16 @@ var File_chatto_core_v1_live_events_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_live_events_proto_rawDesc = "" +
 	"\n" +
-	" chatto/core/v1/live_events.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a chatto/core/v1/room_events.proto\x1a chatto/core/v1/user_events.proto\x1a%chatto/core/v1/user_preferences.proto\"\x91\x0f\n" +
+	" chatto/core/v1/live_events.proto\x12\x0echatto.core.v1\x1a\x1fgoogle/protobuf/timestamp.proto\x1a chatto/core/v1/room_events.proto\x1a chatto/core/v1/user_events.proto\x1a%chatto/core/v1/user_preferences.proto\"\x92\x0f\n" +
 	"\tLiveEvent\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x129\n" +
 	"\n" +
 	"created_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12\x19\n" +
-	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12E\n" +
-	"\fuser_created\x18\x14 \x01(\v2 .chatto.core.v1.UserCreatedEventH\x00R\vuserCreated\x12I\n" +
+	"\bactor_id\x18\x03 \x01(\tR\aactorId\x12I\n" +
+	"\fuser_created\x18\x14 \x01(\v2$.chatto.core.v1.UserCreatedSyncEventH\x00R\vuserCreated\x12I\n" +
 	"\fuser_deleted\x18\x15 \x01(\v2 .chatto.core.v1.UserDeletedEventB\x02\x18\x01H\x00R\vuserDeleted\x12X\n" +
-	"\x14user_profile_updated\x18\x16 \x01(\v2$.chatto.core.v1.UserProfileSyncEventH\x00R\x12userProfileUpdated\x12z\n" +
-	"\x1fserver_user_preferences_updated\x18\x17 \x01(\v21.chatto.core.v1.ServerUserPreferencesUpdatedEventH\x00R\x1cserverUserPreferencesUpdated\x12^\n" +
+	"\x14user_profile_updated\x18\x16 \x01(\v2$.chatto.core.v1.UserProfileSyncEventH\x00R\x12userProfileUpdated\x12w\n" +
+	"\x1fserver_user_preferences_updated\x18\x17 \x01(\v2..chatto.core.v1.ServerUserPreferencesSyncEventH\x00R\x1cserverUserPreferencesUpdated\x12^\n" +
 	"\x15thread_follow_changed\x18\x19 \x01(\v2(.chatto.core.v1.ThreadFollowChangedEventH\x00R\x13threadFollowChanged\x12^\n" +
 	"\x15server_member_deleted\x18\x1e \x01(\v2(.chatto.core.v1.ServerMemberDeletedEventH\x00R\x13serverMemberDeleted\x12K\n" +
 	"\x0eserver_updated\x18\x1f \x01(\v2\".chatto.core.v1.ServerUpdatedEventH\x00R\rserverUpdated\x12B\n" +
@@ -1106,7 +1223,11 @@ const file_chatto_core_v1_live_events_proto_rawDesc = "" +
 	"\x12session_terminated\x18d \x01(\v2&.chatto.core.v1.SessionTerminatedEventH\x00R\x11sessionTerminatedB\a\n" +
 	"\x05eventJ\x04\b\n" +
 	"\x10\vJ\x04\b\x18\x10\x19J\x04\b)\x10*J\x04\b2\x103J\x04\b3\x104J\x04\bF\x10GJ\x04\bG\x10HR\x0econfig_updatedR\x1anotification_level_changedR\x1avideo_processing_completedR\x14mention_notificationR\x1fnew_direct_message_notificationR\x14notification_createdR\x16notification_dismissed\"\x10\n" +
-	"\x0eHeartbeatEvent\"\xb5\x01\n" +
+	"\x0eHeartbeatEvent\"h\n" +
+	"\x14UserCreatedSyncEvent\x12\x17\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
+	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
+	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\"\xb5\x01\n" +
 	"\x14UserProfileSyncEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x1d\n" +
@@ -1114,7 +1235,11 @@ const file_chatto_core_v1_live_events_proto_rawDesc = "" +
 	"avatar_url\x18\x03 \x01(\tR\tavatarUrl\x12\x14\n" +
 	"\x05login\x18\x04 \x01(\tR\x05login\x12\x10\n" +
 	"\x03bio\x18\x05 \x01(\tR\x03bio\x12\x1a\n" +
-	"\btimezone\x18\x06 \x01(\tR\btimezone\"\xa1\x01\n" +
+	"\btimezone\x18\x06 \x01(\tR\btimezone\"y\n" +
+	"\x1eServerUserPreferencesSyncEvent\x12\x1a\n" +
+	"\btimezone\x18\x01 \x01(\tR\btimezone\x12;\n" +
+	"\vtime_format\x18\x02 \x01(\x0e2\x1a.chatto.core.v1.TimeFormatR\n" +
+	"timeFormat\"\xa1\x01\n" +
 	"\x12ServerUpdatedEvent\x12\x1b\n" +
 	"\tserver_id\x18\x01 \x01(\tR\bserverId\x12\x12\n" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
@@ -1161,53 +1286,55 @@ func file_chatto_core_v1_live_events_proto_rawDescGZIP() []byte {
 	return file_chatto_core_v1_live_events_proto_rawDescData
 }
 
-var file_chatto_core_v1_live_events_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_chatto_core_v1_live_events_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_chatto_core_v1_live_events_proto_goTypes = []any{
 	(*LiveEvent)(nil),                               // 0: chatto.core.v1.LiveEvent
 	(*HeartbeatEvent)(nil),                          // 1: chatto.core.v1.HeartbeatEvent
-	(*UserProfileSyncEvent)(nil),                    // 2: chatto.core.v1.UserProfileSyncEvent
-	(*ServerUpdatedEvent)(nil),                      // 3: chatto.core.v1.ServerUpdatedEvent
-	(*UserTypingEvent)(nil),                         // 4: chatto.core.v1.UserTypingEvent
-	(*PresenceChangedEvent)(nil),                    // 5: chatto.core.v1.PresenceChangedEvent
-	(*NotificationOccurrencesInvalidatedEvent)(nil), // 6: chatto.core.v1.NotificationOccurrencesInvalidatedEvent
-	(*ThreadFollowChangedEvent)(nil),                // 7: chatto.core.v1.ThreadFollowChangedEvent
-	(*RoomMarkedAsReadEvent)(nil),                   // 8: chatto.core.v1.RoomMarkedAsReadEvent
-	(*NotificationUnreadChangedEvent)(nil),          // 9: chatto.core.v1.NotificationUnreadChangedEvent
-	(*MentionStatusClearedEvent)(nil),               // 10: chatto.core.v1.MentionStatusClearedEvent
-	(*RoomGroupsUpdatedEvent)(nil),                  // 11: chatto.core.v1.RoomGroupsUpdatedEvent
-	(*SessionTerminatedEvent)(nil),                  // 12: chatto.core.v1.SessionTerminatedEvent
-	(*timestamppb.Timestamp)(nil),                   // 13: google.protobuf.Timestamp
-	(*UserCreatedEvent)(nil),                        // 14: chatto.core.v1.UserCreatedEvent
-	(*UserDeletedEvent)(nil),                        // 15: chatto.core.v1.UserDeletedEvent
-	(*ServerUserPreferencesUpdatedEvent)(nil),       // 16: chatto.core.v1.ServerUserPreferencesUpdatedEvent
+	(*UserCreatedSyncEvent)(nil),                    // 2: chatto.core.v1.UserCreatedSyncEvent
+	(*UserProfileSyncEvent)(nil),                    // 3: chatto.core.v1.UserProfileSyncEvent
+	(*ServerUserPreferencesSyncEvent)(nil),          // 4: chatto.core.v1.ServerUserPreferencesSyncEvent
+	(*ServerUpdatedEvent)(nil),                      // 5: chatto.core.v1.ServerUpdatedEvent
+	(*UserTypingEvent)(nil),                         // 6: chatto.core.v1.UserTypingEvent
+	(*PresenceChangedEvent)(nil),                    // 7: chatto.core.v1.PresenceChangedEvent
+	(*NotificationOccurrencesInvalidatedEvent)(nil), // 8: chatto.core.v1.NotificationOccurrencesInvalidatedEvent
+	(*ThreadFollowChangedEvent)(nil),                // 9: chatto.core.v1.ThreadFollowChangedEvent
+	(*RoomMarkedAsReadEvent)(nil),                   // 10: chatto.core.v1.RoomMarkedAsReadEvent
+	(*NotificationUnreadChangedEvent)(nil),          // 11: chatto.core.v1.NotificationUnreadChangedEvent
+	(*MentionStatusClearedEvent)(nil),               // 12: chatto.core.v1.MentionStatusClearedEvent
+	(*RoomGroupsUpdatedEvent)(nil),                  // 13: chatto.core.v1.RoomGroupsUpdatedEvent
+	(*SessionTerminatedEvent)(nil),                  // 14: chatto.core.v1.SessionTerminatedEvent
+	(*timestamppb.Timestamp)(nil),                   // 15: google.protobuf.Timestamp
+	(*UserDeletedEvent)(nil),                        // 16: chatto.core.v1.UserDeletedEvent
 	(*ServerMemberDeletedEvent)(nil),                // 17: chatto.core.v1.ServerMemberDeletedEvent
 	(*CallParticipantJoinedEvent)(nil),              // 18: chatto.core.v1.CallParticipantJoinedEvent
 	(*CallParticipantLeftEvent)(nil),                // 19: chatto.core.v1.CallParticipantLeftEvent
+	(TimeFormat)(0),                                 // 20: chatto.core.v1.TimeFormat
 }
 var file_chatto_core_v1_live_events_proto_depIdxs = []int32{
-	13, // 0: chatto.core.v1.LiveEvent.created_at:type_name -> google.protobuf.Timestamp
-	14, // 1: chatto.core.v1.LiveEvent.user_created:type_name -> chatto.core.v1.UserCreatedEvent
-	15, // 2: chatto.core.v1.LiveEvent.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
-	2,  // 3: chatto.core.v1.LiveEvent.user_profile_updated:type_name -> chatto.core.v1.UserProfileSyncEvent
-	16, // 4: chatto.core.v1.LiveEvent.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesUpdatedEvent
-	7,  // 5: chatto.core.v1.LiveEvent.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
+	15, // 0: chatto.core.v1.LiveEvent.created_at:type_name -> google.protobuf.Timestamp
+	2,  // 1: chatto.core.v1.LiveEvent.user_created:type_name -> chatto.core.v1.UserCreatedSyncEvent
+	16, // 2: chatto.core.v1.LiveEvent.user_deleted:type_name -> chatto.core.v1.UserDeletedEvent
+	3,  // 3: chatto.core.v1.LiveEvent.user_profile_updated:type_name -> chatto.core.v1.UserProfileSyncEvent
+	4,  // 4: chatto.core.v1.LiveEvent.server_user_preferences_updated:type_name -> chatto.core.v1.ServerUserPreferencesSyncEvent
+	9,  // 5: chatto.core.v1.LiveEvent.thread_follow_changed:type_name -> chatto.core.v1.ThreadFollowChangedEvent
 	17, // 6: chatto.core.v1.LiveEvent.server_member_deleted:type_name -> chatto.core.v1.ServerMemberDeletedEvent
-	3,  // 7: chatto.core.v1.LiveEvent.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
-	4,  // 8: chatto.core.v1.LiveEvent.user_typing:type_name -> chatto.core.v1.UserTypingEvent
-	5,  // 9: chatto.core.v1.LiveEvent.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
+	5,  // 7: chatto.core.v1.LiveEvent.server_updated:type_name -> chatto.core.v1.ServerUpdatedEvent
+	6,  // 8: chatto.core.v1.LiveEvent.user_typing:type_name -> chatto.core.v1.UserTypingEvent
+	7,  // 9: chatto.core.v1.LiveEvent.presence_changed:type_name -> chatto.core.v1.PresenceChangedEvent
 	18, // 10: chatto.core.v1.LiveEvent.call_participant_joined:type_name -> chatto.core.v1.CallParticipantJoinedEvent
 	19, // 11: chatto.core.v1.LiveEvent.call_participant_left:type_name -> chatto.core.v1.CallParticipantLeftEvent
-	6,  // 12: chatto.core.v1.LiveEvent.notification_occurrences_invalidated:type_name -> chatto.core.v1.NotificationOccurrencesInvalidatedEvent
-	9,  // 13: chatto.core.v1.LiveEvent.notification_unread_changed:type_name -> chatto.core.v1.NotificationUnreadChangedEvent
-	8,  // 14: chatto.core.v1.LiveEvent.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
-	10, // 15: chatto.core.v1.LiveEvent.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
-	11, // 16: chatto.core.v1.LiveEvent.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
-	12, // 17: chatto.core.v1.LiveEvent.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
-	18, // [18:18] is the sub-list for method output_type
-	18, // [18:18] is the sub-list for method input_type
-	18, // [18:18] is the sub-list for extension type_name
-	18, // [18:18] is the sub-list for extension extendee
-	0,  // [0:18] is the sub-list for field type_name
+	8,  // 12: chatto.core.v1.LiveEvent.notification_occurrences_invalidated:type_name -> chatto.core.v1.NotificationOccurrencesInvalidatedEvent
+	11, // 13: chatto.core.v1.LiveEvent.notification_unread_changed:type_name -> chatto.core.v1.NotificationUnreadChangedEvent
+	10, // 14: chatto.core.v1.LiveEvent.room_marked_as_read:type_name -> chatto.core.v1.RoomMarkedAsReadEvent
+	12, // 15: chatto.core.v1.LiveEvent.mention_status_cleared:type_name -> chatto.core.v1.MentionStatusClearedEvent
+	13, // 16: chatto.core.v1.LiveEvent.room_groups_updated:type_name -> chatto.core.v1.RoomGroupsUpdatedEvent
+	14, // 17: chatto.core.v1.LiveEvent.session_terminated:type_name -> chatto.core.v1.SessionTerminatedEvent
+	20, // 18: chatto.core.v1.ServerUserPreferencesSyncEvent.time_format:type_name -> chatto.core.v1.TimeFormat
+	19, // [19:19] is the sub-list for method output_type
+	19, // [19:19] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_live_events_proto_init() }
@@ -1237,15 +1364,15 @@ func file_chatto_core_v1_live_events_proto_init() {
 		(*LiveEvent_RoomGroupsUpdated)(nil),
 		(*LiveEvent_SessionTerminated)(nil),
 	}
-	file_chatto_core_v1_live_events_proto_msgTypes[4].OneofWrappers = []any{}
 	file_chatto_core_v1_live_events_proto_msgTypes[6].OneofWrappers = []any{}
+	file_chatto_core_v1_live_events_proto_msgTypes[8].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_live_events_proto_rawDesc), len(file_chatto_core_v1_live_events_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/core/v1/user_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/user_events.pb.go
@@ -70,264 +70,6 @@ func (UserDEKPurpose) EnumDescriptor() ([]byte, []int) {
 	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{0}
 }
 
-// Deprecated: UserCreatedEvent is retained in its original source file for
-// generated-source compatibility. LiveEvent uses UserCreatedSyncEvent.
-//
-// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
-type UserCreatedEvent struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
-	Login         string                 `protobuf:"bytes,2,opt,name=login,proto3" json:"login,omitempty"`
-	DisplayName   string                 `protobuf:"bytes,3,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *UserCreatedEvent) Reset() {
-	*x = UserCreatedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[0]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UserCreatedEvent) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UserCreatedEvent) ProtoMessage() {}
-
-func (x *UserCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[0]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use UserCreatedEvent.ProtoReflect.Descriptor instead.
-func (*UserCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{0}
-}
-
-func (x *UserCreatedEvent) GetUserId() string {
-	if x != nil {
-		return x.UserId
-	}
-	return ""
-}
-
-func (x *UserCreatedEvent) GetLogin() string {
-	if x != nil {
-		return x.Login
-	}
-	return ""
-}
-
-func (x *UserCreatedEvent) GetDisplayName() string {
-	if x != nil {
-		return x.DisplayName
-	}
-	return ""
-}
-
-// Deprecated: UserDeletedEvent is retained for the deprecated LiveEvent field.
-// Current deletion delivery uses SessionTerminatedEvent for the deleted user's
-// clients and ServerMemberDeletedEvent for server-wide invalidation.
-//
-// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
-type UserDeletedEvent struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *UserDeletedEvent) Reset() {
-	*x = UserDeletedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[1]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UserDeletedEvent) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UserDeletedEvent) ProtoMessage() {}
-
-func (x *UserDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[1]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use UserDeletedEvent.ProtoReflect.Descriptor instead.
-func (*UserDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *UserDeletedEvent) GetUserId() string {
-	if x != nil {
-		return x.UserId
-	}
-	return ""
-}
-
-// Deprecated: UserProfileUpdatedEvent is retained in its original source file
-// for generated-source compatibility. LiveEvent uses UserProfileSyncEvent.
-//
-// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
-type UserProfileUpdatedEvent struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
-	DisplayName   string                 `protobuf:"bytes,2,opt,name=display_name,json=displayName,proto3" json:"display_name,omitempty"`
-	AvatarUrl     string                 `protobuf:"bytes,3,opt,name=avatar_url,json=avatarUrl,proto3" json:"avatar_url,omitempty"`
-	Login         string                 `protobuf:"bytes,4,opt,name=login,proto3" json:"login,omitempty"`
-	Bio           string                 `protobuf:"bytes,5,opt,name=bio,proto3" json:"bio,omitempty"`
-	Timezone      string                 `protobuf:"bytes,6,opt,name=timezone,proto3" json:"timezone,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *UserProfileUpdatedEvent) Reset() {
-	*x = UserProfileUpdatedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[2]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *UserProfileUpdatedEvent) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*UserProfileUpdatedEvent) ProtoMessage() {}
-
-func (x *UserProfileUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[2]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use UserProfileUpdatedEvent.ProtoReflect.Descriptor instead.
-func (*UserProfileUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *UserProfileUpdatedEvent) GetUserId() string {
-	if x != nil {
-		return x.UserId
-	}
-	return ""
-}
-
-func (x *UserProfileUpdatedEvent) GetDisplayName() string {
-	if x != nil {
-		return x.DisplayName
-	}
-	return ""
-}
-
-func (x *UserProfileUpdatedEvent) GetAvatarUrl() string {
-	if x != nil {
-		return x.AvatarUrl
-	}
-	return ""
-}
-
-func (x *UserProfileUpdatedEvent) GetLogin() string {
-	if x != nil {
-		return x.Login
-	}
-	return ""
-}
-
-func (x *UserProfileUpdatedEvent) GetBio() string {
-	if x != nil {
-		return x.Bio
-	}
-	return ""
-}
-
-func (x *UserProfileUpdatedEvent) GetTimezone() string {
-	if x != nil {
-		return x.Timezone
-	}
-	return ""
-}
-
-// Deprecated: ServerUserPreferencesUpdatedEvent is retained in its original
-// source file for generated-source compatibility. LiveEvent uses
-// ServerUserPreferencesSyncEvent.
-//
-// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
-type ServerUserPreferencesUpdatedEvent struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Timezone      string                 `protobuf:"bytes,1,opt,name=timezone,proto3" json:"timezone,omitempty"`
-	TimeFormat    TimeFormat             `protobuf:"varint,2,opt,name=time_format,json=timeFormat,proto3,enum=chatto.core.v1.TimeFormat" json:"time_format,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *ServerUserPreferencesUpdatedEvent) Reset() {
-	*x = ServerUserPreferencesUpdatedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[3]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *ServerUserPreferencesUpdatedEvent) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*ServerUserPreferencesUpdatedEvent) ProtoMessage() {}
-
-func (x *ServerUserPreferencesUpdatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[3]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use ServerUserPreferencesUpdatedEvent.ProtoReflect.Descriptor instead.
-func (*ServerUserPreferencesUpdatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{3}
-}
-
-func (x *ServerUserPreferencesUpdatedEvent) GetTimezone() string {
-	if x != nil {
-		return x.Timezone
-	}
-	return ""
-}
-
-func (x *ServerUserPreferencesUpdatedEvent) GetTimeFormat() TimeFormat {
-	if x != nil {
-		return x.TimeFormat
-	}
-	return TimeFormat_TIME_FORMAT_UNSPECIFIED
-}
-
 type EncryptedUserString struct {
 	state           protoimpl.MessageState `protogen:"open.v1"`
 	EncryptedValue  []byte                 `protobuf:"bytes,1,opt,name=encrypted_value,json=encryptedValue,proto3" json:"encrypted_value,omitempty"`
@@ -339,7 +81,7 @@ type EncryptedUserString struct {
 
 func (x *EncryptedUserString) Reset() {
 	*x = EncryptedUserString{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -351,7 +93,7 @@ func (x *EncryptedUserString) String() string {
 func (*EncryptedUserString) ProtoMessage() {}
 
 func (x *EncryptedUserString) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[4]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -364,7 +106,7 @@ func (x *EncryptedUserString) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EncryptedUserString.ProtoReflect.Descriptor instead.
 func (*EncryptedUserString) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{4}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *EncryptedUserString) GetEncryptedValue() []byte {
@@ -402,7 +144,7 @@ type UserAccountCreatedEvent struct {
 
 func (x *UserAccountCreatedEvent) Reset() {
 	*x = UserAccountCreatedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -414,7 +156,7 @@ func (x *UserAccountCreatedEvent) String() string {
 func (*UserAccountCreatedEvent) ProtoMessage() {}
 
 func (x *UserAccountCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[5]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -427,7 +169,7 @@ func (x *UserAccountCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserAccountCreatedEvent.ProtoReflect.Descriptor instead.
 func (*UserAccountCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{5}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *UserAccountCreatedEvent) GetUserId() string {
@@ -477,7 +219,7 @@ type BotApiKeyCreatedEvent struct {
 
 func (x *BotApiKeyCreatedEvent) Reset() {
 	*x = BotApiKeyCreatedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -489,7 +231,7 @@ func (x *BotApiKeyCreatedEvent) String() string {
 func (*BotApiKeyCreatedEvent) ProtoMessage() {}
 
 func (x *BotApiKeyCreatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[6]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -502,7 +244,7 @@ func (x *BotApiKeyCreatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotApiKeyCreatedEvent.ProtoReflect.Descriptor instead.
 func (*BotApiKeyCreatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{6}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *BotApiKeyCreatedEvent) GetUserId() string {
@@ -531,7 +273,7 @@ type BotApiKeyRotatedEvent struct {
 
 func (x *BotApiKeyRotatedEvent) Reset() {
 	*x = BotApiKeyRotatedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -543,7 +285,7 @@ func (x *BotApiKeyRotatedEvent) String() string {
 func (*BotApiKeyRotatedEvent) ProtoMessage() {}
 
 func (x *BotApiKeyRotatedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[7]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -556,7 +298,7 @@ func (x *BotApiKeyRotatedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotApiKeyRotatedEvent.ProtoReflect.Descriptor instead.
 func (*BotApiKeyRotatedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{7}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *BotApiKeyRotatedEvent) GetUserId() string {
@@ -586,7 +328,7 @@ type BotOwnerReassignedEvent struct {
 
 func (x *BotOwnerReassignedEvent) Reset() {
 	*x = BotOwnerReassignedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -598,7 +340,7 @@ func (x *BotOwnerReassignedEvent) String() string {
 func (*BotOwnerReassignedEvent) ProtoMessage() {}
 
 func (x *BotOwnerReassignedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[8]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -611,7 +353,7 @@ func (x *BotOwnerReassignedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BotOwnerReassignedEvent.ProtoReflect.Descriptor instead.
 func (*BotOwnerReassignedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{8}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *BotOwnerReassignedEvent) GetUserId() string {
@@ -645,7 +387,7 @@ type UserLoginChangedEvent struct {
 
 func (x *UserLoginChangedEvent) Reset() {
 	*x = UserLoginChangedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -657,7 +399,7 @@ func (x *UserLoginChangedEvent) String() string {
 func (*UserLoginChangedEvent) ProtoMessage() {}
 
 func (x *UserLoginChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[9]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -670,7 +412,7 @@ func (x *UserLoginChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserLoginChangedEvent.ProtoReflect.Descriptor instead.
 func (*UserLoginChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{9}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *UserLoginChangedEvent) GetUserId() string {
@@ -697,7 +439,7 @@ type UserDisplayNameChangedEvent struct {
 
 func (x *UserDisplayNameChangedEvent) Reset() {
 	*x = UserDisplayNameChangedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -709,7 +451,7 @@ func (x *UserDisplayNameChangedEvent) String() string {
 func (*UserDisplayNameChangedEvent) ProtoMessage() {}
 
 func (x *UserDisplayNameChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[10]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -722,7 +464,7 @@ func (x *UserDisplayNameChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserDisplayNameChangedEvent.ProtoReflect.Descriptor instead.
 func (*UserDisplayNameChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{10}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *UserDisplayNameChangedEvent) GetUserId() string {
@@ -752,7 +494,7 @@ type UserBioChangedEvent struct {
 
 func (x *UserBioChangedEvent) Reset() {
 	*x = UserBioChangedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -764,7 +506,7 @@ func (x *UserBioChangedEvent) String() string {
 func (*UserBioChangedEvent) ProtoMessage() {}
 
 func (x *UserBioChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[11]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -777,7 +519,7 @@ func (x *UserBioChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserBioChangedEvent.ProtoReflect.Descriptor instead.
 func (*UserBioChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{11}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *UserBioChangedEvent) GetUserId() string {
@@ -807,7 +549,7 @@ type UserAvatarSetEvent struct {
 
 func (x *UserAvatarSetEvent) Reset() {
 	*x = UserAvatarSetEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -819,7 +561,7 @@ func (x *UserAvatarSetEvent) String() string {
 func (*UserAvatarSetEvent) ProtoMessage() {}
 
 func (x *UserAvatarSetEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[12]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -832,7 +574,7 @@ func (x *UserAvatarSetEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserAvatarSetEvent.ProtoReflect.Descriptor instead.
 func (*UserAvatarSetEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{12}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *UserAvatarSetEvent) GetUserId() string {
@@ -858,7 +600,7 @@ type UserAvatarClearedEvent struct {
 
 func (x *UserAvatarClearedEvent) Reset() {
 	*x = UserAvatarClearedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -870,7 +612,7 @@ func (x *UserAvatarClearedEvent) String() string {
 func (*UserAvatarClearedEvent) ProtoMessage() {}
 
 func (x *UserAvatarClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[13]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -883,7 +625,7 @@ func (x *UserAvatarClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserAvatarClearedEvent.ProtoReflect.Descriptor instead.
 func (*UserAvatarClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{13}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *UserAvatarClearedEvent) GetUserId() string {
@@ -903,7 +645,7 @@ type UserVerifiedEmailAddedEvent struct {
 
 func (x *UserVerifiedEmailAddedEvent) Reset() {
 	*x = UserVerifiedEmailAddedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[14]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -915,7 +657,7 @@ func (x *UserVerifiedEmailAddedEvent) String() string {
 func (*UserVerifiedEmailAddedEvent) ProtoMessage() {}
 
 func (x *UserVerifiedEmailAddedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[14]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -928,7 +670,7 @@ func (x *UserVerifiedEmailAddedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserVerifiedEmailAddedEvent.ProtoReflect.Descriptor instead.
 func (*UserVerifiedEmailAddedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{14}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *UserVerifiedEmailAddedEvent) GetUserId() string {
@@ -959,7 +701,7 @@ type UserPasswordHashChangedEvent struct {
 
 func (x *UserPasswordHashChangedEvent) Reset() {
 	*x = UserPasswordHashChangedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[15]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -971,7 +713,7 @@ func (x *UserPasswordHashChangedEvent) String() string {
 func (*UserPasswordHashChangedEvent) ProtoMessage() {}
 
 func (x *UserPasswordHashChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[15]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -984,7 +726,7 @@ func (x *UserPasswordHashChangedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserPasswordHashChangedEvent.ProtoReflect.Descriptor instead.
 func (*UserPasswordHashChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{15}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *UserPasswordHashChangedEvent) GetUserId() string {
@@ -1022,7 +764,7 @@ type UserOIDCSubjectLinkedEvent struct {
 
 func (x *UserOIDCSubjectLinkedEvent) Reset() {
 	*x = UserOIDCSubjectLinkedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[16]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1034,7 +776,7 @@ func (x *UserOIDCSubjectLinkedEvent) String() string {
 func (*UserOIDCSubjectLinkedEvent) ProtoMessage() {}
 
 func (x *UserOIDCSubjectLinkedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[16]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1047,7 +789,7 @@ func (x *UserOIDCSubjectLinkedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserOIDCSubjectLinkedEvent.ProtoReflect.Descriptor instead.
 func (*UserOIDCSubjectLinkedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{16}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *UserOIDCSubjectLinkedEvent) GetUserId() string {
@@ -1101,7 +843,7 @@ type UserExternalIdentityLinkedEvent struct {
 
 func (x *UserExternalIdentityLinkedEvent) Reset() {
 	*x = UserExternalIdentityLinkedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[17]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1113,7 +855,7 @@ func (x *UserExternalIdentityLinkedEvent) String() string {
 func (*UserExternalIdentityLinkedEvent) ProtoMessage() {}
 
 func (x *UserExternalIdentityLinkedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[17]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1126,7 +868,7 @@ func (x *UserExternalIdentityLinkedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserExternalIdentityLinkedEvent.ProtoReflect.Descriptor instead.
 func (*UserExternalIdentityLinkedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{17}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *UserExternalIdentityLinkedEvent) GetUserId() string {
@@ -1183,7 +925,7 @@ type UserExternalIdentityUnlinkedEvent struct {
 
 func (x *UserExternalIdentityUnlinkedEvent) Reset() {
 	*x = UserExternalIdentityUnlinkedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[18]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1195,7 +937,7 @@ func (x *UserExternalIdentityUnlinkedEvent) String() string {
 func (*UserExternalIdentityUnlinkedEvent) ProtoMessage() {}
 
 func (x *UserExternalIdentityUnlinkedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[18]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1208,7 +950,7 @@ func (x *UserExternalIdentityUnlinkedEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UserExternalIdentityUnlinkedEvent.ProtoReflect.Descriptor instead.
 func (*UserExternalIdentityUnlinkedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{18}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *UserExternalIdentityUnlinkedEvent) GetUserId() string {
@@ -1235,7 +977,7 @@ type UserServerPreferencesChangedEvent struct {
 
 func (x *UserServerPreferencesChangedEvent) Reset() {
 	*x = UserServerPreferencesChangedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[19]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1247,7 +989,7 @@ func (x *UserServerPreferencesChangedEvent) String() string {
 func (*UserServerPreferencesChangedEvent) ProtoMessage() {}
 
 func (x *UserServerPreferencesChangedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[19]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1260,7 +1002,7 @@ func (x *UserServerPreferencesChangedEvent) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use UserServerPreferencesChangedEvent.ProtoReflect.Descriptor instead.
 func (*UserServerPreferencesChangedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{19}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *UserServerPreferencesChangedEvent) GetUserId() string {
@@ -1286,7 +1028,7 @@ type UserLoginCooldownStartedEvent struct {
 
 func (x *UserLoginCooldownStartedEvent) Reset() {
 	*x = UserLoginCooldownStartedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[20]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1298,7 +1040,7 @@ func (x *UserLoginCooldownStartedEvent) String() string {
 func (*UserLoginCooldownStartedEvent) ProtoMessage() {}
 
 func (x *UserLoginCooldownStartedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[20]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1311,7 +1053,7 @@ func (x *UserLoginCooldownStartedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserLoginCooldownStartedEvent.ProtoReflect.Descriptor instead.
 func (*UserLoginCooldownStartedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{20}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *UserLoginCooldownStartedEvent) GetUserId() string {
@@ -1330,7 +1072,7 @@ type UserLoginCooldownClearedEvent struct {
 
 func (x *UserLoginCooldownClearedEvent) Reset() {
 	*x = UserLoginCooldownClearedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[21]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1342,7 +1084,7 @@ func (x *UserLoginCooldownClearedEvent) String() string {
 func (*UserLoginCooldownClearedEvent) ProtoMessage() {}
 
 func (x *UserLoginCooldownClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[21]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1355,7 +1097,7 @@ func (x *UserLoginCooldownClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserLoginCooldownClearedEvent.ProtoReflect.Descriptor instead.
 func (*UserLoginCooldownClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{21}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *UserLoginCooldownClearedEvent) GetUserId() string {
@@ -1374,7 +1116,7 @@ type UserAccountDeletedEvent struct {
 
 func (x *UserAccountDeletedEvent) Reset() {
 	*x = UserAccountDeletedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[22]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1386,7 +1128,7 @@ func (x *UserAccountDeletedEvent) String() string {
 func (*UserAccountDeletedEvent) ProtoMessage() {}
 
 func (x *UserAccountDeletedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[22]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1399,7 +1141,7 @@ func (x *UserAccountDeletedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserAccountDeletedEvent.ProtoReflect.Descriptor instead.
 func (*UserAccountDeletedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{22}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *UserAccountDeletedEvent) GetUserId() string {
@@ -1419,7 +1161,7 @@ type UserCustomStatusSetEvent struct {
 
 func (x *UserCustomStatusSetEvent) Reset() {
 	*x = UserCustomStatusSetEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[23]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1431,7 +1173,7 @@ func (x *UserCustomStatusSetEvent) String() string {
 func (*UserCustomStatusSetEvent) ProtoMessage() {}
 
 func (x *UserCustomStatusSetEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[23]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1444,7 +1186,7 @@ func (x *UserCustomStatusSetEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserCustomStatusSetEvent.ProtoReflect.Descriptor instead.
 func (*UserCustomStatusSetEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{23}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *UserCustomStatusSetEvent) GetUserId() string {
@@ -1470,7 +1212,7 @@ type UserCustomStatusClearedEvent struct {
 
 func (x *UserCustomStatusClearedEvent) Reset() {
 	*x = UserCustomStatusClearedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[24]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1482,7 +1224,7 @@ func (x *UserCustomStatusClearedEvent) String() string {
 func (*UserCustomStatusClearedEvent) ProtoMessage() {}
 
 func (x *UserCustomStatusClearedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[24]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1495,7 +1237,7 @@ func (x *UserCustomStatusClearedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserCustomStatusClearedEvent.ProtoReflect.Descriptor instead.
 func (*UserCustomStatusClearedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{24}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{20}
 }
 
 func (x *UserCustomStatusClearedEvent) GetUserId() string {
@@ -1518,7 +1260,7 @@ type UserKeyShreddedEvent struct {
 
 func (x *UserKeyShreddedEvent) Reset() {
 	*x = UserKeyShreddedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[25]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1530,7 +1272,7 @@ func (x *UserKeyShreddedEvent) String() string {
 func (*UserKeyShreddedEvent) ProtoMessage() {}
 
 func (x *UserKeyShreddedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[25]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1543,7 +1285,7 @@ func (x *UserKeyShreddedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserKeyShreddedEvent.ProtoReflect.Descriptor instead.
 func (*UserKeyShreddedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{25}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{21}
 }
 
 func (x *UserKeyShreddedEvent) GetUserId() string {
@@ -1566,7 +1308,7 @@ type UserKeyShreddingRequestedEvent struct {
 
 func (x *UserKeyShreddingRequestedEvent) Reset() {
 	*x = UserKeyShreddingRequestedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[26]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[22]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1578,7 +1320,7 @@ func (x *UserKeyShreddingRequestedEvent) String() string {
 func (*UserKeyShreddingRequestedEvent) ProtoMessage() {}
 
 func (x *UserKeyShreddingRequestedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[26]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[22]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1591,7 +1333,7 @@ func (x *UserKeyShreddingRequestedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserKeyShreddingRequestedEvent.ProtoReflect.Descriptor instead.
 func (*UserKeyShreddingRequestedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{26}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{22}
 }
 
 func (x *UserKeyShreddingRequestedEvent) GetUserId() string {
@@ -1620,7 +1362,7 @@ type UserDEKGeneratedEvent struct {
 
 func (x *UserDEKGeneratedEvent) Reset() {
 	*x = UserDEKGeneratedEvent{}
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[27]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1632,7 +1374,7 @@ func (x *UserDEKGeneratedEvent) String() string {
 func (*UserDEKGeneratedEvent) ProtoMessage() {}
 
 func (x *UserDEKGeneratedEvent) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_core_v1_user_events_proto_msgTypes[27]
+	mi := &file_chatto_core_v1_user_events_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1645,7 +1387,7 @@ func (x *UserDEKGeneratedEvent) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UserDEKGeneratedEvent.ProtoReflect.Descriptor instead.
 func (*UserDEKGeneratedEvent) Descriptor() ([]byte, []int) {
-	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{27}
+	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{23}
 }
 
 func (x *UserDEKGeneratedEvent) GetUserId() string {
@@ -1701,25 +1443,7 @@ var File_chatto_core_v1_user_events_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_user_events_proto_rawDesc = "" +
 	"\n" +
-	" chatto/core/v1/user_events.proto\x12\x0echatto.core.v1\x1a%chatto/core/v1/user_preferences.proto\x1a\x1bchatto/core/v1/models.proto\"h\n" +
-	"\x10UserCreatedEvent\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
-	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
-	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName:\x02\x18\x01\"/\n" +
-	"\x10UserDeletedEvent\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId:\x02\x18\x01\"\xbc\x01\n" +
-	"\x17UserProfileUpdatedEvent\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId\x12!\n" +
-	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x1d\n" +
-	"\n" +
-	"avatar_url\x18\x03 \x01(\tR\tavatarUrl\x12\x14\n" +
-	"\x05login\x18\x04 \x01(\tR\x05login\x12\x10\n" +
-	"\x03bio\x18\x05 \x01(\tR\x03bio\x12\x1a\n" +
-	"\btimezone\x18\x06 \x01(\tR\btimezone:\x02\x18\x01\"\x80\x01\n" +
-	"!ServerUserPreferencesUpdatedEvent\x12\x1a\n" +
-	"\btimezone\x18\x01 \x01(\tR\btimezone\x12;\n" +
-	"\vtime_format\x18\x02 \x01(\x0e2\x1a.chatto.core.v1.TimeFormatR\n" +
-	"timeFormat:\x02\x18\x01\"\x80\x01\n" +
+	" chatto/core/v1/user_events.proto\x12\x0echatto.core.v1\x1a%chatto/core/v1/user_preferences.proto\x1a\x1bchatto/core/v1/models.proto\"\x80\x01\n" +
 	"\x13EncryptedUserString\x12'\n" +
 	"\x0fencrypted_value\x18\x01 \x01(\fR\x0eencryptedValue\x12\x14\n" +
 	"\x05nonce\x18\x02 \x01(\fR\x05nonce\x12*\n" +
@@ -1827,59 +1551,53 @@ func file_chatto_core_v1_user_events_proto_rawDescGZIP() []byte {
 }
 
 var file_chatto_core_v1_user_events_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_chatto_core_v1_user_events_proto_msgTypes = make([]protoimpl.MessageInfo, 28)
+var file_chatto_core_v1_user_events_proto_msgTypes = make([]protoimpl.MessageInfo, 24)
 var file_chatto_core_v1_user_events_proto_goTypes = []any{
 	(UserDEKPurpose)(0),                       // 0: chatto.core.v1.UserDEKPurpose
-	(*UserCreatedEvent)(nil),                  // 1: chatto.core.v1.UserCreatedEvent
-	(*UserDeletedEvent)(nil),                  // 2: chatto.core.v1.UserDeletedEvent
-	(*UserProfileUpdatedEvent)(nil),           // 3: chatto.core.v1.UserProfileUpdatedEvent
-	(*ServerUserPreferencesUpdatedEvent)(nil), // 4: chatto.core.v1.ServerUserPreferencesUpdatedEvent
-	(*EncryptedUserString)(nil),               // 5: chatto.core.v1.EncryptedUserString
-	(*UserAccountCreatedEvent)(nil),           // 6: chatto.core.v1.UserAccountCreatedEvent
-	(*BotApiKeyCreatedEvent)(nil),             // 7: chatto.core.v1.BotApiKeyCreatedEvent
-	(*BotApiKeyRotatedEvent)(nil),             // 8: chatto.core.v1.BotApiKeyRotatedEvent
-	(*BotOwnerReassignedEvent)(nil),           // 9: chatto.core.v1.BotOwnerReassignedEvent
-	(*UserLoginChangedEvent)(nil),             // 10: chatto.core.v1.UserLoginChangedEvent
-	(*UserDisplayNameChangedEvent)(nil),       // 11: chatto.core.v1.UserDisplayNameChangedEvent
-	(*UserBioChangedEvent)(nil),               // 12: chatto.core.v1.UserBioChangedEvent
-	(*UserAvatarSetEvent)(nil),                // 13: chatto.core.v1.UserAvatarSetEvent
-	(*UserAvatarClearedEvent)(nil),            // 14: chatto.core.v1.UserAvatarClearedEvent
-	(*UserVerifiedEmailAddedEvent)(nil),       // 15: chatto.core.v1.UserVerifiedEmailAddedEvent
-	(*UserPasswordHashChangedEvent)(nil),      // 16: chatto.core.v1.UserPasswordHashChangedEvent
-	(*UserOIDCSubjectLinkedEvent)(nil),        // 17: chatto.core.v1.UserOIDCSubjectLinkedEvent
-	(*UserExternalIdentityLinkedEvent)(nil),   // 18: chatto.core.v1.UserExternalIdentityLinkedEvent
-	(*UserExternalIdentityUnlinkedEvent)(nil), // 19: chatto.core.v1.UserExternalIdentityUnlinkedEvent
-	(*UserServerPreferencesChangedEvent)(nil), // 20: chatto.core.v1.UserServerPreferencesChangedEvent
-	(*UserLoginCooldownStartedEvent)(nil),     // 21: chatto.core.v1.UserLoginCooldownStartedEvent
-	(*UserLoginCooldownClearedEvent)(nil),     // 22: chatto.core.v1.UserLoginCooldownClearedEvent
-	(*UserAccountDeletedEvent)(nil),           // 23: chatto.core.v1.UserAccountDeletedEvent
-	(*UserCustomStatusSetEvent)(nil),          // 24: chatto.core.v1.UserCustomStatusSetEvent
-	(*UserCustomStatusClearedEvent)(nil),      // 25: chatto.core.v1.UserCustomStatusClearedEvent
-	(*UserKeyShreddedEvent)(nil),              // 26: chatto.core.v1.UserKeyShreddedEvent
-	(*UserKeyShreddingRequestedEvent)(nil),    // 27: chatto.core.v1.UserKeyShreddingRequestedEvent
-	(*UserDEKGeneratedEvent)(nil),             // 28: chatto.core.v1.UserDEKGeneratedEvent
-	(TimeFormat)(0),                           // 29: chatto.core.v1.TimeFormat
-	(*DeprecatedAsset)(nil),                   // 30: chatto.core.v1.DeprecatedAsset
-	(*ServerUserPreferences)(nil),             // 31: chatto.core.v1.ServerUserPreferences
-	(*CustomUserStatus)(nil),                  // 32: chatto.core.v1.CustomUserStatus
+	(*EncryptedUserString)(nil),               // 1: chatto.core.v1.EncryptedUserString
+	(*UserAccountCreatedEvent)(nil),           // 2: chatto.core.v1.UserAccountCreatedEvent
+	(*BotApiKeyCreatedEvent)(nil),             // 3: chatto.core.v1.BotApiKeyCreatedEvent
+	(*BotApiKeyRotatedEvent)(nil),             // 4: chatto.core.v1.BotApiKeyRotatedEvent
+	(*BotOwnerReassignedEvent)(nil),           // 5: chatto.core.v1.BotOwnerReassignedEvent
+	(*UserLoginChangedEvent)(nil),             // 6: chatto.core.v1.UserLoginChangedEvent
+	(*UserDisplayNameChangedEvent)(nil),       // 7: chatto.core.v1.UserDisplayNameChangedEvent
+	(*UserBioChangedEvent)(nil),               // 8: chatto.core.v1.UserBioChangedEvent
+	(*UserAvatarSetEvent)(nil),                // 9: chatto.core.v1.UserAvatarSetEvent
+	(*UserAvatarClearedEvent)(nil),            // 10: chatto.core.v1.UserAvatarClearedEvent
+	(*UserVerifiedEmailAddedEvent)(nil),       // 11: chatto.core.v1.UserVerifiedEmailAddedEvent
+	(*UserPasswordHashChangedEvent)(nil),      // 12: chatto.core.v1.UserPasswordHashChangedEvent
+	(*UserOIDCSubjectLinkedEvent)(nil),        // 13: chatto.core.v1.UserOIDCSubjectLinkedEvent
+	(*UserExternalIdentityLinkedEvent)(nil),   // 14: chatto.core.v1.UserExternalIdentityLinkedEvent
+	(*UserExternalIdentityUnlinkedEvent)(nil), // 15: chatto.core.v1.UserExternalIdentityUnlinkedEvent
+	(*UserServerPreferencesChangedEvent)(nil), // 16: chatto.core.v1.UserServerPreferencesChangedEvent
+	(*UserLoginCooldownStartedEvent)(nil),     // 17: chatto.core.v1.UserLoginCooldownStartedEvent
+	(*UserLoginCooldownClearedEvent)(nil),     // 18: chatto.core.v1.UserLoginCooldownClearedEvent
+	(*UserAccountDeletedEvent)(nil),           // 19: chatto.core.v1.UserAccountDeletedEvent
+	(*UserCustomStatusSetEvent)(nil),          // 20: chatto.core.v1.UserCustomStatusSetEvent
+	(*UserCustomStatusClearedEvent)(nil),      // 21: chatto.core.v1.UserCustomStatusClearedEvent
+	(*UserKeyShreddedEvent)(nil),              // 22: chatto.core.v1.UserKeyShreddedEvent
+	(*UserKeyShreddingRequestedEvent)(nil),    // 23: chatto.core.v1.UserKeyShreddingRequestedEvent
+	(*UserDEKGeneratedEvent)(nil),             // 24: chatto.core.v1.UserDEKGeneratedEvent
+	(*DeprecatedAsset)(nil),                   // 25: chatto.core.v1.DeprecatedAsset
+	(*ServerUserPreferences)(nil),             // 26: chatto.core.v1.ServerUserPreferences
+	(*CustomUserStatus)(nil),                  // 27: chatto.core.v1.CustomUserStatus
 }
 var file_chatto_core_v1_user_events_proto_depIdxs = []int32{
-	29, // 0: chatto.core.v1.ServerUserPreferencesUpdatedEvent.time_format:type_name -> chatto.core.v1.TimeFormat
-	5,  // 1: chatto.core.v1.UserAccountCreatedEvent.encrypted_login:type_name -> chatto.core.v1.EncryptedUserString
-	5,  // 2: chatto.core.v1.UserAccountCreatedEvent.encrypted_display_name:type_name -> chatto.core.v1.EncryptedUserString
-	5,  // 3: chatto.core.v1.UserLoginChangedEvent.encrypted_login:type_name -> chatto.core.v1.EncryptedUserString
-	5,  // 4: chatto.core.v1.UserDisplayNameChangedEvent.encrypted_display_name:type_name -> chatto.core.v1.EncryptedUserString
-	5,  // 5: chatto.core.v1.UserBioChangedEvent.encrypted_bio:type_name -> chatto.core.v1.EncryptedUserString
-	30, // 6: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.DeprecatedAsset
-	5,  // 7: chatto.core.v1.UserVerifiedEmailAddedEvent.encrypted_email:type_name -> chatto.core.v1.EncryptedUserString
-	31, // 8: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
-	32, // 9: chatto.core.v1.UserCustomStatusSetEvent.status:type_name -> chatto.core.v1.CustomUserStatus
-	0,  // 10: chatto.core.v1.UserDEKGeneratedEvent.purpose:type_name -> chatto.core.v1.UserDEKPurpose
-	11, // [11:11] is the sub-list for method output_type
-	11, // [11:11] is the sub-list for method input_type
-	11, // [11:11] is the sub-list for extension type_name
-	11, // [11:11] is the sub-list for extension extendee
-	0,  // [0:11] is the sub-list for field type_name
+	1,  // 0: chatto.core.v1.UserAccountCreatedEvent.encrypted_login:type_name -> chatto.core.v1.EncryptedUserString
+	1,  // 1: chatto.core.v1.UserAccountCreatedEvent.encrypted_display_name:type_name -> chatto.core.v1.EncryptedUserString
+	1,  // 2: chatto.core.v1.UserLoginChangedEvent.encrypted_login:type_name -> chatto.core.v1.EncryptedUserString
+	1,  // 3: chatto.core.v1.UserDisplayNameChangedEvent.encrypted_display_name:type_name -> chatto.core.v1.EncryptedUserString
+	1,  // 4: chatto.core.v1.UserBioChangedEvent.encrypted_bio:type_name -> chatto.core.v1.EncryptedUserString
+	25, // 5: chatto.core.v1.UserAvatarSetEvent.avatar:type_name -> chatto.core.v1.DeprecatedAsset
+	1,  // 6: chatto.core.v1.UserVerifiedEmailAddedEvent.encrypted_email:type_name -> chatto.core.v1.EncryptedUserString
+	26, // 7: chatto.core.v1.UserServerPreferencesChangedEvent.preferences:type_name -> chatto.core.v1.ServerUserPreferences
+	27, // 8: chatto.core.v1.UserCustomStatusSetEvent.status:type_name -> chatto.core.v1.CustomUserStatus
+	0,  // 9: chatto.core.v1.UserDEKGeneratedEvent.purpose:type_name -> chatto.core.v1.UserDEKPurpose
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_chatto_core_v1_user_events_proto_init() }
@@ -1895,7 +1613,7 @@ func file_chatto_core_v1_user_events_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_core_v1_user_events_proto_rawDesc), len(file_chatto_core_v1_user_events_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   28,
+			NumMessages:   24,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/core/v1/user_events.pb.go
+++ b/cli/internal/pb/chatto/core/v1/user_events.pb.go
@@ -70,6 +70,10 @@ func (UserDEKPurpose) EnumDescriptor() ([]byte, []int) {
 	return file_chatto_core_v1_user_events_proto_rawDescGZIP(), []int{0}
 }
 
+// Deprecated: UserCreatedEvent is retained in its original source file for
+// generated-source compatibility. LiveEvent uses UserCreatedSyncEvent.
+//
+// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
 type UserCreatedEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
@@ -130,9 +134,11 @@ func (x *UserCreatedEvent) GetDisplayName() string {
 	return ""
 }
 
-// UserDeletedEvent records a durable user-account deletion fact in EVT.
-// Transient realtime delivery uses SessionTerminatedEvent for the deleted
-// user's own clients and ServerMemberDeletedEvent for server-wide invalidation.
+// Deprecated: UserDeletedEvent is retained for the deprecated LiveEvent field.
+// Current deletion delivery uses SessionTerminatedEvent for the deleted user's
+// clients and ServerMemberDeletedEvent for server-wide invalidation.
+//
+// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
 type UserDeletedEvent struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	UserId        string                 `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
@@ -265,14 +271,15 @@ func (x *UserProfileUpdatedEvent) GetTimezone() string {
 	return ""
 }
 
-// ServerUserPreferencesUpdatedEvent is published when a user updates their display preferences.
-// User-scoped private event for multi-tab/multi-device sync.
+// Deprecated: ServerUserPreferencesUpdatedEvent is retained in its original
+// source file for generated-source compatibility. LiveEvent uses
+// ServerUserPreferencesSyncEvent.
+//
+// Deprecated: Marked as deprecated in chatto/core/v1/user_events.proto.
 type ServerUserPreferencesUpdatedEvent struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// IANA timezone name (empty = cleared/browser default).
-	Timezone string `protobuf:"bytes,1,opt,name=timezone,proto3" json:"timezone,omitempty"`
-	// Time display format preference.
-	TimeFormat    TimeFormat `protobuf:"varint,2,opt,name=time_format,json=timeFormat,proto3,enum=chatto.core.v1.TimeFormat" json:"time_format,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Timezone      string                 `protobuf:"bytes,1,opt,name=timezone,proto3" json:"timezone,omitempty"`
+	TimeFormat    TimeFormat             `protobuf:"varint,2,opt,name=time_format,json=timeFormat,proto3,enum=chatto.core.v1.TimeFormat" json:"time_format,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1694,13 +1701,13 @@ var File_chatto_core_v1_user_events_proto protoreflect.FileDescriptor
 
 const file_chatto_core_v1_user_events_proto_rawDesc = "" +
 	"\n" +
-	" chatto/core/v1/user_events.proto\x12\x0echatto.core.v1\x1a%chatto/core/v1/user_preferences.proto\x1a\x1bchatto/core/v1/models.proto\"d\n" +
+	" chatto/core/v1/user_events.proto\x12\x0echatto.core.v1\x1a%chatto/core/v1/user_preferences.proto\x1a\x1bchatto/core/v1/models.proto\"h\n" +
 	"\x10UserCreatedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12\x14\n" +
 	"\x05login\x18\x02 \x01(\tR\x05login\x12!\n" +
-	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName\"+\n" +
+	"\fdisplay_name\x18\x03 \x01(\tR\vdisplayName:\x02\x18\x01\"/\n" +
 	"\x10UserDeletedEvent\x12\x17\n" +
-	"\auser_id\x18\x01 \x01(\tR\x06userId\"\xbc\x01\n" +
+	"\auser_id\x18\x01 \x01(\tR\x06userId:\x02\x18\x01\"\xbc\x01\n" +
 	"\x17UserProfileUpdatedEvent\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12!\n" +
 	"\fdisplay_name\x18\x02 \x01(\tR\vdisplayName\x12\x1d\n" +
@@ -1708,11 +1715,11 @@ const file_chatto_core_v1_user_events_proto_rawDesc = "" +
 	"avatar_url\x18\x03 \x01(\tR\tavatarUrl\x12\x14\n" +
 	"\x05login\x18\x04 \x01(\tR\x05login\x12\x10\n" +
 	"\x03bio\x18\x05 \x01(\tR\x03bio\x12\x1a\n" +
-	"\btimezone\x18\x06 \x01(\tR\btimezone:\x02\x18\x01\"|\n" +
+	"\btimezone\x18\x06 \x01(\tR\btimezone:\x02\x18\x01\"\x80\x01\n" +
 	"!ServerUserPreferencesUpdatedEvent\x12\x1a\n" +
 	"\btimezone\x18\x01 \x01(\tR\btimezone\x12;\n" +
 	"\vtime_format\x18\x02 \x01(\x0e2\x1a.chatto.core.v1.TimeFormatR\n" +
-	"timeFormat\"\x80\x01\n" +
+	"timeFormat:\x02\x18\x01\"\x80\x01\n" +
 	"\x13EncryptedUserString\x12'\n" +
 	"\x0fencrypted_value\x18\x01 \x01(\fR\x0eencryptedValue\x12\x14\n" +
 	"\x05nonce\x18\x02 \x01(\fR\x05nonce\x12*\n" +

--- a/proto/AGENTS.md
+++ b/proto/AGENTS.md
@@ -29,6 +29,14 @@ For public API packages:
 
 ## Compatibility
 
+- Put new durable `Event` payloads in the applicable domain `*_events.proto`
+  file. Put new payloads that are used only by `LiveEvent` in
+  `chatto/core/v1/live_events.proto`.
+- Protobuf file placement affects generated-source compatibility. Do not move
+  an existing symbol to a different file only to reorganize it. Keep a
+  deprecated symbol in its original file, and define an active replacement in
+  the correct file when necessary. Do not create a general `deprecated.proto`
+  file.
 - The public auth, discovery, integration, admin, and realtime `v1` packages
   are experimental while Chatto is pre-1.0. Prefer compatibility. A breaking
   change requires explicit user approval, a design benefit, a compatibility

--- a/proto/AGENTS.md
+++ b/proto/AGENTS.md
@@ -32,11 +32,11 @@ For public API packages:
 - Put new durable `Event` payloads in the applicable domain `*_events.proto`
   file. Put new payloads that are used only by `LiveEvent` in
   `chatto/core/v1/live_events.proto`.
-- Protobuf file placement affects generated-source compatibility. Do not move
-  an existing symbol to a different file only to reorganize it. Keep a
-  deprecated symbol in its original file, and define an active replacement in
-  the correct file when necessary. Do not create a general `deprecated.proto`
-  file.
+- Protobuf file placement affects generated source code. Never move a persisted
+  symbol only to reorganize it. A transient symbol that is in the wrong file
+  can move as an approved source-breaking change. Do not keep a dead alias only
+  for generated-source compatibility, and do not create a general
+  `deprecated.proto` file.
 - The public auth, discovery, integration, admin, and realtime `v1` packages
   are experimental while Chatto is pre-1.0. Prefer compatibility. A breaking
   change requires explicit user approval, a design benefit, a compatibility

--- a/proto/chatto/core/v1/live_events.proto
+++ b/proto/chatto/core/v1/live_events.proto
@@ -44,14 +44,14 @@ message LiveEvent {
 
   oneof event {
     // ----- User lifecycle / preferences -----
-    UserCreatedEvent user_created = 20;
+    UserCreatedSyncEvent user_created = 20;
     // Deprecated. Account deletion no longer publishes this transient signal;
     // clients receive session_terminated for the deleted user's own sessions and
     // server_member_deleted for server-wide invalidation.
     UserDeletedEvent user_deleted = 21 [deprecated = true];
     // Transient current-profile snapshot derived after a durable profile change.
     UserProfileSyncEvent user_profile_updated = 22;
-    ServerUserPreferencesUpdatedEvent server_user_preferences_updated = 23;
+    ServerUserPreferencesSyncEvent server_user_preferences_updated = 23;
     ThreadFollowChangedEvent thread_follow_changed = 25;
 
     // ----- Server membership / lifecycle -----
@@ -95,8 +95,15 @@ message LiveEvent {
 message HeartbeatEvent {}
 
 // ============================================================================
-// USER PROFILE SYNC
+// USER LIFECYCLE, PROFILE, AND PREFERENCE SYNC
 // ============================================================================
+
+// UserCreatedSyncEvent reports a newly created public user profile.
+message UserCreatedSyncEvent {
+  string user_id = 1;
+  string login = 2;
+  string display_name = 3;
+}
 
 // UserProfileSyncEvent is a transient, projection-derived live snapshot. It
 // is published after a public profile field changes and is never stored in EVT.
@@ -112,6 +119,15 @@ message UserProfileSyncEvent {
   string bio = 5;
   // The user's shared IANA time zone, or empty when none is shared.
   string timezone = 6;
+}
+
+// ServerUserPreferencesSyncEvent reports updated user display preferences for
+// synchronization between the user's active clients.
+message ServerUserPreferencesSyncEvent {
+  // IANA time zone name. An empty value selects the browser default.
+  string timezone = 1;
+  // Preferred time display format.
+  TimeFormat time_format = 2;
 }
 
 // ============================================================================

--- a/proto/chatto/core/v1/live_events.proto
+++ b/proto/chatto/core/v1/live_events.proto
@@ -4,7 +4,6 @@ package chatto.core.v1;
 
 import "google/protobuf/timestamp.proto";
 import "chatto/core/v1/room_events.proto";
-import "chatto/core/v1/user_events.proto";
 import "chatto/core/v1/user_preferences.proto";
 
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
@@ -38,17 +37,14 @@ message LiveEvent {
   // ID of the user or system actor that triggered this signal.
   string actor_id = 3;
 
-  reserved 10, 24, 41, 50, 51, 70, 71;
+  reserved 10, 21, 24, 41, 50, 51, 70, 71;
   reserved "config_updated", "notification_level_changed", "video_processing_completed",
-    "mention_notification", "new_direct_message_notification", "notification_created", "notification_dismissed";
+    "mention_notification", "new_direct_message_notification", "notification_created", "notification_dismissed",
+    "user_deleted";
 
   oneof event {
     // ----- User lifecycle / preferences -----
     UserCreatedSyncEvent user_created = 20;
-    // Deprecated. Account deletion no longer publishes this transient signal;
-    // clients receive session_terminated for the deleted user's own sessions and
-    // server_member_deleted for server-wide invalidation.
-    UserDeletedEvent user_deleted = 21 [deprecated = true];
     // Transient current-profile snapshot derived after a durable profile change.
     UserProfileSyncEvent user_profile_updated = 22;
     ServerUserPreferencesSyncEvent server_user_preferences_updated = 23;

--- a/proto/chatto/core/v1/user_events.proto
+++ b/proto/chatto/core/v1/user_events.proto
@@ -8,26 +8,32 @@ import "chatto/core/v1/models.proto";
 option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 
 // ============================================================================
-// USER LIFECYCLE EVENTS (server-scoped)
+// USER EVENTS
 //
 // Top-level Event oneof tags owned by this file:
-//   - 700-721: durable user aggregate events on evt.user.{userId}.*
-//   - 1010-1015: live-only user lifecycle and preference broadcasts
+//   - 700-722: durable user aggregate events on evt.user.{userId}.*
 //
-// Keep these tags coordinated with event.proto. Message-internal field numbers
-// are local to each message and do not consume top-level Event tag space.
+// This file also retains deprecated live-only messages in their original file
+// for generated-source compatibility. New live-only messages belong in
+// live_events.proto.
 // ============================================================================
 
+// Deprecated: UserCreatedEvent is retained in its original source file for
+// generated-source compatibility. LiveEvent uses UserCreatedSyncEvent.
 message UserCreatedEvent {
+  option deprecated = true;
+
   string user_id = 1;
   string login = 2;
   string display_name = 3;
 }
 
-// UserDeletedEvent records a durable user-account deletion fact in EVT.
-// Transient realtime delivery uses SessionTerminatedEvent for the deleted
-// user's own clients and ServerMemberDeletedEvent for server-wide invalidation.
+// Deprecated: UserDeletedEvent is retained for the deprecated LiveEvent field.
+// Current deletion delivery uses SessionTerminatedEvent for the deleted user's
+// clients and ServerMemberDeletedEvent for server-wide invalidation.
 message UserDeletedEvent {
+  option deprecated = true;
+
   string user_id = 1;
 }
 
@@ -44,16 +50,13 @@ message UserProfileUpdatedEvent {
   string timezone = 6;
 }
 
-// ============================================================================
-// USER PREFERENCE EVENTS (user-scoped)
-// ============================================================================
-
-// ServerUserPreferencesUpdatedEvent is published when a user updates their display preferences.
-// User-scoped private event for multi-tab/multi-device sync.
+// Deprecated: ServerUserPreferencesUpdatedEvent is retained in its original
+// source file for generated-source compatibility. LiveEvent uses
+// ServerUserPreferencesSyncEvent.
 message ServerUserPreferencesUpdatedEvent {
-  // IANA timezone name (empty = cleared/browser default).
+  option deprecated = true;
+
   string timezone = 1;
-  // Time display format preference.
   TimeFormat time_format = 2;
 }
 

--- a/proto/chatto/core/v1/user_events.proto
+++ b/proto/chatto/core/v1/user_events.proto
@@ -12,53 +12,7 @@ option go_package = "hmans.de/chatto/internal/pb/chatto/core/v1;corev1";
 //
 // Top-level Event oneof tags owned by this file:
 //   - 700-722: durable user aggregate events on evt.user.{userId}.*
-//
-// This file also retains deprecated live-only messages in their original file
-// for generated-source compatibility. New live-only messages belong in
-// live_events.proto.
 // ============================================================================
-
-// Deprecated: UserCreatedEvent is retained in its original source file for
-// generated-source compatibility. LiveEvent uses UserCreatedSyncEvent.
-message UserCreatedEvent {
-  option deprecated = true;
-
-  string user_id = 1;
-  string login = 2;
-  string display_name = 3;
-}
-
-// Deprecated: UserDeletedEvent is retained for the deprecated LiveEvent field.
-// Current deletion delivery uses SessionTerminatedEvent for the deleted user's
-// clients and ServerMemberDeletedEvent for server-wide invalidation.
-message UserDeletedEvent {
-  option deprecated = true;
-
-  string user_id = 1;
-}
-
-// Deprecated: UserProfileUpdatedEvent is retained in its original source file
-// for generated-source compatibility. LiveEvent uses UserProfileSyncEvent.
-message UserProfileUpdatedEvent {
-  option deprecated = true;
-
-  string user_id = 1;
-  string display_name = 2;
-  string avatar_url = 3;
-  string login = 4;
-  string bio = 5;
-  string timezone = 6;
-}
-
-// Deprecated: ServerUserPreferencesUpdatedEvent is retained in its original
-// source file for generated-source compatibility. LiveEvent uses
-// ServerUserPreferencesSyncEvent.
-message ServerUserPreferencesUpdatedEvent {
-  option deprecated = true;
-
-  string timezone = 1;
-  TimeFormat time_format = 2;
-}
 
 // ============================================================================
 // DURABLE USER EVENTS (evt.user.{userId})

--- a/tools/check-storage-proto-breaking.mjs
+++ b/tools/check-storage-proto-breaking.mjs
@@ -2,52 +2,6 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const against = process.argv[2];
-if (!against) {
-  console.error("usage: check-storage-proto-breaking.mjs <against-input>");
-  process.exit(2);
-}
-
-const scriptDir = path.dirname(fileURLToPath(import.meta.url));
-const protoDir = path.resolve(scriptDir, "../proto");
-const result = spawnSync(
-  "buf",
-  [
-    "breaking",
-    ".",
-    "--against",
-    against,
-    "--exclude-imports",
-    "--exclude-path",
-    "chatto/auth/v1",
-    "--exclude-path",
-    "chatto/discovery/v1",
-    "--exclude-path",
-    "chatto/api/v1",
-    "--exclude-path",
-    "chatto/admin/v1",
-    "--exclude-path",
-    "chatto/realtime/v1",
-    "--exclude-path",
-    "chatto/core/v1/live_events.proto",
-    "--exclude-path",
-    "chatto/core/v1/projection_snapshots.proto",
-    "--error-format=json",
-  ],
-  { cwd: protoDir, encoding: "utf8" },
-);
-
-if (result.error) {
-  throw result.error;
-}
-if (result.stderr) {
-  process.stderr.write(result.stderr);
-}
-if (result.status === 0) {
-  if (result.stdout) process.stdout.write(result.stdout);
-  process.exit(0);
-}
-
 // These messages were transient LiveEvent payloads that were incorrectly
 // declared in the durable user-events file. They were never stored in EVT.
 const allowedTransientMessages = new Set([
@@ -57,35 +11,93 @@ const allowedTransientMessages = new Set([
   "UserProfileUpdatedEvent",
 ]);
 
-let diagnostics;
-try {
-  diagnostics = result.stdout
-    .split("\n")
-    .filter(Boolean)
-    .map((line) => JSON.parse(line));
-} catch {
-  process.stdout.write(result.stdout);
-  process.exit(result.status ?? 1);
-}
-
-const unexpected = diagnostics.filter((diagnostic) => {
+export function isAllowedStorageBreakingDiagnostic(diagnostic) {
   if (
     diagnostic.path !== "chatto/core/v1/user_events.proto" ||
     diagnostic.type !== "MESSAGE_NO_DELETE"
   ) {
-    return true;
+    return false;
   }
   const match = diagnostic.message.match(
     /^Previously present message "([^"]+)" was deleted from file\.$/,
   );
-  return !match || !allowedTransientMessages.has(match[1]);
-});
-
-if (diagnostics.length === 0 || unexpected.length > 0) {
-  process.stdout.write(result.stdout);
-  process.exit(result.status ?? 1);
+  return Boolean(match && allowedTransientMessages.has(match[1]));
 }
 
-for (const diagnostic of diagnostics) {
-  console.log(`Allowed transient schema cleanup: ${diagnostic.message}`);
+function main() {
+  const against = process.argv[2];
+  if (!against) {
+    console.error("usage: check-storage-proto-breaking.mjs <against-input>");
+    process.exit(2);
+  }
+
+  const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+  const protoDir = path.resolve(scriptDir, "../proto");
+  const result = spawnSync(
+    "buf",
+    [
+      "breaking",
+      ".",
+      "--against",
+      against,
+      "--exclude-imports",
+      "--exclude-path",
+      "chatto/auth/v1",
+      "--exclude-path",
+      "chatto/discovery/v1",
+      "--exclude-path",
+      "chatto/api/v1",
+      "--exclude-path",
+      "chatto/admin/v1",
+      "--exclude-path",
+      "chatto/realtime/v1",
+      "--exclude-path",
+      "chatto/core/v1/live_events.proto",
+      "--exclude-path",
+      "chatto/core/v1/projection_snapshots.proto",
+      "--error-format=json",
+    ],
+    { cwd: protoDir, encoding: "utf8" },
+  );
+
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.stderr) {
+    process.stderr.write(result.stderr);
+  }
+  if (result.status === 0) {
+    if (result.stdout) process.stdout.write(result.stdout);
+    process.exit(0);
+  }
+
+  let diagnostics;
+  try {
+    diagnostics = result.stdout
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line));
+  } catch {
+    process.stdout.write(result.stdout);
+    process.exit(result.status ?? 1);
+  }
+
+  const unexpected = diagnostics.filter(
+    (diagnostic) => !isAllowedStorageBreakingDiagnostic(diagnostic),
+  );
+  if (diagnostics.length === 0 || unexpected.length > 0) {
+    process.stdout.write(result.stdout);
+    process.exit(result.status ?? 1);
+  }
+
+  for (const diagnostic of diagnostics) {
+    console.log(`Allowed transient schema cleanup: ${diagnostic.message}`);
+  }
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main();
 }

--- a/tools/check-storage-proto-breaking.mjs
+++ b/tools/check-storage-proto-breaking.mjs
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const against = process.argv[2];
+if (!against) {
+  console.error("usage: check-storage-proto-breaking.mjs <against-input>");
+  process.exit(2);
+}
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const protoDir = path.resolve(scriptDir, "../proto");
+const result = spawnSync(
+  "buf",
+  [
+    "breaking",
+    ".",
+    "--against",
+    against,
+    "--exclude-imports",
+    "--exclude-path",
+    "chatto/auth/v1",
+    "--exclude-path",
+    "chatto/discovery/v1",
+    "--exclude-path",
+    "chatto/api/v1",
+    "--exclude-path",
+    "chatto/admin/v1",
+    "--exclude-path",
+    "chatto/realtime/v1",
+    "--exclude-path",
+    "chatto/core/v1/live_events.proto",
+    "--exclude-path",
+    "chatto/core/v1/projection_snapshots.proto",
+    "--error-format=json",
+  ],
+  { cwd: protoDir, encoding: "utf8" },
+);
+
+if (result.error) {
+  throw result.error;
+}
+if (result.stderr) {
+  process.stderr.write(result.stderr);
+}
+if (result.status === 0) {
+  if (result.stdout) process.stdout.write(result.stdout);
+  process.exit(0);
+}
+
+// These messages were transient LiveEvent payloads that were incorrectly
+// declared in the durable user-events file. They were never stored in EVT.
+const allowedTransientMessages = new Set([
+  "ServerUserPreferencesUpdatedEvent",
+  "UserCreatedEvent",
+  "UserDeletedEvent",
+  "UserProfileUpdatedEvent",
+]);
+
+let diagnostics;
+try {
+  diagnostics = result.stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+} catch {
+  process.stdout.write(result.stdout);
+  process.exit(result.status ?? 1);
+}
+
+const unexpected = diagnostics.filter((diagnostic) => {
+  if (
+    diagnostic.path !== "chatto/core/v1/user_events.proto" ||
+    diagnostic.type !== "MESSAGE_NO_DELETE"
+  ) {
+    return true;
+  }
+  const match = diagnostic.message.match(
+    /^Previously present message "([^"]+)" was deleted from file\.$/,
+  );
+  return !match || !allowedTransientMessages.has(match[1]);
+});
+
+if (diagnostics.length === 0 || unexpected.length > 0) {
+  process.stdout.write(result.stdout);
+  process.exit(result.status ?? 1);
+}
+
+for (const diagnostic of diagnostics) {
+  console.log(`Allowed transient schema cleanup: ${diagnostic.message}`);
+}

--- a/tools/check-storage-proto-breaking.test.mjs
+++ b/tools/check-storage-proto-breaking.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { isAllowedStorageBreakingDiagnostic } from "./check-storage-proto-breaking.mjs";
+
+const allowedMessages = [
+  "ServerUserPreferencesUpdatedEvent",
+  "UserCreatedEvent",
+  "UserDeletedEvent",
+  "UserProfileUpdatedEvent",
+];
+
+for (const message of allowedMessages) {
+  test(`allows removal of transient ${message}`, () => {
+    assert.equal(
+      isAllowedStorageBreakingDiagnostic({
+        path: "chatto/core/v1/user_events.proto",
+        type: "MESSAGE_NO_DELETE",
+        message: `Previously present message "${message}" was deleted from file.`,
+      }),
+      true,
+    );
+  });
+}
+
+test("rejects removal of a durable user event", () => {
+  assert.equal(
+    isAllowedStorageBreakingDiagnostic({
+      path: "chatto/core/v1/user_events.proto",
+      type: "MESSAGE_NO_DELETE",
+      message:
+        'Previously present message "UserAccountCreatedEvent" was deleted from file.',
+    }),
+    false,
+  );
+});
+
+test("rejects other breaking rules for an allowed message", () => {
+  assert.equal(
+    isAllowedStorageBreakingDiagnostic({
+      path: "chatto/core/v1/user_events.proto",
+      type: "FIELD_NO_DELETE",
+      message:
+        'Previously present message "UserCreatedEvent" was deleted from file.',
+    }),
+    false,
+  );
+});


### PR DESCRIPTION
## Why

Transient `LiveEvent` payloads lived in the durable user-events schema, which obscured the storage boundary and encouraged dead generated aliases.

## What changed

- Move active user-created, profile, and preference-sync payloads into `live_events.proto`; remove four obsolete generated types and reserve the retired `user_deleted` tag and name.
- Add an exact, tested storage-check allowance for those never-persisted deletions while all other durable breaks still fail, and document the placement rule in `proto/AGENTS.md`.

## API compatibility

Breaking generated-source change with no public API or runtime wire-behavior change: older and newer servers decode the same live field numbers and nested layouts in both directions; no capability or minimum version is required, but internal constructors must use the new `*SyncEvent` types.

## Test plan

`mise codegen-proto`, `mise test-cli`, focused core/realtime tests, storage compatibility and allowlist tests, `mise lint-cli`, `mise license-check`, `actionlint` without unavailable local ShellCheck integration, and `git diff --check` passed.