### PR TITLE
fix(frontend): restore neutral server selection

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -50,9 +50,9 @@ keep their semantic priority colour.
 When one route path contains another navigation path, set `aria-current` only
 on the most-specific matching item.
 
-The server gutter follows the same rule. The current server uses its action
-ring and action fill. Do not add a side stripe, a shadow, or a separate accent
-colour for navigation selection.
+The server gutter has a distinct rule. The current server uses a neutral text
+ring and a `surface-selected` fill. This preserves the server identity colour
+inside the icon. Do not add a side stripe or a shadow for navigation selection.
 
 ## Choosing A Primitive
 

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -740,8 +740,8 @@
 }
 
 @utility server-gutter-item-active {
-  @apply bg-action/10 text-text hover:bg-action/15 hover:text-text active:bg-action/20;
-  @apply ring-2 ring-action;
+  @apply bg-surface-selected text-text hover:bg-surface-selected hover:text-text;
+  @apply ring-2 ring-text;
 }
 
 /* Make ServerLogo slightly smaller inside server-icon to leave room for the ring */


### PR DESCRIPTION
## Why

The blue action treatment obscured each server’s own identity colour in the server gutter.

## What changed

- Restore the neutral text ring and `surface-selected` fill for the current server.
- Document the server-gutter selection rule as intentionally distinct from sidebar route selection.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise lint-frontend`
- `mise x -- pnpm --dir apps/frontend exec vitest run --project=storybook src/lib/ServerIcon.stories.svelte`
- `mise build-frontend`
- Verified the selected `ServerIcon` Storybook state in Chrome DevTools in light and dark themes.