### PR TITLE
fix(frontend): keep current room text regular

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -569,7 +569,7 @@
   /* A current route declares itself semantically. The shared item then gives
    * every sidebar navigation surface the same quiet action-coloured treatment. */
   &[aria-current='page'] {
-    @apply bg-action/10 font-medium text-text-top hover:bg-action/15 hover:text-text-top active:bg-action/20;
+    @apply bg-action/10 text-text-top hover:bg-action/15 hover:text-text-top active:bg-action/20;
     @apply focus-visible:bg-action/10;
   }
 


### PR DESCRIPTION
## Why

The current-room highlight used medium-weight text, which also communicates unread activity and made the two states ambiguous.

## What changed

- Keep the existing action-coloured fill, text, and icon treatment for the current sidebar route.
- Reserve medium-weight sidebar text for unread non-current entries.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest run src/lib/RoomList.svelte.spec.ts` — 38 tests passed.
- `mise build-frontend` — production build, bundle checks, and CSP check passed.
- Chrome DevTools computed-style check — current entry uses weight 400; unread entry uses weight 500.