### PR TITLE
fix(ci): update only affected release PRs

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,7 +6,6 @@
   "versioning": "prerelease",
   "prerelease": true,
   "prerelease-type": "alpha.1",
-  "always-update": true,
   "separate-pull-requests": true,
   "draft": true,
   "force-tag-creation": true,


### PR DESCRIPTION
## Why

Release-please rewrites all seven component PRs after every successful `main` build, which starts seven full CI workflows even when most components have no new release content.

## What changed

- Remove `always-update: true` from the release-please manifest configuration
- Keep separate component release PRs and their existing full CI coverage

Release-please now uses its default behavior and updates a component PR only when that component has new release content.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `jq empty .release-please-config.json`
- `git diff --check origin/main...`
- Confirm the complete PR diff is one deleted configuration line

The next component-specific merge to `main` will provide the operational confirmation that unrelated release PR heads remain unchanged.