### PR TITLE
feat(frontend): finish the progressive Neighbor tapestry

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/neighbors.mdx
@@ -68,8 +68,10 @@ administration page keeps the failed server visible so that an administrator
 can review or remove it. A failed server does not prevent the client from
 showing other results.
 
-The client starts one automatic batch of 12 candidate-directory requests. Use
-**Load more** to start each later batch of 12. One page session permits at most:
+The client starts one automatic batch of 12 candidate-directory requests. It
+can start one more batch after you scroll near the end of the results. A short
+page does not start this batch until you scroll. Use **Load more** to start each
+later batch of 12. One page session permits at most:
 
 - 48 directory requests;
 - 24 profile requests;

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -96,8 +96,9 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
     Directory shows direct recommendations from a user's registered servers. It
     follows a remote server recursively only when both servers advertise each
     other, for at most two mutual hops. Results appear as requests finish, and
-    fixed batch, concurrency, timeout, and page-session limits bound browser
-    work. Administrators can add a public testimonial to each
+    one additional batch can load when a user scrolls near the end. Fixed batch,
+    concurrency, timeout, and page-session limits bound browser work.
+    Administrators can add a public testimonial to each
     recommendation. Testimonials support paragraphs and limited inline
     Markdown. The directory shows them as source-labelled review cards below
     each server profile in a tapestry layout. Mutuality is a current client

--- a/apps/frontend/src/routes/chat/servers/+page.svelte
+++ b/apps/frontend/src/routes/chat/servers/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { ConnectError } from '@connectrpc/connect';
   import { onMount } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import {
@@ -34,8 +35,11 @@
   let pendingOrigin = $state<string | null>(null);
   let actionError = $state('');
   let directoryState = $state<ServerDirectorySnapshot | null>(null);
+  let scrollContainer = $state<HTMLDivElement>();
   let directorySession: ServerDirectoryDiscovery | null = null;
   let unsubscribeDirectory: (() => void) | null = null;
+  let automaticLoadApproached = false;
+  let automaticBatchSpent = false;
 
   const registeredOrigins = $derived.by(() => [
     ...new Set(
@@ -64,12 +68,16 @@
   function startDirectoryDiscovery() {
     stopDirectoryDiscovery();
     directoryState = null;
+    automaticLoadApproached = false;
+    automaticBatchSpent = false;
     const session = createServerDirectoryDiscovery(registeredOrigins, {
       initiallyVisible: document.visibilityState === 'visible'
     });
     directorySession = session;
     unsubscribeDirectory = session.subscribe((snapshot) => {
-      if (directorySession === session) directoryState = snapshot;
+      if (directorySession !== session) return;
+      directoryState = snapshot;
+      tryAutomaticLoad();
     });
     session.start();
   }
@@ -83,7 +91,54 @@
 
   function handleVisibilityChange() {
     directorySession?.setVisible(document.visibilityState === 'visible');
+    tryAutomaticLoad();
   }
+
+  function tryAutomaticLoad() {
+    const session = directorySession;
+    if (
+      !session ||
+      automaticBatchSpent ||
+      !automaticLoadApproached ||
+      document.visibilityState !== 'visible' ||
+      !directoryState?.canLoadMore
+    ) {
+      return;
+    }
+    automaticBatchSpent = true;
+    session.loadMore();
+  }
+
+  function loadMoreManually() {
+    automaticBatchSpent = true;
+    directorySession?.loadMore();
+  }
+
+  const observeAutomaticLoadSentinel: Attachment<HTMLElement> = (sentinel) => {
+    const root = scrollContainer;
+    if (!root || typeof IntersectionObserver === 'undefined') return;
+    let isNearEnd = false;
+
+    const recordApproach = () => {
+      if (!isNearEnd || root.scrollTop <= 0) return;
+      automaticLoadApproached = true;
+      tryAutomaticLoad();
+    };
+    const observer = new IntersectionObserver(
+      (observations) => {
+        isNearEnd = observations.some((observation) => observation.isIntersecting);
+        recordApproach();
+      },
+      { root, rootMargin: '0px 0px 160px 0px' }
+    );
+    root.addEventListener('scroll', recordApproach, { passive: true });
+    observer.observe(sentinel);
+
+    return () => {
+      root.removeEventListener('scroll', recordApproach);
+      observer.disconnect();
+    };
+  };
 
   function normalizeCustomInput(value: string): string {
     const trimmed = value.trim();
@@ -257,7 +312,7 @@
     showMobileNav
   />
 
-  <PaneContent>
+  <PaneContent bind:scrollContainer>
     <div class="flex flex-col gap-6">
       <Panel title={m('add_server.directory.custom_title')}>
         <Form onsubmit={probeCustomServer} error={customError} maxWidth="max-w-2xl">
@@ -447,6 +502,14 @@
           </div>
         {/if}
         {#if directoryState && !allSourcesFailed}
+          {#if entries.length > 0 && !directoryState.sessionLimitReached}
+            <div
+              class="h-px"
+              aria-hidden="true"
+              data-testid="server-directory-auto-load-sentinel"
+              {@attach observeAutomaticLoadSentinel}
+            ></div>
+          {/if}
           {#if directoryState.isLoading && !directoryState.isInitialLoading}
             <p class="mt-4 text-center text-muted" aria-live="polite">
               {m('add_server.directory.discovering')}
@@ -458,7 +521,7 @@
             </div>
           {:else if directoryState.canLoadMore}
             <div class="mt-4 flex justify-center">
-              <Button variant="secondary" onclick={() => directorySession?.loadMore()}>
+              <Button variant="secondary" onclick={loadMoreManually}>
                 {m('add_server.directory.load_more')}
               </Button>
             </div>

--- a/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
@@ -1,5 +1,5 @@
 import { flushSync } from 'svelte';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import type { PublicServerInfo } from '$lib/api-client/server';
 import type { ServerDirectorySnapshot } from '$lib/serverDirectory';
@@ -15,6 +15,9 @@ const mocks = vi.hoisted(() => ({
   authenticated: new Set<string>(),
   loadServerDirectory: vi.fn(),
   loadMoreDirectory: vi.fn(),
+  publishDirectorySnapshot: undefined as
+    | ((snapshot: Partial<ServerDirectorySnapshot>) => void)
+    | undefined,
   getPublicServerInfo: vi.fn(),
   startServerOAuthFlow: vi.fn(),
   startRemoteReauthentication: vi.fn(),
@@ -69,9 +72,11 @@ vi.mock('$lib/serverDirectory', async (importOriginal) => {
       return {
         subscribe(callback: (value: ServerDirectorySnapshot) => void) {
           listener = callback;
+          mocks.publishDirectorySnapshot = (value) => listener?.(snapshot(value));
           callback(snapshot({ isStarted: false, isLoading: true, isInitialLoading: true }));
           return () => {
             listener = undefined;
+            mocks.publishDirectorySnapshot = undefined;
           };
         },
         start() {
@@ -142,6 +147,44 @@ function recommendation(
   return { sourceOrigin, testimonial };
 }
 
+let intersectionCallback: IntersectionObserverCallback | undefined;
+
+function mockIntersectionObserver() {
+  intersectionCallback = undefined;
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback: IntersectionObserverCallback) {
+        intersectionCallback = callback;
+      }
+      observe = vi.fn();
+      disconnect = vi.fn();
+    }
+  );
+}
+
+function triggerIntersection(isIntersecting = true) {
+  intersectionCallback?.(
+    [{ isIntersecting } as IntersectionObserverEntry],
+    {} as IntersectionObserver
+  );
+}
+
+function approachAutomaticLoad(container: HTMLElement): HTMLElement {
+  const sentinel = container.querySelector<HTMLElement>(
+    '[data-testid="server-directory-auto-load-sentinel"]'
+  )!;
+  const scrollContainer = sentinel.closest<HTMLElement>('[role="region"]')!;
+  Object.defineProperty(scrollContainer, 'scrollTop', {
+    configurable: true,
+    value: 100,
+    writable: true
+  });
+  triggerIntersection();
+  scrollContainer.dispatchEvent(new Event('scroll'));
+  return scrollContainer;
+}
+
 describe('Server Directory page', () => {
   beforeEach(() => {
     mocks.servers = [
@@ -163,6 +206,7 @@ describe('Server Directory page', () => {
     mocks.authenticated = new Set(['joined']);
     mocks.loadServerDirectory.mockReset();
     mocks.loadMoreDirectory.mockReset();
+    mocks.publishDirectorySnapshot = undefined;
     mocks.getPublicServerInfo.mockReset();
     mocks.startServerOAuthFlow.mockReset();
     mocks.startServerOAuthFlow.mockResolvedValue(undefined);
@@ -170,6 +214,10 @@ describe('Server Directory page', () => {
     mocks.startRemoteReauthentication.mockResolvedValue(undefined);
     mocks.goto.mockReset();
     mocks.goto.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('keeps directory response order and marks registered entries as joined', async () => {
@@ -614,6 +662,150 @@ describe('Server Directory page', () => {
         'https://second.example'
       ]);
     });
+  });
+
+  it('does not add an automatic batch after the user loads more manually', async () => {
+    mockIntersectionObserver();
+    const first = {
+      origin: 'https://first.example',
+      profile: profile('First'),
+      sourceOrigins: ['https://source.example'],
+      recommendations: [recommendation()]
+    };
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [first],
+      canLoadMore: true,
+      queuedCandidateCount: 2
+    });
+    mocks.loadMoreDirectory.mockResolvedValue({
+      entries: [first],
+      canLoadMore: true,
+      queuedCandidateCount: 1
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(button(container, 'Load more')).toBeDefined());
+    button(container, 'Load more')?.click();
+    await vi.waitFor(() => expect(mocks.loadMoreDirectory).toHaveBeenCalledOnce());
+
+    approachAutomaticLoad(container);
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(mocks.loadMoreDirectory).toHaveBeenCalledOnce();
+  });
+
+  it('does not automatically load when a short directory starts near the sentinel', async () => {
+    mockIntersectionObserver();
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [
+        {
+          origin: 'https://first.example',
+          profile: profile('First'),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
+      canLoadMore: true,
+      queuedCandidateCount: 1
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(intersectionCallback).toBeDefined());
+    triggerIntersection();
+
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(mocks.loadMoreDirectory).not.toHaveBeenCalled();
+    expect(button(container, 'Load more')).toBeDefined();
+  });
+
+  it('automatically loads only one batch after the user scrolls near the end', async () => {
+    mockIntersectionObserver();
+    const first = {
+      origin: 'https://first.example',
+      profile: profile('First'),
+      sourceOrigins: ['https://source.example'],
+      recommendations: [recommendation()]
+    };
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [first],
+      canLoadMore: true,
+      queuedCandidateCount: 2
+    });
+    mocks.loadMoreDirectory.mockResolvedValue({
+      entries: [first],
+      canLoadMore: true,
+      queuedCandidateCount: 1
+    });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(intersectionCallback).toBeDefined());
+    const scrollContainer = approachAutomaticLoad(container);
+    triggerIntersection();
+
+    await vi.waitFor(() => expect(mocks.loadMoreDirectory).toHaveBeenCalledOnce());
+    scrollContainer.dispatchEvent(new Event('scroll'));
+    triggerIntersection();
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    expect(mocks.loadMoreDirectory).toHaveBeenCalledOnce();
+    expect(button(container, 'Load more')).toBeDefined();
+  });
+
+  it('waits for active discovery before spending an approached automatic batch', async () => {
+    mockIntersectionObserver();
+    const first = {
+      origin: 'https://first.example',
+      profile: profile('First'),
+      sourceOrigins: ['https://source.example'],
+      recommendations: [recommendation()]
+    };
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [first],
+      isLoading: true,
+      canLoadMore: false,
+      queuedCandidateCount: 1
+    });
+    mocks.loadMoreDirectory.mockResolvedValue({ entries: [first] });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(intersectionCallback).toBeDefined());
+    approachAutomaticLoad(container);
+    expect(mocks.loadMoreDirectory).not.toHaveBeenCalled();
+
+    mocks.publishDirectorySnapshot?.({
+      entries: [first],
+      isLoading: false,
+      canLoadMore: true,
+      queuedCandidateCount: 1
+    });
+
+    await vi.waitFor(() => expect(mocks.loadMoreDirectory).toHaveBeenCalledOnce());
+  });
+
+  it('does not spend the automatic batch while the page is hidden', async () => {
+    mockIntersectionObserver();
+    const visibility = vi.spyOn(document, 'visibilityState', 'get').mockReturnValue('visible');
+    const first = {
+      origin: 'https://first.example',
+      profile: profile('First'),
+      sourceOrigins: ['https://source.example'],
+      recommendations: [recommendation()]
+    };
+    mocks.loadServerDirectory.mockResolvedValue({
+      entries: [first],
+      canLoadMore: true,
+      queuedCandidateCount: 1
+    });
+    mocks.loadMoreDirectory.mockResolvedValue({ entries: [first] });
+
+    const { container } = render(Page);
+    await vi.waitFor(() => expect(intersectionCallback).toBeDefined());
+    visibility.mockReturnValue('hidden');
+    approachAutomaticLoad(container);
+    expect(mocks.loadMoreDirectory).not.toHaveBeenCalled();
+
+    visibility.mockReturnValue('visible');
+    document.dispatchEvent(new Event('visibilitychange'));
+    await vi.waitFor(() => expect(mocks.loadMoreDirectory).toHaveBeenCalledOnce());
+    visibility.mockRestore();
   });
 
   it('uses discovered source profiles for recursive testimonial attribution', async () => {

--- a/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
@@ -218,6 +218,7 @@ describe('Server Directory page', () => {
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   it('keeps directory response order and marks registered entries as joined', async () => {

--- a/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/servers/server-directory.page.svelte.spec.ts
@@ -847,10 +847,19 @@ describe('Server Directory page', () => {
   });
 
   it('explains when the page-session discovery limit is reached', async () => {
+    mockIntersectionObserver();
     mocks.loadServerDirectory.mockResolvedValue({
-      entries: [],
+      entries: [
+        {
+          origin: 'https://first.example',
+          profile: profile('First'),
+          sourceOrigins: ['https://source.example'],
+          recommendations: [recommendation()]
+        }
+      ],
       failedSourceCount: 0,
       sourceCount: 2,
+      canLoadMore: false,
       sessionLimitReached: true
     });
 
@@ -861,5 +870,9 @@ describe('Server Directory page', () => {
       );
     });
     expect(button(container, 'Load more')).toBeUndefined();
+    expect(
+      container.querySelector('[data-testid="server-directory-auto-load-sentinel"]')
+    ).toBeNull();
+    expect(mocks.loadMoreDirectory).not.toHaveBeenCalled();
   });
 });

--- a/docs/fdr/FDR-042-chatto-neighbors.md
+++ b/docs/fdr/FDR-042-chatto-neighbors.md
@@ -44,9 +44,11 @@ recommendation, not a trust or reciprocal relationship.
   visible so that an administrator can review or remove it. A failed request
   does not hide profiles that loaded successfully.
 - The Server Directory starts one automatic batch of 12 candidate-directory
-  requests. **Load more** starts another batch of 12. One page session permits
-  at most 48 directory requests, 24 profile requests, and 72 discovery requests
-  in total. It queues at most 120 canonical candidates.
+  requests. After the user scrolls near the end of the results, the client can
+  start one more automatic batch of 12. **Load more** starts each later batch.
+  One page session permits at most 48 directory requests, 24 profile requests,
+  and 72 discovery requests in total. It queues at most 120 canonical
+  candidates.
 - The client uses at most six active discovery requests. Each request has a
   ten-second timeout. It requests one directory and one profile at most for one
   canonical origin. It does not retry a failed request in the same page session.
@@ -220,14 +222,17 @@ direct join flow, even when it might work with the client.
 **Decision:** The client shows direct recommendations and follows at most two
 verified mutual hops. It uses one shared six-request scheduler and fixed
 candidate, directory, profile, and total request limits. The first candidate
-batch starts automatically. Later batches require **Load more**.
+batch starts automatically. One more batch can start after the user scrolls
+near the end of the results. Later batches require **Load more**.
 
 **Why:** Progressive discovery can find servers beyond a direct recommendation,
 but one malicious or cyclic directory must not start unbounded browser work.
 Fixed limits make the maximum request effect testable.
 
 **Tradeoff:** A page session can stop before it explores every recommendation.
-Discovery order reflects completion and bounded scheduling, not quality.
+The second automatic batch does not start on a short page that the user does
+not scroll. Discovery order reflects completion and bounded scheduling, not
+quality.
 
 ## Non-goals
 
@@ -245,4 +250,5 @@ Discovery order reflects completion and bounded scheduling, not quality.
   Configuration), FDR-031 (Client–Server Compatibility Discovery)
 - **Issues:** [#1669](https://github.com/chattocorp/chatto/issues/1669),
   [#2208](https://github.com/chattocorp/chatto/issues/2208),
-  [#2207](https://github.com/chattocorp/chatto/issues/2207)
+  [#2207](https://github.com/chattocorp/chatto/issues/2207),
+  [#2206](https://github.com/chattocorp/chatto/issues/2206)

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -51,4 +51,4 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-039](FDR-039-message-access-and-interactions.md) | Message Access & Interactions | Experimental | 2026-08-28 |
 | [FDR-040](FDR-040-backup-and-restore.md) | Backup and Restore | Active | 2026-08-27 |
 | [FDR-041](FDR-041-transactional-email-delivery.md) | Transactional Email Delivery | Active | 2026-08-28 |
-| [FDR-042](FDR-042-chatto-neighbors.md) | Chatto Neighbors | Experimental | 2026-08-29 |
+| [FDR-042](FDR-042-chatto-neighbors.md) | Chatto Neighbors | Experimental | 2026-08-30 |


### PR DESCRIPTION
## Why

The Neighbor directory already adds results progressively, but later discovery requires repeated manual input. This change finishes the progressive tapestry while keeping browser work intentionally small and bounded.

## What changed

- Start at most one additional 12-candidate batch after the user scrolls near the end of the directory.
- Keep short, unscrolled pages from starting the additional batch.
- Keep hidden pages, repeated observer events, active discovery, manual loading, and the page-session limit from amplifying requests.
- Preserve the existing **Load more** control for all later batches.
- Update FDR-042, the Neighbor operations guide, and the 0.5 release page with the delivered behavior.
- Correct #2206 and the #1666 epic to distinguish unilateral direct recommendations from reciprocal recursive expansion.

The change uses the existing directory session. It does not change APIs, persistence, the six-request concurrency limit, the ten-second timeout, or any request budget.

## Test plan

- `mise test-frontend`: passed 1,350 server tests, 1,975 browser tests, 228 Storybook tests, and 5 performance-comparison tests.
- `mise lint-frontend`: passed with zero Svelte errors and warnings.
- `mise license-check`: passed for all 3,212 files.
- `mise x -- pnpm --filter docs-website build`: built 73 pages.
- Svelte autofixer: reported no issues or suggestions on the changed page.
- Chrome DevTools: wide/dark and narrow/light layouts passed visual and accessibility review. Both local recommendations and their testimonial paragraphs rendered. The only console error was the existing missing `/favicon` request.

## Compatibility and operations

- No public API, protocol, persistence, migration, permission, or backend change.
- Existing limits remain unchanged: six concurrent requests, ten seconds per request, and the current candidate and page-session budgets.

Closes #2206.
Part of #1666.
