### PR TITLE
fix(neighbors): hand incompatible servers off to their client

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
@@ -60,8 +60,11 @@ can review or remove it. A failed server does not prevent the client from
 showing other results.
 
 Servers that are already registered remain in the directory and have a
-**Joined** label. Use the direct server-address field when the wanted server is
-not listed.
+**Joined** label. A compatible unregistered server has a **Join** action. If
+the server version is too old or unknown, use **Open in new tab** to use the
+client that the server provides. The server icon opens the same destination.
+Use the direct server-address field when the wanted server is not listed. The
+same compatibility rule applies to a server found through this field.
 
 ## Understand the trust boundary
 

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -87,7 +87,8 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   <ReleaseFeatureCard title="Version-aware compatibility">
     Public server discovery reports the running server version. The multi-server client owns
     its minimum expected server release and uses explicit release boundaries to show useful
-    upgrade guidance.
+    upgrade guidance. If a discovered server is incompatible or does not report a valid version,
+    the Server Directory opens that server's own client instead of adding it to the current app.
   </ReleaseFeatureCard>
 
   <ReleaseFeatureCard title="Advertise friendly Chatto servers">

--- a/apps/frontend/e2e/remote-compatibility.compat.ts
+++ b/apps/frontend/e2e/remote-compatibility.compat.ts
@@ -152,7 +152,7 @@ test.describe('unsupported release boundary', () => {
     'Set current and unsupported remote production executables'
   );
 
-  test('current frontend rejects a 0.4 server without opening realtime', async ({
+  test('current frontend hands a 0.4 server off without opening realtime', async ({
     page,
     authPage,
     server
@@ -189,37 +189,27 @@ test.describe('unsupported release boundary', () => {
       await page.getByTitle('Add Server').click();
       await page.getByLabel('Server URL').fill(remoteHost);
       await page.getByRole('button', { name: 'Find server' }).click();
-      await expect(page.getByRole('button', { name: 'Join', exact: true })).toBeVisible({
+      const externalAction = page.getByRole('link', { name: 'Open in new tab', exact: true });
+      await expect(externalAction).toBeVisible({
         timeout: TIMEOUTS.REALTIME_EVENT
       });
+      await expect(externalAction).toHaveAttribute('href', unsupportedServer.baseURL);
+      await expect(externalAction).toHaveAttribute('target', '_blank');
+      await expect(externalAction).toHaveAttribute('rel', 'noopener noreferrer');
       const popupPromise = page.waitForEvent('popup');
-      await page.getByRole('button', { name: 'Join', exact: true }).click();
-      const remoteLoginPage = await popupPromise;
-
-      await expect(remoteLoginPage).toHaveURL(/127\.0\.0\.1.*\/login\?redirect=/, {
-        timeout: TIMEOUTS.REALTIME_EVENT
-      });
-      await remoteLoginPage.locator('input[autocomplete="username"]').fill(remoteUser.login);
-      await remoteLoginPage
-        .locator('input[autocomplete="current-password"]')
-        .fill(remoteUser.password);
-      await remoteLoginPage.getByRole('button', { name: /Sign In/i }).click();
-      await expect(remoteLoginPage).toHaveURL(/127\.0\.0\.1.*\/oauth\/consent/, {
-        timeout: TIMEOUTS.REALTIME_EVENT
-      });
-      const popupClosed = remoteLoginPage.waitForEvent('close');
-      await remoteLoginPage.getByRole('button', { name: 'Allow Access' }).click();
-      await popupClosed;
-
-      const remoteIcon = page.locator(`[data-testid="server-icon"][href*="127.0.0.1"]`).first();
-      await expect(remoteIcon).toBeVisible({ timeout: TIMEOUTS.UI_STANDARD });
-      await expect(
-        remoteIcon.locator('xpath=..').getByTestId('server-compatibility-warning')
-      ).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
-      await expect(remoteIcon).toHaveAttribute(
-        'title',
-        /This server must be upgraded to Chatto 0\.5 or newer before this app can connect\./
+      await externalAction.click();
+      const remoteClient = await popupPromise;
+      await expect(remoteClient).toHaveURL(
+        (url) => url.origin === new URL(unsupportedServer!.baseURL).origin,
+        { timeout: TIMEOUTS.REALTIME_EVENT }
       );
+      const registeredRemote = await page.evaluate((origin) => {
+        const registrations = JSON.parse(
+          localStorage.getItem('chatto:instances') || '[]'
+        ) as Array<{ url?: string }>;
+        return registrations.some((registration) => registration.url === origin);
+      }, unsupportedServer.baseURL);
+      expect(registeredRemote).toBe(false);
       expect(remoteRealtimeConnections).toBe(0);
     } finally {
       if (unsupportedServer) {

--- a/apps/frontend/e2e/remote-compatibility.compat.ts
+++ b/apps/frontend/e2e/remote-compatibility.compat.ts
@@ -168,7 +168,6 @@ test.describe('unsupported release boundary', () => {
         6,
         '127.0.0.1'
       );
-      await createProductionUser(unsupportedServer, remoteUser);
 
       await authPage.gotoLogin();
       await authPage.fillLoginForm(originUser.login, originUser.password);

--- a/apps/frontend/messages/ar/add_server.json
+++ b/apps/frontend/messages/ar/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "فتح في علامة تبويب جديدة",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/cs-CZ/add_server.json
+++ b/apps/frontend/messages/cs-CZ/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Otevřít na nové kartě",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/de-DE/add_server.json
+++ b/apps/frontend/messages/de-DE/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Beigetreten",
       "join": "Beitreten",
       "open": "Öffnen",
+      "open_in_new_tab": "In neuem Tab öffnen",
       "sign_in_unavailable": "Anmeldung nicht verfügbar",
       "profile_unavailable": "Das öffentliche Profil dieses Servers konnte nicht geladen werden.",
       "partial": "Einige deiner Server konnten keine Empfehlungen liefern.",

--- a/apps/frontend/messages/en-GB/add_server.json
+++ b/apps/frontend/messages/en-GB/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Open in new tab",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/eo/add_server.json
+++ b/apps/frontend/messages/eo/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Malfermi en nova langeto",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/es-419/add_server.json
+++ b/apps/frontend/messages/es-419/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Abrir en una pestaña nueva",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/es-ES/add_server.json
+++ b/apps/frontend/messages/es-ES/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Abrir en una pestaña nueva",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/et-EE/add_server.json
+++ b/apps/frontend/messages/et-EE/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Ava uuel vahekaardil",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/fr-CA/add_server.json
+++ b/apps/frontend/messages/fr-CA/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Ouvrir dans un nouvel onglet",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/fr-FR/add_server.json
+++ b/apps/frontend/messages/fr-FR/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Ouvrir dans un nouvel onglet",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/he-IL/add_server.json
+++ b/apps/frontend/messages/he-IL/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "פתיחה בכרטיסייה חדשה",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/it-IT/add_server.json
+++ b/apps/frontend/messages/it-IT/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Apri in una nuova scheda",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/ja-JP/add_server.json
+++ b/apps/frontend/messages/ja-JP/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "新しいタブで開く",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/lv-LV/add_server.json
+++ b/apps/frontend/messages/lv-LV/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Atvērt jaunā cilnē",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/nb-NO/add_server.json
+++ b/apps/frontend/messages/nb-NO/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Åpne i ny fane",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/nl-BE/add_server.json
+++ b/apps/frontend/messages/nl-BE/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Openen in een nieuw tabblad",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/nl-NL/add_server.json
+++ b/apps/frontend/messages/nl-NL/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Openen in een nieuw tabblad",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/pl-PL/add_server.json
+++ b/apps/frontend/messages/pl-PL/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Otwórz w nowej karcie",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/pt-BR/add_server.json
+++ b/apps/frontend/messages/pt-BR/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Abrir em uma nova aba",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/pt-PT/add_server.json
+++ b/apps/frontend/messages/pt-PT/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Abrir num novo separador",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/ru-RU/add_server.json
+++ b/apps/frontend/messages/ru-RU/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Открыть в новой вкладке",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/sv-SE/add_server.json
+++ b/apps/frontend/messages/sv-SE/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Öppna i en ny flik",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/tr-TR/add_server.json
+++ b/apps/frontend/messages/tr-TR/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Yeni sekmede aç",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/uk-UA/add_server.json
+++ b/apps/frontend/messages/uk-UA/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "Відкрити в новій вкладці",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/zh-CN/add_server.json
+++ b/apps/frontend/messages/zh-CN/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "在新标签页中打开",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/messages/zh-TW/add_server.json
+++ b/apps/frontend/messages/zh-TW/add_server.json
@@ -24,6 +24,7 @@
       "joined": "Joined",
       "join": "Join",
       "open": "Open",
+      "open_in_new_tab": "在新分頁中開啟",
       "sign_in_unavailable": "Sign-in unavailable",
       "profile_unavailable": "This server's public profile could not be loaded.",
       "partial": "Some joined servers could not provide their recommendations.",

--- a/apps/frontend/src/lib/components/ServerProfileCard.stories.svelte
+++ b/apps/frontend/src/lib/components/ServerProfileCard.stories.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import type { PublicServerInfo } from '$lib/api-client/server';
+  import { Button } from '$lib/ui/form';
   import ServerProfileCard from './ServerProfileCard.svelte';
   import ServerTestimonialCard from './ServerTestimonialCard.svelte';
 
@@ -44,5 +45,29 @@
         sourceName="Tiny Town"
       />
     </section>
+  </div>
+</Story>
+
+<Story name="External handoff" asChild>
+  <div class="w-full max-w-sm p-4">
+    {#snippet actions()}
+      <Button
+        href="https://old-neighbourhood.example"
+        opensInNewTab
+        variant="secondary"
+        fullWidth
+      >
+        <span>Open in new tab</span>
+        <span class="iconify icon-[uil--external-link-alt]" aria-hidden="true"></span>
+      </Button>
+    {/snippet}
+    <ServerProfileCard
+      origin="https://old-neighbourhood.example"
+      profile={{ ...profile, version: '0.4.19' }}
+      iconHref="https://old-neighbourhood.example"
+      iconOpensInNewTab
+      iconActionLabel="Open in new tab"
+      {actions}
+    />
   </div>
 </Story>

--- a/apps/frontend/src/lib/components/ServerProfileCard.svelte
+++ b/apps/frontend/src/lib/components/ServerProfileCard.svelte
@@ -18,6 +18,8 @@ card. Callers supply trusted badges and actions through explicit props.
     details,
     actions,
     onIconClick,
+    iconHref,
+    iconOpensInNewTab = false,
     iconActionLabel,
     iconActionDisabled = false,
     testId = 'server-profile-card'
@@ -31,6 +33,10 @@ card. Callers supply trusted badges and actions through explicit props.
     actions?: Snippet;
     /** Makes the server icon perform the caller's existing open or join action. */
     onIconClick?: () => void;
+    /** Makes the server icon a link. This takes precedence over `onIconClick`. */
+    iconHref?: string;
+    /** Opens `iconHref` in a separate browsing context without opener access. */
+    iconOpensInNewTab?: boolean;
     iconActionLabel?: string;
     iconActionDisabled?: boolean;
     testId?: string;
@@ -67,7 +73,21 @@ card. Callers supply trusted badges and actions through explicit props.
 
   <div class="flex flex-1 flex-col gap-4 p-4">
     <div class="flex min-w-0 items-start gap-3">
-      {#if onIconClick}
+      {#if iconHref}
+        <!-- eslint-disable svelte/no-navigation-without-resolve -- iconHref is a caller-provided external URL -->
+        <a
+          href={iconHref}
+          target={iconOpensInNewTab ? '_blank' : undefined}
+          rel={iconOpensInNewTab ? 'noopener noreferrer' : undefined}
+          class="-mt-10 h-14 w-14 shrink-0 cursor-pointer overflow-hidden rounded-xl border-2 border-border bg-surface-emphasized transition-transform focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action active:scale-[0.96]"
+          aria-label={accessibleIconActionLabel}
+          title={accessibleIconActionLabel}
+          data-testid={`${testId}-icon-action`}
+        >
+          <ServerLogo server={logoServer} fill />
+        </a>
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
+      {:else if onIconClick}
         <button
           type="button"
           class="-mt-10 h-14 w-14 shrink-0 cursor-pointer overflow-hidden rounded-xl border-2 border-border bg-surface-emphasized transition-transform focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-action active:scale-[0.96] disabled:pointer-events-none disabled:cursor-not-allowed"

--- a/apps/frontend/src/lib/ui/form/Button.stories.svelte
+++ b/apps/frontend/src/lib/ui/form/Button.stories.svelte
@@ -143,6 +143,24 @@
 </Story>
 
 <Story
+  name="In a new tab"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'Use opensInNewTab for an explicit handoff to another site. The component adds safe link attributes.'
+      }
+    }
+  }}
+>
+  <Button href="https://www.chatto.run" opensInNewTab variant="secondary">
+    <span>Open Chatto</span>
+    <span class="iconify icon-[uil--external-link-alt]" aria-hidden="true"></span>
+  </Button>
+</Story>
+
+<Story
   name="Full width"
   asChild
   parameters={{

--- a/apps/frontend/src/lib/ui/form/Button.svelte
+++ b/apps/frontend/src/lib/ui/form/Button.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  /* eslint-disable svelte/no-navigation-without-resolve -- href is a prop; callers pass already-resolved paths */
   import type { Snippet } from 'svelte';
 
   let {
@@ -12,6 +11,7 @@
     defaultAction = false,
     loadingText,
     href,
+    opensInNewTab = false,
     form,
     onclick,
     label,
@@ -30,6 +30,8 @@
     loadingText?: string;
     /** When provided, renders as an <a> link instead of a <button> */
     href?: string;
+    /** Opens an href in a separate browsing context without opener access. */
+    opensInNewTab?: boolean;
     /** ID of the form this button submits when rendered outside that form. */
     form?: string;
     onclick?: (e: MouseEvent) => void;
@@ -83,8 +85,11 @@
 {/snippet}
 
 {#if href}
+  <!-- eslint-disable svelte/no-navigation-without-resolve -- href is a prop; callers pass resolved app paths or external URLs -->
   <a
     {href}
+    target={opensInNewTab ? '_blank' : undefined}
+    rel={opensInNewTab ? 'noopener noreferrer' : undefined}
     onclick={handleClick}
     aria-busy={loading || undefined}
     aria-disabled={disabled || loading || undefined}
@@ -101,6 +106,7 @@
   >
     {@render content()}
   </a>
+  <!-- eslint-enable svelte/no-navigation-without-resolve -->
 {:else}
   <button
     {type}

--- a/apps/frontend/src/routes/chat/servers/+page.svelte
+++ b/apps/frontend/src/routes/chat/servers/+page.svelte
@@ -20,6 +20,7 @@
     loadServerDirectory,
     type ServerDirectoryEntry
   } from '$lib/serverDirectory';
+  import { evaluateServerCompatibility } from '$lib/state/server/compatibility';
   import { serverRegistry, type RegisteredServer } from '$lib/state/server/registry.svelte';
   import { EmptyState, Hint, PageTitle, PaneContent, PaneHeader, Panel } from '$lib/ui';
   import { Button, Form, TextInput } from '$lib/ui/form';
@@ -113,8 +114,17 @@
         ? m('add_server.directory.open')
         : m('add_server.sign_in');
     }
+    if (opensInServerClient(origin, profile)) return m('add_server.directory.open_in_new_tab');
     if (!profile?.authorizeUrl) return m('add_server.directory.sign_in_unavailable');
     return m('add_server.directory.join');
+  }
+
+  function opensInServerClient(origin: string, profile: PublicServerInfo | null): boolean {
+    return (
+      !registeredServer(origin) &&
+      profile !== null &&
+      evaluateServerCompatibility({ serverVersion: profile.version }).status !== 'supported'
+    );
   }
 
   async function openOrJoin(origin: string, profile: PublicServerInfo | null) {
@@ -152,7 +162,11 @@
   }
 
   function cardDisabled(entry: ServerDirectoryEntry): boolean {
-    return !registeredServer(entry.origin) && !entry.profile?.authorizeUrl;
+    return (
+      !registeredServer(entry.origin) &&
+      !opensInServerClient(entry.origin, entry.profile) &&
+      !entry.profile?.authorizeUrl
+    );
   }
 
   function sourceName(origin: string): string {
@@ -242,23 +256,41 @@
         {#if customProfile && customOrigin}
           {@const profile = customProfile}
           {@const joined = registeredServer(customOrigin)}
+          {@const external = opensInServerClient(customOrigin, profile)}
           <div class="mt-5 max-w-md">
             {#snippet customActions()}
-              <Button
-                variant={joined ? 'secondary' : 'action'}
-                fullWidth
-                loading={pendingOrigin === customOrigin}
-                disabled={!joined && !profile.authorizeUrl}
-                onclick={() => openOrJoin(customOrigin, profile)}
-              >
-                {actionLabel(customOrigin, customProfile)}
-              </Button>
+              {#if external}
+                <Button
+                  href={customOrigin}
+                  opensInNewTab
+                  variant="secondary"
+                  fullWidth
+                >
+                  <span>{actionLabel(customOrigin, customProfile)}</span>
+                  <span
+                    class="iconify icon-[uil--external-link-alt]"
+                    aria-hidden="true"
+                  ></span>
+                </Button>
+              {:else}
+                <Button
+                  variant={joined ? 'secondary' : 'action'}
+                  fullWidth
+                  loading={pendingOrigin === customOrigin}
+                  disabled={!joined && !profile.authorizeUrl}
+                  onclick={() => openOrJoin(customOrigin, profile)}
+                >
+                  {actionLabel(customOrigin, customProfile)}
+                </Button>
+              {/if}
             {/snippet}
             <ServerProfileCard
               origin={customOrigin}
               {profile}
               badge={joined ? m('add_server.directory.joined') : undefined}
-              onIconClick={!joined && !profile.authorizeUrl
+              iconHref={external ? customOrigin : undefined}
+              iconOpensInNewTab={external}
+              onIconClick={external || (!joined && !profile.authorizeUrl)
                 ? undefined
                 : () => openOrJoin(customOrigin, profile)}
               iconActionLabel={actionLabel(customOrigin, profile)}
@@ -308,6 +340,7 @@
           <div class="columns-1 gap-4 sm:columns-2 lg:columns-3">
             {#each entries as entry (entry.origin)}
               {@const joined = registeredServer(entry.origin)}
+              {@const external = opensInServerClient(entry.origin, entry.profile)}
               {@const attribution = sourceAttribution(entry)}
               {@const testimonials = testimonialRecommendations(entry)}
               {#snippet cardActions()}
@@ -320,15 +353,30 @@
                   >
                     <bdi>{attribution.visible}</bdi>
                   </p>
-                  <Button
-                    variant={joined ? 'secondary' : 'action'}
-                    fullWidth
-                    loading={pendingOrigin === entry.origin}
-                    disabled={cardDisabled(entry)}
-                    onclick={() => openOrJoin(entry.origin, entry.profile)}
-                  >
-                    {actionLabel(entry.origin, entry.profile)}
-                  </Button>
+                  {#if external}
+                    <Button
+                      href={entry.origin}
+                      opensInNewTab
+                      variant="secondary"
+                      fullWidth
+                    >
+                      <span>{actionLabel(entry.origin, entry.profile)}</span>
+                      <span
+                        class="iconify icon-[uil--external-link-alt]"
+                        aria-hidden="true"
+                      ></span>
+                    </Button>
+                  {:else}
+                    <Button
+                      variant={joined ? 'secondary' : 'action'}
+                      fullWidth
+                      loading={pendingOrigin === entry.origin}
+                      disabled={cardDisabled(entry)}
+                      onclick={() => openOrJoin(entry.origin, entry.profile)}
+                    >
+                      {actionLabel(entry.origin, entry.profile)}
+                    </Button>
+                  {/if}
                 </div>
               {/snippet}
               <div class="mb-4 break-inside-avoid">
@@ -336,7 +384,9 @@
                   origin={entry.origin}
                   profile={entry.profile}
                   badge={joined ? m('add_server.directory.joined') : undefined}
-                  onIconClick={cardDisabled(entry)
+                  iconHref={external ? entry.origin : undefined}
+                  iconOpensInNewTab={external}
+                  onIconClick={external || cardDisabled(entry)
                     ? undefined
                     : () => openOrJoin(entry.origin, entry.profile)}
                   iconActionLabel={actionLabel(entry.origin, entry.profile)}

--- a/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
@@ -75,6 +75,12 @@ function button(container: HTMLElement, label: string): HTMLButtonElement | unde
   );
 }
 
+function link(container: HTMLElement, label: string): HTMLAnchorElement | undefined {
+  return Array.from(container.querySelectorAll<HTMLAnchorElement>('a')).find(
+    (candidate) => candidate.textContent?.trim() === label
+  );
+}
+
 function recommendation(
   sourceOrigin = 'https://source.example',
   testimonial: string | null = null
@@ -220,12 +226,46 @@ describe('Server Directory page', () => {
     });
   });
 
+  it('hands an incompatible advertised server off to its own client', async () => {
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://old.example',
+          profile: profile('Old server', { version: '0.4.19', authorizeUrl: '' }),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 2
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(link(container, 'Open in new tab')).toBeDefined());
+
+    const externalAction = link(container, 'Open in new tab')!;
+    expect(externalAction.href).toBe('https://old.example/');
+    expect(externalAction.target).toBe('_blank');
+    expect(externalAction.rel).toBe('noopener noreferrer');
+    expect(externalAction.querySelector('.iconify')).toBeTruthy();
+    expect(button(container, 'Sign-in unavailable')).toBeUndefined();
+
+    const iconAction = container.querySelector<HTMLAnchorElement>(
+      '[data-testid="server-directory-entry-icon-action"]'
+    )!;
+    expect(iconAction.href).toBe('https://old.example/');
+    expect(iconAction.target).toBe('_blank');
+    expect(iconAction.rel).toBe('noopener noreferrer');
+    expect(iconAction.getAttribute('aria-label')).toBe('Open in new tab: Old server');
+    expect(mocks.startServerOAuthFlow).not.toHaveBeenCalled();
+  });
+
   it('opens an advertised server that is already joined', async () => {
     mocks.loadServerDirectory.mockResolvedValue({
       entries: [
         {
           origin: 'https://a.example',
-          profile: profile('Alpha'),
+          profile: profile('Alpha', { version: '0.4.19' }),
           sourceOrigins: ['https://source.example'],
           recommendations: [recommendation()]
         }
@@ -241,6 +281,56 @@ describe('Server Directory page', () => {
     await vi.waitFor(() => {
       expect(mocks.goto).toHaveBeenCalledWith('/chat/joined');
     });
+  });
+
+  it('keeps sign-in for an incompatible joined server without a session', async () => {
+    mocks.authenticated.clear();
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://a.example',
+          profile: profile('Alpha', { version: '0.4.19' }),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 2
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(button(container, 'Sign in')).toBeDefined());
+    expect(link(container, 'Open in new tab')).toBeUndefined();
+    button(container, 'Sign in')?.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.startRemoteReauthentication).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'joined' })
+      );
+    });
+  });
+
+  it('keeps sign-in unavailable for a supported server without an OAuth URL', async () => {
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://closed.example',
+          profile: profile('Closed', { authorizeUrl: '' }),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 2
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(button(container, 'Sign-in unavailable')).toBeDefined());
+    expect(button(container, 'Sign-in unavailable')?.disabled).toBe(true);
+    expect(link(container, 'Open in new tab')).toBeUndefined();
+    expect(
+      container.querySelector('[data-testid="server-directory-entry-icon-action"]')
+    ).toBeNull();
   });
 
   it('probes a custom address and shows the same profile card', async () => {
@@ -265,6 +355,31 @@ describe('Server Directory page', () => {
       );
       expect(container.textContent).toContain('Custom description');
     });
+  });
+
+  it('hands a custom server with an unknown version off to its own client', async () => {
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [],
+      failedSourceCount: 0,
+      sourceCount: 2
+    });
+    mocks.getPublicServerInfo.mockResolvedValue(
+      profile('Custom build', { version: 'custom-build', authorizeUrl: '' })
+    );
+
+    const { container } = render(Page);
+    const input = container.querySelector<HTMLInputElement>('#add-server-url')!;
+    input.value = 'custom.example';
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    flushSync();
+    container.querySelector('form')!.requestSubmit();
+
+    await vi.waitFor(() => expect(link(container, 'Open in new tab')).toBeDefined());
+    const externalAction = link(container, 'Open in new tab')!;
+    expect(externalAction.href).toBe('https://custom.example/');
+    expect(externalAction.target).toBe('_blank');
+    expect(externalAction.rel).toBe('noopener noreferrer');
+    expect(mocks.startServerOAuthFlow).not.toHaveBeenCalled();
   });
 
   it('shows compact recommendation provenance with the full accessible source list', async () => {

--- a/docs/fdr/FDR-042-chatto-neighbors.md
+++ b/docs/fdr/FDR-042-chatto-neighbors.md
@@ -1,7 +1,7 @@
 # FDR-042: Chatto Neighbors
 
 **Status:** Experimental
-**Last reviewed:** 2026-08-29
+**Last reviewed:** 2026-08-30
 
 ## Overview
 
@@ -36,6 +36,10 @@ recommendation, not a trust or reciprocal relationship.
   A failed request does not hide profiles that loaded successfully.
 - An advertised server that is already registered remains visible and is
   marked as joined.
+- An unregistered server has a join action only when its discovered version is
+  compatible with the client. When the version is incompatible or unknown,
+  the client opens the server origin in a new tab. The server can then provide
+  its own compatible client.
 - A user can enter a server address directly when the wanted server is not in
   the directory.
 - The advertising server does not contact a Neighbor. It does not test
@@ -173,6 +177,20 @@ aliases must not make the same server appear as a separate Neighbor.
 **Tradeoff:** A configuration change can make an existing Neighbor identify
 the server. Chatto keeps that historical Neighbor so an administrator can
 remove it or change it to an external origin.
+
+### 11. Incompatible servers use their own client
+
+**Decision:** The Server Directory does not add an unregistered server when
+the discovered version is below the client's minimum supported version or is
+unknown. It opens the canonical server origin in a new tab. Registered servers
+keep their open or sign-in action.
+
+**Why:** The remote server can provide a client that matches its release. The
+current client must not start a server registration flow that it cannot
+support.
+
+**Tradeoff:** A server with a missing or non-standard version cannot use the
+direct join flow, even when it might work with the client.
 
 ## Non-goals
 


### PR DESCRIPTION
## Why

The bundled PWA knows its minimum supported server version, but the Server Directory still offered **Join** for older and unversioned servers. That started a registration flow which the current client could not use safely.

## What changed

- Keep **Join** for supported, unregistered servers.
- Show **Open in new tab** with an external-link icon for unsupported or unknown unregistered servers.
- Open the canonical server origin with `target="_blank"` and `rel="noopener noreferrer"` from both the action and server logo.
- Apply the same rule to Neighbor results and direct-address discovery.
- Preserve **Open** and **Sign in** for registered servers, and preserve the unavailable state for supported servers without OAuth.
- Extend the shared Button and server-profile card primitives, including Storybook examples and all complete locale catalogs.
- Update FDR-042, the Neighbor operations guide, the 0.5 release page, component coverage, and the real 0.4 compatibility scenario.

## Compatibility and security

This is a frontend-only behavioral change. It uses the existing discovery version and frontend minimum (`0.5.0-0`). Older clients are unchanged. A newer client hands an older or unversioned server to that server's own client. There are no protobuf, ConnectRPC, persistence, permission, backend, migration, or rollout changes. External links use only canonical HTTP or HTTPS origins and do not grant opener access.

## Test plan

- `mise lint-frontend` — passed.
- `mise test-frontend` — passed: 1,331 server tests, 1,947 browser tests, 228 Storybook tests, and 5 performance-comparison tests.
- `mise build-frontend` — passed, including bundle and CSP checks.
- Svelte autofixer — clean for every changed Svelte file.
- Chrome DevTools MCP — verified wide/light and narrow/dark states, long-name truncation, keyboard focus order, accessible names, safe link attributes, overflow, and the console.
- The production mixed-version E2E now verifies the 0.4 handoff. Its release binaries are CI-provided, so that scenario was not run locally.

Closes #2226.