### PR TITLE
fix(frontend): restore visual composer caret

### DIFF
--- a/apps/frontend/e2e/threading.test.ts
+++ b/apps/frontend/e2e/threading.test.ts
@@ -882,8 +882,9 @@ test.describe('Message Threading', () => {
     await message.openThread();
     await roomPage.expectThreadPaneVisible();
 
-    // The thread reply input should be focused
+    // The visual thread reply input should be focused with a visible text caret.
     await roomPage.expectThreadInputFocused();
+    await expect(roomPage.threadReplyInput).toHaveCSS('user-select', 'text');
   });
 
   test('on small screens, thread slideover has back button and covers room', async ({

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte
@@ -614,7 +614,7 @@ and exposes a typed API for text manipulation (mentions, emoji, drafts).
     bind:this={editorElement}
     onscroll={() => editor && updateActiveControls(editor)}
     class={[
-      'composer-code-palette tiptap-editor max-h-50 min-h-8 min-w-0 flex-1 overflow-x-hidden overflow-y-auto bg-transparent py-1 text-text',
+      'composer-code-palette tiptap-editor max-h-50 min-h-8 min-w-0 flex-1 select-text overflow-x-hidden overflow-y-auto bg-transparent py-1 text-text',
       !editable && 'cursor-not-allowed'
     ]}
   ></div>

--- a/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/TipTapEditor.svelte.spec.ts
@@ -26,6 +26,20 @@ describe('TipTapEditor accessibility', () => {
 
     await expect.element(page.getByRole('textbox', { name: 'Edit your message' })).toBeVisible();
   });
+
+  it('shows a text caret when focused inside the non-selectable app shell', async () => {
+    const { container } = render(TipTapEditor, {
+      props: { placeholder: 'Write a message', autofocus: true }
+    });
+    const editor = page.getByRole('textbox', { name: 'Write a message' }).element();
+
+    await vi.waitFor(() => expect(document.activeElement).toBe(editor));
+
+    const style = getComputedStyle(editor);
+    expect(style.userSelect).toBe('text');
+    expect(style.caretColor).toBe(style.color);
+    expect(container.querySelector('.tiptap-editor')?.classList).toContain('select-text');
+  });
 });
 
 describe('TipTapEditor wrapping', () => {


### PR DESCRIPTION
## Why

The Visual message composer inherited the app shell's `user-select: none`. Thread reply inputs received keyboard focus and accepted text, but Chrome did not show a usable caret, so the composer appeared unfocused.

## What changed

- Restore text selection on the TipTap editor surface with the established `select-text` utility.
- Add browser-component coverage for autofocus, computed text selection, and caret colour.
- Strengthen the existing thread autofocus E2E scenario to verify the Visual reply input is text-selectable.
- Keep the existing thread focus lifecycle and Markdown editor behavior unchanged.

This is a frontend-only CSS behavior fix with no API, persistence, migration, security, rollout, or operational implications.

## Test plan

- `mise x -- pnpm exec vitest --run --project=client src/lib/components/composer/TipTapEditor.svelte.spec.ts` — 14 tests passed.
- `mise run lint-frontend` — design-system checks, Svelte type checks, and ESLint passed.
- `mise x -- pnpm exec playwright test e2e/threading.test.ts --grep "opening thread auto-focuses the reply input"` — targeted E2E passed; its production build, bundle-size checks, and CSP checks also passed.
- `mise x -- npx @sveltejs/mcp svelte-autofixer apps/frontend/src/lib/components/composer/TipTapEditor.svelte --svelte-version 5` — no issues.
- Chrome DevTools — confirmed the thread reply input opens focused, computes `user-select: text`, uses the text colour for its caret, and accepts typed text with a collapsed selection inside the editor.