### PR TITLE
refactor(frontend): consolidate UI foundations

### DIFF
--- a/apps/frontend/src/lib/components/admin/index.ts
+++ b/apps/frontend/src/lib/components/admin/index.ts
@@ -1,3 +1,2 @@
-export { default as StatCard } from './StatCard.svelte';
 export { default as UserList } from './UserList.svelte';
 export { formatBytes, formatNumber } from './format';

--- a/apps/frontend/src/lib/demos/AdminDashboard.stories.svelte
+++ b/apps/frontend/src/lib/demos/AdminDashboard.stories.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <script lang="ts">
-  import StatCard from '$lib/components/admin/StatCard.svelte';
+  import StatCard from '$lib/ui/StatCard.svelte';
   import Panel from '$lib/ui/Panel.svelte';
   import DataTable from '$lib/ui/DataTable.svelte';
   import CopyId from '$lib/ui/CopyId.svelte';

--- a/apps/frontend/src/lib/demos/PermissionEditor.stories.svelte
+++ b/apps/frontend/src/lib/demos/PermissionEditor.stories.svelte
@@ -4,13 +4,6 @@
   const { Story } = defineMeta({
     title: 'Demos/Permission editor'
   });
-</script>
-
-<script lang="ts">
-  import Pill from '$lib/ui/Pill.svelte';
-  import ToggleChip from '$lib/ui/ToggleChip.svelte';
-  import HelpTooltip from '$lib/ui/HelpTooltip.svelte';
-  import Hint from '$lib/ui/Hint.svelte';
 
   type State = 'allow' | 'deny' | 'neutral';
 
@@ -18,9 +11,27 @@
     id: string;
     label: string;
     help: string;
-    inherited: 'allow' | 'deny' | 'neutral';
+    inherited: State;
     state: State;
   };
+
+  type PermissionColumn = {
+    id: 'inherited' | 'override';
+    label: string;
+  };
+</script>
+
+<script lang="ts">
+  import Pill from '$lib/ui/Pill.svelte';
+  import HelpTooltip from '$lib/ui/HelpTooltip.svelte';
+  import Hint from '$lib/ui/Hint.svelte';
+  import MatrixCellButton from '$lib/ui/matrix/MatrixCellButton.svelte';
+  import MatrixTable from '$lib/ui/matrix/MatrixTable.svelte';
+
+  const columns: PermissionColumn[] = [
+    { id: 'inherited', label: 'Inherited' },
+    { id: 'override', label: 'Room override' }
+  ];
 
   let permissions = $state<Permission[]>([
     {
@@ -60,8 +71,8 @@
     }
   ]);
 
-  function set(perm: Permission, target: State) {
-    perm.state = perm.state === target ? 'neutral' : target;
+  function cycle(perm: Permission) {
+    perm.state = perm.state === 'neutral' ? 'allow' : perm.state === 'allow' ? 'deny' : 'neutral';
   }
 
   function effective(perm: Permission): 'allow' | 'deny' {
@@ -82,59 +93,84 @@
     </header>
 
     <Hint tone="info">
-      Allow / Deny here override what's inherited from the space-level role.
-      Leave both released to inherit.
+      Activate an override cell to cycle between inherit, allow, and deny.
+      The inherited value still shows the space-level role.
     </Hint>
 
-    <table class="mt-6 w-full">
-      <thead>
-        <tr class="border-b border-border text-left text-xs uppercase text-muted">
-          <th class="pb-2">Permission</th>
-          <th class="pb-2">Inherited</th>
-          <th class="pb-2">Override</th>
-          <th class="pb-2">Effective</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each permissions as perm (perm.id)}
-          <tr class="border-b border-border/40">
-            <td class="py-3">
-              <div class="flex items-center gap-2">
-                <code class="font-mono text-sm">{perm.label}</code>
-                <HelpTooltip>{perm.help}</HelpTooltip>
-              </div>
-            </td>
-            <td class="py-3">
-              <Pill tone={perm.inherited === 'allow' ? 'success' : perm.inherited === 'deny' ? 'danger' : 'muted'} dimmed>
-                {perm.inherited === 'neutral' ? 'inherit' : perm.inherited}
-              </Pill>
-            </td>
-            <td class="py-3">
-              <div class="flex gap-2">
-                <ToggleChip
-                  tone="success"
-                  pressed={perm.state === 'allow'}
-                  onclick={() => set(perm, 'allow')}
-                >
-                  Allow
-                </ToggleChip>
-                <ToggleChip
-                  tone="danger"
-                  pressed={perm.state === 'deny'}
-                  onclick={() => set(perm, 'deny')}
-                >
-                  Deny
-                </ToggleChip>
-              </div>
-            </td>
-            <td class="py-3">
-              <Pill tone={effective(perm) === 'allow' ? 'success' : 'danger'}>
-                {effective(perm)}
-              </Pill>
-            </td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
+    <div class="mt-6">
+      <MatrixTable
+        rows={permissions}
+        {columns}
+        getRowKey={(permission) => permission.id}
+        getColumnKey={(column) => column.id}
+        isCellInteractive={(_, column) => column.id === 'override'}
+        emptyMessage="No permissions found"
+        leadingHeader={permissionHeader}
+        rowHeader={permissionRow}
+        columnHeader={permissionColumn}
+        cell={permissionCell}
+        trailingHeader={effectiveHeader}
+        trailingCell={effectiveCell}
+        trailingColumns={1}
+        rowHeaderWidth="18rem"
+      />
+    </div>
   </div>
 </Story>
+
+{#snippet permissionHeader()}
+  Permission
+{/snippet}
+
+{#snippet permissionRow(permission: Permission, highlighted: boolean)}
+  <div class="flex items-center gap-2">
+    <code class={['font-mono text-sm', highlighted ? 'text-action' : '']}>{permission.label}</code>
+    <HelpTooltip>{permission.help}</HelpTooltip>
+  </div>
+{/snippet}
+
+{#snippet permissionColumn(column: PermissionColumn, highlighted: boolean)}
+  <span class={highlighted ? 'text-action' : 'text-muted'}>{column.label}</span>
+{/snippet}
+
+{#snippet permissionCell(permission: Permission, column: PermissionColumn)}
+  {#if column.id === 'inherited'}
+    <Pill
+      tone={permission.inherited === 'allow'
+        ? 'success'
+        : permission.inherited === 'deny'
+          ? 'danger'
+          : 'muted'}
+      compact
+    >
+      {permission.inherited === 'neutral' ? 'inherit' : permission.inherited}
+    </Pill>
+  {:else}
+    <MatrixCellButton
+      tone={permission.state === 'deny' ? 'danger' : 'success'}
+      explicit={permission.state !== 'neutral'}
+      inheritedMarker={permission.state === 'neutral'}
+      icon={permission.state === 'deny'
+        ? 'icon-[uil--times]'
+        : permission.state === 'allow'
+          ? 'icon-[uil--check]'
+          : 'icon-[uil--link]'}
+      pressed={permission.state !== 'neutral'}
+      ariaLabel={`Override ${permission.label}: ${permission.state}. Activate to cycle the value.`}
+      title="Cycle inherit, allow, deny"
+      onActivate={() => cycle(permission)}
+    />
+  {/if}
+{/snippet}
+
+{#snippet effectiveHeader()}
+  <th class="bg-background px-4 py-3 text-start align-bottom font-medium">Effective</th>
+{/snippet}
+
+{#snippet effectiveCell(permission: Permission)}
+  <td class="bg-background px-4 py-2">
+    <Pill tone={effective(permission) === 'allow' ? 'success' : 'danger'}>
+      {effective(permission)}
+    </Pill>
+  </td>
+{/snippet}

--- a/apps/frontend/src/lib/ui/AppHeader.stories.svelte
+++ b/apps/frontend/src/lib/ui/AppHeader.stories.svelte
@@ -1,0 +1,16 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import AppHeader from './AppHeader.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/App header',
+    component: AppHeader,
+    tags: ['autodocs']
+  });
+</script>
+
+<Story name="Unauthenticated shell" asChild>
+  <div class="max-w-4xl rounded-lg bg-background p-2 ring-1 ring-border">
+    <AppHeader />
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/DataTable.stories.svelte
+++ b/apps/frontend/src/lib/ui/DataTable.stories.svelte
@@ -3,6 +3,7 @@
   import DataTable from './DataTable.svelte';
   import Panel from './Panel.svelte';
   import CopyId from './CopyId.svelte';
+  import EmptyState from './EmptyState.svelte';
   import Pill from '$lib/ui/Pill.svelte';
   import { Button } from '$lib/ui/form';
 
@@ -133,7 +134,8 @@
   parameters={{
     docs: {
       description: {
-        story: 'Use `emptyMessage` to keep empty admin lists quiet and direct.'
+        story:
+          'Use `emptyMessage` for a quiet empty list, or the `empty` snippet when the next useful action belongs in the table.'
       }
     }
   }}
@@ -143,10 +145,20 @@
       <DataTable
         items={[]}
         columns={4}
-        emptyMessage="No spaces found"
         header={tableHeader}
         row={tableRow}
-      />
+      >
+        {#snippet empty()}
+          <div class="flex min-h-52 flex-col">
+            <EmptyState icon="icon-[uil--building]" title="No spaces yet">
+              Create a space to organise conversations for a group of members.
+              <div class="mt-4">
+                <Button size="sm">Create space</Button>
+              </div>
+            </EmptyState>
+          </div>
+        {/snippet}
+      </DataTable>
     </Panel>
   </div>
 </Story>

--- a/apps/frontend/src/lib/ui/DataTable.svelte
+++ b/apps/frontend/src/lib/ui/DataTable.svelte
@@ -17,6 +17,7 @@ and optional incremental loading.
     header,
     row,
     emptyMessage = m('ui.data_table.empty'),
+    empty,
     onRowClick,
     getKey,
     getGroupKey,
@@ -37,7 +38,9 @@ and optional incremental loading.
     columns: number;
     header: Snippet;
     row: Snippet<[T]>;
+    /** Optional rich empty-state content. Takes precedence over `emptyMessage`. */
     emptyMessage?: string;
+    empty?: Snippet;
     onRowClick?: (item: T) => void;
     getKey?: (item: T, index: number) => unknown;
     getGroupKey?: (item: T, index: number) => string | null | undefined;
@@ -163,7 +166,13 @@ and optional incremental loading.
         </tr>
       {:else}
         <tr>
-          <td colspan={columns} class="px-4 py-8 text-center text-muted">{emptyMessage}</td>
+          <td colspan={columns} class={empty ? 'p-0' : 'px-4 py-8 text-center text-muted'}>
+            {#if empty}
+              {@render empty()}
+            {:else}
+              {emptyMessage}
+            {/if}
+          </td>
         </tr>
       {/each}
 

--- a/apps/frontend/src/lib/ui/DataTable.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/DataTable.svelte.spec.ts
@@ -66,6 +66,7 @@ function renderTable(
     loadingMore?: boolean;
     onLoadMore?: () => void | Promise<void>;
     loadMoreRoot?: HTMLElement;
+    empty?: ReturnType<typeof testSnippet>;
   } = {}
 ) {
   return render(DataTable, {
@@ -104,6 +105,24 @@ describe('DataTable.hoverable', () => {
     const { container } = renderTable({ hoverable: false });
     const tr = container.querySelector('tbody tr') as HTMLElement;
     expect(tr.className).not.toContain('hover:bg-surface/70');
+  });
+
+  it('renders rich empty content instead of the fallback message', () => {
+    const { container } = render(DataTable, {
+      props: {
+        items: [],
+        columns: 1,
+        emptyMessage: 'No records',
+        empty: testSnippet('<div data-testid="rich-empty">Create a record</div>'),
+        header: testSnippet('<th>Name</th>'),
+        row: testSnippet('<td>row</td>')
+      }
+    });
+
+    expect(container.querySelector('[data-testid="rich-empty"]')?.textContent).toBe(
+      'Create a record'
+    );
+    expect(container.textContent).not.toContain('No records');
   });
 
   it('uses the shared table viewport beneath the surface header', async () => {

--- a/apps/frontend/src/lib/ui/FloatingPopover.stories.svelte
+++ b/apps/frontend/src/lib/ui/FloatingPopover.stories.svelte
@@ -1,0 +1,59 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import FloatingPopover from './FloatingPopover.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/Floating popover',
+    component: FloatingPopover,
+    tags: ['autodocs']
+  });
+</script>
+
+<script lang="ts">
+  let trigger: HTMLButtonElement;
+  let anchor = $state<{ top: number; bottom: number; left: number } | null>(null);
+  let open = $state(false);
+
+  function toggle() {
+    if (open) {
+      open = false;
+      return;
+    }
+
+    const rect = trigger.getBoundingClientRect();
+    anchor = { top: rect.top, bottom: rect.bottom, left: rect.left };
+    open = true;
+  }
+
+  function captureTrigger(element: HTMLButtonElement) {
+    trigger = element;
+  }
+</script>
+
+<Story name="Anchored menu" asChild>
+  <div class="flex min-h-52 items-center justify-center rounded-lg bg-background p-6">
+    <button
+      {@attach captureTrigger}
+      type="button"
+      class="btn-secondary"
+      aria-expanded={open}
+      onclick={toggle}
+    >
+      Open menu
+    </button>
+
+    {#if open}
+      <FloatingPopover
+        {anchor}
+        role="menu"
+        ariaLabel="Example menu"
+        class="menu min-w-44 p-1 shadow-lg"
+        onclose={() => (open = false)}
+      >
+        <button type="button" class="menu-item" role="menuitem">Rename</button>
+        <button type="button" class="menu-item" role="menuitem">Move to folder</button>
+        <button type="button" class="menu-item text-danger" role="menuitem">Archive</button>
+      </FloatingPopover>
+    {/if}
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/Frame.stories.svelte
+++ b/apps/frontend/src/lib/ui/Frame.stories.svelte
@@ -1,0 +1,26 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import Frame from './Frame.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/Frame',
+    component: Frame,
+    tags: ['autodocs']
+  });
+</script>
+
+<Story name="Application surface" asChild>
+  <div class="flex h-80 max-w-4xl bg-surface p-4">
+    <Frame>
+      <aside class="w-48 border-e border-border bg-surface p-4">
+        <p class="font-medium">Spaces</p>
+        <p class="mt-3 text-sm text-muted">Product</p>
+        <p class="mt-2 text-sm text-muted">Support</p>
+      </aside>
+      <main class="flex-1 p-6">
+        <h1 class="text-xl font-semibold">General</h1>
+        <p class="mt-2 text-muted">The frame provides the shared application boundary.</p>
+      </main>
+    </Frame>
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/ImageModal.stories.svelte
+++ b/apps/frontend/src/lib/ui/ImageModal.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import ImageModal from './ImageModal.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/Image modal',
+    component: ImageModal,
+    tags: ['autodocs']
+  });
+</script>
+
+<script lang="ts">
+  const svgImage = (label: string, colour: string) =>
+    `data:image/svg+xml,${encodeURIComponent(
+      `<svg xmlns="http://www.w3.org/2000/svg" width="960" height="640" viewBox="0 0 960 640"><rect width="960" height="640" fill="${colour}"/><circle cx="480" cy="280" r="150" fill="white" fill-opacity=".18"/><text x="480" y="540" fill="white" font-family="sans-serif" font-size="48" text-anchor="middle">${label}</text></svg>`
+    )}`;
+
+  const images = [
+    { id: 'first', src: svgImage('Conference hall', '#0f766e'), filename: 'conference-hall.svg' },
+    { id: 'second', src: svgImage('Project board', '#4338ca'), filename: 'project-board.svg' }
+  ];
+
+  let index = $state(0);
+  let open = $state(false);
+</script>
+
+<Story name="Gallery" asChild>
+  <div class="flex min-h-52 items-center justify-center rounded-lg bg-background p-6">
+    <button type="button" class="btn-action" onclick={() => (open = true)}>Open gallery</button>
+    {#if open}
+      <ImageModal items={images} bind:index onclose={() => (open = false)} />
+    {/if}
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/MotdContent.stories.svelte
+++ b/apps/frontend/src/lib/ui/MotdContent.stories.svelte
@@ -1,0 +1,16 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import MotdContent from './MotdContent.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/Message of the day content',
+    component: MotdContent,
+    tags: ['autodocs']
+  });
+</script>
+
+<Story name="Markdown message" asChild>
+  <div class="flex max-w-3xl rounded-lg bg-background p-4">
+    <MotdContent motd="**Maintenance window:** Saturday, 10:00–11:00 UTC. [Read details](https://example.com)." />
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/PageTitle.stories.svelte
+++ b/apps/frontend/src/lib/ui/PageTitle.stories.svelte
@@ -1,0 +1,18 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import PageTitle from './PageTitle.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/Page title',
+    component: PageTitle,
+    tags: ['autodocs']
+  });
+</script>
+
+<Story name="Sets document title" asChild>
+  <PageTitle title="Server settings" />
+  <div class="max-w-xl rounded-lg bg-background p-6">
+    <h1 class="text-xl font-semibold">Server settings</h1>
+    <p class="mt-2 text-muted">This mountable helper updates the browser document title.</p>
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/StatCard.stories.svelte
+++ b/apps/frontend/src/lib/ui/StatCard.stories.svelte
@@ -3,37 +3,24 @@
   import StatCard from './StatCard.svelte';
 
   const componentDescription = `
-  Compact metric card for admin dashboards. Use it for countable operational
-  facts that benefit from quick comparison across a row. Tone should describe
-  the metric category or health, not decorate arbitrary numbers.
+  Compact metric card for operational dashboards. Use it for countable facts
+  that benefit from quick comparison across a row. Tone describes the metric
+  category or health, not arbitrary decoration.
   `.trim();
 
   const { Story } = defineMeta({
-    title: 'Admin/StatCard',
+    title: 'UI/Stat card',
     component: StatCard,
     tags: ['autodocs'],
     parameters: {
       docs: {
-        description: {
-          component: componentDescription
-        }
+        description: { component: componentDescription }
       }
     }
   });
 </script>
 
-<Story
-  name="Tones"
-  asChild
-  parameters={{
-    docs: {
-      description: {
-        story:
-          'The four tones cover neutral totals, healthy counts, warning-level attention, and failure/error metrics.'
-      }
-    }
-  }}
->
+<Story name="Tones" asChild>
   <div class="grid max-w-4xl grid-cols-1 gap-4 md:grid-cols-4">
     <StatCard
       color="action"

--- a/apps/frontend/src/lib/ui/StatCard.svelte
+++ b/apps/frontend/src/lib/ui/StatCard.svelte
@@ -1,3 +1,10 @@
+<!--
+@component
+
+Compact metric card for countable operational facts. Use it for values that
+benefit from quick comparison across a dashboard row. The tone communicates
+the category or health of the metric; it is not decorative.
+-->
 <script lang="ts">
   type Color = 'action' | 'success' | 'warning' | 'danger';
 

--- a/apps/frontend/src/lib/ui/index.ts
+++ b/apps/frontend/src/lib/ui/index.ts
@@ -33,6 +33,7 @@ export { default as ScrollFader } from './ScrollFader.svelte';
 export { default as ScrollArea } from './ScrollArea.svelte';
 export { default as SegmentedControl } from './SegmentedControl.svelte';
 export { default as SkeletonImg } from './SkeletonImg.svelte';
+export { default as StatCard } from './StatCard.svelte';
 export { default as ToggleChip } from './ToggleChip.svelte';
 export { default as TopOverlayNotice } from './TopOverlayNotice.svelte';
 export { default as UnreadDot } from './UnreadDot.svelte';

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getAdminSystemInfo } from '$lib/api-client/adminDiagnostics';
-  import { StatCard, formatBytes, formatNumber } from '$lib/components/admin';
+  import { formatBytes, formatNumber } from '$lib/components/admin';
+  import { StatCard } from '$lib/ui';
   import DataTable from '$lib/ui/DataTable.svelte';
   import Panel from '$lib/ui/Panel.svelte';
   import { Hint, PaneContent, Pill } from '$lib/ui';

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/system/+page.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
   import { getAdminSystemInfo } from '$lib/api-client/adminDiagnostics';
   import { formatBytes, formatNumber } from '$lib/components/admin';
-  import { StatCard } from '$lib/ui';
   import DataTable from '$lib/ui/DataTable.svelte';
   import Panel from '$lib/ui/Panel.svelte';
-  import { Hint, PaneContent, Pill } from '$lib/ui';
+  import { Hint, PaneContent, Pill, StatCard } from '$lib/ui';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import PageTitle from '$lib/ui/PageTitle.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';


### PR DESCRIPTION
## Why

The frontend already has shared table and matrix primitives, but the reusable metric card still lived in the Admin directory, several exported UI components had no focused visual reference, and table empty states could not present the next useful action. This PR completes that consolidation without changing product workflows.

## What changed

- Move `StatCard` into `$lib/ui` and update the system page and dashboard demo to consume the shared export.
- Rebuild the Permission Editor demo on `MatrixTable` and `MatrixCellButton`; the demo now cycles an override through inherit, allow, and deny.
- Add focused Storybook stories for `AppHeader`, `FloatingPopover`, `Frame`, `ImageModal`, `MotdContent`, `PageTitle`, and the moved stat card.
- Add an optional `DataTable` `empty` snippet. Existing callers continue to render their `emptyMessage`; the updated story shows an actionable empty state.

## Compatibility and rollout

No API, persisted-data, protocol, security, or migration change. The new DataTable option is additive, and the StatCard move updates all in-repository consumers.

## Test plan

- [x] `mise test-frontend`
- [x] `mise lint-frontend`
- [x] `mise build-frontend` (bundle-size and CSP checks included)
- [x] Chrome DevTools Storybook verification of the matrix state cycle, rich empty state, top-layer popover, and image gallery
- [x] Final adversarial review against `origin/main` at `31e61556e8ac839dfdf68e14144406c254a0dbee`