### PR TITLE
feat(frontend): refresh semantic colors and buttons

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -168,26 +168,21 @@ glow. Invalid fields follow the same treatment with the error-coloured border.
 
 Compact filled controls pair each tone with its `on-*` foreground token.
 Prominent action, success, warning, and danger buttons use dedicated fills with
-contrast-safe labels. The action colour is the single blue accent in each theme:
-primary buttons, links, focus borders, selection indicators, and compact status
-UI all derive from that same token rather than maintaining a separate button blue.
-Each theme's action token must retain WCAG AA contrast both as text on its
-surrounding work surfaces and with its paired `on-action` button label.
-Buttons frame their fills with a tight inset related to `SegmentedControl`.
-Prominent semantic buttons tint the outer border to match their fill; quieter
-secondary and ghost buttons retain the input-coloured border. The tight inset
-keeps a standalone button from looking double-framed. The frame is part of the
-standard button geometry: do not remove it from individual variants or reproduce
-it with feature-local wrappers.
+contrast-safe labels. The action colour is the single blue accent in each
+theme: primary buttons, links, focus borders, selection indicators, and compact
+status UI all derive from that same token rather than maintaining a separate
+button colour. Each theme's action token must retain WCAG AA contrast both as
+text on its surrounding work surfaces and with its paired `on-action` button
+label.
 
-A one-pixel black outer ring keeps framed controls legible on mid-tone surfaces.
-Buttons, form inputs, and `SegmentedControl` share the `control-frame` utility,
-which owns their radius, one-pixel border, and non-layout outer ring. Individual
-controls only add semantic border colours and their appropriate inset treatment.
+Buttons are flat colour controls, not framed form controls. Their fills have a
+matched tonal border. Secondary buttons use a quiet `surface-emphasized` fill and
+an input-coloured border, so they stay visible inside a `surface` card. Do not add
+local frames, shadows, gradients, or bevel effects.
 
-Button frames and `SegmentedControl` use one pixel for both the outer border and
-the inset gap. Keep these dimensions aligned so adjacent controls share the same
-optical height and edge rhythm.
+Form inputs and `SegmentedControl` share the `control-frame` utility. It owns
+their radius, one-pixel border, and non-layout black outer ring, which keeps
+framed controls legible on mid-tone surfaces. Buttons do not use `control-frame`.
 
 Surfaces form a small semantic ladder:
 

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -86,31 +86,37 @@
   --color-input: var(--color-white);
   --color-input-border: var(--color-gray-300);
 
+  /* Action keeps the familiar sky blue. Supporting hues have comparable
+     perceived weight without taking attention from the recommended action. */
   --color-action: var(--color-sky-700);
   --color-action-hover: color-mix(in srgb, var(--color-action), black 15%);
   --color-on-action: var(--color-white);
-  --color-button-success: var(--color-green-700);
-  --color-button-warning: var(--color-amber-700);
-  --color-button-danger: var(--color-red-700);
+  --color-button-success: oklch(49% 0.13 163);
+  --color-button-success-hover: color-mix(in oklch, var(--color-button-success), black 10%);
+  --color-button-warning: oklch(53% 0.13 60);
+  --color-button-warning-hover: color-mix(in oklch, var(--color-button-warning), black 10%);
+  --color-button-danger: oklch(51% 0.18 12);
+  --color-button-danger-hover: color-mix(in oklch, var(--color-button-danger), black 10%);
   --color-neutral-action: var(--color-slate-600);
   --color-neutral-action-hover: var(--color-slate-700);
   --color-on-neutral-action: var(--color-white);
   --color-link: var(--color-sky-700);
   --color-link-hover: var(--color-sky-800);
-  --color-success: var(--color-green-800);
+  --color-success: oklch(44% 0.12 163);
   --color-on-success: var(--color-white);
-  --color-warning: var(--color-amber-800);
+  --color-warning: oklch(50% 0.13 60);
   --color-on-warning: var(--color-white);
-  /* Notification attention stays warm and consistent across both themes. */
-  --color-attention: var(--color-amber-500);
+  /* Attention is brighter than warning so unread and pending states stay
+     noticeable without competing with a committed action. */
+  --color-attention: oklch(68% 0.15 80);
   --color-on-attention: var(--color-neutral-950);
-  --color-danger: var(--color-red-700);
+  --color-danger: oklch(49% 0.17 12);
   --color-on-danger: var(--color-white);
-  --color-error: var(--color-red-700);
-  --color-server: var(--color-indigo-700);
-  --color-presence-online: var(--color-green-500);
-  --color-presence-away: var(--color-yellow-500);
-  --color-presence-do-not-disturb: var(--color-red-500);
+  --color-error: var(--color-danger);
+  --color-server: oklch(48% 0.16 305);
+  --color-presence-online: oklch(60% 0.16 163);
+  --color-presence-away: oklch(75% 0.16 80);
+  --color-presence-do-not-disturb: oklch(60% 0.18 12);
   --color-presence-offline: var(--color-gray-500);
   --color-presence-invisible: var(--color-gray-400);
 
@@ -148,22 +154,19 @@
   --color-action: var(--color-sky-400);
   --color-action-hover: color-mix(in srgb, var(--color-action), white 15%);
   --color-on-action: var(--color-neutral-950);
-  --color-button-success: var(--color-green-700);
-  --color-button-warning: var(--color-amber-700);
-  --color-button-danger: var(--color-red-700);
   --color-neutral-action: var(--color-neutral-600);
   --color-neutral-action-hover: var(--color-neutral-500);
   --color-on-neutral-action: var(--color-white);
   --color-link: var(--color-action);
-  --color-link-hover: color-mix(in srgb, var(--color-action), white 20%);
-  --color-success: var(--color-green-500);
+  --color-link-hover: color-mix(in srgb, var(--color-link), white 20%);
+  --color-success: oklch(75% 0.16 163);
   --color-on-success: var(--color-neutral-950);
-  --color-warning: var(--color-amber-500);
+  --color-warning: oklch(80% 0.15 78);
   --color-on-warning: var(--color-neutral-950);
-  --color-danger: var(--color-red-400);
+  --color-danger: oklch(74% 0.14 12);
   --color-on-danger: var(--color-neutral-950);
-  --color-error: var(--color-red-400);
-  --color-server: var(--color-indigo-400);
+  --color-error: var(--color-danger);
+  --color-server: oklch(74% 0.13 305);
 
   --color-image-outline: rgba(255, 255, 255, 0.1);
 }
@@ -287,9 +290,9 @@
   border-bottom: 1px solid var(--color-border);
 }
 
-/* Buttons place their semantic fill inside framed, inset geometry related to
- * SegmentedControl. The tight inset keeps solid actions from appearing
- * optically larger than equally sized inputs without looking double-framed.
+/* Inputs and SegmentedControl use this firm frame. Buttons use a separate flat
+ * treatment, so a filled button does not read as a thin outline around a
+ * smaller fill.
  */
 @utility control-frame {
   @apply rounded-md border border-input-border;
@@ -299,11 +302,10 @@
 }
 
 @utility btn {
-  @apply inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-2 control-frame px-4 py-1.5 font-medium;
-  @apply transition-[background-color,border-color,color,box-shadow,scale] duration-150 active:scale-[0.97];
+  @apply inline-flex min-h-10 min-w-10 cursor-pointer items-center justify-center gap-2 rounded-md border border-transparent px-4 py-1.5 font-medium;
+  @apply transition-[background-color,border-color,color] duration-150;
   @apply focus-visible:ring-2 focus-visible:ring-action/35 focus-visible:outline-none;
   @apply disabled:cursor-not-allowed disabled:opacity-50;
-  --control-inset-shadow: inset 0 0 0 1px var(--color-input);
 }
 
 @utility btn-neutral {
@@ -311,27 +313,28 @@
 }
 
 @utility btn-action {
-  @apply btn border-action bg-action text-on-action hover:border-action/90 hover:bg-action/90;
+  @apply btn border-action bg-action font-semibold text-on-action hover:border-(--color-action-hover) hover:bg-(--color-action-hover);
 }
 
 @utility btn-success {
-  @apply btn border-(--color-button-success) bg-(--color-button-success) text-white hover:border-(--color-button-success)/90 hover:bg-(--color-button-success)/90;
+  @apply btn border-(--color-button-success) bg-(--color-button-success) font-semibold text-white hover:border-(--color-button-success-hover) hover:bg-(--color-button-success-hover);
 }
 
 @utility btn-secondary {
-  @apply btn bg-surface-emphasized/60 text-text hover:bg-surface-emphasized;
+  @apply btn border-input-border/70 bg-surface-emphasized/60 text-text;
+  @apply hover:border-input-border hover:bg-surface-emphasized;
 }
 
 @utility btn-ghost {
-  @apply btn bg-transparent text-text hover:bg-surface-emphasized;
+  @apply btn bg-transparent text-text hover:bg-action/10 hover:text-action;
 }
 
 @utility btn-warning {
-  @apply btn border-(--color-button-warning) bg-(--color-button-warning) text-white hover:border-(--color-button-warning)/90 hover:bg-(--color-button-warning)/90;
+  @apply btn border-(--color-button-warning) bg-(--color-button-warning) font-semibold text-white hover:border-(--color-button-warning-hover) hover:bg-(--color-button-warning-hover);
 }
 
 @utility btn-danger {
-  @apply btn border-(--color-button-danger) bg-(--color-button-danger) text-white hover:border-(--color-button-danger)/90 hover:bg-(--color-button-danger)/90;
+  @apply btn border-(--color-button-danger) bg-(--color-button-danger) font-semibold text-white hover:border-(--color-button-danger-hover) hover:bg-(--color-button-danger-hover);
 }
 
 /* Quiet destructive action: neutral at rest, destructive on hover/focus. */
@@ -343,8 +346,8 @@
 
 /* Quiet room-membership action that reveals its destructive meaning on hover. */
 @utility btn-danger-ghost {
-  @apply btn border border-border bg-transparent text-muted;
-  @apply hover:border-danger/30 hover:bg-danger/10 hover:text-danger;
+  @apply btn bg-transparent text-muted;
+  @apply hover:bg-danger/10 hover:text-danger;
 }
 
 @utility btn-sm {

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte.spec.ts
@@ -274,7 +274,7 @@ describe('CurrentUserBar', () => {
     expect(q(container, '[data-testid="current-user-edit-status"]')).toBeFalsy();
   });
 
-  it('renders the away presence menu dot in yellow', async () => {
+  it('renders the away presence menu dot in the semantic warm-gold tone', async () => {
     const { container } = render(CurrentUserBarTestHarness);
 
     (q(container, '[data-testid="current-user-presence-menu"]') as HTMLButtonElement).click();
@@ -284,14 +284,14 @@ describe('CurrentUserBar', () => {
         (item) => item.textContent?.includes('Away')
       )!;
       const awayDot = awayOption.querySelector('.rounded-full')!;
-      const yellow500 = window
+      const presenceAway = window
         .getComputedStyle(document.documentElement)
-        .getPropertyValue('--color-yellow-500')
+        .getPropertyValue('--color-presence-away')
         .trim();
 
       expect(awayDot.className).toContain('bg-presence-away');
       expect(window.getComputedStyle(awayDot).backgroundColor).toBe(
-        computedBackgroundColor(yellow500)
+        computedBackgroundColor(presenceAway)
       );
     });
   });

--- a/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
@@ -57,21 +57,21 @@ describe('UserAvatar', () => {
     expect(presenceDot.className).toContain('bg-presence-online');
   });
 
-  it('renders away presence dots in yellow', () => {
+  it('renders away presence dots in the semantic warm-gold tone', () => {
     const { container } = render(UserAvatarTestHarness, {
       size: 'md',
       showPresence: true,
       presenceStatus: PresenceStatus.AWAY
     });
     const presenceDot = q(container, '[aria-label="Away"] span')!;
-    const yellow500 = window
+    const presenceAway = window
       .getComputedStyle(document.documentElement)
-      .getPropertyValue('--color-yellow-500')
+      .getPropertyValue('--color-presence-away')
       .trim();
 
     expect(presenceDot.className).toContain('bg-presence-away');
     expect(window.getComputedStyle(presenceDot).backgroundColor).toBe(
-      computedBackgroundColor(yellow500)
+      computedBackgroundColor(presenceAway)
     );
   });
 

--- a/apps/frontend/src/lib/ui/AppHeader.svelte
+++ b/apps/frontend/src/lib/ui/AppHeader.svelte
@@ -20,14 +20,15 @@
   const totalNotificationCount = $derived(
     serverRegistry.servers.reduce(
       (sum, instance) =>
-        sum + serverRegistry.getStore(instance.id).notifications.unreadNotificationCount,
+        sum + (serverRegistry.tryGetStore(instance.id)?.notifications.unreadNotificationCount ?? 0),
       0
     )
   );
   const totalImportantNotificationCount = $derived(
     serverRegistry.servers.reduce(
       (sum, instance) =>
-        sum + serverRegistry.getStore(instance.id).notifications.importantUnreadNotificationCount,
+        sum +
+        (serverRegistry.tryGetStore(instance.id)?.notifications.importantUnreadNotificationCount ?? 0),
       0
     )
   );

--- a/apps/frontend/src/lib/ui/AppHeader.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/AppHeader.svelte.spec.ts
@@ -88,6 +88,15 @@ describe('AppHeader', () => {
     expect(container.querySelector('a[href="/chat/preferences"]')).not.toBeNull();
   });
 
+  it('treats a server without a store as having no unread notifications', () => {
+    mocks.servers = [{ id: 'remote' }];
+
+    const { container } = render(AppHeader);
+
+    expect(container.querySelector('a[href="/chat/notifications"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="notifications-unread-dot"]')).toBeNull();
+  });
+
   it('opens Appearance for the active authenticated server', () => {
     mocks.servers = [{ id: 'remote' }];
     mocks.activeServer = 'remote';

--- a/apps/frontend/src/lib/ui/form/Button.stories.svelte
+++ b/apps/frontend/src/lib/ui/form/Button.stories.svelte
@@ -53,6 +53,25 @@
 </Story>
 
 <Story
+  name="Tonal hierarchy"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'Buttons use flat fills and tonal borders. Secondary buttons use a quiet surface fill. Ghost buttons use an action tint on hover.'
+      }
+    }
+  }}
+>
+  <div class="flex flex-wrap items-center gap-3 rounded-lg bg-surface p-5">
+    <Button>Send message</Button>
+    <Button variant="secondary">Sign in</Button>
+    <Button variant="ghost">Save draft</Button>
+  </div>
+</Story>
+
+<Story
   name="Sizes"
   asChild
   parameters={{


### PR DESCRIPTION
## Why

Refresh the interface colour hierarchy and remove the inconsistent bevelled button treatment, while retaining Chatto’s familiar blue action accent. Keep the app header safe while Storybook disposes another story’s server store.

## What changed

- Rebalanced semantic light and dark colour tokens, including presence colours, and restored sky blue as the single action, link, and focus accent.
- Made all button variants flat with tonal borders; secondary buttons remain visible on surface cards, and ghost buttons use an action-coloured hover state.
- Updated the design-system rules, semantic presence assertions, and Storybook coverage for button hierarchy in a surface card.
- Treat an absent server store as zero unread notifications in `AppHeader`, which prevents a Storybook teardown from accessing a disposed store.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- Passed: Svelte autofixer for `AppHeader.svelte`; focused AppHeader client test (5/5); complete Storybook project (77 files, 219 tests); `mise build-frontend`.
- The CI failure is covered by a new test for a registered server whose store has already been disposed.