### PR TITLE
fix(frontend): hide inactive preview scroll fades

### DIFF
--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -377,8 +377,7 @@ unknown instance) the component renders nothing.
           fill={false}
           fadeHeight="h-5"
           fadeColorClass="from-surface via-surface/80"
-          class="max-h-52"
-          scrollClass="overscroll-contain"
+          scrollClass="max-h-52 overscroll-contain"
         >
           <div class="px-3 py-2.5 text-sm leading-relaxed pointer-fine:select-text">
             <MessageContent

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -1,4 +1,5 @@
 import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
+import '../../app.css';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import MessagePreviewCard from './MessagePreviewCard.svelte';
@@ -227,7 +228,7 @@ describe('MessagePreviewCard', () => {
     });
   });
 
-  it('renders the linked message body as markdown in a scrollable preview', async () => {
+  it('renders fitted linked message markdown without scroll fades', async () => {
     timelineResults.push(
       bodyPreviewResult('# Release notes\n\n- **Breaking** change\n- More details')
     );
@@ -246,7 +247,8 @@ describe('MessagePreviewCard', () => {
       container.querySelector('[data-testid="message-preview-card"] strong')?.textContent
     ).toBe('Breaking');
     expect(container.querySelector('[data-testid="message-preview-card"] ul')).not.toBeNull();
-    expect(container.querySelector('.max-h-52 .overflow-y-auto')).not.toBeNull();
+    const scrollViewport = container.querySelector<HTMLElement>('.max-h-52.overflow-y-auto');
+    expect(scrollViewport).not.toBeNull();
     expect(
       [...container.querySelectorAll('[data-testid="message-preview-card"] bdi')]
         .map((value) => value.textContent)
@@ -257,6 +259,44 @@ describe('MessagePreviewCard', () => {
     expect(fades[0].className).toContain('from-surface');
     expect(fades[0].className).toContain('z-30');
     expect(fades[1].className).toContain('bg-gradient-to-t');
+    await vi.waitFor(() => {
+      expect(scrollViewport!.scrollHeight).toBeLessThanOrEqual(scrollViewport!.clientHeight + 1);
+      expect(fades[0].classList).toContain('opacity-0');
+      expect(fades[1].classList).toContain('opacity-0');
+    });
+  });
+
+  it('shows only the applicable fade at each edge of an overflowing linked message', async () => {
+    timelineResults.push(
+      bodyPreviewResult(
+        Array.from({ length: 30 }, (_, index) => `Paragraph ${index + 1}`).join('\n\n')
+      )
+    );
+
+    const { container } = render(MessagePreviewCard, {
+      props: { link: link(), showDismiss: false }
+    });
+
+    const scrollViewport = await vi.waitFor(() => {
+      const viewport = container.querySelector<HTMLElement>('.max-h-52.overflow-y-auto');
+      expect(viewport).not.toBeNull();
+      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight + 1);
+      return viewport!;
+    });
+    const fades = container.querySelectorAll<HTMLElement>('[aria-hidden="true"]');
+
+    await vi.waitFor(() => {
+      expect(fades[0].classList).toContain('opacity-0');
+      expect(fades[1].classList).not.toContain('opacity-0');
+    });
+
+    scrollViewport.scrollTop = scrollViewport.scrollHeight;
+    scrollViewport.dispatchEvent(new Event('scroll'));
+
+    await vi.waitFor(() => {
+      expect(fades[0].classList).not.toContain('opacity-0');
+      expect(fades[1].classList).toContain('opacity-0');
+    });
   });
 
   it('refreshes attachment thumbnail asset URLs after image load failure', async () => {

--- a/apps/frontend/src/lib/ui/ScrollFader.stories.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.stories.svelte
@@ -165,19 +165,19 @@ fades use \`transition-opacity\` so the show/hide is animated.
 </Story>
 
 <Story
-  name="Short content (no fades)"
+  name="Intrinsic short content (no fades)"
   asChild
   parameters={{
     docs: {
       description: {
         story:
-          "When content fits without scrolling, both edges count as 'at edge' and both fades stay hidden — no visual noise."
+          "An intrinsic-height viewport grows up to its maximum height. When its content fits, both fades stay hidden. This is the linked-message preview layout."
       }
     }
   }}
 >
-  <div class="flex h-80 w-64 flex-col border border-border bg-background">
-    <ScrollFader top bottom>
+  <div class="w-64 border border-border bg-background">
+    <ScrollFader top bottom fill={false} scrollClass="max-h-52">
       <div class="flex flex-col gap-2 p-3">
         {#each Array(3) as _, i (i)}
           <div class="rounded-md bg-surface px-3 py-2 text-sm">Item {i + 1}</div>


### PR DESCRIPTION
## Summary

- constrain linked-message preview height on the measured scroll viewport
- hide both gradient overlays when the message body fits
- cover fitted content and both overflowing scroll edges in Chromium tests
- document the intrinsic-height composition in Storybook

## Verification

- `mise lint-frontend`
- `mise x -- pnpm --dir apps/frontend exec vitest --run --project=client src/lib/components/MessagePreviewCard.svelte.spec.ts src/lib/ui/ScrollFader.svelte.spec.ts`
- `mise x -- pnpm --dir apps/frontend exec vitest --run --project=storybook src/lib/ui/ScrollFader.stories.svelte`
- Chrome DevTools MCP verification of fitted and overflowing Storybook states