### PR TITLE
fix(frontend): align pane header actions

### DIFF
--- a/apps/frontend/src/lib/ui/PaneHeader.svelte
+++ b/apps/frontend/src/lib/ui/PaneHeader.svelte
@@ -71,7 +71,7 @@ choice).
 
 <div
   class={[
-    'flex h-14 shrink-0 items-center justify-between border-b border-border pe-4',
+    'flex h-14 shrink-0 items-center justify-between border-b border-border pe-2',
     hasBack ? 'ps-2' : 'ps-4'
   ]}
 >


### PR DESCRIPTION
## Why

The Room Sidebar close control sat farther from the pane edge than the rest of the sidebar rhythm.

## What changed

- Reduced the shared PaneHeader end inset from 16px to 8px.
- This moves every trailing pane-header action 8px toward the end edge while keeping its 40px hit target.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise lint-frontend` (passed: design-system checks, Svelte diagnostics, and ESLint).
- Chrome DevTools review of the PaneHeader Storybook action layout (passed).