### PR TITLE
fix(frontend): open settings on appearance

### DIFF
--- a/apps/frontend/e2e/admin.test.ts
+++ b/apps/frontend/e2e/admin.test.ts
@@ -264,19 +264,20 @@ test.describe('Admin System Page', () => {
 });
 
 test.describe('Admin Navigation', () => {
-  test('sidebar Settings entry opens the first permitted server settings page', async ({
-    page,
-    adminPage
-  }) => {
+  test('sidebar Settings entry opens Appearance', async ({ page, adminPage }) => {
     await createAndLoginAdminUser(page);
 
     await page.goto(routes.chat);
 
     await adminPage.expectSettingsLinkVisible();
+    await expect(adminPage.settingsLink).toHaveAttribute('href', routes.settingsRoot);
     await adminPage.navigateToSettings();
-    await adminPage.expectGeneralPageVisible();
+    await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
     await adminPage.expectBackToChatVisible();
-    await adminPage.expectSidebarLinkActive('General');
+    await expect(page.getByRole('link', { name: 'Appearance' })).toHaveAttribute(
+      'aria-current',
+      'page'
+    );
   });
 
   test('admin pages use the dedicated manage/server sidebar shell', async ({ page, adminPage }) => {

--- a/apps/frontend/e2e/pages/AdminPage.ts
+++ b/apps/frontend/e2e/pages/AdminPage.ts
@@ -159,7 +159,7 @@ export class AdminPage {
 
   async navigateToSettings(): Promise<void> {
     await this.settingsLink.click();
-    await this.page.waitForURL(routes.serverAdminGeneral);
+    await this.page.waitForURL(routes.settingsAppearance);
   }
 
   async navigateBackToChat(): Promise<void> {

--- a/apps/frontend/e2e/pages/ServerAdminPage.ts
+++ b/apps/frontend/e2e/pages/ServerAdminPage.ts
@@ -153,6 +153,8 @@ export class ServerAdminPage {
   async goto(_spaceId: string): Promise<void> {
     await this.page.goto(routes.chat);
     await this.settingsLink.click();
+    await this.page.waitForURL(routes.settingsAppearance);
+    await this.generalNavItem.click();
     await this.page.waitForURL(routes.serverAdminGeneral);
     await expect(this.pageHeading).toBeVisible();
   }

--- a/apps/frontend/e2e/routes.ts
+++ b/apps/frontend/e2e/routes.ts
@@ -72,6 +72,8 @@ export const serverAdminMemberPermissions = (userId: string) =>
 
 // --- User settings ---
 
+/** The canonical Settings entry point. */
+export const settingsRoot = `/chat/${HOME}/settings`;
 export const settingsProfile = `/chat/${HOME}/settings/profile`;
 /** The canonical default page for user-settings test flows. */
 export const settings = settingsProfile;

--- a/apps/frontend/e2e/server-roles.test.ts
+++ b/apps/frontend/e2e/server-roles.test.ts
@@ -660,7 +660,8 @@ test.describe('Server Permission Enforcement', () => {
       // General stays hidden without server.manage.
       await serverAdminPage.expectSettingsLinkVisible();
       await serverAdminPage.settingsLink.click();
-      await page.waitForURL(routes.serverAdminBots);
+      await page.waitForURL(routes.settingsAppearance);
+      await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
       await serverAdminPage.expectBotsNavVisible();
       await serverAdminPage.expectGeneralNavNotVisible();
     });
@@ -841,7 +842,8 @@ test.describe('Server Permission Enforcement', () => {
       // Fresh servers grant bot.create to everyone, so the administration
       // entry remains available for Bots while room management stays hidden.
       await page.getByRole('link', { name: 'Settings', exact: true }).click();
-      await page.waitForURL(routes.serverAdminBots);
+      await page.waitForURL(routes.settingsAppearance);
+      await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
       await expect(page.getByRole('link', { name: 'Bots', exact: true })).toBeVisible();
       await expect(page.getByRole('link', { name: 'Rooms', exact: true })).not.toBeVisible();
     });

--- a/apps/frontend/e2e/server-settings-nav.test.ts
+++ b/apps/frontend/e2e/server-settings-nav.test.ts
@@ -95,7 +95,7 @@ test.describe('Server Admin Navigation Permissions', () => {
       await serverAdminPage.expectSettingsLinkVisible();
     });
 
-    test('regular member enters Server Admin through Bots', async ({ serverAdminPage }) => {
+    test('regular member enters Settings through Appearance', async ({ serverAdminPage }) => {
       const { page } = serverAdminPage;
 
       // Create admin user and load the primary server
@@ -111,10 +111,11 @@ test.describe('Server Admin Navigation Permissions', () => {
       await expect(page.getByRole('heading', { name: server.name })).toBeVisible();
 
       // Fresh servers grant bot.create to everyone, so Bots is this member's
-      // only Server Admin entry point. Unrelated sections remain hidden.
+      // only Server Configuration page. Settings still starts at Appearance.
       await serverAdminPage.expectSettingsLinkVisible();
       await serverAdminPage.settingsLink.click();
-      await page.waitForURL(routes.serverAdminBots);
+      await page.waitForURL(routes.settingsAppearance);
+      await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
       await serverAdminPage.expectBotsNavVisible();
       await serverAdminPage.expectGeneralNavNotVisible();
     });

--- a/apps/frontend/e2e/server-settings.test.ts
+++ b/apps/frontend/e2e/server-settings.test.ts
@@ -170,9 +170,7 @@ test.describe('Server Admin Page', () => {
     await serverAdminPage.expectSaveDisabled();
   });
 
-  test('Settings link leads each member to their first permitted Server Configuration section', async ({
-    serverAdminPage
-  }) => {
+  test('Settings link leads each member to Appearance', async ({ serverAdminPage }) => {
     const { page } = serverAdminPage;
 
     // Create first user (server admin)
@@ -199,7 +197,8 @@ test.describe('Server Admin Page', () => {
 
     await serverAdminPage.expectSettingsLinkVisible();
     await serverAdminPage.settingsLink.click();
-    await page.waitForURL(routes.serverAdminBots);
+    await page.waitForURL(routes.settingsAppearance);
+    await expect(page.getByRole('heading', { name: 'Appearance' })).toBeVisible();
     await serverAdminPage.expectBotsNavVisible();
     await serverAdminPage.expectGeneralNavNotVisible();
   });

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -21,6 +21,10 @@
   import { serverStorageKey } from '$lib/storage/serverStorage';
   import { getAdminNavItems } from './adminNav';
   import { m } from '$lib/i18n/messages';
+  import {
+    DEFAULT_SERVER_SETTINGS_ROUTE,
+    SERVER_SETTINGS_ROOT_ROUTE
+  } from '$lib/navigation/settingsRoutes';
 
   let { children }: { children?: Snippet } = $props();
 
@@ -40,7 +44,7 @@
   // Server preferences and permission-gated server administration share one
   // settings shell, regardless of which route family owns the content page.
   const settingsPrefix = $derived(
-    resolve('/chat/[serverId]/settings', { serverId: serverSegment })
+    resolve(SERVER_SETTINGS_ROOT_ROUTE, { serverId: serverSegment })
   );
   const isSettingsMode = $derived(page.url.pathname.startsWith(settingsPrefix));
   const isServerSettingsMode = $derived(isSettingsMode || isManageMode);
@@ -69,7 +73,7 @@
   ]);
   const appPreferenceNavItems = $derived([
     {
-      href: resolve('/chat/[serverId]/settings/appearance', { serverId: serverSegment }),
+      href: resolve(DEFAULT_SERVER_SETTINGS_ROUTE, { serverId: serverSegment }),
       label: m('settings.app_preferences.appearance.title'),
       icon: 'iconify icon-[uil--palette]'
     },
@@ -211,10 +215,6 @@
       )
     }
   ]);
-  const settingsHref = $derived(
-    adminNavItems[0]?.href ??
-      resolve('/chat/[serverId]/settings/profile', { serverId: serverSegment })
-  );
 </script>
 
 <ServerPresenceSync />
@@ -282,8 +282,10 @@
           </a>
         {/if}
         <MyThreadsNavItem active={isMyThreadsActive} />
-        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- settingsHref is resolved above -->
-        <a href={settingsHref} class="sidebar-item">
+        <a
+          href={resolve(SERVER_SETTINGS_ROOT_ROUTE, { serverId: serverSegment })}
+          class="sidebar-item"
+        >
           <span class="iconify sidebar-icon icon-[uil--setting]" aria-hidden="true"></span>
           {m('settings.nav.title')}
         </a>

--- a/apps/frontend/src/lib/navigation/settingsRoutes.ts
+++ b/apps/frontend/src/lib/navigation/settingsRoutes.ts
@@ -1,0 +1,9 @@
+/** The canonical unified Settings entry-point route. */
+export const SERVER_SETTINGS_ROOT_ROUTE = '/chat/[serverId]/settings';
+
+/** The first page in the unified Settings navigation. */
+export const DEFAULT_SETTINGS_PAGE = 'appearance';
+
+/** The route for the first page in the unified Settings navigation. */
+export const DEFAULT_SERVER_SETTINGS_ROUTE =
+	`${SERVER_SETTINGS_ROOT_ROUTE}/${DEFAULT_SETTINGS_PAGE}` as const;

--- a/apps/frontend/src/lib/ui/AppHeader.svelte
+++ b/apps/frontend/src/lib/ui/AppHeader.svelte
@@ -10,6 +10,7 @@
   import { m } from '$lib/i18n/messages';
   import UnreadDot from '$lib/ui/UnreadDot.svelte';
   import MotdContent from '$lib/ui/MotdContent.svelte';
+  import { SERVER_SETTINGS_ROOT_ROUTE } from '$lib/navigation/settingsRoutes';
 
   // MOTD follows the active server; the connection-lost icon below stays
   // bound to the origin store since it reflects the SPA host's own connection.
@@ -98,7 +99,7 @@
 
     <a
       href={preferencesServerId
-        ? resolve('/chat/[serverId]/settings/appearance', {
+        ? resolve(SERVER_SETTINGS_ROOT_ROUTE, {
             serverId: serverIdToSegment(preferencesServerId)
           })
         : resolve('/chat/preferences')}

--- a/apps/frontend/src/lib/ui/AppHeader.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/AppHeader.svelte.spec.ts
@@ -97,7 +97,7 @@ describe('AppHeader', () => {
     expect(container.querySelector('[data-testid="notifications-unread-dot"]')).toBeNull();
   });
 
-  it('opens Appearance for the active authenticated server', () => {
+  it('opens the canonical Settings entry point for the active authenticated server', () => {
     mocks.servers = [{ id: 'remote' }];
     mocks.activeServer = 'remote';
     mocks.authenticated = { remote: true };
@@ -106,7 +106,7 @@ describe('AppHeader', () => {
     const { container } = render(AppHeader);
 
     expect(
-      container.querySelector('a[href="/chat/remote.example.com/settings/appearance"]')
+      container.querySelector('a[href="/chat/remote.example.com/settings"]')
     ).not.toBeNull();
     expect(container.querySelector('a[href="/chat/preferences"]')).toBeNull();
   });

--- a/apps/frontend/src/routes/chat/[serverId]/settings/+page.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/+page.ts
@@ -1,11 +1,12 @@
 import { redirect } from '@sveltejs/kit';
 import { resolve } from '$app/paths';
+import { DEFAULT_SERVER_SETTINGS_ROUTE } from '$lib/navigation/settingsRoutes';
 import type { PageLoad } from './$types';
 
-/** Redirect the former settings root to the named Profile settings route. */
+/** Redirect the canonical Settings entry point to its first displayed page. */
 export const load: PageLoad = ({ params, url }) => {
   redirect(
     308,
-    `${resolve('/chat/[serverId]/settings/profile', { serverId: params.serverId })}${url.search}`
+    `${resolve(DEFAULT_SERVER_SETTINGS_ROUTE, { serverId: params.serverId })}${url.search}`
   );
 };

--- a/apps/frontend/src/routes/chat/[serverId]/settings/legacy-routes.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/legacy-routes.spec.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { load as legacyProfileLoad } from './+page';
+import { load as settingsRootLoad } from './+page';
 import { load as legacyAppearanceLoad } from './app/+page';
 import { load as legacyTimeLoad } from './preferences/+page';
 
@@ -15,7 +15,7 @@ describe('legacy settings routes', () => {
   beforeEach(() => mocks.redirect.mockReset());
 
   it.each([
-    ['settings root', legacyProfileLoad, '/chat/remote/settings/profile'],
+    ['settings root', settingsRootLoad, '/chat/remote/settings/appearance'],
     ['app', legacyAppearanceLoad, '/chat/remote/settings/appearance'],
     ['preferences', legacyTimeLoad, '/chat/remote/settings/time']
   ])('redirects %s to its named route', (_name, load, destination) => {


### PR DESCRIPTION
## Why

The sidebar Settings entry opened a permission-dependent account or administration page instead of matching the header gear and the visible settings order.

## What changed

- Make `/chat/[serverId]/settings` the canonical entry point and redirect it to Appearance while preserving query parameters.
- Share route constants across the settings redirect, sidebar entry, header gear, and Appearance navigation item.
- Update administrator and member coverage, including administration page objects that now select General explicitly after entering Settings through Appearance.

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: No impact.
- Newer client → older server: No impact.
- Capability discovery or minimum client/server version: No change.

## Test plan

- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- Focused Vitest route and header suites — 8 tests passed.
- Focused Playwright settings and admin-navigation flows — 9 tests passed.
- Production frontend build, bundle limits, and CSP checks — passed through the focused Playwright setup.
- Chrome DevTools verification — both entry points used the settings root and landed on active Appearance.