### PR TITLE
fix(dev): unify local embedded NATS data directory

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,27 @@ bundled-binary port layout: `4000` for Chatto, `4001` for embedded NATS,
 `4002` for Prometheus metrics, and `4003` for exporter metrics. Pass explicit
 CLI arguments after the task name, for example `mise chatto version`.
 
+### Local Chatto Data
+
+The local `cli/chatto.toml` file is the source for local data paths. It keeps
+embedded NATS data in `cli/data/nats/` and the search index in
+`cli/data/search/`. The `mise dev` and `mise chatto` tasks use these paths.
+
+Older worktrees can have embedded NATS data in `cli/data/jetstream/`. Stop all
+Chatto processes before you migrate this data. If
+`cli/data/nats/jetstream/` does not exist, preserve the old store and copy it
+to the new location:
+
+```sh
+mkdir -p cli/data/nats
+cp -a cli/data/jetstream cli/data/nats/
+```
+
+Start Chatto and check the data before you remove the old
+`cli/data/jetstream/` directory. If both JetStream directories already contain
+data, do not merge them. Preserve both directories and select the store that
+contains the data that you need.
+
 ## Local Bootstrap Users
 
 Local development instances are bootstrapped from `cli/chatto.toml` when the server is otherwise empty.

--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ Create an Authling account, read its verification code in Mailpit, then choose
 login. The stack also creates Chatto owner `alice` and member `bob`; both use
 the development-only password `foobar123`.
 
-Chatto uses Authling as its development OIDC provider. Chatto data is in
-`cli/data/`; Authling identity data is in
+Chatto uses Authling as its development OIDC provider. Chatto stores embedded
+NATS data in `cli/data/nats/` and search data in `cli/data/search/`. Authling
+identity data is in
 `.context/dev-portless/<workspace>/nested/authling/`.
 
 These credentials and accounts are for local development only. Stop `mise dev`
 to stop the services and unregister the routes. With the stack stopped, remove
-either data directory to reset that service. A new Conductor workspace name
-also creates a new Authling issuer and state directory.
+`cli/data/` to reset Chatto, or remove the Authling identity directory to reset
+Authling. A new Conductor workspace name also creates a new Authling issuer and
+state directory.
+
+If a worktree has NATS data in the former `cli/data/jetstream/` location, use
+the migration steps in [CONTRIBUTING.md](CONTRIBUTING.md#local-chatto-data).
 
 Portless creates and trusts a development CA on its first run. If macOS cannot
 show its authorization prompt, run this command once in an interactive terminal:

--- a/cli/chatto.toml
+++ b/cli/chatto.toml
@@ -103,7 +103,8 @@ api_secret = 'devsecret'
 enabled = true
 port = 4555
 # http_port = 8555
-data_dir = './data'
+# Keep NATS data separate from the disposable search index in './data/search'.
+data_dir = './data/nats'
 auth_token = 'd5ed70d13c4682609dfd0a4f65bf7e59ef22f3be8502762b501d3b7cf0b73b43'
 
 # Dev-only bootstrap. Creates these users + the initial instance only when the

--- a/cli/internal/config/config_test.go
+++ b/cli/internal/config/config_test.go
@@ -11,6 +11,20 @@ import (
 	"hmans.de/chatto/pkg/natsauth"
 )
 
+func TestLocalDevelopmentConfigUsesSeparateDataDirectories(t *testing.T) {
+	cfg, err := ReadConfig(filepath.Join("..", "..", "chatto.toml"))
+	if err != nil {
+		t.Fatalf("ReadConfig() failed for local development config: %v", err)
+	}
+
+	if got := cfg.NATS.Embedded.DataDir; got != "./data/nats" {
+		t.Errorf("embedded NATS data directory = %q, want %q", got, "./data/nats")
+	}
+	if got := cfg.SearchProvider.DirectoryOrDefault(); got != "./data/search" {
+		t.Errorf("search provider directory = %q, want %q", got, "./data/search")
+	}
+}
+
 func TestReadConfig_WithoutConfigFile(t *testing.T) {
 	// Create a temp directory with no config file
 	tmpDir := t.TempDir()

--- a/mise.toml
+++ b/mise.toml
@@ -455,25 +455,21 @@ env = {
 }
 run = '''
 set -eu
-project_dir=$(pwd -P)
 chatto_url=$(portless get "chatto.$CHATTO_DEV_ROUTE_SUFFIX" --no-worktree)
 authling_url=$(portless get "authling.$CHATTO_DEV_ROUTE_SUFFIX" --no-worktree)
 livekit_url=$(portless get "livekit.$CHATTO_DEV_ROUTE_SUFFIX" --no-worktree)
 chatto_url=${chatto_url/http:/https:}
 authling_url=${authling_url/http:/https:}
 livekit_url=${livekit_url/http:/https:}
-data_root="$project_dir/cli/data"
-mkdir -p cli/internal/http_server/.client "$data_root/nats" "$data_root/search"
+mkdir -p cli/internal/http_server/.client
 touch cli/internal/http_server/.client/.gitkeep
 cd cli
 go build -trimpath -tags 'bootstrap nomsgpack' -ldflags "-X main.Version=$CHATTO_DEVELOPMENT_VERSION" -o bin/chatto-dev .
 export CHATTO_WEBSERVER_URL="$chatto_url"
-export CHATTO_SEARCH_PROVIDER_DIRECTORY="$data_root/search"
 export CHATTO_AUTH_PROVIDERS_0_ISSUER_URL="$authling_url"
 export CHATTO_AUTH_PROVIDERS_0_CLIENT_ID="$chatto_url/oauth/client-metadata.json"
 export CHATTO_LIVEKIT_URL="${livekit_url/https:/wss:}"
 export CHATTO_LIVEKIT_WEBHOOK_URL="http://localhost:$CHATTO_WEBSERVER_PORT/webhooks/livekit"
-export CHATTO_NATS_EMBEDDED_DATA_DIR="$data_root/nats"
 exec bin/chatto-dev start
 '''
 


### PR DESCRIPTION
## Why

`mise dev` and `mise chatto restore` could use different embedded NATS directories and create two local JetStream stores.

## What changed

- Make `cli/chatto.toml` the authority for local data paths, with NATS in `cli/data/nats` and search in `cli/data/search`.
- Remove the duplicate data-directory overrides from `mise dev` and add a focused configuration regression test.
- Document a stopped-stack, copy-first migration for legacy `cli/data/jetstream` stores, including the case where both stores contain data.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise x -- go test ./internal/config -run '^TestLocalDevelopmentConfigUsesSeparateDataDirectories$' -count=1 -timeout 30s` — passed
- `mise x -- go test ./internal/config -count=1 -timeout 60s` — passed
- `mise tasks --json` with assertions that local tasks do not override either data directory — passed
- `git diff --check` — passed

