### PR TITLE
fix(frontend): restore bright notification orange

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -106,9 +106,8 @@
   --color-on-success: var(--color-white);
   --color-warning: oklch(50% 0.13 60);
   --color-on-warning: var(--color-white);
-  /* Attention is brighter than warning so unread and pending states stay
-     noticeable without competing with a committed action. */
-  --color-attention: oklch(68% 0.15 80);
+  /* Notification attention stays bright and consistent across both themes. */
+  --color-attention: var(--color-amber-500);
   --color-on-attention: var(--color-neutral-950);
   --color-danger: oklch(49% 0.17 12);
   --color-on-danger: var(--color-white);


### PR DESCRIPTION
## Why

The muted attention colour made important notification indicators too subdued, so this restores their previous visual prominence.

## What changed

The shared attention token now uses Tailwind amber-500 in both themes; notification badges, important unread rows, thread indicators, and notification-policy previews inherit the brighter orange without component changes.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: No impact.
- Newer client → older server: No impact.
- Capability discovery or minimum client/server version: No change.

## Test plan

- mise lint-frontend — passed.
- Focused Vitest browser run — 6 files and 117 tests passed.
- Chrome DevTools Storybook inspection — notification badges, unread dots, navigation attention, and colour tokens verified in light and dark themes with 9.27:1 badge-label contrast.