### PR TITLE
fix(frontend): balance room directory card padding

### DIFF
--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -295,9 +295,10 @@ store owns only optimistic join/leave state.
         {/if}
       {/snippet}
 
-      <!-- Horizontal inset (`px-1` + the menu-item's own `px-3` = 16px)
-           keeps per-row actions aligned within the shared panel inset. -->
-      <ul class="selectable-list py-2">
+      <!-- `Panel noPadding` adds a bottom-only frame inset. Pair `pt-2` with
+           `pb-1` so that frame inset makes the list's top and bottom spacing
+           equal; the horizontal inset keeps row actions aligned. -->
+      <ul class="selectable-list pt-2 pb-1">
         {#each rooms as room (room.id)}
           {@render roomRow(room)}
         {/each}

--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -295,10 +295,10 @@ store owns only optimistic join/leave state.
         {/if}
       {/snippet}
 
-      <!-- `Panel noPadding` adds a bottom-only frame inset. Pair `pt-2` with
-           `pb-1` so that frame inset makes the list's top and bottom spacing
-           equal; the horizontal inset keeps row actions aligned. -->
-      <ul class="selectable-list pt-2 pb-1">
+      <!-- The panel header already creates separation above the inset. Keep
+           the list's top inset compact, while the panel's bottom-only frame
+           inset combines with `pb-1` below. -->
+      <ul class="selectable-list pt-1 pb-1">
         {#each rooms as room (room.id)}
           {@render roomRow(room)}
         {/each}

--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -185,6 +185,12 @@ describe('RoomDirectory', () => {
     expect(shell.className).toContain('shrink-0');
     expect(header.className).toContain('px-6');
     expect(inset).not.toBeNull();
+
+    // `Panel noPadding` contributes a bottom frame inset. The list uses one
+    // less unit of bottom padding so its visual top and bottom insets match.
+    const list = shell.querySelector('ul') as HTMLElement;
+    expect(list.className).toContain('pt-2');
+    expect(list.className).toContain('pb-1');
   });
 
   // -- "Join all" group action -----------------------------------------------

--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -186,10 +186,10 @@ describe('RoomDirectory', () => {
     expect(header.className).toContain('px-6');
     expect(inset).not.toBeNull();
 
-    // `Panel noPadding` contributes a bottom frame inset. The list uses one
-    // less unit of bottom padding so its visual top and bottom insets match.
+    // The header creates separation above the inset; the panel adds the
+    // bottom frame inset. Keep the list's own vertical inset compact.
     const list = shell.querySelector('ul') as HTMLElement;
-    expect(list.className).toContain('pt-2');
+    expect(list.className).toContain('pt-1');
     expect(list.className).toContain('pb-1');
   });
 


### PR DESCRIPTION
## Summary

- balance the top and bottom inset of room-directory group-card lists
- add a regression assertion for the panel/list padding composition

## Verification

- `mise x -- pnpm exec vitest run src/lib/RoomDirectory.svelte.spec.ts`
- `mise lint-frontend`
- `mise build-frontend`
- Svelte autofixer
- Chrome DevTools: local frontend loaded successfully