### PR TITLE
fix(accounts): backport username cooldown bypass to 0.4

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -70,7 +70,7 @@ Room-relevant permissions such as `message.post`, `message.attach`, `message.rea
 | `room.ban-member` | Ban members from channel rooms. |
 | `role.manage` | Create, edit, delete, reorder roles, and edit role permissions. |
 | `role.assign` | Assign or revoke roles for users. |
-| `user.manage-accounts` | Create users, edit account identity, reset passwords, attach verified emails, and clear login cooldowns. |
+| `user.manage-accounts` | Create users, edit account identity, reset passwords, attach verified emails, clear login cooldowns, and bypass your own login cooldown. |
 | `user.manage-permissions` | Edit direct per-user permission overrides. |
 | `user.delete-any` | Delete any user's account. |
 | `user.delete-self` | Delete your own account. |

--- a/apps/frontend/src/routes/chat/[serverId]/settings/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/+page.svelte
@@ -24,7 +24,8 @@
   // `loading` are `$state`), so subsequent profile updates flow through.
   // The connection getter resolves to the active server's API client,
   // so profile/avatar mutations land on the right backend.
-  const currentUser = serverRegistry.getStore(getActiveServer()).currentUser;
+  const serverStore = serverRegistry.getStore(getActiveServer());
+  const currentUser = serverStore.currentUser;
   const connection = useConnection();
 
   function accountAPI() {
@@ -76,7 +77,8 @@
   const isModified = $derived(displayNameModified || loginModified);
   // Cooldown
   const cooldownRemaining = $derived(getLoginChangeCooldownRemaining(lastLoginChange));
-  const canChangeLogin = $derived(cooldownRemaining === 0);
+  const canBypassLoginCooldown = $derived(serverStore.permissions.canAdminManageAccounts);
+  const canChangeLogin = $derived(canBypassLoginCooldown || cooldownRemaining === 0);
 
   function clearProfileMessages() {
     error = '';
@@ -224,7 +226,7 @@
 
       // Update the current user state
       if (currentUser.user) {
-        const lastLoginChange = normalizedLogin
+        const lastLoginChange = normalizedLogin && !canBypassLoginCooldown
           ? new Date().toISOString()
           : currentUser.user.lastLoginChange;
         currentUser.user = {
@@ -240,7 +242,7 @@
       login = updated.login;
 
       // Update cooldown if login was changed
-      if (normalizedLogin) {
+      if (normalizedLogin && !canBypassLoginCooldown) {
         localLastLoginChange = new Date();
       }
 
@@ -379,7 +381,9 @@
   <p class="mb-2">
     {m['settings.profile.username.confirm_prompt']({ login: pendingLogin ?? '' })}
   </p>
-  <p class="mb-4 text-muted">{m['settings.profile.username.confirm_cooldown']()}</p>
+  {#if !canBypassLoginCooldown}
+    <p class="mb-4 text-muted">{m['settings.profile.username.confirm_cooldown']()}</p>
+  {/if}
 
   <div class="flex items-center gap-3">
     <Button onclick={confirmLoginChange}>

--- a/apps/frontend/src/routes/chat/[serverId]/settings/profile.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/settings/profile.page.svelte.spec.ts
@@ -20,9 +20,12 @@ const mocks = vi.hoisted(() => ({
       displayName: 'Alice',
       avatarUrl: null,
       viewerCanDeleteAccount: true,
-      lastLoginChange: null
+      lastLoginChange: null as string | null
     },
     loading: false
+  },
+  permissions: {
+    canAdminManageAccounts: false
   }
 }));
 
@@ -33,7 +36,8 @@ vi.mock('$lib/state/activeServer.svelte', () => ({
 vi.mock('$lib/state/server/registry.svelte', () => ({
   serverRegistry: {
     getStore: () => ({
-      currentUser: mocks.currentUser
+      currentUser: mocks.currentUser,
+      permissions: mocks.permissions
     })
   }
 }));
@@ -83,6 +87,7 @@ describe('Profile settings page', () => {
       lastLoginChange: null
     };
     mocks.query.mockReset();
+    mocks.permissions.canAdminManageAccounts = false;
     mocks.mutation.mockReset();
     mocks.updateProfile.mockReset();
     mocks.updateProfile.mockImplementation((input) =>
@@ -157,6 +162,56 @@ describe('Profile settings page', () => {
 
     await expect.element(q(container, 'form')).toHaveTextContent('consecutive spaces');
     expect(mocks.updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('keeps the username cooldown for a regular user', async () => {
+    mocks.currentUser.user.lastLoginChange = new Date().toISOString();
+    const { container } = render(ProfilePage);
+    await settle();
+
+    const usernameInput = q(container, '[data-testid="settings-username"]') as HTMLInputElement;
+    await expect.element(usernameInput).toBeDisabled();
+    await expect.element(q(container, 'form')).toHaveTextContent(
+      'You can change your username again in'
+    );
+  });
+
+  it('lets an account manager bypass their own username cooldown', async () => {
+    const lastLoginChange = new Date().toISOString();
+    mocks.currentUser.user.lastLoginChange = lastLoginChange;
+    mocks.permissions.canAdminManageAccounts = true;
+    const { container } = render(ProfilePage);
+    await settle();
+
+    const usernameInput = q(container, '[data-testid="settings-username"]') as HTMLInputElement;
+    await expect.element(usernameInput).toBeEnabled();
+    expect(container.textContent).not.toContain('You can change your username again in');
+
+    setInputValue(usernameInput, 'alice2');
+    (q(container, 'button[type="submit"]') as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain(
+        'Are you sure you want to change your username to @alice2?'
+      );
+    });
+    expect(container.textContent).not.toContain(
+      'You can only change your username once every 30 days.'
+    );
+
+    const confirmButton = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('dialog button')
+    ).find((button) => button.textContent?.includes('Change Username'));
+    expect(confirmButton).toBeDefined();
+    confirmButton?.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.updateProfile).toHaveBeenCalledWith({
+        displayName: undefined,
+        login: 'alice2'
+      });
+    });
+    expect(mocks.currentUser.user.lastLoginChange).toBe(lastLoginChange);
   });
 
   it('uploads an avatar through the account API', async () => {

--- a/cli/internal/connectapi/api_test.go
+++ b/cli/internal/connectapi/api_test.go
@@ -1949,6 +1949,32 @@ func TestMyAccountServiceUpdatesSelfProfileAndSettings(t *testing.T) {
 	if user := profileResp.Msg.GetUser(); user.GetId() != env.viewer.Id || user.GetDisplayName() != "Connect Profile" || user.GetLogin() != "connect-profile" {
 		t.Fatalf("updated profile = %+v, want renamed viewer", user)
 	}
+	firstLoginChange, err := env.core.GetLastLoginChange(env.ctx, env.viewer.Id)
+	if err != nil {
+		t.Fatalf("GetLastLoginChange: %v", err)
+	}
+	if firstLoginChange.IsZero() {
+		t.Fatal("first profile login change did not start the cooldown")
+	}
+	if err := env.core.GrantUserPermission(env.ctx, core.SystemActorID, env.viewer.Id, core.PermUserManageAccounts); err != nil {
+		t.Fatalf("GrantUserPermission user.manage-accounts: %v", err)
+	}
+	bypassResp, err := env.account.UpdateProfile(ctx, connect.NewRequest(&apiv1.UpdateProfileRequest{
+		Login: stringPtr("connect-profile-bypass"),
+	}))
+	if err != nil {
+		t.Fatalf("UpdateProfile with own cooldown bypass: %v", err)
+	}
+	if got := bypassResp.Msg.GetUser().GetLogin(); got != "connect-profile-bypass" {
+		t.Fatalf("bypassed profile login = %q, want connect-profile-bypass", got)
+	}
+	bypassLoginChange, err := env.core.GetLastLoginChange(env.ctx, env.viewer.Id)
+	if err != nil {
+		t.Fatalf("GetLastLoginChange after bypass: %v", err)
+	}
+	if !bypassLoginChange.Equal(firstLoginChange) {
+		t.Fatalf("bypassed profile update advanced cooldown timestamp: was %v, now %v", firstLoginChange, bypassLoginChange)
+	}
 
 	tz := "Europe/Berlin"
 	settingsResp, err := env.account.UpdateSettings(ctx, connect.NewRequest(&apiv1.UpdateSettingsRequest{

--- a/cli/internal/core/users.go
+++ b/cli/internal/core/users.go
@@ -1019,10 +1019,16 @@ func userLoginChangedAtKey(userID string) string {
 	return "user_login_changed_at." + userID
 }
 
-// UpdateUserLogin changes a user's login/username with 30-day cooldown enforcement.
+// UpdateUserLogin changes a user's login/username. The 30-day cooldown applies
+// unless the user has user.manage-accounts. A bypassed change does not advance
+// the user's cooldown timestamp.
 // Authorization: Caller should verify the actor is the user being updated.
 func (c *ChattoCore) UpdateUserLogin(ctx context.Context, userID, newLogin string) (*corev1.User, error) {
-	return c.applyLoginChange(ctx, userID, userID, newLogin, true)
+	bypassCooldown, err := c.CanManageUserAccounts(ctx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("check user.manage-accounts: %w", err)
+	}
+	return c.applyLoginChange(ctx, userID, userID, newLogin, !bypassCooldown)
 }
 
 // AdminUpdateUserLogin changes a user's login/username, bypassing the cooldown

--- a/cli/internal/core/users_test.go
+++ b/cli/internal/core/users_test.go
@@ -1467,6 +1467,47 @@ func TestChattoCore_UpdateUserLogin(t *testing.T) {
 		}
 	})
 
+	t.Run("account manager bypass preserves the cooldown timestamp", func(t *testing.T) {
+		core2, _ := setupTestCore(t)
+		ctx2 := testContext(t)
+		u, _ := core2.CreateUser(ctx2, "system", "managercooldown", "Manager", "password123")
+
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managerfirst"); err != nil {
+			t.Fatalf("First login change failed: %v", err)
+		}
+		firstTimestamp, err := core2.GetLastLoginChange(ctx2, u.Id)
+		if err != nil {
+			t.Fatalf("GetLastLoginChange failed: %v", err)
+		}
+		if firstTimestamp.IsZero() {
+			t.Fatal("Expected first login change to record a timestamp")
+		}
+
+		if err := core2.GrantUserPermission(ctx2, SystemActorID, u.Id, PermUserManageAccounts); err != nil {
+			t.Fatalf("GrantUserPermission user.manage-accounts: %v", err)
+		}
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managersecond"); err != nil {
+			t.Fatalf("First bypassed login change failed: %v", err)
+		}
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managerthird"); err != nil {
+			t.Fatalf("Second bypassed login change failed: %v", err)
+		}
+		bypassTimestamp, err := core2.GetLastLoginChange(ctx2, u.Id)
+		if err != nil {
+			t.Fatalf("GetLastLoginChange after bypass failed: %v", err)
+		}
+		if !bypassTimestamp.Equal(firstTimestamp) {
+			t.Fatalf("Bypassed login changes advanced cooldown timestamp: was %v, now %v", firstTimestamp, bypassTimestamp)
+		}
+
+		if err := core2.DenyUserPermission(ctx2, SystemActorID, u.Id, PermUserManageAccounts); err != nil {
+			t.Fatalf("DenyUserPermission user.manage-accounts: %v", err)
+		}
+		if _, err := core2.UpdateUserLogin(ctx2, u.Id, "managerblocked"); err != ErrLoginChangeCooldown {
+			t.Fatalf("Expected original cooldown after permission removal, got: %v", err)
+		}
+	})
+
 	t.Run("admin update bypasses cooldown and does not advance the user clock", func(t *testing.T) {
 		core2, _ := setupTestCore(t)
 		ctx2 := testContext(t)

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -87,7 +87,7 @@ The full permission catalog is in `cli/internal/core/permission.go`. Key permiss
 
 - `role.manage` — create, edit, delete roles and the permissions attached to them.
 - `role.assign` — assign roles to users.
-- `user.manage-accounts` — create users, edit account identity, reset passwords, attach verified emails, and clear login cooldowns.
+- `user.manage-accounts` — create users, edit account identity, reset passwords, attach verified emails, clear login cooldowns, and bypass the holder's own login cooldown.
 - `user.manage-permissions` — edit direct per-user permission overrides.
 - `admin.view-users`, `admin.view-audit` — gate specific admin UI sub-views; admin UI entry is derived from concrete capabilities rather than a standalone `admin.access` permission. System diagnostics are owner-only and exposed through a viewer capability, not through grantable RBAC.
 - `message.post` — post root messages in rooms and start DMs. Fresh servers grant this to `everyone` at server scope; announcement rooms add a room-level `everyone` deny.

--- a/docs/fdr/FDR-022-user-profile.md
+++ b/docs/fdr/FDR-022-user-profile.md
@@ -1,7 +1,7 @@
 # FDR-022: User Profile
 
 **Status:** Active
-**Last reviewed:** 2026-07-12
+**Last reviewed:** 2026-09-02
 
 ## Overview
 
@@ -10,7 +10,7 @@ A user's profile carries the public identity they present to the rest of the ser
 ## Behavior
 
 - **Display name** — freely editable by the user. Shown in messages, member lists, mention autocomplete, etc.
-- **Login (username)** — editable by the user with a 30-day cooldown between changes. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Each successful change records a timestamp; subsequent changes within the window are rejected with a clear error message.
+- **Login (username)** — editable by the user with a 30-day cooldown between changes. A user with `user.manage-accounts` bypasses the cooldown for their own login. Logins start with a letter or number and cannot end with a period; periods remain valid within a login. Each successful change that does not use the bypass records a timestamp; subsequent changes within the window are rejected with a clear error message.
 - **Case-only changes** (e.g., `alice` → `Alice`) bypass the cooldown.
 - **Avatar** — users upload an image; the server resizes to 256×256 max and stores it as lossless WebP. The old avatar is deleted after the new one is committed. Users can also delete their avatar (falling back to an initial-letter placeholder).
 - **Custom status** — users can set an emoji plus short text. The emoji is shown next to their name; the text is shown alongside it where space allows and as hover/accessible text in compact places.
@@ -24,7 +24,7 @@ A user's profile carries the public identity they present to the rest of the ser
 
 ### 1. 30-day login change cooldown
 
-**Decision:** A user can change their login only once every 30 days.
+**Decision:** A user can change their login only once every 30 days. A user with `user.manage-accounts` can bypass this limit for their own login. A bypassed change does not clear or advance the existing cooldown timestamp.
 **Why:** Logins are the basis for `@mentions`, search results, and recognition across the server. Frequent changes are an impersonation/confusion risk — `@alice` today might be a different person tomorrow. A 30-day cooldown discourages rapid churn while still allowing occasional rename for legitimate reasons. Case-only changes are exempt because they don't change identity.
 **Tradeoff:** A user who legitimately needs to change twice in 30 days (e.g., picked a typo'd name) is stuck. The admin clear-cooldown affordance handles those cases.
 
@@ -34,11 +34,11 @@ A user's profile carries the public identity they present to the rest of the ser
 **Why:** User profile state now lives in the event-sourced user aggregate, and new durable login-change facts carry encrypted PII. Projection catch-up plus OCC keeps uniqueness race-safe without reintroducing a separate login KV as source of truth.
 **Tradeoff:** The write path depends on projection readiness and may retry under contention. In exchange, the durable event stream remains append-only and the login index stays derived state.
 
-### 3. Admin path doesn't advance the cooldown timestamp
+### 3. Privileged changes do not advance the cooldown timestamp
 
-**Decision:** When an admin changes a user's login, the user's cooldown clock isn't reset. The user can still wait out their own cooldown and change to a different login.
-**Why:** The cooldown is about the *user's* identity stability, not the admin's. An admin-driven correction shouldn't reset the user's own quota.
-**Tradeoff:** A user who keeps getting admin-renamed has a slightly confusing experience around when their next self-change is allowed. Acceptable; uncommon edge case.
+**Decision:** A login change does not reset the cooldown clock when an account manager changes another user's login or bypasses their own cooldown. The previous self-service cooldown timestamp stays in effect.
+**Why:** A privileged correction does not use the user's normal login-change allowance.
+**Tradeoff:** A user can see a cooldown that started before a privileged login change. This case is uncommon.
 
 ### 4. Avatars are WebP-only, capped at 256×256
 
@@ -84,7 +84,7 @@ A user's profile carries the public identity they present to the rest of the ser
 
 ## Permissions
 
-- Self-edit (display name, avatar, custom status, settings, own login subject to cooldown) — no explicit permission; just authentication.
+- Self-edit (display name, avatar, custom status, settings, own login subject to cooldown) — no explicit permission; only authentication. `user.manage-accounts` bypasses the holder's own login cooldown.
 - Cross-user edit — `user.manage-accounts`.
 - Clear another user's login cooldown — same gate.
 

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,7 @@ buf = "latest"
 go = "1.26.2"
 goreleaser = "latest"
 node = "22"
+uv = "0.11.30"
 
 [env]
 _.file = '.env'
@@ -52,7 +53,7 @@ depends = ["deps-frontend"]
 
 [tasks.license-check]
 description = "Check SPDX/REUSE license metadata"
-run = "mise x uv@latest -- uvx reuse lint"
+run = "uvx --with charset-normalizer 'reuse==6.2.0' lint"
 
 # =============================================================================
 # Code Generation


### PR DESCRIPTION
## Why

Backports #2271 so account managers on release 0.4 can correct their own username during an active cooldown.

## What changed

- Resolve `user.manage-accounts` in the 0.4 self-service username operation while keeping the authenticated user as the event actor.
- Preserve the existing cooldown timestamp after privileged renames, so permission removal restores the original cooldown.
- Keep the username input enabled and omit cooldown warnings for permitted viewers.
- Add core, ConnectRPC, and browser-component coverage, and update FDR and permission documentation.
- Pin the license-check toolchain so CI does not depend on resolving `uv@latest` at runtime.

## Compatibility

- Behavioral change only; no protobuf, event schema, generated-client, migration, or operational change.

## Test plan

- `mise test-cli` — passed.
- `mise test-frontend` — 195 files and 2,032 tests passed.
- `mise lint` — passed with zero Svelte diagnostics.
- Focused core, ConnectRPC, and profile browser-component tests — passed.
- Svelte autofixer — no issues.
- `mise license-check` — all 1,761 files passed REUSE validation.
