### PR TITLE
feat(frontend): finish version easter egg

### DIFF
--- a/apps/frontend/messages/ar/ui.json
+++ b/apps/frontend/messages/ar/ui.json
@@ -47,7 +47,9 @@
       "laser_cooldown": "ليزر {number}، الطاقة {power}: {seconds} ثانية من فترة التهدئة المتبقية",
       "upgrade_power": "ترقية الليزر {number} إلى مستوى الطاقة {level} لنقاط {cost}",
       "buy_laser": "قم بشراء مسدس الليزر {number} مقابل نقاط {cost}",
-      "maximum_lasers": "تم الوصول إلى الحد الأقصى لمدافع الليزر {count}"
+      "maximum_lasers": "تم الوصول إلى الحد الأقصى لمدافع الليزر {count}",
+      "maximum_power": "وصل الليزر {number} إلى الطاقة القصوى {power}",
+      "complete": "تمت إعادة بناء Chatto. النتيجة النهائية: {count} نقطة"
     },
     "pane_header": {
       "back": "العودة"

--- a/apps/frontend/messages/cs-CZ/ui.json
+++ b/apps/frontend/messages/cs-CZ/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, výkon {power}: zbývá {seconds} sekund cooldown",
       "upgrade_power": "Upgradujte laser {number} na úroveň výkonu {level} za {cost} bodů",
       "buy_laser": "Kupte si laserovou pistoli {number} za {cost} bodů",
-      "maximum_lasers": "Bylo dosaženo maximálního počtu {count} laserových děl"
+      "maximum_lasers": "Bylo dosaženo maximálního počtu {count} laserových děl",
+      "maximum_power": "Laser {number} dosáhl maximálního výkonu {power}",
+      "complete": "Chatto bylo obnoveno. Konečné skóre: {count} bodů"
     },
     "pane_header": {
       "back": "Zpět"

--- a/apps/frontend/messages/de-DE/ui.json
+++ b/apps/frontend/messages/de-DE/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, Stärke {power}: noch {seconds} Sekunden Abklingzeit",
       "upgrade_power": "Stärke von Laser {number} für {cost} Punkte auf Stufe {level} erhöhen",
       "buy_laser": "Laserkanone {number} für {cost} Punkte kaufen",
-      "maximum_lasers": "Maximum von {count} Laserkanonen erreicht"
+      "maximum_lasers": "Maximum von {count} Laserkanonen erreicht",
+      "maximum_power": "Laser {number} hat die maximale Stärke {power} erreicht",
+      "complete": "Chatto wurde wieder aufgebaut. Endpunktzahl: {count} Punkte"
     },
     "pane_header": {
       "back": "Zurück"

--- a/apps/frontend/messages/en-GB/ui.json
+++ b/apps/frontend/messages/en-GB/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, power {power}: {seconds} seconds of cooldown remaining",
       "upgrade_power": "Upgrade laser {number} to power level {level} for {cost} points",
       "buy_laser": "Buy laser gun {number} for {cost} points",
-      "maximum_lasers": "Maximum of {count} laser guns reached"
+      "maximum_lasers": "Maximum of {count} laser guns reached",
+      "maximum_power": "Laser {number} has reached maximum power {power}",
+      "complete": "Chatto rebuilt. Final score: {count} points"
     },
     "pane_header": {
       "back": "Back"

--- a/apps/frontend/messages/eo/ui.json
+++ b/apps/frontend/messages/eo/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Lasero {number}, potenco {power}: restas {seconds} sekundoj da malvarmiĝo",
       "upgrade_power": "Altigu laseron {number} al potenca nivelo {level} kontraŭ {cost} poentoj",
       "buy_laser": "Aĉetu laserkanonon {number} kontraŭ {cost} poentoj",
-      "maximum_lasers": "Maksimumo de {count} laserkanonoj atingita"
+      "maximum_lasers": "Maksimumo de {count} laserkanonoj atingita",
+      "maximum_power": "Lasero {number} atingis maksimuman potencon {power}",
+      "complete": "Chatto rekonstruiĝis. Fina poentaro: {count} poentoj"
     },
     "pane_header": {
       "back": "Reen"

--- a/apps/frontend/messages/es-419/ui.json
+++ b/apps/frontend/messages/es-419/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Láser {number}, potencia {power}: quedan {seconds} segundos de recarga",
       "upgrade_power": "Mejorar el láser {number} al nivel de potencia {level} por {cost} puntos",
       "buy_laser": "Comprar el cañón láser {number} por {cost} puntos",
-      "maximum_lasers": "Se alcanzó el máximo de {count} cañones láser"
+      "maximum_lasers": "Se alcanzó el máximo de {count} cañones láser",
+      "maximum_power": "El láser {number} alcanzó la potencia máxima {power}",
+      "complete": "Chatto se reconstruyó. Puntuación final: {count} puntos"
     },
     "pane_header": {
       "back": "Volver"

--- a/apps/frontend/messages/es-ES/ui.json
+++ b/apps/frontend/messages/es-ES/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Láser {number}, potencia {power}: quedan {seconds} segundos de recarga",
       "upgrade_power": "Mejorar el láser {number} al nivel de potencia {level} por {cost} puntos",
       "buy_laser": "Comprar el cañón láser {number} por {cost} puntos",
-      "maximum_lasers": "Se alcanzó el máximo de {count} cañones láser"
+      "maximum_lasers": "Se alcanzó el máximo de {count} cañones láser",
+      "maximum_power": "El láser {number} ha alcanzado la potencia máxima {power}",
+      "complete": "Chatto se ha reconstruido. Puntuación final: {count} puntos"
     },
     "pane_header": {
       "back": "Volver"

--- a/apps/frontend/messages/et-EE/ui.json
+++ b/apps/frontend/messages/et-EE/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, võimsus {power}: {seconds} sekundit jahtumist on jäänud",
       "upgrade_power": "Uuendage laser {number} võimsustasemele {level} {cost} punkti saamiseks",
       "buy_laser": "Ostke laserpüstol {number} {cost} punkti eest",
-      "maximum_lasers": "Saavutatud on maksimaalselt {count} laserrelvi"
+      "maximum_lasers": "Saavutatud on maksimaalselt {count} laserrelvi",
+      "maximum_power": "Laser {number} saavutas suurima võimsuse {power}",
+      "complete": "Chatto ehitati uuesti üles. Lõppskoor: {count} punkti"
     },
     "pane_header": {
       "back": "Tagasi"

--- a/apps/frontend/messages/fr-CA/ui.json
+++ b/apps/frontend/messages/fr-CA/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, puissance {power} : encore {seconds} secondes de recharge",
       "upgrade_power": "Améliorer le laser {number} au niveau de puissance {level} pour {cost} points",
       "buy_laser": "Acheter le canon laser {number} pour {cost} points",
-      "maximum_lasers": "Maximum de {count} canons laser atteint"
+      "maximum_lasers": "Maximum de {count} canons laser atteint",
+      "maximum_power": "Le laser {number} a atteint la puissance maximale {power}",
+      "complete": "Chatto a été reconstruit. Score final : {count} points"
     },
     "pane_header": {
       "back": "Retour"

--- a/apps/frontend/messages/fr-FR/ui.json
+++ b/apps/frontend/messages/fr-FR/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, puissance {power} : encore {seconds} secondes de recharge",
       "upgrade_power": "Améliorer le laser {number} au niveau de puissance {level} pour {cost} points",
       "buy_laser": "Acheter le canon laser {number} pour {cost} points",
-      "maximum_lasers": "Maximum de {count} canons laser atteint"
+      "maximum_lasers": "Maximum de {count} canons laser atteint",
+      "maximum_power": "Le laser {number} a atteint la puissance maximale {power}",
+      "complete": "Chatto a été reconstruit. Score final : {count} points"
     },
     "pane_header": {
       "back": "Retour"

--- a/apps/frontend/messages/he-IL/ui.json
+++ b/apps/frontend/messages/he-IL/ui.json
@@ -44,7 +44,9 @@
       "laser_cooldown": "לייזר {number}, כוח {power}: {seconds} שנותרו שניות של קירור",
       "upgrade_power": "שדרוג לייזר {number} לרמת הספק {level} עבור נקודות {cost}",
       "buy_laser": "קנה אקדח לייזר {number} עבור נקודות {cost}",
-      "maximum_lasers": "הגעת למקסימום של רובי לייזר {count}"
+      "maximum_lasers": "הגעת למקסימום של רובי לייזר {count}",
+      "maximum_power": "לייזר {number} הגיע לעוצמה המרבית {power}",
+      "complete": "Chatto נבנה מחדש. ניקוד סופי: {count} נקודות"
     },
     "pane_header": {
       "back": "חזרה"

--- a/apps/frontend/messages/it-IT/ui.json
+++ b/apps/frontend/messages/it-IT/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, potenza {power}: {seconds} secondi di ricarica rimanenti",
       "upgrade_power": "Aggiorna il laser {number} al livello di potenza {level} per {cost} punti",
       "buy_laser": "Acquista pistola laser {number} per {cost} punti",
-      "maximum_lasers": "È stato raggiunto il numero massimo di {count} pistole laser"
+      "maximum_lasers": "È stato raggiunto il numero massimo di {count} pistole laser",
+      "maximum_power": "Il laser {number} ha raggiunto la potenza massima {power}",
+      "complete": "Chatto è stato ricostruito. Punteggio finale: {count} punti"
     },
     "pane_header": {
       "back": "Indietro"

--- a/apps/frontend/messages/ja-JP/ui.json
+++ b/apps/frontend/messages/ja-JP/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "レーザー{number}、出力{power}：クールダウン残り{seconds}秒",
       "upgrade_power": "{cost}ポイントでレーザー{number}を出力レベル{level}に強化",
       "buy_laser": "{cost}ポイントでレーザー砲{number}を購入",
-      "maximum_lasers": "レーザー砲の上限{count}基に到達"
+      "maximum_lasers": "レーザー砲の上限{count}基に到達",
+      "maximum_power": "レーザー{number}は最大出力{power}に達しました",
+      "complete": "Chattoが再構築されました。最終スコア：{count}ポイント"
     },
     "pane_header": {
       "back": "戻る"

--- a/apps/frontend/messages/lv-LV/ui.json
+++ b/apps/frontend/messages/lv-LV/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Lāzers {number}, jauda {power}: atlikušas {seconds} sekundes no dzesēšanas",
       "upgrade_power": "Jauniniet lāzeru {number} uz jaudas līmeni {level}, lai iegūtu {cost} punktus",
       "buy_laser": "Pērciet lāzera pistoli {number} par {cost} punktiem",
-      "maximum_lasers": "Sasniegts maksimālais {count} lāzera pistoles skaits"
+      "maximum_lasers": "Sasniegts maksimālais {count} lāzera pistoles skaits",
+      "maximum_power": "Lāzers {number} sasniedza maksimālo jaudu {power}",
+      "complete": "Chatto tika atjaunots. Gala rezultāts: {count} punkti"
     },
     "pane_header": {
       "back": "Atpakaļ"

--- a/apps/frontend/messages/nb-NO/ui.json
+++ b/apps/frontend/messages/nb-NO/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, styrke {power}: {seconds} sekunder nedkjøling gjenstår",
       "upgrade_power": "Oppgrader laser {number} til styrkenivå {level} for {cost} poeng",
       "buy_laser": "Kjøp laserkanon {number} for {cost} poeng",
-      "maximum_lasers": "Maksgrensen på {count} laserkanoner er nådd"
+      "maximum_lasers": "Maksgrensen på {count} laserkanoner er nådd",
+      "maximum_power": "Laser {number} har nådd maksimal styrke {power}",
+      "complete": "Chatto ble bygd opp igjen. Sluttpoengsum: {count} poeng"
     },
     "pane_header": {
       "back": "Tilbake"

--- a/apps/frontend/messages/nl-BE/ui.json
+++ b/apps/frontend/messages/nl-BE/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, kracht {power}: nog {seconds} seconden afkoeltijd",
       "upgrade_power": "Verhoog laser {number} naar krachtniveau {level} voor {cost} punten",
       "buy_laser": "Koop laserkanon {number} voor {cost} punten",
-      "maximum_lasers": "Maximum van {count} laserkanonnen bereikt"
+      "maximum_lasers": "Maximum van {count} laserkanonnen bereikt",
+      "maximum_power": "Laser {number} heeft de maximale kracht {power} bereikt",
+      "complete": "Chatto is herbouwd. Eindscore: {count} punten"
     },
     "pane_header": {
       "back": "Terug"

--- a/apps/frontend/messages/nl-NL/ui.json
+++ b/apps/frontend/messages/nl-NL/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, kracht {power}: nog {seconds} seconden afkoeltijd",
       "upgrade_power": "Verhoog laser {number} naar krachtniveau {level} voor {cost} punten",
       "buy_laser": "Koop laserkanon {number} voor {cost} punten",
-      "maximum_lasers": "Maximum van {count} laserkanonnen bereikt"
+      "maximum_lasers": "Maximum van {count} laserkanonnen bereikt",
+      "maximum_power": "Laser {number} heeft de maximale kracht {power} bereikt",
+      "complete": "Chatto is herbouwd. Eindscore: {count} punten"
     },
     "pane_header": {
       "back": "Terug"

--- a/apps/frontend/messages/pl-PL/ui.json
+++ b/apps/frontend/messages/pl-PL/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, moc {power}: pozostało {seconds} s odnowienia",
       "upgrade_power": "Ulepsz laser {number} do poziomu mocy {level} za {cost} punktów",
       "buy_laser": "Kup działo laserowe {number} za {cost} punktów",
-      "maximum_lasers": "Osiągnięto limit {count} dział laserowych"
+      "maximum_lasers": "Osiągnięto limit {count} dział laserowych",
+      "maximum_power": "Laser {number} osiągnął maksymalną moc {power}",
+      "complete": "Chatto zostało odbudowane. Wynik końcowy: {count} punktów"
     },
     "pane_header": {
       "back": "Wróć"

--- a/apps/frontend/messages/pt-BR/ui.json
+++ b/apps/frontend/messages/pt-BR/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, potência {power}: restam {seconds} segundos de recarga",
       "upgrade_power": "Aumentar o laser {number} para o nível de potência {level} por {cost} pontos",
       "buy_laser": "Comprar o canhão laser {number} por {cost} pontos",
-      "maximum_lasers": "Limite de {count} canhões laser atingido"
+      "maximum_lasers": "Limite de {count} canhões laser atingido",
+      "maximum_power": "O laser {number} atingiu a potência máxima {power}",
+      "complete": "O Chatto foi reconstruído. Pontuação final: {count} pontos"
     },
     "pane_header": {
       "back": "Voltar"

--- a/apps/frontend/messages/pt-PT/ui.json
+++ b/apps/frontend/messages/pt-PT/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, potência {power}: restam {seconds} segundos de recarga",
       "upgrade_power": "Aumentar o laser {number} para o nível de potência {level} por {cost} pontos",
       "buy_laser": "Comprar o canhão laser {number} por {cost} pontos",
-      "maximum_lasers": "Limite de {count} canhões laser atingido"
+      "maximum_lasers": "Limite de {count} canhões laser atingido",
+      "maximum_power": "O laser {number} atingiu a potência máxima {power}",
+      "complete": "O Chatto foi reconstruído. Pontuação final: {count} pontos"
     },
     "pane_header": {
       "back": "Voltar"

--- a/apps/frontend/messages/ru-RU/ui.json
+++ b/apps/frontend/messages/ru-RU/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Лазер {number}, мощность {power}: осталось {seconds} секунд восстановления",
       "upgrade_power": "Улучшите лазер {number} до уровня мощности {level} за {cost} баллов.",
       "buy_laser": "Купить лазерную пушку {number} за {cost} баллов",
-      "maximum_lasers": "Достигнуто максимум {count} лазерных пушек."
+      "maximum_lasers": "Достигнуто максимум {count} лазерных пушек.",
+      "maximum_power": "Лазер {number} достиг максимальной мощности {power}",
+      "complete": "Chatto восстановлен. Итоговый счёт: {count} очков"
     },
     "pane_header": {
       "back": "Назад"

--- a/apps/frontend/messages/sv-SE/ui.json
+++ b/apps/frontend/messages/sv-SE/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Laser {number}, styrka {power}: {seconds} sekunders nedkylning återstår",
       "upgrade_power": "Uppgradera laser {number} till styrkenivå {level} för {cost} poäng",
       "buy_laser": "Köp laserkanon {number} för {cost} poäng",
-      "maximum_lasers": "Maxgränsen på {count} laserkanoner är nådd"
+      "maximum_lasers": "Maxgränsen på {count} laserkanoner är nådd",
+      "maximum_power": "Laser {number} har nått maximal styrka {power}",
+      "complete": "Chatto har byggts upp igen. Slutpoäng: {count} poäng"
     },
     "pane_header": {
       "back": "Tillbaka"

--- a/apps/frontend/messages/tr-TR/ui.json
+++ b/apps/frontend/messages/tr-TR/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Lazer {number}, güç {power}: {seconds} saniyelik bekleme süresi kaldı",
       "upgrade_power": "{number} lazerini {cost} puan için {level} güç seviyesine yükseltin",
       "buy_laser": "{cost} puan karşılığında {number} lazer tabancası satın alın",
-      "maximum_lasers": "Maksimum {count} lazer silahı sayısına ulaşıldı"
+      "maximum_lasers": "Maksimum {count} lazer silahı sayısına ulaşıldı",
+      "maximum_power": "{number} lazeri maksimum güç {power} seviyesine ulaştı",
+      "complete": "Chatto yeniden oluşturuldu. Son puan: {count}"
     },
     "pane_header": {
       "back": "Geri"

--- a/apps/frontend/messages/uk-UA/ui.json
+++ b/apps/frontend/messages/uk-UA/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "Лазер {number}, потужність {power}: залишилося {seconds} с перезарядки",
       "upgrade_power": "Підвищити лазер {number} до рівня потужності {level} за {cost} очок",
       "buy_laser": "Придбати лазерну гармату {number} за {cost} очок",
-      "maximum_lasers": "Досягнуто максимуму з {count} лазерних гармат"
+      "maximum_lasers": "Досягнуто максимуму з {count} лазерних гармат",
+      "maximum_power": "Лазер {number} досяг максимальної потужності {power}",
+      "complete": "Chatto відновлено. Підсумковий рахунок: {count} очок"
     },
     "pane_header": {
       "back": "Назад"

--- a/apps/frontend/messages/zh-CN/ui.json
+++ b/apps/frontend/messages/zh-CN/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "激光器 {number}，功率 {power}：剩余冷却时间 {seconds} 秒",
       "upgrade_power": "花费 {cost} 点数将激光器 {number} 升至功率等级 {level}",
       "buy_laser": "花费 {cost} 点数购买激光枪 {number}",
-      "maximum_lasers": "已达到 {count} 把激光枪的上限"
+      "maximum_lasers": "已达到 {count} 把激光枪的上限",
+      "maximum_power": "激光器 {number} 已达到最大功率 {power}",
+      "complete": "Chatto 已重建。最终得分：{count} 分"
     },
     "pane_header": {
       "back": "返回"

--- a/apps/frontend/messages/zh-TW/ui.json
+++ b/apps/frontend/messages/zh-TW/ui.json
@@ -43,7 +43,9 @@
       "laser_cooldown": "雷射 {number}，威力 {power}：冷卻剩餘 {seconds} 秒",
       "upgrade_power": "花費 {cost} 點將雷射 {number} 升級至威力等級 {level}",
       "buy_laser": "花費 {cost} 點購買雷射槍 {number}",
-      "maximum_lasers": "已達雷射槍數量上限 {count} 把"
+      "maximum_lasers": "已達雷射槍數量上限 {count} 把",
+      "maximum_power": "雷射 {number} 已達到最大威力 {power}",
+      "complete": "Chatto 已重建。最終得分：{count} 分"
     },
     "pane_header": {
       "back": "返回"

--- a/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte
+++ b/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte
@@ -5,6 +5,7 @@
     ballisticDisplacement,
     BoundedLruCache,
     canvasPixelRatio,
+    claimParticleHits,
     CONSTRUCTION_DURATION,
     constructionFrame,
     constructionLaserFrame,
@@ -18,6 +19,7 @@
     exponentialSample,
     explosionFrame,
     explosionParticleOpacity,
+    explosionParticleUnavailableDuration,
     GAME_UI_REVEAL_SHOTS,
     glyphFloatOffset,
     IMPACT_LASER_DURATION,
@@ -31,6 +33,7 @@
     laserPowerSmokeScale,
     laserPowerUpgradeCost,
     MAX_LASER_GUNS,
+    MAX_LASER_POWER,
     nextCooldownHudTime,
     nextReadyLaserIndex,
     projectParticleWithRotation,
@@ -45,6 +48,7 @@
     type ProjectionRotation,
     type WordmarkParticle
   } from './simulatedChattoWordmark';
+  import Deadline from '$lib/lifecycle/Deadline.svelte';
 
   type BurstVector = {
     x: number;
@@ -52,6 +56,7 @@
     force: number;
     rotation: number;
     gravity: number;
+    unavailableDuration: number;
   };
   type ActiveBurst = {
     triggeredAt: number;
@@ -62,6 +67,9 @@
     lasers: LaserBeam[];
     smoke: SmokeParticle[];
     smokeIntensity: number;
+    impactResolved: boolean;
+    awardSpendablePoints: boolean;
+    ignoreParticleAvailability: boolean;
   };
   type LaserGunState = {
     id: number;
@@ -102,9 +110,11 @@
 
   const ACTIVE_FRAME_RATE = 60;
   const IDLE_FRAME_RATE = 30;
-  const MAX_ACTIVE_BURSTS = 8;
+  // Keep two complete volleys because a burst lasts twice as long as a laser cooldown.
+  const MAX_ACTIVE_BURSTS = MAX_LASER_GUNS * 2;
   const MAX_EMOJI_SPRITES = 768;
   const FOREGROUND_STAR_DEPTH = 0.66;
+  const FINAL_VOLLEY_COMPLETION_DELAY = IMPACT_LASER_DURATION + EXPLOSION_DURATION;
   type StarFieldLayer = 'background' | 'foreground';
 
   type Props = {
@@ -120,7 +130,7 @@
     initialLaserPowers
       .filter((power) => Number.isFinite(power))
       .slice(0, MAX_LASER_GUNS)
-      .map((power) => Math.max(1, Math.floor(power)))
+      .map((power) => Math.min(MAX_LASER_POWER, Math.max(1, Math.floor(power))))
   );
 
   const particles = createWordmarkParticles();
@@ -147,11 +157,13 @@
   let currentRotateY = 0;
   let constructionStartedAt = Number.NEGATIVE_INFINITY;
   let activeBursts: ActiveBurst[] = [];
+  const particleAvailableAt = new Float64Array(particles.length);
   let reducedMotion = false;
   let hoverCursor: { x: number; y: number } | null = null;
   let points = $state(
     untrack(() => (Number.isFinite(initialPoints) ? Math.max(0, Math.floor(initialPoints)) : 0))
   );
+  let score = $state(0);
   let firstLaserShots = $state(0);
   let laserGuns = $state.raw<LaserGunState[]>(
     (startingLaserPowers.length > 0 ? startingLaserPowers : [1]).map((power, index) => ({
@@ -161,6 +173,9 @@
     }))
   );
   let hudNow = $state(0);
+  let gameCompleted = $state(false);
+  let victoryVisible = $state(false);
+  let completionDeadline = $state<number | null>(null);
 
   const nextLaserCost = $derived(laserGunCost(laserGuns.length));
   const gameUiVisible = $derived(firstLaserShots >= GAME_UI_REVEAL_SHOTS);
@@ -519,6 +534,7 @@
     animationFrame = undefined;
     const context = canvasContext;
     if (!context || canvasWidth <= 0 || canvasHeight <= 0) return;
+    resolveBurstImpacts(now);
     activeBursts = activeBursts.filter(
       (activeBurst) => now - activeBurst.startedAt < EXPLOSION_DURATION
     );
@@ -728,8 +744,113 @@
     requestDraw();
   }
 
+  function createBurstSmoke(originX: number, originY: number, smokeScale: number): SmokeParticle[] {
+    const smokeCount = Math.round(5 + smokeScale * 9);
+    return Array.from({ length: smokeCount }, (_, index) => {
+      const angleDirection = Math.random() < 0.5 ? -1 : 1;
+      return {
+        angle:
+          (index / smokeCount) * Math.PI * 2 +
+          (originX + originY) * 0.001 +
+          angleDirection * Math.min(0.5, exponentialSample(Math.random()) * 0.12),
+        distance:
+          (28 + (index % 4) * 8) * (1 + Math.min(0.65, exponentialSample(Math.random()) * 0.18)),
+        delay: Math.min(180, exponentialSample(Math.random()) * 52),
+        size:
+          (2.2 + (index % 3) * 0.4) *
+          smokeScale *
+          (1 + Math.min(0.9, exponentialSample(Math.random()) * 0.22))
+      };
+    });
+  }
+
+  function createBurstVectors(
+    originX: number,
+    originY: number,
+    projectionFrame: CanvasProjectionFrame,
+    influenceRadius: number,
+    fullStrength = false
+  ): BurstVector[] {
+    return particles.map((particle) => {
+      const position = projectForCanvas(particle, projectionFrame);
+      let vectorX = position.x - originX;
+      let vectorY = position.y - originY;
+      let distance = Math.hypot(vectorX, vectorY);
+
+      if (distance < 1) {
+        vectorX = Math.cos(particle.fallbackAngle);
+        vectorY = Math.sin(particle.fallbackAngle);
+        distance = 1;
+      }
+
+      const radialStrength = radialForce(distance, influenceRadius);
+      const rawForce = Math.min(1, radialStrength / 0.04);
+      const localForce = rawForce >= EXPLOSION_PARTICLE_FORCE_THRESHOLD ? rawForce : 0;
+      const force = fullStrength ? 1 : localForce;
+      const angularDirection = Math.random() < 0.5 ? -1 : 1;
+      const angularSpread = Math.min(0.8, exponentialSample(Math.random()) * 0.2);
+      const trajectoryAngle = Math.atan2(vectorY, vectorX) + angularDirection * angularSpread;
+      const directionX = Math.cos(trajectoryAngle);
+      const directionY = Math.sin(trajectoryAngle);
+      const exitDistance = rayExitDistance(
+        position.x,
+        position.y,
+        directionX,
+        directionY,
+        canvasWidth,
+        canvasHeight
+      );
+      const travelDistance =
+        Math.max(particle.burstDistance, exitDistance + 96 + particle.burstDistance * 0.35) *
+        force *
+        (1 + Math.min(0.75, exponentialSample(Math.random()) * 0.18));
+      const gravity = force * (220 + Math.min(600, exponentialSample(Math.random()) * 180));
+      const bottomToTop = Math.max(
+        0,
+        Math.min(1, (originY + influenceRadius - position.y) / (influenceRadius * 2))
+      );
+      const leftToRight = Math.max(
+        0,
+        Math.min(1, (position.x - originX + influenceRadius) / (influenceRadius * 2))
+      );
+      return {
+        x: directionX * travelDistance,
+        y: directionY * travelDistance - 0.5 * gravity,
+        force,
+        rotation: particle.burstRotation * force,
+        gravity,
+        unavailableDuration: explosionParticleUnavailableDuration(bottomToTop, leftToRight)
+      };
+    });
+  }
+
+  function resolveBurstImpacts(now: number) {
+    for (const activeBurst of activeBursts) {
+      if (activeBurst.impactResolved || now < activeBurst.startedAt) continue;
+
+      const acceptedHits = claimParticleHits(
+        activeBurst.vectors.map((vector) => vector.force),
+        particleAvailableAt,
+        activeBurst.startedAt,
+        activeBurst.vectors.map((vector) => vector.unavailableDuration),
+        activeBurst.ignoreParticleAvailability
+      );
+      let hitCount = 0;
+      activeBurst.vectors = activeBurst.vectors.map((vector, index) => {
+        if (acceptedHits[index]) {
+          hitCount += 1;
+          return vector;
+        }
+        return { x: 0, y: 0, force: 0, rotation: 0, gravity: 0, unavailableDuration: 0 };
+      });
+      activeBurst.impactResolved = true;
+      score += hitCount;
+      if (activeBurst.awardSpendablePoints) points += hitCount;
+    }
+  }
+
   function triggerBurst(event: MouseEvent) {
-    if (canvasWidth <= 0 || canvasHeight <= 0) return;
+    if (gameCompleted || canvasWidth <= 0 || canvasHeight <= 0) return;
 
     const wordmark = event.currentTarget as HTMLButtonElement;
     const bounds = canvasElement?.getBoundingClientRect() ?? wordmark.getBoundingClientRect();
@@ -759,91 +880,33 @@
     const influenceRadius = projectionFrame.wordmark.width * laserPowerRadiusScale(shotPower);
     const lasers = [laserBeamOrigin(laserIndex, canvasWidth, canvasHeight)];
     const smokeScale = laserPowerSmokeScale(shotPower);
-    const smokeCount = Math.round(5 + smokeScale * 9);
-    const smoke: SmokeParticle[] = Array.from({ length: smokeCount }, (_, index) => {
-      const angleDirection = Math.random() < 0.5 ? -1 : 1;
-      return {
-        angle:
-          (index / smokeCount) * Math.PI * 2 +
-          (originX + originY) * 0.001 +
-          angleDirection * Math.min(0.5, exponentialSample(Math.random()) * 0.12),
-        distance:
-          (28 + (index % 4) * 8) * (1 + Math.min(0.65, exponentialSample(Math.random()) * 0.18)),
-        delay: Math.min(180, exponentialSample(Math.random()) * 52),
-        size:
-          (2.2 + (index % 3) * 0.4) *
-          smokeScale *
-          (1 + Math.min(0.9, exponentialSample(Math.random()) * 0.22))
-      };
-    });
-    const vectors = particles.map((particle) => {
-      const position = projectForCanvas(particle, projectionFrame);
-      let vectorX = position.x - originX;
-      let vectorY = position.y - originY;
-      let distance = Math.hypot(vectorX, vectorY);
+    const smoke = createBurstSmoke(originX, originY, smokeScale);
+    const vectors = createBurstVectors(originX, originY, projectionFrame, influenceRadius);
 
-      if (distance < 1) {
-        vectorX = Math.cos(particle.fallbackAngle);
-        vectorY = Math.sin(particle.fallbackAngle);
-        distance = 1;
-      }
-
-      const radialStrength = radialForce(distance, influenceRadius);
-      const rawForce = Math.min(1, radialStrength / 0.04);
-      const force = rawForce >= EXPLOSION_PARTICLE_FORCE_THRESHOLD ? rawForce : 0;
-      const angularDirection = Math.random() < 0.5 ? -1 : 1;
-      const angularSpread = Math.min(0.8, exponentialSample(Math.random()) * 0.2);
-      const trajectoryAngle = Math.atan2(vectorY, vectorX) + angularDirection * angularSpread;
-      const directionX = Math.cos(trajectoryAngle);
-      const directionY = Math.sin(trajectoryAngle);
-      const exitDistance = rayExitDistance(
-        position.x,
-        position.y,
-        directionX,
-        directionY,
-        canvasWidth,
-        canvasHeight
-      );
-      const travelDistance =
-        Math.max(particle.burstDistance, exitDistance + 96 + particle.burstDistance * 0.35) *
-        force *
-        (1 + Math.min(0.75, exponentialSample(Math.random()) * 0.18));
-      const gravity = force * (220 + Math.min(600, exponentialSample(Math.random()) * 180));
-      return {
-        x: directionX * travelDistance,
-        y: directionY * travelDistance - 0.5 * gravity,
-        force,
-        rotation: particle.burstRotation * force,
-        gravity
-      };
-    });
-
-    points += vectors.filter((vector) => vector.force >= EXPLOSION_PARTICLE_FORCE_THRESHOLD).length;
-
-    if (reducedMotion) {
-      requestDraw();
-      return;
-    }
-
+    const impactDelay = reducedMotion ? 0 : IMPACT_LASER_DURATION;
     activeBursts = [
       ...activeBursts.slice(-(MAX_ACTIVE_BURSTS - 1)),
       {
         triggeredAt,
-        startedAt: triggeredAt + IMPACT_LASER_DURATION,
+        startedAt: triggeredAt + impactDelay,
         origin: { x: originX, y: originY },
         influenceRadius,
         vectors,
         lasers,
         smoke,
-        smokeIntensity: Math.min(1, 0.35 + smokeScale * 0.5)
+        smokeIntensity: Math.min(1, 0.35 + smokeScale * 0.5),
+        impactResolved: false,
+        awardSpendablePoints: true,
+        ignoreParticleAvailability: false
       }
     ];
+    if (reducedMotion) resolveBurstImpacts(triggeredAt);
     requestDraw();
   }
 
   function upgradeLaserPower(laserIndex: number) {
     const laser = laserGuns[laserIndex];
-    if (!laser) return;
+    if (!laser || laser.power >= MAX_LASER_POWER) return;
     const upgradeCost = laserPowerUpgradeCost(laser.power);
     if (points < upgradeCost) return;
     points -= upgradeCost;
@@ -852,16 +915,77 @@
     );
   }
 
+  function finishFinalVolley() {
+    completionDeadline = null;
+    victoryVisible = true;
+  }
+
+  function triggerFinalVolley(triggeredAt: number) {
+    gameCompleted = true;
+    laserGuns = laserGuns.map((laser) => ({
+      ...laser,
+      readyAt: triggeredAt + LASER_COOLDOWN
+    }));
+    hudNow = triggeredAt;
+
+    if (canvasWidth <= 0 || canvasHeight <= 0) {
+      score += particles.length;
+      finishFinalVolley();
+      requestDraw();
+      return;
+    }
+
+    const originX = canvasWidth / 2;
+    const originY = canvasHeight / 2;
+    const projectionFrame = createCanvasProjectionFrame(triggeredAt);
+    const influenceRadius = projectionFrame.wordmark.width;
+    const smokeScale = laserPowerSmokeScale(MAX_LASER_POWER);
+    const impactDelay = reducedMotion ? 0 : IMPACT_LASER_DURATION;
+    activeBursts = [
+      {
+        triggeredAt,
+        startedAt: triggeredAt + impactDelay,
+        origin: { x: originX, y: originY },
+        influenceRadius,
+        vectors: createBurstVectors(originX, originY, projectionFrame, influenceRadius, true),
+        lasers: laserGuns.map((_, index) =>
+          laserBeamOrigin(index, canvasWidth, canvasHeight, laserGuns.length)
+        ),
+        smoke: createBurstSmoke(originX, originY, smokeScale),
+        smokeIntensity: 1,
+        impactResolved: false,
+        awardSpendablePoints: false,
+        ignoreParticleAvailability: true
+      }
+    ];
+    if (reducedMotion) {
+      resolveBurstImpacts(triggeredAt);
+      finishFinalVolley();
+      requestDraw();
+      return;
+    }
+    completionDeadline = Date.now() + FINAL_VOLLEY_COMPLETION_DELAY;
+    requestDraw();
+  }
+
   function buyLaserGun() {
     if (laserGuns.length >= MAX_LASER_GUNS || points < nextLaserCost) return;
     points -= nextLaserCost;
     const newLaserIndex = laserGuns.length;
     laserGuns = [...laserGuns, { id: newLaserIndex + 1, power: 1, readyAt: 0 }];
+    if (laserGuns.length === MAX_LASER_GUNS) {
+      triggerFinalVolley(performance.now());
+      return;
+    }
     requestDraw();
   }
 </script>
 
 <svelte:window onpointermove={handlePointerMove} />
+
+{#if completionDeadline !== null}
+  <Deadline at={completionDeadline} onreached={finishFinalVolley} />
+{/if}
 
 <div
   class={[
@@ -872,7 +996,10 @@
   <button
     type="button"
     class="absolute inset-0 cursor-crosshair border-0 bg-transparent p-0 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-action"
-    aria-label={m('ui.easter_egg.fire')}
+    disabled={gameCompleted}
+    aria-label={gameCompleted
+      ? m('ui.easter_egg.complete', { count: score })
+      : m('ui.easter_egg.fire')}
     onclick={triggerBurst}
   >
     <canvas
@@ -893,83 +1020,104 @@
       gameUiVisible ? 'visible opacity-100' : 'invisible opacity-0'
     ]}
     data-game-ui-visible={gameUiVisible}
+    data-game-completed={gameCompleted}
     aria-hidden={!gameUiVisible}
   >
-    <div
-      class="pointer-events-auto absolute top-2 left-2 flex max-w-[72%] flex-wrap items-start gap-1 text-white"
-      role="list"
-      aria-label={m('ui.easter_egg.laser_guns_count', { count: laserGuns.length })}
-    >
-      {#each laserGuns as laser, index (laser.id)}
-        {@const cooldownProgress = laserCooldownProgress(hudNow, laser.readyAt)}
-        {@const cooldownSeconds = Math.max(0, (laser.readyAt - hudNow) / 1000).toFixed(1)}
-        {@const upgradeCost = laserPowerUpgradeCost(laser.power)}
-        <div
-          class="flex w-11 flex-col gap-0.5"
-          role="listitem"
-          data-ready={cooldownProgress >= 1}
-          aria-label={cooldownProgress >= 1
-            ? m('ui.easter_egg.laser_ready', {
-                number: index + 1,
-                power: laser.power
-              })
-            : m('ui.easter_egg.laser_cooldown', {
-                number: index + 1,
-                power: laser.power,
-                seconds: cooldownSeconds
-              })}
+    {#if victoryVisible}
+      <div class="pointer-events-none absolute inset-0 flex items-center justify-center px-4">
+        <p
+          class="rounded border border-white/20 bg-black/75 px-4 py-2 text-center text-sm font-semibold text-white"
+          role="status"
         >
-          <div
-            class="flex min-h-10 w-full flex-col items-center justify-center gap-0.5 rounded border border-white/15 bg-black/65 text-xs text-white tabular-nums"
-          >
-            <span class={cooldownProgress < 1 ? 'opacity-35' : ''} aria-hidden="true"
-              >🔫{laser.power}</span
-            >
-            <span class="h-1 w-7 overflow-hidden rounded-full bg-white/20" aria-hidden="true">
-              <span
-                class="block h-full rounded-full bg-cyan-300"
-                style:width={`${cooldownProgress * 100}%`}
-              ></span>
-            </span>
-          </div>
-          <button
-            type="button"
-            class="min-h-8 w-full cursor-pointer rounded border border-white/20 bg-black/75 px-1 text-[10px] text-white tabular-nums hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-45"
-            disabled={points < upgradeCost}
-            aria-label={m('ui.easter_egg.upgrade_power', {
-              number: index + 1,
-              level: laser.power + 1,
-              cost: upgradeCost
-            })}
-            onclick={() => upgradeLaserPower(index)}>⚡ {upgradeCost}</button
-          >
-        </div>
-      {/each}
-    </div>
+          ✨ {m('ui.easter_egg.complete', { count: score })} ✨
+        </p>
+      </div>
+    {/if}
 
-    <output
-      class="pointer-events-none absolute top-2 right-2 rounded bg-black/65 px-2 py-1 font-mono text-sm text-white tabular-nums"
-      aria-label={m('ui.easter_egg.points', { count: points })}>✨ {points}</output
-    >
-
-    <div
-      class="pointer-events-auto absolute right-2 bottom-2 left-2 flex items-center justify-center gap-2"
-    >
-      <button
-        type="button"
-        class="min-h-10 cursor-pointer rounded border border-white/20 bg-black/75 px-2 text-xs text-white tabular-nums hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-45"
-        disabled={laserGuns.length >= MAX_LASER_GUNS || points < nextLaserCost}
-        aria-label={laserGuns.length >= MAX_LASER_GUNS
-          ? m('ui.easter_egg.maximum_lasers', { count: MAX_LASER_GUNS })
-          : m('ui.easter_egg.buy_laser', {
-              number: laserGuns.length + 1,
-              cost: nextLaserCost
-            })}
-        onclick={buyLaserGun}
-        >🔫 {laserGuns.length}/{MAX_LASER_GUNS} · {laserGuns.length >= MAX_LASER_GUNS
-          ? '⛔'
-          : `✨ ${nextLaserCost}`}</button
+    {#if !victoryVisible}
+      <div
+        class="pointer-events-auto absolute top-2 left-2 flex max-w-[72%] flex-wrap items-start gap-1 text-white"
+        role="list"
+        aria-label={m('ui.easter_egg.laser_guns_count', { count: laserGuns.length })}
       >
-    </div>
+        {#each laserGuns as laser, index (laser.id)}
+          {@const cooldownProgress = laserCooldownProgress(hudNow, laser.readyAt)}
+          {@const cooldownSeconds = Math.max(0, (laser.readyAt - hudNow) / 1000).toFixed(1)}
+          {@const upgradeCost = laserPowerUpgradeCost(laser.power)}
+          {@const maximumPower = laser.power >= MAX_LASER_POWER}
+          <div
+            class="flex w-11 flex-col gap-0.5"
+            role="listitem"
+            data-ready={cooldownProgress >= 1}
+            aria-label={cooldownProgress >= 1
+              ? m('ui.easter_egg.laser_ready', {
+                  number: index + 1,
+                  power: laser.power
+                })
+              : m('ui.easter_egg.laser_cooldown', {
+                  number: index + 1,
+                  power: laser.power,
+                  seconds: cooldownSeconds
+                })}
+          >
+            <div
+              class="flex min-h-10 w-full flex-col items-center justify-center gap-0.5 rounded border border-white/15 bg-black/65 text-xs text-white tabular-nums"
+            >
+              <span class={cooldownProgress < 1 ? 'opacity-35' : ''} aria-hidden="true"
+                >🔫{laser.power}</span
+              >
+              <span class="h-1 w-7 overflow-hidden rounded-full bg-white/20" aria-hidden="true">
+                <span
+                  class="block h-full rounded-full bg-cyan-300"
+                  style:width={`${cooldownProgress * 100}%`}
+                ></span>
+              </span>
+            </div>
+            <button
+              type="button"
+              class="min-h-8 w-full cursor-pointer rounded border border-white/20 bg-black/75 px-1 text-[10px] text-white tabular-nums hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-45"
+              disabled={maximumPower || points < upgradeCost}
+              aria-label={maximumPower
+                ? m('ui.easter_egg.maximum_power', {
+                    number: index + 1,
+                    power: MAX_LASER_POWER
+                  })
+                : m('ui.easter_egg.upgrade_power', {
+                    number: index + 1,
+                    level: laser.power + 1,
+                    cost: upgradeCost
+                  })}
+              onclick={() => upgradeLaserPower(index)}
+              >⚡ {maximumPower ? `${MAX_LASER_POWER}/${MAX_LASER_POWER}` : upgradeCost}</button
+            >
+          </div>
+        {/each}
+      </div>
+
+      <output
+        class="pointer-events-none absolute top-2 right-2 rounded bg-black/65 px-2 py-1 font-mono text-sm text-white tabular-nums"
+        aria-label={m('ui.easter_egg.points', { count: points })}>✨ {points}</output
+      >
+
+      <div
+        class="pointer-events-auto absolute right-2 bottom-2 left-2 flex items-center justify-center gap-2"
+      >
+        <button
+          type="button"
+          class="min-h-10 cursor-pointer rounded border border-white/20 bg-black/75 px-2 text-xs text-white tabular-nums hover:bg-black/90 disabled:cursor-not-allowed disabled:opacity-45"
+          disabled={laserGuns.length >= MAX_LASER_GUNS || points < nextLaserCost}
+          aria-label={laserGuns.length >= MAX_LASER_GUNS
+            ? m('ui.easter_egg.maximum_lasers', { count: MAX_LASER_GUNS })
+            : m('ui.easter_egg.buy_laser', {
+                number: laserGuns.length + 1,
+                cost: nextLaserCost
+              })}
+          onclick={buyLaserGun}
+          >🔫 {laserGuns.length}/{MAX_LASER_GUNS} · {laserGuns.length >= MAX_LASER_GUNS
+            ? '⛔'
+            : `✨ ${nextLaserCost}`}</button
+        >
+      </div>
+    {/if}
   </div>
 </div>

--- a/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte.spec.ts
@@ -6,6 +6,7 @@ import {
   ballisticDisplacement,
   BoundedLruCache,
   canvasPixelRatio,
+  claimParticleHits,
   CONSTRUCTION_DURATION,
   constructionFrame,
   constructionLaserFrame,
@@ -17,6 +18,7 @@ import {
   EXPLOSION_PARTICLE_FORCE_THRESHOLD,
   exponentialSample,
   explosionFrame,
+  explosionParticleUnavailableDuration,
   explosionParticleOpacity,
   GAME_UI_REVEAL_SHOTS,
   glyphFloatOffset,
@@ -31,6 +33,7 @@ import {
   laserPowerSmokeScale,
   laserPowerUpgradeCost,
   MAX_LASER_GUNS,
+  MAX_LASER_POWER,
   nextCooldownHudTime,
   nextReadyLaserIndex,
   projectParticle,
@@ -65,7 +68,9 @@ describe('SimulatedChattoWordmark', () => {
     ]);
     expect(container.querySelectorAll('.emoji-point')).toHaveLength(0);
     expect(container.querySelector('[data-game-ui-visible="false"]')).not.toBeNull();
-    expect(container.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe('1 laser gun');
+    expect(container.querySelector('[role="list"]')?.getAttribute('aria-label')).toBe(
+      '1 laser gun'
+    );
     expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(1);
     expect(container.querySelector('[role="listitem"]')?.getAttribute('aria-label')).toBe(
       'Laser 1, power 1, ready'
@@ -90,7 +95,6 @@ describe('SimulatedChattoWordmark', () => {
     expect(container.querySelector('[data-game-ui-visible="false"]')).not.toBeNull();
     let now = performance.now();
     const performanceNow = vi.spyOn(performance, 'now').mockImplementation(() => now);
-    const pointsAfterShots: number[] = [];
     for (let shot = 1; shot <= GAME_UI_REVEAL_SHOTS; shot += 1) {
       wordmark.click();
       await expect
@@ -103,13 +107,9 @@ describe('SimulatedChattoWordmark', () => {
           pointsAfterFirstShot
         );
       }
-      pointsAfterShots.push(
-        Number.parseInt(container.querySelector('output')?.textContent?.replace(/\D/g, '') ?? '0')
-      );
       now += LASER_COOLDOWN + 1;
     }
     performanceNow.mockRestore();
-    expect(pointsAfterShots[0]! - 100).toBeGreaterThan(20);
     expect(
       container.querySelector('[role="listitem"][aria-label^="Laser 1, power 7"]')
     ).not.toBeNull();
@@ -125,6 +125,8 @@ describe('SimulatedChattoWordmark', () => {
     await new Promise((resolve) => requestAnimationFrame(resolve));
     wordmark.click();
 
+    expect(container.querySelector('output')?.getAttribute('aria-label')).toBe('0 points');
+
     await expect
       .poll(() => container.querySelector('output')?.getAttribute('aria-label'))
       .toMatch(/^[1-9]\d* points$/);
@@ -133,6 +135,58 @@ describe('SimulatedChattoWordmark', () => {
 
     wordmark.click();
     expect(container.querySelector('output')?.getAttribute('aria-label')).toBe(scoreAfterFirstShot);
+  });
+
+  it('does not score particles twice while their first explosion is active', async () => {
+    const matchMedia = vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    });
+    let now = performance.now();
+    const performanceNow = vi.spyOn(performance, 'now').mockImplementation(() => now);
+
+    try {
+      const { container } = render(SimulatedChattoWordmark, {
+        props: { initialLaserPowers: [7, 7, 7] }
+      });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const wordmark = q(
+        container,
+        'button[aria-label="Fire a ready laser at Chatto"]'
+      ) as HTMLButtonElement;
+
+      for (let shot = 0; shot < GAME_UI_REVEAL_SHOTS; shot += 1) {
+        wordmark.click();
+        now += LASER_COOLDOWN + 1;
+      }
+      await expect
+        .poll(() => container.querySelector('[data-game-ui-visible="true"]'))
+        .not.toBeNull();
+      now += EXPLOSION_DURATION + 1;
+
+      const scoreBeforeHit = container.querySelector('output')?.getAttribute('aria-label');
+      wordmark.click();
+      await expect
+        .poll(() => container.querySelector('output')?.getAttribute('aria-label'))
+        .not.toBe(scoreBeforeHit);
+      const scoreAfterFirstHit = container.querySelector('output')?.getAttribute('aria-label');
+      expect(scoreAfterFirstHit).not.toBe(scoreBeforeHit);
+
+      wordmark.click();
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      expect(container.querySelector('output')?.getAttribute('aria-label')).toBe(
+        scoreAfterFirstHit
+      );
+    } finally {
+      performanceNow.mockRestore();
+      matchMedia.mockRestore();
+    }
   });
 
   it('fires the final allowed laser without interrupting canvas rendering', async () => {
@@ -155,9 +209,9 @@ describe('SimulatedChattoWordmark', () => {
 
     await expect
       .poll(() =>
-        container.querySelector(`[aria-label^="Laser ${MAX_LASER_GUNS}, power 1"]`)?.getAttribute(
-          'data-ready'
-        )
+        container
+          .querySelector(`[aria-label^="Laser ${MAX_LASER_GUNS}, power 1"]`)
+          ?.getAttribute('data-ready')
       )
       .toBe('false');
     await new Promise((resolve) => requestAnimationFrame(resolve));
@@ -213,6 +267,110 @@ describe('SimulatedChattoWordmark', () => {
     expect(container.querySelector('output')?.getAttribute('aria-label')).toBe('62 points');
   });
 
+  it('caps each laser at the highest effective power', async () => {
+    const { container } = render(SimulatedChattoWordmark, {
+      props: { initialPoints: 100_000, initialLaserPowers: [MAX_LASER_POWER + 10] }
+    });
+
+    await expect
+      .poll(() =>
+        container.querySelector(
+          `button[aria-label="Laser 1 has reached maximum power ${MAX_LASER_POWER}"]`
+        )
+      )
+      .not.toBeNull();
+    const upgrade = q(
+      container,
+      `button[aria-label="Laser 1 has reached maximum power ${MAX_LASER_POWER}"]`
+    ) as HTMLButtonElement;
+
+    expect(upgrade.disabled).toBe(true);
+    expect(upgrade.textContent).toContain(`${MAX_LASER_POWER}/${MAX_LASER_POWER}`);
+    expect(container.querySelector('[role="listitem"]')?.getAttribute('aria-label')).toBe(
+      `Laser 1, power ${MAX_LASER_POWER}, ready`
+    );
+  });
+
+  it('fires every laser and completes the game when the tenth gun is bought', async () => {
+    const finalLaserCost = laserGunCost(MAX_LASER_GUNS - 1);
+    const { container } = render(SimulatedChattoWordmark, {
+      props: {
+        initialPoints: finalLaserCost,
+        initialLaserPowers: Array.from({ length: MAX_LASER_GUNS - 1 }, () => 1)
+      }
+    });
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    const wordmark = q(
+      container,
+      'button[aria-label="Fire a ready laser at Chatto"]'
+    ) as HTMLButtonElement;
+    wordmark.click();
+    await expect
+      .poll(() => container.querySelector('output')?.getAttribute('aria-label'))
+      .not.toBe(`${finalLaserCost} points`);
+    const availablePoints = Number.parseInt(
+      container.querySelector('output')?.getAttribute('aria-label') ?? '0'
+    );
+    const earnedScore = availablePoints - finalLaserCost;
+    const finalScore = earnedScore + createWordmarkParticles().length;
+    const buyFinalLaser = q(
+      container,
+      `button[aria-label="Buy laser gun ${MAX_LASER_GUNS} for ${finalLaserCost} points"]`
+    ) as HTMLButtonElement;
+    buyFinalLaser.click();
+
+    await expect.poll(() => container.querySelector('[data-game-completed="true"]')).not.toBeNull();
+    expect(container.querySelectorAll('[role="listitem"]')).toHaveLength(MAX_LASER_GUNS);
+    expect(
+      Array.from(container.querySelectorAll('[role="listitem"]')).every(
+        (laser) => laser.getAttribute('data-ready') === 'false'
+      )
+    ).toBe(true);
+    await expect
+      .poll(() =>
+        container
+          .querySelector('button[disabled][aria-label^="Chatto rebuilt. Final score:"]')
+          ?.getAttribute('aria-label')
+      )
+      .toBe(`Chatto rebuilt. Final score: ${finalScore} points`);
+  });
+
+  it('shows the final score immediately when reduced motion is active', async () => {
+    const matchMedia = vi.spyOn(window, 'matchMedia').mockReturnValue({
+      matches: true,
+      media: '(prefers-reduced-motion: reduce)',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn()
+    });
+    const finalLaserCost = laserGunCost(MAX_LASER_GUNS - 1);
+
+    try {
+      const { container } = render(SimulatedChattoWordmark, {
+        props: {
+          initialPoints: finalLaserCost,
+          initialLaserPowers: Array.from({ length: MAX_LASER_GUNS - 1 }, () => 1)
+        }
+      });
+      await new Promise((resolve) => requestAnimationFrame(resolve));
+      const buyFinalLaser = q(
+        container,
+        `button[aria-label="Buy laser gun ${MAX_LASER_GUNS} for ${finalLaserCost} points"]`
+      ) as HTMLButtonElement;
+      buyFinalLaser.click();
+
+      await expect
+        .poll(() => container.querySelector('[role="status"]')?.textContent)
+        .toContain('Chatto rebuilt. Final score: 600 points');
+    } finally {
+      matchMedia.mockRestore();
+    }
+  });
+
   it('ignores previously saved game state', async () => {
     localStorage.setItem(
       'chatto.simulated-wordmark-game.v1',
@@ -230,6 +388,7 @@ describe('SimulatedChattoWordmark', () => {
   it('prices laser progression and tracks independent cooldowns', () => {
     expect(LASER_COOLDOWN).toBe(1500);
     expect(MAX_LASER_GUNS).toBe(10);
+    expect(MAX_LASER_POWER).toBe(17);
     expect(laserGunCost(1)).toBe(48);
     expect(laserGunCost(2)).toBeGreaterThan(laserGunCost(1));
     expect(laserGunCost(10)).toBeGreaterThan(laserGunCost(9));
@@ -253,6 +412,34 @@ describe('SimulatedChattoWordmark', () => {
     expect(origins).toHaveLength(MAX_LASER_GUNS);
     expect(new Set(origins.map(({ x, y }) => `${x},${y}`)).size).toBe(MAX_LASER_GUNS);
     expect(origins.every(({ x, y }) => x === 0 || x === 800 || y === 0 || y === 400)).toBe(true);
+  });
+
+  it('claims only particles that are present when a laser hits', () => {
+    const particleAvailableAt = new Float64Array(4);
+    const forces = [1, 0.5, 0, EXPLOSION_PARTICLE_FORCE_THRESHOLD];
+    const unavailableDurations = [1000, 1500, 2000, 2500];
+
+    expect(claimParticleHits(forces, particleAvailableAt, 100, unavailableDurations)).toEqual([
+      true,
+      true,
+      false,
+      true
+    ]);
+    expect(claimParticleHits(forces, particleAvailableAt, 101, unavailableDurations)).toEqual([
+      false,
+      false,
+      false,
+      false
+    ]);
+    expect(claimParticleHits([0, 0, 1, 0], particleAvailableAt, 101, unavailableDurations)).toEqual(
+      [false, false, true, false]
+    );
+    expect(
+      claimParticleHits(forces, particleAvailableAt, 100 + 2500, unavailableDurations)
+    ).toEqual([true, true, false, true]);
+    expect(explosionParticleUnavailableDuration(0, 0)).toBeLessThan(
+      explosionParticleUnavailableDuration(1, 1)
+    );
   });
 
   it('builds four depth layers for the rounded glyphs', () => {

--- a/apps/frontend/src/lib/components/simulatedChattoWordmark.ts
+++ b/apps/frontend/src/lib/components/simulatedChattoWordmark.ts
@@ -162,6 +162,8 @@ export const CONSTRUCTION_DURATION = 1650;
 export const CANVAS_PIXEL_RATIO_LIMIT = 1.5;
 export const LASER_COOLDOWN = 1500;
 export const MAX_LASER_GUNS = 10;
+/** Highest laser power that increases the blast radius. */
+export const MAX_LASER_POWER = 17;
 export const GAME_UI_REVEAL_SHOTS = 4;
 
 const CONSTRUCTION_FIRST_ROW_DELAY = 80;
@@ -170,13 +172,43 @@ const CONSTRUCTION_SWEEP_DURATION = 460;
 const CONSTRUCTION_LASER_FADE_DURATION = 140;
 const CONSTRUCTION_PARTICLE_SETTLE_DURATION = 160;
 
+/**
+ * Claim candidate particle hits at one laser-impact time.
+ *
+ * A particle can belong to only one active explosion. The caller owns the
+ * availability timestamps and uses the returned mask to remove rejected
+ * particles from the later burst animation.
+ */
+export function claimParticleHits(
+  candidateForces: readonly number[],
+  particleAvailableAt: Float64Array,
+  impactAt: number,
+  unavailableDurations: number | readonly number[],
+  ignoreAvailability = false
+): boolean[] {
+  return candidateForces.map((force, index) => {
+    if (force < EXPLOSION_PARTICLE_FORCE_THRESHOLD) return false;
+    if (!ignoreAvailability && particleAvailableAt[index] > impactAt) return false;
+
+    const unavailableDuration =
+      typeof unavailableDurations === 'number'
+        ? unavailableDurations
+        : (unavailableDurations[index] ?? 0);
+    particleAvailableAt[index] = Math.max(
+      particleAvailableAt[index] ?? 0,
+      impactAt + Math.max(0, unavailableDuration)
+    );
+    return true;
+  });
+}
+
 /** Cost of the next gun, with each additional gun becoming substantially dearer. */
 export function laserGunCost(currentGunCount: number): number {
   const owned = Math.max(1, Math.min(MAX_LASER_GUNS, Math.floor(currentGunCount)));
   return Math.round(48 * Math.pow(1.9, owned - 1));
 }
 
-/** Cost of increasing the shared power level for every owned laser gun. */
+/** Cost of increasing one laser gun's power level. */
 export function laserPowerUpgradeCost(currentPower: number): number {
   const power = Math.max(1, Math.floor(currentPower));
   return Math.round(16 * Math.pow(1.55, power - 1));
@@ -555,6 +587,14 @@ export function rebuildParticleFrame(
     scale: lerp(0.18, 1, eased),
     glow: 1 - localProgress
   };
+}
+
+/** Time from impact until an exploded particle starts to reappear. */
+export function explosionParticleUnavailableDuration(
+  bottomToTop: number,
+  leftToRight: number
+): number {
+  return (rebuildParticleArrival(bottomToTop, leftToRight) + 0.025) * EXPLOSION_DURATION;
 }
 
 function rebuildParticleArrival(bottomToTop: number, leftToRight: number): number {


### PR DESCRIPTION
## Why

The hidden version game has no clear ending and awards points before a laser hits, including for emoji particles that another explosion has already displaced.

## What changed

- End the game when the tenth laser gun is bought, fire a final volley, show a lifetime final score, cap effective laser power, and localize the new completion and power-cap text.
- Resolve regular and final-volley scoring at impact time, claim only particles that are present, and make each particle available again when its rebuild animation makes it reappear.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise test-frontend` passed all server, client, Storybook, and performance-comparison tests; frontend checks, ESLint, Prettier, focused component tests, and Chrome DevTools verification also passed.
