### PR TITLE
docs(api): explain the realtime protocol

### DIFF
--- a/apps/docs-website/astro.config.mjs
+++ b/apps/docs-website/astro.config.mjs
@@ -104,6 +104,8 @@ export default defineConfig({
           label: "Integrations",
           items: [
             "guides/integrations/chatto-api",
+            "guides/integrations/realtime-protocol",
+            "guides/integrations/realtime-typescript",
             "guides/integrations/mcp",
             "guides/integrations/bot-accounts",
             "guides/integrations/api-compatibility",

--- a/apps/docs-website/src/assets/realtime-protocol-sequence.svg
+++ b/apps/docs-website/src/assets/realtime-protocol-sequence.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 560" role="img" aria-labelledby="title desc" style="display:block;width:100%;height:auto;min-width:42rem;max-width:920px;margin-inline:auto">
+  <title id="title">Chatto realtime protocol sequence</title>
+  <desc id="desc">A client opens a WebSocket, exchanges hello frames, subscribes, receives bootstrap or replay operations, reaches caught up, and then receives live operations.</desc>
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--sl-color-gray-3, #64748b)"/>
+    </marker>
+  </defs>
+  <style>
+    .box { fill: var(--sl-color-bg-nav, #f8fafc); stroke: var(--sl-color-gray-4, #94a3b8); stroke-width: 2; }
+    .lane { stroke: var(--sl-color-gray-5, #cbd5e1); stroke-width: 2; stroke-dasharray: 7 7; }
+    .flow { stroke: var(--sl-color-gray-3, #64748b); stroke-width: 2.5; marker-end: url(#arrow); }
+    .durable { stroke: var(--sl-color-accent, #6366f1); }
+    .label { fill: var(--sl-color-white, #fff); font: 600 18px system-ui, sans-serif; }
+    .text { fill: var(--sl-color-text, #1e293b); font: 15px system-ui, sans-serif; }
+    .small { fill: var(--sl-color-gray-2, #475569); font: 13px system-ui, sans-serif; }
+    .pill { fill: var(--sl-color-accent-low, #e0e7ff); stroke: var(--sl-color-accent, #6366f1); stroke-width: 1.5; }
+  </style>
+  <rect x="65" y="20" width="190" height="50" rx="12" class="box"/>
+  <rect x="665" y="20" width="190" height="50" rx="12" class="box"/>
+  <text x="160" y="52" text-anchor="middle" class="text">Client</text>
+  <text x="760" y="52" text-anchor="middle" class="text">Chatto server</text>
+  <line x1="160" y1="80" x2="160" y2="530" class="lane"/>
+  <line x1="760" y1="80" x2="760" y2="530" class="lane"/>
+
+  <line x1="170" y1="105" x2="748" y2="105" class="flow"/>
+  <text x="460" y="96" text-anchor="middle" class="text">Open GET /api/realtime</text>
+
+  <line x1="170" y1="155" x2="748" y2="155" class="flow"/>
+  <text x="460" y="146" text-anchor="middle" class="text">hello · protocol 2 · bearer token if needed</text>
+
+  <line x1="750" y1="205" x2="172" y2="205" class="flow"/>
+  <text x="460" y="196" text-anchor="middle" class="text">hello · accepted version · capabilities · heartbeat</text>
+
+  <line x1="170" y1="255" x2="748" y2="255" class="flow"/>
+  <text x="460" y="246" text-anchor="middle" class="text">subscribe_events · cursor? · retained rooms</text>
+
+  <line x1="750" y1="305" x2="172" y2="305" class="flow"/>
+  <text x="460" y="296" text-anchor="middle" class="text">subscribed</text>
+
+  <rect x="250" y="330" width="420" height="76" rx="12" class="pill"/>
+  <text x="460" y="357" text-anchor="middle" class="text">Fresh or unusable cursor: reset + current state</text>
+  <text x="460" y="384" text-anchor="middle" class="text">Valid cursor: ordered projection replay</text>
+
+  <line x1="750" y1="435" x2="172" y2="435" class="flow durable"/>
+  <text x="460" y="426" text-anchor="middle" class="text">caught_up · safe resume cursor</text>
+
+  <line x1="750" y1="485" x2="172" y2="485" class="flow durable"/>
+  <text x="460" y="476" text-anchor="middle" class="text">live projection operations + transient events</text>
+  <text x="460" y="535" text-anchor="middle" class="small">Apply projection operations in order. Save a cursor only after the complete event succeeds.</text>
+</svg>

--- a/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
@@ -122,8 +122,11 @@ The recorded time can be delayed by approximately one minute.
 
 ## Activate a bot from Chatto activity
 
-Use the normal `subscribe_events` realtime subscription. Chatto sends the
-bot's visible notification occurrences in
+Use the normal `subscribe_events` realtime subscription. See the
+[Realtime Protocol Overview](/guides/integrations/realtime-protocol/) for the
+connection and resume model, or follow the
+[TypeScript tutorial](/guides/integrations/realtime-typescript/) to build a
+small client. Chatto sends the bot's visible notification occurrences in
 `notification_occurrences_replace`. Chatto does not use a bot-only realtime
 channel or a separate bot-interaction event.
 

--- a/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
@@ -64,6 +64,11 @@ agent integration.
 
 Authenticated realtime clients connect to `/api/realtime` and exchange protobuf `chatto.realtime.v1` frames. The package name is the protobuf namespace; 0.5 servers accept only behavioural protocol version 2. It sends one ordered server-scoped projection stream for initial state, bounded replay after reconnect, lazy room-timeline hydration, and later live mutations. A subscription includes IDs for room timelines the client already retains; `hydrate_room` adds another joined room through the same projection reducer. Resume and timeline cursors are opaque capabilities: clients must store and return them unchanged and must not infer persistence coordinates from them. Timeline cursors are bound to the authenticated viewer and exact room or thread that issued them; cross-resource reuse is rejected.
 
+Start with the [Realtime Protocol Overview](/guides/integrations/realtime-protocol/)
+for the connection lifecycle and reducer rules. Then use the
+[TypeScript tutorial](/guides/integrations/realtime-typescript/) to connect a
+small browser client.
+
 For 0.5, durable message, reaction, room, asset, and call changes are `RealtimeProjectionEvent` operations, not `RealtimeEventEnvelope` alternatives. The latter is reserved for transient, non-replayable signals. This is a breaking migration from the 0.4 live-event contract.
 
 Notification, viewer-preference, thread follow/read, profile, layout, and
@@ -120,6 +125,8 @@ support inline timestamps.
 
 <CardGrid>
   <LinkCard title="ConnectRPC API" href="/reference/connectrpc-api/" description="Generated public, admin, and realtime API reference." />
+  <LinkCard title="Realtime Overview" href="/guides/integrations/realtime-protocol/" description="Connection lifecycle, projection semantics, hydration, and reconnect behavior." />
+  <LinkCard title="Realtime TypeScript Tutorial" href="/guides/integrations/realtime-typescript/" description="Generate bindings and connect a small browser client." />
   <LinkCard title="Realtime API" href="/reference/connectrpc-api/realtime/" description="Protobuf realtime WebSocket frame reference." />
   <LinkCard title="Server Discovery" href="/reference/connectrpc-api/server-discovery/" description="Discovery endpoint for compatible clients." />
   <LinkCard title="API Compatibility" href="/guides/integrations/api-compatibility/" description="Experimental API posture and version-skew guidance." />

--- a/apps/docs-website/src/content/docs/guides/integrations/realtime-protocol.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/realtime-protocol.mdx
@@ -1,0 +1,151 @@
+---
+title: Realtime Protocol Overview
+description: Understand Chatto's ordered projection stream, resumable delivery, room hydration, and connection lifecycle.
+---
+
+import { Aside, CardGrid, LinkCard } from "@astrojs/starlight/components";
+import realtimeSequence from "../../../../assets/realtime-protocol-sequence.svg?raw";
+
+Use the realtime protocol when your client must keep an authenticated local
+view of one Chatto server. The protocol sends binary protobuf frames over a
+WebSocket at `/api/realtime`.
+
+Use [ConnectRPC](/reference/connectrpc-api/) for commands, explicit reads,
+pagination, and read-your-writes results. Realtime protocol 2 complements those
+calls. It does not replace them.
+
+| Need | Use |
+| --- | --- |
+| Create, update, or delete a resource | ConnectRPC |
+| Read one resource or a paginated list | ConnectRPC |
+| Build an initial local server view | Realtime |
+| Keep that local view current | Realtime |
+| Resume a short connection gap | Realtime |
+
+## Connection lifecycle
+
+<div style="margin-block:1.5rem;overflow-x:auto" set:html={realtimeSequence} />
+
+1. Open a WebSocket to `wss://chat.example.com/api/realtime`.
+2. Send a binary [`RealtimeClientFrame`](/reference/connectrpc-api/realtime/#realtimeclientframe)
+   that contains `hello`. Request protocol version `2` and include a bearer
+   credential when you do not use a same-origin cookie.
+3. Wait for the server `hello`. Check that it accepts version `2` and includes
+   `chatto.realtime.projection.v1` in `capabilities`.
+4. Send `subscribe_events`. Include the last safe resume cursor and the IDs of
+   room timelines that your projection still retains.
+5. Apply all projection operations in order. The server sends `caught_up` when
+   the bootstrap or replay has reached the live boundary.
+6. Continue to apply live projection operations. Handle transient events on a
+   separate path.
+
+The server can send `subscribed` before it sends projection data. This frame
+confirms the start cursor. It does not mean that the projection is current.
+Treat the projection as current only after `caught_up`.
+
+## One projection, two ways to catch up
+
+A new client has no cursor. The server first sends a `reset` operation and then
+sends current resources as projection operations. This is a compacted
+bootstrap. It contains current public state, not every historical change.
+
+A reconnecting client can send its last safe cursor. When the cursor is usable,
+the server derives authorized projection operations for later durable facts.
+The same reducer handles the bootstrap, replay, and live operations.
+
+The server can choose a compacted bootstrap when a cursor is missing, invalid,
+expired, too far behind, or no longer safe for the current authorization state.
+This is normal recovery behavior. It is not a client error.
+
+<Aside type="caution">
+  Keep a resume cursor with the exact projection state that it describes. Do
+  not apply a cursor to an empty or different store. A cursor is valid for up
+  to 24 hours, and the server binds it to the authenticated viewer.
+</Aside>
+
+## Apply projection events atomically
+
+Each `RealtimeProjectionEvent` contains one or more ordered operations. Before
+you change local state:
+
+1. Decode the complete server frame.
+2. Check that every operation is present and supported by your client.
+3. Apply all operations to a temporary next state, in their received order.
+4. Commit the next state only when every operation succeeds.
+5. Save the event's `resume_cursor` only after the commit.
+
+A `reset` clears all state that came from the projection. Apply later operations
+in the same event or stream to rebuild it. Do not start parallel ConnectRPC
+refreshes for the same canonical state.
+
+If a frame cannot be decoded, a top-level frame is unknown, or a projection
+operation is unknown, close the connection and keep the preceding cursor. A
+client must not advance across data that it did not understand.
+
+## Durable state and transient events
+
+`RealtimeProjectionEvent` carries the durable, convergent client view. It
+includes server, viewer, user, room, room-group, notification, call, presence,
+and retained timeline state. An operation can replace a complete finite set,
+upsert one resource, or remove one resource.
+
+`RealtimeEventEnvelope` carries signals that are not replayed:
+
+- typing activity;
+- presence transitions;
+- termination of the current session.
+
+Do not use transient events as durable state. For example, every subscription
+also receives a finite presence replacement before `caught_up`, because a
+client can miss presence transitions while it is disconnected.
+
+## Hydrate room timelines only when needed
+
+The initial server projection contains lightweight state for every visible
+room. It does not include every room timeline. Send `hydrate_room` when the
+client first needs a joined room's recent timeline.
+
+The server returns `room_timeline_replace` through the normal projection
+stream. The replacement contains at most 50 recent rows and complete channel
+membership for that room. Later timeline mutations arrive only while the room
+is retained by the connection.
+
+Keep track of rooms whose timeline replacement was applied. Send those room IDs
+again in the next `subscribe_events` frame. One connection can retain at most
+64 room timelines. Evict an old retained timeline before you add another one.
+
+Hydration admission errors are non-fatal. They identify the room and can include
+`retry_after_ms`. Retry that room on the same connection after the delay. A
+`room_unavailable` result means that the room does not exist or the viewer
+cannot access it.
+
+## Detect a dead connection
+
+The server `hello` reports an approximate heartbeat interval. Reset your
+liveness timer after every server frame, not only after a heartbeat. Replace
+the socket when no frame arrives for several expected heartbeat intervals.
+
+You can also send a `ping` with an opaque nonce. The server returns the same
+nonce in `pong`. WebSocket control pings do not replace the application-level
+heartbeat contract.
+
+## Handle errors and reconnects
+
+| Frame | Client action |
+| --- | --- |
+| Non-fatal `error` | Keep the socket open. Retry only the rejected operation and honor `retry_after_ms`. |
+| Fatal `error` | Stop processing that socket and keep the preceding cursor. Retry temporary server failures with backoff. Require a client, protocol, or authentication fix for other codes. |
+| `close` with `reconnect: true` | Close the socket, wait for `retry_after_ms` or local backoff, and subscribe again with the last safe cursor. |
+| `close` with `reconnect: false` | Stop automatic reconnects and require the relevant authentication or user action. |
+| Network close without guidance | Retry with bounded exponential backoff and the last safe cursor. |
+
+Bearer access credentials can expire while the socket is open. Rotate the
+credential and reconnect when the server requests authentication. Same-origin
+cookie clients can receive a session-renewal close and must renew the browser
+session before they reconnect.
+
+<CardGrid>
+  <LinkCard title="TypeScript Tutorial" href="/guides/integrations/realtime-typescript/" description="Connect, decode frames, inspect operations, hydrate a room, and reconnect." />
+  <LinkCard title="Realtime Frame Reference" href="/reference/connectrpc-api/realtime/" description="Read every realtime protobuf message, field, and enum." />
+  <LinkCard title="API Compatibility" href="/guides/integrations/api-compatibility/" description="Plan for API and protocol changes while Chatto is pre-1.0." />
+</CardGrid>

--- a/apps/docs-website/src/content/docs/guides/integrations/realtime-typescript.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/realtime-typescript.mdx
@@ -1,0 +1,449 @@
+---
+title: Use Realtime From TypeScript
+description: Generate TypeScript bindings and build a small browser client for Chatto realtime protocol 2.
+---
+
+import { Aside, Steps, CardGrid, LinkCard } from "@astrojs/starlight/components";
+
+This tutorial builds a browser-based stream inspector. It connects to one
+Chatto server, applies projection events to a small inspection state, hydrates
+a room, and reconnects with the last safe cursor.
+
+The example does not build a complete Chatto user interface. A production
+client must materialize every projection operation that it supports.
+
+<Aside type="caution">
+  Chatto's public API is experimental before 1.0. Generate bindings from the
+  exact Chatto release that your server runs. Do not mix schemas from different
+  releases.
+</Aside>
+
+## Before you start
+
+You need:
+
+- a Chatto server URL, such as `https://chat.example.com`;
+- a bearer credential for a user or bot that can read the required resources;
+- [Buf](https://buf.build/docs/cli/installation/) and Node.js;
+- the `proto/` directory from the exact Chatto server release.
+
+Keep the credential out of source control, logs, URLs, screenshots, and support
+requests. The example reads it from the caller. It never prints it.
+
+## Generate TypeScript bindings
+
+<Steps>
+
+1. Create a client project and install the protobuf runtime.
+
+   ```sh
+   mkdir chatto-realtime-client
+   cd chatto-realtime-client
+   npm init -y
+   npm install @bufbuild/protobuf@1.10.1
+   npm install --save-dev @bufbuild/protoc-gen-es@1.10.1 typescript vite
+   npm pkg set type=module scripts.dev=vite scripts.check="tsc --noEmit"
+   ```
+
+2. Copy the matching Chatto release's `proto/` directory into the project.
+   Keep its `buf.yaml` file and all imported API definitions.
+
+3. Create `tsconfig.json` in the project root.
+
+   ```json
+   {
+     "compilerOptions": {
+       "target": "ES2022",
+       "module": "NodeNext",
+       "moduleResolution": "NodeNext",
+       "lib": ["ES2022", "DOM"],
+       "strict": true,
+       "noEmit": true
+     },
+     "include": ["src"]
+   }
+   ```
+
+4. Create `buf.gen.yaml` in the project root.
+
+   ```yaml
+   version: v2
+   plugins:
+     - local: node_modules/.bin/protoc-gen-es
+       out: src/gen
+       opt:
+         - target=ts
+   ```
+
+5. Generate the bindings.
+
+   ```sh
+   buf generate proto --template buf.gen.yaml
+   ```
+
+</Steps>
+
+The client below imports from the generated
+`src/gen/chatto/realtime/v1/realtime_pb.ts` file. The generator also creates the
+imported `chatto.api.v1` types.
+
+## Create the inspector
+
+Create `src/realtime.ts`:
+
+```ts
+import {
+  RealtimeClientFrame,
+  RealtimeClientHello,
+  RealtimeHydrateRoom,
+  RealtimeProjectionEvent,
+  RealtimeProjectionOperation,
+  RealtimeServerFrame,
+  RealtimeSubscribeEvents,
+} from "./gen/chatto/realtime/v1/realtime_pb.js";
+
+const PROTOCOL_VERSION = 2;
+const PROJECTION_CAPABILITY = "chatto.realtime.projection.v1";
+const BASE_RECONNECT_MS = 1_000;
+const MAX_RECONNECT_MS = 30_000;
+
+const supportedOperations = new Set<
+  RealtimeProjectionOperation["operation"]["case"]
+>([
+  "reset",
+  "serverUpsert",
+  "viewerUpsert",
+  "userUpsert",
+  "userRemove",
+  "roomUpsert",
+  "roomRemove",
+  "roomGroupsReplace",
+  "roomTimelineReplace",
+  "roomTimelineEventUpsert",
+  "serverStateUpsert",
+  "roomTimelineEventRemove",
+  "roomViewerStateReplace",
+  "activeCallsReplace",
+  "presencesReplace",
+  "threadViewerStatesReplace",
+  "roomActivity",
+  "notificationOccurrencesReplace",
+]);
+
+type InspectedEvent = {
+  id: string;
+  operations: Exclude<
+    RealtimeProjectionOperation["operation"]["case"],
+    undefined
+  >[];
+};
+
+type InspectorState = {
+  events: InspectedEvent[];
+  phase: "empty" | "catching-up" | "live";
+  resumeCursor?: string;
+};
+
+export class ChattoRealtimeInspector {
+  #socket?: WebSocket;
+  #stopped = false;
+  #reconnectAttempt = 0;
+  #reconnectDelay?: number;
+  #lastFrameAt = 0;
+  #heartbeatStallMs = 75_000;
+  #watchdog?: number;
+  #retainedRoomIds = new Set<string>();
+  #state: InspectorState = { events: [], phase: "empty" };
+
+  constructor(
+    private readonly serverUrl: string,
+    private readonly bearerToken?: string,
+  ) {}
+
+  get state(): Readonly<InspectorState> {
+    return this.#state;
+  }
+
+  start(): void {
+    this.#stopped = false;
+    this.#connect();
+  }
+
+  stop(): void {
+    this.#stopped = true;
+    window.clearInterval(this.#watchdog);
+    this.#socket?.close(1000, "client stopped");
+  }
+
+  hydrateRoom(roomId: string): void {
+    this.#send(
+      new RealtimeClientFrame({
+        frame: {
+          case: "hydrateRoom",
+          value: new RealtimeHydrateRoom({ roomId }),
+        },
+      }),
+    );
+  }
+
+  #connect(): void {
+    if (this.#stopped) return;
+    const url = new URL("/api/realtime", this.serverUrl);
+    url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+
+    const socket = new WebSocket(url);
+    socket.binaryType = "arraybuffer";
+    this.#socket = socket;
+    this.#reconnectDelay = undefined;
+
+    socket.onopen = () => {
+      if (this.#stopped || this.#socket !== socket) return;
+      this.#lastFrameAt = Date.now();
+      this.#send(
+        new RealtimeClientFrame({
+          frame: {
+            case: "hello",
+            value: new RealtimeClientHello({
+              protocolVersion: PROTOCOL_VERSION,
+              bearerToken: this.bearerToken,
+            }),
+          },
+        }),
+      );
+    };
+
+    socket.onmessage = async (message) => {
+      if (this.#stopped || this.#socket !== socket) return;
+      try {
+        const bytes = await this.#binaryBytes(message.data);
+        const frame = RealtimeServerFrame.fromBinary(bytes);
+        this.#lastFrameAt = Date.now();
+        this.#handleFrame(frame);
+      } catch (error) {
+        console.error("Realtime frame rejected", error);
+        socket.close(1008, "unsupported realtime frame");
+      }
+    };
+
+    socket.onclose = () => {
+      if (this.#socket !== socket) return;
+      this.#socket = undefined;
+      window.clearInterval(this.#watchdog);
+      if (this.#stopped) return;
+
+      const delay = this.#reconnectDelay ?? Math.min(
+        BASE_RECONNECT_MS * 2 ** this.#reconnectAttempt,
+        MAX_RECONNECT_MS,
+      );
+      this.#reconnectAttempt += 1;
+      window.setTimeout(() => this.#connect(), delay);
+    };
+  }
+
+  #handleFrame(frame: RealtimeServerFrame): void {
+    switch (frame.frame.case) {
+      case "hello": {
+        const hello = frame.frame.value;
+        if (
+          hello.protocolVersion !== PROTOCOL_VERSION ||
+          !hello.capabilities.includes(PROJECTION_CAPABILITY)
+        ) {
+          this.#stopped = true;
+          throw new Error("The server does not support realtime protocol 2");
+        }
+
+        this.#heartbeatStallMs = hello.heartbeatIntervalSeconds > 0
+          ? Math.max(hello.heartbeatIntervalSeconds * 3_000, 15_000)
+          : 75_000;
+        this.#startWatchdog();
+        this.#state = { ...this.#state, phase: "catching-up" };
+        this.#send(
+          new RealtimeClientFrame({
+            frame: {
+              case: "subscribeEvents",
+              value: new RealtimeSubscribeEvents({
+                resumeCursor: this.#state.resumeCursor,
+                retainedRoomIds: [...this.#retainedRoomIds],
+              }),
+            },
+          }),
+        );
+        return;
+      }
+
+      case "subscribed":
+        return;
+
+      case "projectionEvent":
+        this.#applyProjectionEvent(frame.frame.value);
+        return;
+
+      case "caughtUp":
+        this.#state = {
+          ...this.#state,
+          phase: "live",
+          resumeCursor: frame.frame.value.cursor,
+        };
+        this.#reconnectAttempt = 0;
+        return;
+
+      case "event":
+        console.info("Transient realtime event", frame.frame.value.event.case);
+        return;
+
+      case "heartbeat":
+      case "pong":
+        return;
+
+      case "error": {
+        const error = frame.frame.value;
+        console.error("Realtime request failed", error.code, error.message);
+        if (error.fatal) {
+          const retryable = [
+            "temporarily_unavailable",
+            "replay_unavailable",
+            "subscribe_failed",
+          ].includes(error.code);
+          this.#stopped = !retryable;
+          this.#reconnectDelay = error.retryAfterMs || BASE_RECONNECT_MS;
+          this.#socket?.close(1008, "fatal realtime error");
+        } else if (error.roomId && error.retryAfterMs !== undefined) {
+          window.setTimeout(() => this.hydrateRoom(error.roomId!), error.retryAfterMs);
+        }
+        return;
+      }
+
+      case "close": {
+        const close = frame.frame.value;
+        this.#stopped = !close.reconnect;
+        this.#reconnectDelay = close.retryAfterMs || BASE_RECONNECT_MS;
+        this.#socket?.close(1000, "server requested reconnect");
+        return;
+      }
+
+      case undefined:
+        throw new Error("Unknown realtime server frame");
+    }
+  }
+
+  #applyProjectionEvent(event: RealtimeProjectionEvent): void {
+    const operationCases = event.operations.map(({ operation }) => {
+      if (!operation.case || !supportedOperations.has(operation.case)) {
+        throw new Error("Unknown realtime projection operation");
+      }
+      return operation.case;
+    });
+
+    // Build the next state first. A production reducer applies each operation
+    // to resource maps here, in this exact order.
+    const resetIndex = operationCases.lastIndexOf("reset");
+    const previousEvents = resetIndex === -1 ? this.#state.events : [];
+    const nextState: InspectorState = {
+      ...this.#state,
+      events: [
+        ...previousEvents,
+        { id: event.id, operations: operationCases },
+      ],
+    };
+
+    // Commit the cursor only with the state produced by the complete event.
+    if (event.resumeCursor !== undefined) {
+      nextState.resumeCursor = event.resumeCursor;
+    }
+    this.#state = nextState;
+
+    for (const operation of event.operations) {
+      if (operation.operation.case === "roomTimelineReplace") {
+        this.#retainedRoomIds.add(operation.operation.value.roomId);
+      }
+    }
+  }
+
+  #startWatchdog(): void {
+    window.clearInterval(this.#watchdog);
+    this.#watchdog = window.setInterval(() => {
+      if (Date.now() - this.#lastFrameAt >= this.#heartbeatStallMs) {
+        this.#socket?.close(1012, "heartbeat stalled");
+      }
+    }, 5_000);
+  }
+
+  #send(frame: RealtimeClientFrame): void {
+    if (this.#socket?.readyState !== WebSocket.OPEN) {
+      throw new Error("Realtime socket is not open");
+    }
+    this.#socket.send(Uint8Array.from(frame.toBinary()).buffer);
+  }
+
+  async #binaryBytes(data: unknown): Promise<Uint8Array> {
+    if (data instanceof ArrayBuffer) return new Uint8Array(data);
+    if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer());
+    throw new Error("Expected a binary protobuf frame");
+  }
+}
+```
+
+The inspector recognizes every protocol-2 projection operation. It records the
+operation names instead of building UI resource maps. Replace the marked block
+in `#applyProjectionEvent` with your reducer. Keep the validation, atomic
+commit, operation order, and cursor rules unchanged.
+
+## Start the connection
+
+Pass the access credential from a secure runtime source:
+
+```ts
+import { ChattoRealtimeInspector } from "./realtime.js";
+
+const inspector = new ChattoRealtimeInspector(
+  "https://chat.example.com",
+  accessToken,
+);
+
+inspector.start();
+```
+
+A same-origin browser client can omit `accessToken`. The browser then sends its
+HttpOnly Chatto cookie during the WebSocket upgrade. A cross-origin browser
+client must use the OAuth authorization code flow with PKCE and pass the current
+access token in `hello`.
+
+Do not put the token in the WebSocket URL or a log message. Rotate an expiring
+OAuth access credential before you reconnect.
+
+## Hydrate a room
+
+After the stream reaches `caught_up`, request a joined room when the user first
+opens it:
+
+```ts
+inspector.hydrateRoom("R…");
+```
+
+Wait for a projection event that contains `roomTimelineReplace`. Only then add
+the room to the retained set. If the socket closes before that replacement,
+request the room again after the next `caught_up` frame.
+
+The sample automatically sends confirmed retained room IDs in later
+subscriptions. A production client must evict retained timelines before it
+reaches the 64-room limit.
+
+## Add a production reducer
+
+Materialize each operation according to its contract in the
+[frame reference](/reference/connectrpc-api/realtime/#realtimeprojectionoperation).
+Use keyed maps for individual resource upserts and removals. Replace complete
+finite collections when you receive a `*_replace` operation.
+
+Do not infer missing history from the convergence stream. Use ConnectRPC for:
+
+- commands and their read-your-writes responses;
+- explicit resource reads;
+- older room or thread history;
+- paginated lists and searches.
+
+<CardGrid>
+  <LinkCard title="Realtime Overview" href="/guides/integrations/realtime-protocol/" description="Review projection, cursor, hydration, and reconnect semantics." />
+  <LinkCard title="Realtime Frame Reference" href="/reference/connectrpc-api/realtime/" description="Read every protobuf frame and operation field." />
+  <LinkCard title="Integrating With Chatto" href="/guides/integrations/chatto-api/" description="Choose among Chatto's public integration surfaces." />
+</CardGrid>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
@@ -10,7 +10,11 @@ Chatto exposes realtime updates at `GET /api/realtime` using binary protobuf fra
 
 
 
-Realtime frames are documented separately from ConnectRPC services because they are exchanged over a long-lived WebSocket session rather than `/api/connect` RPC methods.
+Read the [Realtime Protocol Overview](/guides/integrations/realtime-protocol/) before you implement the connection lifecycle, projection reducer, room hydration, or reconnect behavior. Follow [Use Realtime From TypeScript](/guides/integrations/realtime-typescript/) for a complete browser example.
+
+
+
+This page is the field-level reference. Realtime frames are documented separately from ConnectRPC services because they are exchanged over a long-lived WebSocket session rather than `/api/connect` RPC methods.
 
 
 

--- a/tools/split-connectrpc-docs.mjs
+++ b/tools/split-connectrpc-docs.mjs
@@ -587,7 +587,9 @@ function renderRealtimePage(typeSections, enumSections) {
   const body = [
     'Chatto exposes realtime updates at `GET /api/realtime` using binary protobuf frames from `chatto.realtime.v1`.',
     '',
-    'Realtime frames are documented separately from ConnectRPC services because they are exchanged over a long-lived WebSocket session rather than `/api/connect` RPC methods.',
+    'Read the [Realtime Protocol Overview](/guides/integrations/realtime-protocol/) before you implement the connection lifecycle, projection reducer, room hydration, or reconnect behavior. Follow [Use Realtime From TypeScript](/guides/integrations/realtime-typescript/) for a complete browser example.',
+    '',
+    'This page is the field-level reference. Realtime frames are documented separately from ConnectRPC services because they are exchanged over a long-lived WebSocket session rather than `/api/connect` RPC methods.',
     '',
     '## Protocol Types',
     '',


### PR DESCRIPTION
## Why

API users have a field reference for realtime protobuf messages but no protocol overview or complete client example.

## What changed

- Add an overview of protocol version 2 lifecycle, projection semantics, atomic reducers, room hydration, cursors, and recovery.
- Add a browser TypeScript tutorial with release-matched Buf generation, binary frame handling, safe cursor commits, heartbeat detection, hydration, and reconnects.
- Add a responsive light/dark sequence diagram, sidebar entries, integration and bot cross-links, and generated-reference guide links.

## API compatibility

- No public API or protocol behaviour changed; protocol version 2 and all existing wire contracts remain unchanged.
- Older client → newer server: unaffected; newer client → older server: unaffected; capability discovery or minimum version: unchanged.

## Test plan

- `mise codegen-proto` — passed; only the intended generated realtime introduction changed.
- Exact-release Buf generation plus strict TypeScript checking of the tutorial — passed.
- `pnpm --filter docs-website build` and `mise license-check` — passed.
- Chrome DevTools verification at desktop and mobile widths, in light and dark themes, including navigation and links — passed.