### PR TITLE
fix(frontend): backport preview scroll fades to 0.4

### DIFF
--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte
@@ -39,6 +39,7 @@ unknown instance) the component renders nothing.
     type ExpiringAssetUrl
   } from '$lib/attachments/attachmentUrls';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
+  import ScrollFader from '$lib/ui/ScrollFader.svelte';
   import MessageContent from './MessageContent.svelte';
   import UserAvatar, { UserAvatarViewData } from './UserAvatar.svelte';
   import DeletedUserLabel from './DeletedUserLabel.svelte';
@@ -416,21 +417,18 @@ unknown instance) the component renders nothing.
         </div>
       </div>
       {#if hasBody}
-        <div class="relative">
-          <div
-            class="pointer-events-none absolute inset-x-0 top-0 z-10 h-5 bg-gradient-to-b from-surface-100 via-surface-100/80 to-transparent"
-            aria-hidden="true"
-          ></div>
-          <div
-            class="pointer-events-none absolute inset-x-0 bottom-0 z-10 h-5 bg-gradient-to-t from-surface-100 via-surface-100/80 to-transparent"
-            aria-hidden="true"
-          ></div>
-          <div
-            class="max-h-52 overflow-y-auto overscroll-contain px-3 py-2.5 text-sm leading-relaxed pointer-fine:select-text"
-          >
+        <ScrollFader
+          top
+          bottom
+          fill={false}
+          fadeHeight="h-5"
+          fadeColorClass="from-surface-100 via-surface-100/80"
+          scrollClass="max-h-52 overscroll-contain"
+        >
+          <div class="px-3 py-2.5 text-sm leading-relaxed pointer-fine:select-text">
             <MessageContent body={bodyMarkdown} />
           </div>
-        </div>
+        </ScrollFader>
       {/if}
       {#if preview.attachments.length > 0}
         <div

--- a/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessagePreviewCard.svelte.spec.ts
@@ -1,3 +1,4 @@
+import '../../app.css';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import MessagePreviewCard from './MessagePreviewCard.svelte';
@@ -218,7 +219,7 @@ describe('MessagePreviewCard', () => {
     });
   });
 
-  it('renders the linked message body as markdown in a scrollable preview', async () => {
+  it('renders fitted linked message markdown without scroll fades', async () => {
     timelineResults.push(
       bodyPreviewResult('# Release notes\n\n- **Breaking** change\n- More details')
     );
@@ -237,9 +238,50 @@ describe('MessagePreviewCard', () => {
       container.querySelector('[data-testid="message-preview-card"] strong')?.textContent
     ).toBe('Breaking');
     expect(container.querySelector('[data-testid="message-preview-card"] ul')).not.toBeNull();
-    expect(container.querySelector('.max-h-52.overflow-y-auto')).not.toBeNull();
-    expect(container.querySelector('.bg-gradient-to-b')).not.toBeNull();
-    expect(container.querySelector('.bg-gradient-to-t')).not.toBeNull();
+    const scrollViewport = container.querySelector<HTMLElement>('.max-h-52.overflow-y-auto');
+    expect(scrollViewport).not.toBeNull();
+    const fades = container.querySelectorAll<HTMLElement>('[aria-hidden="true"]');
+    expect(fades).toHaveLength(2);
+    expect(fades[0].className).toContain('from-surface-100');
+    expect(fades[1].className).toContain('bg-gradient-to-t');
+    await vi.waitFor(() => {
+      expect(scrollViewport!.scrollHeight).toBeLessThanOrEqual(scrollViewport!.clientHeight + 1);
+      expect(fades[0].classList).toContain('opacity-0');
+      expect(fades[1].classList).toContain('opacity-0');
+    });
+  });
+
+  it('shows only the applicable fade at each edge of an overflowing linked message', async () => {
+    timelineResults.push(
+      bodyPreviewResult(
+        Array.from({ length: 30 }, (_, index) => `Paragraph ${index + 1}`).join('\n\n')
+      )
+    );
+
+    const { container } = render(MessagePreviewCard, {
+      props: { link: link(), showDismiss: false }
+    });
+
+    const scrollViewport = await vi.waitFor(() => {
+      const viewport = container.querySelector<HTMLElement>('.max-h-52.overflow-y-auto');
+      expect(viewport).not.toBeNull();
+      expect(viewport!.scrollHeight).toBeGreaterThan(viewport!.clientHeight + 1);
+      return viewport!;
+    });
+    const fades = container.querySelectorAll<HTMLElement>('[aria-hidden="true"]');
+
+    await vi.waitFor(() => {
+      expect(fades[0].classList).toContain('opacity-0');
+      expect(fades[1].classList).not.toContain('opacity-0');
+    });
+
+    scrollViewport.scrollTop = scrollViewport.scrollHeight;
+    scrollViewport.dispatchEvent(new Event('scroll'));
+
+    await vi.waitFor(() => {
+      expect(fades[0].classList).not.toContain('opacity-0');
+      expect(fades[1].classList).toContain('opacity-0');
+    });
   });
 
   it('refreshes attachment thumbnail asset URLs after image load failure', async () => {

--- a/apps/frontend/src/lib/ui/ScrollFader.stories.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.stories.svelte
@@ -27,6 +27,9 @@ Reserve \`scrollClass\` for properties that target the scroll container
 itself (e.g. \`overscroll-y-contain\`, \`scrollbar-hide\`). Padding,
 gap, alignment, and \`[&>*]\` selectors belong on the nested wrapper.
 
+Set \`fill={false}\` for a scrollable region that should retain its intrinsic
+height up to a max-height, such as a linked-message preview.
+
 ### Plumbing the scroll element out
 
 When something outside \`ScrollFader\` needs the scroll element —
@@ -135,19 +138,19 @@ fades use \`transition-opacity\` so the show/hide is animated.
 </Story>
 
 <Story
-  name="Short content (no fades)"
+  name="Intrinsic short content (no fades)"
   asChild
   parameters={{
     docs: {
       description: {
         story:
-          "When content fits without scrolling, both edges count as 'at edge' and both fades stay hidden — no visual noise."
+          "An intrinsic-height viewport grows up to its maximum height. When its content fits, both fades stay hidden. This is the linked-message preview layout."
       }
     }
   }}
 >
-  <div class="flex h-80 w-64 flex-col border border-border bg-background">
-    <ScrollFader top bottom>
+  <div class="w-64 border border-border bg-background">
+    <ScrollFader top bottom fill={false} scrollClass="max-h-52">
       <div class="flex flex-col gap-2 p-3">
         {#each Array(3) as _, i (i)}
           <div class="rounded-md bg-surface px-3 py-2 text-sm">Item {i + 1}</div>

--- a/apps/frontend/src/lib/ui/ScrollFader.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.svelte
@@ -25,6 +25,10 @@ scroll container; children render inside the scroll container.
     bottom?: boolean;
     /** Tailwind class for fade height. Default `h-8`. */
     fadeHeight?: string;
+    /** Fill the remaining height of a flex parent. Disable for intrinsic-height viewports. */
+    fill?: boolean;
+    /** Tailwind classes for the opaque end of each fade. */
+    fadeColorClass?: string;
     /** Extra classes for the outer positioning wrapper. */
     class?: string;
     /** Extra classes for the inner scroll container. */
@@ -39,6 +43,8 @@ scroll container; children render inside the scroll container.
     top = false,
     bottom = false,
     fadeHeight = 'h-8',
+    fill = true,
+    fadeColorClass = 'from-background',
     class: className = '',
     scrollClass = '',
     scrollEl = $bindable(),
@@ -94,7 +100,7 @@ scroll container; children render inside the scroll container.
   }
 </script>
 
-<div class={['relative flex min-h-0 min-w-0 flex-1 flex-col', className]}>
+<div class={['relative flex min-h-0 min-w-0 flex-col', fill && 'flex-1', className]}>
   <div
     bind:this={scrollEl}
     {@attach trackScrollEdges}
@@ -107,7 +113,8 @@ scroll container; children render inside the scroll container.
     <div
       aria-hidden="true"
       class={[
-        'pointer-events-none absolute inset-x-0 top-0 bg-gradient-to-b from-background to-transparent transition-opacity',
+        'pointer-events-none absolute inset-x-0 top-0 bg-gradient-to-b to-transparent transition-opacity',
+        fadeColorClass,
         fadeHeight,
         !scrolledFromTop && 'opacity-0'
       ]}
@@ -117,7 +124,8 @@ scroll container; children render inside the scroll container.
     <div
       aria-hidden="true"
       class={[
-        'pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t from-background to-transparent transition-opacity',
+        'pointer-events-none absolute inset-x-0 bottom-0 bg-gradient-to-t to-transparent transition-opacity',
+        fadeColorClass,
         fadeHeight,
         !scrolledFromBottom && 'opacity-0'
       ]}


### PR DESCRIPTION
## Summary

- backport the linked-message preview fade fix from #2261 to the 0.4 release line
- replace the 0.4 preview's static gradients with its existing overflow-aware `ScrollFader`
- add the minimal intrinsic-height and fade-colour options needed by the older component
- cover fitted content and both overflowing scroll edges in Chromium tests

## Backport notes

A direct cherry-pick was not possible because `release-0.4` predates the
`MessagePreviewCard` integration with `ScrollFader`. This PR applies the
equivalent behavior against the older frontend without pulling in unrelated
main-line UI changes.

This replaces #2262, which GitHub closed when its remote branch was renamed.

## Verification

- `mise lint-frontend`
- `mise x -- pnpm --dir apps/frontend exec vitest --run --project=client src/lib/components/MessagePreviewCard.svelte.spec.ts src/lib/ui/ScrollFader.svelte.spec.ts`
- Chrome DevTools MCP verification of fitted and overflowing Storybook states
