### PR TITLE
docs(frontend): clarify e2e entry routes

### DIFF
--- a/apps/frontend/AGENTS.md
+++ b/apps/frontend/AGENTS.md
@@ -312,6 +312,10 @@ and Storybook.
   timers or dispatch the complete input value synchronously instead of timing
   multi-keystroke `userEvent.type` calls against the production delay.
 - E2E is for real backend/NATS/WebSocket/multi-user/cross-route behavior.
+- Page objects that open a canonical entry route must model its actual landing
+  page. If a method promises a child page, first open the entry route, then
+  select and wait for that child page. When an entry route changes, inspect all
+  page-object methods and callers that depend on its landing page.
 - When changing multi-server authentication or shared chat providers, cover an
   authenticated remote server with an anonymous origin server.
 - Use helpers from `$lib/test-utils` rather than re-rolling connection/context


### PR DESCRIPTION
## Why

Canonical entry routes can change their landing page, which can leave shared E2E page objects with stale navigation assumptions.

## What changed

- Require page objects to model the actual landing page and to select and wait for a promised child page explicitly.
- Require route changes to include a review of dependent page-object methods and callers.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `git diff --check` — passed.
- Reviewed `git diff origin/main...HEAD`; the PR changes only `apps/frontend/AGENTS.md`.
