### PR TITLE
refactor(frontend): load pending SSO confirmation flows

### DIFF
--- a/apps/frontend/src/routes/sso/confirm/+page.svelte
+++ b/apps/frontend/src/routes/sso/confirm/+page.svelte
@@ -1,13 +1,11 @@
 <script lang="ts">
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
-  import { Code, ConnectError } from '@connectrpc/connect';
   import { completeOriginAuthentication } from '$lib/auth/originAuthentication';
   import AuthLayout from '$lib/components/AuthLayout.svelte';
   import {
     createExternalIdentityFlowAPI,
-    ExternalIdentityFlowKind,
-    type PendingExternalIdentityInfo
+    ExternalIdentityFlowKind
   } from '$lib/api-client/externalIdentities';
   import { m } from '$lib/i18n/messages';
   import { validateDisplayName } from '$lib/validation/displayName';
@@ -18,14 +16,11 @@
   const { data } = $props();
   const flowAPI = createExternalIdentityFlowAPI();
 
-  let pending = $state<PendingExternalIdentityInfo | null>(null);
-  let loadError = $state('');
+  const pending = $derived(data.pending);
   let actionError = $state('');
-  let loading = $state(true);
   let submitting = $state(false);
-  let login = $state('');
-  let displayName = $state('');
-  let loadedToken = '';
+  let login = $derived(pending?.loginHint ?? '');
+  let displayName = $derived(pending?.displayNameHint || pending?.loginHint || '');
 
   const loginSchema = z
     .string()
@@ -51,51 +46,20 @@
         isLink)
   );
 
-  $effect(() => {
-    const token = data.token;
-    if (!token || token === loadedToken) return;
-    loadedToken = token;
-    void loadPending(token);
-  });
-
-  async function loadPending(token: string) {
-    loading = true;
-    loadError = '';
-    actionError = '';
-    pending = null;
-    try {
-      const result = await flowAPI.getPending(token);
-      if (!result) {
-        loadError = m('auth.sso.invalid');
-        return;
-      }
-      pending = result;
-      login = result.loginHint;
-      displayName = result.displayNameHint || result.loginHint;
-    } catch (err) {
-      if (err instanceof ConnectError && err.code === Code.NotFound) {
-        loadError = m('auth.sso.invalid');
-      } else {
-        loadError = err instanceof Error ? err.message : m('auth.sso.load_failed');
-      }
-    } finally {
-      loading = false;
-    }
-  }
-
   async function handleCreate(e: Event) {
     e.preventDefault();
     if (!pending || !data.token || loginError || displayNameError) {
       actionError = loginError || displayNameError || m('common.validation.fix_errors');
       return;
     }
+    const redirectPath = pending.redirectPath || '/';
     submitting = true;
     actionError = '';
     try {
       await flowAPI.createAccount({ token: data.token, login, displayName });
       const resumedReturnNavigation = await completeOriginAuthentication();
       if (!resumedReturnNavigation) {
-        goto(resolve((pending.redirectPath || '/') as '/'), { replaceState: true });
+        goto(resolve(redirectPath as '/'), { replaceState: true });
       }
     } catch (err) {
       actionError = err instanceof Error ? err.message : m('auth.sso.create_failed');
@@ -106,11 +70,12 @@
 
   async function handleLink() {
     if (!pending || !data.token) return;
+    const redirectPath = pending.redirectPath || '/';
     submitting = true;
     actionError = '';
     try {
       await flowAPI.confirmLink(data.token);
-      goto(resolve((pending.redirectPath || '/') as '/'), { replaceState: true });
+      goto(resolve(redirectPath as '/'), { replaceState: true });
     } catch (err) {
       actionError = err instanceof Error ? err.message : m('auth.sso.link_failed');
     } finally {
@@ -140,10 +105,10 @@
     <p class="mt-6 text-center">
       <a href={resolve('/login')} class="link">{m('common.sign_in')}</a>
     </p>
-  {:else if loading}
-    <div class="text-center text-sm text-muted">{m('auth.sso.loading')}</div>
-  {:else if loadError}
-    <Hint tone="danger">{loadError}</Hint>
+  {:else if data.loadError}
+    <Hint tone="danger">
+      {data.loadError === 'invalid' ? m('auth.sso.invalid') : m('auth.sso.load_failed')}
+    </Hint>
     <p class="mt-6 text-center">
       <a href={resolve('/login')} class="link">{m('common.sign_in')}</a>
     </p>

--- a/apps/frontend/src/routes/sso/confirm/+page.ts
+++ b/apps/frontend/src/routes/sso/confirm/+page.ts
@@ -1,7 +1,37 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+import {
+  createExternalIdentityFlowAPI,
+  type PendingExternalIdentityInfo
+} from '$lib/api-client/externalIdentities';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = ({ url }) => {
-  return {
-    token: url.searchParams.get('token') ?? ''
-  };
+/** Settled result of loading an external-identity confirmation flow. */
+export type SSOConfirmLoadData = {
+  /** Confirmation token from the URL, if present. */
+  token: string;
+  /** Pending confirmation flow, when the token is valid. */
+  pending: PendingExternalIdentityInfo | null;
+  /** Stable error code for the confirmation page, if loading did not succeed. */
+  loadError: 'invalid' | 'failed' | null;
+};
+
+/** Load the pending external-identity flow before the confirmation page renders. */
+export const load: PageLoad = async ({ url }): Promise<SSOConfirmLoadData> => {
+  const token = url.searchParams.get('token') ?? '';
+  if (!token) {
+    return { token, pending: null, loadError: 'invalid' };
+  }
+
+  try {
+    const pending = await createExternalIdentityFlowAPI().getPending(token);
+    return pending
+      ? { token, pending, loadError: null }
+      : { token, pending: null, loadError: 'invalid' };
+  } catch (error) {
+    return {
+      token,
+      pending: null,
+      loadError: error instanceof ConnectError && error.code === Code.NotFound ? 'invalid' : 'failed'
+    };
+  }
 };

--- a/apps/frontend/src/routes/sso/confirm/confirm.load.spec.ts
+++ b/apps/frontend/src/routes/sso/confirm/confirm.load.spec.ts
@@ -1,0 +1,85 @@
+import { Code, ConnectError } from '@connectrpc/connect';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  getPending: vi.fn()
+}));
+
+vi.mock('$lib/api-client/externalIdentities', () => ({
+  createExternalIdentityFlowAPI: () => ({ getPending: mocks.getPending })
+}));
+
+import { load } from './+page';
+
+async function loadConfirmation(token?: string) {
+  const url = new URL('https://chat.example.test/sso/confirm');
+  if (token) url.searchParams.set('token', token);
+  return load({ url } as never);
+}
+
+describe('SSO confirmation load', () => {
+  beforeEach(() => {
+    mocks.getPending.mockReset();
+  });
+
+  it('does not request a pending flow without a token', async () => {
+    await expect(loadConfirmation()).resolves.toEqual({
+      token: '',
+      pending: null,
+      loadError: 'invalid'
+    });
+    expect(mocks.getPending).not.toHaveBeenCalled();
+  });
+
+  it('returns the pending flow for a valid token', async () => {
+    const pending = {
+      kind: 1,
+      providerId: 'example',
+      providerType: 'oidc',
+      providerLabel: 'Example',
+      verifiedEmail: null,
+      loginHint: 'new-user',
+      displayNameHint: 'New User',
+      boundUserId: null,
+      redirectPath: '/chat/-'
+    };
+    mocks.getPending.mockResolvedValue(pending);
+
+    await expect(loadConfirmation('confirmation-token')).resolves.toEqual({
+      token: 'confirmation-token',
+      pending,
+      loadError: null
+    });
+    expect(mocks.getPending).toHaveBeenCalledWith('confirmation-token');
+  });
+
+  it('maps a missing pending flow to the invalid state', async () => {
+    mocks.getPending.mockResolvedValue(null);
+
+    await expect(loadConfirmation('expired-token')).resolves.toEqual({
+      token: 'expired-token',
+      pending: null,
+      loadError: 'invalid'
+    });
+  });
+
+  it('maps a not-found API response to the invalid state', async () => {
+    mocks.getPending.mockRejectedValue(new ConnectError('not found', Code.NotFound));
+
+    await expect(loadConfirmation('missing-token')).resolves.toEqual({
+      token: 'missing-token',
+      pending: null,
+      loadError: 'invalid'
+    });
+  });
+
+  it('does not expose unexpected API error details', async () => {
+    mocks.getPending.mockRejectedValue(new Error('sensitive backend detail'));
+
+    await expect(loadConfirmation('failed-token')).resolves.toEqual({
+      token: 'failed-token',
+      pending: null,
+      loadError: 'failed'
+    });
+  });
+});


### PR DESCRIPTION
## Why

The SSO confirmation page loaded its pending external-identity flow from a
component `$effect`. This made initial page data depend on post-render work and
kept loading/error state in the component.

## What changed

- Load the pending flow in the SvelteKit page load before the confirmation page
  renders.
- Return stable `invalid` and `failed` result codes instead of rendering raw API
  error messages.
- Keep create, link, and cancel as explicit user actions.
- Preserve the target redirect before account creation invalidates the consumed
  flow's route data.
- Add route-load coverage for missing, valid, expired, not-found, and generic
  failure cases.

## Test plan

- `mise lint-frontend`
- `mise x -- pnpm --dir apps/frontend exec vitest run src/routes/sso/confirm/confirm.load.spec.ts`
- `mise x -- pnpm --dir apps/frontend exec playwright test e2e/external-identities.test.ts --retries=0`

No protocol, persistence, compatibility, migration, or deployment changes.
