### PR TITLE
fix(accounts): bypass own username cooldown

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -97,7 +97,7 @@ also includes `server.manage-neighbors` through the same explicit metadata.
 | `role.manage`             | Configure role definitions and role permission decisions, including room and room-group overrides.                                                                              |
 | `role.assign`             | Assign or revoke roles for users. Non-owners can only manage roles whose explicit scoped decisions are within their own authority; the `owner` role is owner-only.              |
 | `user.invite`             | List, create, copy, and revoke invite links. This exposes every active invite-link capability to the holder.                                                              |
-| `user.manage-accounts`    | Create users, edit account identity, reset passwords, attach verified emails, and clear login cooldowns.                                                                        |
+| `user.manage-accounts`    | Create users, edit account identity, reset passwords, attach verified emails, clear login cooldowns, and bypass your own login cooldown.                                         |
 | `user.manage-permissions` | Edit direct per-user permission overrides.                                                                                                                                      |
 | `user.delete-any`         | Delete any user's account.                                                                                                                                                      |
 | `user.delete-self`        | Delete your own account.                                                                                                                                                        |

--- a/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/ProfileDetailsSettings.svelte
@@ -43,7 +43,10 @@
   const bioModified = $derived((bio || '') !== (currentUser.user?.bio ?? ''));
   const isModified = $derived(displayNameModified || loginModified || bioModified);
   const cooldownRemaining = $derived(getLoginChangeCooldownRemaining(lastLoginChange));
-  const canChangeLogin = $derived(cooldownRemaining === 0);
+  const canBypassLoginCooldown = $derived(
+    serverScope.store.permissions.canAdminManageAccounts
+  );
+  const canChangeLogin = $derived(canBypassLoginCooldown || cooldownRemaining === 0);
 
   function clearMessages() {
     error = '';
@@ -126,7 +129,7 @@
       });
 
       if (currentUser.user) {
-        const lastLoginChange = normalizedLogin
+        const lastLoginChange = normalizedLogin && !canBypassLoginCooldown
           ? new Date().toISOString()
           : currentUser.user.lastLoginChange;
         currentUser.user = {
@@ -142,7 +145,7 @@
       login = updated.login;
       bio = updated.bio ?? '';
 
-      if (normalizedLogin) {
+      if (normalizedLogin && !canBypassLoginCooldown) {
         localLastLoginChange = new Date();
       }
 
@@ -220,5 +223,7 @@
   <p>
     {m('settings.profile.username.confirm_prompt', { login: pendingLogin ?? '' })}
   </p>
-  <p class="mt-3">{m('settings.profile.username.confirm_cooldown')}</p>
+  {#if !canBypassLoginCooldown}
+    <p class="mt-3">{m('settings.profile.username.confirm_cooldown')}</p>
+  {/if}
 </ConfirmDialog>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/profile/profile.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/profile/profile.page.svelte.spec.ts
@@ -21,9 +21,12 @@ const mocks = vi.hoisted(() => ({
       avatarUrl: null,
       bio: null,
       viewerCanDeleteAccount: true,
-      lastLoginChange: null
+      lastLoginChange: null as string | null
     },
     loading: false
+  },
+  permissions: {
+    canAdminManageAccounts: false
   }
 }));
 
@@ -36,6 +39,7 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
     serverId: 'origin',
     store: {
       currentUser: mocks.currentUser,
+      permissions: mocks.permissions,
       serverInfo: {
         supportsFeature: (feature: string) => feature !== 'userAvatars' || mocks.supportsUserAvatars
       }
@@ -93,6 +97,7 @@ describe('Profile settings page', () => {
       lastLoginChange: null
     };
     mocks.query.mockReset();
+    mocks.permissions.canAdminManageAccounts = false;
     mocks.supportsUserAvatars = true;
     mocks.mutation.mockReset();
     mocks.updateProfile.mockReset();
@@ -247,6 +252,57 @@ describe('Profile settings page', () => {
         bio: undefined
       });
     });
+  });
+
+  it('keeps the username cooldown for a regular user', async () => {
+    mocks.currentUser.user.lastLoginChange = new Date().toISOString();
+    const { container } = render(ProfilePage);
+    await settle();
+
+    const usernameInput = q(container, '[data-testid="settings-username"]') as HTMLInputElement;
+    await expect.element(usernameInput).toBeDisabled();
+    await expect.element(q(container, 'form')).toHaveTextContent(
+      'You can change your username again in'
+    );
+  });
+
+  it('lets an account manager bypass their own username cooldown', async () => {
+    const lastLoginChange = new Date().toISOString();
+    mocks.currentUser.user.lastLoginChange = lastLoginChange;
+    mocks.permissions.canAdminManageAccounts = true;
+    const { container } = render(ProfilePage);
+    await settle();
+
+    const usernameInput = q(container, '[data-testid="settings-username"]') as HTMLInputElement;
+    await expect.element(usernameInput).toBeEnabled();
+    expect(container.textContent).not.toContain('You can change your username again in');
+
+    setInputValue(usernameInput, 'alice2');
+    (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        'Are you sure you want to change your username to @alice2?'
+      );
+    });
+    expect(container.textContent).not.toContain(
+      'You can only change your username once every 30 days.'
+    );
+
+    const confirmButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('dialog button')
+    ).find((button) => button.textContent?.includes('Change username'));
+    expect(confirmButton).toBeDefined();
+    confirmButton?.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.updateProfile).toHaveBeenCalledWith({
+        displayName: undefined,
+        login: 'alice2',
+        bio: undefined
+      });
+    });
+    expect(mocks.currentUser.user.lastLoginChange).toBe(lastLoginChange);
   });
 
   it('uploads an avatar through the targeted user API', async () => {

--- a/cli/internal/connectapi/account_server_services_test.go
+++ b/cli/internal/connectapi/account_server_services_test.go
@@ -139,6 +139,32 @@ func TestMyAccountServiceUpdatesSelfProfileAndSettings(t *testing.T) {
 	if user := profileResp.Msg.GetUser(); user.GetId() != env.viewer.Id || user.GetDisplayName() != "Connect Profile" || user.GetLogin() != "connect-profile" || user.GetBio() != "Connect profile bio" {
 		t.Fatalf("updated profile = %+v, want renamed viewer", user)
 	}
+	firstLoginChange, err := env.core.GetLastLoginChange(env.ctx, env.viewer.Id)
+	if err != nil {
+		t.Fatalf("GetLastLoginChange: %v", err)
+	}
+	if firstLoginChange.IsZero() {
+		t.Fatal("first profile login change did not start the cooldown")
+	}
+	if err := env.core.GrantUserPermission(env.ctx, core.SystemActorID, env.viewer.Id, core.PermUserManageAccounts); err != nil {
+		t.Fatalf("GrantUserPermission user.manage-accounts: %v", err)
+	}
+	bypassResp, err := env.account.UpdateProfile(ctx, connect.NewRequest(&apiv1.UpdateProfileRequest{
+		Login: stringPtr("connect-profile-bypass"),
+	}))
+	if err != nil {
+		t.Fatalf("UpdateProfile with own cooldown bypass: %v", err)
+	}
+	if got := bypassResp.Msg.GetUser().GetLogin(); got != "connect-profile-bypass" {
+		t.Fatalf("bypassed profile login = %q, want connect-profile-bypass", got)
+	}
+	bypassLoginChange, err := env.core.GetLastLoginChange(env.ctx, env.viewer.Id)
+	if err != nil {
+		t.Fatalf("GetLastLoginChange after bypass: %v", err)
+	}
+	if !bypassLoginChange.Equal(firstLoginChange) {
+		t.Fatalf("bypassed profile update advanced cooldown timestamp: was %v, now %v", firstLoginChange, bypassLoginChange)
+	}
 
 	tz := "Europe/Berlin"
 	settingsResp, err := env.account.UpdateSettings(ctx, connect.NewRequest(&apiv1.UpdateSettingsRequest{

--- a/cli/internal/core/user_profiles.go
+++ b/cli/internal/core/user_profiles.go
@@ -368,10 +368,23 @@ func userLoginChangedAtKey(userID string) string {
 	return "user_login_changed_at." + userID
 }
 
-// UpdateUserLogin changes a user's login/username with 30-day cooldown enforcement.
+// UpdateUserLogin changes a user's login/username. The 30-day cooldown applies
+// unless the user has user.manage-accounts. A bypassed change does not advance
+// the user's cooldown timestamp.
 // Authorization: Caller should verify the actor is the user being updated.
 func (c *ChattoCore) UpdateUserLogin(ctx context.Context, userID, newLogin string) (*evtv1.User, error) {
-	return c.applyLoginChange(ctx, userID, userID, newLogin, true)
+	bypassCooldown := false
+	if err := c.authorizeAtStableInputs(ctx, func() error {
+		canManageAccounts, err := c.CanManageUserAccounts(ctx, userID)
+		if err != nil {
+			return fmt.Errorf("check user.manage-accounts: %w", err)
+		}
+		bypassCooldown = canManageAccounts
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	return c.applyLoginChange(ctx, userID, userID, newLogin, !bypassCooldown)
 }
 
 // AdminUpdateUserLogin changes a user's login/username, bypassing the cooldown

--- a/cli/internal/core/user_profiles_test.go
+++ b/cli/internal/core/user_profiles_test.go
@@ -487,6 +487,48 @@ func TestChattoCore_UpdateUserLogin(t *testing.T) {
 		}
 	})
 
+	t.Run("account manager bypasses own cooldown without advancing it", func(t *testing.T) {
+		core2, _ := setupTestCore(t)
+		ctx2 := testContext(t)
+		u, _ := core2.CreateUser(ctx2, SystemActorID, "managercooldown", "Manager", "password123")
+
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managerfirst"); err != nil {
+			t.Fatalf("First login change failed: %v", err)
+		}
+		firstTimestamp, err := core2.GetLastLoginChange(ctx2, u.Id)
+		if err != nil {
+			t.Fatalf("GetLastLoginChange failed: %v", err)
+		}
+		if firstTimestamp.IsZero() {
+			t.Fatal("Expected first login change to record a timestamp")
+		}
+
+		if err := core2.GrantUserPermission(ctx2, SystemActorID, u.Id, PermUserManageAccounts); err != nil {
+			t.Fatalf("GrantUserPermission user.manage-accounts: %v", err)
+		}
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managersecond"); err != nil {
+			t.Fatalf("Account manager second login change failed: %v", err)
+		}
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managerthird"); err != nil {
+			t.Fatalf("Account manager third login change failed: %v", err)
+		}
+
+		bypassTimestamp, err := core2.GetLastLoginChange(ctx2, u.Id)
+		if err != nil {
+			t.Fatalf("GetLastLoginChange after bypass failed: %v", err)
+		}
+		if !bypassTimestamp.Equal(firstTimestamp) {
+			t.Fatalf("Bypassed change advanced cooldown timestamp: was %v, now %v", firstTimestamp, bypassTimestamp)
+		}
+
+		if err := core2.DenyUserPermission(ctx2, SystemActorID, u.Id, PermUserManageAccounts); err != nil {
+			t.Fatalf("DenyUserPermission user.manage-accounts: %v", err)
+		}
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managerblocked"); err != ErrLoginChangeCooldown {
+			t.Fatalf("Login change after permission revocation error = %v, want ErrLoginChangeCooldown", err)
+		}
+	})
+
 	t.Run("admin update bypasses cooldown and does not advance the user clock", func(t *testing.T) {
 		core2, _ := setupTestCore(t)
 		ctx2 := testContext(t)

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -123,7 +123,7 @@ The full permission catalog is in `cli/internal/core/permission.go`. Key permiss
 
 - `role.manage` — configure role definitions and the permissions attached to them.
 - `role.assign` — assign or revoke roles, bounded for non-owners by the target role's explicit scoped permission decisions.
-- `user.manage-accounts` — create users, edit account identity, reset passwords, attach verified emails, and clear login cooldowns.
+- `user.manage-accounts` — create users, edit account identity, reset passwords, attach verified emails, clear login cooldowns, and bypass the holder's own login cooldown.
 - `user.manage-permissions` — edit direct per-user permission overrides.
 - `admin.view-users`, `admin.view-audit` — gate specific admin UI sub-views; admin UI entry is derived from concrete capabilities rather than a standalone `admin.access` permission. System diagnostics are owner-only and exposed through a viewer capability, not through grantable RBAC.
 - `message.read` — read message content and message-specific metadata in

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,7 +1,7 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-08-30
+**Last reviewed:** 2026-09-02
 
 ## Overview
 
@@ -10,7 +10,7 @@ A user's profile carries the public identity they present to the rest of the ser
 ## Behavior
 
 - **Display name** — freely editable by a human or bot account. Shown in messages, member lists, mention autocomplete, etc.
-- **Login (username)** — editable by a human or bot account with a 30-day cooldown between changes. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Bot logins must end in `_bot`. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
+- **Login (username)** — editable by a human or bot account with a 30-day cooldown between changes. A user with `user.manage-accounts` bypasses the cooldown for their own login. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Bot logins must end in `_bot`. Each successful change that does not use the bypass records a timestamp; subsequent changes within the window are rejected with a clear error message.
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
 - **Avatar** — human and bot users can upload an image. The server resizes it to 256×256 maximum and stores it as lossless WebP. The old avatar is deleted after the new avatar is committed. Users can also delete their avatar and use the initial-letter placeholder. A human with `user.manage-accounts` can manage another human's avatar. A bot owner, a human with `bot.manage`, or a human with `user.manage-accounts` can manage a bot's avatar.
 - **Custom status** — human users can set an emoji plus short text. The emoji is shown next to their name; the text is shown alongside it where space allows and as hover/accessible text in compact places.
@@ -29,7 +29,7 @@ A user's profile carries the public identity they present to the rest of the ser
 
 ### 1. 30-day login change cooldown
 
-**Decision:** A user can change their login only once every 30 days.
+**Decision:** A user can change their login only once every 30 days. A user with `user.manage-accounts` can bypass this limit for their own login. A bypassed change does not clear or advance the existing cooldown timestamp.
 **Why:** Logins are the basis for `@mentions`, search results, and recognition across the server. Frequent changes are an impersonation/confusion risk — `@alice` today might be a different person tomorrow. A 30-day cooldown discourages rapid churn while still allowing occasional rename for legitimate reasons. Case-only changes are exempt because they don't change identity.
 **Tradeoff:** A user who legitimately needs to change twice in 30 days (e.g., picked a typo'd name) is stuck. The admin clear-cooldown affordance handles those cases.
 
@@ -39,11 +39,11 @@ A user's profile carries the public identity they present to the rest of the ser
 **Why:** User profile state now lives in the event-sourced user aggregate, and new durable login-change facts carry encrypted PII. Projection catch-up plus OCC keeps uniqueness race-safe without reintroducing a separate login KV as source of truth.
 **Tradeoff:** The write path depends on projection readiness and may retry under contention. In exchange, the durable event stream remains append-only and the login index stays derived state.
 
-### 3. Admin path doesn't advance the cooldown timestamp
+### 3. Privileged changes do not advance the cooldown timestamp
 
-**Decision:** When an admin changes a user's login, the user's cooldown clock isn't reset. The user can still wait out their own cooldown and change to a different login.
-**Why:** The cooldown is about the _user's_ identity stability, not the admin's. An admin-driven correction shouldn't reset the user's own quota.
-**Tradeoff:** A user who keeps getting admin-renamed has a slightly confusing experience around when their next self-change is allowed. Acceptable; uncommon edge case.
+**Decision:** A login change does not reset the cooldown clock when an account manager changes another user's login or bypasses their own cooldown. The previous self-service cooldown timestamp stays in effect.
+**Why:** A privileged correction does not use the user's normal login-change allowance.
+**Tradeoff:** A user can see a cooldown that started before a privileged login change. This case is uncommon.
 
 ### 4. Avatars are WebP-only, capped at 256×256
 
@@ -114,7 +114,7 @@ A user's profile carries the public identity they present to the rest of the ser
 ## Permissions
 
 - Human or bot self-edit of an avatar — no explicit permission; only authentication.
-- Human self-edit of display name, custom status, settings, and own login subject to cooldown — no explicit permission; only authentication.
+- Human self-edit of display name, custom status, settings, and own login subject to cooldown — no explicit permission; only authentication. `user.manage-accounts` bypasses the holder's own login cooldown.
 - Cross-human-user edit — `user.manage-accounts`.
 - Clear another user's login cooldown — same gate.
 - Bot avatar edit by another human — bot ownership, `user.manage-accounts`, or `bot.manage`.


### PR DESCRIPTION
## Why

Account managers need to correct their own username during an active cooldown without changing the cooldown that applies if the permission is later removed.

## What changed

- Resolve `user.manage-accounts` in the self-service username operation and preserve the authenticated user as the event actor.
- Keep the username field enabled for permitted viewers, omit cooldown warnings, and preserve the existing client timestamp after a privileged rename.
- Add core, ConnectRPC, and browser-component coverage, and update FDR-001, FDR-022, and the permission guide.

## API compatibility

- Behavioural change with no protobuf, event schema, subject, generated-client, or HTTP-shape change.
- Older client → newer server: permitted callers can repeat an existing `MyAccountService.UpdateProfile` username update during cooldown.
- Newer client → older server: the UI can offer the bypass, but the older server still rejects the update during cooldown.
- Capability discovery or minimum client/server version: none; the UI uses the existing effective-permission capability.

## Test plan

- `mise test-cli` — passed.
- `mise test-frontend` — passed.
- `mise lint` — passed with zero Svelte diagnostics.
- Public `buf breaking` check against `origin/main` — passed.
- Svelte autofixer — passed with no issues or suggestions.
- Chrome DevTools verification — regular users remained blocked; a permitted user renamed repeatedly without cooldown messaging or timestamp advancement.
