### PR TITLE
fix(neighbors): reject server origins

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,10 @@ the Authling toolchain and workflow.
 For an ad-hoc tool command, use `mise x -- ...`. Do not assume that `go`,
 `pnpm`, `node`, or related binaries are on `PATH`.
 
+`mise codegen-proto` removes and rebuilds generated TypeScript API files. Do
+not run it at the same time as `mise test-cli`, a frontend build, or another
+task that reads `packages/api-types/dist`.
+
 When an agent needs the long-running development stack, launch `mise dev`; the
 task runs the child processes through `tools/dev-supervisor.sh` so lifecycle
 signals reach them directly. Stop it before handing control back to the user.

--- a/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
@@ -18,7 +18,8 @@ includes this authority.
 
 The administration page extracts the HTTP or HTTPS origin from the value. It
 removes paths, queries, and fragments before storage. A server can advertise at
-most 100 Neighbors.
+most 100 Neighbors. Chatto rejects its own `webserver.url` origin and each exact
+`webserver.allowed_origins` alias.
 
 ## Edit or delete a Neighbor
 
@@ -78,7 +79,8 @@ advertised origins without a session.
 
 Administrative API callers must send a canonical HTTP or HTTPS origin without
 a path, query, fragment, or credentials. The hostname and deep-link input
-normalization is a bundled-client feature.
+normalization is a bundled-client feature. Create and update operations return
+`FailedPrecondition` when the origin identifies the current server.
 
 An older server can return `Unimplemented` for the public method. Treat that
 result as no available Neighbor directory.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-server.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-server.mdx
@@ -334,7 +334,8 @@ One configured Neighbor.
 
 ### CreateNeighbor
 
-Advertises one server origin. This RPC requires server.manage-neighbors.
+Advertises one server origin. The origin must not identify this server.
+This RPC requires server.manage-neighbors.
 
 ```http
 POST /api/connect/chatto.admin.v1.AdminServerService/CreateNeighbor
@@ -366,8 +367,8 @@ Newly configured Neighbor.
 
 ### UpdateNeighbor
 
-Changes one advertised server origin. This RPC requires
-server.manage-neighbors.
+Changes one advertised server origin. The new origin must not identify
+this server. This RPC requires server.manage-neighbors.
 
 ```http
 POST /api/connect/chatto.admin.v1.AdminServerService/UpdateNeighbor

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -1973,7 +1973,8 @@ One configured Neighbor.
 
 ### CreateNeighbor
 
-Advertises one server origin. This RPC requires server.manage-neighbors.
+Advertises one server origin. The origin must not identify this server.
+This RPC requires server.manage-neighbors.
 
 ```http
 POST /api/connect/chatto.admin.v1.AdminServerService/CreateNeighbor
@@ -2005,8 +2006,8 @@ Newly configured Neighbor.
 
 ### UpdateNeighbor
 
-Changes one advertised server origin. This RPC requires
-server.manage-neighbors.
+Changes one advertised server origin. The new origin must not identify
+this server. This RPC requires server.manage-neighbors.
 
 ```http
 POST /api/connect/chatto.admin.v1.AdminServerService/UpdateNeighbor

--- a/cli/cmd/run.go
+++ b/cli/cmd/run.go
@@ -175,6 +175,7 @@ func runServer(configPath string) {
 	cfg.Core.Limits = cfg.Limits
 	cfg.Core.Owners = cfg.Owners
 	cfg.Core.Version = Version
+	cfg.Core.ServerOrigins = cfg.Webserver.ServerOrigins()
 	chattoCore, err := core.NewChattoCore(ctx, nc, cfg.Core)
 	if err != nil {
 		log.Error("Failed to create Chatto core", "error", err)

--- a/cli/internal/config/assets.go
+++ b/cli/internal/config/assets.go
@@ -145,6 +145,7 @@ type CoreConfig struct {
 	Limits                      LimitsConfig   `toml:"-" env:"-"` // Set by caller from ChattoConfig.Limits
 	Owners                      OwnersConfig   `toml:"-" env:"-"` // Set by caller from ChattoConfig.Owners — used by core to auto-promote on email verification
 	Version                     string         `toml:"-" env:"-"` // Set by caller from the running build version; diagnostics only
+	ServerOrigins               []string       `toml:"-" env:"-"` // Canonical origins derived from WebserverConfig.ServerOrigins().
 }
 
 // ProjectionSnapshotRetentionOrDefault returns the configured retention, or

--- a/cli/internal/config/process.go
+++ b/cli/internal/config/process.go
@@ -61,6 +61,33 @@ type WebserverConfig struct {
 	Shields                ShieldsConfig `toml:"shields,commented" comment:"Public Shields.io-compatible community badges. Disabled by default."`
 }
 
+// ServerOrigins returns the canonical HTTP or HTTPS origins that identify this
+// server. It includes webserver.url and exact allowed origins, but not wildcard
+// entries. Invalid entries are omitted because ChattoConfig.Validate reports
+// them before the server starts.
+func (c WebserverConfig) ServerOrigins() []string {
+	origins := make([]string, 0, len(c.AllowedOrigins)+1)
+	seen := make(map[string]struct{}, len(c.AllowedOrigins)+1)
+	appendOrigin := func(raw string) {
+		origin, _, ok := canonicalHTTPOriginAndRequestHost(raw)
+		if !ok {
+			return
+		}
+		if _, exists := seen[origin]; exists {
+			return
+		}
+		seen[origin] = struct{}{}
+		origins = append(origins, origin)
+	}
+	appendOrigin(c.URL)
+	for _, origin := range c.AllowedOrigins {
+		if origin != "*" {
+			appendOrigin(origin)
+		}
+	}
+	return origins
+}
+
 // MetricsConfig controls the process-local Prometheus scrape endpoint.
 type MetricsConfig struct {
 	Enabled     bool   `toml:"enabled" env:"CHATTO_METRICS_ENABLED" comment:"Expose a Prometheus-compatible metrics endpoint on a separate internal HTTP listener. Default: false."`

--- a/cli/internal/config/process_test.go
+++ b/cli/internal/config/process_test.go
@@ -1050,6 +1050,22 @@ func TestChattoConfig_Validate_URLsAndOrigins(t *testing.T) {
 	}
 }
 
+func TestWebserverConfig_ServerOrigins(t *testing.T) {
+	cfg := WebserverConfig{
+		URL: "https://Chat.Example:443/chatto",
+		AllowedOrigins: []string{
+			"*",
+			"https://Alias.Example:0443",
+			"https://chat.example",
+			"invalid",
+		},
+	}
+
+	if got, want := cfg.ServerOrigins(), []string{"https://chat.example", "https://alias.example"}; !slices.Equal(got, want) {
+		t.Fatalf("ServerOrigins() = %v, want %v", got, want)
+	}
+}
+
 func TestChattoConfig_Validate_Metrics(t *testing.T) {
 	base := validTestConfig()
 

--- a/cli/internal/connectapi/api_contract_test.go
+++ b/cli/internal/connectapi/api_contract_test.go
@@ -477,6 +477,7 @@ func TestConnectErrorMapping(t *testing.T) {
 		{"room archived", core.ErrRoomArchived, connect.CodeFailedPrecondition},
 		{"edit window expired", core.ErrEditWindowExpired, connect.CodeFailedPrecondition},
 		{"asset not attachable", core.ErrAssetNotAttachable, connect.CodeFailedPrecondition},
+		{"Neighbor matches server origin", core.ErrNeighborMatchesServerOrigin, connect.CodeFailedPrecondition},
 		{"unknown", errors.New("boom"), connect.CodeInternal},
 	}
 

--- a/cli/internal/connectapi/api_test_helpers_test.go
+++ b/cli/internal/connectapi/api_test_helpers_test.go
@@ -138,7 +138,8 @@ func newConnectAPITestEnv(t *testing.T) *connectAPITestEnv {
 	t.Cleanup(cancel)
 
 	c, err := core.NewChattoCore(ctx, nc, config.CoreConfig{
-		SecretKey: "test-core-secret",
+		SecretKey:     "test-core-secret",
+		ServerOrigins: []string{"https://self.example"},
 		Assets: config.AssetsConfig{
 			SigningSecret: "test-signing-secret",
 		},

--- a/cli/internal/connectapi/errors.go
+++ b/cli/internal/connectapi/errors.go
@@ -50,7 +50,8 @@ func connectError(err error) error {
 		return connect.NewError(connect.CodePermissionDenied, err)
 	}
 	if errors.Is(err, core.ErrHumanAccountRequired) ||
-		errors.Is(err, core.ErrBotOwnerPermissionCeiling) {
+		errors.Is(err, core.ErrBotOwnerPermissionCeiling) ||
+		errors.Is(err, core.ErrNeighborMatchesServerOrigin) {
 		return connect.NewError(connect.CodeFailedPrecondition, err)
 	}
 	if errors.Is(err, core.ErrRoomNameExists) {

--- a/cli/internal/connectapi/neighbors_test.go
+++ b/cli/internal/connectapi/neighbors_test.go
@@ -34,6 +34,8 @@ func TestAdminServerServiceNeighborCRUDAndPublicDiscovery(t *testing.T) {
 	requireConnectCode(t, err, connect.CodeAlreadyExists)
 	_, err = env.serverState.CreateNeighbor(callerCtx, connect.NewRequest(&adminv1.CreateNeighborRequest{Origin: "neighbor.example"}))
 	requireConnectCode(t, err, connect.CodeInvalidArgument)
+	_, err = env.serverState.CreateNeighbor(callerCtx, connect.NewRequest(&adminv1.CreateNeighborRequest{Origin: "https://self.example"}))
+	requireConnectCode(t, err, connect.CodeFailedPrecondition)
 
 	listed, err := env.serverState.ListNeighbors(callerCtx, connect.NewRequest(&adminv1.ListNeighborsRequest{}))
 	require.NoError(t, err)
@@ -48,6 +50,10 @@ func TestAdminServerServiceNeighborCRUDAndPublicDiscovery(t *testing.T) {
 	}))
 	require.NoError(t, err)
 	require.Equal(t, "https://updated.example", updated.Msg.GetNeighbor().GetOrigin())
+	_, err = env.serverState.UpdateNeighbor(callerCtx, connect.NewRequest(&adminv1.UpdateNeighborRequest{
+		NeighborId: neighbor.GetId(), Origin: "https://self.example", Revision: updated.Msg.GetNeighbor().GetRevision(),
+	}))
+	requireConnectCode(t, err, connect.CodeFailedPrecondition)
 
 	_, err = env.serverState.DeleteNeighbor(callerCtx, connect.NewRequest(&adminv1.DeleteNeighborRequest{NeighborId: neighbor.GetId(), Revision: neighbor.GetRevision()}))
 	requireConnectCode(t, err, connect.CodeAborted)

--- a/cli/internal/core/core.go
+++ b/cli/internal/core/core.go
@@ -67,6 +67,7 @@ type ChattoCore struct {
 	linkPreviewFetcher        *linkpreview.Fetcher // Fetcher for link preview metadata
 	projectionSnapshotWorker  *projectionSnapshotWorker
 	credentialUsage           *credentialUsageRecorder
+	serverOrigins             map[string]struct{}
 	natsRecoveryState         atomic.Int32
 	natsRecoveryStartedAt     atomic.Int64
 	natsRecoveredReconnects   atomic.Uint64

--- a/cli/internal/core/core_services.go
+++ b/cli/internal/core/core_services.go
@@ -21,6 +21,11 @@ func assembleCore(
 	projections *coreProjections,
 	logger *log.Logger,
 ) *ChattoCore {
+	serverOrigins := make(map[string]struct{}, len(cfg.ServerOrigins))
+	for _, origin := range cfg.ServerOrigins {
+		serverOrigins[origin] = struct{}{}
+	}
+	cfg.ServerOrigins = append([]string(nil), cfg.ServerOrigins...)
 	configModel := NewConfigModel(
 		infra.eventPublisher,
 		projections.serverConfig,
@@ -55,6 +60,7 @@ func assembleCore(
 		invitationModel:  newInvitationModel(infra.eventPublisher, projections.invitations, cfg.SecretKey),
 		oauthClientModel: newOAuthClientModel(projections.oauthClients),
 		s3Client:         infra.s3Client,
+		serverOrigins:    serverOrigins,
 		EventPublisher:   infra.eventPublisher,
 		projections:      projections.registrations,
 		bootDone:         make(chan struct{}),

--- a/cli/internal/core/neighbors.go
+++ b/cli/internal/core/neighbors.go
@@ -30,6 +30,9 @@ var (
 	ErrNeighborNotFound = errors.New("Neighbor not found")
 	// ErrNeighborAlreadyExists means that the canonical origin is advertised.
 	ErrNeighborAlreadyExists = errors.New("Neighbor origin already exists")
+	// ErrNeighborMatchesServerOrigin means that the configured origin identifies
+	// this server and cannot be advertised as a Neighbor.
+	ErrNeighborMatchesServerOrigin = errors.New("Neighbor origin identifies this server")
 	// ErrNeighborRevisionChanged prevents a stale update or delete.
 	ErrNeighborRevisionChanged = errors.New("Neighbor was changed by another request")
 	// ErrNeighborLimitReached means that the directory is full.
@@ -102,6 +105,9 @@ func (c *ChattoCore) CreateNeighbor(ctx context.Context, actorID, rawOrigin stri
 			return Neighbor{}, err
 		}
 		neighbors := c.ConfigModel().ListNeighbors()
+		if c.isServerOrigin(origin) {
+			return Neighbor{}, ErrNeighborMatchesServerOrigin
+		}
 		if len(neighbors) >= MaxNeighbors {
 			return Neighbor{}, ErrNeighborLimitReached
 		}
@@ -141,6 +147,9 @@ func (c *ChattoCore) UpdateNeighbor(ctx context.Context, actorID, neighborID, ra
 		if current.Revision != revision {
 			return Neighbor{}, ErrNeighborRevisionChanged
 		}
+		if c.isServerOrigin(origin) {
+			return Neighbor{}, ErrNeighborMatchesServerOrigin
+		}
 		if neighborOriginExists(c.ConfigModel().ListNeighbors(), origin, neighborID) {
 			return Neighbor{}, ErrNeighborAlreadyExists
 		}
@@ -157,6 +166,11 @@ func (c *ChattoCore) UpdateNeighbor(ctx context.Context, actorID, neighborID, ra
 		}
 	}
 	return Neighbor{}, fmt.Errorf("update Neighbor retry exhausted: %w", events.ErrConflict)
+}
+
+func (c *ChattoCore) isServerOrigin(origin string) bool {
+	_, exists := c.serverOrigins[origin]
+	return exists
 }
 
 // DeleteNeighbor removes one Neighbor if its revision is current.

--- a/cli/internal/core/neighbors_test.go
+++ b/cli/internal/core/neighbors_test.go
@@ -143,6 +143,41 @@ func TestNeighborCRUDAndPermission(t *testing.T) {
 	require.ErrorIs(t, err, ErrNeighborNotFound)
 }
 
+func TestNeighborRejectsServerOrigins(t *testing.T) {
+	chatto, _ := setupTestCore(t)
+	ctx := testContext(t)
+	actor, err := chatto.CreateUser(ctx, SystemActorID, "self-neighbor-manager", "Self Neighbor Manager", "password123")
+	require.NoError(t, err)
+	require.NoError(t, chatto.GrantServerPermission(ctx, SystemActorID, RoleEveryone, PermServerManageNeighbors))
+
+	chatto.serverOrigins = nil
+	historical, err := chatto.CreateNeighbor(ctx, actor.GetId(), "https://self.example")
+	require.NoError(t, err)
+	external, err := chatto.CreateNeighbor(ctx, actor.GetId(), "https://external.example")
+	require.NoError(t, err)
+
+	chatto.serverOrigins = map[string]struct{}{
+		"https://self.example":  {},
+		"https://alias.example": {},
+	}
+
+	_, err = chatto.CreateNeighbor(ctx, actor.GetId(), " HTTPS://SELF.EXAMPLE:443/ ")
+	require.ErrorIs(t, err, ErrNeighborMatchesServerOrigin)
+	_, err = chatto.CreateNeighbor(ctx, actor.GetId(), "https://alias.example")
+	require.ErrorIs(t, err, ErrNeighborMatchesServerOrigin)
+
+	_, err = chatto.UpdateNeighbor(ctx, actor.GetId(), external.ID, "https://alias.example", external.Revision)
+	require.ErrorIs(t, err, ErrNeighborMatchesServerOrigin)
+	unchanged, err := chatto.GetManagedNeighbor(ctx, actor.GetId(), external.ID)
+	require.NoError(t, err)
+	require.Equal(t, external, unchanged)
+
+	corrected, err := chatto.UpdateNeighbor(ctx, actor.GetId(), historical.ID, "https://corrected.example", historical.Revision)
+	require.NoError(t, err)
+	require.Equal(t, "https://corrected.example", corrected.Origin)
+	require.Len(t, chatto.ConfigModel().ListNeighbors(), 2)
+}
+
 func TestServerManageIncludesNeighborManagement(t *testing.T) {
 	chatto, _ := setupTestCore(t)
 	ctx := testContext(t)

--- a/cli/internal/pb/chatto/admin/v1/adminv1connect/server.connect.go
+++ b/cli/internal/pb/chatto/admin/v1/adminv1connect/server.connect.go
@@ -99,10 +99,11 @@ type AdminServerServiceClient interface {
 	ListNeighbors(context.Context, *connect.Request[v1.ListNeighborsRequest]) (*connect.Response[v1.ListNeighborsResponse], error)
 	// Gets one configured Neighbor. This RPC requires server.manage-neighbors.
 	GetNeighbor(context.Context, *connect.Request[v1.GetNeighborRequest]) (*connect.Response[v1.GetNeighborResponse], error)
-	// Advertises one server origin. This RPC requires server.manage-neighbors.
+	// Advertises one server origin. The origin must not identify this server.
+	// This RPC requires server.manage-neighbors.
 	CreateNeighbor(context.Context, *connect.Request[v1.CreateNeighborRequest]) (*connect.Response[v1.CreateNeighborResponse], error)
-	// Changes one advertised server origin. This RPC requires
-	// server.manage-neighbors.
+	// Changes one advertised server origin. The new origin must not identify
+	// this server. This RPC requires server.manage-neighbors.
 	UpdateNeighbor(context.Context, *connect.Request[v1.UpdateNeighborRequest]) (*connect.Response[v1.UpdateNeighborResponse], error)
 	// Stops advertising one server origin. This RPC requires
 	// server.manage-neighbors.
@@ -308,10 +309,11 @@ type AdminServerServiceHandler interface {
 	ListNeighbors(context.Context, *connect.Request[v1.ListNeighborsRequest]) (*connect.Response[v1.ListNeighborsResponse], error)
 	// Gets one configured Neighbor. This RPC requires server.manage-neighbors.
 	GetNeighbor(context.Context, *connect.Request[v1.GetNeighborRequest]) (*connect.Response[v1.GetNeighborResponse], error)
-	// Advertises one server origin. This RPC requires server.manage-neighbors.
+	// Advertises one server origin. The origin must not identify this server.
+	// This RPC requires server.manage-neighbors.
 	CreateNeighbor(context.Context, *connect.Request[v1.CreateNeighborRequest]) (*connect.Response[v1.CreateNeighborResponse], error)
-	// Changes one advertised server origin. This RPC requires
-	// server.manage-neighbors.
+	// Changes one advertised server origin. The new origin must not identify
+	// this server. This RPC requires server.manage-neighbors.
 	UpdateNeighbor(context.Context, *connect.Request[v1.UpdateNeighborRequest]) (*connect.Response[v1.UpdateNeighborResponse], error)
 	// Stops advertising one server origin. This RPC requires
 	// server.manage-neighbors.

--- a/docs/fdr/FDR-042-chatto-neighbors.md
+++ b/docs/fdr/FDR-042-chatto-neighbors.md
@@ -17,6 +17,8 @@ recommendation, not a trust or reciprocal relationship.
   only the canonical HTTP or HTTPS origin for storage.
 - Each Neighbor contains one canonical HTTP or HTTPS server origin. A server
   can advertise at most 100 Neighbors.
+- A Neighbor origin cannot match the server's canonical `webserver.url` origin
+  or an exact `webserver.allowed_origins` alias.
 - The directory has no ordering contract.
 - Any caller can list the advertised origins through the public discovery API.
 - The Server Directory page combines the direct Neighbors from all servers
@@ -126,6 +128,19 @@ duplicate server cards.
 
 **Tradeoff:** The source names depend on the server catalogue on the user's
 device.
+
+### 8. A server cannot advertise itself
+
+**Decision:** Create and update operations reject an origin that identifies
+the server. This set includes the canonical `webserver.url` origin and each
+exact non-wildcard `webserver.allowed_origins` entry.
+
+**Why:** A self-reference does not recommend another server. Reverse-proxy
+aliases must not make the same server appear as a separate Neighbor.
+
+**Tradeoff:** A configuration change can make an existing Neighbor identify
+the server. Chatto keeps that historical Neighbor so an administrator can
+remove it or change it to an external origin.
 
 ## Non-goals
 

--- a/packages/api-types/src/chatto/admin/v1/server_connect.ts
+++ b/packages/api-types/src/chatto/admin/v1/server_connect.ts
@@ -129,7 +129,8 @@ export const AdminServerService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Advertises one server origin. This RPC requires server.manage-neighbors.
+     * Advertises one server origin. The origin must not identify this server.
+     * This RPC requires server.manage-neighbors.
      *
      * @generated from rpc chatto.admin.v1.AdminServerService.CreateNeighbor
      */
@@ -140,8 +141,8 @@ export const AdminServerService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Changes one advertised server origin. This RPC requires
-     * server.manage-neighbors.
+     * Changes one advertised server origin. The new origin must not identify
+     * this server. This RPC requires server.manage-neighbors.
      *
      * @generated from rpc chatto.admin.v1.AdminServerService.UpdateNeighbor
      */

--- a/proto/chatto/admin/v1/server.proto
+++ b/proto/chatto/admin/v1/server.proto
@@ -225,10 +225,11 @@ service AdminServerService {
   rpc ListNeighbors(ListNeighborsRequest) returns (ListNeighborsResponse);
   // Gets one configured Neighbor. This RPC requires server.manage-neighbors.
   rpc GetNeighbor(GetNeighborRequest) returns (GetNeighborResponse);
-  // Advertises one server origin. This RPC requires server.manage-neighbors.
+  // Advertises one server origin. The origin must not identify this server.
+  // This RPC requires server.manage-neighbors.
   rpc CreateNeighbor(CreateNeighborRequest) returns (CreateNeighborResponse);
-  // Changes one advertised server origin. This RPC requires
-  // server.manage-neighbors.
+  // Changes one advertised server origin. The new origin must not identify
+  // this server. This RPC requires server.manage-neighbors.
   rpc UpdateNeighbor(UpdateNeighborRequest) returns (UpdateNeighborResponse);
   // Stops advertising one server origin. This RPC requires
   // server.manage-neighbors.


### PR DESCRIPTION
## Why

A server could advertise its own public origin as a Neighbor. This creates a
self-reference instead of a recommendation for another server and lets a
reverse-proxy alias make the same server look like a separate Neighbor.

## What changed

- Derive a canonical, deduplicated server-origin set from `webserver.url` and
  exact non-wildcard `webserver.allowed_origins` entries.
- Pass that immutable set into `ChattoCore` and reject matching Neighbor create
  or update commands after authorization with Connect `FailedPrecondition`.
- Keep historical self-Neighbors replayable, visible, removable, and editable
  to an external origin. This change adds no event or storage migration.
- Document the behavior in FDR-042, the operations guide, and the public RPC
  comments, then regenerate Go, TypeScript, and API-reference artifacts.
- Document that protobuf codegen must not run concurrently with frontend tasks
  because it rebuilds `packages/api-types/dist`.

## Compatibility

This is a behavioral public API change with no protobuf wire-shape change.

- Older client → newer server: a create or update that uses this server's own
  origin now returns `FailedPrecondition`; other behavior is unchanged.
- Newer client → older server: an older server can still accept a self-origin.
- No capability negotiation, client fallback, or data migration is required.
- During a mixed-version server rollout, an older replica can still accept a
  self-origin until all serving replicas run the new version.

## Test plan

- `mise test-cli` — passed after rebasing onto current `origin/main`.
- Focused config, core Neighbor, and ConnectAPI regression tests — passed on
  final HEAD.
- `mise codegen-proto` — passed; generated output is clean.
- Public `buf breaking` against `origin/main` — passed.
- `mise lint-cli` — passed.
- `mise license-check` — passed.
- `git diff --check origin/main...HEAD` — passed on final HEAD.

Repository-wide `buf lint` still reports existing naming violations in
unrelated OAuth-client, push-notification, and room-member schemas.

Related design record: [FDR-042](docs/fdr/FDR-042-chatto-neighbors.md).
