### PR TITLE
docs(frontend): clarify panel collection treatments

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -36,8 +36,8 @@ message search results:
 - Rows rest transparently on the owning `background` work plane. Hover and
   keyboard focus rise exactly one level to `surface`; do not introduce ruled
   separators or a stronger surface jump.
-- Each row owns its rounded shape. The collection owns only the 1px inset and
-  gap, so selections never merge into a single slab.
+- Each row owns its rounded shape. The collection owns only the standard
+  `p-1` inset and `gap-1`, so selections never merge into a single slab.
 
 ## Sidebar Navigation
 
@@ -99,7 +99,7 @@ behaviour, content width, spacing, and panel hierarchy.
       </Panel>
 
       <Panel title={resultsTitle} noPadding>
-        <!-- edge-to-edge list, table, or result state -->
+        <!-- child-owned collection, table, or result state -->
       </Panel>
     </div>
   </PaneContent>
@@ -122,8 +122,9 @@ Follow these defaults:
   single form field's visible label, keep the field label available to
   assistive technology with the field component's `labelHidden` option.
 - Use the default padded `Panel` for forms, prose, summaries, and grouped
-  controls. Use `noPadding` for tables, lists, search results, and other
-  edge-to-edge collections; the child owns its row padding and dividers.
+  controls. Use `noPadding` when the child owns its work-plane treatment.
+  `DataTable` rows are flush and use dividers. A `selectable-list` keeps its
+  standard `p-1` inset and `gap-1` so separately rounded rows have clear boundaries.
 - Render loading, error, and empty states inside the panel whose content they
   replace. A single full-page availability state may use one untitled panel
   because there are no peer sections to distinguish.
@@ -249,6 +250,12 @@ add feature-local radius overrides for this composition. Dense matrices may keep
 an intrinsic content width inside the viewport; ordinary record tables fill it.
 Standard record-table headings use `table-header-cell`; matrix headings remain
 bespoke because their vertical labels have different spatial needs.
+
+`noPadding` does not require every child to be flush. `DataTable` uses a
+continuous grid, so its header and rows meet the work-plane edge. A
+`selectable-list` uses independent rounded rows, so it keeps the shared `p-1`
+inset and `gap-1` inside that same work plane. Do not add local padding utilities to
+either primitive to make it resemble the other.
 
 Panel title bands use `px-6 py-3`. The horizontal inset aligns titles with
 `p-5` panel content after accounting for the frame, while keeping the band

--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -295,10 +295,7 @@ store owns only optimistic join/leave state.
         {/if}
       {/snippet}
 
-      <!-- The panel header already creates separation above the inset. Keep
-           the list's top inset compact, while the panel's bottom-only frame
-           inset combines with `pb-1` below. -->
-      <ul class="selectable-list pt-1 pb-1">
+      <ul class="selectable-list">
         {#each rooms as room (room.id)}
           {@render roomRow(room)}
         {/each}

--- a/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomDirectory.svelte.spec.ts
@@ -186,11 +186,9 @@ describe('RoomDirectory', () => {
     expect(header.className).toContain('px-6');
     expect(inset).not.toBeNull();
 
-    // The header creates separation above the inset; the panel adds the
-    // bottom frame inset. Keep the list's own vertical inset compact.
+    // Selectable lists own their standard compact inset inside `Panel noPadding`.
     const list = shell.querySelector('ul') as HTMLElement;
-    expect(list.className).toContain('pt-1');
-    expect(list.className).toContain('pb-1');
+    expect(list.className).toBe('selectable-list');
   });
 
   // -- "Join all" group action -----------------------------------------------

--- a/apps/frontend/src/lib/ui/DataTable.stories.svelte
+++ b/apps/frontend/src/lib/ui/DataTable.stories.svelte
@@ -30,7 +30,8 @@
   Record-table primitive with a standalone rounded scroll viewport, contrasting
   header and body, empty state row, optional row hover/click affordance, and
   automatic load-more support. Inside \`Panel noPadding\`, the panel owns the
-  shared radius and the table meets adjacent content at square internal seams.
+  shared radius and the table uses flush ruled rows that meet adjacent content
+  at square internal seams.
   `.trim();
 
   const { Story } = defineMeta({

--- a/apps/frontend/src/lib/ui/Panel.stories.svelte
+++ b/apps/frontend/src/lib/ui/Panel.stories.svelte
@@ -54,7 +54,7 @@
 
       <p class="text-sm text-muted">
         Panel content can be form sections, summary rows, or a table. Use <code>noPadding</code>
-        when a child component owns its own edge-to-edge spacing.
+        when a child component owns its work-plane treatment.
       </p>
     </Panel>
   </div>
@@ -103,7 +103,7 @@
     docs: {
       description: {
         story:
-          'Use `noPadding` for tables and dense list components that need to meet the panel edge.'
+          'Use `noPadding` when a table or another dense child owns the panel work plane. Tables use flush ruled rows.'
       }
     }
   }}
@@ -120,6 +120,44 @@
           <span class="text-muted">12 minutes ago</span>
         </div>
       </div>
+    </Panel>
+  </div>
+</Story>
+
+<Story
+  name="Inset selectable list"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'Use the shared `selectable-list` inset for individually rounded, navigable, or directly actionable rows. This differs intentionally from a flush ruled table.'
+      }
+    }
+  }}
+>
+  <div class="max-w-2xl">
+    <Panel title="Rooms" noPadding>
+      <ul class="selectable-list">
+        <li>
+          <button type="button" class="flex w-full items-center gap-3 selectable-list-item px-3 py-2 text-start">
+            <span class="text-muted" aria-hidden="true">#</span>
+            <span class="min-w-0 flex-1">
+              <span class="block font-medium">announcements</span>
+              <span class="block truncate text-sm text-muted">Updates for everyone.</span>
+            </span>
+          </button>
+        </li>
+        <li>
+          <button type="button" class="flex w-full items-center gap-3 selectable-list-item px-3 py-2 text-start">
+            <span class="text-muted" aria-hidden="true">#</span>
+            <span class="min-w-0 flex-1">
+              <span class="block font-medium">general</span>
+              <span class="block truncate text-sm text-muted">General discussion.</span>
+            </span>
+          </button>
+        </li>
+      </ul>
     </Panel>
   </div>
 </Story>


### PR DESCRIPTION
## Summary

- restore the Room Directory to the standard inset selectable-list utility
- document the intentional difference between flush tables and inset selectable lists
- add an inset selectable-list Panel story next to the flush table examples

## Verification

- `mise x -- pnpm exec vitest run src/lib/RoomDirectory.svelte.spec.ts`
- `mise lint-frontend`
- `mise build-frontend`
- Svelte autofixer for changed Svelte files
- Chrome DevTools Storybook review