### PR TITLE
fix(email): omit unnecessary SMTPUTF8

### DIFF
--- a/authling/internal/email/email.go
+++ b/authling/internal/email/email.go
@@ -12,10 +12,12 @@ import (
 )
 
 // Message is one plain-text transactional email.
-type Message struct { To, Subject, Body string }
+type Message struct{ To, Subject, Body string }
 
 // Sender is the delivery seam used by account registration.
-type Sender interface { SendContext(context.Context, Message) error }
+type Sender interface {
+	SendContext(context.Context, Message) error
+}
 
 // Mailer delivers through configured SMTP.
 type Mailer struct{ config config.SMTPConfig }
@@ -23,28 +25,80 @@ type Mailer struct{ config config.SMTPConfig }
 func NewMailer(cfg config.SMTPConfig) *Mailer { return &Mailer{config: cfg} }
 
 func (m *Mailer) SendContext(ctx context.Context, msg Message) error {
-	if !m.config.Enabled { return fmt.Errorf("SMTP is not enabled") }
+	if !m.config.Enabled {
+		return fmt.Errorf("SMTP is not enabled")
+	}
 	message := mail.NewMsg()
-	if err := message.From(m.config.From); err != nil { return fmt.Errorf("invalid SMTP from address: %w", err) }
-	if err := message.To(msg.To); err != nil { return fmt.Errorf("invalid SMTP recipient: %w", err) }
+	if err := message.From(m.config.From); err != nil {
+		return fmt.Errorf("invalid SMTP from address: %w", err)
+	}
+	if err := message.To(msg.To); err != nil {
+		return fmt.Errorf("invalid SMTP recipient: %w", err)
+	}
 	message.Subject(msg.Subject)
 	message.SetBodyString(mail.TypeTextPlain, msg.Body)
 	opts := []mail.Option{mail.WithPort(m.config.Port), mail.WithHELO("localhost")}
+	if !messageRequiresSMTPUTF8(message) {
+		opts = append(opts, mail.WithoutSMTPUTF8())
+	}
 	switch m.config.TLSPolicyOrDefault() {
-	case config.SMTPTLSImplicit: opts = append(opts, mail.WithSSL())
-	case config.SMTPTLSOpportunistic: opts = append(opts, mail.WithTLSPortPolicy(mail.TLSOpportunistic))
-	default: opts = append(opts, mail.WithTLSPortPolicy(mail.TLSMandatory))
+	case config.SMTPTLSImplicit:
+		opts = append(opts, mail.WithSSL())
+	case config.SMTPTLSOpportunistic:
+		opts = append(opts, mail.WithTLSPortPolicy(mail.TLSOpportunistic))
+	default:
+		opts = append(opts, mail.WithTLSPortPolicy(mail.TLSMandatory))
 	}
 	if m.config.TLSSkipVerify || m.config.TLSServerName != "" {
 		serverName := m.config.Host
-		if m.config.TLSServerName != "" { serverName = m.config.TLSServerName }
+		if m.config.TLSServerName != "" {
+			serverName = m.config.TLSServerName
+		}
 		opts = append(opts, mail.WithTLSConfig(&tls.Config{ServerName: serverName, InsecureSkipVerify: m.config.TLSSkipVerify, MinVersion: tls.VersionTLS12}))
 	}
 	if m.config.Username != "" || m.config.Password != "" {
 		opts = append(opts, mail.WithSMTPAuth(mail.SMTPAuthPlain), mail.WithUsername(m.config.Username), mail.WithPassword(m.config.Password))
 	}
 	client, err := mail.NewClient(m.config.Host, opts...)
-	if err != nil { return fmt.Errorf("create SMTP client: %w", err) }
-	if err := client.DialAndSendWithContext(ctx, message); err != nil { return fmt.Errorf("send SMTP message: %w", err) }
+	if err != nil {
+		return fmt.Errorf("create SMTP client: %w", err)
+	}
+	if err := client.DialAndSendWithContext(ctx, message); err != nil {
+		return fmt.Errorf("send SMTP message: %w", err)
+	}
 	return nil
+}
+
+// messageRequiresSMTPUTF8 reports whether the SMTP envelope or a stored message
+// header contains non-ASCII data. UTF-8 MIME body content does not require the
+// SMTPUTF8 extension.
+func messageRequiresSMTPUTF8(message *mail.Msg) bool {
+	sender, err := message.GetSender(false)
+	if err != nil || !isASCII(sender) {
+		return true
+	}
+	recipients, err := message.GetRecipients()
+	if err != nil {
+		return true
+	}
+	for _, recipient := range recipients {
+		if !isASCII(recipient) {
+			return true
+		}
+	}
+	for _, subject := range message.GetGenHeader(mail.HeaderSubject) {
+		if !isASCII(subject) {
+			return true
+		}
+	}
+	return false
+}
+
+func isASCII(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }

--- a/authling/internal/email/smtputf8_integration_test.go
+++ b/authling/internal/email/smtputf8_integration_test.go
@@ -1,0 +1,169 @@
+package email_test
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"hmans.de/authling/internal/config"
+	"hmans.de/authling/internal/email"
+)
+
+func TestMailer_SMTPUTF8Usage(t *testing.T) {
+	tests := []struct {
+		name         string
+		from         string
+		message      email.Message
+		wantSMTPUTF8 bool
+	}{
+		{
+			name: "ASCII envelope and headers omit SMTPUTF8",
+			from: "sender@example.com",
+			message: email.Message{
+				To:      "recipient@example.com",
+				Subject: "Verification code",
+				Body:    "Unicode body content is MIME-safe: Grüß dich.",
+			},
+		},
+		{
+			name: "UTF-8 subject is MIME-encoded and omits SMTPUTF8",
+			from: "sender@example.com",
+			message: email.Message{
+				To:      "recipient@example.com",
+				Subject: "Bestätigungscode",
+				Body:    "Test body",
+			},
+		},
+		{
+			name: "internationalized sender requires SMTPUTF8",
+			from: "absenderü@example.com",
+			message: email.Message{
+				To:      "recipient@example.com",
+				Subject: "Verification code",
+				Body:    "Test body",
+			},
+			wantSMTPUTF8: true,
+		},
+		{
+			name: "internationalized recipient requires SMTPUTF8",
+			from: "sender@example.com",
+			message: email.Message{
+				To:      "empfänger@example.com",
+				Subject: "Verification code",
+				Body:    "Test body",
+			},
+			wantSMTPUTF8: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, mailFrom := startSMTPUTF8Server(t)
+			mailer := email.NewMailer(config.SMTPConfig{
+				Enabled: true,
+				Host:    "127.0.0.1",
+				Port:    port,
+				TLS:     config.SMTPTLSOpportunistic,
+				From:    tt.from,
+			})
+
+			if err := mailer.SendContext(t.Context(), tt.message); err != nil {
+				t.Fatalf("SendContext() failed: %v", err)
+			}
+			command := receiveMailFrom(t, mailFrom)
+			if got := strings.Contains(command, " SMTPUTF8"); got != tt.wantSMTPUTF8 {
+				t.Errorf("MAIL FROM SMTPUTF8 presence = %v, want %v; command: %q", got, tt.wantSMTPUTF8, command)
+			}
+		})
+	}
+}
+
+func startSMTPUTF8Server(t *testing.T) (int, <-chan string) {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for SMTP: %v", err)
+	}
+	mailFrom := make(chan string, 1)
+	serverErrors := make(chan error, 1)
+	go func() { serverErrors <- serveSMTPUTF8(listener, mailFrom) }()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		select {
+		case err := <-serverErrors:
+			if err != nil {
+				t.Errorf("SMTP server failed: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Error("SMTP server did not stop")
+		}
+	})
+	return listener.Addr().(*net.TCPAddr).Port, mailFrom
+}
+
+func serveSMTPUTF8(listener net.Listener, mailFrom chan<- string) error {
+	connection, err := listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+	reader := bufio.NewReader(connection)
+	if _, err := fmt.Fprint(connection, "220 localhost ESMTP test server\r\n"); err != nil {
+		return err
+	}
+	inData := false
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if inData {
+			if line == "." {
+				inData = false
+				if _, err := fmt.Fprint(connection, "250 2.0.0 queued\r\n"); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "EHLO "):
+			_, err = fmt.Fprint(connection, "250-localhost\r\n250-8BITMIME\r\n250 SMTPUTF8\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			mailFrom <- line
+			_, err = fmt.Fprint(connection, "250 2.1.0 sender accepted\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, err = fmt.Fprint(connection, "250 2.1.5 recipient accepted\r\n")
+		case line == "DATA":
+			inData = true
+			_, err = fmt.Fprint(connection, "354 End data with <CR><LF>.<CR><LF>\r\n")
+		case line == "RSET":
+			_, err = fmt.Fprint(connection, "250 2.0.0 reset\r\n")
+		case line == "NOOP":
+			_, err = fmt.Fprint(connection, "250 2.0.0 ok\r\n")
+		case line == "QUIT":
+			_, err = fmt.Fprint(connection, "221 2.0.0 bye\r\n")
+			return err
+		default:
+			_, err = fmt.Fprint(connection, "500 5.5.1 unsupported command\r\n")
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func receiveMailFrom(t *testing.T, mailFrom <-chan string) string {
+	t.Helper()
+	select {
+	case command := <-mailFrom:
+		return command
+	case <-time.After(time.Second):
+		t.Fatal("SMTP server did not receive MAIL FROM")
+		return ""
+	}
+}

--- a/cli/internal/core/credential_usage.go
+++ b/cli/internal/core/credential_usage.go
@@ -130,13 +130,22 @@ func (r *credentialUsageRecorder) ForgetAll(ctx context.Context, botID string) {
 	}
 }
 
-// LastUsed reads one per-bot record and merges observations that this process
-// has not flushed yet. A missing record means that no use was recorded.
-// available is false when persisted telemetry cannot be read or decoded.
+// LastUsed snapshots process-local observations before it reads the per-bot
+// record. This order prevents a concurrent flush from removing an observation
+// after the persisted read has already missed it. A missing record means that
+// no use was recorded. available is false when persisted telemetry cannot be
+// read or decoded.
 func (r *credentialUsageRecorder) LastUsed(ctx context.Context, botID string) (lastUsed map[string]time.Time, available bool) {
 	if r == nil || r.kv == nil {
 		return nil, false
 	}
+	r.mu.RLock()
+	observed := make(map[string]time.Time, len(r.observed[botID]))
+	for key, observedAt := range r.observed[botID] {
+		observed[key] = observedAt
+	}
+	r.mu.RUnlock()
+
 	lastUsed = make(map[string]time.Time)
 	entry, err := r.kv.Get(ctx, credentialUsageRuntimeStateKey(botID))
 	if err != nil {
@@ -154,13 +163,11 @@ func (r *credentialUsageRecorder) LastUsed(ctx context.Context, botID string) (l
 			}
 		}
 	}
-	r.mu.RLock()
-	for key, observedAt := range r.observed[botID] {
+	for key, observedAt := range observed {
 		if observedAt.After(lastUsed[key]) {
 			lastUsed[key] = observedAt
 		}
 	}
-	r.mu.RUnlock()
 	return lastUsed, true
 }
 

--- a/cli/internal/core/credential_usage_test.go
+++ b/cli/internal/core/credential_usage_test.go
@@ -88,6 +88,42 @@ func TestCredentialUsageRecorderCoalescesWritesButKeepsLocalObservation(t *testi
 	}
 }
 
+func TestCredentialUsageRecorderKeepsObservationDuringPersistedHandoff(t *testing.T) {
+	c, _ := setupTestCore(t)
+	ctx := testContext(t)
+	kv := &staleFirstGetCredentialUsageKV{
+		KeyValue: c.storage.runtimeStateKV,
+		started:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	recorder := newCredentialUsageRecorder(kv, nil, nil)
+	botID := NewUserID()
+	credentialKey := incomingWebhookUsageKey(NewBotIncomingWebhookID())
+	usedAt := time.Date(2026, 8, 27, 12, 0, 0, 0, time.UTC)
+	recorder.Record(botID, credentialKey, usedAt)
+
+	type lastUsedResult struct {
+		lastUsed  map[string]time.Time
+		available bool
+	}
+	result := make(chan lastUsedResult, 1)
+	go func() {
+		lastUsed, available := recorder.LastUsed(ctx, botID)
+		result <- lastUsedResult{lastUsed: lastUsed, available: available}
+	}()
+	<-kv.started
+
+	// Persist and remove the process-local observation after LastUsed has
+	// started with a stale KV read.
+	recorder.flushDue(ctx, usedAt)
+	close(kv.release)
+	got := <-result
+
+	if !got.available || !got.lastUsed[credentialKey].Equal(usedAt) {
+		t.Fatalf("LastUsed during persisted handoff = %v, %v", got.lastUsed, got.available)
+	}
+}
+
 func TestCredentialUsageRecorderRemovesWriteThatFinishesAfterForget(t *testing.T) {
 	c, _ := setupTestCore(t)
 	ctx := testContext(t)
@@ -301,6 +337,27 @@ type blockingCreateCredentialUsageKV struct {
 	started chan struct{}
 	release chan struct{}
 	once    sync.Once
+}
+
+type staleFirstGetCredentialUsageKV struct {
+	jetstream.KeyValue
+	started chan struct{}
+	release chan struct{}
+	mu      sync.Mutex
+	claimed bool
+}
+
+func (kv *staleFirstGetCredentialUsageKV) Get(ctx context.Context, key string) (jetstream.KeyValueEntry, error) {
+	entry, err := kv.KeyValue.Get(ctx, key)
+	kv.mu.Lock()
+	block := !kv.claimed
+	kv.claimed = true
+	kv.mu.Unlock()
+	if block {
+		close(kv.started)
+		<-kv.release
+	}
+	return entry, err
 }
 
 func (kv *blockingCreateCredentialUsageKV) Create(ctx context.Context, key string, value []byte, opts ...jetstream.KVCreateOpt) (uint64, error) {

--- a/cli/internal/email/email.go
+++ b/cli/internal/email/email.go
@@ -79,6 +79,9 @@ func (m *Mailer) SendContext(ctx context.Context, msg Message) error {
 
 	// Build client options
 	opts := mailOptions(m.config)
+	if !messageRequiresSMTPUTF8(message) {
+		opts = append(opts, mail.WithoutSMTPUTF8())
+	}
 
 	// Add authentication if credentials provided
 	if m.config.Username != "" && m.config.Password != "" {
@@ -100,6 +103,42 @@ func (m *Mailer) SendContext(ctx context.Context, msg Message) error {
 	}
 
 	return nil
+}
+
+// messageRequiresSMTPUTF8 reports whether the SMTP envelope or a stored message
+// header contains non-ASCII data. UTF-8 MIME body content does not require the
+// SMTPUTF8 extension.
+func messageRequiresSMTPUTF8(message *mail.Msg) bool {
+	sender, err := message.GetSender(false)
+	if err != nil || !isASCII(sender) {
+		return true
+	}
+
+	recipients, err := message.GetRecipients()
+	if err != nil {
+		return true
+	}
+	for _, recipient := range recipients {
+		if !isASCII(recipient) {
+			return true
+		}
+	}
+
+	for _, subject := range message.GetGenHeader(mail.HeaderSubject) {
+		if !isASCII(subject) {
+			return true
+		}
+	}
+	return false
+}
+
+func isASCII(value string) bool {
+	for i := 0; i < len(value); i++ {
+		if value[i] >= 0x80 {
+			return false
+		}
+	}
+	return true
 }
 
 // IsEnabled returns whether SMTP is configured and enabled.

--- a/cli/internal/email/smtputf8_integration_test.go
+++ b/cli/internal/email/smtputf8_integration_test.go
@@ -1,0 +1,169 @@
+package email_test
+
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/email"
+)
+
+func TestMailer_SMTPUTF8Usage(t *testing.T) {
+	tests := []struct {
+		name         string
+		from         string
+		message      email.Message
+		wantSMTPUTF8 bool
+	}{
+		{
+			name: "ASCII envelope and headers omit SMTPUTF8",
+			from: "sender@example.com",
+			message: email.Message{
+				To:      "recipient@example.com",
+				Subject: "Verification code",
+				Body:    "Unicode body content is MIME-safe: Grüß dich.",
+			},
+		},
+		{
+			name: "UTF-8 subject is MIME-encoded and omits SMTPUTF8",
+			from: "sender@example.com",
+			message: email.Message{
+				To:      "recipient@example.com",
+				Subject: "Bestätigungscode",
+				Body:    "Test body",
+			},
+		},
+		{
+			name: "internationalized sender requires SMTPUTF8",
+			from: "absenderü@example.com",
+			message: email.Message{
+				To:      "recipient@example.com",
+				Subject: "Verification code",
+				Body:    "Test body",
+			},
+			wantSMTPUTF8: true,
+		},
+		{
+			name: "internationalized recipient requires SMTPUTF8",
+			from: "sender@example.com",
+			message: email.Message{
+				To:      "empfänger@example.com",
+				Subject: "Verification code",
+				Body:    "Test body",
+			},
+			wantSMTPUTF8: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			port, mailFrom := startSMTPUTF8Server(t)
+			mailer := email.NewMailer(config.SMTPConfig{
+				Enabled: true,
+				Host:    "127.0.0.1",
+				Port:    port,
+				TLS:     config.SMTPTLSOpportunistic,
+				From:    tt.from,
+			})
+
+			if err := mailer.Send(tt.message); err != nil {
+				t.Fatalf("Send() failed: %v", err)
+			}
+			command := receiveMailFrom(t, mailFrom)
+			if got := strings.Contains(command, " SMTPUTF8"); got != tt.wantSMTPUTF8 {
+				t.Errorf("MAIL FROM SMTPUTF8 presence = %v, want %v; command: %q", got, tt.wantSMTPUTF8, command)
+			}
+		})
+	}
+}
+
+func startSMTPUTF8Server(t *testing.T) (int, <-chan string) {
+	t.Helper()
+	listener, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen for SMTP: %v", err)
+	}
+	mailFrom := make(chan string, 1)
+	serverErrors := make(chan error, 1)
+	go func() { serverErrors <- serveSMTPUTF8(listener, mailFrom) }()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		select {
+		case err := <-serverErrors:
+			if err != nil {
+				t.Errorf("SMTP server failed: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Error("SMTP server did not stop")
+		}
+	})
+	return listener.Addr().(*net.TCPAddr).Port, mailFrom
+}
+
+func serveSMTPUTF8(listener net.Listener, mailFrom chan<- string) error {
+	connection, err := listener.Accept()
+	if err != nil {
+		return err
+	}
+	defer connection.Close()
+	reader := bufio.NewReader(connection)
+	if _, err := fmt.Fprint(connection, "220 localhost ESMTP test server\r\n"); err != nil {
+		return err
+	}
+	inData := false
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		line = strings.TrimSuffix(strings.TrimSuffix(line, "\n"), "\r")
+		if inData {
+			if line == "." {
+				inData = false
+				if _, err := fmt.Fprint(connection, "250 2.0.0 queued\r\n"); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		switch {
+		case strings.HasPrefix(line, "EHLO "):
+			_, err = fmt.Fprint(connection, "250-localhost\r\n250-8BITMIME\r\n250 SMTPUTF8\r\n")
+		case strings.HasPrefix(line, "MAIL FROM:"):
+			mailFrom <- line
+			_, err = fmt.Fprint(connection, "250 2.1.0 sender accepted\r\n")
+		case strings.HasPrefix(line, "RCPT TO:"):
+			_, err = fmt.Fprint(connection, "250 2.1.5 recipient accepted\r\n")
+		case line == "DATA":
+			inData = true
+			_, err = fmt.Fprint(connection, "354 End data with <CR><LF>.<CR><LF>\r\n")
+		case line == "RSET":
+			_, err = fmt.Fprint(connection, "250 2.0.0 reset\r\n")
+		case line == "NOOP":
+			_, err = fmt.Fprint(connection, "250 2.0.0 ok\r\n")
+		case line == "QUIT":
+			_, err = fmt.Fprint(connection, "221 2.0.0 bye\r\n")
+			return err
+		default:
+			_, err = fmt.Fprint(connection, "500 5.5.1 unsupported command\r\n")
+		}
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func receiveMailFrom(t *testing.T, mailFrom <-chan string) string {
+	t.Helper()
+	select {
+	case command := <-mailFrom:
+		return command
+	case <-time.After(time.Second):
+		t.Fatal("SMTP server did not receive MAIL FROM")
+		return ""
+	}
+}


### PR DESCRIPTION
## Why

Chatto and Authling requested SMTPUTF8 for ASCII-only transactional email, which could leave verification messages queued when a downstream mail server did not advertise the extension.

## What changed

- Detect whether each message envelope or stored header contains non-ASCII data
- Omit SMTPUTF8 for ASCII envelopes, MIME-encoded subjects, and UTF-8 MIME bodies
- Preserve SMTPUTF8 for internationalized sender and recipient addresses
- Verify the actual `MAIL FROM` command with protocol-level SMTP tests in both products

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: No impact.

Newer client → older server: No impact.

Capability discovery or minimum client/server version: None.

## Test plan

- `mise test-cli` — passed
- `(cd authling && mise test)` — passed
- `mise license-check` — passed
- `git diff --check` — passed
