### PR TITLE
fix(frontend): divide member search from presence groups

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -476,7 +476,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
               {m('room.sidebar.no_members')}
             </div>
           {:else}
-            {#each memberGroups as group, i (group.id)}
+            {#each memberGroups as group (group.id)}
               <RoomGroupSection
                 label={group.label}
                 items={group.items}
@@ -484,7 +484,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
                 persistKey={group.persistKey}
                 defaultCollapsed={group.defaultCollapsed}
                 testid={group.testid}
-                separated={i > 0}
+                separated
               />
             {/each}
           {/if}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -1618,6 +1618,27 @@ describe('RoomSidebar', () => {
     expect(buttonByText(container, 'Online (1)')).toBeTruthy();
     expect(buttonByText(container, 'Offline (1)')).toBeTruthy();
     expect(container.querySelectorAll('[data-testid="room-group-section"].border-t')).toHaveLength(
+      2
+    );
+  });
+
+  it('separates an offline-only member group from member search', async () => {
+    memberDirectoryMocks.listRoomMembers.mockResolvedValueOnce(
+      memberPage([{ ...member(1), presenceStatus: PresenceStatus.OFFLINE }])
+    );
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false)
+      }
+    });
+
+    await vi.waitFor(() => {
+      expect(buttonByText(container, 'Offline (1)')).toBeTruthy();
+    });
+
+    expect(buttonByText(container, 'Online (1)')).toBeFalsy();
+    expect(container.querySelectorAll('[data-testid="room-group-section"].border-t')).toHaveLength(
       1
     );
   });


### PR DESCRIPTION
## Summary

- add the existing full-width group divider between member search and the first visible presence group
- preserve the divider between Online and Offline groups
- cover both mixed-presence and offline-only member lists

## Verification

- `mise x -- pnpm --filter chatto-frontend exec vitest --run --project=client "src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts"`
- `mise x -- pnpm --filter chatto-frontend check`
- Svelte autofixer on `RoomSidebar.svelte`
- Chrome DevTools visual verification in dark and light themes