### PR TITLE
fix(frontend): make notification dismissal safer

### DIFF
--- a/apps/frontend/e2e/notifications.test.ts
+++ b/apps/frontend/e2e/notifications.test.ts
@@ -546,7 +546,7 @@ test.describe('Notification dismissal', () => {
     await notificationsPage.expectEmptyState();
   });
 
-  test('dismisses all notifications via Dismiss All', async ({
+  test('Dismiss read preserves a notification that just arrived', async ({
     page,
     chatPage,
     roomPage,
@@ -558,7 +558,7 @@ test.describe('Notification dismissal', () => {
     const userA = await createAndLoginTestUser(page);
     await chatPage.goto();
     await chatPage.enterRoom('general');
-    const rootMessage = `Dismiss all test ${Date.now()}`;
+    const rootMessage = `Dismiss read test ${Date.now()}`;
     await roomPage.sendMessage(rootMessage);
     // User A creates the additional room (room.create is not granted to everyone by default)
     const secondRoomName = await chatPage.createRoom();
@@ -575,26 +575,32 @@ test.describe('Notification dismissal', () => {
       await chatPage.enterRoom(secondRoomName);
 
       // Create mention in the second room (User A is not in any room)
-      await roomPage.sendMessage(`@${userA.login} dismiss all test 1`);
+      await roomPage.sendMessage(`@${userA.login} dismiss read test 1`);
       await chatPage.enterRoom('general');
       const message2 = roomPage.getMessage(rootMessage);
       await message2.openThread();
       await roomPage.expectThreadPaneVisible();
-      await roomPage.postThreadReply('Dismiss all test 2');
+      await roomPage.postThreadReply('Dismiss read test 2');
     });
 
-    // User A: Dismiss every notification group.
-    // Use longer timeout to allow real-time events to propagate
+    // Handle the mention, then return while the newer reply remains unread.
     await notificationsPage.goto();
     await notificationsPage.expectNotificationCount(2, TIMEOUTS.COMPLEX_OPERATION);
-    await notificationsPage.dismissAll();
+    const mention = notificationsPage.getNotificationBySummary('mentioned you.');
+    await notificationsPage.clickNotification(mention);
+    await page.waitForURL(routes.patterns.anyRoomWithQuery);
+    await notificationsPage.gotoDirectly();
+    await notificationsPage.expectReadNotEmpty();
+    await notificationsPage.expectUnreadNotEmpty();
 
-    // Dismissed groups are no longer visible.
-    await notificationsPage.expectUnreadEmpty();
-    await notificationsPage.expectEmptyState();
+    await notificationsPage.dismissRead();
+
+    // The handled notification is gone. The notification that arrived later remains.
+    await notificationsPage.expectNotificationCount(1);
+    await notificationsPage.expectUnreadNotEmpty();
   });
 
-  test('bell indicator clears after dismissing all notifications', async ({
+  test('bell indicator clears after dismissing an unread notification', async ({
     page,
     chatPage,
     notificationsPage,
@@ -612,9 +618,9 @@ test.describe('Notification dismissal', () => {
     // User A: Verify bell has indicator
     await notificationsPage.expectBellIndicatorVisible();
 
-    // Dismiss all notification groups.
+    // An explicit row deletion can still remove unread activity.
     await notificationsPage.goto();
-    await notificationsPage.dismissAll();
+    await notificationsPage.dismiss(notificationsPage.getNotificationBySummary('mentioned you.'));
 
     // Navigate back to chat and verify bell indicator is gone
     await chatPage.goto();
@@ -1084,7 +1090,7 @@ test.describe('Page Title Notification Count', () => {
     await expect(page).toHaveTitle(/^\(2\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
   });
 
-  test('page title returns to normal after dismissing all notifications', async ({
+  test('page title returns to normal after dismissing the unread notification', async ({
     page,
     chatPage,
     notificationsPage,
@@ -1102,9 +1108,9 @@ test.describe('Page Title Notification Count', () => {
     // User A: Verify title has count
     await expect(page).toHaveTitle(/^\(1\) /, { timeout: TIMEOUTS.REALTIME_EVENT });
 
-    // Dismiss all notifications.
+    // Dismiss the unread notification explicitly.
     await notificationsPage.goto();
-    await notificationsPage.dismissAll();
+    await notificationsPage.dismiss(notificationsPage.getNotificationBySummary('mentioned you.'));
 
     // Title should no longer have count prefix
     await expect(page).toHaveTitle(/^(?!\(\d+\)).*$/);

--- a/apps/frontend/e2e/pages/NotificationsPage.ts
+++ b/apps/frontend/e2e/pages/NotificationsPage.ts
@@ -105,18 +105,19 @@ export class NotificationsPage {
    * Permanently dismiss a specific notification group.
    */
   async dismiss(notification: Locator): Promise<void> {
+    await notification.hover();
     await this.getDeleteButton(notification).click();
   }
 
   /**
-   * Permanently dismiss every currently visible notification group.
+   * Permanently dismiss every loaded notification occurrence that is already read.
    */
-  async dismissAll(): Promise<void> {
-    await expect(this.notificationItems.first()).toBeVisible({
+  async dismissRead(): Promise<void> {
+    await expect(this.readItems.first()).toBeVisible({
       timeout: TIMEOUTS.REALTIME_EVENT
     });
-    await this.page.getByRole('button', { name: 'Dismiss all' }).click();
-    await expect(this.notificationItems).toHaveCount(0);
+    await this.page.getByRole('button', { name: 'Dismiss read' }).click();
+    await expect(this.readItems).toHaveCount(0);
   }
 
   // --- Assertions ---

--- a/apps/frontend/messages/ar/chat.json
+++ b/apps/frontend/messages/ar/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "الإشعارات",
       "subtitle": "إليك ما هو جديد",
-      "clear_all": "مسح الكل",
+      "clear_read": "حذف المقروءة",
       "empty_title": "لا توجد إخطارات",
       "empty_body": "أنتم جميعًا محاصرون!",
       "time_now": "الآن",

--- a/apps/frontend/messages/cs-CZ/chat.json
+++ b/apps/frontend/messages/cs-CZ/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Oznámení",
       "subtitle": "Zde je novinka",
-      "clear_all": "Vymazat vše",
+      "clear_read": "Odstranit přečtené",
       "empty_title": "Žádná upozornění",
       "empty_body": "Už jste všichni chyceni!",
       "time_now": "Právě teď",

--- a/apps/frontend/messages/de-DE/chat.json
+++ b/apps/frontend/messages/de-DE/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Benachrichtigungen",
       "subtitle": "Das ist neu",
-      "clear_all": "Alle löschen",
+      "clear_read": "Gelesene löschen",
       "empty_title": "Keine Benachrichtigungen",
       "empty_body": "Du bist auf dem neuesten Stand!",
       "time_now": "Gerade eben",

--- a/apps/frontend/messages/en-GB/chat.json
+++ b/apps/frontend/messages/en-GB/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notifications",
       "subtitle": "Here's what's new",
-      "clear_all": "Dismiss all",
+      "clear_read": "Dismiss read",
       "empty_title": "No notifications",
       "empty_body": "You're all caught up!",
       "time_now": "Just now",

--- a/apps/frontend/messages/eo/chat.json
+++ b/apps/frontend/messages/eo/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Sciigoj",
       "subtitle": "Jen kio estas nova",
-      "clear_all": "Forigi ĉion",
+      "clear_read": "Forigi legitajn",
       "empty_title": "Neniuj sciigoj",
       "empty_body": "Vi ĉiuj estas kaptitaj!",
       "time_now": "Ĝuste nun",

--- a/apps/frontend/messages/es-419/chat.json
+++ b/apps/frontend/messages/es-419/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notificaciones",
       "subtitle": "Esto es lo nuevo",
-      "clear_all": "Borrar todo",
+      "clear_read": "Borrar leídas",
       "empty_title": "Sin notificaciones",
       "empty_body": "¡Están todos atrapados!",
       "time_now": "Justo ahora",

--- a/apps/frontend/messages/es-ES/chat.json
+++ b/apps/frontend/messages/es-ES/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notificaciones",
       "subtitle": "Esto es lo nuevo",
-      "clear_all": "Borrar todo",
+      "clear_read": "Borrar leídas",
       "empty_title": "Sin notificaciones",
       "empty_body": "¡Están todos atrapados!",
       "time_now": "Justo ahora",

--- a/apps/frontend/messages/et-EE/chat.json
+++ b/apps/frontend/messages/et-EE/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Märguanded",
       "subtitle": "Siin on, mis on uut",
-      "clear_all": "Tühjenda kõik",
+      "clear_read": "Kustuta loetud",
       "empty_title": "Märguandeid pole",
       "empty_body": "Olete kõik kinni!",
       "time_now": "Just praegu",

--- a/apps/frontend/messages/fr-CA/chat.json
+++ b/apps/frontend/messages/fr-CA/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notifications",
       "subtitle": "Voici les nouveautés",
-      "clear_all": "Tout effacer",
+      "clear_read": "Effacer les notifications lues",
       "empty_title": "Aucune notification",
       "empty_body": "Vous êtes tous rattrapés !",
       "time_now": "Tout à l'heure",

--- a/apps/frontend/messages/fr-FR/chat.json
+++ b/apps/frontend/messages/fr-FR/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notifications",
       "subtitle": "Voici les nouveautés",
-      "clear_all": "Tout effacer",
+      "clear_read": "Effacer les notifications lues",
       "empty_title": "Aucune notification",
       "empty_body": "Vous êtes tous rattrapés !",
       "time_now": "Tout à l'heure",

--- a/apps/frontend/messages/he-IL/chat.json
+++ b/apps/frontend/messages/he-IL/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "התראות",
       "subtitle": "הנה מה חדש",
-      "clear_all": "נקה הכל",
+      "clear_read": "מחיקת הודעות שנקראו",
       "empty_title": "אין התראות",
       "empty_body": "כולכם מדורגים!",
       "time_now": "ממש עכשיו",

--- a/apps/frontend/messages/it-IT/chat.json
+++ b/apps/frontend/messages/it-IT/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notifiche",
       "subtitle": "Ecco le novità",
-      "clear_all": "Cancella tutto",
+      "clear_read": "Elimina quelle lette",
       "empty_title": "Nessuna notifica",
       "empty_body": "Siete tutti presi!",
       "time_now": "Proprio adesso",

--- a/apps/frontend/messages/ja-JP/chat.json
+++ b/apps/frontend/messages/ja-JP/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "通知",
       "subtitle": "新機能はこちら",
-      "clear_all": "すべてクリア",
+      "clear_read": "既読を削除",
       "empty_title": "通知はありません",
       "empty_body": "みんなも追いつきました！",
       "time_now": "ただいま",

--- a/apps/frontend/messages/lv-LV/chat.json
+++ b/apps/frontend/messages/lv-LV/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Paziņojumi",
       "subtitle": "Lūk, kas jauns",
-      "clear_all": "Notīrīt visu",
+      "clear_read": "Dzēst izlasītos",
       "empty_title": "Nav paziņojumu",
       "empty_body": "Jūs visi esat nokļuvuši!",
       "time_now": "Tikai tagad",

--- a/apps/frontend/messages/nb-NO/chat.json
+++ b/apps/frontend/messages/nb-NO/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Varsler",
       "subtitle": "Her er hva som er nytt",
-      "clear_all": "Fjern alt",
+      "clear_read": "Fjern leste",
       "empty_title": "Ingen varsler",
       "empty_body": "Dere er helt fanget!",
       "time_now": "Akkurat nå",

--- a/apps/frontend/messages/nl-BE/chat.json
+++ b/apps/frontend/messages/nl-BE/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Meldingen",
       "subtitle": "Dit is wat er nieuw is",
-      "clear_all": "Alles wissen",
+      "clear_read": "Gelezen wissen",
       "empty_title": "Geen meldingen",
       "empty_body": "Jullie zijn helemaal in beslag genomen!",
       "time_now": "Zojuist",

--- a/apps/frontend/messages/nl-NL/chat.json
+++ b/apps/frontend/messages/nl-NL/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Meldingen",
       "subtitle": "Dit is wat er nieuw is",
-      "clear_all": "Alles wissen",
+      "clear_read": "Gelezen wissen",
       "empty_title": "Geen meldingen",
       "empty_body": "Jullie zijn helemaal in beslag genomen!",
       "time_now": "Zojuist",

--- a/apps/frontend/messages/pl-PL/chat.json
+++ b/apps/frontend/messages/pl-PL/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Powiadomienia",
       "subtitle": "Oto nowości",
-      "clear_all": "Wyczyść wszystko",
+      "clear_read": "Usuń przeczytane",
       "empty_title": "Brak powiadomień",
       "empty_body": "Wszyscy jesteście zajęci!",
       "time_now": "Właśnie teraz",

--- a/apps/frontend/messages/pt-BR/chat.json
+++ b/apps/frontend/messages/pt-BR/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notificações",
       "subtitle": "Aqui estão as novidades",
-      "clear_all": "Limpar tudo",
+      "clear_read": "Limpar lidas",
       "empty_title": "Nenhuma notificação",
       "empty_body": "Vocês estão todos atualizados!",
       "time_now": "Agora mesmo",

--- a/apps/frontend/messages/pt-PT/chat.json
+++ b/apps/frontend/messages/pt-PT/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Notificações",
       "subtitle": "Aqui estão as novidades",
-      "clear_all": "Limpar tudo",
+      "clear_read": "Limpar lidas",
       "empty_title": "Sem notificação",
       "empty_body": "Estão todos actualizados!",
       "time_now": "Neste momento",

--- a/apps/frontend/messages/ru-RU/chat.json
+++ b/apps/frontend/messages/ru-RU/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Уведомления",
       "subtitle": "Вот что нового",
-      "clear_all": "Очистить все",
+      "clear_read": "Удалить прочитанные",
       "empty_title": "Нет уведомлений",
       "empty_body": "Вы все в плену!",
       "time_now": "только что",

--- a/apps/frontend/messages/sv-SE/chat.json
+++ b/apps/frontend/messages/sv-SE/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Aviseringar",
       "subtitle": "Här är vad som är nytt",
-      "clear_all": "Rensa alla",
+      "clear_read": "Rensa lästa",
       "empty_title": "Inga aviseringar",
       "empty_body": "Ni är alla ikapp!",
       "time_now": "Just nu",

--- a/apps/frontend/messages/tr-TR/chat.json
+++ b/apps/frontend/messages/tr-TR/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Bildirimler",
       "subtitle": "İşte yenilikler",
-      "clear_all": "Tümünü temizle",
+      "clear_read": "Okunanları temizle",
       "empty_title": "Bildirim yok",
       "empty_body": "Hepiniz yakalandınız!",
       "time_now": "Az önce",

--- a/apps/frontend/messages/uk-UA/chat.json
+++ b/apps/frontend/messages/uk-UA/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "Сповіщення",
       "subtitle": "Ось що нового",
-      "clear_all": "Очистити все",
+      "clear_read": "Видалити прочитані",
       "empty_title": "Немає сповіщень",
       "empty_body": "Ви все наздогнали!",
       "time_now": "Щойно",

--- a/apps/frontend/messages/zh-CN/chat.json
+++ b/apps/frontend/messages/zh-CN/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "通知",
       "subtitle": "最新动态",
-      "clear_all": "全部清除",
+      "clear_read": "清除已读",
       "empty_title": "暂无通知",
       "empty_body": "你已查看所有通知！",
       "time_now": "刚刚",

--- a/apps/frontend/messages/zh-TW/chat.json
+++ b/apps/frontend/messages/zh-TW/chat.json
@@ -3,7 +3,7 @@
     "notifications": {
       "title": "通知",
       "subtitle": "最新消息",
-      "clear_all": "全部清除",
+      "clear_read": "清除已讀",
       "empty_title": "沒有通知",
       "empty_body": "所有通知都已查看！",
       "time_now": "剛剛",

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -658,6 +658,22 @@
   @apply focus-visible:outline-2 focus-visible:outline-action;
 }
 
+/* Keep a row action visible on touch devices. Reveal it on hover or keyboard
+ * focus only when the primary input can hover precisely.
+ */
+@utility hover-reveal-action {
+  @apply transition-opacity duration-150;
+
+  @media (hover: hover) and (pointer: fine) {
+    @apply pointer-events-none opacity-0;
+
+    .group:hover &,
+    .group:focus-within & {
+      @apply pointer-events-auto opacity-100;
+    }
+  }
+}
+
 /* Hide scrollbar while maintaining scroll functionality */
 @utility scrollbar-hide {
   -ms-overflow-style: none; /* IE and Edge */

--- a/apps/frontend/src/routes/chat/notifications/+page.svelte
+++ b/apps/frontend/src/routes/chat/notifications/+page.svelte
@@ -50,16 +50,21 @@
     items: ServerGroup[];
   };
 
+  type ReadOccurrenceBatch = {
+    serverId: string;
+    occurrenceIds: string[];
+  };
+
   const activeLocale = $derived(getLocale());
   const appUi = getAppUiState();
   const hydrationAttempts = new SvelteSet<string>();
-  const optimisticallyDismissedOccurrenceIds = new SvelteSet<string>();
+  const optimisticallyDismissedOccurrenceKeys = new SvelteSet<string>();
   const groups = $derived.by(notificationGroupsFromProjection);
   const pagination = $derived.by(notificationPaginationFromProjection);
   const loading = $derived(!notificationProjectionHasLoaded());
   let loadingMore = $state(false);
   let loadMoreError = $state(false);
-  let dismissingAll = $state(false);
+  let dismissingRead = $state(false);
   const pendingMutationKeys = new SvelteSet<string>();
   const hasPendingMutation = $derived(pendingMutationKeys.size > 0);
   const hasMore = $derived(pagination.some((source) => source.hasMore));
@@ -89,6 +94,7 @@
     return sorted.filter((item) => item.group.latestAt >= newestUnloadedBoundary!);
   });
   const dateSections = $derived.by(() => groupNotificationsByDate(visibleGroups));
+  const readOccurrenceBatches = $derived.by(readOccurrencesByServer);
 
   // Realtime normally hydrates this retained store before the route is opened.
   // Fetch only genuinely missing projections as a transport fallback.
@@ -160,6 +166,10 @@
     return `${item.serverId}:${item.group.id}`;
   }
 
+  function occurrenceKey(serverId: string, occurrenceId: string): string {
+    return `${serverId}:${occurrenceId}`;
+  }
+
   function visibleOccurrencesForServer(
     serverId: string,
     occurrences: NotificationOccurrenceItem[]
@@ -189,7 +199,8 @@
         }
         return groupNotificationOccurrences(
           visibleOccurrencesForServer(instance.id, stores.notifications.occurrences).filter(
-            (occurrence) => !optimisticallyDismissedOccurrenceIds.has(occurrence.id)
+            (occurrence) =>
+              !optimisticallyDismissedOccurrenceKeys.has(occurrenceKey(instance.id, occurrence.id))
           )
         ).map((group): ServerGroup => ({
           serverId: instance.id,
@@ -220,6 +231,22 @@
       const stores = serverRegistry.getStore(instance.id);
       return !stores.isAuthenticated || stores.notifications.hasLoaded;
     });
+  }
+
+  function readOccurrencesByServer(): ReadOccurrenceBatch[] {
+    const occurrencesByServer = new SvelteMap<string, string[]>();
+    for (const item of groups) {
+      for (const occurrence of item.group.occurrences) {
+        if (occurrence.unread) continue;
+        const occurrenceIds = occurrencesByServer.get(item.serverId) ?? [];
+        occurrenceIds.push(occurrence.id);
+        occurrencesByServer.set(item.serverId, occurrenceIds);
+      }
+    }
+    return [...occurrencesByServer].map(([serverId, occurrenceIds]) => ({
+      serverId,
+      occurrenceIds
+    }));
   }
 
   function compareGroups(a: ServerGroup, b: ServerGroup): number {
@@ -391,7 +418,7 @@
     setMutationPending(key, true);
     const store = serverRegistry.getStore(item.serverId).notifications;
     for (const occurrence of item.group.occurrences) {
-      optimisticallyDismissedOccurrenceIds.add(occurrence.id);
+      optimisticallyDismissedOccurrenceKeys.add(occurrenceKey(item.serverId, occurrence.id));
     }
     try {
       await store.deleteOccurrences(
@@ -414,31 +441,32 @@
     }
   }
 
-  async function dismissAll() {
-    if (dismissingAll || hasPendingMutation || groups.length === 0) return;
-    dismissingAll = true;
-    for (const item of groups) {
-      for (const occurrence of item.group.occurrences) {
-        optimisticallyDismissedOccurrenceIds.add(occurrence.id);
+  async function dismissRead() {
+    if (dismissingRead || hasPendingMutation || readOccurrenceBatches.length === 0) return;
+    dismissingRead = true;
+    const batches = readOccurrenceBatches.map((batch) => ({
+      serverId: batch.serverId,
+      occurrenceIds: [...batch.occurrenceIds]
+    }));
+    for (const batch of batches) {
+      for (const occurrenceId of batch.occurrenceIds) {
+        optimisticallyDismissedOccurrenceKeys.add(occurrenceKey(batch.serverId, occurrenceId));
       }
     }
-
-    const serverIds = serverRegistry.servers.flatMap((instance) => {
-      const store = serverRegistry.getStore(instance.id);
-      return store.isAuthenticated ? [instance.id] : [];
-    });
     const results = await Promise.allSettled(
-      serverIds.map((serverId) =>
-        serverRegistry.getStore(serverId).notifications.deleteAllOccurrences()
+      batches.map((batch) =>
+        serverRegistry
+          .getStore(batch.serverId)
+          .notifications.deleteOccurrences(batch.occurrenceIds, {
+            unread: 0,
+            importantUnread: 0
+          })
       )
     );
-    const failedServerIds = new Set(
-      results.flatMap((result, index) => (result.status === 'rejected' ? [serverIds[index]!] : []))
-    );
-    if (failedServerIds.size > 0) {
+    if (results.some((result) => result.status === 'rejected')) {
       toast.error(m('common.error.network'));
     }
-    dismissingAll = false;
+    dismissingRead = false;
   }
 </script>
 
@@ -449,16 +477,16 @@
     showMobileNav
   >
     {#snippet actions()}
-      {#if groups.length > 0 || dismissingAll}
+      {#if readOccurrenceBatches.length > 0 || dismissingRead}
         <Button
           variant="danger-secondary"
           size="sm"
-          disabled={dismissingAll || hasPendingMutation}
-          label={m('chat.notifications.clear_all')}
-          onclick={dismissAll}
+          disabled={dismissingRead || hasPendingMutation}
+          label={m('chat.notifications.clear_read')}
+          onclick={dismissRead}
         >
           <span class="iconify icon-[uil--trash-alt] text-base" aria-hidden="true"></span>
-          <span>{m('chat.notifications.clear_all')}</span>
+          <span>{m('chat.notifications.clear_read')}</span>
         </Button>
       {/if}
     {/snippet}
@@ -486,7 +514,8 @@
               {@const isReaction = occurrence?.signalKind === NotificationSignalKind.REACTION}
               {@const actor = occurrence?.actor ?? null}
               {@const actors = notificationActors(item.group)}
-              {@const mutationPending = dismissingAll || pendingMutationKeys.has(mutationKey(item))}
+              {@const mutationPending =
+                dismissingRead || pendingMutationKeys.has(mutationKey(item))}
               <div
                 class={[
                   'group flex w-full items-center gap-3 selectable-list-item px-3 py-2.5 transition-colors',
@@ -551,17 +580,17 @@
                     </span>
                   </span>
                 </button>
-                <div class="flex shrink-0 items-center gap-2">
-                  <Button
-                    variant="danger-secondary"
-                    size="sm"
+                <div class="hover-reveal-action flex shrink-0 items-center">
+                  <button
+                    type="button"
+                    class="icon-action hover:text-danger focus-visible:text-danger"
                     disabled={mutationPending}
-                    label={m('common.delete')}
+                    aria-label={m('common.delete')}
                     title={m('common.delete')}
                     onclick={() => dismiss(item)}
                   >
                     <span class="iconify icon-[uil--trash-alt] text-base" aria-hidden="true"></span>
-                  </Button>
+                  </button>
                 </div>
               </div>
             {/each}

--- a/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/notifications/notifications.page.svelte.spec.ts
@@ -86,8 +86,8 @@ vi.mock('$lib/state/presenceCache.svelte', () => ({
 }));
 
 vi.mock('$lib/state/userProfiles.svelte', () => ({
-    getLiveBio: () => null,
-    getLiveTimezone: () => null,
+  getLiveBio: () => null,
+  getLiveTimezone: () => null,
   getLiveDisplayName: (_userId: string, fallback: string) => fallback,
   getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback,
   getLiveCustomStatus: (_userId: string, fallback: unknown) => fallback
@@ -176,7 +176,7 @@ describe('notifications page', () => {
     expect(mocks.store.notifications.markOccurrenceRead).not.toHaveBeenCalled();
   });
 
-  it('uses the notification orange and exposes only the delete action', async () => {
+  it('uses the notification orange and reveals a quiet delete action from the row', async () => {
     const { container } = render(NotificationsPage);
     const row = await vi.waitFor(() => {
       const element = q(container, '[data-testid="notification-group"]');
@@ -190,7 +190,8 @@ describe('notifications page', () => {
     expect(row.classList.contains('bg-attention/5')).toBe(true);
     expect(q(row, '[data-testid="notification-unread-dot"]')).toBeNull();
     expect(rowTarget.classList.contains('cursor-pointer')).toBe(true);
-    expect(deleteButton.classList.contains('btn-danger-secondary')).toBe(true);
+    expect(deleteButton.classList.contains('icon-action')).toBe(true);
+    expect(deleteButton.parentElement?.classList.contains('hover-reveal-action')).toBe(true);
     expect(row.querySelectorAll('button')).toHaveLength(2);
     expect(row.textContent).not.toContain('Move to inbox');
     expect(row.textContent).not.toContain('Mark done');
@@ -680,7 +681,7 @@ describe('notifications page', () => {
     });
   });
 
-  it('does not start Dismiss All while an exact dismissal is in flight', async () => {
+  it('does not start Dismiss read while an exact dismissal is in flight', async () => {
     let resolveMutation: (() => void) | undefined;
     mocks.store.notifications.deleteOccurrences.mockImplementation(
       () => new Promise<void>((resolve) => (resolveMutation = resolve))
@@ -691,28 +692,32 @@ describe('notifications page', () => {
         ...mocks.occurrence,
         id: 'mention-2',
         eventId: 'event-2',
-        createdAt: new Date(Date.now() - 1_000).toISOString()
+        createdAt: new Date(Date.now() - 1_000).toISOString(),
+        unread: false
       }
     ]);
 
     const { container } = render(NotificationsPage);
     const deleteButton = await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
-      return q(container, 'button[aria-label="Delete"]') as HTMLButtonElement;
+      return q(
+        container,
+        '[data-notification-state="unread"] button[aria-label="Delete"]'
+      ) as HTMLButtonElement;
     });
     deleteButton.click();
 
-    const dismissAll = await vi.waitFor(() => {
+    const dismissRead = await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
-      const button = q(container, 'button[aria-label="Dismiss all"]') as HTMLButtonElement;
+      const button = q(container, 'button[aria-label="Dismiss read"]') as HTMLButtonElement;
       expect(button.disabled).toBe(true);
       return button;
     });
-    dismissAll.click();
-    expect(mocks.store.notifications.deleteAllOccurrences).not.toHaveBeenCalled();
+    dismissRead.click();
+    expect(mocks.store.notifications.deleteOccurrences).toHaveBeenCalledTimes(1);
 
     resolveMutation?.();
-    await vi.waitFor(() => expect(dismissAll.disabled).toBe(false));
+    await vi.waitFor(() => expect(dismissRead.disabled).toBe(false));
   });
 
   it('groups rows by date in the viewer timezone', async () => {
@@ -750,70 +755,82 @@ describe('notifications page', () => {
     expect(firstHeading.querySelectorAll('.h-px.bg-border')).toHaveLength(2);
   });
 
-  it('dismisses all notifications optimistically with one request per server', async () => {
+  it('dismisses only the read snapshot with one exact request per server', async () => {
     let resolveOrigin: (() => void) | undefined;
     let resolveRemote: (() => void) | undefined;
-    mocks.store.notifications.deleteAllOccurrences.mockImplementation(
+    mocks.store.notifications.deleteOccurrences.mockImplementation(
       () => new Promise<void>((resolve) => (resolveOrigin = resolve))
     );
+    retainProjection([
+      { ...mocks.occurrence, id: 'origin-read', unread: false },
+      { ...mocks.occurrence, id: 'shared-id', eventId: 'event-new', unread: true }
+    ]);
     const remoteStore = {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        occurrences: [{ ...mocks.occurrence, id: 'remote-notification' }],
+        occurrences: [{ ...mocks.occurrence, id: 'shared-id', unread: false }],
         consumedCount: 1,
         totalCount: 1,
         hasMore: false,
         hasLoaded: true,
         error: null,
-        deleteAllOccurrences: vi.fn(() => new Promise<void>((resolve) => (resolveRemote = resolve)))
+        deleteOccurrences: vi.fn(() => new Promise<void>((resolve) => (resolveRemote = resolve)))
       }
     };
     mocks.servers.push({ id: 'remote', url: 'https://remote.example.test' });
     mocks.stores.set('remote', remoteStore);
 
     const { container } = render(NotificationsPage);
-    const dismissAll = await vi.waitFor(() => {
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
-      const button = q(container, 'button[aria-label="Dismiss all"]');
+    const dismissRead = await vi.waitFor(() => {
+      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(3);
+      const button = q(container, 'button[aria-label="Dismiss read"]');
       expect(button).not.toBeNull();
       return button as HTMLButtonElement;
     });
 
-    dismissAll.click();
+    dismissRead.click();
     await vi.waitFor(() => {
-      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(0);
+      expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(1);
     });
-    expect(mocks.store.notifications.deleteAllOccurrences).toHaveBeenCalledTimes(1);
-    expect(remoteStore.notifications.deleteAllOccurrences).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain('chat.example.test');
+    expect(mocks.store.notifications.deleteOccurrences).toHaveBeenCalledWith(['origin-read'], {
+      unread: 0,
+      importantUnread: 0
+    });
+    expect(remoteStore.notifications.deleteOccurrences).toHaveBeenCalledWith(['shared-id'], {
+      unread: 0,
+      importantUnread: 0
+    });
 
     resolveOrigin?.();
     resolveRemote?.();
   });
 
-  it('keeps every server absent after an ambiguous optimistic Dismiss All', async () => {
+  it('keeps the exact read snapshot absent after an ambiguous Dismiss read', async () => {
+    retainProjection([{ ...mocks.occurrence, unread: false }]);
     const remoteStore = {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        occurrences: [{ ...mocks.occurrence, id: 'remote-notification' }],
+        occurrences: [{ ...mocks.occurrence, id: 'remote-notification', unread: false }],
         consumedCount: 1,
         totalCount: 1,
         hasMore: false,
         hasLoaded: true,
         error: null,
-        deleteAllOccurrences: vi.fn().mockRejectedValue(new Error('remote offline'))
+        deleteOccurrences: vi.fn().mockRejectedValue(new Error('remote offline'))
       }
     };
     mocks.servers.push({ id: 'remote', url: 'https://remote.example.test' });
     mocks.stores.set('remote', remoteStore);
 
     const { container } = render(NotificationsPage);
-    const dismissAll = await vi.waitFor(() => {
+    const dismissRead = await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
-      return q(container, 'button[aria-label="Dismiss all"]') as HTMLButtonElement;
+      return q(container, 'button[aria-label="Dismiss read"]') as HTMLButtonElement;
     });
-    dismissAll.click();
+    dismissRead.click();
 
     await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(0);
@@ -821,34 +838,35 @@ describe('notifications page', () => {
     });
     expect(container.textContent).not.toContain('remote.example.test');
     expect(container.textContent).not.toContain('chat.example.test');
-    expect(mocks.store.notifications.deleteAllOccurrences).toHaveBeenCalledTimes(1);
-    expect(remoteStore.notifications.deleteAllOccurrences).toHaveBeenCalledTimes(1);
+    expect(mocks.store.notifications.deleteOccurrences).toHaveBeenCalledTimes(1);
+    expect(remoteStore.notifications.deleteOccurrences).toHaveBeenCalledTimes(1);
   });
 
-  it('does not restore the origin after an ambiguous optimistic Dismiss All', async () => {
-    mocks.store.notifications.deleteAllOccurrences.mockRejectedValue(new Error('origin offline'));
+  it('does not restore the origin after an ambiguous optimistic Dismiss read', async () => {
+    retainProjection([{ ...mocks.occurrence, unread: false }]);
+    mocks.store.notifications.deleteOccurrences.mockRejectedValue(new Error('origin offline'));
     const remoteStore = {
       ...mocks.store,
       notifications: {
         ...mocks.store.notifications,
-        occurrences: [{ ...mocks.occurrence, id: 'remote-notification' }],
+        occurrences: [{ ...mocks.occurrence, id: 'remote-notification', unread: false }],
         consumedCount: 1,
         totalCount: 1,
         hasMore: false,
         hasLoaded: true,
         error: null,
-        deleteAllOccurrences: vi.fn().mockResolvedValue(undefined)
+        deleteOccurrences: vi.fn().mockResolvedValue(undefined)
       }
     };
     mocks.servers.push({ id: 'remote', url: 'https://remote.example.test' });
     mocks.stores.set('remote', remoteStore);
 
     const { container } = render(NotificationsPage);
-    const dismissAll = await vi.waitFor(() => {
+    const dismissRead = await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(2);
-      return q(container, 'button[aria-label="Dismiss all"]') as HTMLButtonElement;
+      return q(container, 'button[aria-label="Dismiss read"]') as HTMLButtonElement;
     });
-    dismissAll.click();
+    dismissRead.click();
 
     await vi.waitFor(() => {
       expect(container.querySelectorAll('[data-testid="notification-group"]')).toHaveLength(0);

--- a/docs/fdr/FDR-012-notifications.md
+++ b/docs/fdr/FDR-012-notifications.md
@@ -1,7 +1,7 @@
 # FDR-012: Notifications
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-27
+**Last reviewed:** 2026-08-29
 
 ## Overview
 
@@ -38,9 +38,13 @@ targets, unread counts, read state, or deletion semantics.
   covered according to the reacted-to message and reaction horizon.
 - Notifications cannot be marked Unread. There is no Done state or Inbox/Done
   split.
-- Trash deletes the exact visible occurrences represented by the current row.
-  Dismiss All deletes every visible occurrence current at the server boundary.
-  Both actions update the UI optimistically and then reconcile with the server.
+- The Delete action deletes the exact visible occurrences in the current row.
+  On devices that support hover, this action appears when the row has hover or
+  keyboard focus. It remains visible on touch devices.
+- Dismiss read deletes only the loaded occurrences that were Read when the user
+  selected the action. It does not delete Unread occurrences that arrived
+  before or during the action. Both deletion actions update the UI
+  optimistically and then reconcile with the server.
 - Every occurrence leaves application-visible state exactly 90 days after its
   source activity. Reading or deleting it does not extend that lifetime.
   Physical cleanup may continue during ADR-076's 24-hour grace period without

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -21,7 +21,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-08-27 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-08-25 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-08-27 |
-| [FDR-012](FDR-012-notifications.md) | Notifications | Experimental | 2026-08-27 |
+| [FDR-012](FDR-012-notifications.md) | Notifications | Experimental | 2026-08-29 |
 | [FDR-013](FDR-013-web-push-notifications.md) | Web Push Notifications | Active | 2026-08-26 |
 | [FDR-014](FDR-014-jump-to-present.md) | Jump to Present | Active | 2026-05-19 |
 | [FDR-015](FDR-015-quick-switcher.md) | Quick Switcher (Cmd-K) | Active | 2026-08-27 |


### PR DESCRIPTION
## Summary

- replace Dismiss all with exact-ID Dismiss read behavior so unread and concurrently arriving notifications remain
- reveal the quiet per-row delete action on hover or keyboard focus while keeping it visible for touch input
- scope optimistic dismissal state by server and update localized copy, FDR-012, component coverage, and end-to-end coverage

## Verification

- mise lint-frontend
- mise test-frontend
- notification page component tests (26 passed)
- focused notification end-to-end test
- production frontend build, bundle budget checks, and CSP checks
- Chrome DevTools verification for desktop idle/focus and touch input