### PR TITLE
fix(frontend): layer jump button above scroll fade

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte
@@ -723,7 +723,7 @@
       transition:fade={{ duration: 150 }}
       onclick={reloadsTimelineOnReturn ? handleJumpToPresentClick : scrollToBottom}
       data-testid="jump-to-present"
-      class="absolute bottom-4 left-1/2 -translate-x-1/2 cursor-pointer menu whitespace-nowrap"
+      class="absolute bottom-4 left-1/2 z-40 -translate-x-1/2 cursor-pointer menu whitespace-nowrap"
     >
       <div class="flex items-center gap-2 menu-section px-3 py-1">
         {#if firstVisibleDate}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts
@@ -164,6 +164,7 @@ describe('EventList jump completion', () => {
     });
 
     await expect.element(page.getByTestId('jump-to-present')).toBeVisible();
+    expect(page.getByTestId('jump-to-present').element().classList).toContain('z-40');
     await expect
       .element(page.getByTestId('virtualizer-scroll-alignment'))
       .toHaveTextContent('center');


### PR DESCRIPTION
## Why

The Jump to Present control was rendered below the timeline scroll fade, which dimmed the control where the two surfaces overlap.

## What changed

- Place the control at `z-40`, above the fade's existing `z-30` layer.
- Add a component regression assertion for the control's stacking class.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run 'src/routes/chat/[serverId]/[roomId]/EventList.svelte.spec.ts'` — 8 tests passed.
- Svelte autofixer — no issues; Chrome DevTools visual verification confirmed the overlapping control computes to z-index 40 above the fade's z-index 30.
