### PR TITLE
feat(frontend): add compact composer formatting shelf

### DIFF
--- a/apps/docs-website/src/content/docs/getting-started/message-formatting.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/message-formatting.mdx
@@ -14,6 +14,8 @@ Select the App Preferences gear in the Application Header. Settings opens the **
 
 The setting applies to every Chatto server you use in the current browser. It does not sync to other browsers or devices.
 
+Select **Formatting options** in the message input to show or hide the toolbar. Chatto hides the toolbar by default. It remembers your selection in this browser and uses it for all message inputs.
+
 Both editors provide the same formatting toolbar, mentions, emoji completion, attachments, reply quotes, timestamps, and message editing. The Markdown editor always shows source; it does not include a separate preview.
 
 The toolbar's indent and outdent actions follow the selected editor. In the visual editor they nest and unnest list items. In the Markdown editor they indent or outdent the current source line, or every line in a selection; Tab and Shift+Tab perform the same source-line actions. Tab continues to accept an active mention or emoji suggestion first. To move keyboard focus out of the Markdown editor, press Escape and then Tab.

--- a/apps/frontend/e2e/composer.test.ts
+++ b/apps/frontend/e2e/composer.test.ts
@@ -174,7 +174,7 @@ test.describe('Composer keyboard behavior', () => {
     const message = `Keyboard send ${Date.now()}`;
     await roomPage.waitForInputEditable();
     await roomPage.messageInput.fill(message);
-    await expect(page.getByTestId('composer-toolbar')).not.toContainText(/to send/i);
+    await expect(page.getByTestId('composer-action-toolbar')).not.toContainText(/to send/i);
 
     await roomPage.messageInput.press('Enter');
     await expect(roomPage.getMessage(message).locator).not.toBeVisible();
@@ -299,6 +299,13 @@ test.describe('Markdown composer', () => {
     await waitForRoomReady(page, 'general');
 
     await roomPage.messageInput.fill('first\nsecond');
+    const formattingToggle = page.getByRole('button', {
+      name: 'Formatting options',
+      exact: true
+    });
+    await expect(formattingToggle).toHaveAttribute('aria-expanded', 'false');
+    await formattingToggle.click();
+    await expect(formattingToggle).toHaveAttribute('aria-expanded', 'true');
     const indent = page.getByRole('button', { name: 'Indent', exact: true });
     const outdent = page.getByRole('button', { name: 'Outdent', exact: true });
     await expect(indent).toBeEnabled();

--- a/apps/frontend/e2e/message-editing.test.ts
+++ b/apps/frontend/e2e/message-editing.test.ts
@@ -49,7 +49,7 @@ test.describe('Up arrow to edit last message', () => {
 
     const editedMessage = `Simple up edit saved ${Date.now()}`;
     await roomPage.messageInput.fill(editedMessage);
-    await expect(page.getByTestId('composer-toolbar')).not.toContainText(/to send/i);
+    await expect(page.getByTestId('composer-action-toolbar')).not.toContainText(/to send/i);
 
     await roomPage.messageInput.press('Control+Enter');
     await roomPage.expectEditModeInactive();

--- a/apps/frontend/messages/ar/composer.json
+++ b/apps/frontend/messages/ar/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "قم بإرفاق الملف",
+    "formatting_options": "خيارات التنسيق",
     "send": "أرسل الرسالة",
     "send_label": "إرسال",
     "also_send_to_channel": "أرسل أيضًا إلى القناة",

--- a/apps/frontend/messages/cs-CZ/composer.json
+++ b/apps/frontend/messages/cs-CZ/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Připojit soubor",
+    "formatting_options": "Možnosti formátování",
     "send": "Odeslat zprávu",
     "send_label": "Odeslat",
     "also_send_to_channel": "Také odeslat na kanál",

--- a/apps/frontend/messages/de-DE/composer.json
+++ b/apps/frontend/messages/de-DE/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Datei anhängen",
+    "formatting_options": "Formatierungsoptionen",
     "send": "Nachricht senden",
     "send_label": "Senden",
     "also_send_to_channel": "Auch an Kanal senden",

--- a/apps/frontend/messages/en-GB/composer.json
+++ b/apps/frontend/messages/en-GB/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Attach file",
+    "formatting_options": "Formatting options",
     "send": "Send message",
     "send_label": "Send",
     "also_send_to_channel": "Also send to channel",

--- a/apps/frontend/messages/eo/composer.json
+++ b/apps/frontend/messages/eo/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Alektu dosieron",
+    "formatting_options": "Formataj opcioj",
     "send": "Sendu mesaĝon",
     "send_label": "Sendu",
     "also_send_to_channel": "Ankaŭ sendu al kanalo",

--- a/apps/frontend/messages/es-419/composer.json
+++ b/apps/frontend/messages/es-419/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Adjuntar archivo",
+    "formatting_options": "Opciones de formato",
     "send": "Enviar mensaje",
     "send_label": "Enviar",
     "also_send_to_channel": "También enviar al canal",

--- a/apps/frontend/messages/es-ES/composer.json
+++ b/apps/frontend/messages/es-ES/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Adjuntar archivo",
+    "formatting_options": "Opciones de formato",
     "send": "Enviar mensaje",
     "send_label": "Enviar",
     "also_send_to_channel": "También enviar al canal",

--- a/apps/frontend/messages/et-EE/composer.json
+++ b/apps/frontend/messages/et-EE/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Manusta fail",
+    "formatting_options": "Vormindusvalikud",
     "send": "Saada sõnum",
     "send_label": "Saada",
     "also_send_to_channel": "Saada ka kanalile",

--- a/apps/frontend/messages/fr-CA/composer.json
+++ b/apps/frontend/messages/fr-CA/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Joindre un fichier",
+    "formatting_options": "Options de mise en forme",
     "send": "Envoyer un message",
     "send_label": "Envoyer",
     "also_send_to_channel": "Envoyer aussi au canal",

--- a/apps/frontend/messages/fr-FR/composer.json
+++ b/apps/frontend/messages/fr-FR/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Joindre un fichier",
+    "formatting_options": "Options de mise en forme",
     "send": "Envoyer un message",
     "send_label": "Envoyer",
     "also_send_to_channel": "Envoyer également au canal",

--- a/apps/frontend/messages/he-IL/composer.json
+++ b/apps/frontend/messages/he-IL/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "צרף קובץ",
+    "formatting_options": "אפשרויות עיצוב",
     "send": "שלח הודעה",
     "send_label": "שלח",
     "also_send_to_channel": "שלח גם לערוץ",

--- a/apps/frontend/messages/it-IT/composer.json
+++ b/apps/frontend/messages/it-IT/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Allega file",
+    "formatting_options": "Opzioni di formattazione",
     "send": "Invia messaggio",
     "send_label": "Invia",
     "also_send_to_channel": "Invia anche al canale",

--- a/apps/frontend/messages/ja-JP/composer.json
+++ b/apps/frontend/messages/ja-JP/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "ファイルを添付",
+    "formatting_options": "書式設定オプション",
     "send": "メッセージを送信",
     "send_label": "送信",
     "also_send_to_channel": "チャンネルにも送信します",

--- a/apps/frontend/messages/lv-LV/composer.json
+++ b/apps/frontend/messages/lv-LV/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Pievienojiet failu",
+    "formatting_options": "Formatēšanas opcijas",
     "send": "Nosūtīt ziņu",
     "send_label": "Sūtīt",
     "also_send_to_channel": "Sūtīt arī uz kanālu",

--- a/apps/frontend/messages/nb-NO/composer.json
+++ b/apps/frontend/messages/nb-NO/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Legg ved fil",
+    "formatting_options": "Formateringsalternativer",
     "send": "Send melding",
     "send_label": "Send",
     "also_send_to_channel": "Send også til kanalen",

--- a/apps/frontend/messages/nl-BE/composer.json
+++ b/apps/frontend/messages/nl-BE/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Bestand bijvoegen",
+    "formatting_options": "Opmaakopties",
     "send": "Bericht verzenden",
     "send_label": "Verzenden",
     "also_send_to_channel": "Stuur ook naar kanaal",

--- a/apps/frontend/messages/nl-NL/composer.json
+++ b/apps/frontend/messages/nl-NL/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Bestand bijvoegen",
+    "formatting_options": "Opmaakopties",
     "send": "Bericht verzenden",
     "send_label": "Verzenden",
     "also_send_to_channel": "Stuur ook naar kanaal",

--- a/apps/frontend/messages/pl-PL/composer.json
+++ b/apps/frontend/messages/pl-PL/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Załącz plik",
+    "formatting_options": "Opcje formatowania",
     "send": "Wyślij wiadomość",
     "send_label": "Wyślij",
     "also_send_to_channel": "Wyślij także do kanału",

--- a/apps/frontend/messages/pt-BR/composer.json
+++ b/apps/frontend/messages/pt-BR/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Anexar arquivo",
+    "formatting_options": "Opções de formatação",
     "send": "Enviar mensagem",
     "send_label": "Enviar",
     "also_send_to_channel": "Enviar também para o canal",

--- a/apps/frontend/messages/pt-PT/composer.json
+++ b/apps/frontend/messages/pt-PT/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Anexar ficheiro",
+    "formatting_options": "Opções de formatação",
     "send": "Enviar mensagem",
     "send_label": "Enviar",
     "also_send_to_channel": "Enviar também para o canal",

--- a/apps/frontend/messages/ru-RU/composer.json
+++ b/apps/frontend/messages/ru-RU/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Прикрепить файл",
+    "formatting_options": "Параметры форматирования",
     "send": "Отправить сообщение",
     "send_label": "Отправить",
     "also_send_to_channel": "Также отправь на канал",

--- a/apps/frontend/messages/sv-SE/composer.json
+++ b/apps/frontend/messages/sv-SE/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Bifoga fil",
+    "formatting_options": "Formateringsalternativ",
     "send": "Skicka meddelande",
     "send_label": "Skicka",
     "also_send_to_channel": "Skicka även till kanal",

--- a/apps/frontend/messages/tr-TR/composer.json
+++ b/apps/frontend/messages/tr-TR/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Dosya ekle",
+    "formatting_options": "Biçimlendirme seçenekleri",
     "send": "Mesaj gönder",
     "send_label": "Gönder",
     "also_send_to_channel": "Ayrıca kanala gönder",

--- a/apps/frontend/messages/uk-UA/composer.json
+++ b/apps/frontend/messages/uk-UA/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "Прикріпити файл",
+    "formatting_options": "Параметри форматування",
     "send": "Надіслати повідомлення",
     "send_label": "Надіслати",
     "also_send_to_channel": "Також надіслати на канал",

--- a/apps/frontend/messages/zh-CN/composer.json
+++ b/apps/frontend/messages/zh-CN/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "添加文件",
+    "formatting_options": "格式选项",
     "send": "发送消息",
     "send_label": "发送",
     "also_send_to_channel": "同时发送到频道",

--- a/apps/frontend/messages/zh-TW/composer.json
+++ b/apps/frontend/messages/zh-TW/composer.json
@@ -1,6 +1,7 @@
 {
   "composer": {
     "attach_file": "附加檔案",
+    "formatting_options": "格式選項",
     "send": "傳送訊息",
     "send_label": "傳送",
     "also_send_to_channel": "同時傳送至頻道",

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -732,6 +732,11 @@
   }
 }
 
+/* Composer input and formatting surfaces share the app shell's compact radius. */
+@utility composer-surface {
+  @apply rounded-xl bg-surface;
+}
+
 /* Server Gutter item — icon buttons in the leftmost sidebar (the Server Gutter). */
 @utility server-gutter-item {
   @apply shimmer-hover relative flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-3xl transition-[background-color,color] duration-150;

--- a/apps/frontend/src/lib/components/composer/ComposerFormattingToolbar.svelte
+++ b/apps/frontend/src/lib/components/composer/ComposerFormattingToolbar.svelte
@@ -1,0 +1,126 @@
+<!--
+@component
+
+Formatting-only shelf for the message composer. The owning composer controls
+whether the shelf is visible and keeps message-level actions in its compact
+input row.
+-->
+<script lang="ts">
+  import { m } from '$lib/i18n/messages';
+  import type {
+    ComposerEditorApi,
+    ComposerFormattingCommand,
+    ComposerFormattingState,
+    ComposerIndentState
+  } from './editorTypes';
+
+  let {
+    id,
+    formattingState,
+    indentState,
+    editorApi,
+    inputDisabled
+  }: {
+    id: string;
+    formattingState: ComposerFormattingState;
+    indentState: ComposerIndentState;
+    editorApi: ComposerEditorApi | null;
+    inputDisabled: boolean;
+  } = $props();
+
+  const formattingControls: {
+    command: ComposerFormattingCommand;
+    icon: string;
+  }[] = [
+    { command: 'bold', icon: 'icon-[mdi--format-bold]' },
+    { command: 'italic', icon: 'icon-[mdi--format-italic]' },
+    { command: 'inlineCode', icon: 'icon-[mdi--code-tags]' },
+    { command: 'heading', icon: 'icon-[mdi--format-header-2]' },
+    { command: 'bulletList', icon: 'icon-[mdi--format-list-bulleted]' },
+    { command: 'orderedList', icon: 'icon-[mdi--format-list-numbered]' },
+    { command: 'blockquote', icon: 'icon-[mdi--format-quote-open]' },
+    { command: 'codeBlock', icon: 'icon-[mdi--code-block-braces]' }
+  ];
+
+  function formattingLabel(command: ComposerFormattingCommand): string {
+    switch (command) {
+      case 'bold':
+        return m('composer.format.bold');
+      case 'italic':
+        return m('composer.format.italic');
+      case 'inlineCode':
+        return m('composer.format.inline_code');
+      case 'heading':
+        return m('composer.format.heading');
+      case 'bulletList':
+        return m('composer.format.bullet_list');
+      case 'orderedList':
+        return m('composer.format.ordered_list');
+      case 'blockquote':
+        return m('composer.format.blockquote');
+      case 'codeBlock':
+        return m('composer.format.code_block');
+    }
+  }
+</script>
+
+<div
+	{id}
+	class="composer-surface flex min-h-8 w-fit max-w-full items-center self-start overflow-hidden px-1 py-1"
+	data-testid="composer-formatting-shelf"
+>
+  <div
+    class="flex min-w-0 [scrollbar-width:none] flex-nowrap items-center gap-0.5 overflow-x-auto overscroll-x-contain [&::-webkit-scrollbar]:hidden"
+    data-testid="composer-formatting-toolbar"
+  >
+    {#each formattingControls as control (control.command)}
+      {@const label = formattingLabel(control.command)}
+      {@const active = formattingState[control.command]}
+      <button
+        type="button"
+        onpointerdown={(event) => event.preventDefault()}
+        onclick={() => editorApi?.toggleFormatting(control.command)}
+        disabled={inputDisabled || !editorApi}
+        aria-label={label}
+        aria-pressed={active}
+        title={label}
+        class={[
+          'flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded transition-[background-color,color,scale] duration-100 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50',
+          active
+            ? 'bg-surface-emphasized text-text'
+            : 'text-muted enabled:hover:bg-surface-emphasized enabled:hover:text-text'
+        ]}
+      >
+        <span class={['iconify text-[15px]', control.icon]}></span>
+      </button>
+      {#if control.command === 'orderedList'}
+        <button
+          type="button"
+          onpointerdown={(event) => event.preventDefault()}
+          onclick={() => editorApi?.adjustIndent('outdent')}
+          disabled={inputDisabled || !editorApi || !indentState.canOutdent}
+          aria-label={m('composer.format.outdent')}
+          aria-keyshortcuts="Shift+Tab"
+          title={m('composer.format.outdent')}
+          class="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] duration-100 active:scale-[0.96] enabled:hover:bg-surface-emphasized enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <span class="iconify icon-[mdi--format-indent-decrease] text-[15px] rtl:scale-x-[-1]"
+          ></span>
+        </button>
+        <button
+          type="button"
+          onpointerdown={(event) => event.preventDefault()}
+          onclick={() => editorApi?.adjustIndent('indent')}
+          disabled={inputDisabled || !editorApi || !indentState.canIndent}
+          aria-label={m('composer.format.indent')}
+          aria-keyshortcuts="Tab"
+          title={m('composer.format.indent')}
+          class="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] duration-100 active:scale-[0.96] enabled:hover:bg-surface-emphasized enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <span class="iconify icon-[mdi--format-indent-increase] text-[15px] rtl:scale-x-[-1]"
+          ></span>
+        </button>
+      {/if}
+    {/each}
+  </div>
+</div>

--- a/apps/frontend/src/lib/components/composer/ComposerToolbar.svelte
+++ b/apps/frontend/src/lib/components/composer/ComposerToolbar.svelte
@@ -1,16 +1,16 @@
+<!--
+@component
+
+Compact message-level actions for the composer input row. Formatting commands
+live in `ComposerFormattingToolbar` so this row can stay aligned with the
+48-pixel app-shell controls.
+-->
 <script lang="ts">
   import { m } from '$lib/i18n/messages';
   import ComposerTimestampPicker from './ComposerTimestampPicker.svelte';
-  import type {
-    ComposerFormattingCommand,
-    ComposerFormattingState,
-    ComposerEditorApi,
-    ComposerIndentState
-  } from './editorTypes';
+  import type { ComposerEditorApi } from './editorTypes';
 
   let {
-    formattingState,
-    indentState,
     editorApi,
     inputDisabled,
     canAttach,
@@ -27,8 +27,6 @@
     onToggleAlsoSendToChannel = () => {},
     onsubmit
   }: {
-    formattingState: ComposerFormattingState;
-    indentState: ComposerIndentState;
     editorApi: ComposerEditorApi | null;
     inputDisabled: boolean;
     canAttach: boolean;
@@ -45,104 +43,10 @@
     onToggleAlsoSendToChannel?: () => void;
     onsubmit: () => void;
   } = $props();
-
-  const formattingControls: {
-    command: ComposerFormattingCommand;
-    icon: string;
-  }[] = [
-    { command: 'bold', icon: 'icon-[mdi--format-bold]' },
-    { command: 'italic', icon: 'icon-[mdi--format-italic]' },
-    { command: 'inlineCode', icon: 'icon-[mdi--code-tags]' },
-    { command: 'heading', icon: 'icon-[mdi--format-header-2]' },
-    { command: 'bulletList', icon: 'icon-[mdi--format-list-bulleted]' },
-    { command: 'orderedList', icon: 'icon-[mdi--format-list-numbered]' },
-    { command: 'blockquote', icon: 'icon-[mdi--format-quote-open]' },
-    { command: 'codeBlock', icon: 'icon-[mdi--code-block-braces]' }
-  ];
-  function formattingLabel(command: ComposerFormattingCommand): string {
-    switch (command) {
-      case 'bold':
-        return m('composer.format.bold');
-      case 'italic':
-        return m('composer.format.italic');
-      case 'inlineCode':
-        return m('composer.format.inline_code');
-      case 'heading':
-        return m('composer.format.heading');
-      case 'bulletList':
-        return m('composer.format.bullet_list');
-      case 'orderedList':
-        return m('composer.format.ordered_list');
-      case 'blockquote':
-        return m('composer.format.blockquote');
-      case 'codeBlock':
-        return m('composer.format.code_block');
-    }
-  }
 </script>
 
-<div
-  class="mt-0 flex min-h-7 items-center justify-between gap-2 border-t border-border/60 pt-0.5"
-  data-testid="composer-toolbar"
->
-  <div class="flex min-w-0 flex-1 items-center gap-1 overflow-hidden">
-    <div
-      class="flex min-w-0 [scrollbar-width:none] flex-nowrap items-center gap-0.5 overflow-x-auto overscroll-x-contain [&::-webkit-scrollbar]:hidden"
-      data-testid="composer-formatting-toolbar"
-    >
-      {#each formattingControls as control (control.command)}
-        {@const label = formattingLabel(control.command)}
-        {@const active = formattingState[control.command]}
-        <button
-          type="button"
-          onpointerdown={(event) => event.preventDefault()}
-          onclick={() => editorApi?.toggleFormatting(control.command)}
-          disabled={inputDisabled || !editorApi}
-          aria-label={label}
-          aria-pressed={active}
-          title={label}
-          class={[
-            'flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded transition-[background-color,color,scale] duration-100 active:scale-[0.96] disabled:cursor-not-allowed disabled:opacity-50',
-            active
-              ? 'bg-surface-emphasized text-text'
-              : 'text-muted enabled:hover:bg-surface-emphasized enabled:hover:text-text'
-          ]}
-        >
-          <span class={['iconify text-[15px]', control.icon]}></span>
-        </button>
-        {#if control.command === 'orderedList'}
-          <button
-            type="button"
-            onpointerdown={(event) => event.preventDefault()}
-            onclick={() => editorApi?.adjustIndent('outdent')}
-            disabled={inputDisabled || !editorApi || !indentState.canOutdent}
-            aria-label={m('composer.format.outdent')}
-            aria-keyshortcuts="Shift+Tab"
-            title={m('composer.format.outdent')}
-            class="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] duration-100 active:scale-[0.96] enabled:hover:bg-surface-emphasized enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <span class="iconify icon-[mdi--format-indent-decrease] text-[15px] rtl:scale-x-[-1]"
-            ></span>
-          </button>
-          <button
-            type="button"
-            onpointerdown={(event) => event.preventDefault()}
-            onclick={() => editorApi?.adjustIndent('indent')}
-            disabled={inputDisabled || !editorApi || !indentState.canIndent}
-            aria-label={m('composer.format.indent')}
-            aria-keyshortcuts="Tab"
-            title={m('composer.format.indent')}
-            class="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color,scale] duration-100 active:scale-[0.96] enabled:hover:bg-surface-emphasized enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            <span class="iconify icon-[mdi--format-indent-increase] text-[15px] rtl:scale-x-[-1]"
-            ></span>
-          </button>
-        {/if}
-      {/each}
-    </div>
-
-    <div class="mx-1 h-4 w-px shrink-0 bg-border/60"></div>
-
+<div class="mb-1.5 flex shrink-0 items-center gap-1" data-testid="composer-action-toolbar">
+  <div class="flex items-center gap-0.5">
     {#if !isEditing && canAttach}
       <button
         type="button"
@@ -159,63 +63,61 @@
     <ComposerTimestampPicker disabled={inputDisabled} {editorApi} {effectiveTimezone} />
   </div>
 
-  <div class="flex shrink-0 items-center gap-2">
-    <div class="flex items-center gap-0.5">
-      {#if showCreateThread}
-        <button
-          type="button"
-          onpointerdown={(event) => event.preventDefault()}
-          onclick={onToggleCreateThread}
-          disabled={inputDisabled || createThreadRequired}
-          aria-label={m('composer.post_as_thread')}
-          aria-pressed={createThread}
-          title={m('composer.post_as_thread')}
-          class={[
-            'flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-xs font-medium transition-[background-color,color] duration-100 disabled:cursor-not-allowed @min-[560px]:w-auto @min-[560px]:gap-1 @min-[560px]:px-1.5',
-            inputDisabled && 'opacity-50',
-            createThread
-              ? 'bg-action/10 text-action'
-              : 'text-muted enabled:hover:bg-surface-emphasized enabled:hover:text-text'
-          ]}
-        >
-          <span class="iconify icon-[uil--comment-alt-lines] text-[15px]"></span>
-          <span class="hidden @min-[560px]:inline">{m('composer.thread_label')}</span>
-        </button>
-      {/if}
+  <div class="flex items-center gap-0.5">
+    {#if showCreateThread}
+      <button
+        type="button"
+        onpointerdown={(event) => event.preventDefault()}
+        onclick={onToggleCreateThread}
+        disabled={inputDisabled || createThreadRequired}
+        aria-label={m('composer.post_as_thread')}
+        aria-pressed={createThread}
+        title={m('composer.post_as_thread')}
+        class={[
+          'flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-xs font-medium transition-[background-color,color] duration-100 disabled:cursor-not-allowed @min-[560px]:w-auto @min-[560px]:gap-1 @min-[560px]:px-1.5',
+          inputDisabled && 'opacity-50',
+          createThread
+            ? 'bg-action/10 text-action'
+            : 'text-muted enabled:hover:bg-surface-emphasized enabled:hover:text-text'
+        ]}
+      >
+        <span class="iconify icon-[uil--comment-alt-lines] text-[15px]"></span>
+        <span class="hidden @min-[560px]:inline">{m('composer.thread_label')}</span>
+      </button>
+    {/if}
 
-      {#if showAlsoSendToChannel}
-        <button
-          type="button"
-          onpointerdown={(event) => event.preventDefault()}
-          onclick={onToggleAlsoSendToChannel}
-          disabled={inputDisabled}
-          aria-label={m('composer.also_send_to_channel')}
-          aria-pressed={alsoSendToChannel}
-          title={m('composer.also_send_to_channel')}
-          class={[
-            'flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-xs font-medium transition-[background-color,color] duration-100 disabled:cursor-not-allowed disabled:opacity-50 @min-[560px]:w-auto @min-[560px]:gap-1 @min-[560px]:px-1.5',
-            alsoSendToChannel
-              ? 'bg-action/10 text-action'
-              : 'text-muted enabled:hover:bg-surface-emphasized enabled:hover:text-text'
-          ]}
-        >
-          <span class="iconify icon-[uil--megaphone] text-[15px]"></span>
-          <span class="hidden @min-[560px]:inline">{m('composer.echo_label')}</span>
-        </button>
-      {/if}
-    </div>
-
-    <button
-      type="button"
-      onpointerdown={(event) => event.preventDefault()}
-      onclick={onsubmit}
-      disabled={!canSubmit}
-      class="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-xs font-medium text-muted transition-[background-color,color,scale] duration-100 active:scale-[0.96] enabled:hover:bg-surface-emphasized enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50 @min-[560px]:w-auto @min-[560px]:gap-1 @min-[560px]:px-1.5"
-      aria-label={m('composer.send')}
-      title={m('composer.send')}
-    >
-      <span class="iconify icon-[uil--telegram-alt] text-[15px]"></span>
-      <span class="hidden @min-[560px]:inline">{m('composer.send_label')}</span>
-    </button>
+    {#if showAlsoSendToChannel}
+      <button
+        type="button"
+        onpointerdown={(event) => event.preventDefault()}
+        onclick={onToggleAlsoSendToChannel}
+        disabled={inputDisabled}
+        aria-label={m('composer.also_send_to_channel')}
+        aria-pressed={alsoSendToChannel}
+        title={m('composer.also_send_to_channel')}
+        class={[
+          'flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-xs font-medium transition-[background-color,color] duration-100 disabled:cursor-not-allowed disabled:opacity-50 @min-[560px]:w-auto @min-[560px]:gap-1 @min-[560px]:px-1.5',
+          alsoSendToChannel
+            ? 'bg-action/10 text-action'
+            : 'text-muted enabled:hover:bg-surface-emphasized enabled:hover:text-text'
+        ]}
+      >
+        <span class="iconify icon-[uil--megaphone] text-[15px]"></span>
+        <span class="hidden @min-[560px]:inline">{m('composer.echo_label')}</span>
+      </button>
+    {/if}
   </div>
+
+  <button
+    type="button"
+    onpointerdown={(event) => event.preventDefault()}
+    onclick={onsubmit}
+    disabled={!canSubmit}
+    class="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-xs font-medium text-muted transition-[background-color,color,scale] duration-100 active:scale-[0.96] enabled:hover:bg-surface-emphasized enabled:hover:text-text disabled:cursor-not-allowed disabled:opacity-50 @min-[560px]:w-auto @min-[560px]:gap-1 @min-[560px]:px-1.5"
+    aria-label={m('composer.send')}
+    title={m('composer.send')}
+  >
+    <span class="iconify icon-[uil--telegram-alt] text-[15px]"></span>
+    <span class="hidden @min-[560px]:inline">{m('composer.send_label')}</span>
+  </button>
 </div>

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -27,6 +27,7 @@
   import MentionAutocomplete from './MentionAutocomplete.svelte';
   import ComposerLinkPreview from './ComposerLinkPreview.svelte';
   import ComposerAttachmentPreviews from './ComposerAttachmentPreviews.svelte';
+  import ComposerFormattingToolbar from './ComposerFormattingToolbar.svelte';
   import ComposerToolbar from './ComposerToolbar.svelte';
   import ComposerModeIndicators from './ComposerModeIndicators.svelte';
   import { MessageComposerState, type MessageComposerProps } from './messageComposerState.svelte';
@@ -97,6 +98,8 @@
   );
   const slowModeBlocked = $derived(slowModeRemainingSeconds > 0);
   const editorModule = $derived(editorLoaders[userPreferences.composerEditor]());
+  const composerId = $props.id();
+  const formattingToolbarId = `${composerId}-formatting-toolbar`;
 
   $effect(() => {
     const deadline = slowModeDeadline;
@@ -210,11 +213,21 @@
     />
   {/if}
 
-  <div
-    data-testid="composer-input-surface"
-    class="@container relative flex flex-col rounded-lg bg-surface px-2.5 py-1.5"
-    class:opacity-50={composer.inputDisabled}
-  >
+  {#if userPreferences.composerFormattingToolbarVisible}
+    <ComposerFormattingToolbar
+      id={formattingToolbarId}
+      formattingState={composer.formattingState}
+      indentState={composer.indentState}
+      editorApi={composer.editorApi}
+      inputDisabled={composer.inputDisabled}
+    />
+  {/if}
+
+	<div
+		data-testid="composer-input-surface"
+		class="composer-surface @container relative flex min-h-12 min-w-0 items-end gap-1 px-2.5 py-1.5"
+		class:opacity-50={composer.inputDisabled}
+	>
     {#if composer.autocomplete.emoji}
       <EmojiAutocomplete
         bind:this={composer.autocomplete.emojiRef}
@@ -235,7 +248,31 @@
       />
     {/if}
 
-    <div class="min-h-9 min-w-0 px-0.5 py-0.5" data-testid="composer-editor-row">
+    <button
+      type="button"
+      onpointerdown={(event) => event.preventDefault()}
+      onclick={() =>
+        (userPreferences.composerFormattingToolbarVisible =
+          !userPreferences.composerFormattingToolbarVisible)}
+      aria-label={m('composer.formatting_options')}
+      aria-controls={formattingToolbarId}
+      aria-expanded={userPreferences.composerFormattingToolbarVisible}
+      aria-pressed={userPreferences.composerFormattingToolbarVisible}
+      title={m('composer.formatting_options')}
+      class={[
+        'mb-1.5 flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded text-sm font-semibold transition-[background-color,color,scale] duration-100 active:scale-[0.96]',
+        userPreferences.composerFormattingToolbarVisible
+          ? 'bg-surface-emphasized text-text'
+          : 'text-muted hover:bg-surface-emphasized hover:text-text'
+      ]}
+    >
+      <span aria-hidden="true">Aa</span>
+    </button>
+
+    <div
+      class="min-h-9 min-w-0 flex-1 px-0.5 py-0.5"
+      data-testid="composer-editor-row"
+    >
       {#await editorModule}
         <div class="min-h-8 min-w-0" aria-hidden="true"></div>
       {:then { default: Editor }}
@@ -256,8 +293,6 @@
     </div>
 
     <ComposerToolbar
-      formattingState={composer.formattingState}
-      indentState={composer.indentState}
       editorApi={composer.editorApi}
       inputDisabled={composer.inputDisabled}
       {canAttach}

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -346,10 +346,22 @@ function selectFirstAttachment(input: HTMLInputElement, file = imageFile()) {
   return file;
 }
 
+async function openFormattingShelf(container: HTMLElement) {
+  const toggle = q(
+    container,
+    'button[aria-label="Formatting options"]'
+  ) as HTMLButtonElement;
+  if (toggle.getAttribute('aria-expanded') !== 'true') await userEvent.click(toggle);
+  await vi.waitFor(() =>
+    expect(q(container, '[data-testid="composer-formatting-shelf"]')).toBeTruthy()
+  );
+}
+
 describe('MessageComposer', () => {
   beforeEach(() => {
     userPreferences.composerEditor = 'visual';
     userPreferences.composerSendMode = 'modifier-enter';
+    userPreferences.composerFormattingToolbarVisible = false;
     window.getSelection()?.removeAllRanges();
     mockInstanceStores.serverInfo.videoProcessingEnabled = false;
     mockInstanceStores.serverInfo.maxUploadSize = 25 * 1024 * 1024;
@@ -437,18 +449,49 @@ describe('MessageComposer', () => {
         .toBeInTheDocument();
     });
 
-    it('keeps editor input above the compact action toolbar', async () => {
+    it('keeps the editor and message actions in one compact input row', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
 
       const editor = await findEditor(container);
+      const surface = q(container, '[data-testid="composer-input-surface"]');
       const editorRow = q(container, '[data-testid="composer-editor-row"]');
-      const toolbar = q(container, '[data-testid="composer-toolbar"]');
+      const actions = q(container, '[data-testid="composer-action-toolbar"]');
 
       expect(editorRow?.contains(editor)).toBe(true);
-      expect(toolbar?.contains(q(container, 'button[title="Attach file"]'))).toBe(true);
-      expect(toolbar?.contains(q(container, 'button[aria-label="Bold"]'))).toBe(true);
-      expect(toolbar?.contains(q(container, 'button[aria-label="Insert timestamp"]'))).toBe(true);
-      expect(toolbar?.contains(q(container, 'button[aria-label="Send message"]'))).toBe(true);
+      expect(surface?.contains(editorRow)).toBe(true);
+      expect(actions?.contains(q(container, 'button[title="Attach file"]'))).toBe(true);
+      expect(actions?.contains(q(container, 'button[aria-label="Insert timestamp"]'))).toBe(true);
+      expect(actions?.contains(q(container, 'button[aria-label="Send message"]'))).toBe(true);
+      expect(surface).toHaveClass('composer-surface');
+      expect(q(container, '[data-testid="composer-formatting-shelf"]')).toBeNull();
+    });
+
+    it('toggles, persists, and restores the formatting shelf without losing editor focus', async () => {
+      const first = renderMessageComposer({ roomId: 'formatting-shelf-first' });
+      const editor = await findEditor(first.container);
+      await userEvent.click(editor);
+      const toggle = q(
+        first.container,
+        'button[aria-label="Formatting options"]'
+      ) as HTMLButtonElement;
+
+      await userEvent.click(toggle);
+
+      await expect.element(toggle).toHaveAttribute('aria-expanded', 'true');
+      await expect.element(toggle).toHaveAttribute('aria-pressed', 'true');
+      expect(toggle.getAttribute('aria-controls')).toBe(
+        q(first.container, '[data-testid="composer-formatting-shelf"]')?.id
+      );
+      expect(document.activeElement).toBe(editor);
+      expect(userPreferences.composerFormattingToolbarVisible).toBe(true);
+      expect(q(first.container, '[data-testid="composer-formatting-shelf"]')).toHaveClass(
+        'composer-surface'
+      );
+
+      first.unmount();
+      const second = renderMessageComposer({ roomId: 'formatting-shelf-second' });
+      await findEditor(second.container);
+      expect(q(second.container, '[data-testid="composer-formatting-shelf"]')).toBeTruthy();
     });
 
     it('preserves an editor selection when a mouse drag ends over composer padding', async () => {
@@ -474,6 +517,7 @@ describe('MessageComposer', () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
 
       await findEditor(container);
+      await openFormattingShelf(container);
 
       expect(q(container, '[data-testid="composer-input-surface"]')).toHaveClass('@container');
       expect(q(container, '[data-testid="composer-formatting-toolbar"]')).toHaveClass(
@@ -529,6 +573,7 @@ describe('MessageComposer', () => {
     it('formats and submits Markdown source with Ctrl+Enter', async () => {
       const { container, roomId } = renderMessageComposer({ roomId: 'markdown-send' });
       const editor = await findEditor(container);
+      await openFormattingShelf(container);
       await typeEditorKeys(editor, 'first');
       await userEvent.click(q(container, 'button[aria-label="Bullet list"]')!);
 
@@ -545,6 +590,7 @@ describe('MessageComposer', () => {
     it('uses CodeMirror line indentation with the toolbar and Tab', async () => {
       const { container } = renderMessageComposer({ roomId: 'markdown-list-indent' });
       const editor = await findEditor(container);
+      await openFormattingShelf(container);
       const indent = q(container, 'button[aria-label="Indent"]') as HTMLButtonElement;
       const outdent = q(container, 'button[aria-label="Outdent"]') as HTMLButtonElement;
 
@@ -593,7 +639,7 @@ describe('MessageComposer', () => {
       await userEvent.click(editor);
       await userEvent.keyboard('{Escape}{Tab}');
 
-      expect(document.activeElement).toBe(q(container, 'button[aria-label="Bold"]'));
+      expect(document.activeElement).toBe(q(container, 'button[aria-label="Attach file"]'));
     });
 
     it('completes mentions before Enter can submit Markdown', async () => {
@@ -1192,7 +1238,7 @@ describe('MessageComposer', () => {
     it('does not show a send shortcut hint', async () => {
       const { container } = renderMessageComposer({ roomId: 'room_456' });
       await findEditor(container);
-      const toolbar = q(container, '[data-testid="composer-toolbar"]');
+      const toolbar = q(container, '[data-testid="composer-action-toolbar"]');
       expect(toolbar?.textContent).not.toMatch(/to send/i);
       expect(toolbar?.querySelector('[title*="to send"]')).toBeNull();
     });
@@ -2179,6 +2225,7 @@ describe('MessageComposer', () => {
     it('posts markdown after composer formatting buttons are applied', async () => {
       const { container, roomId } = renderMessageComposer({ roomId: 'room_456' });
       const editor = await findEditor(container);
+      await openFormattingShelf(container);
       const boldButton = q(container, 'button[aria-label="Bold"]') as HTMLButtonElement;
 
       await userEvent.click(boldButton);
@@ -2804,6 +2851,7 @@ describe('MessageComposer', () => {
     it('indents visual list items with both the toolbar and Tab', async () => {
       const { container } = renderMessageComposer({ roomId: 'visual-list-indent' });
       const editor = await findEditor(container);
+      await openFormattingShelf(container);
       const indent = q(container, 'button[aria-label="Indent"]') as HTMLButtonElement;
       const outdent = q(container, 'button[aria-label="Outdent"]') as HTMLButtonElement;
 
@@ -3014,7 +3062,7 @@ describe('MessageComposer', () => {
         container,
         'button[aria-label="Also send to channel"]'
       ) as HTMLButtonElement;
-      expect(echoToggle.closest('[data-testid="composer-toolbar"]')).toBeTruthy();
+      expect(echoToggle.closest('[data-testid="composer-action-toolbar"]')).toBeTruthy();
       expect(echoToggle).toHaveTextContent('Echo');
       expect(echoToggle.querySelector('.iconify')).toHaveClass('icon-[uil--megaphone]');
       expect(echoToggle.querySelector('span:not(.iconify)')).toHaveClass(
@@ -3064,7 +3112,7 @@ describe('MessageComposer', () => {
       const threadToggle = q(container, 'button[aria-label="Post as thread"]') as HTMLButtonElement;
 
       await expect.element(threadToggle).toHaveAttribute('aria-pressed', 'false');
-      expect(threadToggle.closest('[data-testid="composer-toolbar"]')).toBeTruthy();
+      expect(threadToggle.closest('[data-testid="composer-action-toolbar"]')).toBeTruthy();
       expect(threadToggle).toHaveTextContent('Thread');
       expect(threadToggle.querySelector('span:not(.iconify)')).toHaveClass(
         'hidden',

--- a/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
@@ -33,13 +33,14 @@ describe('UserPreferencesState', () => {
     document.documentElement.style.colorScheme = '';
   });
 
-  it('uses the system theme, Markdown editor, and Return-to-send by default', () => {
+  it('uses the system theme, Markdown editor, Return-to-send, and a closed formatting shelf by default', () => {
     const state = new UserPreferencesState();
 
     expect(state.displayTheme).toBe('system');
     expect(state.effectiveDisplayTheme).toBe('light');
     expect(state.composerEditor).toBe('markdown');
     expect(state.composerSendMode).toBe('enter');
+    expect(state.composerFormattingToolbarVisible).toBe(false);
   });
 
   it('resolves the system display theme from prefers-color-scheme', () => {
@@ -69,7 +70,8 @@ describe('UserPreferencesState', () => {
       JSON.stringify({
         displayTheme: 'sepia',
         composerEditor: 'plain-text',
-        composerSendMode: 'spacebar'
+        composerSendMode: 'spacebar',
+        composerFormattingToolbarVisible: 'yes'
       })
     );
 
@@ -78,6 +80,7 @@ describe('UserPreferencesState', () => {
     expect(state.displayTheme).toBe('system');
     expect(state.composerEditor).toBe('markdown');
     expect(state.composerSendMode).toBe('enter');
+    expect(state.composerFormattingToolbarVisible).toBe(false);
   });
 
   it('updates, persists, and applies the display theme', () => {
@@ -99,13 +102,25 @@ describe('UserPreferencesState', () => {
 
     state.composerEditor = 'visual';
     state.composerSendMode = 'modifier-enter';
+    state.composerFormattingToolbarVisible = true;
 
     expect(state.composerEditor).toBe('visual');
     expect(state.composerSendMode).toBe('modifier-enter');
+    expect(state.composerFormattingToolbarVisible).toBe(true);
     expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')).toMatchObject({
       composerEditor: 'visual',
-      composerSendMode: 'modifier-enter'
+      composerSendMode: 'modifier-enter',
+      composerFormattingToolbarVisible: true
     });
+  });
+
+  it('hydrates a persisted formatting shelf choice', () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ composerFormattingToolbarVisible: true })
+    );
+
+    expect(new UserPreferencesState().composerFormattingToolbarVisible).toBe(true);
   });
 
   it('keeps former global sound fields available only as a migration seed', () => {

--- a/apps/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.ts
@@ -23,6 +23,7 @@ interface AppPreferences {
   displayTheme: DisplayTheme;
   composerEditor: ComposerEditorKind;
   composerSendMode: ComposerSendMode;
+  composerFormattingToolbarVisible: boolean;
 }
 
 export interface LegacyNotificationSoundPreferences {
@@ -35,7 +36,8 @@ interface StoredPreferences extends AppPreferences, LegacyNotificationSoundPrefe
 const defaultAppPreferences: AppPreferences = {
   displayTheme: 'system',
   composerEditor: 'markdown',
-  composerSendMode: 'enter'
+  composerSendMode: 'enter',
+  composerFormattingToolbarVisible: false
 };
 
 const defaultStoredPreferences: StoredPreferences = {
@@ -134,7 +136,11 @@ function loadAppPreferences(): AppPreferences {
       : defaultAppPreferences.composerEditor,
     composerSendMode: isComposerSendMode(stored.composerSendMode)
       ? stored.composerSendMode
-      : defaultAppPreferences.composerSendMode
+      : defaultAppPreferences.composerSendMode,
+    composerFormattingToolbarVisible:
+      typeof stored.composerFormattingToolbarVisible === 'boolean'
+        ? stored.composerFormattingToolbarVisible
+        : defaultAppPreferences.composerFormattingToolbarVisible
   };
 }
 
@@ -191,6 +197,17 @@ export class UserPreferencesState {
     this.#preferences.composerSendMode = isComposerSendMode(value)
       ? value
       : defaultAppPreferences.composerSendMode;
+    this.#persist();
+  }
+
+  /** Whether message formatting controls stay visible above each composer. */
+  get composerFormattingToolbarVisible(): boolean {
+    return this.#preferences.composerFormattingToolbarVisible;
+  }
+
+  set composerFormattingToolbarVisible(value: boolean) {
+    this.#preferences.composerFormattingToolbarVisible =
+      typeof value === 'boolean' ? value : defaultAppPreferences.composerFormattingToolbarVisible;
     this.#persist();
   }
 

--- a/docs/fdr/FDR-032-message-formatting.md
+++ b/docs/fdr/FDR-032-message-formatting.md
@@ -1,7 +1,7 @@
 # FDR-032: Message Formatting
 
 **Status:** Active
-**Last reviewed:** 2026-08-23
+**Last reviewed:** 2026-08-29
 
 ## Overview
 
@@ -22,6 +22,7 @@ Message bodies are stored and exchanged as plain text while bundled clients rend
 - The app applies the sending keys to every registered Chatto server. Return sends by default. People can select the platform modifier plus Return instead.
 - The key not assigned to sending performs the selected editor's normal Return action. In the visual editor that includes paragraph splitting, list continuation, leaving an empty list item, and new lines inside code blocks; Shift+Return remains a hard line break.
 - Both editors provide toolbar actions to indent and outdent. In the visual editor they change list nesting. In the Markdown source editor they apply CodeMirror's normal line indentation to the current line or selection, as do Tab and Shift+Tab; autocomplete consumes Tab first when a suggestion is active.
+- The composer shows message actions in its input row. A Formatting options control shows or hides the formatting toolbar above the input. The toolbar is hidden by default. The app stores the last selection in the browser and applies it to all composers.
 - Touch-primary devices always use Return for editing and the visible Send button, even when Return-to-send is selected.
 
 ## Design Decisions
@@ -46,9 +47,9 @@ Message bodies are stored and exchanged as plain text while bundled clients rend
 
 ### 4. Composer presentation is an App Preference
 
-**Decision:** The bundled client supplies visual and Markdown source editors for the same message body. App Preferences stores the editor and send-key choices on the Composer page. Markdown and Return-to-send are the defaults when a preference is absent or invalid. The key that does not send keeps the editor's normal Return behavior. Each editor uses its own indent model. The visual editor changes list structure. The Markdown editor changes source-line indentation.
+**Decision:** The bundled client supplies visual and Markdown source editors for the same message body. App Preferences stores the editor and send-key choices on the Composer page. It also stores the formatting-toolbar state when a person changes it in the composer. Markdown, Return-to-send, and a hidden formatting toolbar are the defaults when a preference is absent or invalid. The key that does not send keeps the editor's normal Return behavior. Each editor uses its own indent model. The visual editor changes list structure. The Markdown editor changes source-line indentation.
 **Why:** People can choose direct source control or a syntax-free editing experience without changing the server contract, message history, or what other clients receive. They can also preserve their preferred chat shortcut and familiar keyboard editing behavior in paragraphs, lists, or code blocks.
-**Tradeoff:** App Preferences do not follow a person to another browser or device. Each editor must have the same composer integrations and formatting controls. The indent controls operate differently in each editor. The alternate Return shortcut changes meaning with the selected send mode.
+**Tradeoff:** App Preferences do not follow a person to another browser or device. Each editor must have the same composer integrations and formatting controls. A person must open the toolbar before they can select a formatting control. The indent controls operate differently in each editor. The alternate Return shortcut changes meaning with the selected send mode.
 
 ## Related
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -41,7 +41,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-029](FDR-029-chatto-shields.md) | Chatto Shields | Active | 2026-08-23 |
 | [FDR-030](FDR-030-inline-message-timestamps.md) | Inline Message Timestamps | Active | 2026-07-12 |
 | [FDR-031](FDR-031-client-server-compatibility-discovery.md) | Client–Server Compatibility Discovery | Experimental | 2026-08-21 |
-| [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-08-23 |
+| [FDR-032](FDR-032-message-formatting.md) | Message Formatting | Active | 2026-08-29 |
 | [FDR-033](FDR-033-message-search.md) | Message Search | Experimental | 2026-08-25 |
 | [FDR-034](FDR-034-chatto-desktop.md) | Chatto Desktop | Experimental | 2026-08-20 |
 | [FDR-035](FDR-035-slow-mode.md) | Slow Mode | Active | 2026-08-11 |


### PR DESCRIPTION
## Why

The composer toolbar made the empty input taller than the Add Server control and user card, which weakened the app shell alignment.

## What changed

- Restored the empty composer to a 48 px action row with responsive message actions
- Moved formatting and indentation commands into a collapsible shelf that preserves editor focus and selection
- Added a validated, browser-local remembered preference plus an accessible localized toggle
- Applied one shared composer surface radius and updated FDR-032 and the message-formatting guide
- Updated E2E coverage to open the formatting shelf and target the split action toolbar

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise test-frontend` — passed: 409 files and 3,445 tests
- Focused composer suite after the final styling change — passed: 159 tests
- Targeted composer and message-editing E2E with retries disabled — passed: 32 tests
- `mise lint-frontend`, production frontend build, bundle/CSP checks, and `mise license-check` — passed
- Svelte autofixer — no issues in changed Svelte files
- Chrome DevTools — verified light and dark themes, wide and narrow layouts, mobile width, RTL, multiline input, open and closed shelf states, and matching 12 px radii; the empty composer, user card, and Add Server control each measured 48 px high