### PR TITLE
feat(frontend): unify checkbox and choice row styling

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -80,6 +80,10 @@ inside the icon. Do not add a side stripe or a shadow for navigation selection.
 | Empty collection or search result         | `EmptyState`                                                               | Bespoke centered placeholder markup                          |
 | Loading image                             | `SkeletonImg`                                                              | `<img class="skeleton">`                                     |
 
+`Checkbox` and `ChoiceRow` use the same option-row shape and selected fill.
+Use the square check indicator for an independent boolean setting. Use the
+circular radio indicator for one choice in a group.
+
 ## Standard Pane Pages
 
 Use the pane-page composition for primary application pages such as search,

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -386,23 +386,31 @@
   @apply input resize-none;
 }
 
-/* Checkbox utility */
-@utility checkbox {
-  @apply h-4 w-4 cursor-pointer rounded border-input-border bg-input text-action;
-  @apply transition-[border-color,box-shadow] duration-100;
-  @apply focus:ring-2 focus:ring-action/30 focus:ring-offset-0;
-  @apply disabled:cursor-not-allowed disabled:opacity-60;
+@utility checkbox-option {
+  @apply flex cursor-pointer items-start gap-3 rounded-lg border border-border px-3 py-2;
+  @apply transition-[background-color,border-color,box-shadow] duration-100;
+  @apply hover:border-input-border hover:bg-surface;
 }
 
-@utility checkbox-option {
-  @apply flex cursor-pointer items-start gap-3 rounded-md border border-border bg-surface px-3 py-3;
-  @apply transition-[background-color,border-color,box-shadow] duration-100;
-  @apply hover:border-input-border hover:bg-surface-emphasized;
+@utility checkbox-option-selected {
+  @apply border-action bg-action/10 hover:border-action hover:bg-action/10;
+}
+
+@utility checkbox-option-error {
+  @apply border-error/70 bg-error/5 hover:border-error/80 hover:bg-error/10;
 }
 
 @utility checkbox-box {
-  @apply mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-md border border-input-border bg-input text-transparent;
-  @apply transition-[background-color,border-color,box-shadow,color] duration-100;
+  @apply mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-md border-2 border-muted bg-transparent text-transparent;
+  @apply transition-[background-color,border-color,color] duration-100;
+}
+
+@utility checkbox-box-selected {
+  @apply border-action bg-action text-on-action;
+}
+
+@utility checkbox-box-error {
+  @apply border-error;
 }
 
 /* Single-choice rows used by settings radio groups. */

--- a/apps/frontend/src/lib/ui/form/Checkbox.stories.svelte
+++ b/apps/frontend/src/lib/ui/form/Checkbox.stories.svelte
@@ -6,7 +6,8 @@
   const componentDescription = `
     Use Checkbox for independent boolean settings. Prefer immediate-save behavior for settings where
     one checkbox maps to one backend change, and keep supporting text inside the component instead of
-    building custom option rows.
+    building custom option rows. Its selected row matches ChoiceRow, while the square check indicator
+    distinguishes a boolean setting from a one-of-many choice.
   `.trim();
 
   const { Story } = defineMeta({
@@ -46,7 +47,9 @@
   asChild
   parameters={{
     docs: {
-      description: { story: 'Checked state uses the shared action treatment.' }
+      description: {
+        story: 'The complete checked row uses the same action treatment as a selected ChoiceRow.'
+      }
     }
   }}
 >

--- a/apps/frontend/src/lib/ui/form/Checkbox.svelte
+++ b/apps/frontend/src/lib/ui/form/Checkbox.svelte
@@ -3,8 +3,9 @@
 
 Reusable checkbox option row for forms. Use this for settings, toggles, and
 other boolean controls that need a label plus optional helper or error text.
-The visible box is custom-styled, while the native checkbox remains in the
-DOM for form semantics, keyboard focus, and screen-reader state.
+The complete row shows the selected state, and its square indicator distinguishes
+it from the circular ChoiceRow radio pattern. The native checkbox remains in
+the DOM for form semantics, keyboard focus, and screen-reader state.
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
@@ -41,8 +42,10 @@ DOM for form semantics, keyboard focus, and screen-reader state.
   aria-busy={loading || undefined}
   class={[
     'checkbox-option',
-    error && 'border-error/70 bg-error/5 hover:border-error/80 hover:bg-error/10',
-    disabled && 'cursor-not-allowed opacity-60 hover:border-border hover:bg-surface/45'
+    checked && !error && 'checkbox-option-selected',
+    error && 'checkbox-option-error',
+    disabled && 'cursor-not-allowed opacity-60',
+    disabled && !checked && !error && 'hover:border-border hover:bg-transparent'
   ]}
 >
   <input
@@ -60,8 +63,8 @@ DOM for form semantics, keyboard focus, and screen-reader state.
     class={[
       'checkbox-box',
       'peer-focus-visible:ring-2 peer-focus-visible:ring-action/35 peer-focus-visible:ring-offset-0',
-      'peer-checked:border-action peer-checked:bg-action peer-checked:text-background',
-      error && 'border-error peer-focus-visible:ring-error/30',
+      checked && 'checkbox-box-selected',
+      error && 'checkbox-box-error peer-focus-visible:ring-error/30',
       loading && 'animate-pulse'
     ]}
     aria-hidden="true"
@@ -69,8 +72,8 @@ DOM for form semantics, keyboard focus, and screen-reader state.
     <span class="iconify text-base icon-[uil--check]"></span>
   </span>
 
-  <span class="flex min-w-0 flex-1 flex-col gap-1">
-    <span class="text-sm font-semibold text-text">
+  <span class="min-w-0 flex-1">
+    <span class={['block text-text', checked && 'font-medium']}>
       {#if children}
         {@render children()}
       {:else if label}
@@ -79,9 +82,9 @@ DOM for form semantics, keyboard focus, and screen-reader state.
     </span>
 
     {#if error}
-      <span id={`${id}-error`} role="alert" class="text-xs leading-5 text-error">{error}</span>
+      <span id={`${id}-error`} role="alert" class="block text-sm text-error">{error}</span>
     {:else if description}
-      <span id={`${id}-description`} class="text-xs leading-5 text-muted">{description}</span>
+      <span id={`${id}-description`} class="block text-sm text-muted">{description}</span>
     {/if}
   </span>
 </label>

--- a/apps/frontend/src/lib/ui/form/Checkbox.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/form/Checkbox.svelte.spec.ts
@@ -3,6 +3,47 @@ import { render } from 'vitest-browser-svelte';
 import Checkbox from './Checkbox.svelte';
 
 describe('Checkbox', () => {
+  it('toggles through the native input and selects the complete row', async () => {
+    const { container, getByRole, getByText } = render(Checkbox, {
+      props: {
+        id: 'timezone-sharing',
+        label: 'Show my time zone on my profile',
+        description: 'Other members can see your current local time.'
+      }
+    });
+
+    const label = container.querySelector('label') as HTMLLabelElement;
+    const input = getByRole('checkbox', { name: 'Show my time zone on my profile' });
+
+    expect(label.classList.contains('checkbox-option-selected')).toBe(false);
+    await getByText('Show my time zone on my profile').click();
+    await expect.element(input).toBeChecked();
+    expect(label.classList.contains('checkbox-option-selected')).toBe(true);
+    expect(input.element().getAttribute('aria-describedby')).toBe('timezone-sharing-description');
+  });
+
+  it('keeps the error treatment when a checked option is invalid', () => {
+    const { container, getByRole } = render(Checkbox, {
+      props: {
+        id: 'terms',
+        label: 'Accept the terms',
+        checked: true,
+        error: 'Review the terms before you continue.'
+      }
+    });
+
+    const label = container.querySelector('label') as HTMLLabelElement;
+    const box = container.querySelector('.checkbox-box') as HTMLSpanElement;
+    const input = getByRole('checkbox', { name: 'Accept the terms' });
+
+    expect(label.classList.contains('checkbox-option-error')).toBe(true);
+    expect(label.classList.contains('checkbox-option-selected')).toBe(false);
+    expect(box.classList.contains('checkbox-box-selected')).toBe(true);
+    expect(box.classList.contains('checkbox-box-error')).toBe(true);
+    expect(input.element().getAttribute('aria-invalid')).toBe('true');
+    expect(input.element().getAttribute('aria-describedby')).toBe('terms-error');
+  });
+
   it('keeps a saving option checked and non-interactive', () => {
     const { container } = render(Checkbox, {
       props: {
@@ -17,6 +58,7 @@ describe('Checkbox', () => {
     const input = container.querySelector('input') as HTMLInputElement;
 
     expect(label.getAttribute('aria-busy')).toBe('true');
+    expect(label.classList.contains('checkbox-option-selected')).toBe(true);
     expect(input.checked).toBe(true);
     expect(input.disabled).toBe(true);
   });


### PR DESCRIPTION
## Why

Checkboxes looked weaker than adjacent radio choices, and their indicators did not align with the first label line when helper text wrapped.

## What changed

- Match checkbox rows to the shared `ChoiceRow` shape, spacing, typography, hover state, and full-row selected treatment while retaining a square indicator.
- Keep native checkbox semantics and explicit checked, error, disabled, loading, focus, and wrapped-text alignment states in the shared component.
- Document the checkbox/radio relationship in the design system and Storybook, and add focused browser-component coverage.

## API compatibility

- No public API or protocol behaviour changed; client/server compatibility, capability discovery, rollout, and migration are not affected.

## Test plan

- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- `mise test-frontend` — passed: 148 server files / 1,315 tests, 183 browser files / 1,924 tests, 78 Storybook files / 222 tests, and 5 performance-comparison tests.
- Focused Checkbox browser spec — 3 tests passed; Svelte autofixer and design-system guardrails passed.
- Chrome DevTools — verified Storybook and Time & region in light/dark and desktop/mobile layouts, including checked, unchecked, error, focus, and wrapped-description states.
