### PR TITLE
refactor(frontend): standardize context menu entries

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -67,6 +67,7 @@ inside the icon. Do not add a side stripe or a shadow for navigation selection.
 | Confirmation                              | `ConfirmDialog`                                                            | A custom destructive modal                                   |
 | General dialog                            | `Dialog`; `BottomSheet` for touch-specific presentation                    | Fixed-position modal shells                                  |
 | Floating menu or tooltip                  | `ContextMenu`, `HelpTooltip`, or `FloatingPopover`                         | Hand-written fixed positioning and z-index                   |
+| Context-menu command                      | `MenuItem` inside `MenuSection`                                            | `sidebar-item` or repeated icon and state markup             |
 | Standard pane page                        | `PageTitle`, `PaneHeader`, `PaneContent`, and titled `Panel` sections      | Hand-rolled page widths, scrolling, and section cards        |
 | Pane title and toolbar                    | `PaneHeader` with `HeaderIconButton` actions                               | Textual primary actions in the pane header                   |
 | Inline icon action with standard hit area | `icon-action`                                                              | Repeating hit-area, hover, and pressed classes               |
@@ -316,9 +317,15 @@ in the component explaining why Tailwind or a semantic utility is insufficient.
 Menus, compact chat hover bars, media overlays, and icon toolbars use their
 context-specific primitive.
 
-Context-menu action groups use sibling `menu-section` surfaces. Let the
-`ContextMenu` gap separate those surfaces; never draw a hairline divider inside
-a `menu-section`, because it conflicts with the standard surface-gap separator.
+Context-menu commands use `MenuItem` inside sibling `MenuSection` components.
+`ContextMenu` supplies the compact or touch-safe density. `MenuItem` supplies
+button and link semantics, optional leading and trailing content, disabled and
+selected states, and danger tone. It also aligns an icon with the first line of
+a wrapped label. Use `sidebar-item` only for sidebar navigation.
+
+Let the `ContextMenu` gap separate sibling sections. Do not draw a hairline
+divider inside a section because it conflicts with the standard surface-gap
+separator.
 
 The supported variants are `action`, `neutral`, `secondary`, `ghost`,
 `warning`, `danger`, and `danger-secondary`. Use the variant whose meaning

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -801,6 +801,34 @@
   @apply bg-surface;
 }
 
+/* Semantic command rows for ContextMenu and related action surfaces. */
+@utility menu-entry {
+  @apply relative flex min-h-8 w-full shrink-0 cursor-pointer items-center gap-2 overflow-hidden rounded-md px-1 py-1 text-start text-text;
+  @apply transition-[background-color,color] duration-150 hover:bg-surface hover:text-text active:bg-surface-emphasized;
+  @apply focus-visible:bg-surface focus-visible:outline-2 focus-visible:outline-action;
+  @apply disabled:cursor-not-allowed disabled:opacity-50;
+
+  &[aria-disabled='true'] {
+    @apply cursor-not-allowed opacity-50;
+  }
+}
+
+@utility menu-entry-sheet {
+  @apply min-h-11 gap-3 px-3 py-2.5 text-base;
+}
+
+@utility menu-entry-selected {
+  @apply bg-surface;
+}
+
+@utility menu-entry-leading {
+  @apply flex h-5 w-5 shrink-0 items-center justify-center text-base;
+}
+
+@utility menu-entry-leading-sheet {
+  @apply mt-0.5;
+}
+
 /* Simple non-interactive tooltip surface for FloatingTooltip. */
 @utility floating-tooltip {
   @apply max-w-xs rounded-md border border-text/10 bg-surface-emphasized px-2.5 py-1.5 text-xs leading-snug text-text shadow-lg;

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -825,6 +825,10 @@
   @apply flex h-5 w-5 shrink-0 items-center justify-center text-base;
 }
 
+@utility menu-entry-leading-floating {
+  margin-top: 1.5px;
+}
+
 @utility menu-entry-leading-sheet {
   @apply mt-0.5;
 }

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -826,7 +826,7 @@
 }
 
 @utility menu-entry-leading-floating {
-  margin-top: 1.5px;
+  @apply mt-0.5;
 }
 
 @utility menu-entry-leading-sheet {

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -37,6 +37,8 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
   } from '$lib/state/server/rooms.svelte';
   import type { CallRoomParticipant } from '$lib/state/server/activeCallRooms.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
   import NavigationContextMenu from '$lib/components/menus/NavigationContextMenu.svelte';
   import {
     contextMenuTrigger,
@@ -519,19 +521,11 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     ariaLabel={m('room_list.group_settings', { group: contextGroup.name })}
     onclose={() => (groupContextMenu = null)}
   >
-    <div class="menu-section">
-      <nav class="sidebar-nav">
-        <button
-          type="button"
-          class="sidebar-item"
-          onclick={() => handleConfigureGroup(contextGroup)}
-          role="menuitem"
-        >
-          <span class="iconify sidebar-icon icon-[uil--setting]" aria-hidden="true"></span>
-          {m('room_list.group_settings', { group: contextGroup.name })}
-        </button>
-      </nav>
-    </div>
+    <MenuSection>
+      <MenuItem icon="icon-[uil--setting]" onclick={() => handleConfigureGroup(contextGroup)}>
+        {m('room_list.group_settings', { group: contextGroup.name })}
+      </MenuItem>
+    </MenuSection>
   </ContextMenu>
 {/if}
 
@@ -556,19 +550,14 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
       onConfigure={() => handleConfigureRoom(contextRoom)}
       onLeave={() => handleLeaveRoom(contextRoom)}
     />
-    <div class="menu-section">
-      <nav class="sidebar-nav">
-        <button
-          type="button"
-          class="sidebar-item"
-          onclick={() => void handleCopyRoomId(contextRoom.id)}
-          role="menuitem"
-          data-testid="copy-room-id"
-        >
-          <span class="iconify sidebar-icon icon-[uil--copy]" aria-hidden="true"></span>
-          {m('room_list.copy_room_id')}
-        </button>
-      </nav>
-    </div>
+    <MenuSection>
+      <MenuItem
+        icon="icon-[uil--copy]"
+        onclick={() => void handleCopyRoomId(contextRoom.id)}
+        dataTestid="copy-room-id"
+      >
+        {m('room_list.copy_room_id')}
+      </MenuItem>
+    </MenuSection>
   </ContextMenu>
 {/if}

--- a/apps/frontend/src/lib/ServerSidebarEntry.svelte
+++ b/apps/frontend/src/lib/ServerSidebarEntry.svelte
@@ -11,6 +11,8 @@
   import ServerIcon from './ServerIcon.svelte';
   import { m } from '$lib/i18n/messages';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
   import NavigationContextMenu from '$lib/components/menus/NavigationContextMenu.svelte';
   import {
     contextMenuTrigger,
@@ -86,9 +88,7 @@
       compatibility.status === 'supported' &&
       !serverConnection.showConnectionLostIcon
   );
-  const iconDimmed = $derived(
-    signInRequired || !loaded || serverConnection.showConnectionLostIcon
-  );
+  const iconDimmed = $derived(signInRequired || !loaded || serverConnection.showConnectionLostIcon);
   const iconTitle = $derived(
     signInRequired
       ? m('ui.auth_status.sidebar_reauth', { server: iconServer.name })
@@ -286,20 +286,15 @@
       onLeave={handleRemoveServer}
     />
     {#if serverHost}
-      <div class="menu-section">
-        <nav class="sidebar-nav">
-          <button
-            type="button"
-            class="sidebar-item"
-            onclick={() => void handleCopyServerHostname()}
-            role="menuitem"
-            data-testid="copy-server-hostname"
-          >
-            <span class="iconify sidebar-icon icon-[uil--copy]" aria-hidden="true"></span>
-            {m('room_list.copy_server_hostname')}
-          </button>
-        </nav>
-      </div>
+      <MenuSection>
+        <MenuItem
+          icon="icon-[uil--copy]"
+          onclick={() => void handleCopyServerHostname()}
+          dataTestid="copy-server-hostname"
+        >
+          {m('room_list.copy_server_hostname')}
+        </MenuItem>
+      </MenuSection>
     {/if}
   </ContextMenu>
 {/if}

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -23,6 +23,8 @@ sidebar. Shows the avatar with presence and the live display name.
   import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
   import Dialog from '$lib/ui/Dialog.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
   import UserAvatar from './UserAvatar.svelte';
   import UserCustomStatusBadge from './UserCustomStatusBadge.svelte';
   import ScreenShareControlButton from './voice/ScreenShareControlButton.svelte';
@@ -292,52 +294,45 @@ sidebar. Shows the avatar with presence and the live display name.
     class="w-80 max-w-[calc(100vw-2rem)]"
     onclose={() => (statusMenuAnchor = null)}
   >
-    <div class="flex w-full flex-col gap-1">
-      <div class="menu-section p-1">
-        <div class="px-2 py-1 text-xs font-semibold text-muted">
-          {m('settings.profile.presence.title')}
-        </div>
-        {#each presenceModes as mode (mode)}
-          <button
-            type="button"
-            class={[
-              'sidebar-item w-full gap-3 text-start',
-              presencePreference.mode === mode ? 'bg-surface' : ''
-            ]}
-            role="menuitemradio"
-            aria-checked={presencePreference.mode === mode}
-            onclick={() => choosePresenceMode(mode)}
-          >
-            <span class="grid w-5 shrink-0 place-items-center" aria-hidden="true">
+    <MenuSection ariaLabel={m('settings.profile.presence.title')}>
+      <div class="px-2 py-1 text-xs font-semibold text-muted">
+        {m('settings.profile.presence.title')}
+      </div>
+      {#each presenceModes as mode (mode)}
+        <MenuItem
+          role="menuitemradio"
+          checked={presencePreference.mode === mode}
+          selected={presencePreference.mode === mode}
+          onclick={() => choosePresenceMode(mode)}
+        >
+          {#snippet leading()}
+            <span class="grid size-full place-items-center">
               <span class={['h-2.5 w-2.5 rounded-full', presenceModeDotClass(mode)]}></span>
             </span>
-            <span class="min-w-0 truncate">{presenceModeLabel(mode)}</span>
+          {/snippet}
+          {#snippet trailing()}
             {#if presencePreference.mode === mode}
-              <span class="iconify ms-auto icon-[uil--check] shrink-0" aria-hidden="true"></span>
+              <span class="iconify icon-[uil--check]"></span>
             {/if}
-          </button>
-        {/each}
-      </div>
-      <div class="menu-section p-1">
-        <button
-          type="button"
-          class="sidebar-item w-full gap-3 text-start"
-          data-testid="current-user-custom-status-action"
-          onclick={openCustomStatusDialog}
-        >
-          <span class="grid w-5 shrink-0 place-items-center" aria-hidden="true">
+          {/snippet}
+          <span class="block truncate">{presenceModeLabel(mode)}</span>
+        </MenuItem>
+      {/each}
+    </MenuSection>
+    <MenuSection>
+      <MenuItem dataTestid="current-user-custom-status-action" onclick={openCustomStatusDialog}>
+        {#snippet leading()}
+          <span class="grid size-full place-items-center">
             {#if activeServerUser.customStatus}
               {activeServerUser.customStatus.emoji}
             {:else}
               <span class="iconify icon-[uil--comment-alt-edit] text-muted"></span>
             {/if}
           </span>
-          <span class="min-w-0 truncate">
-            {m('settings.profile.status.set_custom_status')}
-          </span>
-        </button>
-      </div>
-    </div>
+        {/snippet}
+        <span class="block truncate">{m('settings.profile.status.set_custom_status')}</span>
+      </MenuItem>
+    </MenuSection>
   </ContextMenu>
 {/if}
 

--- a/apps/frontend/src/lib/components/LinkPreviewCard.svelte
+++ b/apps/frontend/src/lib/components/LinkPreviewCard.svelte
@@ -20,6 +20,8 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
   import { pushState } from '$app/navigation';
   import { m } from '$lib/i18n/messages';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
   import { toast } from '$lib/ui/toast';
   import YouTubeEmbed from './YouTubeEmbed.svelte';
   import SocialPostEmbed from './SocialPostEmbed.svelte';
@@ -169,27 +171,18 @@ When `canDelete` is true, right-click / long-press opens a context menu with Ope
 <!-- Context menu (posted message mode only) -->
 {#if contextMenuPos}
   <ContextMenu position={contextMenuPos} onclose={() => (contextMenuPos = null)}>
-    <div class="menu-section">
-      <nav class="sidebar-nav">
-        <button class="sidebar-item" onclick={handleOpenLink} role="menuitem">
-          <span class="iconify sidebar-icon icon-[uil--external-link-alt]"></span>
-          {isYouTube ? m('preview.youtube_open') : m('preview.open_link')}
-        </button>
-        <button class="sidebar-item" onclick={handleCopyUrl} role="menuitem">
-          <span class="iconify sidebar-icon icon-[uil--copy]"></span>
-          {m('preview.copy_url')}
-        </button>
-        {#if canDelete}
-          <button
-            class="sidebar-item text-danger hover:text-danger"
-            onclick={handleDeleteFromMenu}
-            role="menuitem"
-          >
-            <span class="iconify sidebar-icon icon-[uil--trash-alt]"></span>
-            {isYouTube ? m('preview.youtube_delete_embed') : m('preview.delete')}
-          </button>
-        {/if}
-      </nav>
-    </div>
+    <MenuSection>
+      <MenuItem icon="icon-[uil--external-link-alt]" onclick={handleOpenLink}>
+        {isYouTube ? m('preview.youtube_open') : m('preview.open_link')}
+      </MenuItem>
+      <MenuItem icon="icon-[uil--copy]" onclick={handleCopyUrl}>
+        {m('preview.copy_url')}
+      </MenuItem>
+      {#if canDelete}
+        <MenuItem icon="icon-[uil--trash-alt]" tone="danger" onclick={handleDeleteFromMenu}>
+          {isYouTube ? m('preview.youtube_delete_embed') : m('preview.delete')}
+        </MenuItem>
+      {/if}
+    </MenuSection>
   </ContextMenu>
 {/if}

--- a/apps/frontend/src/lib/components/menus/NavigationContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/NavigationContextMenu.svelte
@@ -7,6 +7,8 @@ presentation-only.
 -->
 <script lang="ts">
   import { m } from '$lib/i18n/messages';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
 
   let {
     kind,
@@ -36,60 +38,33 @@ presentation-only.
 </script>
 
 {#if (kind === 'room' && !isRoomMember) || showMarkRead || (canConfigure && onConfigure)}
-  <div class="menu-section">
-    <nav class="sidebar-nav">
-      {#if kind === 'room' && !isRoomMember}
-        <button
-          type="button"
-          class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
-          onclick={onJoin}
-          disabled={!canJoin}
-          role="menuitem"
-        >
-          <span class="iconify sidebar-icon icon-[uil--sign-in-alt]" aria-hidden="true"></span>
-          {m('room.join.action')}
-        </button>
-      {:else if showMarkRead}
-        <button
-          type="button"
-          class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
-          onclick={onMarkRead}
-          disabled={!canMarkRead}
-          role="menuitem"
-        >
-          <span class="iconify sidebar-icon icon-[uil--check-circle]" aria-hidden="true"></span>
-          {m('room_list.mark_as_read')}
-        </button>
-      {/if}
+  <MenuSection>
+    {#if kind === 'room' && !isRoomMember}
+      <MenuItem icon="icon-[uil--sign-in-alt]" onclick={onJoin} disabled={!canJoin}>
+        {m('room.join.action')}
+      </MenuItem>
+    {:else if showMarkRead}
+      <MenuItem icon="icon-[uil--check-circle]" onclick={onMarkRead} disabled={!canMarkRead}>
+        {m('room_list.mark_as_read')}
+      </MenuItem>
+    {/if}
 
-      {#if canConfigure && onConfigure}
-        <button type="button" class="sidebar-item" onclick={onConfigure} role="menuitem">
-          <span class="iconify sidebar-icon icon-[uil--setting]" aria-hidden="true"></span>
-          {m('room_list.room_settings')}
-        </button>
-      {/if}
-    </nav>
-  </div>
+    {#if canConfigure && onConfigure}
+      <MenuItem icon="icon-[uil--setting]" onclick={onConfigure}>
+        {m('room_list.room_settings')}
+      </MenuItem>
+    {/if}
+  </MenuSection>
 {/if}
 
 {#if isRoomMember && canLeave}
-  <div class="menu-section">
-    <nav class="sidebar-nav">
-      <button
-        type="button"
-        class="sidebar-item text-danger hover:text-danger"
-        onclick={onLeave}
-        role="menuitem"
-      >
-        <span
-          class={[
-            'iconify sidebar-icon',
-            kind === 'server' ? 'icon-[uil--minus-circle]' : 'icon-[uil--sign-out-alt]'
-          ]}
-          aria-hidden="true"
-        ></span>
-        {kind === 'server' ? m('room_list.remove_server') : m('room_list.leave_room')}
-      </button>
-    </nav>
-  </div>
+  <MenuSection>
+    <MenuItem
+      icon={kind === 'server' ? 'icon-[uil--minus-circle]' : 'icon-[uil--sign-out-alt]'}
+      tone="danger"
+      onclick={onLeave}
+    >
+      {kind === 'server' ? m('room_list.remove_server') : m('room_list.leave_room')}
+    </MenuItem>
+  </MenuSection>
 {/if}

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte
@@ -34,6 +34,8 @@ keep the compact menu without a navigation action.
   import { serverIdToSegment } from '$lib/navigation';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
   import {
     getLiveBio,
     getLiveCustomStatus,
@@ -122,10 +124,15 @@ keep the compact menu without a navigation action.
     if (!currentUserId) return false;
     return [...serverScope.store.projection.rooms.values()].some((entry) => {
       const memberIds = entry.memberUserIds;
-      const isSelfDM = memberIds.length === 1 && memberIds[0] === currentUserId && user.id === currentUserId;
+      const isSelfDM =
+        memberIds.length === 1 && memberIds[0] === currentUserId && user.id === currentUserId;
       const isOneToOneDM =
         memberIds.length === 2 && memberIds.includes(currentUserId) && memberIds.includes(user.id);
-      return entry.room?.room?.kind === RoomKind.DM && entry.room.viewerState?.isMember && (isSelfDM || isOneToOneDM);
+      return (
+        entry.room?.room?.kind === RoomKind.DM &&
+        entry.room.viewerState?.isMember &&
+        (isSelfDM || isOneToOneDM)
+      );
     });
   });
   function handleSendMessage() {
@@ -189,78 +196,52 @@ keep the compact menu without a navigation action.
   {/if}
 
   {#if canSendMessage || onOpenProfile || adminUserHref || canBanFromRoom}
-    <div class="menu-section">
-      <nav class="sidebar-nav">
-        {#if canSendMessage}
-          <button type="button" class="sidebar-item" onclick={handleSendMessage}>
-            <span
-              class="iconify sidebar-icon self-start icon-[uil--comment-alt-message]"
-              aria-hidden="true"
-            ></span>
-            {m('chat.user_menu.send_message')}
-          </button>
-        {/if}
-        {#if onOpenProfile}
-          <button
-            type="button"
-            class="sidebar-item disabled:cursor-not-allowed disabled:opacity-50"
-            onclick={handleOpenProfile}
-            disabled={!canOpenProfile}
-            title={canOpenProfile ? undefined : m('chat.user_menu.profile_requires_direct_message')}
-          >
-            <span
-              class="iconify sidebar-icon self-start icon-[uil--user]"
-              aria-hidden="true"
-            ></span>
-            {m('chat.user_menu.view_profile')}
-          </button>
-        {/if}
-        {#if adminUserHref}
-          <a
-            class="sidebar-item"
-            href={adminUserHref}
-            onclick={() => onClose?.()}
-            data-testid="view-user-admin"
-          >
-            <span
-              class="iconify sidebar-icon self-start icon-[uil--servers]"
-              aria-hidden="true"
-            ></span>
-            {m('chat.user_menu.view_in_admin')}
-          </a>
-        {/if}
-        {#if canBanFromRoom}
-          <button
-            type="button"
-            class="sidebar-item text-danger disabled:cursor-not-allowed disabled:opacity-50"
-            onclick={handleBanFromRoom}
-            disabled={banningFromRoom}
-          >
-            <span
-              class="iconify sidebar-icon self-start icon-[uil--ban]"
-              aria-hidden="true"
-            ></span>
-            {banningFromRoom ? m('admin.moderation.banning') : m('admin.moderation.ban_action')}
-          </button>
-        {/if}
-      </nav>
-    </div>
+    <MenuSection>
+      {#if canSendMessage}
+        <MenuItem icon="icon-[uil--comment-alt-message]" onclick={handleSendMessage}>
+          {m('chat.user_menu.send_message')}
+        </MenuItem>
+      {/if}
+      {#if onOpenProfile}
+        <MenuItem
+          icon="icon-[uil--user]"
+          onclick={handleOpenProfile}
+          disabled={!canOpenProfile}
+          title={canOpenProfile ? undefined : m('chat.user_menu.profile_requires_direct_message')}
+        >
+          {m('chat.user_menu.view_profile')}
+        </MenuItem>
+      {/if}
+      {#if adminUserHref}
+        <MenuItem
+          href={adminUserHref}
+          icon="icon-[uil--servers]"
+          onclick={() => onClose?.()}
+          dataTestid="view-user-admin"
+        >
+          {m('chat.user_menu.view_in_admin')}
+        </MenuItem>
+      {/if}
+      {#if canBanFromRoom}
+        <MenuItem
+          icon="icon-[uil--ban]"
+          tone="danger"
+          onclick={handleBanFromRoom}
+          disabled={banningFromRoom}
+        >
+          {banningFromRoom ? m('admin.moderation.banning') : m('admin.moderation.ban_action')}
+        </MenuItem>
+      {/if}
+    </MenuSection>
   {/if}
 
-  <div class="menu-section">
-    <nav class="sidebar-nav">
-      <button
-        type="button"
-        class="sidebar-item"
-        onclick={() => void handleCopyUserId()}
-        data-testid="copy-user-id"
-      >
-        <span
-          class="iconify sidebar-icon self-start icon-[uil--copy]"
-          aria-hidden="true"
-        ></span>
-        {m('chat.user_menu.copy_user_id')}
-      </button>
-    </nav>
-  </div>
+  <MenuSection>
+    <MenuItem
+      icon="icon-[uil--copy]"
+      onclick={() => void handleCopyUserId()}
+      dataTestid="copy-user-id"
+    >
+      {m('chat.user_menu.copy_user_id')}
+    </MenuItem>
+  </MenuSection>
 </ContextMenu>

--- a/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/menus/UserContextMenu.svelte.spec.ts
@@ -30,12 +30,12 @@ vi.mock('$lib/navigation', () => ({
 
 vi.mock('$lib/state/server/scope.svelte', () => ({
   useServerScope: () => ({
-      serverId: serverScopeMock.serverId,
-      store: {
-        permissions: serverScopeMock.permissions,
-        currentUser: serverScopeMock.currentUser,
-        projection: serverScopeMock.projection
-      }
+    serverId: serverScopeMock.serverId,
+    store: {
+      permissions: serverScopeMock.permissions,
+      currentUser: serverScopeMock.currentUser,
+      projection: serverScopeMock.projection
+    }
   })
 }));
 
@@ -306,7 +306,7 @@ describe('UserContextMenu', () => {
       'View in Server Admin',
       'Ban from room'
     ]);
-    const actionIcons = Array.from(dialog.querySelectorAll('.sidebar-item > .sidebar-icon'));
+    const actionIcons = Array.from(dialog.querySelectorAll('.menu-entry > .menu-entry-leading'));
     expect(
       actionIcons.map((icon) =>
         Array.from(icon.classList).find((className) => className.startsWith('icon-[uil--'))
@@ -318,7 +318,6 @@ describe('UserContextMenu', () => {
       'icon-[uil--ban]',
       'icon-[uil--copy]'
     ]);
-    expect(actionIcons.every((icon) => icon.classList.contains('self-start'))).toBe(true);
     expect(sections[2]?.textContent).toContain('Copy User ID');
     expect(sections[0]?.parentElement).toBe(sections[1]?.parentElement);
     expect(sections[1]?.parentElement).toBe(sections[2]?.parentElement);

--- a/apps/frontend/src/lib/components/voice/AudioDeviceMenu.svelte
+++ b/apps/frontend/src/lib/components/voice/AudioDeviceMenu.svelte
@@ -13,6 +13,8 @@ Reads available devices and current selection from `voiceCallState`.
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { m } from '$lib/i18n/messages';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
 
   const serverScope = useServerScope();
   const voiceCallState = $derived(serverScope.store.voiceCall);
@@ -56,31 +58,27 @@ Reads available devices and current selection from `voiceCallState`.
 
 <ContextMenu {anchor} {onclose}>
   {#each sections as section (section.label)}
-    <div class="menu-section">
+    <MenuSection ariaLabel={section.label}>
       <div class="px-3 py-1.5 text-xs font-medium text-muted">{section.label}</div>
-      <nav class="sidebar-nav">
-        {#each section.devices as device (device.deviceId)}
-          <button
-            class="sidebar-item"
-            role="menuitem"
-            onclick={async () => {
-              await section.select(device.deviceId);
-              onclose();
-            }}
-          >
+      {#each section.devices as device (device.deviceId)}
+        <MenuItem
+          onclick={async () => {
+            await section.select(device.deviceId);
+            onclose();
+          }}
+        >
+          {#snippet leading()}
             {#if device.deviceId === section.selectedId}
-              <span class="iconify sidebar-icon icon-[uil--check] text-action"></span>
-            {:else}
-              <span class="sidebar-icon"></span>
+              <span class="iconify icon-[uil--check] text-action"></span>
             {/if}
-            <span class="truncate">{device.label || m('voice.unknown_device')}</span>
-          </button>
-        {/each}
+          {/snippet}
+          <span class="block truncate">{device.label || m('voice.unknown_device')}</span>
+        </MenuItem>
+      {/each}
 
-        {#if section.devices.length === 0}
-          <div class="px-3 py-2 text-sm text-muted">{m('voice.no_devices')}</div>
-        {/if}
-      </nav>
-    </div>
+      {#if section.devices.length === 0}
+        <div class="px-3 py-2 text-sm text-muted">{m('voice.no_devices')}</div>
+      {/if}
+    </MenuSection>
   {/each}
 </ContextMenu>

--- a/apps/frontend/src/lib/ui/ContextMenu.stories.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.stories.svelte
@@ -1,6 +1,8 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import ContextMenu from './ContextMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+  import MenuSection from './MenuSection.svelte';
 
   const { Story } = defineMeta({
     title: 'UI/ContextMenu',
@@ -40,20 +42,13 @@
       ariaLabel="Example actions"
       onclose={() => (open = false)}
     >
-      <div class="menu-section">
-        <button type="button" class="menu-item" onclick={() => (open = false)}>
-          <span class="sidebar-icon iconify icon-[uil--edit]"></span>
-          Edit
-        </button>
-        <button type="button" class="menu-item" onclick={() => (open = false)}>
-          <span class="sidebar-icon iconify icon-[uil--copy]"></span>
-          Copy
-        </button>
-        <button type="button" class="menu-item text-danger" onclick={() => (open = false)}>
-          <span class="sidebar-icon iconify icon-[uil--trash]"></span>
+      <MenuSection>
+        <MenuItem icon="icon-[uil--edit]" onclick={() => (open = false)}>Edit</MenuItem>
+        <MenuItem icon="icon-[uil--copy]" onclick={() => (open = false)}>Copy</MenuItem>
+        <MenuItem icon="icon-[uil--trash]" tone="danger" onclick={() => (open = false)}>
           Delete
-        </button>
-      </div>
+        </MenuItem>
+      </MenuSection>
     </ContextMenu>
   {/if}
 </Story>
@@ -67,30 +62,15 @@
       ariaLabel="Example touch actions"
       onclose={() => (sheetOpen = false)}
     >
-      <div class="menu-section">
-        <nav class="sidebar-nav">
-          <button type="button" class="sidebar-item" onclick={() => (sheetOpen = false)}>
-            <span class="iconify sidebar-icon icon-[uil--edit]" aria-hidden="true"></span>
-            Edit
-          </button>
-          <button type="button" class="sidebar-item" onclick={() => (sheetOpen = false)}>
-            <span class="iconify sidebar-icon icon-[uil--copy]" aria-hidden="true"></span>
-            Copy
-          </button>
-        </nav>
-      </div>
-      <div class="menu-section">
-        <nav class="sidebar-nav">
-          <button
-            type="button"
-            class="sidebar-item text-danger"
-            onclick={() => (sheetOpen = false)}
-          >
-            <span class="iconify sidebar-icon icon-[uil--trash]" aria-hidden="true"></span>
-            Delete
-          </button>
-        </nav>
-      </div>
+      <MenuSection>
+        <MenuItem icon="icon-[uil--edit]" onclick={() => (sheetOpen = false)}>Edit</MenuItem>
+        <MenuItem icon="icon-[uil--copy]" onclick={() => (sheetOpen = false)}>Copy</MenuItem>
+      </MenuSection>
+      <MenuSection>
+        <MenuItem icon="icon-[uil--trash]" tone="danger" onclick={() => (sheetOpen = false)}>
+          Delete
+        </MenuItem>
+      </MenuSection>
     </ContextMenu>
   {/if}
 </Story>

--- a/apps/frontend/src/lib/ui/ContextMenu.svelte
+++ b/apps/frontend/src/lib/ui/ContextMenu.svelte
@@ -25,6 +25,7 @@ ignored (the BottomSheet handles its own positioning).
   import type { Snippet } from 'svelte';
   import BottomSheet from './BottomSheet.svelte';
   import FloatingPopover from './FloatingPopover.svelte';
+  import { provideMenuContext } from './menuContext.svelte';
   import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
 
   type ContextMenuPresentation = 'auto' | 'floating' | 'sheet';
@@ -59,6 +60,10 @@ ignored (the BottomSheet handles its own positioning).
     presentation === 'sheet' ||
       (presentation === 'auto' && prefersTouchActions() && !supportsHoverActions())
   );
+  provideMenuContext({
+    presentation: () => (useSheet ? 'sheet' : 'floating'),
+    containerRole: () => role
+  });
   let sheetVisible = $state(true);
 
   function handleKeydown(e: KeyboardEvent) {

--- a/apps/frontend/src/lib/ui/MenuItem.stories.svelte
+++ b/apps/frontend/src/lib/ui/MenuItem.stories.svelte
@@ -1,0 +1,65 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  import MenuItem from './MenuItem.svelte';
+  import MenuSection from './MenuSection.svelte';
+
+  const { Story } = defineMeta({
+    title: 'UI/MenuItem',
+    component: MenuItem,
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: {
+          component:
+            'Standard command entry for context menus and action sheets. Supports buttons, links, optional or custom leading content, trailing content, destructive tone, disabled state, wrapped labels, and RTL icon mirroring.'
+        }
+      }
+    }
+  });
+</script>
+
+<script lang="ts">
+  import { provideMenuContext } from './menuContext.svelte';
+
+  provideMenuContext({
+    presentation: () => 'floating',
+    containerRole: () => 'menu'
+  });
+</script>
+
+<Story name="Common states" asChild>
+  <div class="w-64 menu" role="menu" aria-label="Common menu entry states">
+    <MenuSection>
+      <MenuItem icon="icon-[uil--edit]">Edit</MenuItem>
+      <MenuItem icon="icon-[uil--copy]">Copy</MenuItem>
+      <MenuItem>Text-only action</MenuItem>
+      <MenuItem icon="icon-[uil--trash]" tone="danger">Delete</MenuItem>
+      <MenuItem icon="icon-[uil--lock]" disabled>Unavailable</MenuItem>
+    </MenuSection>
+  </div>
+</Story>
+
+<Story name="Wrapped and selected" asChild>
+  <div class="w-64 menu" role="menu" aria-label="Wrapped and selected menu entries">
+    <MenuSection ariaLabel="Account actions">
+      <MenuItem icon="icon-[uil--servers]">In der Serveradministration anzeigen</MenuItem>
+      <MenuItem role="menuitemradio" checked selected>
+        {#snippet leading()}<span>🙂</span>{/snippet}
+        {#snippet trailing()}
+          <span class="iconify icon-[uil--check]"></span>
+        {/snippet}
+        Custom leading and trailing content
+      </MenuItem>
+    </MenuSection>
+  </div>
+</Story>
+
+<Story name="RTL" asChild>
+  <div class="w-64 menu" role="menu" aria-label="RTL menu entries" dir="rtl">
+    <MenuSection>
+      <MenuItem icon="icon-[uil--corner-up-left]" mirrorIconInRtl>ردّ</MenuItem>
+      <MenuItem icon="icon-[uil--copy]">نسخ الرابط</MenuItem>
+    </MenuSection>
+  </div>
+</Story>

--- a/apps/frontend/src/lib/ui/MenuItem.svelte
+++ b/apps/frontend/src/lib/ui/MenuItem.svelte
@@ -77,7 +77,7 @@ three for a text-only entry.
   const leadingClasses = $derived([
     'menu-entry-leading',
     'self-start',
-    isSheet ? 'menu-entry-leading-sheet' : 'mt-px'
+    isSheet ? 'menu-entry-leading-sheet' : 'menu-entry-leading-floating'
   ]);
 
   function handleClick(event: MouseEvent): void {

--- a/apps/frontend/src/lib/ui/MenuItem.svelte
+++ b/apps/frontend/src/lib/ui/MenuItem.svelte
@@ -77,7 +77,7 @@ three for a text-only entry.
   const leadingClasses = $derived([
     'menu-entry-leading',
     'self-start',
-    isSheet && 'menu-entry-leading-sheet'
+    isSheet ? 'menu-entry-leading-sheet' : 'mt-px'
   ]);
 
   function handleClick(event: MouseEvent): void {

--- a/apps/frontend/src/lib/ui/MenuItem.svelte
+++ b/apps/frontend/src/lib/ui/MenuItem.svelte
@@ -1,0 +1,139 @@
+<!--
+@component
+
+Standard command entry for `ContextMenu`. It renders a button by default or an
+anchor when `href` is set. Render it below a `ContextMenu`; review fixtures can
+provide the same internal menu context directly.
+
+Use `icon` for an Iconify glyph, `leading` for custom leading content such as
+an emoji or selection marker, and `trailing` for checks or shortcuts. Omit all
+three for a text-only entry.
+-->
+<script lang="ts">
+  /* eslint-disable svelte/no-navigation-without-resolve -- callers must pass an already-resolved URL */
+  import type { Snippet } from 'svelte';
+  import type { ClassValue } from 'svelte/elements';
+
+  import { useMenuContext } from './menuContext.svelte';
+
+  type MenuItemRole = 'menuitem' | 'menuitemcheckbox' | 'menuitemradio';
+  type MenuItemTone = 'default' | 'danger';
+
+  let {
+    href,
+    icon,
+    mirrorIconInRtl = false,
+    tone = 'default',
+    selected = false,
+    disabled = false,
+    busy = false,
+    role,
+    checked,
+    ariaLabel,
+    title,
+    dataTestid,
+    onclick,
+    class: className,
+    leading,
+    trailing,
+    children
+  }: {
+    /** An already-resolved URL. When set, the entry renders as an anchor. */
+    href?: string;
+    /** Iconify utility class, for example `icon-[uil--copy]`. */
+    icon?: string;
+    mirrorIconInRtl?: boolean;
+    tone?: MenuItemTone;
+    selected?: boolean;
+    disabled?: boolean;
+    busy?: boolean;
+    role?: MenuItemRole;
+    /** Checked state for checkbox and radio menu items. */
+    checked?: boolean;
+    ariaLabel?: string;
+    title?: string;
+    dataTestid?: string;
+    onclick?: (event: MouseEvent) => unknown;
+    /** Layout-only classes for exceptional placement. */
+    class?: ClassValue;
+    leading?: Snippet;
+    trailing?: Snippet;
+    children: Snippet;
+  } = $props();
+
+  const menuContext = useMenuContext();
+  const isSheet = $derived(menuContext.presentation() === 'sheet');
+  const effectiveRole = $derived<MenuItemRole | undefined>(
+    role ?? (menuContext.containerRole() === 'menu' ? 'menuitem' : undefined)
+  );
+  const unavailable = $derived(disabled || busy);
+  const itemClasses = $derived([
+    'menu-entry',
+    isSheet && 'menu-entry-sheet',
+    selected && 'menu-entry-selected',
+    tone === 'danger' && 'text-danger hover:text-danger',
+    className
+  ]);
+  const leadingClasses = $derived([
+    'menu-entry-leading',
+    'self-start',
+    isSheet && 'menu-entry-leading-sheet'
+  ]);
+
+  function handleClick(event: MouseEvent): void {
+    if (unavailable) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+    void onclick?.(event);
+  }
+</script>
+
+{#snippet content()}
+  {#if icon}
+    <span
+      class={['iconify', leadingClasses, icon, mirrorIconInRtl && 'rtl:-scale-x-100']}
+      aria-hidden="true"
+    ></span>
+  {:else if leading}
+    <span class={leadingClasses} aria-hidden="true">{@render leading()}</span>
+  {/if}
+  <span class="min-w-0 flex-1">{@render children()}</span>
+  {#if trailing}
+    <span class="ms-auto shrink-0" aria-hidden="true">{@render trailing()}</span>
+  {/if}
+{/snippet}
+
+{#if href}
+  <a
+    {href}
+    class={itemClasses}
+    role={effectiveRole}
+    aria-checked={checked}
+    aria-disabled={unavailable || undefined}
+    aria-busy={busy || undefined}
+    aria-label={ariaLabel}
+    {title}
+    tabindex={unavailable ? -1 : undefined}
+    data-testid={dataTestid}
+    onclick={handleClick}
+  >
+    {@render content()}
+  </a>
+{:else}
+  <button
+    type="button"
+    class={itemClasses}
+    role={effectiveRole}
+    aria-checked={checked}
+    aria-busy={busy || undefined}
+    aria-label={ariaLabel}
+    {title}
+    disabled={unavailable}
+    data-testid={dataTestid}
+    onclick={handleClick}
+  >
+    {@render content()}
+  </button>
+{/if}

--- a/apps/frontend/src/lib/ui/MenuItem.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/MenuItem.svelte.spec.ts
@@ -1,0 +1,100 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+
+import { q } from '$lib/test-utils';
+import MenuItemTestHarness from './MenuItemTestHarness.svelte';
+
+let originalShowPopover: typeof HTMLElement.prototype.showPopover;
+let originalShowModal: typeof HTMLDialogElement.prototype.showModal;
+
+beforeAll(() => {
+  originalShowPopover = HTMLElement.prototype.showPopover;
+  originalShowModal = HTMLDialogElement.prototype.showModal;
+  HTMLElement.prototype.showPopover = function showPopover() {
+    this.setAttribute('popover-open', '');
+  };
+  HTMLDialogElement.prototype.showModal = function showModal() {
+    this.setAttribute('open', '');
+  };
+});
+
+afterAll(() => {
+  HTMLElement.prototype.showPopover = originalShowPopover;
+  HTMLDialogElement.prototype.showModal = originalShowModal;
+});
+
+describe('MenuItem', () => {
+  it('renders button, link, icon, and text-only entries with menu semantics', () => {
+    const { container } = render(MenuItemTestHarness);
+    const iconButton = q(container, '[data-testid="icon-button"]') as HTMLButtonElement;
+    const textButton = q(container, '[data-testid="text-button"]') as HTMLButtonElement;
+    const link = q(container, '[data-testid="link-item"]') as HTMLAnchorElement;
+
+    expect(iconButton.type).toBe('button');
+    expect(iconButton.getAttribute('role')).toBe('menuitem');
+    expect(
+      Array.from(iconButton.querySelectorAll('.iconify')).some((icon) =>
+        icon.classList.contains('icon-[uil--copy]')
+      )
+    ).toBe(true);
+    expect(iconButton.querySelector('.menu-entry-leading')?.classList).toContain('self-start');
+    expect(textButton.querySelector('.menu-entry-leading')).toBeNull();
+    expect(link.tagName).toBe('A');
+    expect(link.getAttribute('href')).toBe('/settings');
+    expect(link.getAttribute('role')).toBe('menuitem');
+  });
+
+  it('calls button actions and blocks disabled links', () => {
+    const { container } = render(MenuItemTestHarness);
+    const iconButton = q(container, '[data-testid="icon-button"]') as HTMLButtonElement;
+    const disabledLink = q(container, '[data-testid="disabled-link"]') as HTMLAnchorElement;
+    const clickCount = q(container, '[data-testid="click-count"]');
+
+    iconButton.click();
+    flushSync();
+    expect(clickCount?.textContent).toBe('1');
+
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    disabledLink.dispatchEvent(event);
+    expect(event.defaultPrevented).toBe(true);
+    expect(disabledLink.getAttribute('aria-disabled')).toBe('true');
+    expect(disabledLink.tabIndex).toBe(-1);
+    expect(clickCount?.textContent).toBe('1');
+  });
+
+  it('renders custom leading and trailing content with checked state', () => {
+    const { container } = render(MenuItemTestHarness);
+    const customItem = q(container, '[data-testid="custom-item"]') as HTMLButtonElement;
+
+    expect(customItem.getAttribute('role')).toBe('menuitemradio');
+    expect(customItem.getAttribute('aria-checked')).toBe('true');
+    expect(customItem.classList).toContain('menu-entry-selected');
+    expect(customItem.querySelector('.menu-entry-leading')?.textContent).toContain('🙂');
+    expect(
+      Array.from(customItem.querySelectorAll('.iconify')).some((icon) =>
+        icon.classList.contains('icon-[uil--check]')
+      )
+    ).toBe(true);
+  });
+
+  it('uses touch-safe density in the sheet presentation', () => {
+    const { container } = render(MenuItemTestHarness, {
+      props: { presentation: 'sheet' }
+    });
+    const item = q(container, '[data-testid="icon-button"]');
+
+    expect(item?.classList).toContain('menu-entry-sheet');
+    expect(item?.querySelector('.menu-entry-leading')?.classList).toContain(
+      'menu-entry-leading-sheet'
+    );
+  });
+
+  it('does not add menu roles inside a dialog-style context menu', () => {
+    const { container } = render(MenuItemTestHarness, {
+      props: { containerRole: 'dialog' }
+    });
+
+    expect(q(container, '[data-testid="icon-button"]')?.getAttribute('role')).toBeNull();
+  });
+});

--- a/apps/frontend/src/lib/ui/MenuItem.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/MenuItem.svelte.spec.ts
@@ -39,7 +39,9 @@ describe('MenuItem', () => {
       )
     ).toBe(true);
     expect(iconButton.querySelector('.menu-entry-leading')?.classList).toContain('self-start');
-    expect(iconButton.querySelector('.menu-entry-leading')?.classList).toContain('mt-px');
+    expect(iconButton.querySelector('.menu-entry-leading')?.classList).toContain(
+      'menu-entry-leading-floating'
+    );
     expect(textButton.querySelector('.menu-entry-leading')).toBeNull();
     expect(link.tagName).toBe('A');
     expect(link.getAttribute('href')).toBe('/settings');
@@ -89,7 +91,9 @@ describe('MenuItem', () => {
     expect(item?.querySelector('.menu-entry-leading')?.classList).toContain(
       'menu-entry-leading-sheet'
     );
-    expect(item?.querySelector('.menu-entry-leading')?.classList).not.toContain('mt-px');
+    expect(item?.querySelector('.menu-entry-leading')?.classList).not.toContain(
+      'menu-entry-leading-floating'
+    );
   });
 
   it('does not add menu roles inside a dialog-style context menu', () => {

--- a/apps/frontend/src/lib/ui/MenuItem.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/MenuItem.svelte.spec.ts
@@ -39,6 +39,7 @@ describe('MenuItem', () => {
       )
     ).toBe(true);
     expect(iconButton.querySelector('.menu-entry-leading')?.classList).toContain('self-start');
+    expect(iconButton.querySelector('.menu-entry-leading')?.classList).toContain('mt-px');
     expect(textButton.querySelector('.menu-entry-leading')).toBeNull();
     expect(link.tagName).toBe('A');
     expect(link.getAttribute('href')).toBe('/settings');
@@ -88,6 +89,7 @@ describe('MenuItem', () => {
     expect(item?.querySelector('.menu-entry-leading')?.classList).toContain(
       'menu-entry-leading-sheet'
     );
+    expect(item?.querySelector('.menu-entry-leading')?.classList).not.toContain('mt-px');
   });
 
   it('does not add menu roles inside a dialog-style context menu', () => {

--- a/apps/frontend/src/lib/ui/MenuItemTestHarness.svelte
+++ b/apps/frontend/src/lib/ui/MenuItemTestHarness.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+  import ContextMenu from './ContextMenu.svelte';
+  import MenuItem from './MenuItem.svelte';
+  import MenuSection from './MenuSection.svelte';
+
+  let {
+    presentation = 'floating',
+    containerRole = 'menu'
+  }: {
+    presentation?: 'floating' | 'sheet';
+    containerRole?: 'menu' | 'dialog';
+  } = $props();
+
+  let clickCount = $state(0);
+</script>
+
+<output data-testid="click-count">{clickCount}</output>
+
+<ContextMenu
+  position={{ x: 24, y: 32 }}
+  {presentation}
+  role={containerRole}
+  ariaLabel="Example actions"
+  onclose={() => {}}
+>
+  <MenuSection ariaLabel="Primary actions">
+    <MenuItem icon="icon-[uil--copy]" dataTestid="icon-button" onclick={() => (clickCount += 1)}>
+      Copy identifier
+    </MenuItem>
+    <MenuItem dataTestid="text-button">Text-only action</MenuItem>
+    <MenuItem href="/settings" dataTestid="link-item">Open settings</MenuItem>
+    <MenuItem
+      href="/blocked"
+      disabled
+      tone="danger"
+      dataTestid="disabled-link"
+      onclick={() => (clickCount += 1)}
+    >
+      Blocked action
+    </MenuItem>
+    <MenuItem role="menuitemradio" checked selected dataTestid="custom-item">
+      {#snippet leading()}<span>🙂</span>{/snippet}
+      {#snippet trailing()}
+        <span class="iconify icon-[uil--check]"></span>
+      {/snippet}
+      A custom item with a label that can wrap onto another line
+    </MenuItem>
+  </MenuSection>
+</ContextMenu>

--- a/apps/frontend/src/lib/ui/MenuSection.svelte
+++ b/apps/frontend/src/lib/ui/MenuSection.svelte
@@ -1,0 +1,31 @@
+<!--
+@component
+
+Groups related `MenuItem` components on one standard menu surface. Use sibling
+sections to separate action groups; the owning `ContextMenu` supplies the gap.
+
+Set `ariaLabel` only when the group needs its own accessible name.
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { ClassValue } from 'svelte/elements';
+
+  let {
+    ariaLabel,
+    class: className,
+    children
+  }: {
+    ariaLabel?: string;
+    /** Layout-only classes for exceptional section composition. */
+    class?: ClassValue;
+    children: Snippet;
+  } = $props();
+</script>
+
+<div
+  class={['flex flex-col gap-1 menu-section', className]}
+  role={ariaLabel ? 'group' : undefined}
+  aria-label={ariaLabel}
+>
+  {@render children()}
+</div>

--- a/apps/frontend/src/lib/ui/index.ts
+++ b/apps/frontend/src/lib/ui/index.ts
@@ -22,6 +22,8 @@ export { default as ImageModal } from './ImageModal.svelte';
 export type { ImageItem } from './ImageModal.svelte';
 export { default as LoadingPage } from './LoadingPage.svelte';
 export { default as MarkdownHtml } from './MarkdownHtml.svelte';
+export { default as MenuItem } from './MenuItem.svelte';
+export { default as MenuSection } from './MenuSection.svelte';
 export { default as MotdContent } from './MotdContent.svelte';
 export { default as NotificationBadge } from './NotificationBadge.svelte';
 export { default as PageTitle } from './PageTitle.svelte';

--- a/apps/frontend/src/lib/ui/menuContext.svelte.ts
+++ b/apps/frontend/src/lib/ui/menuContext.svelte.ts
@@ -1,0 +1,20 @@
+import { createContext } from 'svelte';
+
+export type MenuPresentation = 'floating' | 'sheet';
+
+export type MenuContext = {
+  presentation: () => MenuPresentation;
+  containerRole: () => string;
+};
+
+const [getMenuContext, setMenuContext] = createContext<MenuContext>();
+
+/** Provides presentation and semantic context to menu descendants. */
+export function provideMenuContext(context: MenuContext): void {
+  setMenuContext(context);
+}
+
+/** Returns the menu context provided by the owning ContextMenu or review fixture. */
+export function useMenuContext(): MenuContext {
+  return getMenuContext();
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte
@@ -10,6 +10,8 @@ surface-specific sizing and menu semantics.
 
   import { m } from '$lib/i18n/messages';
   import { getRecentEmojis } from '$lib/state/recentEmojis.svelte';
+  import MenuItem from '$lib/ui/MenuItem.svelte';
+  import MenuSection from '$lib/ui/MenuSection.svelte';
   import type { MessageActionModel } from './messageActionModel';
 
   let {
@@ -117,26 +119,18 @@ surface-specific sizing and menu semantics.
   destructive = false,
   mirrorInRtl = false
 )}
-  <button
-    class={[
-      'sidebar-item',
-      isSheet && 'min-h-11 gap-3 px-3 py-2.5 text-base',
-      destructive && 'text-danger hover:text-danger'
-    ]}
+  <MenuItem
+    {icon}
+    tone={destructive ? 'danger' : 'default'}
+    mirrorIconInRtl={mirrorInRtl}
     {onclick}
-    role={isSheet ? undefined : 'menuitem'}
   >
-    <span class={['iconify sidebar-icon', icon, mirrorInRtl && 'rtl:-scale-x-100']}></span>
     {label}
-  </button>
+  </MenuItem>
 {/snippet}
 
 {#snippet actionGroup(content: Snippet)}
-  <div class={isSheet ? undefined : 'menu-section'}>
-    <nav class={['sidebar-nav', isSheet && 'gap-0 menu-section p-1']}>
-      {@render content()}
-    </nav>
-  </div>
+  <MenuSection>{@render content()}</MenuSection>
 {/snippet}
 
 {#snippet menuContent()}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenu.svelte.spec.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { q } from '$lib/test-utils';
-import MessageActionMenu from './MessageActionMenu.svelte';
+import MessageActionMenuTestHarness from './MessageActionMenuTestHarness.svelte';
 import MessageEventActionOverlays from './MessageEventActionOverlays.svelte';
 import { MessageEventInteractionState } from './messageEventInteractions.svelte';
 import { buildMessageActionModel } from './messageActionModel';
@@ -81,7 +81,7 @@ function renderMenu({
   presentation?: 'menu' | 'sheet';
   onOpenEmojiPicker?: () => void;
 } = {}) {
-  return render(MessageActionMenu, {
+  return render(MessageActionMenuTestHarness, {
     props: {
       action: buildAction(overrides),
       presentation,
@@ -91,8 +91,8 @@ function renderMenu({
   });
 }
 
-function navActionLabels(container: HTMLElement): string[] {
-  return Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+function actionLabels(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('.menu-entry'))
     .map((button) => button.textContent?.trim())
     .filter((label): label is string => !!label);
 }
@@ -162,7 +162,7 @@ describe('MessageActionMenu', () => {
       onSecondaryReplyInRoom: vi.fn()
     });
 
-    expect(navActionLabels(container)).toEqual([
+    expect(actionLabels(container)).toEqual([
       'Reply',
       'Reply in thread',
       'Reply in room',
@@ -310,7 +310,7 @@ describe('MessageActionMenu', () => {
         onReplyInRoom: vi.fn()
       });
 
-      expect(navActionLabels(container)).toEqual([
+      expect(actionLabels(container)).toEqual([
         'Reply',
         'Reply in thread',
         'Edit',
@@ -319,15 +319,19 @@ describe('MessageActionMenu', () => {
         'Delete'
       ]);
       expect(
-        Array.from(container.querySelectorAll('nav')).map((section) =>
-          Array.from(section.querySelectorAll('button')).map((button) => button.textContent?.trim())
-        )
+        Array.from(container.querySelectorAll('.menu-section'))
+          .filter((section) => section.querySelector('.menu-entry'))
+          .map((section) =>
+            Array.from(section.querySelectorAll('button')).map((button) =>
+              button.textContent?.trim()
+            )
+          )
       ).toEqual([['Reply', 'Reply in thread', 'Edit'], ['Copy text', 'Copy link'], ['Delete']]);
       expect(container.querySelector('[role="menuitem"]')).toBeNull();
-      expect(container.querySelector('nav button')).toHaveClass('min-h-11');
+      expect(container.querySelector('.menu-entry')).toHaveClass('menu-entry-sheet');
       expect(q(container, '[aria-label="React with 👍"]')).toHaveClass('rounded-full', 'text-xl');
       expect(
-        Array.from(container.querySelectorAll<HTMLButtonElement>('nav button')).find((button) =>
+        Array.from(container.querySelectorAll<HTMLButtonElement>('.menu-entry')).find((button) =>
           button.textContent?.includes('Delete')
         )
       ).toHaveClass('text-danger');
@@ -340,7 +344,7 @@ describe('MessageActionMenu', () => {
         onReplyInRoom
       });
 
-      Array.from(container.querySelectorAll<HTMLButtonElement>('nav button'))
+      Array.from(container.querySelectorAll<HTMLButtonElement>('.menu-entry'))
         .find((button) => button.textContent?.trim() === 'Reply')!
         .click();
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenuTestHarness.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageActionMenuTestHarness.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { provideMenuContext } from '$lib/ui/menuContext.svelte';
+  import MessageActionMenu from './MessageActionMenu.svelte';
+  import type { MessageActionModel } from './messageActionModel';
+
+  let {
+    presentation = 'menu',
+    action,
+    onOpenEmojiPicker,
+    onClose
+  }: {
+    presentation?: 'menu' | 'sheet';
+    action: MessageActionModel;
+    onOpenEmojiPicker?: () => void;
+    onClose: () => void;
+  } = $props();
+
+  provideMenuContext({
+    presentation: () => (presentation === 'sheet' ? 'sheet' : 'floating'),
+    containerRole: () => (presentation === 'sheet' ? 'dialog' : 'menu')
+  });
+</script>
+
+<MessageActionMenu {presentation} {action} {onOpenEmojiPicker} {onClose} />

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageEventActionOverlays.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
   import { m } from '$lib/i18n/messages';
   import type { MessageActionModel } from './messageActionModel';
@@ -121,7 +120,12 @@
 {/if}
 
 {#if interactions.showActionSheet}
-  <BottomSheet bind:visible={interactions.showActionSheet} onclose={closeActionSheet}>
+  <ContextMenu
+    presentation="sheet"
+    role="dialog"
+    ariaLabel={m('room.message.actions.toolbar')}
+    onclose={closeActionSheet}
+  >
     {@render actionMenu('sheet')}
-  </BottomSheet>
+  </ContextMenu>
 {/if}


### PR DESCRIPTION
## Why

Context-menu commands repeated long Tailwind class lists and icon markup. They also used the sidebar navigation recipe on action surfaces. This made spacing, touch density, disabled states, and wrapped-label alignment easy to implement differently in each menu.

## What changed

- Add `MenuItem` and `MenuSection` Svelte primitives with shared semantic Tailwind utilities.
- Let `ContextMenu` provide floating or sheet presentation and container semantics to its entries.
- Support button and link commands, optional or custom leading content, trailing content, selected and checked states, danger tone, disabled and busy states, and RTL icon mirroring.
- Align leading icons with the first line when labels wrap, and keep 44 px targets in touch sheets.
- Migrate user, room, server, message, link-preview, presence, and audio-device action menus. Keep `sidebar-item` for actual sidebar navigation.
- Add component tests, Storybook states with accessibility coverage, and design-system guidance.

## Test plan

- `mise lint-frontend` — passed; Svelte check reported 0 errors and 0 warnings.
- `mise test-frontend` — passed: 1,329 server tests, 1,938 client tests, 225 Storybook tests, and 5 performance comparison tests.
- `mise build-frontend` — passed, including bundle budgets and CSP validation.
- `mise license-check` — passed.
- Chrome DevTools — verified wrapped-label alignment, light and dark themes, RTL mirroring, iconless, danger, and disabled states, plus 44 px sheet targets.

## Implications

This is a frontend-only refactor and visual consistency change. It does not change public protocols, persisted data, server runtime behavior, deployment, or migration requirements.
