### PR TITLE
feat(frontend): add bounded recursive neighbor discovery

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
@@ -42,15 +42,21 @@ as a rank or preference.
 ## Use the Server Directory
 
 Select **Add Server** in the Server Gutter to open the Server Directory. The
-client combines the direct Neighbors advertised by every server that is
-registered on the device. It removes duplicate origins, but it does not sort or
-rank the results. Each result shows the registered servers that recommend it.
-When more than two servers recommend the same result, the card shows two server
-names and the number of other recommendations. Each available testimonial has
-a review card under the server profile. The review card shows the device-local
-name and icon of the source server. Different sources can publish different
-testimonials for the same server. Cards use a tapestry layout so that cards
-with different text lengths fit together.
+client starts from every server that is registered on the device. It follows a
+recommendation only when the source and target servers currently advertise each
+other. The client follows at most two verified mutual hops from a registered
+server.
+
+The page adds a server when mutuality and its public profile are verified. A
+later result does not move a card that is already visible. The client removes
+duplicate origins, but it does not sort or rank the results. Each result shows
+the verified servers that recommend it. When more than two servers recommend
+the same result, the card shows two server names and the number of other
+recommendations. Each available testimonial has a review card under the server
+profile. The review card shows the known name and icon of the source server.
+Different sources can publish different testimonials for the same server.
+Cards use a tapestry layout so that cards with different text lengths fit
+together.
 
 The client requests each advertised server's public profile. A result can show
 the server name, description, logo, and banner. If a server is offline or does
@@ -58,6 +64,20 @@ not return a valid public profile, the Server Directory omits it. The Neighbors
 administration page keeps the failed server visible so that an administrator
 can review or remove it. A failed server does not prevent the client from
 showing other results.
+
+The client starts one automatic batch of 12 candidate-directory requests. Use
+**Load more** to start each later batch of 12. One page session permits at most:
+
+- 48 directory requests;
+- 24 profile requests;
+- 72 discovery requests in total; and
+- 120 queued canonical candidates.
+
+The client uses no more than six active discovery requests. Each request has a
+ten-second timeout. It requests one directory and one profile at most for one
+canonical origin. It does not retry a failed request in the same page session.
+A hidden page does not start queued requests. Leaving the page cancels active
+and queued work.
 
 Servers that are already registered remain in the directory and have a
 **Joined** label. A compatible unregistered server has a **Join** action. If
@@ -76,12 +96,17 @@ Neighbor. It does not verify that:
 - the remote administrator approves the listing; or
 - the two servers trust each other.
 
-Reciprocal confirmation is future work. Describe current Neighbors as
-advertised or recommended servers, not as verified partners.
+The client can observe a mutual recommendation when two public directories
+advertise each other. This observation is not authenticated consent, a durable
+relationship, compatibility, or trust. Describe these servers as mutually
+recommended, not as verified partners.
 
 Opening the Neighbors administration page or the Server Directory makes the
-client contact advertised origins and load their public images. The
-server-side Neighbor configuration remains passive.
+client contact advertised origins and load their public images. Public
+discovery requests contain no reusable user credential and do not follow
+redirects. A failed cross-origin request can still send an unauthenticated CORS
+preflight. The session limits bound this request effect. The server-side
+Neighbor configuration remains passive.
 
 ## Use the API
 

--- a/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
@@ -42,21 +42,24 @@ as a rank or preference.
 ## Use the Server Directory
 
 Select **Add Server** in the Server Gutter to open the Server Directory. The
-client starts from every server that is registered on the device. It follows a
-recommendation only when the source and target servers currently advertise each
-other. The client follows at most two verified mutual hops from a registered
-server.
+client starts from every server that is registered on the device. It shows each
+direct recommendation after its public profile loads. Direct recommendations
+do not need reciprocal confirmation.
 
-The page adds a server when mutuality and its public profile are verified. A
-later result does not move a card that is already visible. The client removes
+The client reads a recommended server's directory before it uses that server as
+a recursive source. It expands the server only when the source and target
+currently advertise each other. It follows at most two mutual hops from a
+registered server.
+
+A later result does not move a card that is already visible. The client removes
 duplicate origins, but it does not sort or rank the results. Each result shows
-the verified servers that recommend it. When more than two servers recommend
-the same result, the card shows two server names and the number of other
-recommendations. Each available testimonial has a review card under the server
-profile. The review card shows the known name and icon of the source server.
-Different sources can publish different testimonials for the same server.
-Cards use a tapestry layout so that cards with different text lengths fit
-together.
+the servers whose recommendations are displayed. When more than two servers
+recommend the same result, the card shows two server names and the number of
+other recommendations. Each available testimonial has a review card under the
+server profile. The review card shows the known name and icon of the source
+server. Different sources can publish different testimonials for the same
+server. Cards use a tapestry layout so that cards with different text lengths
+fit together.
 
 The client requests each advertised server's public profile. A result can show
 the server name, description, logo, and banner. If a server is offline or does
@@ -97,9 +100,9 @@ Neighbor. It does not verify that:
 - the two servers trust each other.
 
 The client can observe a mutual recommendation when two public directories
-advertise each other. This observation is not authenticated consent, a durable
-relationship, compatibility, or trust. Describe these servers as mutually
-recommended, not as verified partners.
+advertise each other. It uses this observation only to expand recursive
+discovery. Direct recommendations can remain one-sided. Neither case is
+authenticated consent, a durable relationship, compatibility, or trust.
 
 Opening the Neighbors administration page or the Server Directory makes the
 client contact advertised origins and load their public images. Public

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -93,10 +93,11 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
   <ReleaseFeatureCard title="Advertise friendly Chatto servers">
     Server administrators can maintain a public Neighbor directory. The Server
-    Directory follows mutually advertised recommendations for at most two hops
-    from a user's registered servers. Verified results appear as requests
-    finish, and fixed batch, concurrency, timeout, and page-session limits bound
-    browser work. Administrators can add a public testimonial to each
+    Directory shows direct recommendations from a user's registered servers. It
+    follows a remote server recursively only when both servers advertise each
+    other, for at most two mutual hops. Results appear as requests finish, and
+    fixed batch, concurrency, timeout, and page-session limits bound browser
+    work. Administrators can add a public testimonial to each
     recommendation. Testimonials support paragraphs and limited inline
     Markdown. The directory shows them as source-labelled review cards below
     each server profile in a tapestry layout. Mutuality is a current client

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -93,13 +93,14 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
   <ReleaseFeatureCard title="Advertise friendly Chatto servers">
     Server administrators can maintain a public Neighbor directory. The Server
-    Directory combines recommendations from a user's registered servers, loads
-    their public profiles, and keeps joined servers visible. Administrators can
-    add a public testimonial to each recommendation. Testimonials support
-    paragraphs and limited inline Markdown. The directory shows them as
-    source-labelled review cards below each server profile in a tapestry
-    layout. A listing is a
-    recommendation, not a verified or reciprocal relationship.
+    Directory follows mutually advertised recommendations for at most two hops
+    from a user's registered servers. Verified results appear as requests
+    finish, and fixed batch, concurrency, timeout, and page-session limits bound
+    browser work. Administrators can add a public testimonial to each
+    recommendation. Testimonials support paragraphs and limited inline
+    Markdown. The directory shows them as source-labelled review cards below
+    each server profile in a tapestry layout. Mutuality is a current client
+    observation, not a verified relationship or trust statement.
   </ReleaseFeatureCard>
 
   <ReleaseFeatureCard title="Remote clients connect without allowlists" size="large">

--- a/apps/frontend/messages/ar/add_server.json
+++ b/apps/frontend/messages/ar/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "شهادات عن {server}"
+      "testimonials_for": "شهادات عن {server}",
+      "discovering": "جارٍ اكتشاف المزيد من الخوادم…",
+      "load_more": "تحميل المزيد",
+      "session_limit_reached": "تم بلوغ حد الاكتشاف لهذه الجلسة."
     }
   }
 }

--- a/apps/frontend/messages/cs-CZ/add_server.json
+++ b/apps/frontend/messages/cs-CZ/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Reference pro {server}"
+      "testimonials_for": "Reference pro {server}",
+      "discovering": "Probíhá hledání dalších serverů…",
+      "load_more": "Načíst další",
+      "session_limit_reached": "Byl dosažen limit vyhledávání pro tuto relaci."
     }
   }
 }

--- a/apps/frontend/messages/de-DE/add_server.json
+++ b/apps/frontend/messages/de-DE/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "Deine Server konnten keine Empfehlungen liefern. Du kannst dich weiterhin direkt verbinden.",
       "empty_title": "Noch keine empfohlenen Server",
       "empty_body": "Du kannst dich weiterhin direkt über eine Serveradresse verbinden.",
-      "testimonials_for": "Empfehlungstexte für {server}"
+      "testimonials_for": "Empfehlungstexte für {server}",
+      "discovering": "Weitere Server werden gesucht…",
+      "load_more": "Mehr laden",
+      "session_limit_reached": "Das Suchlimit für diese Sitzung wurde erreicht."
     }
   }
 }

--- a/apps/frontend/messages/en-GB/add_server.json
+++ b/apps/frontend/messages/en-GB/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Testimonials for {server}"
+      "testimonials_for": "Testimonials for {server}",
+      "discovering": "Discovering more servers…",
+      "load_more": "Load more",
+      "session_limit_reached": "The discovery limit for this session has been reached."
     }
   }
 }

--- a/apps/frontend/messages/eo/add_server.json
+++ b/apps/frontend/messages/eo/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Atestoj pri {server}"
+      "testimonials_for": "Atestoj pri {server}",
+      "discovering": "Pliaj serviloj estas serĉataj…",
+      "load_more": "Ŝargi pli",
+      "session_limit_reached": "La malkovra limo por ĉi tiu seanco estas atingita."
     }
   }
 }

--- a/apps/frontend/messages/es-419/add_server.json
+++ b/apps/frontend/messages/es-419/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Testimonios sobre {server}"
+      "testimonials_for": "Testimonios sobre {server}",
+      "discovering": "Buscando más servidores…",
+      "load_more": "Cargar más",
+      "session_limit_reached": "Se alcanzó el límite de descubrimiento para esta sesión."
     }
   }
 }

--- a/apps/frontend/messages/es-ES/add_server.json
+++ b/apps/frontend/messages/es-ES/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Testimonios sobre {server}"
+      "testimonials_for": "Testimonios sobre {server}",
+      "discovering": "Buscando más servidores…",
+      "load_more": "Cargar más",
+      "session_limit_reached": "Se ha alcanzado el límite de descubrimiento para esta sesión."
     }
   }
 }

--- a/apps/frontend/messages/et-EE/add_server.json
+++ b/apps/frontend/messages/et-EE/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Serveri {server} iseloomustused"
+      "testimonials_for": "Serveri {server} iseloomustused",
+      "discovering": "Otsime veel servereid…",
+      "load_more": "Laadi veel",
+      "session_limit_reached": "Selle seansi otsingulimiit on täis."
     }
   }
 }

--- a/apps/frontend/messages/fr-CA/add_server.json
+++ b/apps/frontend/messages/fr-CA/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Témoignages pour {server}"
+      "testimonials_for": "Témoignages pour {server}",
+      "discovering": "Recherche d’autres serveurs…",
+      "load_more": "Charger plus",
+      "session_limit_reached": "La limite de découverte pour cette session est atteinte."
     }
   }
 }

--- a/apps/frontend/messages/fr-FR/add_server.json
+++ b/apps/frontend/messages/fr-FR/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Témoignages pour {server}"
+      "testimonials_for": "Témoignages pour {server}",
+      "discovering": "Recherche d’autres serveurs…",
+      "load_more": "Charger plus",
+      "session_limit_reached": "La limite de découverte pour cette session est atteinte."
     }
   }
 }

--- a/apps/frontend/messages/he-IL/add_server.json
+++ b/apps/frontend/messages/he-IL/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "המלצות על {server}"
+      "testimonials_for": "המלצות על {server}",
+      "discovering": "מתבצע חיפוש אחר שרתים נוספים…",
+      "load_more": "טעינת שרתים נוספים",
+      "session_limit_reached": "הגעת למגבלת הגילוי עבור הפעלה זו."
     }
   }
 }

--- a/apps/frontend/messages/it-IT/add_server.json
+++ b/apps/frontend/messages/it-IT/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Testimonianze per {server}"
+      "testimonials_for": "Testimonianze per {server}",
+      "discovering": "Ricerca di altri server…",
+      "load_more": "Carica altri",
+      "session_limit_reached": "È stato raggiunto il limite di scoperta per questa sessione."
     }
   }
 }

--- a/apps/frontend/messages/ja-JP/add_server.json
+++ b/apps/frontend/messages/ja-JP/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "{server} への推薦文"
+      "testimonials_for": "{server} への推薦文",
+      "discovering": "さらにサーバーを検索しています…",
+      "load_more": "さらに読み込む",
+      "session_limit_reached": "このセッションの検索上限に達しました。"
     }
   }
 }

--- a/apps/frontend/messages/lv-LV/add_server.json
+++ b/apps/frontend/messages/lv-LV/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Atsauksmes par {server}"
+      "testimonials_for": "Atsauksmes par {server}",
+      "discovering": "Meklē citus serverus…",
+      "load_more": "Ielādēt vēl",
+      "session_limit_reached": "Ir sasniegts šīs sesijas atklāšanas limits."
     }
   }
 }

--- a/apps/frontend/messages/nb-NO/add_server.json
+++ b/apps/frontend/messages/nb-NO/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Omtaler av {server}"
+      "testimonials_for": "Omtaler av {server}",
+      "discovering": "Oppdager flere servere…",
+      "load_more": "Last inn flere",
+      "session_limit_reached": "Oppdagelsesgrensen for denne økten er nådd."
     }
   }
 }

--- a/apps/frontend/messages/nl-BE/add_server.json
+++ b/apps/frontend/messages/nl-BE/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Aanbevelingen voor {server}"
+      "testimonials_for": "Aanbevelingen voor {server}",
+      "discovering": "Meer servers zoeken…",
+      "load_more": "Meer laden",
+      "session_limit_reached": "De ontdekkingslimiet voor deze sessie is bereikt."
     }
   }
 }

--- a/apps/frontend/messages/nl-NL/add_server.json
+++ b/apps/frontend/messages/nl-NL/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Aanbevelingen voor {server}"
+      "testimonials_for": "Aanbevelingen voor {server}",
+      "discovering": "Meer servers zoeken…",
+      "load_more": "Meer laden",
+      "session_limit_reached": "De ontdekkingslimiet voor deze sessie is bereikt."
     }
   }
 }

--- a/apps/frontend/messages/pl-PL/add_server.json
+++ b/apps/frontend/messages/pl-PL/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Opinie o {server}"
+      "testimonials_for": "Opinie o {server}",
+      "discovering": "Wyszukiwanie kolejnych serwerów…",
+      "load_more": "Wczytaj więcej",
+      "session_limit_reached": "Osiągnięto limit wyszukiwania dla tej sesji."
     }
   }
 }

--- a/apps/frontend/messages/pt-BR/add_server.json
+++ b/apps/frontend/messages/pt-BR/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Depoimentos sobre {server}"
+      "testimonials_for": "Depoimentos sobre {server}",
+      "discovering": "Descobrindo mais servidores…",
+      "load_more": "Carregar mais",
+      "session_limit_reached": "O limite de descoberta desta sessão foi atingido."
     }
   }
 }

--- a/apps/frontend/messages/pt-PT/add_server.json
+++ b/apps/frontend/messages/pt-PT/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Testemunhos sobre {server}"
+      "testimonials_for": "Testemunhos sobre {server}",
+      "discovering": "A descobrir mais servidores…",
+      "load_more": "Carregar mais",
+      "session_limit_reached": "O limite de descoberta desta sessão foi atingido."
     }
   }
 }

--- a/apps/frontend/messages/ru-RU/add_server.json
+++ b/apps/frontend/messages/ru-RU/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Отзывы о {server}"
+      "testimonials_for": "Отзывы о {server}",
+      "discovering": "Поиск других серверов…",
+      "load_more": "Загрузить ещё",
+      "session_limit_reached": "Достигнут лимит обнаружения для этого сеанса."
     }
   }
 }

--- a/apps/frontend/messages/sv-SE/add_server.json
+++ b/apps/frontend/messages/sv-SE/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Omdömen för {server}"
+      "testimonials_for": "Omdömen för {server}",
+      "discovering": "Upptäcker fler servrar…",
+      "load_more": "Läs in fler",
+      "session_limit_reached": "Upptäcktsgränsen för den här sessionen har nåtts."
     }
   }
 }

--- a/apps/frontend/messages/tr-TR/add_server.json
+++ b/apps/frontend/messages/tr-TR/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "{server} için görüşler"
+      "testimonials_for": "{server} için görüşler",
+      "discovering": "Daha fazla sunucu keşfediliyor…",
+      "load_more": "Daha fazla yükle",
+      "session_limit_reached": "Bu oturumun keşif sınırına ulaşıldı."
     }
   }
 }

--- a/apps/frontend/messages/uk-UA/add_server.json
+++ b/apps/frontend/messages/uk-UA/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "Відгуки про {server}"
+      "testimonials_for": "Відгуки про {server}",
+      "discovering": "Пошук інших серверів…",
+      "load_more": "Завантажити ще",
+      "session_limit_reached": "Досягнуто ліміту пошуку для цього сеансу."
     }
   }
 }

--- a/apps/frontend/messages/zh-CN/add_server.json
+++ b/apps/frontend/messages/zh-CN/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "给 {server} 的推荐语"
+      "testimonials_for": "给 {server} 的推荐语",
+      "discovering": "正在发现更多服务器…",
+      "load_more": "加载更多",
+      "session_limit_reached": "已达到本次会话的发现上限。"
     }
   }
 }

--- a/apps/frontend/messages/zh-TW/add_server.json
+++ b/apps/frontend/messages/zh-TW/add_server.json
@@ -32,7 +32,10 @@
       "unavailable_body": "The joined servers could not provide their recommendations. You can still connect directly.",
       "empty_title": "No recommended servers yet",
       "empty_body": "You can still connect directly with a server address.",
-      "testimonials_for": "給 {server} 的推薦語"
+      "testimonials_for": "給 {server} 的推薦語",
+      "discovering": "正在探索更多伺服器…",
+      "load_more": "載入更多",
+      "session_limit_reached": "已達到本次工作階段的探索上限。"
     }
   }
 }

--- a/apps/frontend/src/lib/api-client-tests/server.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/server.spec.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getPublicNeighbors,
   getPublicServerInfo,
@@ -25,6 +25,8 @@ vi.mock('@connectrpc/connect-web', () => ({
 }));
 
 describe('public server discovery', () => {
+  afterEach(() => vi.unstubAllGlobals());
+
   beforeEach(() => {
     mocks.createClient.mockReset();
     mocks.createConnectTransport.mockReset();
@@ -97,6 +99,7 @@ describe('public server discovery', () => {
 
     expect(mocks.createConnectTransport).toHaveBeenCalledWith({
       baseUrl: 'https://chat.example.test/api/connect',
+      fetch: expect.any(Function),
       useBinaryFormat: false
     });
     expect(mocks.getServer).toHaveBeenCalledWith({}, { signal: undefined });
@@ -122,6 +125,31 @@ describe('public server discovery', () => {
         }
       ]
     });
+  });
+
+  it('omits browser credentials, referrers, and redirects from public discovery', async () => {
+    const browserFetch = vi.fn().mockResolvedValue(new Response());
+    vi.stubGlobal('fetch', browserFetch);
+    mocks.getServer.mockResolvedValue({ profile: { name: 'Chatto', version: '0.5.0' } });
+
+    await getPublicServerInfo('https://chat.example.test');
+    const transportOptions = mocks.createConnectTransport.mock.calls[0]?.[0] as {
+      fetch: typeof fetch;
+    };
+    await transportOptions.fetch('https://chat.example.test/api/connect/discovery', {
+      credentials: 'include',
+      redirect: 'follow',
+      referrerPolicy: 'origin'
+    });
+
+    expect(browserFetch).toHaveBeenCalledWith(
+      'https://chat.example.test/api/connect/discovery',
+      expect.objectContaining({
+        credentials: 'omit',
+        redirect: 'error',
+        referrerPolicy: 'no-referrer'
+      })
+    );
   });
 
   it('uses profile defaults when optional public profile fields are absent', async () => {

--- a/apps/frontend/src/lib/api-client/connect.ts
+++ b/apps/frontend/src/lib/api-client/connect.ts
@@ -99,10 +99,17 @@ export function createPublicChattoClient<T extends ServiceType>(
 ): Client<T> {
   return createClient(
     service,
-    createChattoTransport(
-      { baseUrl: connectEndpoint(baseUrl) },
-      { useBinaryFormat: false },
-    ),
+    createConnectTransport({
+      baseUrl: connectEndpoint(baseUrl),
+      useBinaryFormat: false,
+      fetch: (input, init) =>
+        fetch(input, {
+          ...init,
+          credentials: "omit",
+          redirect: "error",
+          referrerPolicy: "no-referrer",
+        }),
+    }),
   );
 }
 

--- a/apps/frontend/src/lib/serverDirectory.spec.ts
+++ b/apps/frontend/src/lib/serverDirectory.spec.ts
@@ -2,12 +2,15 @@ import { Code, ConnectError } from '@connectrpc/connect';
 import { describe, expect, it, vi } from 'vitest';
 import {
   canonicalServerOrigin,
-  loadServerDirectory,
-  serverOriginFromInput
+  createServerDirectoryDiscovery,
+  SERVER_DIRECTORY_LIMITS,
+  serverOriginFromInput,
+  type ServerDirectoryDiscovery,
+  type ServerDirectorySnapshot
 } from './serverDirectory';
-import type { PublicServerInfo } from '$lib/api-client/server';
+import type { PublicNeighbor, PublicServerInfo } from '$lib/api-client/server';
 
-function recommendation(origin: string, testimonial: string | null = null) {
+function recommendation(origin: string, testimonial: string | null = null): PublicNeighbor {
   return { origin, testimonial };
 }
 
@@ -25,6 +28,20 @@ function profile(name: string): PublicServerInfo {
     bannerUrl: null,
     authProviders: []
   };
+}
+
+function observe(discovery: ServerDirectoryDiscovery): {
+  snapshots: ServerDirectorySnapshot[];
+  latest: () => ServerDirectorySnapshot;
+} {
+  const snapshots: ServerDirectorySnapshot[] = [];
+  discovery.subscribe((snapshot) => snapshots.push(snapshot));
+  return { snapshots, latest: () => snapshots.at(-1)! };
+}
+
+async function startAndSettle(discovery: ServerDirectoryDiscovery): Promise<void> {
+  discovery.start();
+  await discovery.whenIdle();
 }
 
 describe('canonicalServerOrigin', () => {
@@ -49,148 +66,248 @@ describe('serverOriginFromInput', () => {
   });
 });
 
-describe('loadServerDirectory', () => {
-  it('keeps first-seen order, deduplicates origins, and tolerates failed sources and profiles', async () => {
+describe('ServerDirectoryDiscovery', () => {
+  it('requires a mutual recommendation and preserves bounded testimonial text', async () => {
+    const oversized = `  ${'界'.repeat(505)}  `;
     const listNeighbors = vi.fn(async (origin: string) => {
-      if (origin === 'https://broken.example') throw new Error('offline');
-      if (origin === 'https://one.example') {
+      if (origin === 'https://source.example') {
         return [
-          recommendation('https://z.example', 'A quiet place for careful conversations.'),
-          recommendation('HTTPS://A.EXAMPLE:443/', 'A lively maker community.'),
-          recommendation('https://invalid.example/path')
+          recommendation('HTTPS://NEIGHBOR.EXAMPLE:443/path', oversized),
+          recommendation('https://neighbor.example', 'ignored duplicate')
         ];
       }
-      return [
-        recommendation('https://a.example', 'A second endorsement.'),
-        recommendation('mailto:not-a-server')
-      ];
+      return [recommendation('https://source.example', 'The return recommendation.')];
     });
-    const getServerInfo = vi.fn(async (origin: string) => {
-      if (origin === 'https://invalid.example') throw new Error('not Chatto');
-      return profile(origin);
+    const discovery = createServerDirectoryDiscovery(['HTTPS://SOURCE.EXAMPLE:443/path'], {
+      listNeighbors,
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
     });
+    const observed = observe(discovery);
 
-    const snapshot = await loadServerDirectory(
-      ['https://one.example', 'https://broken.example', 'https://two.example'],
-      { listNeighbors, getServerInfo }
-    );
+    await startAndSettle(discovery);
 
-    expect(snapshot).toMatchObject({ failedSourceCount: 1, sourceCount: 3 });
-    expect(snapshot.entries.map((entry) => entry.origin)).toEqual([
-      'https://z.example',
+    expect(listNeighbors).toHaveBeenCalledTimes(2);
+    const neighbor = observed
+      .latest()
+      .entries.find((entry) => entry.origin === 'https://neighbor.example');
+    expect(neighbor).toMatchObject({
+      sourceOrigins: ['https://source.example'],
+      recommendations: [{ sourceOrigin: 'https://source.example', testimonial: '界'.repeat(500) }]
+    });
+  });
+
+  it('hides unilateral candidates and records them separately from failures', async () => {
+    const discovery = createServerDirectoryDiscovery(['https://source.example'], {
+      listNeighbors: vi.fn(async (origin: string) =>
+        origin === 'https://source.example' ? [recommendation('https://unilateral.example')] : []
+      ),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+
+    await startAndSettle(discovery);
+
+    expect(observed.latest().entries).toEqual([]);
+    expect(observed.latest()).toMatchObject({
+      failedSourceCount: 0,
+      failedCandidateCount: 0,
+      nonMutualCandidateCount: 1
+    });
+  });
+
+  it('does not let two unverified candidates promote each other', async () => {
+    const directories: Record<string, PublicNeighbor[]> = {
+      'https://a.example': [recommendation('https://b.example')],
+      'https://c.example': [recommendation('https://x.example')],
+      'https://b.example': [recommendation('https://x.example')],
+      'https://x.example': [recommendation('https://b.example')]
+    };
+    const discovery = createServerDirectoryDiscovery(['https://a.example', 'https://c.example'], {
+      listNeighbors: vi.fn(async (origin: string) => directories[origin] ?? []),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+
+    await startAndSettle(discovery);
+
+    expect(observed.latest().entries).toEqual([]);
+    expect(observed.latest().profileRequestCount).toBe(0);
+  });
+
+  it('discovers two mutual hops and does not expand the second hop', async () => {
+    const directories: Record<string, PublicNeighbor[]> = {
+      'https://a.example': [recommendation('https://b.example')],
+      'https://b.example': [
+        recommendation('https://a.example'),
+        recommendation('https://c.example')
+      ],
+      'https://c.example': [
+        recommendation('https://b.example'),
+        recommendation('https://too-far.example')
+      ]
+    };
+    const listNeighbors = vi.fn(async (origin: string) => directories[origin] ?? []);
+    const discovery = createServerDirectoryDiscovery(['https://a.example'], {
+      listNeighbors,
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+
+    await startAndSettle(discovery);
+
+    expect(observed.latest().entries.map(({ origin }) => origin)).toEqual([
+      'https://b.example',
       'https://a.example',
-      'https://invalid.example'
+      'https://c.example'
     ]);
-    expect(snapshot.entries.map((entry) => entry.sourceOrigins)).toEqual([
-      ['https://one.example'],
-      ['https://one.example', 'https://two.example'],
-      ['https://one.example']
-    ]);
-    expect(snapshot.entries[1]?.recommendations).toEqual([
-      {
-        sourceOrigin: 'https://one.example',
-        testimonial: 'A lively maker community.'
-      },
-      { sourceOrigin: 'https://two.example', testimonial: 'A second endorsement.' }
-    ]);
-    expect(snapshot.entries.at(-1)?.profile).toBeNull();
+    expect(listNeighbors).not.toHaveBeenCalledWith('https://too-far.example', expect.anything());
   });
 
-  it('deduplicates repeated recommendations from the same source', async () => {
-    const snapshot = await loadServerDirectory(['https://source.example'], {
-      listNeighbors: vi.fn(async () => [
-        recommendation('https://neighbor.example', 'First testimonial'),
-        recommendation('HTTPS://NEIGHBOR.EXAMPLE:443/path', 'Ignored duplicate')
-      ]),
-      getServerInfo: vi.fn(async (origin: string) => profile(origin))
-    });
-
-    expect(snapshot.entries).toEqual([
-      {
-        origin: 'https://neighbor.example',
-        profile: profile('https://neighbor.example'),
-        sourceOrigins: ['https://source.example'],
-        recommendations: [
-          { sourceOrigin: 'https://source.example', testimonial: 'First testimonial' }
-        ]
-      }
-    ]);
-  });
-
-  it('normalizes and bounds untrusted testimonial text', async () => {
-    const oversized = `  ${'界'.repeat(505)}  `;
-    const snapshot = await loadServerDirectory(['https://source.example'], {
-      listNeighbors: vi.fn(async () => [
-        recommendation('https://bounded.example', oversized),
-        recommendation('https://empty.example', '   ')
-      ]),
-      getServerInfo: vi.fn(async (origin: string) => profile(origin))
-    });
-
-    expect(snapshot.entries[0]?.recommendations[0]?.testimonial).toBe('界'.repeat(500));
-    expect(snapshot.entries[1]?.recommendations[0]?.testimonial).toBeNull();
-  });
-
-  it('canonicalizes and deduplicates registered source origins', async () => {
-    const listNeighbors = vi.fn(async () => [recommendation('https://neighbor.example')]);
-
-    const snapshot = await loadServerDirectory(
-      ['HTTPS://SOURCE.EXAMPLE:443/path', 'https://source.example', 'not a URL'],
-      {
-        listNeighbors,
-        getServerInfo: vi.fn(async (origin: string) => profile(origin))
-      }
-    );
-
-    expect(listNeighbors).toHaveBeenCalledOnce();
-    expect(listNeighbors).toHaveBeenCalledWith(
-      'https://source.example',
-      expect.objectContaining({ signal: expect.any(AbortSignal) })
-    );
-    expect(snapshot.sourceCount).toBe(1);
-    expect(snapshot.entries[0]?.sourceOrigins).toEqual(['https://source.example']);
-  });
-
-  it('limits each source to the server-side directory maximum', async () => {
-    const advertised = Array.from({ length: 105 }, (_, index) =>
-      recommendation(`https://n${index}.example`)
+  it('deduplicates cycles and canonical aliases before requests', async () => {
+    const listNeighbors = vi.fn(async (origin: string) =>
+      origin === 'https://a.example'
+        ? [recommendation('https://b.example'), recommendation('HTTPS://B.EXAMPLE:443/path')]
+        : [recommendation('https://a.example')]
     );
     const getServerInfo = vi.fn(async (origin: string) => profile(origin));
+    const discovery = createServerDirectoryDiscovery(
+      ['HTTPS://A.EXAMPLE:443/path', 'https://a.example', 'not a URL'],
+      { listNeighbors, getServerInfo }
+    );
+    const observed = observe(discovery);
 
-    const snapshot = await loadServerDirectory(['https://source.example'], {
-      listNeighbors: vi.fn(async () => advertised),
-      getServerInfo
+    await startAndSettle(discovery);
+
+    expect(listNeighbors.mock.calls.map(([origin]) => origin).sort()).toEqual([
+      'https://a.example',
+      'https://b.example'
+    ]);
+    expect(getServerInfo).toHaveBeenCalledTimes(2);
+    expect(observed.latest().entries).toHaveLength(2);
+    expect(observed.latest().sourceCount).toBe(1);
+  });
+
+  it('publishes a completed branch while another root is still slow', async () => {
+    let releaseSlow!: () => void;
+    const slow = new Promise<PublicNeighbor[]>((resolve) => {
+      releaseSlow = () => resolve([]);
     });
+    const listNeighbors = vi.fn(async (origin: string) => {
+      if (origin === 'https://slow.example') return slow;
+      if (origin === 'https://a.example') return [recommendation('https://b.example')];
+      return [recommendation('https://a.example')];
+    });
+    const discovery = createServerDirectoryDiscovery(
+      ['https://a.example', 'https://slow.example'],
+      { listNeighbors, getServerInfo: vi.fn(async (origin: string) => profile(origin)) }
+    );
+    const observed = observe(discovery);
+    discovery.start();
 
-    expect(snapshot.entries).toHaveLength(100);
-    expect(getServerInfo).toHaveBeenCalledTimes(100);
+    await vi.waitFor(() =>
+      expect(observed.latest().entries.some(({ origin }) => origin === 'https://b.example')).toBe(
+        true
+      )
+    );
+    expect(observed.latest().isLoading).toBe(true);
+    releaseSlow();
+    await discovery.whenIdle();
   });
 
-  it('does not turn query cancellation into a cached partial-failure result', async () => {
-    const controller = new AbortController();
-    controller.abort(new DOMException('cancelled', 'AbortError'));
+  it('enriches an existing entry without moving it', async () => {
+    let releaseSecond!: () => void;
+    const second = new Promise<PublicNeighbor[]>((resolve) => {
+      releaseSecond = () => resolve([recommendation('https://target.example')]);
+    });
+    const directories: Record<string, PublicNeighbor[]> = {
+      'https://one.example': [recommendation('https://target.example', 'First')],
+      'https://target.example': [
+        recommendation('https://one.example'),
+        recommendation('https://two.example')
+      ]
+    };
+    const listNeighbors = vi.fn(async (origin: string) => {
+      if (origin === 'https://two.example') return second;
+      return directories[origin] ?? [];
+    });
+    const discovery = createServerDirectoryDiscovery(
+      ['https://one.example', 'https://two.example'],
+      { listNeighbors, getServerInfo: vi.fn(async (origin: string) => profile(origin)) }
+    );
+    const observed = observe(discovery);
+    discovery.start();
 
-    await expect(
-      loadServerDirectory(['https://source.example'], {
-        signal: controller.signal,
-        listNeighbors: vi.fn(async () => [recommendation('https://neighbor.example')]),
-        getServerInfo: vi.fn(async () => profile('Neighbor'))
-      })
-    ).rejects.toMatchObject({ name: 'AbortError' });
+    await vi.waitFor(() => {
+      const target = observed
+        .latest()
+        .entries.find((entry) => entry.origin === 'https://target.example');
+      expect(target?.sourceOrigins).toEqual(['https://one.example']);
+    });
+    const position = observed
+      .latest()
+      .entries.findIndex((entry) => entry.origin === 'https://target.example');
+
+    releaseSecond();
+    await discovery.whenIdle();
+
+    const target = observed
+      .latest()
+      .entries.find((entry) => entry.origin === 'https://target.example');
+    expect(target?.sourceOrigins).toEqual(['https://one.example', 'https://two.example']);
+    expect(observed.latest().entries[position]?.origin).toBe('https://target.example');
   });
 
-  it('treats an older server without ListNeighbors as an empty source', async () => {
-    const snapshot = await loadServerDirectory(['https://old.example'], {
+  it('keeps failed profiles hidden and distinguishes root and candidate failures', async () => {
+    const discovery = createServerDirectoryDiscovery(
+      ['https://source.example', 'https://broken-root.example'],
+      {
+        listNeighbors: vi.fn(async (origin: string) => {
+          if (origin === 'https://broken-root.example') throw new Error('offline');
+          if (origin === 'https://source.example') {
+            return [
+              recommendation('https://hidden.example'),
+              recommendation('https://broken-candidate.example')
+            ];
+          }
+          if (origin === 'https://broken-candidate.example') throw new Error('offline');
+          return [recommendation('https://source.example')];
+        }),
+        getServerInfo: vi.fn(async (origin: string) => {
+          if (origin === 'https://hidden.example') throw new Error('invalid profile');
+          return profile(origin);
+        })
+      }
+    );
+    const observed = observe(discovery);
+
+    await startAndSettle(discovery);
+
+    expect(
+      observed.latest().entries.some(({ origin }) => origin === 'https://hidden.example')
+    ).toBe(false);
+    expect(observed.latest()).toMatchObject({ failedSourceCount: 1, failedCandidateCount: 1 });
+  });
+
+  it('treats Unimplemented as an empty directory without a failure', async () => {
+    const discovery = createServerDirectoryDiscovery(['https://old.example'], {
       listNeighbors: vi.fn(async () => {
         throw new ConnectError('not implemented', Code.Unimplemented);
       }),
-      getServerInfo: vi.fn(async () => profile('unused'))
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
     });
+    const observed = observe(discovery);
 
-    expect(snapshot).toEqual({ entries: [], failedSourceCount: 0, sourceCount: 1 });
+    await startAndSettle(discovery);
+
+    expect(observed.latest()).toMatchObject({
+      entries: [],
+      failedSourceCount: 0,
+      failedCandidateCount: 0,
+      sourceCount: 1
+    });
   });
 
-  it('loads at most six source directories concurrently', async () => {
+  it('uses one shared six-request scheduler', async () => {
     let active = 0;
     let maximumActive = 0;
     let releaseRequests!: () => void;
@@ -204,17 +321,217 @@ describe('loadServerDirectory', () => {
       active -= 1;
       return [];
     });
-
-    const loading = loadServerDirectory(
+    const discovery = createServerDirectoryDiscovery(
       Array.from({ length: 12 }, (_, index) => `https://source-${index}.example`),
       { listNeighbors, getServerInfo: vi.fn(async (origin: string) => profile(origin)) }
     );
+    discovery.start();
 
     await vi.waitFor(() => expect(listNeighbors).toHaveBeenCalledTimes(6));
     expect(maximumActive).toBe(6);
     releaseRequests();
-    await loading;
+    await discovery.whenIdle();
     expect(listNeighbors).toHaveBeenCalledTimes(12);
     expect(maximumActive).toBe(6);
+  });
+
+  it('keeps combined directory and profile work within the shared ceiling', async () => {
+    const candidates = Array.from({ length: 12 }, (_, index) => `https://n-${index}.example`);
+    let active = 0;
+    let maximumActive = 0;
+    let releaseFirst!: () => void;
+    let releaseRest!: () => void;
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const restGate = new Promise<void>((resolve) => {
+      releaseRest = resolve;
+    });
+    const listNeighbors = vi.fn(async (origin: string) => {
+      if (origin === 'https://source.example') {
+        return candidates.map((candidate) => recommendation(candidate));
+      }
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await (origin === candidates[0] ? firstGate : restGate);
+      active -= 1;
+      return [recommendation('https://source.example')];
+    });
+    const getServerInfo = vi.fn(async (origin: string) => {
+      active += 1;
+      maximumActive = Math.max(maximumActive, active);
+      await restGate;
+      active -= 1;
+      return profile(origin);
+    });
+    const discovery = createServerDirectoryDiscovery(['https://source.example'], {
+      listNeighbors,
+      getServerInfo
+    });
+    discovery.start();
+
+    await vi.waitFor(() => expect(listNeighbors).toHaveBeenCalledTimes(7));
+    releaseFirst();
+    await vi.waitFor(() => expect(getServerInfo).toHaveBeenCalled());
+    expect(active).toBe(6);
+    expect(maximumActive).toBe(6);
+
+    releaseRest();
+    await discovery.whenIdle();
+    expect(maximumActive).toBe(6);
+  });
+
+  it('rotates ready sources within one candidate batch', async () => {
+    const fromA = Array.from({ length: 20 }, (_, index) => `https://a-${index}.example`);
+    const fromB = Array.from({ length: 20 }, (_, index) => `https://b-${index}.example`);
+    const listNeighbors = vi.fn(async (origin: string) => {
+      if (origin === 'https://a.example') return fromA.map((value) => recommendation(value));
+      if (origin === 'https://b.example') return fromB.map((value) => recommendation(value));
+      return [
+        recommendation(origin.startsWith('https://a-') ? 'https://a.example' : 'https://b.example')
+      ];
+    });
+    const discovery = createServerDirectoryDiscovery(
+      ['https://a.example', 'https://b.example'],
+      { listNeighbors, getServerInfo: vi.fn(async (origin: string) => profile(origin)) }
+    );
+
+    await startAndSettle(discovery);
+
+    const candidateCalls = listNeighbors.mock.calls
+      .map(([origin]) => origin)
+      .filter((origin) => origin !== 'https://a.example' && origin !== 'https://b.example');
+    expect(candidateCalls).toHaveLength(SERVER_DIRECTORY_LIMITS.candidateBatchSize);
+    expect(candidateCalls).toContain('https://b-0.example');
+  });
+
+  it('times out a stalled request after ten seconds', async () => {
+    expect(SERVER_DIRECTORY_LIMITS.timeoutMs).toBe(10_000);
+    const discovery = createServerDirectoryDiscovery(['https://slow.example'], {
+      requestTimeoutMs: 5,
+      listNeighbors: vi.fn(
+        async (_origin: string, options?: { signal?: AbortSignal }): Promise<PublicNeighbor[]> =>
+          new Promise((_, reject) =>
+            options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+              once: true
+            })
+          )
+      ),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+    discovery.start();
+
+    await discovery.whenIdle();
+
+    expect(observed.latest().failedSourceCount).toBe(1);
+  });
+
+  it('pauses queued work while hidden and resumes it when visible', async () => {
+    let releaseRequests!: () => void;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequests = resolve;
+    });
+    const listNeighbors = vi.fn(async () => {
+      await requestGate;
+      return [];
+    });
+    const discovery = createServerDirectoryDiscovery(
+      Array.from({ length: 8 }, (_, index) => `https://source-${index}.example`),
+      {
+        listNeighbors,
+        getServerInfo: vi.fn(async (origin: string) => profile(origin))
+      }
+    );
+    const observed = observe(discovery);
+    discovery.start();
+
+    await vi.waitFor(() => expect(listNeighbors).toHaveBeenCalledTimes(6));
+    discovery.setVisible(false);
+    releaseRequests();
+    await vi.waitFor(() => expect(observed.latest().activeRequestCount).toBe(0));
+    expect(listNeighbors).toHaveBeenCalledTimes(6);
+    expect(observed.latest().isPaused).toBe(true);
+
+    discovery.setVisible(true);
+    await discovery.whenIdle();
+    expect(listNeighbors).toHaveBeenCalledTimes(8);
+  });
+
+  it('aborts active work and rejects idle waiters on cancellation', async () => {
+    let requestSignal: AbortSignal | undefined;
+    const discovery = createServerDirectoryDiscovery(['https://source.example'], {
+      listNeighbors: vi.fn(
+        async (_origin: string, options?: { signal?: AbortSignal }): Promise<PublicNeighbor[]> => {
+          requestSignal = options?.signal;
+          return new Promise((_, reject) =>
+            options?.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+              once: true
+            })
+          );
+        }
+      ),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+    discovery.start();
+    const idle = discovery.whenIdle();
+    await vi.waitFor(() => expect(requestSignal).toBeDefined());
+
+    discovery.cancel();
+
+    await expect(idle).rejects.toMatchObject({ name: 'AbortError' });
+    expect(requestSignal?.aborted).toBe(true);
+    expect(observed.latest().failedSourceCount).toBe(0);
+  });
+
+  it('requires explicit non-overlapping batches after the automatic batch', async () => {
+    const candidates = Array.from({ length: 30 }, (_, index) => `https://n-${index}.example`);
+    const listNeighbors = vi.fn(async (origin: string) => {
+      if (origin === 'https://source.example')
+        return candidates.map((value) => recommendation(value));
+      return [recommendation('https://source.example')];
+    });
+    const discovery = createServerDirectoryDiscovery(['https://source.example'], {
+      listNeighbors,
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+
+    await startAndSettle(discovery);
+    expect(observed.latest().directoryRequestCount).toBe(13);
+    expect(observed.latest().canLoadMore).toBe(true);
+
+    discovery.loadMore();
+    discovery.loadMore();
+    await discovery.whenIdle();
+    expect(observed.latest().directoryRequestCount).toBe(25);
+    expect(observed.latest().canLoadMore).toBe(true);
+  });
+
+  it('enforces directory, profile, total, and candidate session limits', async () => {
+    const candidates = Array.from({ length: 100 }, (_, index) => `https://n-${index}.example`);
+    const discovery = createServerDirectoryDiscovery(['https://source.example'], {
+      listNeighbors: vi.fn(async (origin: string) =>
+        origin === 'https://source.example'
+          ? candidates.map((value) => recommendation(value))
+          : [recommendation('https://source.example')]
+      ),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+    await startAndSettle(discovery);
+
+    while (observed.latest().canLoadMore) {
+      discovery.loadMore();
+      await discovery.whenIdle();
+    }
+
+    expect(observed.latest()).toMatchObject({
+      directoryRequestCount: SERVER_DIRECTORY_LIMITS.directoryRequests,
+      profileRequestCount: SERVER_DIRECTORY_LIMITS.profileRequests,
+      totalRequestCount: SERVER_DIRECTORY_LIMITS.totalRequests,
+      sessionLimitReached: true
+    });
   });
 });

--- a/apps/frontend/src/lib/serverDirectory.spec.ts
+++ b/apps/frontend/src/lib/serverDirectory.spec.ts
@@ -96,7 +96,7 @@ describe('ServerDirectoryDiscovery', () => {
     });
   });
 
-  it('hides unilateral candidates and records them separately from failures', async () => {
+  it('shows a direct root recommendation even when it is not mutual', async () => {
     const discovery = createServerDirectoryDiscovery(['https://source.example'], {
       listNeighbors: vi.fn(async (origin: string) =>
         origin === 'https://source.example' ? [recommendation('https://unilateral.example')] : []
@@ -107,7 +107,9 @@ describe('ServerDirectoryDiscovery', () => {
 
     await startAndSettle(discovery);
 
-    expect(observed.latest().entries).toEqual([]);
+    expect(observed.latest().entries.map(({ origin }) => origin)).toEqual([
+      'https://unilateral.example'
+    ]);
     expect(observed.latest()).toMatchObject({
       failedSourceCount: 0,
       failedCandidateCount: 0,
@@ -115,7 +117,7 @@ describe('ServerDirectoryDiscovery', () => {
     });
   });
 
-  it('does not let two unverified candidates promote each other', async () => {
+  it('does not let two direct but non-mutual candidates promote each other', async () => {
     const directories: Record<string, PublicNeighbor[]> = {
       'https://a.example': [recommendation('https://b.example')],
       'https://c.example': [recommendation('https://x.example')],
@@ -130,8 +132,39 @@ describe('ServerDirectoryDiscovery', () => {
 
     await startAndSettle(discovery);
 
-    expect(observed.latest().entries).toEqual([]);
-    expect(observed.latest().profileRequestCount).toBe(0);
+    expect(observed.latest().entries.map(({ origin }) => origin)).toEqual([
+      'https://b.example',
+      'https://x.example'
+    ]);
+    expect(observed.latest().entries.map(({ sourceOrigins }) => sourceOrigins)).toEqual([
+      ['https://a.example'],
+      ['https://c.example']
+    ]);
+    expect(observed.latest().profileRequestCount).toBe(2);
+  });
+
+  it('hides a unilateral recommendation from a recursive source', async () => {
+    const directories: Record<string, PublicNeighbor[]> = {
+      'https://a.example': [recommendation('https://b.example')],
+      'https://b.example': [
+        recommendation('https://a.example'),
+        recommendation('https://c.example')
+      ],
+      'https://c.example': []
+    };
+    const discovery = createServerDirectoryDiscovery(['https://a.example'], {
+      listNeighbors: vi.fn(async (origin: string) => directories[origin] ?? []),
+      getServerInfo: vi.fn(async (origin: string) => profile(origin))
+    });
+    const observed = observe(discovery);
+
+    await startAndSettle(discovery);
+
+    expect(observed.latest().entries.map(({ origin }) => origin)).toEqual([
+      'https://b.example',
+      'https://a.example'
+    ]);
+    expect(observed.latest().nonMutualCandidateCount).toBe(1);
   });
 
   it('discovers two mutual hops and does not expand the second hop', async () => {
@@ -336,26 +369,24 @@ describe('ServerDirectoryDiscovery', () => {
   });
 
   it('keeps combined directory and profile work within the shared ceiling', async () => {
-    const candidates = Array.from({ length: 12 }, (_, index) => `https://n-${index}.example`);
     let active = 0;
     let maximumActive = 0;
-    let releaseFirst!: () => void;
     let releaseRest!: () => void;
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve;
-    });
     const restGate = new Promise<void>((resolve) => {
       releaseRest = resolve;
     });
     const listNeighbors = vi.fn(async (origin: string) => {
-      if (origin === 'https://source.example') {
-        return candidates.map((candidate) => recommendation(candidate));
-      }
       active += 1;
       maximumActive = Math.max(maximumActive, active);
-      await (origin === candidates[0] ? firstGate : restGate);
+      if (origin === 'https://source.example') {
+        active -= 1;
+        return [recommendation('https://candidate.example')];
+      }
+      await restGate;
       active -= 1;
-      return [recommendation('https://source.example')];
+      return origin === 'https://candidate.example'
+        ? [recommendation('https://source.example')]
+        : [];
     });
     const getServerInfo = vi.fn(async (origin: string) => {
       active += 1;
@@ -364,14 +395,15 @@ describe('ServerDirectoryDiscovery', () => {
       active -= 1;
       return profile(origin);
     });
-    const discovery = createServerDirectoryDiscovery(['https://source.example'], {
-      listNeighbors,
-      getServerInfo
-    });
+    const discovery = createServerDirectoryDiscovery(
+      [
+        'https://source.example',
+        ...Array.from({ length: 5 }, (_, index) => `https://slow-${index}.example`)
+      ],
+      { listNeighbors, getServerInfo }
+    );
     discovery.start();
 
-    await vi.waitFor(() => expect(listNeighbors).toHaveBeenCalledTimes(7));
-    releaseFirst();
     await vi.waitFor(() => expect(getServerInfo).toHaveBeenCalled());
     expect(active).toBe(6);
     expect(maximumActive).toBe(6);

--- a/apps/frontend/src/lib/serverDirectory.ts
+++ b/apps/frontend/src/lib/serverDirectory.ts
@@ -26,9 +26,9 @@ export type ServerProfileEntry = {
 };
 
 export type ServerDirectoryEntry = ServerProfileEntry & {
-  /** Canonical origins of the servers with a verified mutual recommendation. */
+  /** Canonical origins of the servers whose recommendations are shown. */
   sourceOrigins: string[];
-  /** Ordered verified recommendations, including source-specific testimonials. */
+  /** Ordered recommendations, including source-specific testimonials. */
   recommendations: ServerDirectoryRecommendation[];
 };
 
@@ -150,7 +150,11 @@ export class ServerDirectoryDiscovery {
   private readonly profileStatuses = new Map<string, ProfileStatus>();
   private readonly outgoingByOrigin = new Map<string, OrderedRecommendation[]>();
   private readonly incomingByOrigin = new Map<string, Map<string, OrderedRecommendation>>();
-  private readonly verifiedByOrigin = new Map<string, Map<string, OrderedRecommendation>>();
+  private readonly recommendationsByOrigin = new Map<
+    string,
+    Map<string, OrderedRecommendation>
+  >();
+  private readonly mutualOrigins = new Set<string>();
   private readonly edgeOutcomes = new Map<string, 'verified' | 'non-mutual'>();
   private readonly depths = new Map<string, number>();
   private readonly expansionSources = new Set<string>();
@@ -331,6 +335,12 @@ export class ServerDirectoryDiscovery {
     }
     this.outgoingByOrigin.set(origin, outgoing);
 
+    if (this.rootOrigins.has(origin)) {
+      for (const recommendation of outgoing) {
+        this.recordRecommendation(recommendation.targetOrigin, origin, recommendation);
+      }
+    }
+
     for (const sourceOrigin of this.incomingByOrigin.get(origin)?.keys() ?? []) {
       this.evaluateEdge(sourceOrigin, origin);
     }
@@ -356,12 +366,8 @@ export class ServerDirectoryDiscovery {
     const recommendation = this.incomingByOrigin.get(targetOrigin)?.get(sourceOrigin);
     if (!recommendation) return;
     this.edgeOutcomes.set(edgeKey, 'verified');
-    let verified = this.verifiedByOrigin.get(targetOrigin);
-    if (!verified) {
-      verified = new Map();
-      this.verifiedByOrigin.set(targetOrigin, verified);
-    }
-    verified.set(sourceOrigin, recommendation);
+    this.mutualOrigins.add(targetOrigin);
+    this.recordRecommendation(targetOrigin, sourceOrigin, recommendation);
 
     const sourceDepth = this.depths.get(sourceOrigin);
     if (sourceDepth !== undefined) {
@@ -370,9 +376,22 @@ export class ServerDirectoryDiscovery {
       if (priorDepth === undefined || depth < priorDepth) this.depths.set(targetOrigin, depth);
     }
 
+    this.activateSource(targetOrigin);
+  }
+
+  private recordRecommendation(
+    targetOrigin: string,
+    sourceOrigin: string,
+    recommendation: OrderedRecommendation
+  ): void {
+    let recommendations = this.recommendationsByOrigin.get(targetOrigin);
+    if (!recommendations) {
+      recommendations = new Map();
+      this.recommendationsByOrigin.set(targetOrigin, recommendations);
+    }
+    recommendations.set(sourceOrigin, recommendation);
     this.scheduleProfile(targetOrigin);
     this.refreshEntry(targetOrigin);
-    this.activateSource(targetOrigin);
   }
 
   private activateSource(origin: string): void {
@@ -475,9 +494,9 @@ export class ServerDirectoryDiscovery {
 
   private refreshEntry(origin: string): void {
     const profile = this.profiles.get(origin);
-    const verified = this.verifiedByOrigin.get(origin);
-    if (!profile || !verified?.size) return;
-    const recommendations = [...verified.values()]
+    const availableRecommendations = this.recommendationsByOrigin.get(origin);
+    if (!profile || !availableRecommendations?.size) return;
+    const recommendations = [...availableRecommendations.values()]
       .sort((left, right) => left.order - right.order)
       .map(({ sourceOrigin, testimonial }) => ({ sourceOrigin, testimonial }));
     const entry: ServerDirectoryEntry = {
@@ -498,7 +517,7 @@ export class ServerDirectoryDiscovery {
   }
 
   private isEligibleSource(origin: string): boolean {
-    return this.rootOrigins.has(origin) || this.verifiedByOrigin.has(origin);
+    return this.rootOrigins.has(origin) || this.mutualOrigins.has(origin);
   }
 
   private hasDirectoryBudget(): boolean {

--- a/apps/frontend/src/lib/serverDirectory.ts
+++ b/apps/frontend/src/lib/serverDirectory.ts
@@ -6,11 +6,19 @@ import {
   type PublicServerInfo
 } from '$lib/api-client/server';
 
-const DISCOVERY_TIMEOUT_MS = 10_000;
-const SOURCE_CONCURRENCY = 6;
-const PROFILE_CONCURRENCY = 6;
-const MAX_NEIGHBORS_PER_SOURCE = 100;
-const MAX_TESTIMONIAL_LENGTH = 500;
+/** Hard page-session limits for public Neighbor discovery. */
+export const SERVER_DIRECTORY_LIMITS = {
+  concurrency: 6,
+  timeoutMs: 10_000,
+  mutualHopDepth: 2,
+  candidateBatchSize: 12,
+  directoryRequests: 48,
+  profileRequests: 24,
+  totalRequests: 72,
+  candidates: 120,
+  neighborsPerSource: 100,
+  testimonialLength: 500
+} as const;
 
 export type ServerProfileEntry = {
   origin: string;
@@ -18,9 +26,9 @@ export type ServerProfileEntry = {
 };
 
 export type ServerDirectoryEntry = ServerProfileEntry & {
-  /** Canonical origins of the registered servers that advertised this entry. */
+  /** Canonical origins of the servers with a verified mutual recommendation. */
   sourceOrigins: string[];
-  /** Ordered recommendations, including source-specific public testimonials. */
+  /** Ordered verified recommendations, including source-specific testimonials. */
   recommendations: ServerDirectoryRecommendation[];
 };
 
@@ -29,19 +37,55 @@ export type ServerDirectoryRecommendation = {
   testimonial: string | null;
 };
 
+/** Progressive state published by one page-session discovery crawl. */
 export type ServerDirectorySnapshot = {
   entries: ServerDirectoryEntry[];
   failedSourceCount: number;
+  failedCandidateCount: number;
+  nonMutualCandidateCount: number;
   sourceCount: number;
+  activeRequestCount: number;
+  queuedCandidateCount: number;
+  directoryRequestCount: number;
+  profileRequestCount: number;
+  totalRequestCount: number;
+  isStarted: boolean;
+  isLoading: boolean;
+  isInitialLoading: boolean;
+  isPaused: boolean;
+  canLoadMore: boolean;
+  sessionLimitReached: boolean;
 };
 
 type DirectoryLoadOptions = {
   signal?: AbortSignal;
+  initiallyVisible?: boolean;
+  /** Test override. Production sessions use the fixed ten-second limit. */
+  requestTimeoutMs?: number;
   listNeighbors?: typeof getPublicNeighbors;
   getServerInfo?: typeof getPublicServerInfo;
 };
 
 type ProfileLoadOptions = Pick<DirectoryLoadOptions, 'signal' | 'getServerInfo'>;
+type DirectoryListener = (snapshot: ServerDirectorySnapshot) => void;
+type DirectoryStatus = 'queued' | 'loaded' | 'failed' | 'unsupported';
+type ProfileStatus = 'queued' | 'loaded' | 'failed';
+
+type OrderedRecommendation = ServerDirectoryRecommendation & {
+  targetOrigin: string;
+  order: number;
+};
+
+type Candidate = {
+  origin: string;
+  sourceOrigin: string;
+};
+
+type ScheduledRequest<T> = {
+  operation: () => Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+};
 
 /** Convert an advertised URL to a canonical HTTP(S) origin. */
 export function canonicalServerOrigin(value: string): string | null {
@@ -70,8 +114,10 @@ export async function loadServerProfiles(
   options: ProfileLoadOptions = {}
 ): Promise<ServerProfileEntry[]> {
   const getServerInfo = options.getServerInfo ?? getPublicServerInfo;
-  const profiles = await mapWithConcurrency(origins, PROFILE_CONCURRENCY, (origin) =>
-    getServerInfo(origin, { signal: discoverySignal(options.signal) }).catch(() => null)
+  const profiles = await mapWithConcurrency(
+    origins,
+    SERVER_DIRECTORY_LIMITS.concurrency,
+    (origin) => getServerInfo(origin, { signal: discoverySignal(options.signal) }).catch(() => null)
   );
   throwIfAborted(options.signal);
 
@@ -79,85 +125,528 @@ export async function loadServerProfiles(
 }
 
 /**
- * Load the direct Neighbor directories of registered servers and hydrate each
- * distinct advertised origin with its public profile. Result order follows the
- * source responses but is not a product ordering contract.
+ * Create one bounded, cancellable Neighbor discovery session. The session
+ * fetches each canonical directory and profile at most once and publishes a
+ * new immutable snapshot whenever useful progress occurs.
  */
-export async function loadServerDirectory(
+export function createServerDirectoryDiscovery(
   registeredOrigins: readonly string[],
   options: DirectoryLoadOptions = {}
-): Promise<ServerDirectorySnapshot> {
-  const listNeighbors = options.listNeighbors ?? getPublicNeighbors;
-  const getServerInfo = options.getServerInfo ?? getPublicServerInfo;
-  const sourceOrigins = [
-    ...new Set(
-      registeredOrigins.flatMap((value) => {
-        const origin = canonicalServerOrigin(value);
-        return origin ? [origin] : [];
-      })
-    )
-  ];
-  const sourceResults = await mapWithConcurrency(
-    sourceOrigins,
-    SOURCE_CONCURRENCY,
-    async (sourceOrigin) => {
-      try {
-        const advertisedNeighbors = await listNeighbors(sourceOrigin, {
-          signal: discoverySignal(options.signal)
+): ServerDirectoryDiscovery {
+  return new ServerDirectoryDiscovery(registeredOrigins, options);
+}
+
+/** A bounded progressive crawl of mutually recommending Chatto servers. */
+export class ServerDirectoryDiscovery {
+  private readonly listNeighbors: typeof getPublicNeighbors;
+  private readonly getServerInfo: typeof getPublicServerInfo;
+  private readonly requestTimeoutMs: number;
+  private readonly controller = new AbortController();
+  private readonly scheduler: RequestScheduler;
+  private readonly listeners = new Set<DirectoryListener>();
+  private readonly sourceOrigins: string[];
+  private readonly rootOrigins: Set<string>;
+  private readonly directoryStatuses = new Map<string, DirectoryStatus>();
+  private readonly profileStatuses = new Map<string, ProfileStatus>();
+  private readonly outgoingByOrigin = new Map<string, OrderedRecommendation[]>();
+  private readonly incomingByOrigin = new Map<string, Map<string, OrderedRecommendation>>();
+  private readonly verifiedByOrigin = new Map<string, Map<string, OrderedRecommendation>>();
+  private readonly edgeOutcomes = new Map<string, 'verified' | 'non-mutual'>();
+  private readonly depths = new Map<string, number>();
+  private readonly expansionSources = new Set<string>();
+  private readonly sourceCandidateCursors = new Map<string, number>();
+  private readonly sourcesWithQueuedCandidate = new Set<string>();
+  private readonly exhaustedSources = new Set<string>();
+  private readonly candidateQueue: Candidate[] = [];
+  private readonly candidateOrigins = new Set<string>();
+  private readonly profiles = new Map<string, PublicServerInfo>();
+  private entries: ServerDirectoryEntry[] = [];
+  private failedSourceCount = 0;
+  private failedCandidateCount = 0;
+  private nonMutualCandidateCount = 0;
+  private directoryRequestCount = 0;
+  private profileRequestCount = 0;
+  private recommendationOrder = 0;
+  private candidateCredits = 0;
+  private started = false;
+  private cancelled = false;
+  private sessionLimitReached = false;
+  private pumping = false;
+  private readonly idleWaiters = new Set<{
+    resolve: () => void;
+    reject: (reason: unknown) => void;
+  }>();
+
+  constructor(registeredOrigins: readonly string[], options: DirectoryLoadOptions = {}) {
+    this.listNeighbors = options.listNeighbors ?? getPublicNeighbors;
+    this.getServerInfo = options.getServerInfo ?? getPublicServerInfo;
+    this.requestTimeoutMs = options.requestTimeoutMs ?? SERVER_DIRECTORY_LIMITS.timeoutMs;
+    this.sourceOrigins = [
+      ...new Set(
+        registeredOrigins.flatMap((value) => {
+          const origin = canonicalServerOrigin(value);
+          return origin ? [origin] : [];
+        })
+      )
+    ];
+    this.rootOrigins = new Set(this.sourceOrigins);
+    for (const origin of this.sourceOrigins) this.depths.set(origin, 0);
+
+    if (options.signal) {
+      if (options.signal.aborted) {
+        this.controller.abort(options.signal.reason);
+        this.cancelled = true;
+      } else {
+        options.signal.addEventListener('abort', () => this.cancel(options.signal?.reason), {
+          once: true
         });
-        return { status: 'fulfilled' as const, sourceOrigin, advertisedNeighbors };
-      } catch (error) {
-        if (error instanceof ConnectError && error.code === Code.Unimplemented) {
-          return { status: 'fulfilled' as const, sourceOrigin, advertisedNeighbors: [] };
+      }
+    }
+
+    this.scheduler = new RequestScheduler(
+      SERVER_DIRECTORY_LIMITS.concurrency,
+      () => this.schedulerChanged(),
+      options.initiallyVisible === false
+    );
+  }
+
+  /** Receive the current snapshot immediately and after each state change. */
+  subscribe(listener: DirectoryListener): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot());
+    return () => this.listeners.delete(listener);
+  }
+
+  /** Start root discovery and grant the single automatic candidate batch. */
+  start(): void {
+    if (this.started || this.cancelled) return;
+    this.started = true;
+    this.candidateCredits = SERVER_DIRECTORY_LIMITS.candidateBatchSize;
+
+    for (const sourceOrigin of this.sourceOrigins) {
+      if (!this.scheduleDirectory(sourceOrigin)) {
+        this.sessionLimitReached = true;
+        break;
+      }
+    }
+    this.pumpCandidates();
+    this.emit();
+    this.settleIdleWaiters();
+  }
+
+  /** Spend one more fixed-size candidate batch when the current work is idle. */
+  loadMore(): void {
+    if (!this.snapshot().canLoadMore || this.cancelled) return;
+    this.candidateCredits += SERVER_DIRECTORY_LIMITS.candidateBatchSize;
+    this.pumpCandidates();
+    this.emit();
+  }
+
+  /** Pause or resume the launch of queued browser requests. */
+  setVisible(visible: boolean): void {
+    if (this.cancelled) return;
+    this.scheduler.setPaused(!visible);
+    if (visible) this.pumpCandidates();
+    this.emit();
+  }
+
+  /** Abort active work and discard every queued request. */
+  cancel(reason: unknown = new DOMException('Cancelled', 'AbortError')): void {
+    if (this.cancelled) return;
+    this.cancelled = true;
+    this.controller.abort(reason);
+    this.scheduler.cancel(reason);
+    for (const waiter of this.idleWaiters) waiter.reject(reason);
+    this.idleWaiters.clear();
+  }
+
+  /** Wait until the currently granted work and all resulting profiles settle. */
+  whenIdle(): Promise<void> {
+    if (this.cancelled) return Promise.reject(this.controller.signal.reason);
+    if (this.isIdle()) return Promise.resolve();
+    return new Promise<void>((resolve, reject) => this.idleWaiters.add({ resolve, reject }));
+  }
+
+  private scheduleDirectory(origin: string): boolean {
+    if (this.cancelled || this.directoryStatuses.has(origin)) return true;
+    if (!this.hasDirectoryBudget()) return false;
+
+    this.directoryStatuses.set(origin, 'queued');
+    this.directoryRequestCount += 1;
+    void this.scheduler
+      .schedule(async () => {
+        try {
+          const neighbors = await this.listNeighbors(origin, {
+            signal: discoverySignal(this.controller.signal, this.requestTimeoutMs)
+          });
+          return { status: 'loaded' as const, neighbors };
+        } catch (error) {
+          if (this.controller.signal.aborted) throw this.controller.signal.reason;
+          if (error instanceof ConnectError && error.code === Code.Unimplemented) {
+            return { status: 'unsupported' as const, neighbors: [] };
+          }
+          return { status: 'failed' as const, neighbors: [] };
         }
-        return { status: 'rejected' as const, sourceOrigin };
+      })
+      .then((result) => {
+        if (this.cancelled) return;
+        if (result.status === 'failed') {
+          this.directoryStatuses.set(origin, 'failed');
+          if (this.rootOrigins.has(origin)) this.failedSourceCount += 1;
+          else this.failedCandidateCount += 1;
+        } else {
+          this.directoryStatuses.set(origin, result.status);
+          this.processDirectory(origin, result.neighbors);
+        }
+        this.emit();
+      })
+      .catch(() => {
+        // Session cancellation owns the error and must not publish partial state.
+      });
+    return true;
+  }
+
+  private processDirectory(origin: string, advertisedNeighbors: readonly PublicNeighbor[]): void {
+    const outgoing: OrderedRecommendation[] = [];
+    const seenTargets = new Set<string>();
+    for (const advertised of advertisedNeighbors.slice(
+      0,
+      SERVER_DIRECTORY_LIMITS.neighborsPerSource
+    )) {
+      const targetOrigin = canonicalServerOrigin(advertised.origin);
+      if (!targetOrigin || targetOrigin === origin || seenTargets.has(targetOrigin)) continue;
+      seenTargets.add(targetOrigin);
+      const recommendation = {
+        ...recommendationFrom(origin, advertised),
+        targetOrigin,
+        order: this.recommendationOrder++
+      };
+      outgoing.push(recommendation);
+      let incoming = this.incomingByOrigin.get(targetOrigin);
+      if (!incoming) {
+        incoming = new Map();
+        this.incomingByOrigin.set(targetOrigin, incoming);
       }
+      incoming.set(origin, recommendation);
     }
-  );
-  throwIfAborted(options.signal);
+    this.outgoingByOrigin.set(origin, outgoing);
 
-  const recommendationsByAdvertisedOrigin = new Map<string, ServerDirectoryRecommendation[]>();
-  let failedSourceCount = 0;
-
-  for (const result of sourceResults) {
-    if (result.status === 'rejected') {
-      failedSourceCount += 1;
-      continue;
+    for (const sourceOrigin of this.incomingByOrigin.get(origin)?.keys() ?? []) {
+      this.evaluateEdge(sourceOrigin, origin);
     }
-    for (const advertised of result.advertisedNeighbors.slice(0, MAX_NEIGHBORS_PER_SOURCE)) {
-      const origin = canonicalServerOrigin(advertised.origin);
-      if (!origin) continue;
-      const recommendations = recommendationsByAdvertisedOrigin.get(origin);
-      if (!recommendations) {
-        recommendationsByAdvertisedOrigin.set(origin, [
-          recommendationFrom(result.sourceOrigin, advertised)
-        ]);
-      } else if (
-        !recommendations.some(({ sourceOrigin }) => sourceOrigin === result.sourceOrigin)
+    this.activateSource(origin);
+  }
+
+  private evaluateEdge(sourceOrigin: string, targetOrigin: string): void {
+    if (!this.isEligibleSource(sourceOrigin)) return;
+    const edgeKey = `${sourceOrigin}\n${targetOrigin}`;
+    if (this.edgeOutcomes.has(edgeKey)) return;
+    const targetStatus = this.directoryStatuses.get(targetOrigin);
+    if (targetStatus !== 'loaded' && targetStatus !== 'unsupported') return;
+
+    const reverseExists = this.outgoingByOrigin
+      .get(targetOrigin)
+      ?.some((recommendation) => recommendation.targetOrigin === sourceOrigin);
+    if (!reverseExists) {
+      this.edgeOutcomes.set(edgeKey, 'non-mutual');
+      this.nonMutualCandidateCount += 1;
+      return;
+    }
+
+    const recommendation = this.incomingByOrigin.get(targetOrigin)?.get(sourceOrigin);
+    if (!recommendation) return;
+    this.edgeOutcomes.set(edgeKey, 'verified');
+    let verified = this.verifiedByOrigin.get(targetOrigin);
+    if (!verified) {
+      verified = new Map();
+      this.verifiedByOrigin.set(targetOrigin, verified);
+    }
+    verified.set(sourceOrigin, recommendation);
+
+    const sourceDepth = this.depths.get(sourceOrigin);
+    if (sourceDepth !== undefined) {
+      const depth = Math.min(sourceDepth + 1, SERVER_DIRECTORY_LIMITS.mutualHopDepth);
+      const priorDepth = this.depths.get(targetOrigin);
+      if (priorDepth === undefined || depth < priorDepth) this.depths.set(targetOrigin, depth);
+    }
+
+    this.scheduleProfile(targetOrigin);
+    this.refreshEntry(targetOrigin);
+    this.activateSource(targetOrigin);
+  }
+
+  private activateSource(origin: string): void {
+    if (!this.isEligibleSource(origin)) return;
+    for (const recommendation of this.outgoingByOrigin.get(origin) ?? []) {
+      this.evaluateEdge(origin, recommendation.targetOrigin);
+    }
+    if (this.canExpand(origin)) this.addExpansionSource(origin);
+  }
+
+  private addExpansionSource(sourceOrigin: string): void {
+    if (this.expansionSources.has(sourceOrigin)) return;
+    this.expansionSources.add(sourceOrigin);
+    this.sourceCandidateCursors.set(sourceOrigin, 0);
+    this.refillSourceCandidate(sourceOrigin);
+    this.pumpCandidates();
+  }
+
+  private refillSourceCandidate(sourceOrigin: string): void {
+    if (
+      this.sourcesWithQueuedCandidate.has(sourceOrigin) ||
+      this.exhaustedSources.has(sourceOrigin) ||
+      this.candidateOrigins.size >= SERVER_DIRECTORY_LIMITS.candidates
+    ) {
+      if (this.candidateOrigins.size >= SERVER_DIRECTORY_LIMITS.candidates) {
+        this.sessionLimitReached = true;
+      }
+      return;
+    }
+
+    const outgoing = this.outgoingByOrigin.get(sourceOrigin) ?? [];
+    let cursor = this.sourceCandidateCursors.get(sourceOrigin) ?? 0;
+    while (cursor < outgoing.length) {
+      const recommendation = outgoing[cursor++]!;
+      const targetOrigin = recommendation.targetOrigin;
+      this.sourceCandidateCursors.set(sourceOrigin, cursor);
+      if (this.directoryStatuses.has(targetOrigin) || this.candidateOrigins.has(targetOrigin)) {
+        this.evaluateEdge(sourceOrigin, targetOrigin);
+        continue;
+      }
+      this.candidateOrigins.add(targetOrigin);
+      this.candidateQueue.push({ origin: targetOrigin, sourceOrigin });
+      this.sourcesWithQueuedCandidate.add(sourceOrigin);
+      return;
+    }
+    this.exhaustedSources.add(sourceOrigin);
+  }
+
+  private pumpCandidates(): void {
+    if (this.pumping || this.cancelled || this.scheduler.isPaused) return;
+    this.pumping = true;
+    try {
+      while (
+        this.candidateCredits > 0 &&
+        this.candidateQueue.length > 0 &&
+        this.scheduler.availableSlots > 0
       ) {
-        recommendations.push(recommendationFrom(result.sourceOrigin, advertised));
+        if (!this.hasDirectoryBudget()) {
+          this.sessionLimitReached = true;
+          break;
+        }
+        const candidate = this.candidateQueue.shift()!;
+        this.sourcesWithQueuedCandidate.delete(candidate.sourceOrigin);
+        this.refillSourceCandidate(candidate.sourceOrigin);
+        this.candidateCredits -= 1;
+        this.scheduleDirectory(candidate.origin);
       }
+    } finally {
+      this.pumping = false;
     }
   }
 
-  const profiles = await loadServerProfiles([...recommendationsByAdvertisedOrigin.keys()], {
-    signal: options.signal,
-    getServerInfo
-  });
-  const entries = profiles.map((entry) => ({
-    ...entry,
-    sourceOrigins:
-      recommendationsByAdvertisedOrigin
-        .get(entry.origin)
-        ?.map(({ sourceOrigin }) => sourceOrigin) ?? [],
-    recommendations: recommendationsByAdvertisedOrigin.get(entry.origin) ?? []
-  }));
+  private scheduleProfile(origin: string): void {
+    if (this.profileStatuses.has(origin) || this.cancelled) return;
+    if (!this.hasProfileBudget()) {
+      this.sessionLimitReached = true;
+      return;
+    }
+    this.profileStatuses.set(origin, 'queued');
+    this.profileRequestCount += 1;
+    void this.scheduler
+      .schedule(() =>
+        this.getServerInfo(origin, {
+          signal: discoverySignal(this.controller.signal, this.requestTimeoutMs)
+        })
+      )
+      .then((profile) => {
+        if (this.cancelled) return;
+        this.profileStatuses.set(origin, 'loaded');
+        this.profiles.set(origin, profile);
+        this.refreshEntry(origin);
+        this.emit();
+      })
+      .catch(() => {
+        if (this.cancelled) return;
+        this.profileStatuses.set(origin, 'failed');
+        this.emit();
+      });
+  }
 
-  return {
-    entries,
-    failedSourceCount,
-    sourceCount: sourceOrigins.length
-  };
+  private refreshEntry(origin: string): void {
+    const profile = this.profiles.get(origin);
+    const verified = this.verifiedByOrigin.get(origin);
+    if (!profile || !verified?.size) return;
+    const recommendations = [...verified.values()]
+      .sort((left, right) => left.order - right.order)
+      .map(({ sourceOrigin, testimonial }) => ({ sourceOrigin, testimonial }));
+    const entry: ServerDirectoryEntry = {
+      origin,
+      profile,
+      sourceOrigins: recommendations.map(({ sourceOrigin }) => sourceOrigin),
+      recommendations
+    };
+    const index = this.entries.findIndex((candidate) => candidate.origin === origin);
+    if (index === -1) this.entries = [...this.entries, entry];
+    else this.entries = this.entries.with(index, entry);
+  }
+
+  private canExpand(origin: string): boolean {
+    const depth = this.depths.get(origin);
+    if (depth === undefined || depth >= SERVER_DIRECTORY_LIMITS.mutualHopDepth) return false;
+    return this.isEligibleSource(origin);
+  }
+
+  private isEligibleSource(origin: string): boolean {
+    return this.rootOrigins.has(origin) || this.verifiedByOrigin.has(origin);
+  }
+
+  private hasDirectoryBudget(): boolean {
+    return (
+      this.directoryRequestCount < SERVER_DIRECTORY_LIMITS.directoryRequests &&
+      this.totalRequestCount() < SERVER_DIRECTORY_LIMITS.totalRequests
+    );
+  }
+
+  private hasProfileBudget(): boolean {
+    return (
+      this.profileRequestCount < SERVER_DIRECTORY_LIMITS.profileRequests &&
+      this.totalRequestCount() < SERVER_DIRECTORY_LIMITS.totalRequests
+    );
+  }
+
+  private schedulerChanged(): void {
+    if (this.cancelled) return;
+    this.pumpCandidates();
+    this.emit();
+    this.settleIdleWaiters();
+  }
+
+  private isIdle(): boolean {
+    if (!this.started) return true;
+    const candidateCanRun =
+      !this.scheduler.isPaused &&
+      this.candidateCredits > 0 &&
+      this.candidateQueue.length > 0 &&
+      this.hasDirectoryBudget();
+    return (
+      this.scheduler.activeCount === 0 && this.scheduler.pendingCount === 0 && !candidateCanRun
+    );
+  }
+
+  private settleIdleWaiters(): void {
+    if (!this.isIdle()) return;
+    for (const waiter of this.idleWaiters) waiter.resolve();
+    this.idleWaiters.clear();
+  }
+
+  private totalRequestCount(): number {
+    return this.directoryRequestCount + this.profileRequestCount;
+  }
+
+  private snapshot(): ServerDirectorySnapshot {
+    const isLoading =
+      this.started && (this.scheduler.activeCount > 0 || this.scheduler.pendingCount > 0);
+    const canLoadMore =
+      this.started &&
+      !isLoading &&
+      !this.scheduler.isPaused &&
+      this.candidateCredits === 0 &&
+      this.candidateQueue.length > 0 &&
+      this.hasDirectoryBudget();
+    return {
+      entries: this.entries,
+      failedSourceCount: this.failedSourceCount,
+      failedCandidateCount: this.failedCandidateCount,
+      nonMutualCandidateCount: this.nonMutualCandidateCount,
+      sourceCount: Math.min(this.sourceOrigins.length, SERVER_DIRECTORY_LIMITS.directoryRequests),
+      activeRequestCount: this.scheduler.activeCount,
+      queuedCandidateCount: this.candidateQueue.length,
+      directoryRequestCount: this.directoryRequestCount,
+      profileRequestCount: this.profileRequestCount,
+      totalRequestCount: this.totalRequestCount(),
+      isStarted: this.started,
+      isLoading,
+      isInitialLoading: isLoading && this.entries.length === 0,
+      isPaused: this.scheduler.isPaused,
+      canLoadMore,
+      sessionLimitReached: this.sessionLimitReached
+    };
+  }
+
+  private emit(): void {
+    const snapshot = this.snapshot();
+    for (const listener of this.listeners) listener(snapshot);
+  }
+}
+
+class RequestScheduler {
+  private readonly queue: ScheduledRequest<unknown>[] = [];
+  private active = 0;
+  private paused: boolean;
+  private cancelledReason: unknown;
+
+  constructor(
+    private readonly concurrency: number,
+    private readonly onStateChange: () => void,
+    initiallyPaused: boolean
+  ) {
+    this.paused = initiallyPaused;
+  }
+
+  get activeCount(): number {
+    return this.active;
+  }
+
+  get pendingCount(): number {
+    return this.queue.length;
+  }
+
+  get availableSlots(): number {
+    return Math.max(0, this.concurrency - this.active - this.queue.length);
+  }
+
+  get isPaused(): boolean {
+    return this.paused;
+  }
+
+  schedule<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.cancelledReason !== undefined) return Promise.reject(this.cancelledReason);
+    const promise = new Promise<T>((resolve, reject) => {
+      this.queue.push({ operation, resolve, reject } as ScheduledRequest<unknown>);
+    });
+    this.drain();
+    this.onStateChange();
+    return promise;
+  }
+
+  setPaused(paused: boolean): void {
+    if (this.paused === paused) return;
+    this.paused = paused;
+    if (!paused) this.drain();
+    this.onStateChange();
+  }
+
+  cancel(reason: unknown): void {
+    this.cancelledReason = reason;
+    for (const request of this.queue.splice(0)) request.reject(reason);
+    this.onStateChange();
+  }
+
+  private drain(): void {
+    while (!this.paused && this.active < this.concurrency && this.queue.length > 0) {
+      const request = this.queue.shift()!;
+      this.active += 1;
+      void request
+        .operation()
+        .then(request.resolve, request.reject)
+        .finally(() => {
+          this.active -= 1;
+          this.drain();
+          this.onStateChange();
+        });
+    }
+  }
 }
 
 function recommendationFrom(
@@ -173,15 +662,18 @@ function boundedTestimonial(value: string | null): string | null {
   let bounded = '';
   let length = 0;
   for (const character of trimmed) {
-    if (length === MAX_TESTIMONIAL_LENGTH) break;
+    if (length === SERVER_DIRECTORY_LIMITS.testimonialLength) break;
     bounded += character;
     length += 1;
   }
   return bounded;
 }
 
-function discoverySignal(parent?: AbortSignal): AbortSignal {
-  const timeout = AbortSignal.timeout(DISCOVERY_TIMEOUT_MS);
+function discoverySignal(
+  parent?: AbortSignal,
+  timeoutMs: number = SERVER_DIRECTORY_LIMITS.timeoutMs
+): AbortSignal {
+  const timeout = AbortSignal.timeout(timeoutMs);
   return parent ? AbortSignal.any([parent, timeout]) : timeout;
 }
 

--- a/apps/frontend/src/routes/chat/servers/+page.svelte
+++ b/apps/frontend/src/routes/chat/servers/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { ConnectError } from '@connectrpc/connect';
-  import { createQuery } from '@tanstack/svelte-query';
+  import { onMount } from 'svelte';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import {
@@ -14,11 +14,12 @@
   import { m } from '$lib/i18n/messages';
   import { getReactiveLocale } from '$lib/i18n/state.svelte';
   import { serverIdToSegment } from '$lib/navigation';
-  import { queryClient } from '$lib/query/client';
   import {
     canonicalServerOrigin,
-    loadServerDirectory,
-    type ServerDirectoryEntry
+    createServerDirectoryDiscovery,
+    type ServerDirectoryDiscovery,
+    type ServerDirectoryEntry,
+    type ServerDirectorySnapshot
   } from '$lib/serverDirectory';
   import { evaluateServerCompatibility } from '$lib/state/server/compatibility';
   import { serverRegistry, type RegisteredServer } from '$lib/state/server/registry.svelte';
@@ -32,6 +33,9 @@
   let probing = $state(false);
   let pendingOrigin = $state<string | null>(null);
   let actionError = $state('');
+  let directoryState = $state<ServerDirectorySnapshot | null>(null);
+  let directorySession: ServerDirectoryDiscovery | null = null;
+  let unsubscribeDirectory: (() => void) | null = null;
 
   const registeredOrigins = $derived.by(() => [
     ...new Set(
@@ -41,26 +45,45 @@
       })
     )
   ]);
-  const directoryQuery = createQuery(
-    () => ({
-      queryKey: ['public', 'server-directory', registeredOrigins],
-      queryFn: ({ signal }) => loadServerDirectory(registeredOrigins, { signal }),
-      staleTime: 0,
-      refetchOnMount: 'always'
-    }),
-    () => queryClient
-  );
-  const entries = $derived(
-    directoryQuery.data?.entries.filter((entry) => entry.profile !== null) ?? []
-  );
+  const entries = $derived(directoryState?.entries.filter((entry) => entry.profile !== null) ?? []);
   const allSourcesFailed = $derived(
-    !!directoryQuery.data &&
-      directoryQuery.data.sourceCount > 0 &&
-      directoryQuery.data.failedSourceCount === directoryQuery.data.sourceCount
+    !!directoryState &&
+      !directoryState.isLoading &&
+      directoryState.sourceCount > 0 &&
+      directoryState.failedSourceCount === directoryState.sourceCount
   );
   const someSourcesFailed = $derived(
-    !!directoryQuery.data && directoryQuery.data.failedSourceCount > 0 && !allSourcesFailed
+    !!directoryState && directoryState.failedSourceCount > 0 && !allSourcesFailed
   );
+
+  onMount(() => {
+    startDirectoryDiscovery();
+    return stopDirectoryDiscovery;
+  });
+
+  function startDirectoryDiscovery() {
+    stopDirectoryDiscovery();
+    directoryState = null;
+    const session = createServerDirectoryDiscovery(registeredOrigins, {
+      initiallyVisible: document.visibilityState === 'visible'
+    });
+    directorySession = session;
+    unsubscribeDirectory = session.subscribe((snapshot) => {
+      if (directorySession === session) directoryState = snapshot;
+    });
+    session.start();
+  }
+
+  function stopDirectoryDiscovery() {
+    unsubscribeDirectory?.();
+    unsubscribeDirectory = null;
+    directorySession?.cancel();
+    directorySession = null;
+  }
+
+  function handleVisibilityChange() {
+    directorySession?.setVisible(document.visibilityState === 'visible');
+  }
 
   function normalizeCustomInput(value: string): string {
     const trimmed = value.trim();
@@ -172,6 +195,8 @@
   function sourceName(origin: string): string {
     const registered = registeredServer(origin);
     if (registered) return registered.name;
+    const discovered = entries.find((entry) => entry.origin === origin);
+    if (discovered?.profile?.name) return discovered.profile.name;
     try {
       return new URL(origin).host;
     } catch {
@@ -208,7 +233,11 @@
             {
               sourceOrigin: recommendation.sourceOrigin,
               sourceName: sourceName(recommendation.sourceOrigin),
-              sourceIconUrl: registeredServer(recommendation.sourceOrigin)?.iconUrl ?? null,
+              sourceIconUrl:
+                registeredServer(recommendation.sourceOrigin)?.iconUrl ??
+                entries.find((candidate) => candidate.origin === recommendation.sourceOrigin)?.profile
+                  ?.iconUrl ??
+                null,
               testimonial: recommendation.testimonial
             }
           ]
@@ -216,6 +245,8 @@
     );
   }
 </script>
+
+<svelte:document onvisibilitychange={handleVisibilityChange} />
 
 <PageTitle title={m('add_server.directory.title')} />
 
@@ -314,20 +345,20 @@
           <div class="mb-4"><Hint tone="warning">{m('add_server.directory.partial')}</Hint></div>
         {/if}
 
-        {#if directoryQuery.isPending}
+        {#if !directoryState || directoryState.isInitialLoading}
           <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3" aria-busy="true">
             {#each Array(3) as _, index (index)}
               <div class="skeleton h-64 rounded-xl bg-surface"></div>
             {/each}
           </div>
-        {:else if directoryQuery.isError || allSourcesFailed}
+        {:else if allSourcesFailed}
           <EmptyState
             icon="icon-[uil--exclamation-triangle]"
             title={m('add_server.directory.unavailable_title')}
           >
             <div class="flex flex-col items-center gap-3">
               <span>{m('add_server.directory.unavailable_body')}</span>
-              <Button variant="secondary" onclick={() => directoryQuery.refetch()}>
+              <Button variant="secondary" onclick={startDirectoryDiscovery}>
                 {m('common.retry')}
               </Button>
             </div>
@@ -414,6 +445,24 @@
               </div>
             {/each}
           </div>
+        {/if}
+        {#if directoryState && !allSourcesFailed}
+          {#if directoryState.isLoading && !directoryState.isInitialLoading}
+            <p class="mt-4 text-center text-muted" aria-live="polite">
+              {m('add_server.directory.discovering')}
+            </p>
+          {/if}
+          {#if directoryState.sessionLimitReached}
+            <div class="mt-4">
+              <Hint tone="warning">{m('add_server.directory.session_limit_reached')}</Hint>
+            </div>
+          {:else if directoryState.canLoadMore}
+            <div class="mt-4 flex justify-center">
+              <Button variant="secondary" onclick={() => directorySession?.loadMore()}>
+                {m('add_server.directory.load_more')}
+              </Button>
+            </div>
+          {/if}
         {/if}
       </Panel>
     </div>

--- a/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
@@ -2,7 +2,7 @@ import { flushSync } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import type { PublicServerInfo } from '$lib/api-client/server';
-import { queryClient } from '$lib/query/client';
+import type { ServerDirectorySnapshot } from '$lib/serverDirectory';
 
 const mocks = vi.hoisted(() => ({
   servers: [] as Array<{
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   }>,
   authenticated: new Set<string>(),
   loadServerDirectory: vi.fn(),
+  loadMoreDirectory: vi.fn(),
   getPublicServerInfo: vi.fn(),
   startServerOAuthFlow: vi.fn(),
   startRemoteReauthentication: vi.fn(),
@@ -35,7 +36,60 @@ vi.mock('$lib/api-client/server', async (importOriginal) => {
 });
 vi.mock('$lib/serverDirectory', async (importOriginal) => {
   const actual = await importOriginal<typeof import('$lib/serverDirectory')>();
-  return { ...actual, loadServerDirectory: mocks.loadServerDirectory };
+  return {
+    ...actual,
+    createServerDirectoryDiscovery: (origins: readonly string[]) => {
+      let listener: ((snapshot: ServerDirectorySnapshot) => void) | undefined;
+      let cancelled = false;
+      const snapshot = (value: Partial<ServerDirectorySnapshot> = {}): ServerDirectorySnapshot => ({
+        entries: [],
+        failedSourceCount: 0,
+        failedCandidateCount: 0,
+        nonMutualCandidateCount: 0,
+        sourceCount: origins.length,
+        activeRequestCount: 0,
+        queuedCandidateCount: 0,
+        directoryRequestCount: origins.length,
+        profileRequestCount: 0,
+        totalRequestCount: origins.length,
+        isStarted: true,
+        isLoading: false,
+        isInitialLoading: false,
+        isPaused: false,
+        canLoadMore: false,
+        sessionLimitReached: false,
+        ...value
+      });
+      const publish = async (
+        loader: (values: readonly string[]) => Promise<Partial<ServerDirectorySnapshot>>
+      ) => {
+        const value = await loader(origins);
+        if (!cancelled) listener?.(snapshot(value));
+      };
+      return {
+        subscribe(callback: (value: ServerDirectorySnapshot) => void) {
+          listener = callback;
+          callback(snapshot({ isStarted: false, isLoading: true, isInitialLoading: true }));
+          return () => {
+            listener = undefined;
+          };
+        },
+        start() {
+          void publish(mocks.loadServerDirectory);
+        },
+        loadMore() {
+          if (mocks.loadMoreDirectory.getMockImplementation()) {
+            void publish(mocks.loadMoreDirectory);
+          }
+        },
+        setVisible: vi.fn(),
+        cancel() {
+          cancelled = true;
+        },
+        whenIdle: vi.fn(async () => undefined)
+      };
+    }
+  };
 });
 vi.mock('$lib/auth/reauth', () => ({
   startServerOAuthFlow: mocks.startServerOAuthFlow,
@@ -90,7 +144,6 @@ function recommendation(
 
 describe('Server Directory page', () => {
   beforeEach(() => {
-    queryClient.clear();
     mocks.servers = [
       {
         id: 'joined',
@@ -109,6 +162,7 @@ describe('Server Directory page', () => {
     ];
     mocks.authenticated = new Set(['joined']);
     mocks.loadServerDirectory.mockReset();
+    mocks.loadMoreDirectory.mockReset();
     mocks.getPublicServerInfo.mockReset();
     mocks.startServerOAuthFlow.mockReset();
     mocks.startServerOAuthFlow.mockResolvedValue(undefined);
@@ -491,5 +545,128 @@ describe('Server Directory page', () => {
     expect(profileCard.contains(section)).toBe(false);
     expect(profileCard.nextElementSibling).toBe(section);
     expect(container.querySelector('.columns-1')).not.toBeNull();
+  });
+
+  it('shows verified entries while discovery is still active', async () => {
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://ready.example',
+          profile: profile('Ready'),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 2,
+      isLoading: true,
+      isInitialLoading: false,
+      activeRequestCount: 1
+    });
+
+    const { container } = render(Page);
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Ready description');
+      expect(container.textContent).toContain('Discovering more servers');
+    });
+    expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+  });
+
+  it('loads one additional discovery batch without removing existing entries', async () => {
+    const first = {
+      origin: 'https://first.example',
+      profile: profile('First'),
+      sourceOrigins: ['https://source.example'],
+      recommendations: [recommendation()]
+    };
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [first],
+      failedSourceCount: 0,
+      sourceCount: 2,
+      canLoadMore: true,
+      queuedCandidateCount: 1
+    });
+    mocks.loadMoreDirectory.mockResolvedValue({
+      entries: [
+        first,
+        {
+          origin: 'https://second.example',
+          profile: profile('Second'),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 2
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(button(container, 'Load more')).toBeDefined());
+    button(container, 'Load more')?.click();
+
+    await vi.waitFor(() => {
+      const entries = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-testid="server-directory-entry"]')
+      );
+      expect(entries.map(({ dataset }) => dataset.origin)).toEqual([
+        'https://first.example',
+        'https://second.example'
+      ]);
+    });
+  });
+
+  it('uses discovered source profiles for recursive testimonial attribution', async () => {
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://neighbor.example',
+          profile: profile('Neighbor source', {
+            iconUrl: 'https://cdn.example/neighbor-source.webp'
+          }),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        },
+        {
+          origin: 'https://second-hop.example',
+          profile: profile('Second hop'),
+          sourceOrigins: ['https://neighbor.example'],
+          recommendations: [recommendation('https://neighbor.example', 'A mutual second hop.')]
+        }
+      ],
+      failedSourceCount: 0,
+      sourceCount: 2
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(container.textContent).toContain('A mutual second hop.'));
+
+    const secondHop = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-testid="server-directory-entry"]')
+    ).find(({ dataset }) => dataset.origin === 'https://second-hop.example')!;
+    const testimonial = secondHop.parentElement?.querySelector<HTMLElement>(
+      '[data-testid="server-testimonial"]'
+    );
+    expect(testimonial?.textContent).toContain('Neighbor source');
+    expect(testimonial?.querySelector<HTMLImageElement>('img')?.src).toBe(
+      'https://cdn.example/neighbor-source.webp'
+    );
+  });
+
+  it('explains when the page-session discovery limit is reached', async () => {
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [],
+      failedSourceCount: 0,
+      sourceCount: 2,
+      sessionLimitReached: true
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        'The discovery limit for this session has been reached'
+      );
+    });
+    expect(button(container, 'Load more')).toBeUndefined();
   });
 });

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -60,7 +60,7 @@ User-facing concepts. If a user might say the word, it goes here.
 
 **Neighbor** — Chatto server that another server advertises in its public directory. A Neighbor has a canonical origin and can have a public testimonial. It is a recommendation, not a trust or reciprocal relationship. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
 
-**Server Directory** — Client page that follows bounded mutual Neighbor recommendations from registered servers. It adds a server after mutuality and its public profile are verified, keeps registered results visible as joined, shows source testimonials in a tapestry layout, and also accepts a direct server address. It does not rank its results. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
+**Server Directory** — Client page that shows direct Neighbor recommendations from registered servers and follows bounded mutual recommendations recursively. It adds a direct server after its public profile loads, expands a remote server only after mutuality is observed, keeps registered results visible as joined, shows source testimonials in a tapestry layout, and also accepts a direct server address. It does not rank its results. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
 
 **Testimonial** — Optional public text in a Neighbor that explains why one server recommends another server. A testimonial belongs to the directed recommendation that supplied it. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -60,7 +60,7 @@ User-facing concepts. If a user might say the word, it goes here.
 
 **Neighbor** — Chatto server that another server advertises in its public directory. A Neighbor has a canonical origin and can have a public testimonial. It is a recommendation, not a trust or reciprocal relationship. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
 
-**Server Directory** — Client page that combines the direct Neighbors advertised by registered servers. It shows Neighbors whose public server profiles load successfully, keeps registered results visible as joined, shows source testimonials in a tapestry layout, and also accepts a direct server address. It does not rank its results. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
+**Server Directory** — Client page that follows bounded mutual Neighbor recommendations from registered servers. It adds a server after mutuality and its public profile are verified, keeps registered results visible as joined, shows source testimonials in a tapestry layout, and also accepts a direct server address. It does not rank its results. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
 
 **Testimonial** — Optional public text in a Neighbor that explains why one server recommends another server. A testimonial belongs to the directed recommendation that supplied it. See [FDR-042](fdr/FDR-042-chatto-neighbors.md).
 

--- a/docs/fdr/FDR-042-chatto-neighbors.md
+++ b/docs/fdr/FDR-042-chatto-neighbors.md
@@ -23,24 +23,26 @@ recommendation, not a trust or reciprocal relationship.
 - The directory has no ordering contract.
 - Any caller can list the advertised origins through the public discovery API.
 - The Server Directory starts with all servers registered in the client. It
-  follows mutual recommendations for at most two hops from those roots. A
-  mutual recommendation exists when both public directories currently
-  advertise the other server.
-- The client adds a result only after it verifies a mutual recommendation and
-  loads the result's public profile. It adds results as requests finish and
-  does not move results that are already visible.
+  shows their direct recommendations after it loads each public profile. A
+  direct recommendation does not need reciprocal confirmation.
+- The client expands a recommended server only when the source and target
+  public directories currently advertise each other. It follows at most two
+  such mutual hops from a registered server.
+- The client adds results as public profiles load and does not move results
+  that are already visible.
 - The client removes duplicate canonical origins but does not rank or sort the
-  results. Each result identifies all verified sources that recommend it. It
-  preserves each source's testimonial.
+  results. Each result identifies all sources whose recommendations are shown.
+  It preserves each source's testimonial.
 - The Server Directory uses a tapestry layout. It shows each testimonial in a
   review card below the server profile. The review card shows the known name
   and icon of the server that supplied it.
 - The Server Directory and Neighbor administration page load each applicable
   server's public name, description, logo, and banner. The Server Directory
-  omits a server when mutuality is not verified or its public profile does not
-  load. The administration page keeps an advertised server visible so that an
-  administrator can review or remove it. A failed request does not hide
-  profiles that loaded successfully.
+  omits a direct recommendation when its public profile does not load. It omits
+  a recursive recommendation when mutuality is not verified or its public
+  profile does not load. The administration page keeps an advertised server
+  visible so that an administrator can review or remove it. A failed request
+  does not hide profiles that loaded successfully.
 - The Server Directory starts one automatic batch of 12 candidate-directory
   requests. **Load more** starts another batch of 12. One page session permits
   at most 48 directory requests, 24 profile requests, and 72 discovery requests
@@ -81,18 +83,21 @@ unrelated directory state.
 **Tradeoff:** The server maintains resource IDs and revisions in addition to
 origins.
 
-### 2. Each Neighbor remains unilateral
+### 2. Direct recommendations remain unilateral
 
-**Decision:** A server can advertise another server without confirmation. The
-Server Directory shows a server only when the client observes that both public
-directories currently advertise each other.
+**Decision:** The Server Directory shows a direct recommendation from a
+registered server without reciprocal confirmation. It expands that remote
+server only when the client observes that both public directories advertise
+each other.
 
-**Why:** Client-observed mutuality reduces one-sided listings without adding
-server-to-server communication, authentication, queues, or a relationship
-lifecycle.
+**Why:** Direct recommendations keep the directory useful for old servers and
+for registered servers that are not publicly reachable. Client-observed
+mutuality prevents one unilateral recommendation from amplifying the recursive
+crawl.
 
-**Tradeoff:** Two matching public responses are not durable consent or an
-authenticated relationship. The observation can change between requests.
+**Tradeoff:** A direct result can remain one-sided. Two matching public
+responses are not durable consent or an authenticated relationship. The
+observation can change between requests.
 
 ### 3. The server stays passive and the client loads public profiles
 
@@ -147,7 +152,7 @@ join.
 ### 7. Deduplication preserves recommendation sources
 
 **Decision:** One server appears once in the Server Directory. The result also
-identifies each verified source server that advertises it.
+identifies each source server whose recommendation is shown.
 
 **Why:** A user can see where a recommendation comes from without seeing
 duplicate server cards.
@@ -212,10 +217,10 @@ direct join flow, even when it might work with the client.
 
 ### 12. Recursive discovery has a page-session budget
 
-**Decision:** The client follows at most two verified mutual hops. It uses one
-shared six-request scheduler and fixed candidate, directory, profile, and total
-request limits. The first candidate batch starts automatically. Later batches
-require **Load more**.
+**Decision:** The client shows direct recommendations and follows at most two
+verified mutual hops. It uses one shared six-request scheduler and fixed
+candidate, directory, profile, and total request limits. The first candidate
+batch starts automatically. Later batches require **Load more**.
 
 **Why:** Progressive discovery can find servers beyond a direct recommendation,
 but one malicious or cyclic directory must not start unbounded browser work.

--- a/docs/fdr/FDR-042-chatto-neighbors.md
+++ b/docs/fdr/FDR-042-chatto-neighbors.md
@@ -22,18 +22,34 @@ recommendation, not a trust or reciprocal relationship.
   or an exact `webserver.allowed_origins` alias.
 - The directory has no ordering contract.
 - Any caller can list the advertised origins through the public discovery API.
-- The Server Directory page combines the direct Neighbors from all servers
-  registered in the client. It removes duplicate canonical origins but does
-  not rank or sort the results. Each result identifies the registered servers
-  that recommend it. It preserves each source's testimonial.
+- The Server Directory starts with all servers registered in the client. It
+  follows mutual recommendations for at most two hops from those roots. A
+  mutual recommendation exists when both public directories currently
+  advertise the other server.
+- The client adds a result only after it verifies a mutual recommendation and
+  loads the result's public profile. It adds results as requests finish and
+  does not move results that are already visible.
+- The client removes duplicate canonical origins but does not rank or sort the
+  results. Each result identifies all verified sources that recommend it. It
+  preserves each source's testimonial.
 - The Server Directory uses a tapestry layout. It shows each testimonial in a
-  review card below the server profile. The review card shows the device-local
-  name and icon of the registered server that supplied it.
-- The Server Directory and Neighbor administration page load each advertised
+  review card below the server profile. The review card shows the known name
+  and icon of the server that supplied it.
+- The Server Directory and Neighbor administration page load each applicable
   server's public name, description, logo, and banner. The Server Directory
-  omits a server when its public profile does not load. The administration page
-  keeps that server visible so that an administrator can review or remove it.
-  A failed request does not hide profiles that loaded successfully.
+  omits a server when mutuality is not verified or its public profile does not
+  load. The administration page keeps an advertised server visible so that an
+  administrator can review or remove it. A failed request does not hide
+  profiles that loaded successfully.
+- The Server Directory starts one automatic batch of 12 candidate-directory
+  requests. **Load more** starts another batch of 12. One page session permits
+  at most 48 directory requests, 24 profile requests, and 72 discovery requests
+  in total. It queues at most 120 canonical candidates.
+- The client uses at most six active discovery requests. Each request has a
+  ten-second timeout. It requests one directory and one profile at most for one
+  canonical origin. It does not retry a failed request in the same page session.
+- A hidden page does not start queued requests. Active requests can finish.
+  Leaving the page cancels active work and removes queued work.
 - An advertised server that is already registered remains visible and is
   marked as joined.
 - An unregistered server has a join action only when its discovered version is
@@ -65,16 +81,18 @@ unrelated directory state.
 **Tradeoff:** The server maintains resource IDs and revisions in addition to
 origins.
 
-### 2. The directory is unilateral
+### 2. Each Neighbor remains unilateral
 
-**Decision:** A server can advertise another server without a reciprocal
-confirmation.
+**Decision:** A server can advertise another server without confirmation. The
+Server Directory shows a server only when the client observes that both public
+directories currently advertise each other.
 
-**Why:** The first iteration is a small directory feature. It does not require
-server-to-server communication, queues, or a request lifecycle.
+**Why:** Client-observed mutuality reduces one-sided listings without adding
+server-to-server communication, authentication, queues, or a relationship
+lifecycle.
 
-**Tradeoff:** An advertised server has not confirmed the relationship.
-Administrators and clients must not present a Neighbor as trusted or mutual.
+**Tradeoff:** Two matching public responses are not durable consent or an
+authenticated relationship. The observation can change between requests.
 
 ### 3. The server stays passive and the client loads public profiles
 
@@ -129,13 +147,13 @@ join.
 ### 7. Deduplication preserves recommendation sources
 
 **Decision:** One server appears once in the Server Directory. The result also
-identifies each registered server that advertises it.
+identifies each verified source server that advertises it.
 
 **Why:** A user can see where a recommendation comes from without seeing
 duplicate server cards.
 
-**Tradeoff:** The source names depend on the server catalogue on the user's
-device.
+**Tradeoff:** A source name can come from the device-local catalogue or from a
+public profile that the current discovery session loaded.
 
 ### 8. A testimonial belongs to one recommendation
 
@@ -192,11 +210,25 @@ support.
 **Tradeoff:** A server with a missing or non-standard version cannot use the
 direct join flow, even when it might work with the client.
 
+### 12. Recursive discovery has a page-session budget
+
+**Decision:** The client follows at most two verified mutual hops. It uses one
+shared six-request scheduler and fixed candidate, directory, profile, and total
+request limits. The first candidate batch starts automatically. Later batches
+require **Load more**.
+
+**Why:** Progressive discovery can find servers beyond a direct recommendation,
+but one malicious or cyclic directory must not start unbounded browser work.
+Fixed limits make the maximum request effect testable.
+
+**Tradeoff:** A page session can stop before it explores every recommendation.
+Discovery order reflects completion and bounded scheduling, not quality.
+
 ## Non-goals
 
-- Reciprocal requests, approval, rejection, or revocation
+- Authenticated reciprocal requests, approval, rejection, or revocation
 - Server-to-server authentication or trust
-- Recursive Neighbor discovery
+- Unbounded recursive Neighbor discovery
 - Directory ranking or sorting
 - Remote-server moderation or blocking
 - Server-side reachability or compatibility checks
@@ -207,4 +239,5 @@ direct join flow, even when it might work with the client.
 - **FDRs:** FDR-001 (Roles & Permissions), FDR-020 (Server Branding &
   Configuration), FDR-031 (Client–Server Compatibility Discovery)
 - **Issues:** [#1669](https://github.com/chattocorp/chatto/issues/1669),
-  [#2208](https://github.com/chattocorp/chatto/issues/2208)
+  [#2208](https://github.com/chattocorp/chatto/issues/2208),
+  [#2207](https://github.com/chattocorp/chatto/issues/2207)


### PR DESCRIPTION
## Why

The first Server Directory iteration showed direct unilateral recommendations. Recursive discovery needs a mutuality check and strict browser-request limits so that a malicious, cyclic, or slow remote directory cannot amplify the crawl. Direct results must remain useful for old servers and registered servers that are not publicly reachable.

## What changed

- Start from the device-local server catalogue and show its direct recommendations after their public profiles load.
- Follow a remote server recursively only after mutuality is observed, for at most two mutual Neighbor hops.
- Publish accepted cards progressively. Enrich later provenance in place without moving the card.
- Use one fair six-request scheduler for directory and profile calls. Pause queued work in hidden tabs, cancel it on navigation, and do not retry failures in the same page session.
- Start 12 candidate-directory requests automatically and let **Load more** grant another 12-request batch.
- Keep Joined, Open, Sign in, incompatible-server handoff, direct-address, testimonial, and partial/all-source-failure behavior.
- Prevent direct but non-mutual candidates from promoting each other. Canonicalize each origin before queueing, and fetch each directory and profile at most once.
- Send public discovery without browser credentials or referrer data, and reject redirects.
- Update FDR-042, the glossary, the Neighbor operations guide, the 0.5 release page, and all complete frontend locales.

### Fixed page-session limits

- Mutual depth: 2 hops
- Active discovery requests: 6
- Timeout per request: 10 seconds
- Candidate batch: 12 automatic or manual directory requests
- Directory requests: 48
- Profile requests: 24
- Total discovery RPCs: 72
- Canonical candidate queue: 120
- Recommendations considered per source: 100

A Connect RPC can cause one unauthenticated CORS preflight and one POST. The upper bound is therefore 144 discovery HTTP exchanges per page session. At most 24 loaded profiles can add new cards and load their public logo and banner URLs.

## Compatibility, security, and operations

- Classification: behavioral frontend change only. There is no protobuf, ConnectRPC service, persistence, permission, or backend change.
- Older client with newer server: unchanged.
- Newer client with older server: the existing origin-only Neighbor response remains supported. A direct recommendation stays visible when its profile loads. `Unimplemented` prevents only recursive expansion.
- No migration or coordinated rollout is required.
- Contacted servers can observe the browser network address, CORS origin, and request timing. They receive no reusable Chatto credential or registered-server catalogue.
- Private or locally resolved advertised origins can still receive an unauthenticated CORS preflight. The per-origin, concurrency, timeout, batch, and session limits bound this residual browser-side request effect. Redirects are rejected.

## Test plan

- `mise test-frontend`: 1,342 server tests, 1,951 client tests, 228 Storybook tests, and 5 performance-comparison tests passed (3,526 total).
- `mise lint-frontend`: passed with zero Svelte errors and zero warnings.
- Svelte autofixer: no issues or suggestions.
- Docs website production build: passed.
- `mise license-check`: passed.
- Chrome DevTools: verified the real local server's two unilateral direct recommendations, progressive fixture loading, **Load more**, stable cards, partial root failure, Joined state, long names, multi-source accessible attribution, testimonial paragraphs, responsive layouts, and browser console output.

Closes #2207.
Part of #1666.
