### PR TITLE
feat(neighbors): show recommendation sources

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
@@ -37,7 +37,9 @@ as a rank or preference.
 Select **Add Server** in the Server Gutter to open the Server Directory. The
 client combines the direct Neighbors advertised by every server that is
 registered on the device. It removes duplicate origins, but it does not sort or
-rank the results.
+rank the results. Each result shows the registered servers that recommend it.
+When more than two servers recommend the same result, the card shows two server
+names and the number of other recommendations.
 
 The client requests each advertised server's public profile. A result can show
 the server name, description, logo, and banner. If a server is offline or does

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -93,8 +93,9 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   <ReleaseFeatureCard title="Advertise friendly Chatto servers">
     Server administrators can maintain a public Neighbor directory. The Server
     Directory combines recommendations from a user's registered servers, loads
-    their public profiles, and keeps joined servers visible. A listing is a
-    recommendation, not a verified or reciprocal relationship.
+    their public profiles, shows the source of each recommendation, and keeps
+    joined servers visible. A listing is a recommendation, not a verified or
+    reciprocal relationship.
   </ReleaseFeatureCard>
 
   <ReleaseFeatureCard title="Remote clients connect without allowlists" size="large">

--- a/apps/frontend/messages/ar/add_server.json
+++ b/apps/frontend/messages/ar/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "موصى به من {servers}",
+      "more_recommenders_count": { "other": "{count} آخرين" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/cs-CZ/add_server.json
+++ b/apps/frontend/messages/cs-CZ/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Doporučují {servers}",
+      "more_recommenders_count": { "other": "dalších {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/de-DE/add_server.json
+++ b/apps/frontend/messages/de-DE/add_server.json
@@ -17,6 +17,8 @@
       "find": "Server suchen",
       "servers_title": "Server",
       "servers_description": "Von Servern empfohlen, denen du beigetreten bist. Die Ergebnisse haben keine Rangfolge.",
+      "recommended_by": "Empfohlen von {servers}",
+      "more_recommenders_count": { "other": "{count} weitere" },
       "joined": "Beigetreten",
       "join": "Beitreten",
       "open": "Öffnen",

--- a/apps/frontend/messages/en-GB/add_server.json
+++ b/apps/frontend/messages/en-GB/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recommended by {servers}",
+      "more_recommenders_count": { "other": "{count} more" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/eo/add_server.json
+++ b/apps/frontend/messages/eo/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Rekomendita de {servers}",
+      "more_recommenders_count": { "other": "{count} pliaj" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/es-419/add_server.json
+++ b/apps/frontend/messages/es-419/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recomendado por {servers}",
+      "more_recommenders_count": { "other": "{count} más" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/es-ES/add_server.json
+++ b/apps/frontend/messages/es-ES/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recomendado por {servers}",
+      "more_recommenders_count": { "other": "{count} más" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/et-EE/add_server.json
+++ b/apps/frontend/messages/et-EE/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Soovitajad: {servers}",
+      "more_recommenders_count": { "other": "veel {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/fr-CA/add_server.json
+++ b/apps/frontend/messages/fr-CA/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recommandé par {servers}",
+      "more_recommenders_count": { "other": "{count} de plus" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/fr-FR/add_server.json
+++ b/apps/frontend/messages/fr-FR/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recommandé par {servers}",
+      "more_recommenders_count": { "other": "{count} de plus" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/he-IL/add_server.json
+++ b/apps/frontend/messages/he-IL/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "מומלץ על ידי {servers}",
+      "more_recommenders_count": { "other": "עוד {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/it-IT/add_server.json
+++ b/apps/frontend/messages/it-IT/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Consigliato da {servers}",
+      "more_recommenders_count": { "other": "altri {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/ja-JP/add_server.json
+++ b/apps/frontend/messages/ja-JP/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "{servers} からのおすすめ",
+      "more_recommenders_count": { "other": "他{count}件" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/lv-LV/add_server.json
+++ b/apps/frontend/messages/lv-LV/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Iesaka {servers}",
+      "more_recommenders_count": { "other": "vēl {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/nb-NO/add_server.json
+++ b/apps/frontend/messages/nb-NO/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Anbefalt av {servers}",
+      "more_recommenders_count": { "other": "{count} til" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/nl-BE/add_server.json
+++ b/apps/frontend/messages/nl-BE/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Aanbevolen door {servers}",
+      "more_recommenders_count": { "other": "nog {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/nl-NL/add_server.json
+++ b/apps/frontend/messages/nl-NL/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Aanbevolen door {servers}",
+      "more_recommenders_count": { "other": "nog {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/pl-PL/add_server.json
+++ b/apps/frontend/messages/pl-PL/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Polecane przez {servers}",
+      "more_recommenders_count": { "other": "jeszcze {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/pt-BR/add_server.json
+++ b/apps/frontend/messages/pt-BR/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recomendado por {servers}",
+      "more_recommenders_count": { "other": "mais {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/pt-PT/add_server.json
+++ b/apps/frontend/messages/pt-PT/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Recomendado por {servers}",
+      "more_recommenders_count": { "other": "mais {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/ru-RU/add_server.json
+++ b/apps/frontend/messages/ru-RU/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Рекомендуют {servers}",
+      "more_recommenders_count": { "other": "ещё {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/sv-SE/add_server.json
+++ b/apps/frontend/messages/sv-SE/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Rekommenderas av {servers}",
+      "more_recommenders_count": { "other": "{count} till" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/tr-TR/add_server.json
+++ b/apps/frontend/messages/tr-TR/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Önerenler: {servers}",
+      "more_recommenders_count": { "other": "{count} tane daha" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/uk-UA/add_server.json
+++ b/apps/frontend/messages/uk-UA/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "Рекомендують {servers}",
+      "more_recommenders_count": { "other": "ще {count}" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/zh-CN/add_server.json
+++ b/apps/frontend/messages/zh-CN/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "由{servers}推荐",
+      "more_recommenders_count": { "other": "另有{count}个" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/messages/zh-TW/add_server.json
+++ b/apps/frontend/messages/zh-TW/add_server.json
@@ -17,6 +17,8 @@
       "find": "Find server",
       "servers_title": "Servers",
       "servers_description": "Recommended by servers you have joined. Results are not ranked.",
+      "recommended_by": "由{servers}推薦",
+      "more_recommenders_count": { "other": "另有{count}個" },
       "joined": "Joined",
       "join": "Join",
       "open": "Open",

--- a/apps/frontend/src/lib/serverDirectory.spec.ts
+++ b/apps/frontend/src/lib/serverDirectory.spec.ts
@@ -76,7 +76,50 @@ describe('loadServerDirectory', () => {
       'https://a.example',
       'https://invalid.example'
     ]);
+    expect(snapshot.entries.map((entry) => entry.sourceOrigins)).toEqual([
+      ['https://one.example'],
+      ['https://one.example', 'https://two.example'],
+      ['https://one.example']
+    ]);
     expect(snapshot.entries.at(-1)?.profile).toBeNull();
+  });
+
+  it('deduplicates repeated recommendations from the same source', async () => {
+    const snapshot = await loadServerDirectory(['https://source.example'], {
+      listNeighbors: vi.fn(async () => [
+        'https://neighbor.example',
+        'HTTPS://NEIGHBOR.EXAMPLE:443/path'
+      ]),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+
+    expect(snapshot.entries).toEqual([
+      {
+        origin: 'https://neighbor.example',
+        profile: profile('https://neighbor.example'),
+        sourceOrigins: ['https://source.example']
+      }
+    ]);
+  });
+
+  it('canonicalizes and deduplicates registered source origins', async () => {
+    const listNeighbors = vi.fn(async () => ['https://neighbor.example']);
+
+    const snapshot = await loadServerDirectory(
+      ['HTTPS://SOURCE.EXAMPLE:443/path', 'https://source.example', 'not a URL'],
+      {
+        listNeighbors,
+        getServerInfo: vi.fn(async (origin: string) => profile(origin))
+      }
+    );
+
+    expect(listNeighbors).toHaveBeenCalledOnce();
+    expect(listNeighbors).toHaveBeenCalledWith(
+      'https://source.example',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+    expect(snapshot.sourceCount).toBe(1);
+    expect(snapshot.entries[0]?.sourceOrigins).toEqual(['https://source.example']);
   });
 
   it('limits each source to the server-side directory maximum', async () => {
@@ -114,5 +157,33 @@ describe('loadServerDirectory', () => {
     });
 
     expect(snapshot).toEqual({ entries: [], failedSourceCount: 0, sourceCount: 1 });
+  });
+
+  it('loads at most six source directories concurrently', async () => {
+    let active = 0;
+    let maximumActive = 0;
+    let releaseRequests!: () => void;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequests = resolve;
+    });
+    const listNeighbors = vi.fn(async () => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await requestGate;
+      active -= 1;
+      return [];
+    });
+
+    const loading = loadServerDirectory(
+      Array.from({ length: 12 }, (_, index) => `https://source-${index}.example`),
+      { listNeighbors, getServerInfo: vi.fn(async (origin: string) => profile(origin)) }
+    );
+
+    await vi.waitFor(() => expect(listNeighbors).toHaveBeenCalledTimes(6));
+    expect(maximumActive).toBe(6);
+    releaseRequests();
+    await loading;
+    expect(listNeighbors).toHaveBeenCalledTimes(12);
+    expect(maximumActive).toBe(6);
   });
 });

--- a/apps/frontend/src/lib/serverDirectory.ts
+++ b/apps/frontend/src/lib/serverDirectory.ts
@@ -6,12 +6,18 @@ import {
 } from '$lib/api-client/server';
 
 const DISCOVERY_TIMEOUT_MS = 10_000;
+const SOURCE_CONCURRENCY = 6;
 const PROFILE_CONCURRENCY = 6;
 const MAX_NEIGHBORS_PER_SOURCE = 100;
 
-export type ServerDirectoryEntry = {
+export type ServerProfileEntry = {
   origin: string;
   profile: PublicServerInfo | null;
+};
+
+export type ServerDirectoryEntry = ServerProfileEntry & {
+  /** Canonical origins of the registered servers that advertised this entry. */
+  sourceOrigins: string[];
 };
 
 export type ServerDirectorySnapshot = {
@@ -53,7 +59,7 @@ export function serverOriginFromInput(value: string): string | null {
 export async function loadServerProfiles(
   origins: readonly string[],
   options: ProfileLoadOptions = {}
-): Promise<ServerDirectoryEntry[]> {
+): Promise<ServerProfileEntry[]> {
   const getServerInfo = options.getServerInfo ?? getPublicServerInfo;
   const profiles = await mapWithConcurrency(origins, PROFILE_CONCURRENCY, (origin) =>
     getServerInfo(origin, { signal: discoverySignal(options.signal) }).catch(() => null)
@@ -74,18 +80,34 @@ export async function loadServerDirectory(
 ): Promise<ServerDirectorySnapshot> {
   const listNeighbors = options.listNeighbors ?? getPublicNeighborOrigins;
   const getServerInfo = options.getServerInfo ?? getPublicServerInfo;
-  const sourceResults = await Promise.allSettled(
-    registeredOrigins.map((origin) =>
-      listNeighbors(origin, { signal: discoverySignal(options.signal) }).catch((error) => {
-        if (error instanceof ConnectError && error.code === Code.Unimplemented) return [];
-        throw error;
+  const sourceOrigins = [
+    ...new Set(
+      registeredOrigins.flatMap((value) => {
+        const origin = canonicalServerOrigin(value);
+        return origin ? [origin] : [];
       })
     )
+  ];
+  const sourceResults = await mapWithConcurrency(
+    sourceOrigins,
+    SOURCE_CONCURRENCY,
+    async (sourceOrigin) => {
+      try {
+        const advertisedOrigins = await listNeighbors(sourceOrigin, {
+          signal: discoverySignal(options.signal)
+        });
+        return { status: 'fulfilled' as const, sourceOrigin, advertisedOrigins };
+      } catch (error) {
+        if (error instanceof ConnectError && error.code === Code.Unimplemented) {
+          return { status: 'fulfilled' as const, sourceOrigin, advertisedOrigins: [] };
+        }
+        return { status: 'rejected' as const, sourceOrigin };
+      }
+    }
   );
   throwIfAborted(options.signal);
 
-  const advertisedOrigins: string[] = [];
-  const seen = new Set<string>();
+  const sourcesByAdvertisedOrigin = new Map<string, string[]>();
   let failedSourceCount = 0;
 
   for (const result of sourceResults) {
@@ -93,23 +115,31 @@ export async function loadServerDirectory(
       failedSourceCount += 1;
       continue;
     }
-    for (const advertised of result.value.slice(0, MAX_NEIGHBORS_PER_SOURCE)) {
+    for (const advertised of result.advertisedOrigins.slice(0, MAX_NEIGHBORS_PER_SOURCE)) {
       const origin = canonicalServerOrigin(advertised);
-      if (!origin || seen.has(origin)) continue;
-      seen.add(origin);
-      advertisedOrigins.push(origin);
+      if (!origin) continue;
+      const sourceOrigins = sourcesByAdvertisedOrigin.get(origin);
+      if (!sourceOrigins) {
+        sourcesByAdvertisedOrigin.set(origin, [result.sourceOrigin]);
+      } else if (!sourceOrigins.includes(result.sourceOrigin)) {
+        sourceOrigins.push(result.sourceOrigin);
+      }
     }
   }
 
-  const entries = await loadServerProfiles(advertisedOrigins, {
+  const profiles = await loadServerProfiles([...sourcesByAdvertisedOrigin.keys()], {
     signal: options.signal,
     getServerInfo
   });
+  const entries = profiles.map((entry) => ({
+    ...entry,
+    sourceOrigins: sourcesByAdvertisedOrigin.get(entry.origin) ?? []
+  }));
 
   return {
     entries,
     failedSourceCount,
-    sourceCount: registeredOrigins.length
+    sourceCount: sourceOrigins.length
   };
 }
 

--- a/apps/frontend/src/routes/chat/servers/+page.svelte
+++ b/apps/frontend/src/routes/chat/servers/+page.svelte
@@ -11,6 +11,7 @@
   import { startRemoteReauthentication, startServerOAuthFlow } from '$lib/auth/reauth';
   import ServerProfileCard from '$lib/components/ServerProfileCard.svelte';
   import { m } from '$lib/i18n/messages';
+  import { getReactiveLocale } from '$lib/i18n/state.svelte';
   import { serverIdToSegment } from '$lib/navigation';
   import { queryClient } from '$lib/query/client';
   import {
@@ -152,6 +153,35 @@
   function cardDisabled(entry: ServerDirectoryEntry): boolean {
     return !registeredServer(entry.origin) && !entry.profile?.authorizeUrl;
   }
+
+  function sourceName(origin: string): string {
+    const registered = registeredServer(origin);
+    if (registered) return registered.name;
+    try {
+      return new URL(origin).host;
+    } catch {
+      return origin;
+    }
+  }
+
+  function sourceAttribution(entry: ServerDirectoryEntry): { visible: string; full: string } {
+    const names = entry.sourceOrigins.map(sourceName);
+    const formatter = new Intl.ListFormat(getReactiveLocale(), {
+      style: 'long',
+      type: 'conjunction'
+    });
+    const remaining = names.length - 2;
+    const visibleNames =
+      remaining > 0
+        ? [...names.slice(0, 2), m('add_server.directory.more_recommenders_count', { count: remaining })]
+        : names;
+    return {
+      visible: m('add_server.directory.recommended_by', {
+        servers: formatter.format(visibleNames)
+      }),
+      full: m('add_server.directory.recommended_by', { servers: formatter.format(names) })
+    };
+  }
 </script>
 
 <PageTitle title={m('add_server.directory.title')} />
@@ -259,16 +289,27 @@
           <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {#each entries as entry (entry.origin)}
               {@const joined = registeredServer(entry.origin)}
+              {@const attribution = sourceAttribution(entry)}
               {#snippet cardActions()}
-                <Button
-                  variant={joined ? 'secondary' : 'action'}
-                  fullWidth
-                  loading={pendingOrigin === entry.origin}
-                  disabled={cardDisabled(entry)}
-                  onclick={() => openOrJoin(entry.origin, entry.profile)}
-                >
-                  {actionLabel(entry.origin, entry.profile)}
-                </Button>
+                <div class="flex flex-col gap-3">
+                  <p
+                    class="line-clamp-2 text-sm text-muted"
+                    aria-label={attribution.full}
+                    title={attribution.full}
+                    data-testid="server-recommendation-sources"
+                  >
+                    <bdi>{attribution.visible}</bdi>
+                  </p>
+                  <Button
+                    variant={joined ? 'secondary' : 'action'}
+                    fullWidth
+                    loading={pendingOrigin === entry.origin}
+                    disabled={cardDisabled(entry)}
+                    onclick={() => openOrJoin(entry.origin, entry.profile)}
+                  >
+                    {actionLabel(entry.origin, entry.profile)}
+                  </Button>
+                </div>
               {/snippet}
               <ServerProfileCard
                 origin={entry.origin}

--- a/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
@@ -108,8 +108,16 @@ describe('Server Directory page', () => {
   it('keeps directory response order and marks registered entries as joined', async () => {
     mocks.loadServerDirectory.mockResolvedValue({
       entries: [
-        { origin: 'https://z.example', profile: profile('Zulu') },
-        { origin: 'https://a.example', profile: profile('Alpha') }
+        {
+          origin: 'https://z.example',
+          profile: profile('Zulu'),
+          sourceOrigins: ['https://source.example']
+        },
+        {
+          origin: 'https://a.example',
+          profile: profile('Alpha'),
+          sourceOrigins: ['https://source.example']
+        }
       ],
       failedSourceCount: 0,
       sourceCount: 2
@@ -135,8 +143,16 @@ describe('Server Directory page', () => {
   it('hides unavailable entries and reports partial source failures', async () => {
     mocks.loadServerDirectory.mockResolvedValue({
       entries: [
-        { origin: 'https://offline.example', profile: null },
-        { origin: 'https://online.example', profile: profile('Online') }
+        {
+          origin: 'https://offline.example',
+          profile: null,
+          sourceOrigins: ['https://source.example']
+        },
+        {
+          origin: 'https://online.example',
+          profile: profile('Online'),
+          sourceOrigins: ['https://source.example']
+        }
       ],
       failedSourceCount: 1,
       sourceCount: 2
@@ -160,7 +176,13 @@ describe('Server Directory page', () => {
   it('starts the OAuth flow for an advertised server', async () => {
     const remoteProfile = profile('Remote');
     mocks.loadServerDirectory.mockResolvedValue({
-      entries: [{ origin: 'https://remote.example', profile: remoteProfile }],
+      entries: [
+        {
+          origin: 'https://remote.example',
+          profile: remoteProfile,
+          sourceOrigins: ['https://source.example']
+        }
+      ],
       failedSourceCount: 0,
       sourceCount: 2
     });
@@ -188,7 +210,13 @@ describe('Server Directory page', () => {
 
   it('opens an advertised server that is already joined', async () => {
     mocks.loadServerDirectory.mockResolvedValue({
-      entries: [{ origin: 'https://a.example', profile: profile('Alpha') }],
+      entries: [
+        {
+          origin: 'https://a.example',
+          profile: profile('Alpha'),
+          sourceOrigins: ['https://source.example']
+        }
+      ],
       failedSourceCount: 0,
       sourceCount: 2
     });
@@ -224,5 +252,53 @@ describe('Server Directory page', () => {
       );
       expect(container.textContent).toContain('Custom description');
     });
+  });
+
+  it('shows compact recommendation provenance with the full accessible source list', async () => {
+    mocks.servers = [
+      { id: 'one', url: 'https://one.example', name: 'One', iconUrl: null, addedAt: 1 },
+      { id: 'two', url: 'https://two.example', name: 'Two', iconUrl: null, addedAt: 2 },
+      { id: 'three', url: 'https://three.example', name: 'Three', iconUrl: null, addedAt: 3 }
+    ];
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://single.example',
+          profile: profile('Single'),
+          sourceOrigins: ['https://one.example']
+        },
+        {
+          origin: 'https://double.example',
+          profile: profile('Double'),
+          sourceOrigins: ['https://one.example', 'https://two.example']
+        },
+        {
+          origin: 'https://triple.example',
+          profile: profile('Triple'),
+          sourceOrigins: [
+            'https://one.example',
+            'https://two.example',
+            'https://three.example'
+          ]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 3
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="server-recommendation-sources"]')).toHaveLength(
+        3
+      );
+    });
+    const attributions = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid="server-recommendation-sources"]')
+    );
+    expect(attributions[0]?.textContent).toContain('Recommended by One');
+    expect(attributions[1]?.textContent).toContain('Recommended by One and Two');
+    expect(attributions[2]?.textContent).toContain('Recommended by One, Two, and 1 more');
+    expect(attributions[2]?.getAttribute('aria-label')).toContain('One, Two, and Three');
+    expect(attributions[2]?.title).toContain('One, Two, and Three');
   });
 });

--- a/docs/fdr/FDR-042-chatto-neighbors.md
+++ b/docs/fdr/FDR-042-chatto-neighbors.md
@@ -21,7 +21,8 @@ recommendation, not a trust or reciprocal relationship.
 - Any caller can list the advertised origins through the public discovery API.
 - The Server Directory page combines the direct Neighbors from all servers
   registered in the client. It removes duplicate canonical origins but does
-  not rank or sort the results.
+  not rank or sort the results. Each result identifies the registered servers
+  that recommend it.
 - The Server Directory and Neighbor administration page load each advertised
   server's public name, description, logo, and banner. The Server Directory
   omits a server when its public profile does not load. The administration page
@@ -114,6 +115,17 @@ making entries disappear after a user joins them.
 
 **Tradeoff:** The directory includes entries that do not offer a new server to
 join.
+
+### 7. Deduplication preserves recommendation sources
+
+**Decision:** One server appears once in the Server Directory. The result also
+identifies each registered server that advertises it.
+
+**Why:** A user can see where a recommendation comes from without seeing
+duplicate server cards.
+
+**Tradeoff:** The source names depend on the server catalogue on the user's
+device.
 
 ## Non-goals
 


### PR DESCRIPTION
## Why

The Server Directory deduplicated advertised servers but discarded which registered servers recommended each result. It also started every source-directory request at once. Users need recommendation provenance, and clients need bounded work when many servers are registered.

## What changed

- Preserve the ordered, canonical set of registered source origins for each deduplicated directory result.
- Canonicalize and deduplicate registered sources, and load at most six source directories concurrently while retaining existing timeouts, mixed-version handling, and failure isolation.
- Show up to two local server names on each directory card, followed by a localized remaining count. Expose the complete source list through the accessible label and title.
- Keep unavailable advertised profiles hidden and preserve Joined, sign-in, direct-address, partial-failure, and result-order behavior.
- Update FDR-042, the Neighbor operations guide, localized catalogs, and the unreleased 0.5 release page.

This is an internal frontend change. It does not change public APIs, persisted data, permissions, deployment, or compatibility behavior.

## Test plan

- Focused loader and browser-component tests: 16 passed.
- `mise lint-frontend`: passed with zero Svelte diagnostics and clean ESLint.
- `mise test-frontend`: passed with 1,329 server tests, 1,932 browser tests, 222 Storybook tests, and 5 performance-comparison tests.
- Svelte autofixer: no issues or suggestions.
- Docs website build: 73 pages built successfully.
- `mise license-check`: REUSE 3.3 validation passed.
- Chrome DevTools: verified one and multiple sources, long source names, compact remaining count, full accessible attribution, Joined and partial-failure states, wide/light and narrow/dark layouts, and a clean console after removing the intentional failed-source fixture.

Closes #1667.

Related: FDR-042.
