### PR TITLE
feat(frontend): add user menu action icons

### DIFF
--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
@@ -193,6 +193,10 @@ keep the compact menu without a navigation action.
       <nav class="sidebar-nav">
         {#if canSendMessage}
           <button type="button" class="sidebar-item" onclick={handleSendMessage}>
+            <span
+              class="iconify sidebar-icon self-start icon-[uil--comment-alt-message]"
+              aria-hidden="true"
+            ></span>
             {m('chat.user_menu.send_message')}
           </button>
         {/if}
@@ -204,6 +208,10 @@ keep the compact menu without a navigation action.
             disabled={!canOpenProfile}
             title={canOpenProfile ? undefined : m('chat.user_menu.profile_requires_direct_message')}
           >
+            <span
+              class="iconify sidebar-icon self-start icon-[uil--user]"
+              aria-hidden="true"
+            ></span>
             {m('chat.user_menu.view_profile')}
           </button>
         {/if}
@@ -214,6 +222,10 @@ keep the compact menu without a navigation action.
             onclick={() => onClose?.()}
             data-testid="view-user-admin"
           >
+            <span
+              class="iconify sidebar-icon self-start icon-[uil--servers]"
+              aria-hidden="true"
+            ></span>
             {m('chat.user_menu.view_in_admin')}
           </a>
         {/if}
@@ -224,6 +236,10 @@ keep the compact menu without a navigation action.
             onclick={handleBanFromRoom}
             disabled={banningFromRoom}
           >
+            <span
+              class="iconify sidebar-icon self-start icon-[uil--ban]"
+              aria-hidden="true"
+            ></span>
             {banningFromRoom ? m('admin.moderation.banning') : m('admin.moderation.ban_action')}
           </button>
         {/if}
@@ -239,6 +255,10 @@ keep the compact menu without a navigation action.
         onclick={() => void handleCopyUserId()}
         data-testid="copy-user-id"
       >
+        <span
+          class="iconify sidebar-icon self-start icon-[uil--copy]"
+          aria-hidden="true"
+        ></span>
         {m('chat.user_menu.copy_user_id')}
       </button>
     </nav>

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
@@ -306,6 +306,19 @@ describe('UserContextMenu', () => {
       'View in Server Admin',
       'Ban from room'
     ]);
+    const actionIcons = Array.from(dialog.querySelectorAll('.sidebar-item > .sidebar-icon'));
+    expect(
+      actionIcons.map((icon) =>
+        Array.from(icon.classList).find((className) => className.startsWith('icon-[uil--'))
+      )
+    ).toEqual([
+      'icon-[uil--comment-alt-message]',
+      'icon-[uil--user]',
+      'icon-[uil--servers]',
+      'icon-[uil--ban]',
+      'icon-[uil--copy]'
+    ]);
+    expect(actionIcons.every((icon) => icon.classList.contains('self-start'))).toBe(true);
     expect(sections[2]?.textContent).toContain('Copy User ID');
     expect(sections[0]?.parentElement).toBe(sections[1]?.parentElement);
     expect(sections[1]?.parentElement).toBe(sections[2]?.parentElement);


### PR DESCRIPTION
## Why

User context-menu actions were harder to scan because they did not have icons.

## What changed

- Added semantic icons to message, profile, Server Admin, room-ban, and copy-ID actions.
- Aligned icons with the first text line when translated labels wrap.
- Extended the component test to cover icon selection and alignment.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- pnpm --dir apps/frontend exec vitest --run --project=client src/lib/components/menus/UserContextMenu.svelte.spec.ts` — 16 tests passed.
- `mise x -- pnpm --dir apps/frontend run check` — design-system guardrails passed; Svelte reported 0 errors and 0 warnings.
- Svelte autofixer — no issues or suggestions.
- Chrome DevTools — verified the English and wrapped German menu labels in the live app.
