### PR TITLE
feat(frontend): consolidate standard modal design

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -89,6 +89,35 @@ inside the icon. Do not add a side stripe or a shadow for navigation selection.
 Use the square check indicator for an independent boolean setting. Use the
 circular radio indicator for one choice in a group.
 
+## Standard Dialogs
+
+Use the standard dialog family for focused tasks:
+
+- Use `ConfirmDialog` when a user must confirm one command.
+- Use `FormDialog` when a dialog collects input and submits one form.
+- Use `Dialog` for information, custom content, or two or more action paths.
+
+All three components use the same structure. A `surface` tray frames one
+inset `background` work plane. The header and footer stay visible. Only the
+body scrolls when the content is long. Do not add a `Panel`, another work
+plane, or a footer divider inside this structure.
+
+Pass footer buttons directly to the `Dialog` footer snippet. `Dialog` owns the
+horizontal, end-aligned layout and wraps the buttons when the viewport is too
+narrow. Put Cancel first. Use `secondary` for Cancel, `action` for the
+recommended path, and a semantic tone such as `danger` only when the action
+has that meaning. Use an action-specific icon on the committing action. Do not
+add an icon to Cancel by default.
+
+Use the `sm` size for short confirmations, `md` for ordinary custom dialogs,
+and `lg` for dense content such as screen selection. Keep the standard
+viewport gutter. Do not add a feature-specific width to a task dialog.
+
+`ImageModal`, fullscreen video, `QuickSwitcher`, popovers, and `BottomSheet`
+are specialized overlays. They can use their own geometry because they do not
+represent a standard task dialog. Keep each exception local and do not copy
+its layout into a task dialog.
+
 ## Standard Pane Pages
 
 Use the pane-page composition for primary application pages such as search,

--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -103,11 +103,12 @@ body scrolls when the content is long. Do not add a `Panel`, another work
 plane, or a footer divider inside this structure.
 
 Pass footer buttons directly to the `Dialog` footer snippet. `Dialog` owns the
-horizontal, end-aligned layout and wraps the buttons when the viewport is too
-narrow. Put Cancel first. Use `secondary` for Cancel, `action` for the
-recommended path, and a semantic tone such as `danger` only when the action
-has that meaning. Use an action-specific icon on the committing action. Do not
-add an icon to Cancel by default.
+horizontal, end-aligned layout. The actions always stay in one row. A button
+label truncates when the viewport cannot show the full label. Put Cancel
+first. Use `secondary` for Cancel, `action` for the recommended path, and a
+semantic tone such as `danger` only when the action has that meaning. Use an
+action-specific icon on the committing action. Do not add an icon to Cancel by
+default.
 
 Use the `sm` size for short confirmations, `md` for ordinary custom dialogs,
 and `lg` for dense content such as screen selection. Keep the standard

--- a/apps/frontend/scripts/check-design-system.mjs
+++ b/apps/frontend/scripts/check-design-system.mjs
@@ -138,9 +138,9 @@ for (const file of await svelteFiles(sourceRoot)) {
   }
 
   const directModalImport = utilitySource.match(
-    /(?:from\s+|import\s*\(\s*)['"]\$lib\/ui\/(?:Dialog|FormDialog|ConfirmDialog)\.svelte['"]/
+    /(?:from\s+|import\s*\(\s*)['"][^'"]*\/(?:Dialog|FormDialog|ConfirmDialog)\.svelte['"]/
   );
-  if (directModalImport) {
+  if (directModalImport && !path.startsWith('src/lib/ui/')) {
     const line = utilitySource.slice(0, directModalImport.index).split('\n').length;
     failures.push(`${path}:${line}: import public modal primitives from $lib/ui`);
   }

--- a/apps/frontend/scripts/check-design-system.mjs
+++ b/apps/frontend/scripts/check-design-system.mjs
@@ -18,6 +18,18 @@ const styleBlockAllowlist = new Set([
   'src/lib/ui/toast/ToastContainer.svelte'
 ]);
 
+// These components own specialized native-dialog behavior. Standard task
+// dialogs must use Dialog, FormDialog, or ConfirmDialog instead.
+const nativeDialogAllowlist = new Set([
+  'src/lib/components/QuickSwitcher.svelte',
+  'src/lib/ui/BottomSheet.svelte',
+  'src/lib/ui/Dialog.svelte',
+  'src/lib/ui/ImageModal.svelte',
+  'src/routes/chat/ModalContainerConfirmDialogMock.svelte',
+  'src/routes/chat/ModalContainerDialogMock.svelte',
+  'src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersConfirmDialogMock.svelte'
+]);
+
 const checks = [
   {
     description: 'bare transition utilities; name the transitioned properties',
@@ -117,6 +129,27 @@ for (const file of await svelteFiles(sourceRoot)) {
     failures.push(
       `${path}: unreviewed <style> block; use Tailwind or update the documented allowlist`
     );
+  }
+
+  if (/<dialog\b/.test(utilitySource) && !nativeDialogAllowlist.has(path)) {
+    failures.push(
+      `${path}: raw <dialog> is reserved for reviewed foundations and specialized overlays; use Dialog, FormDialog, or ConfirmDialog`
+    );
+  }
+
+  const directModalImport = utilitySource.match(
+    /(?:from\s+|import\s*\(\s*)['"]\$lib\/ui\/(?:Dialog|FormDialog|ConfirmDialog)\.svelte['"]/
+  );
+  if (directModalImport) {
+    const line = utilitySource.slice(0, directModalImport.index).split('\n').length;
+    failures.push(`${path}:${line}: import public modal primitives from $lib/ui`);
+  }
+
+  if (
+    path !== 'src/lib/ui/FormDialog.svelte' &&
+    /<Dialog\b(?:(?!<\/Dialog>).)*<form\b/s.test(utilitySource)
+  ) {
+    failures.push(`${path}: modal forms must use FormDialog instead of nesting a form in Dialog`);
   }
 
   for (const { description, pattern } of checks) {

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -307,6 +307,35 @@
   @apply disabled:cursor-not-allowed disabled:opacity-50;
 }
 
+@utility button-content {
+  @apply block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap;
+
+  & > :where(.iconify):not(:last-child) {
+    margin-inline-end: --spacing(2);
+  }
+}
+
+/* Dialog actions form one stable row. Buttons can surrender label width in a
+ * narrow viewport, but they never wrap or force a second action row. */
+@utility dialog-actions {
+  @apply mt-6 flex min-w-0 shrink-0 flex-nowrap justify-end gap-2;
+
+  & > :is(button, a) {
+    min-width: 0;
+    max-width: 100%;
+    flex-shrink: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* The standard first action is Cancel. Keep that stable while committing
+   * actions surrender their longer labels first. */
+  & > :is(button, a):first-child:not(:last-child) {
+    flex-shrink: 0;
+  }
+}
+
 @utility btn-neutral {
   @apply btn border-neutral-action bg-neutral-action text-on-neutral-action hover:border-neutral-action-hover hover:bg-neutral-action-hover;
 }

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -308,11 +308,7 @@
 }
 
 @utility button-content {
-  @apply block min-w-0 overflow-hidden text-ellipsis whitespace-nowrap;
-
-  & > :where(.iconify):not(:last-child) {
-    margin-inline-end: --spacing(2);
-  }
+  @apply max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap;
 }
 
 /* Dialog actions form one stable row. Buttons can surrender label width in a

--- a/apps/frontend/src/lib/RoomDirectory.svelte
+++ b/apps/frontend/src/lib/RoomDirectory.svelte
@@ -15,8 +15,7 @@ store owns only optimistic join/leave state.
   import { resolve } from '$app/paths';
   import { toast } from '$lib/ui/toast';
   import { m } from '$lib/i18n/messages';
-  import { Button } from '$lib/ui/form';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
   import Panel from '$lib/ui/Panel.svelte';
   import type { RoomDirectoryStore, DirectoryRoom } from '$lib/state/server/roomDirectory.svelte';
 
@@ -343,15 +342,13 @@ store owns only optimistic join/leave state.
   </div>
 {/if}
 
-<Dialog bind:visible={leaveConfirmVisible} title={m('room.leave.title')} size="sm">
-  <p class="mb-4">
-    {m('room.directory.leave_confirm', { room: leaveConfirmRoom?.name ?? '' })}
-  </p>
-
-  <div class="flex items-center gap-3">
-    <Button defaultAction variant="danger" onclick={confirmLeaveRoom}>{m('room.leave.action')}</Button>
-    <Button variant="ghost" onclick={() => (leaveConfirmVisible = false)}>
-      {m('common.cancel')}
-    </Button>
-  </div>
-</Dialog>
+<ConfirmDialog
+  bind:visible={leaveConfirmVisible}
+  title={m('room.leave.title')}
+  actionLabel={m('room.leave.action')}
+  actionIcon="iconify icon-[uil--sign-out-alt]"
+  onconfirm={confirmLeaveRoom}
+  onclose={() => (leaveConfirmVisible = false)}
+>
+  {m('room.directory.leave_confirm', { room: leaveConfirmRoom?.name ?? '' })}
+</ConfirmDialog>

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -1142,7 +1142,10 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 {/if}
 
 {#if linkDialogVisible}
-  {#await Promise.all( [import('$lib/ui/FormDialog.svelte'), import('$lib/ui/form/TextInput.svelte')] ) then [FormDialogModule, TextInputModule]}
+  {#await Promise.all([
+    import('$lib/ui').then(({ FormDialog }) => ({ default: FormDialog })),
+    import('$lib/ui/form').then(({ TextInput }) => ({ default: TextInput }))
+  ]) then [FormDialogModule, TextInputModule]}
     <FormDialogModule.default
       bind:visible={linkDialogVisible}
       title={editingLinkId ? m('admin.rooms_admin.edit_link') : m('admin.rooms_admin.create_link')}
@@ -1169,7 +1172,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 {/if}
 
 {#if deleteGroupDialogVisible && deleteGroupTarget}
-  {#await import('$lib/ui/ConfirmDialog.svelte') then ConfirmDialogModule}
+  {#await import('$lib/ui').then(({ ConfirmDialog }) => ({ default: ConfirmDialog })) then ConfirmDialogModule}
     <ConfirmDialogModule.default
       title={m('admin.rooms_admin.delete_group')}
       actionLabel={m('admin.rooms_admin.delete_group')}
@@ -1187,7 +1190,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 {/if}
 
 {#if deleteLinkDialogVisible && deleteLinkTarget?.type === 'link'}
-  {#await import('$lib/ui/ConfirmDialog.svelte') then ConfirmDialogModule}
+  {#await import('$lib/ui').then(({ ConfirmDialog }) => ({ default: ConfirmDialog })) then ConfirmDialogModule}
     <ConfirmDialogModule.default
       title={m('admin.rooms_admin.delete_link')}
       actionLabel={m('admin.rooms_admin.delete_link')}
@@ -1205,7 +1208,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 {/if}
 
 {#if archiveRoomDialogVisible && archiveRoomTarget}
-  {#await import('$lib/ui/ConfirmDialog.svelte') then ConfirmDialogModule}
+  {#await import('$lib/ui').then(({ ConfirmDialog }) => ({ default: ConfirmDialog })) then ConfirmDialogModule}
     <ConfirmDialogModule.default
       title={m('admin.rooms_admin.archive_room')}
       actionLabel={m('admin.rooms_admin.archive_room')}

--- a/apps/frontend/src/lib/components/CurrentUserBar.svelte
+++ b/apps/frontend/src/lib/components/CurrentUserBar.svelte
@@ -22,7 +22,7 @@ sidebar. Shows the avatar with presence and the live display name.
   import { prefersTouchActions, supportsHoverActions } from '$lib/utils/inputCapabilities';
   import BottomSheet from '$lib/ui/BottomSheet.svelte';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { Dialog } from '$lib/ui';
   import MenuItem from '$lib/ui/MenuItem.svelte';
   import MenuSection from '$lib/ui/MenuSection.svelte';
   import UserAvatar from './UserAvatar.svelte';

--- a/apps/frontend/src/lib/components/bots/ShowOnceCredentialDialog.svelte
+++ b/apps/frontend/src/lib/components/bots/ShowOnceCredentialDialog.svelte
@@ -52,8 +52,9 @@
         {m('common.copy_to_clipboard')}
       </Button>
     </div>
-    <div class="flex justify-end">
-      <Button defaultAction onclick={close}>{m('common.got_it')}</Button>
-    </div>
   </div>
+
+  {#snippet footer()}
+    <Button defaultAction onclick={close}>{m('common.got_it')}</Button>
+  {/snippet}
 </Dialog>

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -7,8 +7,7 @@
   import { createLinkPreviewAPI } from '$lib/api-client/linkPreviews';
   import { m } from '$lib/i18n/messages';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { ConfirmDialog, Dialog } from '$lib/ui';
   import { Button } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast';
   import { getRoomMembers, getRoomMembersStore, getComposerContext } from '$lib/state/room';
@@ -346,18 +345,16 @@
     <p class="text-muted">{m('composer.recent_thread_confirm_body')}</p>
 
     {#snippet footer()}
-      <div class="flex justify-end gap-2">
-        <Button variant="secondary" onclick={() => composer.cancelThreadDestinationConfirmation()}>
-          {m('common.cancel')}
-        </Button>
-        <Button variant="secondary" onclick={() => composer.postAsNewRoot()}>
-          {m('composer.post_as_new_message')}
-        </Button>
-        <Button defaultAction variant="action" onclick={() => composer.postInRecentThread()}>
-          <span class="iconify icon-[uil--comment-alt-lines]"></span>
-          {m('composer.continue_in_thread')}
-        </Button>
-      </div>
+      <Button variant="secondary" onclick={() => composer.cancelThreadDestinationConfirmation()}>
+        {m('common.cancel')}
+      </Button>
+      <Button variant="secondary" onclick={() => composer.postAsNewRoot()}>
+        {m('composer.post_as_new_message')}
+      </Button>
+      <Button defaultAction variant="action" onclick={() => composer.postInRecentThread()}>
+        <span class="iconify icon-[uil--comment-alt-lines]"></span>
+        {m('composer.continue_in_thread')}
+      </Button>
     {/snippet}
   </Dialog>
 {/if}

--- a/apps/frontend/src/lib/components/moderation/BanRoomMemberModal.svelte
+++ b/apps/frontend/src/lib/components/moderation/BanRoomMemberModal.svelte
@@ -3,7 +3,7 @@
 
   import UserAvatar from '$lib/components/UserAvatar.svelte';
   import { getLiveDisplayName, getLiveLogin } from '$lib/state/userProfiles.svelte';
-  import FormDialog from '$lib/ui/FormDialog.svelte';
+  import { FormDialog } from '$lib/ui';
   import { ExpirySelect, TextArea } from '$lib/ui/form';
   import { m } from '$lib/i18n/messages';
 

--- a/apps/frontend/src/lib/components/moderation/UnbanRoomMemberModal.svelte
+++ b/apps/frontend/src/lib/components/moderation/UnbanRoomMemberModal.svelte
@@ -2,7 +2,7 @@
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
 
   import UserAvatar from '$lib/components/UserAvatar.svelte';
-  import FormDialog from '$lib/ui/FormDialog.svelte';
+  import { FormDialog } from '$lib/ui';
   import { TextArea } from '$lib/ui/form';
   import { m } from '$lib/i18n/messages';
 

--- a/apps/frontend/src/lib/components/rbac/DeleteRoleModal.svelte
+++ b/apps/frontend/src/lib/components/rbac/DeleteRoleModal.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
-  import { Button } from '$lib/ui/form';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
   import { m } from '$lib/i18n/messages';
 
   let {
@@ -23,7 +22,16 @@
   }
 </script>
 
-<Dialog {visible} title={m('rbac.delete_role.title')} size="sm" onclose={handleClose}>
+<ConfirmDialog
+  {visible}
+  title={m('rbac.delete_role.title')}
+  actionLabel={m('rbac.delete_role.action')}
+  actionLoadingLabel={m('rbac.delete_role.deleting')}
+  actionIcon="iconify icon-[uil--trash-alt]"
+  loading={deleting}
+  onconfirm={onConfirm}
+  onclose={handleClose}
+>
   <p class="mb-4 text-muted">
     {m('rbac.delete_role.prompt', { role: roleDisplayName })}
   </p>
@@ -32,15 +40,4 @@
     <li>{m('rbac.delete_role.delete_grants')}</li>
   </ul>
   <p class="text-sm font-medium text-error">{m('rbac.delete_role.irreversible')}</p>
-
-  {#snippet footer()}
-    <div class="flex justify-end gap-3">
-      <Button variant="secondary" onclick={handleClose} disabled={deleting}
-        >{m('common.cancel')}</Button
-      >
-      <Button defaultAction variant="danger" onclick={onConfirm} disabled={deleting}>
-        {deleting ? m('rbac.delete_role.deleting') : m('rbac.delete_role.action')}
-      </Button>
-    </div>
-  {/snippet}
-</Dialog>
+</ConfirmDialog>

--- a/apps/frontend/src/lib/components/voice/NativeScreenShareDialog.svelte
+++ b/apps/frontend/src/lib/components/voice/NativeScreenShareDialog.svelte
@@ -9,7 +9,7 @@ URL when its source changes or leaves the DOM.
   import type { Attachment } from 'svelte/attachments';
   import { m } from '$lib/i18n/messages';
   import type { NativeScreenShareSource } from '$lib/desktop/nativeScreenShare';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { Dialog } from '$lib/ui';
   import EmptyState from '$lib/ui/EmptyState.svelte';
   import SegmentedControl from '$lib/ui/SegmentedControl.svelte';
   import SkeletonImg from '$lib/ui/SkeletonImg.svelte';
@@ -80,9 +80,7 @@ URL when its source changes or leaves the DOM.
 </script>
 
 {#snippet footer()}
-  <div class="flex justify-end gap-2">
-    <Button variant="secondary" onclick={close}>{m('common.cancel')}</Button>
-  </div>
+  <Button variant="secondary" onclick={close}>{m('common.cancel')}</Button>
 {/snippet}
 
 <Dialog bind:visible title={m('voice.share_screen')} size="lg" onclose={handleClose} {footer}>

--- a/apps/frontend/src/lib/ui/ConfirmDialog.stories.svelte
+++ b/apps/frontend/src/lib/ui/ConfirmDialog.stories.svelte
@@ -127,6 +127,7 @@
     bind:visible={loadingVisible}
     title="Leave Space"
     actionLabel="Leave Space"
+    actionLoadingLabel="Leaving Space…"
     actionIcon="iconify icon-[uil--sign-out-alt]"
     {loading}
     onconfirm={startLoading}

--- a/apps/frontend/src/lib/ui/ConfirmDialog.svelte
+++ b/apps/frontend/src/lib/ui/ConfirmDialog.svelte
@@ -2,8 +2,8 @@
 @component
 
 A small dialog that asks the user to confirm an action. Built on top of
-`FormDialog` so it shares the same chrome (footer divider, button layout,
-Enter-to-confirm) and tone-driven button color.
+`FormDialog` so it shares the standard chrome, action layout,
+Enter-to-confirm behavior, and tone-driven button color.
 
 Use the `tone` prop to communicate the weight of the action:
 
@@ -38,6 +38,7 @@ Use the `tone` prop to communicate the weight of the action:
     tone = 'danger',
     actionLabel = m('common.confirm'),
     actionIcon,
+    actionLoadingLabel,
     loading = false,
     onconfirm,
     onclose
@@ -50,6 +51,8 @@ Use the `tone` prop to communicate the weight of the action:
     actionLabel?: string;
     /** Iconify class for the confirm button. Defaults to a sensible icon per tone. */
     actionIcon?: string;
+    /** Optional localized label to show while the confirmation is running. */
+    actionLoadingLabel?: string;
     loading?: boolean;
     onconfirm: () => void;
     onclose: () => void;
@@ -71,7 +74,7 @@ Use the `tone` prop to communicate the weight of the action:
   submitLabel={actionLabel}
   submitTone={tone === 'info' ? 'action' : tone}
   submitIcon={resolvedIcon}
-  submitLoadingText={m('ui.dialog.submit_loading', { label: actionLabel })}
+  submitLoadingText={actionLoadingLabel ?? m('ui.dialog.submit_loading', { label: actionLabel })}
   {loading}
   onsubmit={() => onconfirm()}
   {onclose}

--- a/apps/frontend/src/lib/ui/ConfirmDialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ConfirmDialog.svelte.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { testSnippet } from '$lib/test-utils';
+import ConfirmDialog from './ConfirmDialog.svelte';
+
+describe('ConfirmDialog', () => {
+  it('uses the caller-provided loading label and locks both actions', async () => {
+    const { getByRole } = render(ConfirmDialog, {
+      props: {
+        visible: true,
+        title: 'Delete Role',
+        actionLabel: 'Delete Role',
+        actionLoadingLabel: 'Deleting Role…',
+        loading: true,
+        children: testSnippet('<p>This action cannot be undone.</p>'),
+        onconfirm: vi.fn(),
+        onclose: vi.fn()
+      }
+    });
+
+    const cancel = getByRole('button', { name: 'Cancel' });
+    const confirm = getByRole('button', { name: 'Deleting Role…' });
+    await expect.element(cancel).toBeDisabled();
+    await expect.element(confirm).toBeDisabled();
+  });
+});

--- a/apps/frontend/src/lib/ui/Dialog.stories.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.stories.svelte
@@ -118,13 +118,13 @@
 </Story>
 
 <Story
-  name="Narrow action wrapping"
+  name="Narrow action truncation"
   asChild
   parameters={{
     docs: {
       description: {
         story:
-          'Resize the canvas to a narrow viewport. The footer keeps every action visible and wraps the row from the inline start.'
+          'Resize the canvas to a narrow viewport. Actions stay in one row and long labels truncate before the row can wrap.'
       }
     }
   }}
@@ -137,11 +137,11 @@
     {#snippet footer()}
       <Button variant="secondary" onclick={() => (narrowDialogVisible = false)}>Cancel</Button>
       <Button variant="secondary" onclick={() => (narrowDialogVisible = false)}>
-        Post as New Message
+        Post as a Completely New Message
       </Button>
       <Button defaultAction onclick={() => (narrowDialogVisible = false)}>
         <span class="iconify icon-[uil--comment-alt-lines]"></span>
-        Continue in Thread
+        Continue in the Existing Thread
       </Button>
     {/snippet}
   </Dialog>

--- a/apps/frontend/src/lib/ui/Dialog.stories.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.stories.svelte
@@ -26,6 +26,9 @@
   let smallDialogVisible = $state(false);
   let largeDialogVisible = $state(false);
   let dialogWithFooterVisible = $state(false);
+  let referenceDialogVisible = $state(false);
+  let longDialogVisible = $state(false);
+  let narrowDialogVisible = $state(false);
 </script>
 
 <Story
@@ -46,6 +49,101 @@
     <p class="mt-2">
       Click outside the dialog to dismiss it. The dialog uses a blurred background overlay.
     </p>
+  </Dialog>
+</Story>
+
+<Story
+  name="Reference multi-action dialog"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'The standard framed tray, inset work plane, semantic actions, and action-specific icons match the canonical modal direction.'
+      }
+    }
+  }}
+>
+  <Button onclick={() => (referenceDialogVisible = true)}>Open sign-out dialog</Button>
+
+  <Dialog bind:visible={referenceDialogVisible} title="Sign Out" size="md">
+    <p class="text-muted">
+      Sign out of only the selected server, or disconnect every server from this client.
+    </p>
+
+    {#snippet footer()}
+      <Button variant="secondary" onclick={() => (referenceDialogVisible = false)}>Cancel</Button>
+      <Button defaultAction onclick={() => (referenceDialogVisible = false)}>
+        <span class="iconify icon-[uil--sign-out-alt]"></span>
+        Current Server
+      </Button>
+      <Button variant="danger" onclick={() => (referenceDialogVisible = false)}>
+        <span class="iconify icon-[uil--signout]"></span>
+        All Servers
+      </Button>
+    {/snippet}
+  </Dialog>
+</Story>
+
+<Story
+  name="Long scrolling content"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story: 'The title and actions remain visible while only the dialog body scrolls.'
+      }
+    }
+  }}
+>
+  <Button onclick={() => (longDialogVisible = true)}>Open long dialog</Button>
+
+  <Dialog bind:visible={longDialogVisible} title="Review Changes" size="md">
+    <div class="flex flex-col gap-4 text-muted">
+      {#each Array(14) as _, index (index)}
+        <p>
+          Change {index + 1}: Review this item before you apply the configuration to the server.
+        </p>
+      {/each}
+    </div>
+
+    {#snippet footer()}
+      <Button variant="secondary" onclick={() => (longDialogVisible = false)}>Cancel</Button>
+      <Button defaultAction onclick={() => (longDialogVisible = false)}>
+        <span class="iconify icon-[uil--check]"></span>
+        Apply Changes
+      </Button>
+    {/snippet}
+  </Dialog>
+</Story>
+
+<Story
+  name="Narrow action wrapping"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'Resize the canvas to a narrow viewport. The footer keeps every action visible and wraps the row from the inline start.'
+      }
+    }
+  }}
+>
+  <Button onclick={() => (narrowDialogVisible = true)}>Open narrow dialog</Button>
+
+  <Dialog bind:visible={narrowDialogVisible} title="Choose Destination" size="md">
+    <p class="text-muted">Choose where Chatto should post this message.</p>
+
+    {#snippet footer()}
+      <Button variant="secondary" onclick={() => (narrowDialogVisible = false)}>Cancel</Button>
+      <Button variant="secondary" onclick={() => (narrowDialogVisible = false)}>
+        Post as New Message
+      </Button>
+      <Button defaultAction onclick={() => (narrowDialogVisible = false)}>
+        <span class="iconify icon-[uil--comment-alt-lines]"></span>
+        Continue in Thread
+      </Button>
+    {/snippet}
   </Dialog>
 </Story>
 
@@ -124,18 +222,16 @@
     </p>
 
     {#snippet footer()}
-      <div class="flex justify-end gap-2">
-        <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
-          Cancel
-        </Button>
-        <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
-          Post as new message
-        </Button>
-        <Button defaultAction onclick={() => (dialogWithFooterVisible = false)}>
-          <span class="iconify icon-[uil--comment-alt-lines]"></span>
-          Continue in thread
-        </Button>
-      </div>
+      <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
+        Cancel
+      </Button>
+      <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
+        Post as new message
+      </Button>
+      <Button defaultAction onclick={() => (dialogWithFooterVisible = false)}>
+        <span class="iconify icon-[uil--comment-alt-lines]"></span>
+        Continue in thread
+      </Button>
     {/snippet}
   </Dialog>
 </Story>

--- a/apps/frontend/src/lib/ui/Dialog.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.svelte
@@ -5,7 +5,7 @@ The standard task-dialog shell. It owns the framed tray, inset work plane,
 fixed header and footer, scrollable body, focus behavior, and dismissal.
 
 Pass footer actions as direct children of the `footer` snippet. The dialog
-owns their responsive, end-aligned layout.
+owns their single-line, end-aligned layout and truncates labels when needed.
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
@@ -214,7 +214,7 @@ owns their responsive, end-aligned layout.
         </div>
 
         {#if footer}
-          <footer class="mt-6 flex shrink-0 flex-wrap justify-end gap-2">
+          <footer class="dialog-actions">
             {@render footer()}
           </footer>
         {/if}

--- a/apps/frontend/src/lib/ui/Dialog.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.svelte
@@ -1,3 +1,12 @@
+<!--
+@component
+
+The standard task-dialog shell. It owns the framed tray, inset work plane,
+fixed header and footer, scrollable body, focus behavior, and dismissal.
+
+Pass footer actions as direct children of the `footer` snippet. The dialog
+owns their responsive, end-aligned layout.
+-->
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import { m } from '$lib/i18n/messages';
@@ -174,38 +183,42 @@
   -->
   {#if visible || closing}
     <div
-      class="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden rounded-lg border border-text/10 bg-surface p-5 shadow-xl sm:max-h-[78vh]"
+      class="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden rounded-lg border border-text/10 bg-surface p-2 shadow-xl sm:max-h-[78vh]"
     >
-      <!--
+      <div class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md bg-background p-3">
+        <!--
           Header row holds the title (if any) and the close button, so
-          they share a baseline and the title isn't artificially indented
-          relative to the body content below.
+          they share a baseline and the title is not indented relative to
+          the body content.
         -->
-      <header class={['flex shrink-0 items-center justify-between gap-3', title ? 'mb-4' : 'mb-2']}>
-        {#if title}
-          <h2 id={titleId} class="text-lg font-semibold text-balance text-text-top">{title}</h2>
-        {:else}
-          <span></span>
-        {/if}
-        <button
-          type="button"
-          onclick={close}
-          class="-m-2 icon-action shrink-0"
-          aria-label={m('ui.close')}
+        <header
+          class={['flex shrink-0 items-center justify-between gap-3', title ? 'mb-4' : 'mb-2']}
         >
-          <span class="iconify icon-[uil--times] text-xl"></span>
-        </button>
-      </header>
+          {#if title}
+            <h2 id={titleId} class="text-xl font-semibold text-balance text-text-top">{title}</h2>
+          {:else}
+            <span></span>
+          {/if}
+          <button
+            type="button"
+            onclick={close}
+            class="-m-2 icon-action shrink-0"
+            aria-label={m('ui.close')}
+          >
+            <span class="iconify icon-[uil--times] text-xl"></span>
+          </button>
+        </header>
 
-      <div class="min-h-0 overflow-y-auto text-text">
-        {@render children()}
+        <div class="min-h-0 overflow-y-auto text-text">
+          {@render children()}
+        </div>
+
+        {#if footer}
+          <footer class="mt-6 flex shrink-0 flex-wrap justify-end gap-2">
+            {@render footer()}
+          </footer>
+        {/if}
       </div>
-
-      {#if footer}
-        <footer class="mt-6 shrink-0">
-          {@render footer()}
-        </footer>
-      {/if}
     </div>
   {/if}
 </dialog>

--- a/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
@@ -157,7 +157,7 @@ describe('Dialog', () => {
   });
 
   describe('footer', () => {
-    it('owns the responsive end-aligned action layout', async () => {
+    it('owns the single-line end-aligned action layout', async () => {
       const { container } = renderDialog({
         visible: true,
         children: testSnippet('<span>Content</span>'),
@@ -165,11 +165,10 @@ describe('Dialog', () => {
       });
 
       const footer = q(container, `${WELL} > footer`);
-      await expect.element(footer).toHaveClass('flex');
-      await expect.element(footer).toHaveClass('flex-wrap');
-      await expect.element(footer).toHaveClass('justify-end');
-      await expect.element(footer).toHaveClass('gap-2');
+      await expect.element(footer).toHaveClass('dialog-actions');
+      await expect.element(footer).not.toHaveClass('flex-wrap');
       expect(footer?.querySelectorAll('button')).toHaveLength(1);
+      expect(getComputedStyle(footer!).flexWrap).toBe('nowrap');
     });
   });
 

--- a/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
@@ -9,11 +9,13 @@ function renderDialog(props: {
   title?: string;
   size?: 'sm' | 'md' | 'lg';
   children: ReturnType<typeof testSnippet>;
+  footer?: ReturnType<typeof testSnippet>;
 }) {
   return render(Dialog, { props });
 }
 
 const FRAME = 'dialog > div';
+const WELL = `${FRAME} > div`;
 
 describe('Dialog', () => {
   describe('dialog element', () => {
@@ -99,7 +101,7 @@ describe('Dialog', () => {
         children: testSnippet('<span>Test Content</span>')
       });
 
-      await expect.element(q(container, `${FRAME} > div.text-text`)).toBeInTheDocument();
+      await expect.element(q(container, `${WELL} > div.text-text`)).toBeInTheDocument();
     });
   });
 
@@ -118,23 +120,26 @@ describe('Dialog', () => {
     });
   });
 
-  describe('flat surface styling', () => {
-    it('does not nest a second background well', async () => {
+  describe('inset work-plane styling', () => {
+    it('nests one background work plane inside the surface tray', async () => {
       const { container } = renderDialog({
         visible: true,
         children: testSnippet('<span>Content</span>')
       });
 
-      expect(q(container, `${FRAME} > .bg-background`)).toBeNull();
+      const well = q(container, WELL);
+      await expect.element(well).toHaveClass('bg-background');
+      await expect.element(well).toHaveClass('rounded-md');
     });
 
-    it('keeps content padding on the surface frame', async () => {
+    it('uses separate tray and work-plane padding', async () => {
       const { container } = renderDialog({
         visible: true,
         children: testSnippet('<span>Content</span>')
       });
 
-      await expect.element(q(container, FRAME)).toHaveClass('p-5');
+      await expect.element(q(container, FRAME)).toHaveClass('p-2');
+      await expect.element(q(container, WELL)).toHaveClass('p-3');
     });
   });
 
@@ -146,7 +151,25 @@ describe('Dialog', () => {
       });
 
       await expect.element(q(container, FRAME)).toHaveClass('overflow-hidden');
-      await expect.element(q(container, `${FRAME} > div.text-text`)).toHaveClass('overflow-y-auto');
+      await expect.element(q(container, WELL)).toHaveClass('overflow-hidden');
+      await expect.element(q(container, `${WELL} > div.text-text`)).toHaveClass('overflow-y-auto');
+    });
+  });
+
+  describe('footer', () => {
+    it('owns the responsive end-aligned action layout', async () => {
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span>Content</span>'),
+        footer: testSnippet('<button>Continue</button>')
+      });
+
+      const footer = q(container, `${WELL} > footer`);
+      await expect.element(footer).toHaveClass('flex');
+      await expect.element(footer).toHaveClass('flex-wrap');
+      await expect.element(footer).toHaveClass('justify-end');
+      await expect.element(footer).toHaveClass('gap-2');
+      expect(footer?.querySelectorAll('button')).toHaveLength(1);
     });
   });
 

--- a/apps/frontend/src/lib/ui/FormDialog.stories.svelte
+++ b/apps/frontend/src/lib/ui/FormDialog.stories.svelte
@@ -39,6 +39,12 @@
   let inviteWelcome = $state('');
   let inviteSendEmail = $state(true);
 
+  let validationErrorVisible = $state(false);
+  let validationEmail = $state('not-an-email');
+
+  let narrowVisible = $state(false);
+  let narrowName = $state('');
+
   function fakeSubmit() {
     loading = true;
     setTimeout(() => {
@@ -77,6 +83,66 @@
 
     <TextInput id="story-room-name" label="Room Name" bind:value={basicName} />
     <TextArea id="story-room-desc" label="Description (optional)" bind:value={basicDesc} rows={3} />
+  </FormDialog>
+</Story>
+
+<Story
+  name="Validation error"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story: 'Submission errors stay with the form fields and above the fixed action footer.'
+      }
+    }
+  }}
+>
+  <Button onclick={() => (validationErrorVisible = true)}>Open invalid form</Button>
+
+  <FormDialog
+    bind:visible={validationErrorVisible}
+    title="Invite Member"
+    submitLabel="Send Invite"
+    error="Enter a complete email address."
+    onsubmit={() => undefined}
+    onclose={() => (validationErrorVisible = false)}
+  >
+    <TextInput
+      id="story-validation-email"
+      label="Email address"
+      type="email"
+      bind:value={validationEmail}
+    />
+  </FormDialog>
+</Story>
+
+<Story
+  name="Narrow layout"
+  asChild
+  parameters={{
+    docs: {
+      description: {
+        story:
+          'Resize the canvas to 375 pixels. The dialog keeps its viewport gutter and visible footer actions.'
+      }
+    }
+  }}
+>
+  <Button onclick={() => (narrowVisible = true)}>Open narrow form</Button>
+
+  <FormDialog
+    bind:visible={narrowVisible}
+    title="Create a New Conversation Room"
+    submitLabel="Create Conversation Room"
+    disabled={!narrowName.trim()}
+    onsubmit={() => (narrowVisible = false)}
+    onclose={() => (narrowVisible = false)}
+  >
+    {#snippet description()}
+      Give the room a clear name that members can recognize on a narrow screen.
+    {/snippet}
+
+    <TextInput id="story-narrow-name" label="Room name" bind:value={narrowName} />
   </FormDialog>
 </Story>
 

--- a/apps/frontend/src/lib/ui/FormDialog.svelte
+++ b/apps/frontend/src/lib/ui/FormDialog.svelte
@@ -44,7 +44,7 @@ The submit button's color follows `submitTone` (`action` by default; use
     submitIcon = 'iconify icon-[uil--check]',
     submitLoadingText,
     cancelLabel = m('common.cancel'),
-    cancelIcon = 'iconify icon-[uil--times]',
+    cancelIcon = '',
     loading = false,
     disabled = false,
     error,
@@ -69,7 +69,7 @@ The submit button's color follows `submitTone` (`action` by default; use
     /** Optional override for the submit button label while `loading`. */
     submitLoadingText?: string;
     cancelLabel?: string;
-    /** Iconify class for the cancel button. Pass an empty string to suppress. */
+    /** Optional Iconify class for the cancel button. The quiet default has no icon. */
     cancelIcon?: string;
     loading?: boolean;
     /** Disables the submit button (e.g., when validation fails). */
@@ -115,25 +115,20 @@ The submit button's color follows `submitTone` (`action` by default; use
   </form>
 
   {#snippet footer()}
-    <div class="-mx-3">
-      <div class="h-px bg-text/10" aria-hidden="true"></div>
-      <div class="flex flex-wrap justify-end gap-2 px-3 pt-3">
-        <Button type="button" variant="secondary" onclick={onclose} disabled={loading}>
-          {#if cancelIcon}<span class={cancelIcon}></span>{/if}
-          {cancelLabel}
-        </Button>
-        <Button
-          type="submit"
-          form={formId}
-          variant={submitVariant}
-          {loading}
-          loadingText={submitLoadingText}
-          {disabled}
-        >
-          {#if submitIcon}<span class={submitIcon}></span>{/if}
-          {submitLabel}
-        </Button>
-      </div>
-    </div>
+    <Button type="button" variant="secondary" onclick={onclose} disabled={loading}>
+      {#if cancelIcon}<span class={cancelIcon}></span>{/if}
+      {cancelLabel}
+    </Button>
+    <Button
+      type="submit"
+      form={formId}
+      variant={submitVariant}
+      {loading}
+      loadingText={submitLoadingText}
+      {disabled}
+    >
+      {#if submitIcon}<span class={submitIcon}></span>{/if}
+      {submitLabel}
+    </Button>
   {/snippet}
 </Dialog>

--- a/apps/frontend/src/lib/ui/FormDialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/FormDialog.svelte.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { q, testSnippet } from '$lib/test-utils';
+import FormDialog from './FormDialog.svelte';
+
+describe('FormDialog', () => {
+  it('renders standard footer actions without a divider or cancel icon', async () => {
+    const { container } = render(FormDialog, {
+      props: {
+        visible: true,
+        title: 'Create Room',
+        submitLabel: 'Create Room',
+        children: testSnippet('<input name="name" />'),
+        onsubmit: vi.fn(),
+        onclose: vi.fn()
+      }
+    });
+
+    const footer = q(container, 'footer');
+    await expect.element(footer).toBeInTheDocument();
+    expect(footer?.querySelector('[aria-hidden="true"]')).toBeNull();
+
+    const cancel = Array.from(footer?.querySelectorAll('button') ?? []).find(
+      (button) => button.textContent?.trim() === 'Cancel'
+    );
+    expect(cancel).toBeDefined();
+    expect(cancel?.querySelector('.iconify')).toBeNull();
+  });
+
+  it('submits with Enter through the owned form', () => {
+    const onsubmit = vi.fn();
+    const { container } = render(FormDialog, {
+      props: {
+        visible: true,
+        title: 'Create Room',
+        submitLabel: 'Create Room',
+        children: testSnippet('<input name="name" value="General" />'),
+        onsubmit,
+        onclose: vi.fn()
+      }
+    });
+
+    q(container, 'form')?.dispatchEvent(new SubmitEvent('submit', { bubbles: true, cancelable: true }));
+
+    expect(onsubmit).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/frontend/src/lib/ui/form/Button.svelte
+++ b/apps/frontend/src/lib/ui/form/Button.svelte
@@ -105,7 +105,9 @@
       disabled || loading ? 'pointer-events-none opacity-60' : ''
     ]}
   >
-    <span class="button-content">{@render content()}</span>
+    <span class="button-content inline-flex items-center gap-2 [&>.iconify]:shrink-0">
+      {@render content()}
+    </span>
   </a>
   <!-- eslint-enable svelte/no-navigation-without-resolve -->
 {:else}
@@ -125,6 +127,8 @@
       fullWidth ? 'w-full' : ''
     ]}
   >
-    <span class="button-content">{@render content()}</span>
+    <span class="button-content inline-flex items-center gap-2 [&>.iconify]:shrink-0">
+      {@render content()}
+    </span>
   </button>
 {/if}

--- a/apps/frontend/src/lib/ui/form/Button.svelte
+++ b/apps/frontend/src/lib/ui/form/Button.svelte
@@ -105,7 +105,7 @@
       disabled || loading ? 'pointer-events-none opacity-60' : ''
     ]}
   >
-    {@render content()}
+    <span class="button-content">{@render content()}</span>
   </a>
   <!-- eslint-enable svelte/no-navigation-without-resolve -->
 {:else}
@@ -125,6 +125,6 @@
       fullWidth ? 'w-full' : ''
     ]}
   >
-    {@render content()}
+    <span class="button-content">{@render content()}</span>
   </button>
 {/if}

--- a/apps/frontend/src/lib/ui/form/Button.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/form/Button.svelte.spec.ts
@@ -4,7 +4,7 @@ import { testSnippet } from '$lib/test-utils';
 import Button from './Button.svelte';
 
 describe('Button', () => {
-  it('keeps translated labels on one line without shrinking', async () => {
+  it('keeps translated content in one centered flex row', async () => {
     const { container } = render(Button, {
       props: {
         children: testSnippet('<span>Schlüssel widerrufen</span>')
@@ -17,5 +17,9 @@ describe('Button', () => {
     const content = button!.querySelector<HTMLElement>('.button-content');
     await expect.element(content).toHaveTextContent('Schlüssel widerrufen');
     await expect.element(content).toHaveClass('button-content');
+    await expect.element(content).toHaveClass('inline-flex');
+    await expect.element(content).toHaveClass('items-center');
+    await expect.element(content).toHaveClass('gap-2');
+    await expect.element(content).toHaveClass('[&>.iconify]:shrink-0');
   });
 });

--- a/apps/frontend/src/lib/ui/form/Button.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/form/Button.svelte.spec.ts
@@ -14,5 +14,8 @@ describe('Button', () => {
     const button = container.querySelector('button');
     await expect.element(button).toHaveClass('whitespace-nowrap');
     await expect.element(button).toHaveClass('shrink-0');
+    const content = button!.querySelector<HTMLElement>('.button-content');
+    await expect.element(content).toHaveTextContent('Schlüssel widerrufen');
+    await expect.element(content).toHaveClass('button-content');
   });
 });

--- a/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/ModalContainer.svelte.spec.ts
@@ -206,6 +206,14 @@ vi.mock('$lib/ui/Dialog.svelte', async () => {
   return { default: DialogMock };
 });
 
+vi.mock('$lib/ui', async () => {
+  const [{ default: ConfirmDialog }, { default: Dialog }] = await Promise.all([
+    import('./ModalContainerConfirmDialogMock.svelte'),
+    import('./ModalContainerDialogMock.svelte')
+  ]);
+  return { ConfirmDialog, Dialog };
+});
+
 vi.mock('$lib/ui/form', async () => {
   const { default: ButtonMock } = await import('./ModalContainerButtonMock.svelte');
   return { Button: ButtonMock };

--- a/apps/frontend/src/routes/chat/SignOutDialog.svelte
+++ b/apps/frontend/src/routes/chat/SignOutDialog.svelte
@@ -8,7 +8,7 @@
   import { clientAccount, type ClientAccountNavigation } from '$lib/state/clientAccount';
   import { hardRedirectAfterSignOut } from '$lib/auth/signOut';
   import { m } from '$lib/i18n/messages';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { Dialog } from '$lib/ui';
   import { Button } from '$lib/ui/form';
   import { toast } from '$lib/ui/toast';
 
@@ -82,28 +82,26 @@
 
 <Dialog visible title={m('chat.sign_out.title')} size="md" {onclose}>
   {#snippet footer()}
-    <div class="flex flex-wrap justify-end gap-2">
-      <Button variant="secondary" onclick={onclose}>{m('common.cancel')}</Button>
-      <Button
-        defaultAction
-        variant="action"
-        loading={signingOutCurrent}
-        disabled={signingOutAll || !canSignOutCurrentServer}
-        onclick={handleSignOutCurrentServer}
-      >
-        <span class="iconify icon-[uil--sign-out-alt]"></span>
-        {m('chat.sign_out.current_server')}
-      </Button>
-      <Button
-        variant="danger"
-        loading={signingOutAll}
-        disabled={signingOutCurrent && canSignOutCurrentServer}
-        onclick={handleSignOutAllServers}
-      >
-        <span class="iconify icon-[uil--signout]"></span>
-        {m('chat.sign_out.all_servers')}
-      </Button>
-    </div>
+    <Button variant="secondary" onclick={onclose}>{m('common.cancel')}</Button>
+    <Button
+      defaultAction
+      variant="action"
+      loading={signingOutCurrent}
+      disabled={signingOutAll || !canSignOutCurrentServer}
+      onclick={handleSignOutCurrentServer}
+    >
+      <span class="iconify icon-[uil--sign-out-alt]"></span>
+      {m('chat.sign_out.current_server')}
+    </Button>
+    <Button
+      variant="danger"
+      loading={signingOutAll}
+      disabled={signingOutCurrent && canSignOutCurrentServer}
+      onclick={handleSignOutAllServers}
+    >
+      <span class="iconify icon-[uil--signout]"></span>
+      {m('chat.sign_out.all_servers')}
+    </Button>
   {/snippet}
 
   <p class="text-muted">

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageMetaBar.svelte
@@ -17,7 +17,7 @@ local to the footer.
   import FloatingPopover from '$lib/ui/FloatingPopover.svelte';
   import { getEmojiByName, getEmojiDisplayName } from '$lib/emoji';
   import { m } from '$lib/i18n/messages';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
   import type { MessageActionModel } from './messageActionModel';
 
   // Extract the MessagePostedEvent type from the union

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageUserOverlays.svelte
@@ -4,7 +4,7 @@
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import type { RoomMember } from '$lib/state/room';
   import ContextMenu from '$lib/ui/ContextMenu.svelte';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { Dialog } from '$lib/ui';
   import { toast } from '$lib/ui/toast';
   import { m } from '$lib/i18n/messages';
   import type { MessageUserInteractionState } from './messageUserInteractions.svelte';

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/AdminRoomLayoutEditor.svelte
@@ -11,9 +11,7 @@
     GroupReorderResult,
     RoomMoveFlushResult
   } from '$lib/state/server/adminRoomLayout.svelte';
-  import { EmptyState, Hint, Pill, ToggleChip } from '$lib/ui';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
-  import FormDialog from '$lib/ui/FormDialog.svelte';
+  import { ConfirmDialog, EmptyState, FormDialog, Hint, Pill, ToggleChip } from '$lib/ui';
   import { Button, TextInput } from '$lib/ui/form';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import { toast } from '$lib/ui/toast';

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomMembersPanel.svelte
@@ -7,7 +7,7 @@
   import DataTable from '$lib/ui/DataTable.svelte';
   import Panel from '$lib/ui/Panel.svelte';
   import UserAvatar from '$lib/components/UserAvatar.svelte';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
   import Hint from '$lib/ui/Hint.svelte';
   import { Button, Combobox } from '$lib/ui/form';
   import { useProjectionEvent } from '$lib/hooks';

--- a/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
@@ -3,7 +3,7 @@
   import type { AccountAPI } from '$lib/api-client/account';
   import Panel from '$lib/ui/Panel.svelte';
   import { m } from '$lib/i18n/messages';
-  import { Dialog, Hint } from '$lib/ui';
+  import { ConfirmDialog, Hint } from '$lib/ui';
   import { Button, Form, TextArea, TextInput } from '$lib/ui/form';
   import {
     formatCooldownRemaining,
@@ -208,24 +208,17 @@
   </Form>
 </Panel>
 
-<Dialog
+<ConfirmDialog
   bind:visible={showLoginConfirm}
   title={m('settings.profile.username.confirm_title')}
-  size="sm"
+  tone="info"
+  actionLabel={m('settings.profile.username.confirm_button')}
+  actionIcon="iconify icon-[uil--check]"
+  onconfirm={confirmLoginChange}
+  onclose={() => (showLoginConfirm = false)}
 >
-  <p class="mb-2">
+  <p>
     {m('settings.profile.username.confirm_prompt', { login: pendingLogin ?? '' })}
   </p>
-  <p class="mb-4 text-muted">{m('settings.profile.username.confirm_cooldown')}</p>
-
-  <div class="flex items-center gap-3">
-    <Button defaultAction onclick={confirmLoginChange}>
-      <span class="iconify icon-[uil--check]"></span>
-      {m('settings.profile.username.confirm_button')}
-    </Button>
-    <Button variant="ghost" onclick={() => (showLoginConfirm = false)}>
-      <span class="iconify icon-[uil--times]"></span>
-      {m('common.cancel')}
-    </Button>
-  </div>
-</Dialog>
+  <p class="mt-3">{m('settings.profile.username.confirm_cooldown')}</p>
+</ConfirmDialog>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/DeleteAccountSection.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/DeleteAccountSection.svelte
@@ -6,8 +6,8 @@
   import Panel from '$lib/ui/Panel.svelte';
   import { m } from '$lib/i18n/messages';
   import { serverRegistry } from '$lib/state/server/registry.svelte';
-  import { Dialog, Hint } from '$lib/ui';
-  import { Button, FormError, TextInput } from '$lib/ui/form';
+  import { FormDialog, Hint } from '$lib/ui';
+  import { Button, TextInput } from '$lib/ui/form';
 
   let {
     canDeleteAccount,
@@ -86,52 +86,40 @@
   </Panel>
 {/if}
 
-<Dialog
+<FormDialog
   visible={showDeleteModal}
   title={m('settings.account.delete_modal.title')}
   size="sm"
+  submitLabel={m('settings.account.delete_button')}
+  submitTone="danger"
+  submitIcon="iconify icon-[uil--trash-alt]"
+  submitLoadingText={m('settings.account.delete_modal.deleting')}
+  loading={isDeleting}
+  disabled={!canDelete}
+  {error}
+  onsubmit={handleDeleteAccount}
   onclose={closeDeleteModal}
 >
-  <div class="flex flex-col gap-4">
-    <Hint tone="danger">
-      <strong>{m('settings.account.delete_modal.warning_label')}</strong>
-      {m('settings.account.delete_modal.warning_text')}
-    </Hint>
+  <Hint tone="danger">
+    <strong>{m('settings.account.delete_modal.warning_label')}</strong>
+    {m('settings.account.delete_modal.warning_text')}
+  </Hint>
 
-    <p class="text-sm text-muted">{m('settings.account.delete_modal.intro')}</p>
-    <ul class="list-inside list-disc text-sm text-muted">
+  <div class="text-sm text-muted">
+    <p>{m('settings.account.delete_modal.intro')}</p>
+    <ul class="mt-3 list-inside list-disc">
       <li>{m('settings.account.delete_modal.remove_from_rooms')}</li>
       <li>{m('settings.account.delete_modal.delete_messages')}</li>
       <li>{m('settings.account.delete_modal.delete_profile')}</li>
     </ul>
-
-    <TextInput
-      id="delete-confirm"
-      label={m('settings.account.delete_modal.confirm_label')}
-      bind:value={confirmText}
-      placeholder={m('settings.account.delete_modal.confirm_placeholder')}
-      disabled={isDeleting}
-      autocomplete="off"
-    />
-
-    {#if error}
-      <FormError {error} />
-    {/if}
-
-    <div class="flex flex-wrap justify-end gap-2">
-      <Button variant="secondary" onclick={closeDeleteModal} disabled={isDeleting}>
-        {m('common.cancel')}
-      </Button>
-      <Button
-        defaultAction
-        variant="danger"
-        onclick={handleDeleteAccount}
-        disabled={!canDelete || isDeleting}
-        loading={isDeleting}
-        loadingText={m('settings.account.delete_modal.deleting')}
-      >
-        {m('settings.account.delete_button')}
-      </Button>
-    </div>
   </div>
-</Dialog>
+
+  <TextInput
+    id="delete-confirm"
+    label={m('settings.account.delete_modal.confirm_label')}
+    bind:value={confirmText}
+    placeholder={m('settings.account.delete_modal.confirm_placeholder')}
+    disabled={isDeleting}
+    autocomplete="off"
+  />
+</FormDialog>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/account/ExternalIdentitySettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/account/ExternalIdentitySettings.svelte
@@ -23,8 +23,8 @@
   import { serverRegistry } from '$lib/state/server/registry.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
-  import { ConfirmDialog, Dialog, Hint } from '$lib/ui';
-  import { Button, FormError, TextInput } from '$lib/ui/form';
+  import { ConfirmDialog, Dialog, FormDialog, Hint } from '$lib/ui';
+  import { Button, TextInput } from '$lib/ui/form';
 
   let {
     currentUser,
@@ -468,49 +468,36 @@
 {/if}
 
 {#if disconnectFreshAuthTarget}
-  <Dialog
+  {@const freshAuthTarget = disconnectFreshAuthTarget}
+  <FormDialog
     visible
     title={m('settings.account.sso.disconnect_fresh_auth_modal.title')}
     size="sm"
+    submitLabel={m('settings.account.sso.disconnect_fresh_auth_modal.action')}
+    submitIcon="iconify icon-[uil--link-broken]"
+    loading={disconnectingSubjectHash === freshAuthTarget.subjectHash}
+    disabled={!disconnectCurrentPassword || disconnectingSubjectHash !== ''}
+    error={disconnectFreshAuthError}
+    onsubmit={confirmDisconnectFreshAuth}
     onclose={closeDisconnectFreshAuthDialog}
   >
-    <form class="flex flex-col gap-4" onsubmit={confirmDisconnectFreshAuth}>
-      <p class="text-sm text-muted">
+    {#snippet description()}
+      <p>
         {m('settings.account.sso.disconnect_fresh_auth_modal.body', {
-          provider: disconnectFreshAuthTarget.providerLabel
+          provider: freshAuthTarget.providerLabel
         })}
       </p>
-      <TextInput
-        id="sso-disconnect-current-password"
-        label={m('settings.account.password.current_label')}
-        type="password"
-        bind:value={disconnectCurrentPassword}
-        disabled={disconnectingSubjectHash !== ''}
-        autocomplete="current-password"
-      />
-      {#if disconnectFreshAuthError}
-        <FormError error={disconnectFreshAuthError} />
-      {/if}
-      <div class="flex flex-wrap justify-end gap-2">
-        <Button
-          type="button"
-          variant="secondary"
-          onclick={closeDisconnectFreshAuthDialog}
-          disabled={disconnectingSubjectHash !== ''}
-        >
-          {m('common.cancel')}
-        </Button>
-        <Button
-          type="submit"
-          loading={disconnectingSubjectHash === disconnectFreshAuthTarget.subjectHash}
-          disabled={!disconnectCurrentPassword || disconnectingSubjectHash !== ''}
-        >
-          <span class="iconify icon-[uil--link-broken]"></span>
-          {m('settings.account.sso.disconnect_fresh_auth_modal.action')}
-        </Button>
-      </div>
-    </form>
-  </Dialog>
+    {/snippet}
+
+    <TextInput
+      id="sso-disconnect-current-password"
+      label={m('settings.account.password.current_label')}
+      type="password"
+      bind:value={disconnectCurrentPassword}
+      disabled={disconnectingSubjectHash !== ''}
+      autocomplete="current-password"
+    />
+  </FormDialog>
 {/if}
 
 <Dialog
@@ -519,62 +506,48 @@
   size="sm"
   onclose={closeDisconnectBlockedModal}
 >
-  <div class="flex flex-col gap-4">
-    <Hint tone="warning">
-      {m('settings.account.sso.disconnect_blocked_modal.body', {
-        provider: blockedDisconnectProviderLabel
-      })}
-    </Hint>
-    <div class="flex justify-end">
-      <Button defaultAction variant="secondary" onclick={closeDisconnectBlockedModal}>
-        {m('ui.close')}
-      </Button>
-    </div>
-  </div>
+  <Hint tone="warning">
+    {m('settings.account.sso.disconnect_blocked_modal.body', {
+      provider: blockedDisconnectProviderLabel
+    })}
+  </Hint>
+
+  {#snippet footer()}
+    <Button defaultAction variant="secondary" onclick={closeDisconnectBlockedModal}>
+      {m('ui.close')}
+    </Button>
+  {/snippet}
 </Dialog>
 
 {#if linkFreshAuthProvider}
-  <Dialog
+  {@const freshAuthProvider = linkFreshAuthProvider}
+  <FormDialog
     visible
     title={m('settings.account.sso.fresh_auth_modal.title')}
     size="sm"
+    submitLabel={m('settings.account.sso.fresh_auth_modal.action')}
+    submitIcon="iconify icon-[uil--link]"
+    loading={linkingProviderId === freshAuthProvider.id}
+    disabled={!linkCurrentPassword || linkingProviderId !== ''}
+    error={linkFreshAuthError}
+    onsubmit={confirmLinkFreshAuth}
     onclose={closeLinkFreshAuthDialog}
   >
-    <form class="flex flex-col gap-4" onsubmit={confirmLinkFreshAuth}>
-      <p class="text-sm text-muted">
+    {#snippet description()}
+      <p>
         {m('settings.account.sso.fresh_auth_modal.body', {
-          provider: linkFreshAuthProvider.label
+          provider: freshAuthProvider.label
         })}
       </p>
-      <TextInput
-        id="sso-link-current-password"
-        label={m('settings.account.password.current_label')}
-        type="password"
-        bind:value={linkCurrentPassword}
-        disabled={linkingProviderId !== ''}
-        autocomplete="current-password"
-      />
-      {#if linkFreshAuthError}
-        <FormError error={linkFreshAuthError} />
-      {/if}
-      <div class="flex flex-wrap justify-end gap-2">
-        <Button
-          type="button"
-          variant="secondary"
-          onclick={closeLinkFreshAuthDialog}
-          disabled={linkingProviderId !== ''}
-        >
-          {m('common.cancel')}
-        </Button>
-        <Button
-          type="submit"
-          loading={linkingProviderId === linkFreshAuthProvider.id}
-          disabled={!linkCurrentPassword || linkingProviderId !== ''}
-        >
-          <span class="iconify icon-[uil--link]"></span>
-          {m('settings.account.sso.fresh_auth_modal.action')}
-        </Button>
-      </div>
-    </form>
-  </Dialog>
+    {/snippet}
+
+    <TextInput
+      id="sso-link-current-password"
+      label={m('settings.account.password.current_label')}
+      type="password"
+      bind:value={linkCurrentPassword}
+      disabled={linkingProviderId !== ''}
+      autocomplete="current-password"
+    />
+  </FormDialog>
 {/if}

--- a/apps/frontend/src/routes/chat/modals/AboutChattoModal.svelte
+++ b/apps/frontend/src/routes/chat/modals/AboutChattoModal.svelte
@@ -12,7 +12,7 @@
 <script lang="ts">
   import { version } from '$app/environment';
   import { m } from '$lib/i18n/messages';
-  import Dialog from '$lib/ui/Dialog.svelte';
+  import { Dialog } from '$lib/ui';
 
   let {
     onclose

--- a/apps/frontend/src/routes/chat/modals/DeleteMessageContentModal.svelte
+++ b/apps/frontend/src/routes/chat/modals/DeleteMessageContentModal.svelte
@@ -5,7 +5,7 @@
   import { notifyRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
   import { toast } from '$lib/ui/toast';
   import { m } from '$lib/i18n/messages';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
 
   let {
     modal,

--- a/apps/frontend/src/routes/chat/modals/LeaveRoomModal.svelte
+++ b/apps/frontend/src/routes/chat/modals/LeaveRoomModal.svelte
@@ -8,7 +8,7 @@
   import { clearLastRoom } from '$lib/storage/lastRoom';
   import { toast } from '$lib/ui/toast';
   import { m } from '$lib/i18n/messages';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
 
   let {
     modal,

--- a/apps/frontend/src/routes/chat/modals/RemoveServerModal.svelte
+++ b/apps/frontend/src/routes/chat/modals/RemoveServerModal.svelte
@@ -8,7 +8,7 @@
   import { clearLastRoom } from '$lib/storage/lastRoom';
   import { m } from '$lib/i18n/messages';
   import { unsubscribeBeforeLeaving as unsubscribePushBeforeLeaving } from '$lib/notifications/pushNotifications';
-  import ConfirmDialog from '$lib/ui/ConfirmDialog.svelte';
+  import { ConfirmDialog } from '$lib/ui';
   import { toast } from '$lib/ui/toast';
 
   let {


### PR DESCRIPTION
## Why

Standard task dialogs used several local shells and footer recipes. This caused visual drift, inconsistent form and confirmation behavior, and action buttons that could wrap into a second row in narrow or translated layouts. This change makes the reference framed modal the enforced default.

## What changed

- Make `Dialog` own the framed `surface` tray, inset `background` work plane, fixed header and footer, scrollable body, viewport-safe sizes, and single-line action row.
- Let action buttons shrink inside dialog footers. Keep the first Cancel action stable and truncate longer labels safely when space is limited.
- Put button icons and labels in a centered flex row, preserve a stable gap, and prevent icons from collapsing when a dialog is narrow.
- Align `FormDialog` and `ConfirmDialog` with the shared shell, including quiet Cancel actions, semantic action tones and icons, and localized loading labels.
- Migrate remaining standard forms and confirmations. Remove local footer layout wrappers from custom task dialogs.
- Add reference, tone, loading, validation, destructive, long-content, scrolling, and narrow-width Storybook states.
- Document modal selection and anatomy. Reject unapproved raw dialogs, implementation-file imports, and forms nested directly in `Dialog` through the design-system checker.

Specialized media viewers, fullscreen video, the quick switcher, popovers, and bottom sheets remain intentional exceptions.

## Test plan

- `mise lint-frontend` — passed with zero Svelte errors or warnings.
- `mise test-frontend` — passed: 150 server files / 1,363 tests; 190 client files / 2,010 tests; 82 Storybook files / 236 tests; 5 performance checks.
- `mise build-frontend` — passed, including bundle budgets and CSP verification.
- `mise test-e2e -- accessibility.test.ts --grep "server administration and its room dialog"` — passed, 1 test.
- `pnpm build-storybook` from `apps/frontend` — passed.
- `pnpm run check:design-system` from `apps/frontend` — passed.
- Svelte autofixer on every changed Svelte file — no remaining findings.
- Chrome DevTools inspection — passed in light and dark themes at desktop width and at 375 by 667 pixels. Focus, scrolling, disabled/loading states, long copy, and single-row label truncation were checked.
- Chrome DevTools icon-alignment regression check — passed at 1,000 by 700 and 375 by 667 pixels. Button, content, and icon centers matched exactly; icons retained their full width under pressure.

No verification remains outstanding.

## Compatibility and operations

- No backend, public API, protocol, persistence, routing, rollout, migration, security, or operational behavior changes.
- No FDR, ADR, glossary, architecture inventory, or self-hosting documentation update is required.
