### PR TITLE
fix(frontend): backport resilient unread markers to 0.4

### DIFF
--- a/apps/frontend/e2e/unread-indicators.test.ts
+++ b/apps/frontend/e2e/unread-indicators.test.ts
@@ -222,6 +222,139 @@ test.describe('Unread indicators', () => {
     );
   });
 
+  test('retries a failed room read when the browser comes online', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    test.setTimeout(60000);
+
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    const generalRoomId = await getRoomIdByNameViaConnect(page, 'general');
+    await waitForRoomReadViaConnect(page, generalRoomId);
+    await chatPage.enterRoom('announcements');
+    await waitForRoomReady(page, 'announcements');
+
+    await withServerUser(
+      browser!,
+      serverURL,
+      async ({ page: otherPage, chatPage: otherChatPage, roomPage: otherRoomPage }) => {
+        await otherChatPage.enterRoom('general');
+        await waitForRoomReady(otherPage, 'general');
+        await otherRoomPage.sendMessage(`Read retry ${Date.now()}`);
+        await waitForRoomUnreadViaConnect(page, generalRoomId, true);
+
+        const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
+        const unreadDot = generalLink.getByTestId('room-unread-dot');
+        await expect(unreadDot).toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+
+        const markReadRoute = '**/api/connect/chatto.api.v1.RoomService/MarkRoomAsRead';
+        let allowMarkRead = false;
+        let failedAttempts = 0;
+        let allowedAttempts = 0;
+
+        await page.route(markReadRoute, async (route) => {
+          if (!allowMarkRead) {
+            failedAttempts += 1;
+            await route.abort('internetdisconnected');
+            return;
+          }
+
+          allowedAttempts += 1;
+          await route.continue();
+        });
+
+        try {
+          await chatPage.enterRoom('general');
+          await expect.poll(() => failedAttempts).toBeGreaterThan(0);
+
+          // The optimistic read must roll back while the server cursor stays
+          // behind the new message.
+          await waitForRoomUnreadViaConnect(page, generalRoomId, true);
+          await expect(unreadDot).toBeVisible();
+
+          allowMarkRead = true;
+          await page.evaluate(() => window.dispatchEvent(new Event('online')));
+
+          await expect
+            .poll(() => allowedAttempts, { timeout: TIMEOUTS.REALTIME_EVENT })
+            .toBeGreaterThan(0);
+          await waitForRoomReadViaConnect(page, generalRoomId);
+          await expect(unreadDot).not.toBeVisible({ timeout: TIMEOUTS.REALTIME_EVENT });
+        } finally {
+          await page.unroute(markReadRoute);
+        }
+      }
+    );
+  });
+
+  test('marks a background-entered room read when visibility returns without a focus event', async ({
+    page,
+    chatPage,
+    browser,
+    serverURL
+  }) => {
+    test.setTimeout(60000);
+
+    await createAndLoginTestUser(page);
+    await chatPage.goto();
+    await chatPage.enterRoom('general');
+    await waitForRoomReady(page, 'general');
+
+    const generalRoomId = await getRoomIdByNameViaConnect(page, 'general');
+    await waitForRoomReadViaConnect(page, generalRoomId);
+    await chatPage.enterRoom('announcements');
+    await waitForRoomReady(page, 'announcements');
+
+    await withServerUser(
+      browser!,
+      serverURL,
+      async ({ page: otherPage, chatPage: otherChatPage, roomPage: otherRoomPage }) => {
+        await otherChatPage.enterRoom('general');
+        await waitForRoomReady(otherPage, 'general');
+        await otherRoomPage.sendMessage(`Foreground read ${Date.now()}`);
+        await waitForRoomUnreadViaConnect(page, generalRoomId, true);
+
+        const generalLink = chatPage.roomList.locator('a', { hasText: '# general' });
+        await expect(generalLink.getByTestId('room-unread-dot')).toBeVisible({
+          timeout: TIMEOUTS.REALTIME_EVENT
+        });
+
+        // Model Android PWA backgrounding while the page and connection stay
+        // alive.
+        await page.evaluate(() => {
+          Object.defineProperties(document, {
+            hidden: { configurable: true, value: true },
+            visibilityState: { configurable: true, value: 'hidden' }
+          });
+          window.dispatchEvent(new Event('blur'));
+          document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        // Enter through an untrusted programmatic click so trusted interaction
+        // recovery does not activate the app before visibility is restored.
+        await generalLink.evaluate((link: HTMLAnchorElement) => link.click());
+        await waitForRoomReady(page, 'general');
+        await waitForRoomUnreadViaConnect(page, generalRoomId, true);
+
+        // Android can restore visibility without a matching focus event.
+        await page.evaluate(() => {
+          Object.defineProperties(document, {
+            hidden: { configurable: true, value: false },
+            visibilityState: { configurable: true, value: 'visible' }
+          });
+          document.dispatchEvent(new Event('visibilitychange'));
+        });
+        await waitForRoomReadViaConnect(page, generalRoomId);
+      }
+    );
+  });
+
   test('unread indicator clears when navigating to room', async ({ page, chatPage, roomPage }) => {
     await createAndLoginTestUser(page);
     await chatPage.goto();

--- a/apps/frontend/src/lib/api-client-tests/readState.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/readState.spec.ts
@@ -75,6 +75,22 @@ describe('createReadStateAPI', () => {
     });
   });
 
+  it('forwards an abort signal to the room read request', async () => {
+    mocks.markRoomAsRead.mockResolvedValue({});
+    const controller = new AbortController();
+    const api = createReadStateAPI({
+      baseUrl: 'https://remote.example.test/api/connect',
+      bearerToken: null
+    });
+
+    await api.markRoomAsRead({ roomId: 'room-1' }, { signal: controller.signal });
+
+    expect(mocks.markRoomAsRead).toHaveBeenCalledWith(
+      { roomId: 'room-1', upToEventId: '' },
+      { headers: undefined, signal: controller.signal }
+    );
+  });
+
   it('marks a thread read without auth headers when no token is available', async () => {
     mocks.markThreadAsRead.mockResolvedValue({
       previousReadAt: Timestamp.fromDate(new Date('2026-06-01T10:00:00Z'))

--- a/apps/frontend/src/lib/api-client/readState.ts
+++ b/apps/frontend/src/lib/api-client/readState.ts
@@ -1,6 +1,6 @@
-import { authHeaders, createChattoClient, handleAuthError } from "./connect.js";
-import { RoomService } from "@chatto/api-types/api/v1/rooms_connect";
-import { ThreadService } from "@chatto/api-types/api/v1/threads_connect";
+import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
+import { RoomService } from '@chatto/api-types/api/v1/rooms_connect';
+import { ThreadService } from '@chatto/api-types/api/v1/threads_connect';
 
 export type ConnectAPIConfig = {
   serverId?: string;
@@ -23,49 +23,59 @@ export function createReadStateAPI(config: ConnectAPIConfig) {
   const threads = createChattoClient(ThreadService, config);
   const headers = () => authHeaders(config);
   return {
-    async markRoomAsRead(input: {
-      roomId: string;
-      upToEventId?: string;
-    }): Promise<MarkRoomAsReadResult> {
+    async markRoomAsRead(
+      input: {
+        roomId: string;
+        upToEventId?: string;
+      },
+      options: { signal?: AbortSignal } = {}
+    ): Promise<MarkRoomAsReadResult> {
       try {
         const response = await rooms.markRoomAsRead(
           {
             roomId: input.roomId,
-            upToEventId: input.upToEventId ?? "",
+            upToEventId: input.upToEventId ?? ''
           },
-          { headers: headers() },
+          {
+            headers: headers(),
+            ...(options.signal ? { signal: options.signal } : {})
+          }
         );
         return {
           lastReadAt: response.lastReadAt?.toDate().toISOString() ?? null,
-          previousLastReadAt:
-            response.previousLastReadAt?.toDate().toISOString() ?? null,
+          previousLastReadAt: response.previousLastReadAt?.toDate().toISOString() ?? null
         };
       } catch (err) {
         return handleAuthError(config, err);
       }
     },
 
-    async markThreadAsRead(input: {
-      roomId: string;
-      threadRootEventId: string;
-      upToEventId?: string;
-    }): Promise<MarkThreadAsReadResult> {
+    async markThreadAsRead(
+      input: {
+        roomId: string;
+        threadRootEventId: string;
+        upToEventId?: string;
+      },
+      options: { signal?: AbortSignal } = {}
+    ): Promise<MarkThreadAsReadResult> {
       try {
         const response = await threads.markThreadAsRead(
           {
             roomId: input.roomId,
             threadRootEventId: input.threadRootEventId,
-            upToEventId: input.upToEventId ?? "",
+            upToEventId: input.upToEventId ?? ''
           },
-          { headers: headers() },
+          {
+            headers: headers(),
+            ...(options.signal ? { signal: options.signal } : {})
+          }
         );
         return {
-          previousReadAt:
-            response.previousReadAt?.toDate().toISOString() ?? null,
+          previousReadAt: response.previousReadAt?.toDate().toISOString() ?? null
         };
       } catch (err) {
         return handleAuthError(config, err);
       }
-    },
+    }
   };
 }

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -15,9 +15,8 @@ const { getRoomEventsAroundMock, timelineResults, refreshAssetUrlsMock } = vi.ho
 );
 
 function testImageUrl(label: string): string {
-  return `data:image/svg+xml,${encodeURIComponent(
-    `<svg xmlns="http://www.w3.org/2000/svg"><title>${label}</title></svg>`
-  )}`;
+  return new URL(`/icons/favicon.png?label=${encodeURIComponent(label)}`, window.location.origin)
+    .href;
 }
 
 function deferred<T>() {

--- a/apps/frontend/src/lib/hooks/UseUnreadMarkerHarness.svelte
+++ b/apps/frontend/src/lib/hooks/UseUnreadMarkerHarness.svelte
@@ -11,15 +11,21 @@
   let {
     targetId,
     markAsRead,
+    canMarkAsRead = true,
     onReady
   }: {
     targetId: string;
-    markAsRead: (targetId: string, upToEventId?: string) => Promise<ReadResult | null>;
+    markAsRead: (
+      targetId: string,
+      upToEventId: string | undefined,
+      signal: AbortSignal
+    ) => Promise<ReadResult>;
+    canMarkAsRead?: boolean;
     onReady: (api: UnreadMarkerHarnessAPI) => void;
   } = $props();
 
   const unread = useUnreadMarker(() => targetId, {
-    markAsRead: (target, upToEventId) => markAsRead(target, upToEventId),
+    markAsRead: (target, upToEventId, signal) => markAsRead(target, upToEventId, signal),
     markerWindowFromReadResult: (result, markedAtMs): UnreadMarkerWindow | null => {
       if (!result.previousLastReadAt || !result.lastReadAt) return null;
       if (result.previousLastReadAt === result.lastReadAt) return null;
@@ -27,10 +33,13 @@
         afterTime: result.previousLastReadAt,
         beforeTime: markedAtMs
       };
-    }
+    },
+    canMarkAsRead: () => canMarkAsRead
   });
 
   $effect(() => {
     onReady(unread);
   });
 </script>
+
+<button type="button">Interaction target</button>

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.spec.ts
@@ -1,6 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
+import { Code, ConnectError } from '@connectrpc/connect';
 import { RoomUnreadStore } from '$lib/state/server/roomUnread.svelte';
 import Harness from './UseRoomUnreadHarness.svelte';
 
@@ -61,6 +62,11 @@ describe('useRoomUnread', () => {
     setPresent();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
   it('rolls back the optimistic read when the RPC fails', async () => {
     const request = deferred<never>();
     mocks.markRoomAsRead.mockReturnValue(request.promise);
@@ -77,6 +83,61 @@ describe('useRoomUnread', () => {
 
     request.reject(new Error('network down'));
     await vi.waitFor(() => expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(true));
+    rendered.unmount();
+  });
+
+  it('aborts an in-flight room read and rolls back on unmount', async () => {
+    let requestSignal: AbortSignal | undefined;
+    mocks.markRoomAsRead.mockImplementation(
+      (_input: unknown, options: { signal?: AbortSignal } = {}) =>
+        new Promise((_resolve, reject) => {
+          requestSignal = options.signal;
+          options.signal?.addEventListener('abort', () => {
+            reject(new DOMException('Request canceled', 'AbortError'));
+          });
+        })
+    );
+    mocks.roomUnread!.setRoomUnread('room-1', true);
+
+    const rendered = render(Harness, {
+      props: { roomId: 'room-1', onReady: () => {} }
+    });
+    flushSync();
+
+    await vi.waitFor(() => expect(mocks.markRoomAsRead).toHaveBeenCalledOnce());
+    expect(requestSignal?.aborted).toBe(false);
+    expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(false);
+
+    rendered.unmount();
+
+    await vi.waitFor(() => expect(requestSignal?.aborted).toBe(true));
+    await vi.waitFor(() => expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(true));
+  });
+
+  it('retries a failed room read and clears the unread overlay after success', async () => {
+    vi.useFakeTimers();
+    mocks.markRoomAsRead
+      .mockRejectedValueOnce(new ConnectError('network down', Code.Unavailable))
+      .mockResolvedValueOnce({
+        lastReadAt: '2026-07-10T20:00:00.000Z',
+        previousLastReadAt: null
+      });
+    mocks.roomUnread!.setRoomUnread('room-1', true);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const rendered = render(Harness, {
+      props: { roomId: 'room-1', onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(true);
+    await vi.advanceTimersByTimeAsync(500);
+    flushSync();
+
+    expect(mocks.markRoomAsRead).toHaveBeenCalledTimes(2);
+    expect(mocks.roomUnread!.roomIsUnread('room-1')).toBe(false);
     rendered.unmount();
   });
 

--- a/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useRoomUnread.svelte.ts
@@ -6,7 +6,7 @@ import { useUnreadMarker } from './useUnreadMarker.svelte';
 
 /**
  * Room-specific unread marker wrapper. The shared unread marker hook owns the
- * focus/refocus lifecycle; this wrapper only wires room read-state mutation
+ * entry and foreground lifecycle; this wrapper only wires read-state mutation
  * and room-list unread clearing.
  *
  * Must be called during component initialization (uses context).
@@ -16,7 +16,11 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
   const roomUnreadStore = serverRegistry.getStore(getActiveServer()).roomUnread;
 
   const unread = useUnreadMarker(() => getProps().roomId, {
-    markAsRead: async (targetRoomId: string, upToEventId?: string) => {
+    markAsRead: async (
+      targetRoomId: string,
+      upToEventId: string | undefined,
+      signal: AbortSignal
+    ) => {
       const optimisticRead = roomUnreadStore.beginOptimisticRead(targetRoomId);
 
       try {
@@ -25,13 +29,12 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
           serverId: conn.serverId ?? getActiveServer(),
           baseUrl: conn.connectBaseUrl,
           bearerToken: conn.bearerToken
-        }).markRoomAsRead({ roomId: targetRoomId, upToEventId });
+        }).markRoomAsRead({ roomId: targetRoomId, upToEventId }, { signal });
         optimisticRead.commit();
         return result;
       } catch (err) {
         optimisticRead.rollback();
-        console.error('Failed to mark room as read:', err);
-        return null;
+        throw err;
       }
     },
     markerWindowFromReadResult: (result: MarkRoomAsReadResult, markedAtMs: number) => {
@@ -41,7 +44,8 @@ export function useRoomUnread(getProps: () => { roomId: string }) {
         afterTime: result.previousLastReadAt,
         beforeTime: markedAtMs
       };
-    }
+    },
+    onMarkAsReadError: (error) => console.error('Failed to mark room as read:', error)
   });
 
   return {

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.spec.ts
@@ -1,7 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { userEvent } from 'vitest/browser';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
+import { Code, ConnectError } from '@connectrpc/connect';
 import Harness from './UseUnreadMarkerHarness.svelte';
+
+const NO_MARKER_RESULT = {
+  previousLastReadAt: null,
+  lastReadAt: null
+};
 
 type HarnessAPI = {
   readonly unreadMarkerEventId: string | null;
@@ -18,6 +25,14 @@ function getApi(api: HarnessAPI | undefined): HarnessAPI {
     throw new Error('Unread marker harness API was not initialized');
   }
   return api;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((nextResolve) => {
+    resolve = nextResolve;
+  });
+  return { promise, resolve };
 }
 
 function setVisibility(value: DocumentVisibilityState): void {
@@ -41,12 +56,13 @@ describe('useUnreadMarker', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     setPresent(true);
     vi.restoreAllMocks();
   });
 
   it('marks the same target as read again on refocus', async () => {
-    const markAsRead = vi.fn().mockResolvedValue(null);
+    const markAsRead = vi.fn().mockResolvedValue(NO_MARKER_RESULT);
 
     const rendered = render(Harness, {
       props: {
@@ -62,20 +78,270 @@ describe('useUnreadMarker', () => {
     setPresent(true);
 
     await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
-    expect(markAsRead).toHaveBeenLastCalledWith('room-1', undefined);
+    expect(markAsRead).toHaveBeenLastCalledWith('room-1', undefined, expect.any(AbortSignal));
+    rendered.unmount();
+  });
+
+  it('marks a visible target on entry without requiring focus', async () => {
+    setVisibility('visible');
+    window.dispatchEvent(new Event('blur'));
+    flushSync();
+    const markAsRead = vi.fn().mockResolvedValue(NO_MARKER_RESULT);
+
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+    expect(markAsRead).toHaveBeenCalledWith('room-1', undefined, expect.any(AbortSignal));
+    rendered.unmount();
+  });
+
+  it('marks a hidden target when it becomes visible without a focus event', async () => {
+    setVisibility('hidden');
+    window.dispatchEvent(new Event('blur'));
+    flushSync();
+    const markAsRead = vi.fn().mockResolvedValue(NO_MARKER_RESULT);
+
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+    expect(markAsRead).not.toHaveBeenCalled();
+
+    setVisibility('visible');
+    window.dispatchEvent(new Event('blur'));
+    flushSync();
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+    rendered.unmount();
+  });
+
+  it('marks the target after pageshow and ignores duplicate foreground signals', async () => {
+    const markAsRead = vi.fn().mockResolvedValue(NO_MARKER_RESULT);
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    window.dispatchEvent(new Event('pagehide'));
+    window.dispatchEvent(new Event('pageshow'));
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+
+    window.dispatchEvent(new Event('pageshow'));
+    document.dispatchEvent(new Event('resume'));
+    setVisibility('visible');
+    flushSync();
+    await Promise.resolve();
+    expect(markAsRead).toHaveBeenCalledTimes(2);
+    rendered.unmount();
+  });
+
+  it('recovers foreground state from trusted interaction after pagehide', async () => {
+    const markAsRead = vi.fn().mockResolvedValue(NO_MARKER_RESULT);
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    window.dispatchEvent(new Event('pagehide'));
+    flushSync();
+    await userEvent.click(rendered.container.querySelector('button')!);
+    flushSync();
+
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+    rendered.unmount();
+  });
+
+  it('retries transient failures with exponential backoff', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable))
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable))
+      .mockResolvedValueOnce(NO_MARKER_RESULT);
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+    expect(markAsRead).toHaveBeenCalledOnce();
+
+    await vi.advanceTimersByTimeAsync(499);
+    expect(markAsRead).toHaveBeenCalledOnce();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(markAsRead).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(markAsRead).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(markAsRead).toHaveBeenCalledTimes(3);
+    rendered.unmount();
+  });
+
+  it('does not retry permanent failures', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValue(new ConnectError('permission denied', Code.PermissionDenied));
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(markAsRead).toHaveBeenCalledOnce();
+    rendered.unmount();
+  });
+
+  it('cancels a scheduled retry when the target becomes hidden', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable));
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+
+    setVisibility('hidden');
+    flushSync();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(markAsRead).toHaveBeenCalledOnce();
+    rendered.unmount();
+  });
+
+  it('cancels a scheduled retry on pagehide without visibilitychange', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable));
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+
+    window.dispatchEvent(new Event('pagehide'));
+    flushSync();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(markAsRead).toHaveBeenCalledOnce();
+    rendered.unmount();
+  });
+
+  it('aborts an in-flight request and ignores its response after hiding', async () => {
+    const request = deferred<{
+      previousLastReadAt: string;
+      lastReadAt: string;
+    }>();
+    let requestSignal: AbortSignal | undefined;
+    const markAsRead = vi.fn(
+      (_targetId: string, _upToEventId: string | undefined, signal: AbortSignal) => {
+        requestSignal = signal;
+        return request.promise;
+      }
+    );
+    let api: HarnessAPI | undefined;
+    const rendered = render(Harness, {
+      props: {
+        targetId: 'room-1',
+        markAsRead,
+        onReady: (nextApi: HarnessAPI) => {
+          api = nextApi;
+        }
+      }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    setVisibility('hidden');
+    flushSync();
+    expect(requestSignal?.aborted).toBe(true);
+
+    request.resolve({
+      previousLastReadAt: '2026-07-08T09:00:00.000Z',
+      lastReadAt: '2026-07-08T10:00:00.000Z'
+    });
+    await request.promise;
+    flushSync();
+
+    expect(getApi(api).unreadMarkerWindow).toBeNull();
+    rendered.unmount();
+  });
+
+  it('retries immediately when the browser comes online', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable))
+      .mockResolvedValueOnce(NO_MARKER_RESULT);
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+    expect(markAsRead).toHaveBeenCalledOnce();
+
+    window.dispatchEvent(new Event('online'));
+    flushSync();
+    await Promise.resolve();
+    expect(markAsRead).toHaveBeenCalledTimes(2);
+    rendered.unmount();
+  });
+
+  it('cancels retries on permission loss and marks after permission returns', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable))
+      .mockResolvedValue(NO_MARKER_RESULT);
+    const onReady = () => {};
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, canMarkAsRead: true, onReady }
+    });
+    flushSync();
+    await Promise.resolve();
+
+    const permissionRemoved = rendered.rerender({
+      targetId: 'room-1',
+      markAsRead,
+      canMarkAsRead: false,
+      onReady
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await permissionRemoved;
+    flushSync();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(markAsRead).toHaveBeenCalledOnce();
+
+    const permissionRestored = rendered.rerender({
+      targetId: 'room-1',
+      markAsRead,
+      canMarkAsRead: true,
+      onReady
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    await permissionRestored;
+    flushSync();
+    await Promise.resolve();
+    expect(markAsRead).toHaveBeenCalledTimes(2);
     rendered.unmount();
   });
 
   it('uses the read-state window returned on refocus', async () => {
     const markedAtMs = Date.UTC(2026, 6, 8, 10, 0, 30);
     vi.spyOn(Date, 'now').mockReturnValue(markedAtMs);
-    const markAsRead = vi
-      .fn()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce({
-        previousLastReadAt: '2026-07-08T09:00:00.000Z',
-        lastReadAt: '2026-07-08T10:00:00.000Z'
-      });
+    const markAsRead = vi.fn().mockResolvedValueOnce(NO_MARKER_RESULT).mockResolvedValueOnce({
+      previousLastReadAt: '2026-07-08T09:00:00.000Z',
+      lastReadAt: '2026-07-08T10:00:00.000Z'
+    });
     let api: HarnessAPI | undefined;
 
     const rendered = render(Harness, {
@@ -176,10 +442,7 @@ describe('useUnreadMarker', () => {
   it('preserves a pending refocus marker after a newer explicit read', async () => {
     const markedAtMs = Date.UTC(2026, 6, 8, 10, 0, 30);
     vi.spyOn(Date, 'now').mockReturnValue(markedAtMs);
-    let resolveRefocus!: (value: {
-      previousLastReadAt: string;
-      lastReadAt: string;
-    }) => void;
+    let resolveRefocus!: (value: { previousLastReadAt: string; lastReadAt: string }) => void;
     const refocusRead = new Promise<{
       previousLastReadAt: string;
       lastReadAt: string;
@@ -188,9 +451,9 @@ describe('useUnreadMarker', () => {
     });
     const markAsRead = vi
       .fn()
-      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(NO_MARKER_RESULT)
       .mockReturnValueOnce(refocusRead)
-      .mockResolvedValueOnce(null);
+      .mockResolvedValueOnce(NO_MARKER_RESULT);
     let api: HarnessAPI | undefined;
 
     const rendered = render(Harness, {
@@ -229,7 +492,7 @@ describe('useUnreadMarker', () => {
   });
 
   it('marks a new target as read when the target changes', async () => {
-    const markAsRead = vi.fn().mockResolvedValue(null);
+    const markAsRead = vi.fn().mockResolvedValue(NO_MARKER_RESULT);
 
     const rendered = render(Harness, {
       props: {
@@ -249,7 +512,89 @@ describe('useUnreadMarker', () => {
     flushSync();
 
     await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
-    expect(markAsRead).toHaveBeenLastCalledWith('room-2', undefined);
+    expect(markAsRead).toHaveBeenLastCalledWith('room-2', undefined, expect.any(AbortSignal));
+    rendered.unmount();
+  });
+
+  it('cancels the old retry when the target changes', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable))
+      .mockResolvedValue(NO_MARKER_RESULT);
+    const onReady = () => {};
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady }
+    });
+    flushSync();
+    await Promise.resolve();
+
+    const rerendered = rendered.rerender({ targetId: 'room-2', markAsRead, onReady });
+    await vi.advanceTimersByTimeAsync(0);
+    await rerendered;
+    flushSync();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(markAsRead.mock.calls.map(([targetId]) => targetId)).toEqual(['room-1', 'room-2']);
+    rendered.unmount();
+  });
+
+  it('cancels a scheduled retry on unmount', async () => {
+    vi.useFakeTimers();
+    const markAsRead = vi
+      .fn()
+      .mockRejectedValueOnce(new ConnectError('temporarily unavailable', Code.Unavailable));
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady: () => {} }
+    });
+    flushSync();
+    await Promise.resolve();
+
+    rendered.unmount();
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(markAsRead).toHaveBeenCalledOnce();
+  });
+
+  it('ignores a stale read-state response after the target changes', async () => {
+    const firstRead = deferred<{
+      previousLastReadAt: string;
+      lastReadAt: string;
+    }>();
+    let firstSignal: AbortSignal | undefined;
+    const markAsRead = vi
+      .fn()
+      .mockImplementationOnce(
+        (_targetId: string, _upToEventId: string | undefined, signal: AbortSignal) => {
+          firstSignal = signal;
+          return firstRead.promise;
+        }
+      )
+      .mockResolvedValueOnce(NO_MARKER_RESULT);
+    let api: HarnessAPI | undefined;
+    const onReady = (nextApi: HarnessAPI) => {
+      api = nextApi;
+    };
+
+    const rendered = render(Harness, {
+      props: { targetId: 'room-1', markAsRead, onReady }
+    });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledOnce());
+
+    await rendered.rerender({ targetId: 'room-2', markAsRead, onReady });
+    flushSync();
+    await vi.waitFor(() => expect(markAsRead).toHaveBeenCalledTimes(2));
+    expect(firstSignal?.aborted).toBe(true);
+
+    firstRead.resolve({
+      previousLastReadAt: '2026-07-08T09:00:00.000Z',
+      lastReadAt: '2026-07-08T10:00:00.000Z'
+    });
+    await firstRead.promise;
+    flushSync();
+
+    expect(getApi(api).unreadMarkerWindow).toBeNull();
     rendered.unmount();
   });
 });

--- a/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useUnreadMarker.svelte.ts
@@ -1,4 +1,6 @@
+import { Code, ConnectError } from '$lib/api-client/connect';
 import { appState } from '$lib/state/globals.svelte';
+import { onDestroy } from 'svelte';
 
 export type UnreadMarkerWindow = {
   afterTime: string;
@@ -6,33 +8,246 @@ export type UnreadMarkerWindow = {
 };
 
 type UseUnreadMarkerOptions<TReadResult> = {
-  markAsRead: (targetId: string, upToEventId?: string) => Promise<TReadResult | null>;
+  markAsRead: (
+    targetId: string,
+    upToEventId: string | undefined,
+    signal: AbortSignal
+  ) => Promise<TReadResult>;
   markerWindowFromReadResult: (
     result: TReadResult,
     markedAtMs: number
   ) => UnreadMarkerWindow | null;
+  canMarkAsRead?: () => boolean;
+  onMarkAsReadError?: (error: unknown) => void;
 };
+
+type ReadAttempt = {
+  generation: number;
+  targetId: string;
+  upToEventId?: string;
+  markedAtMs: number;
+  retryCount: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  inFlight: boolean;
+  retryWhenSettled: boolean;
+  errorReported: boolean;
+  updatesMarker: boolean;
+  markerGeneration: number;
+  controller: AbortController;
+};
+
+const INITIAL_RETRY_DELAY_MS = 500;
+const MAX_RETRY_DELAY_MS = 30_000;
+
+/** Return true when another read attempt can succeed without a user change. */
+export function isTransientReadError(error: unknown): boolean {
+  if (error instanceof TypeError) return true;
+  if (
+    typeof DOMException !== 'undefined' &&
+    error instanceof DOMException &&
+    ['AbortError', 'NetworkError', 'TimeoutError'].includes(error.name)
+  ) {
+    return true;
+  }
+  if (!(error instanceof ConnectError)) return false;
+
+  switch (error.code) {
+    case Code.Canceled:
+    case Code.Unknown:
+    case Code.DeadlineExceeded:
+    case Code.ResourceExhausted:
+    case Code.Aborted:
+    case Code.Internal:
+    case Code.Unavailable:
+      return true;
+    default:
+      return false;
+  }
+}
 
 /**
  * Shared unread separator lifecycle for room and thread timelines.
  *
- * The rendered separator is always a concrete event id. Server read-state
- * timestamp windows are resolved once by the timeline pane. The server read
- * cursor is the source of truth on entry, target changes, and refocus.
+ * A visible target is marked as read on entry and after the app returns to the
+ * foreground. Focus still controls reads for messages that arrive while the
+ * target stays open. Failed transient requests retry while the target stays
+ * visible and readable.
+ *
+ * The rendered separator is always a concrete event id. The owning 0.4
+ * timeline resolves server read-state timestamp windows. The server read
+ * cursor remains the source of truth.
  */
 export function useUnreadMarker<TReadResult>(
   getTargetId: () => string,
-  { markAsRead, markerWindowFromReadResult }: UseUnreadMarkerOptions<TReadResult>
+  {
+    markAsRead,
+    markerWindowFromReadResult,
+    canMarkAsRead = () => true,
+    onMarkAsReadError
+  }: UseUnreadMarkerOptions<TReadResult>
 ) {
   let unreadMarkerEventId = $state<string | null>(null);
   let unreadMarkerWindow = $state<UnreadMarkerWindow | null>(null);
 
-  let lastFiredTargetId = '';
+  let lifecycleAttempt: ReadAttempt | null = null;
+  let explicitAttempt: ReadAttempt | null = null;
+  let lifecycleGeneration = 0;
+  let explicitGeneration = 0;
+  let markerGeneration = 0;
+  let destroyed = false;
+
+  let initialized = false;
+  let lastTargetId = '';
   let wasPresent = false;
-  let readMarkerGeneration = 0;
+  let wasReadable = false;
+  let lastForegroundRevision = 0;
+  let lastOnlineRevision = 0;
+
+  function isCurrentAttempt(attempt: ReadAttempt): boolean {
+    const currentAttempt = attempt.updatesMarker ? lifecycleAttempt : explicitAttempt;
+    const currentGeneration = attempt.updatesMarker ? lifecycleGeneration : explicitGeneration;
+    return (
+      !destroyed &&
+      currentAttempt === attempt &&
+      currentGeneration === attempt.generation &&
+      getTargetId() === attempt.targetId &&
+      appState.isVisible &&
+      canMarkAsRead()
+    );
+  }
+
+  function cancelAttempt(attempt: ReadAttempt | null) {
+    if (attempt?.timer !== null && attempt?.timer !== undefined) {
+      clearTimeout(attempt.timer);
+    }
+    attempt?.controller.abort();
+  }
+
+  function cancelLifecycleAttempt() {
+    cancelAttempt(lifecycleAttempt);
+    lifecycleAttempt = null;
+    lifecycleGeneration += 1;
+  }
+
+  function cancelExplicitAttempt() {
+    cancelAttempt(explicitAttempt);
+    explicitAttempt = null;
+    explicitGeneration += 1;
+  }
+
+  function cancelAllAttempts() {
+    cancelLifecycleAttempt();
+    cancelExplicitAttempt();
+  }
+
+  function retryDelay(retryCount: number): number {
+    return Math.min(INITIAL_RETRY_DELAY_MS * 2 ** retryCount, MAX_RETRY_DELAY_MS);
+  }
+
+  function scheduleRetry(attempt: ReadAttempt, immediately = false) {
+    if (!isCurrentAttempt(attempt)) return;
+
+    const delay = immediately ? 0 : retryDelay(attempt.retryCount);
+    attempt.retryCount += 1;
+    attempt.timer = setTimeout(() => {
+      attempt.timer = null;
+      void runAttempt(attempt);
+    }, delay);
+  }
+
+  function finishAttempt(attempt: ReadAttempt) {
+    if (attempt.updatesMarker) {
+      if (lifecycleAttempt === attempt) lifecycleAttempt = null;
+    } else if (explicitAttempt === attempt) {
+      explicitAttempt = null;
+    }
+  }
+
+  async function runAttempt(attempt: ReadAttempt): Promise<TReadResult | null> {
+    if (!isCurrentAttempt(attempt) || attempt.inFlight) return null;
+
+    attempt.inFlight = true;
+    try {
+      const result = await markAsRead(
+        attempt.targetId,
+        attempt.upToEventId,
+        attempt.controller.signal
+      );
+      if (!isCurrentAttempt(attempt)) return null;
+
+      if (attempt.updatesMarker && attempt.markerGeneration === markerGeneration) {
+        unreadMarkerEventId = null;
+        unreadMarkerWindow = markerWindowFromReadResult(result, attempt.markedAtMs);
+      }
+      finishAttempt(attempt);
+      return result;
+    } catch (error) {
+      if (!isCurrentAttempt(attempt)) return null;
+
+      if (!attempt.errorReported) {
+        attempt.errorReported = true;
+        onMarkAsReadError?.(error);
+      }
+      if (isTransientReadError(error)) {
+        scheduleRetry(attempt, attempt.retryWhenSettled);
+      } else {
+        finishAttempt(attempt);
+      }
+      return null;
+    } finally {
+      attempt.inFlight = false;
+      attempt.retryWhenSettled = false;
+    }
+  }
+
+  function createAttempt(
+    targetId: string,
+    upToEventId: string | undefined,
+    updatesMarker: boolean
+  ): ReadAttempt {
+    return {
+      generation: updatesMarker ? ++lifecycleGeneration : ++explicitGeneration,
+      targetId,
+      upToEventId,
+      markedAtMs: Date.now(),
+      retryCount: 0,
+      timer: null,
+      inFlight: false,
+      retryWhenSettled: false,
+      errorReported: false,
+      updatesMarker,
+      markerGeneration: updatesMarker ? ++markerGeneration : markerGeneration,
+      controller: new AbortController()
+    };
+  }
+
+  function startLifecycleAttempt(targetId: string) {
+    cancelLifecycleAttempt();
+    const attempt = createAttempt(targetId, undefined, true);
+    lifecycleAttempt = attempt;
+    void runAttempt(attempt);
+  }
 
   async function markTargetAsRead(targetId: string, upToEventId?: string) {
-    return markAsRead(targetId, upToEventId);
+    if (!appState.isVisible || !canMarkAsRead() || getTargetId() !== targetId) return null;
+
+    cancelExplicitAttempt();
+    const attempt = createAttempt(targetId, upToEventId, false);
+    explicitAttempt = attempt;
+    return runAttempt(attempt);
+  }
+
+  function retryAttemptNow(attempt: ReadAttempt | null) {
+    if (!attempt || !isCurrentAttempt(attempt)) return;
+    if (attempt.inFlight) {
+      attempt.retryWhenSettled = true;
+      return;
+    }
+    if (attempt.timer !== null) {
+      clearTimeout(attempt.timer);
+      attempt.timer = null;
+      void runAttempt(attempt);
+    }
   }
 
   function setUnreadMarkerEventId(eventId: string | null) {
@@ -49,33 +264,55 @@ export function useUnreadMarker<TReadResult>(
 
   $effect(() => {
     const targetId = getTargetId();
+    const visible = appState.isVisible;
     const present = appState.isPresent;
+    const readable = canMarkAsRead();
+    const foregroundRevision = appState.foregroundRevision;
+    const onlineRevision = appState.onlineRevision;
 
-    if (!present) {
-      wasPresent = false;
-      return;
-    }
+    const targetChanged = initialized && targetId !== lastTargetId;
+    const foregroundChanged = initialized && foregroundRevision !== lastForegroundRevision;
+    const onlineChanged = initialized && onlineRevision !== lastOnlineRevision;
+    const becamePresent = initialized && !wasPresent && present;
+    const becameReadable = initialized && !wasReadable && readable;
 
-    const isTargetChange = lastFiredTargetId !== targetId;
-
-    if (wasPresent && !isTargetChange) return;
-
-    wasPresent = true;
-    lastFiredTargetId = targetId;
-
-    if (isTargetChange) {
+    if (targetChanged) {
+      cancelAllAttempts();
       clearUnreadMarker();
     }
 
-    const markedAtMs = Date.now();
-    const generation = ++readMarkerGeneration;
-    markAsRead(targetId).then((result) => {
-      if (generation !== readMarkerGeneration) return;
-      if (getTargetId() !== targetId || !result) return;
+    if (!visible || !readable || !targetId) {
+      cancelAllAttempts();
+    } else if (
+      !initialized ||
+      targetChanged ||
+      foregroundChanged ||
+      becamePresent ||
+      becameReadable
+    ) {
+      startLifecycleAttempt(targetId);
+    }
 
-      unreadMarkerEventId = null;
-      unreadMarkerWindow = markerWindowFromReadResult(result, markedAtMs);
-    });
+    if (foregroundChanged && visible && readable) {
+      retryAttemptNow(explicitAttempt);
+    }
+
+    if (onlineChanged && visible && readable) {
+      retryAttemptNow(lifecycleAttempt);
+      retryAttemptNow(explicitAttempt);
+    }
+
+    initialized = true;
+    lastTargetId = targetId;
+    wasPresent = present;
+    wasReadable = readable;
+    lastForegroundRevision = foregroundRevision;
+    lastOnlineRevision = onlineRevision;
+  });
+
+  onDestroy(() => {
+    destroyed = true;
+    cancelAllAttempts();
   });
 
   return {

--- a/apps/frontend/src/lib/state/globals.svelte.ts
+++ b/apps/frontend/src/lib/state/globals.svelte.ts
@@ -6,7 +6,7 @@
  */
 
 // ---------------------------------------------------------------------------
-// AppState — browser focus tracking
+// AppState — browser lifecycle tracking
 // ---------------------------------------------------------------------------
 
 class AppState {
@@ -14,12 +14,16 @@ class AppState {
   isVisible = $state(
     typeof document !== 'undefined' ? document.visibilityState === 'visible' : true
   );
+  foregroundRevision = $state(0);
+  onlineRevision = $state(0);
+
+  private foregroundActive =
+    typeof document !== 'undefined' ? document.visibilityState === 'visible' : true;
 
   /**
-   * True when the user is actually present at the app: window focused AND
-   * tab visible. Drives read-cursor advancement — we only mark messages
-   * read while the user can actually see them. A blur or tab-hide flips
-   * this false; refocus / re-show flips it back.
+   * True when the app is visible and focused. Continuous message arrivals
+   * use this stricter state. Target entry and foreground activation only need
+   * visibility because some mobile app resumes do not restore focus events.
    */
   get isPresent(): boolean {
     return this.isFocused && this.isVisible;
@@ -33,11 +37,71 @@ class AppState {
       window.addEventListener('blur', () => {
         this.isFocused = false;
       });
+      window.addEventListener('pageshow', () => {
+        this.reconcileVisibility();
+      });
+      window.addEventListener('pagehide', () => {
+        this.markBackgrounded();
+      });
+      window.addEventListener('online', () => {
+        this.onlineRevision += 1;
+      });
     }
     if (typeof document !== 'undefined') {
       document.addEventListener('visibilitychange', () => {
-        this.isVisible = document.visibilityState === 'visible';
+        this.reconcileVisibility();
       });
+      document.addEventListener('freeze', () => {
+        this.markBackgrounded();
+      });
+      document.addEventListener('resume', () => {
+        this.reconcileVisibility();
+      });
+      document.addEventListener(
+        'pointerdown',
+        (event) => {
+          if (event.isTrusted) this.activateFromInteraction();
+        },
+        { capture: true }
+      );
+      document.addEventListener(
+        'keydown',
+        (event) => {
+          if (event.isTrusted) this.activateFromInteraction();
+        },
+        { capture: true }
+      );
+    }
+  }
+
+  private markBackgrounded() {
+    this.foregroundActive = false;
+    this.isFocused = false;
+    this.isVisible = false;
+  }
+
+  private activateFromInteraction() {
+    this.isFocused = true;
+    this.isVisible = true;
+    if (!this.foregroundActive) {
+      this.foregroundActive = true;
+      this.foregroundRevision += 1;
+    }
+  }
+
+  private reconcileVisibility() {
+    const visible = document.visibilityState === 'visible';
+    this.isVisible = visible;
+
+    if (!visible) {
+      this.foregroundActive = false;
+      return;
+    }
+
+    this.isFocused = document.hasFocus();
+    if (!this.foregroundActive) {
+      this.foregroundActive = true;
+      this.foregroundRevision += 1;
     }
   }
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -88,7 +88,8 @@
   const unread = useUnreadMarker(() => threadRootEventId, {
     markAsRead: markThreadAsRead,
     markerWindowFromReadResult: (result, markedAtMs) =>
-      result.previousReadAt ? { afterTime: result.previousReadAt, beforeTime: markedAtMs } : null
+      result.previousReadAt ? { afterTime: result.previousReadAt, beforeTime: markedAtMs } : null,
+    onMarkAsReadError: (error) => console.error('Failed to mark thread as read:', error)
   });
 
   // Typing indicator for this thread
@@ -306,22 +307,18 @@
 
   async function markThreadAsRead(
     currentThreadId: string,
-    upToEventId?: string
-  ): Promise<MarkThreadAsReadResult | null> {
-    try {
-      const conn = connection();
-      const result = await createReadStateAPI({
-        serverId: conn.serverId ?? getActiveServer(),
-        baseUrl: conn.connectBaseUrl,
-        bearerToken: conn.bearerToken
-      }).markThreadAsRead({ roomId, threadRootEventId: currentThreadId, upToEventId });
-      void serverStore.rooms.refreshUnreadFollowedThreads();
-      onMarkedRead?.();
-      return result;
-    } catch (err) {
-      console.error('Failed to mark thread as read:', err);
-      return null;
-    }
+    upToEventId: string | undefined,
+    signal: AbortSignal
+  ): Promise<MarkThreadAsReadResult> {
+    const conn = connection();
+    const result = await createReadStateAPI({
+      serverId: conn.serverId ?? getActiveServer(),
+      baseUrl: conn.connectBaseUrl,
+      bearerToken: conn.bearerToken
+    }).markThreadAsRead({ roomId, threadRootEventId: currentThreadId, upToEventId }, { signal });
+    void serverStore.rooms.refreshUnreadFollowedThreads();
+    onMarkedRead?.();
+    return result;
   }
 </script>
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -53,9 +53,15 @@ vi.mock('$lib/hooks', () => ({
   useEvent: vi.fn(),
   useUnreadMarker: (
     getTargetId: () => string,
-    options: { markAsRead: (targetId: string, upToEventId?: string) => unknown }
+    options: {
+      markAsRead: (
+        targetId: string,
+        upToEventId: string | undefined,
+        signal: AbortSignal
+      ) => unknown;
+    }
   ) => {
-    void options.markAsRead(getTargetId());
+    void options.markAsRead(getTargetId(), undefined, new AbortController().signal);
     return {
       unreadMarkerEventId: null,
       unreadMarkerWindow: null,
@@ -180,11 +186,14 @@ describe('ThreadPane', () => {
     });
 
     await vi.waitFor(() =>
-      expect(mocks.markThreadAsRead).toHaveBeenCalledWith({
-        roomId: 'room-1',
-        threadRootEventId: 'thread-root',
-        upToEventId: undefined
-      })
+      expect(mocks.markThreadAsRead).toHaveBeenCalledWith(
+        {
+          roomId: 'room-1',
+          threadRootEventId: 'thread-root',
+          upToEventId: undefined
+        },
+        { signal: expect.any(AbortSignal) }
+      )
     );
 
     expect(mocks.setThread).toHaveBeenCalledWith('room-1', 'thread-root');


### PR DESCRIPTION
## Why

Backport the persistent unread fix from #2229 to the supported 0.4 release
line. Android PWA resume paths can omit focus events, and a temporary mark-read
request failure can leave the server cursor and notification dots unread.

## What changed

- Reconcile foreground state on visibility changes, page show, resume, and
  trusted interaction.
- Mark visible rooms and threads on entry or foreground activation without
  requiring focus. Keep reads for continuously arriving messages focus-gated.
- Retry temporary mark-read failures with bounded exponential backoff and
  immediate foreground or online retry.
- Abort and ignore stale work after backgrounding, navigation, permission loss,
  or unmount.
- Preserve the 0.4 room optimistic-read race protection and timeline-owned
  unread-separator resolution.
- Refresh the 0.4 followed-thread notification state only after a successful
  thread read, including a successful retry.
- Add browser coverage for lifecycle events, retries, cancellation, stale
  responses, room rollback, Connect abort signals, and thread behavior.
- Add Playwright coverage for online retry and return-to-visible recovery
  without a focus event.
- Stabilize the existing preview-thumbnail refresh tests by using a valid
  same-origin image after a simulated load failure.

## Test plan

- Svelte autofixer: no issues in changed Svelte files.
- `mise lint-frontend`: passed with zero Svelte errors or warnings.
- Focused Vitest run: 32 tests passed.
- `mise test-frontend`: 2,029 tests passed.
- `mise build-frontend`: passed.
- `mise test-e2e -- e2e/unread-indicators.test.ts`: 17 tests passed.
- `mise test-e2e -- e2e/threading.test.ts --grep 'unread separator'`: 4 tests
  passed.
- `git diff --check origin/release-0.4...HEAD`: passed.

## Compatibility and operations

This backport is frontend-only. It does not change protobuf definitions,
ConnectRPC services, backend behavior, persistence, configuration, or public
API behavior. It needs no migration or operator action.
