### PR TITLE
fix(messages): let managers bypass edit window

### DIFF
--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
@@ -103,9 +103,10 @@ Result of creating a message.
 ### UpdateMessage
 
 Edits a message body. Authors can edit their own messages within the edit
-window. Non-authors need message.manage and cannot change channel echo
-state. Disabled rooms reject creation of a new channel echo while allowing
-an existing echo to be removed. Room membership is also required.
+window. Effective message.manage permits edits at any time. Only the
+message author can change channel echo state. Disabled rooms reject
+creation of a new channel echo while allowing an existing echo to be
+removed. Room membership is also required.
 Channel-room edits require message.read or a matching thread relationship
 with message.read-interactions. DM membership authorizes the DM read.
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1204,9 +1204,10 @@ Result of creating a message.
 ### UpdateMessage
 
 Edits a message body. Authors can edit their own messages within the edit
-window. Non-authors need message.manage and cannot change channel echo
-state. Disabled rooms reject creation of a new channel echo while allowing
-an existing echo to be removed. Room membership is also required.
+window. Effective message.manage permits edits at any time. Only the
+message author can change channel echo state. Disabled rooms reject
+creation of a new channel echo while allowing an existing echo to be
+removed. Room membership is also required.
 Channel-room edits require message.read or a matching thread relationship
 with message.read-interactions. DM membership authorizes the DM read.
 

--- a/cli/internal/core/can.go
+++ b/cli/internal/core/can.go
@@ -449,10 +449,10 @@ func (c *ChattoCore) CanEchoMessage(ctx context.Context, userID string, kind Roo
 	return c.hasRoomPermission(ctx, kind, roomID, userID, PermMessageEcho)
 }
 
-// CanManageOthersMessage checks if a user can edit/delete other users'
-// messages in a specific room. Authors editing/deleting their own messages
-// don't need this permission — that's always allowed and gated only by
-// authorship + the edit window in core.
+// CanManageOthersMessage checks if a user has effective message.manage in a
+// specific room. This permission allows edits and deletions of other users'
+// messages. It also lets an author edit their own message after the edit
+// window closes.
 func (c *ChattoCore) CanManageOthersMessage(ctx context.Context, userID string, kind RoomKind, roomID string) (bool, error) {
 	return c.hasRoomPermission(ctx, kind, roomID, userID, PermMessageManage)
 }

--- a/cli/internal/core/errors.go
+++ b/cli/internal/core/errors.go
@@ -249,8 +249,9 @@ func invalidArgument(message string) error {
 // This is intentional for consistent storage cost control - a 10KB message costs the same
 // regardless of whether it contains ASCII or multi-byte UTF-8 characters.
 const (
-	// MessageEditWindow is the duration after posting during which a user can edit
-	// their own message. Moderators with message.manage can edit at any time.
+	// MessageEditWindow is the duration after posting during which an author can
+	// edit their own message without message.manage. Effective message.manage
+	// permits edits at any time.
 	MessageEditWindow = 3 * time.Hour
 
 	// MaxMessageBodyLength is the maximum length of a message body in bytes.

--- a/cli/internal/core/message_model.go
+++ b/cli/internal/core/message_model.go
@@ -456,10 +456,11 @@ func (s *MessageModel) slowModeNextPostAt(room *evtv1.Room, actorID string, bypa
 
 // UpdateMessage edits an existing message. Authorization: actor must be a room
 // member. Channel-room edits also require message.read. DM membership
-// authorizes the DM read. Authors may edit their own messages subject to the
-// core edit window. Non-authors need message.manage. Changing a thread reply's
-// channel echo state is author-only and, when enabling the echo, additionally
-// requires message.echo and message.post.
+// authorizes the DM read. Authors may edit their own messages within the core
+// edit window. Effective message.manage bypasses the window and permits edits
+// to other authors' messages. Changing a thread reply's channel echo state is
+// author-only and, when enabling the echo, additionally requires message.echo
+// and message.post.
 func (s *MessageModel) UpdateMessage(ctx context.Context, input MessageUpdateInput) (*evtv1.Event, RoomKind, error) {
 	room, kind, err := s.core.requireMessageReader(ctx, input.ActorID, input.RoomID, input.EventID)
 	if err != nil {

--- a/cli/internal/core/messages.go
+++ b/cli/internal/core/messages.go
@@ -1332,7 +1332,7 @@ func (c *ChattoCore) authorizeMessageMutation(
 		}
 	}
 
-	entry, err := c.validateMessageMutationIdentity(actorID, roomID, eventID, policy, now)
+	entry, err := c.validateMessageMutationIdentity(ctx, actorID, kind, roomID, eventID, policy, now)
 	if err != nil {
 		return err
 	}
@@ -1367,8 +1367,15 @@ func (c *ChattoCore) authorizeMessageMutation(
 	return nil
 }
 
+// validateMessageMutationIdentity checks current message identity and the
+// author-only rules for one mutation attempt. Effective message.manage lets an
+// author continue after the edit window closes, but it does not replace an
+// authorOnly requirement.
 func (c *ChattoCore) validateMessageMutationIdentity(
-	actorID, roomID, eventID string,
+	ctx context.Context,
+	actorID string,
+	kind RoomKind,
+	roomID, eventID string,
 	policy messageMutationAuthorization,
 	now time.Time,
 ) (*TimelineEntry, error) {
@@ -1382,7 +1389,13 @@ func (c *ChattoCore) validateMessageMutationIdentity(
 	}
 	if entry.Event.GetActorId() == actorID {
 		if policy.enforceEditWindow && now.After(entry.Event.GetCreatedAt().AsTime().Add(MessageEditWindow)) {
-			return nil, ErrEditWindowExpired
+			canManage, err := c.CanManageOthersMessage(ctx, actorID, kind, roomID)
+			if err != nil {
+				return nil, err
+			}
+			if !canManage {
+				return nil, ErrEditWindowExpired
+			}
 		}
 		return entry, nil
 	}
@@ -1486,8 +1499,9 @@ func (c *ChattoCore) DeleteMessage(ctx context.Context, actorID string, kind Roo
 
 // EditMessage edits a message body. Updates the body content and sets updated_at.
 // Publishes a MessageEditedEvent to notify connected clients in real-time.
-// Business rule: Authors can only edit their own messages within MessageEditWindow (3 hours).
-// Non-authors (moderators with message.manage) can edit at any time.
+// Business rule: Authors can edit their own messages within MessageEditWindow
+// (3 hours). Effective message.manage bypasses the window and also permits
+// editing other authors' messages.
 //
 // Authorization: Caller must verify the actor is the author OR
 // CanManageOthersMessage before calling.
@@ -1522,14 +1536,10 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		return ErrMessageNotFound
 	}
 
-	// Author / edit-window check. Edit window only applies to the
-	// original author; moderators bypass it (their authorization is
-	// gated upstream at the resolver).
-	authorID := originalEntry.Event.GetActorId()
-	if authorID == actorID {
-		if time.Since(originalEntry.Event.GetCreatedAt().AsTime()) > MessageEditWindow {
-			return ErrEditWindowExpired
-		}
+	// Check the author window before preparing echo reconciliation. The same
+	// rule runs inside every authorized OCC attempt below.
+	if _, err := c.validateMessageMutationIdentity(ctx, actorID, kind, roomID, eventID, messageMutationAuthorization{enforceEditWindow: true}, now()); err != nil {
+		return err
 	}
 	channelEchoCreationTargetID := ""
 	channelEchoRetractionTargetID := ""
@@ -1554,8 +1564,8 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 		if echoTargetEvent.GetActorId() != actorID {
 			return ErrNotMessageAuthor
 		}
-		if time.Since(echoTargetEvent.GetCreatedAt().AsTime()) > MessageEditWindow {
-			return ErrEditWindowExpired
+		if _, err := c.validateMessageMutationIdentity(ctx, actorID, kind, roomID, echoTargetEvent.GetId(), messageMutationAuthorization{authorOnly: true, enforceEditWindow: true}, now()); err != nil {
+			return err
 		}
 		_, channelEchoExistedBefore = c.roomModel.channelEchoEventID(echoTargetEvent.GetId())
 		if *options.channelEcho {
@@ -1589,7 +1599,7 @@ func (c *ChattoCore) EditMessage(ctx context.Context, actorID string, kind RoomK
 			return nil
 		}
 		validateCommit = func() error {
-			_, err := c.validateMessageMutationIdentity(actorID, roomID, eventID, policy, now())
+			_, err := c.validateMessageMutationIdentity(ctx, actorID, kind, roomID, eventID, policy, now())
 			return err
 		}
 	}
@@ -2095,7 +2105,7 @@ func (c *ChattoCore) editEmbeddedBody(
 		return nil
 	}
 	validateCommit := func() error {
-		_, err := c.validateMessageMutationIdentity(actorID, roomID, eventID, policy, time.Now())
+		_, err := c.validateMessageMutationIdentity(ctx, actorID, kind, roomID, eventID, policy, time.Now())
 		return err
 	}
 	_, err := c.publishAuthorizedMessageEdit(ctx, actorID, agg, roomID, eventID, authorize, validateCommit, "", "", func(ctx context.Context, updated *evtv1.MessageBody) (string, error) {

--- a/cli/internal/core/messages_test.go
+++ b/cli/internal/core/messages_test.go
@@ -451,6 +451,9 @@ func TestChattoCore_EditMessageRejectsInvalidEchoStateTargets(t *testing.T) {
 	if _, err := core.JoinRoom(ctx, other.Id, KindChannel, other.Id, room.Id); err != nil {
 		t.Fatalf("JoinRoom other: %v", err)
 	}
+	if err := core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, other.Id, PermMessageManage); err != nil {
+		t.Fatalf("Grant message.manage to other: %v", err)
+	}
 
 	root, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "root", nil, "", "", nil, false)
 	if err != nil {
@@ -464,7 +467,7 @@ func TestChattoCore_EditMessageRejectsInvalidEchoStateTargets(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Post reply: %v", err)
 	}
-	if err := core.EditMessage(ctx, other.Id, KindChannel, room.Id, reply.Id, "other edit", WithMessageChannelEcho(true)); !errors.Is(err, ErrNotMessageAuthor) {
+	if err := core.EditMessage(ctx, other.Id, KindChannel, room.Id, reply.Id, "other edit", WithMessageChannelEcho(true), withEditMessageAuthorization()); !errors.Is(err, ErrNotMessageAuthor) {
 		t.Fatalf("expected ErrNotMessageAuthor, got %v", err)
 	}
 	if body, err := core.GetMessageBody(ctx, reply.Id); err != nil || body != "reply" {
@@ -1154,6 +1157,108 @@ func TestDeleteMessageReauthorizesAfterRoomArchive(t *testing.T) {
 	assertNoMessageMutationEvents(t, core, ctx, room.Id)
 }
 
+func TestEditMessageRejectsExpiredAuthorWithoutManage(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-expired-author", "Edit Expired Author", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-expired-author", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	expiresAt := message.GetCreatedAt().AsTime().Add(MessageEditWindow)
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, message.Id, "must not land",
+		withEditMessageAuthorization(),
+		withEditMessageClock(func() time.Time { return expiresAt.Add(time.Nanosecond) }),
+	)
+	require.ErrorIs(t, err, ErrEditWindowExpired)
+	assertNoMessageMutationEvents(t, core, ctx, room.Id)
+}
+
+func TestEditMessageAllowsExpiredAuthorWithManage(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-expired-manager", "Edit Expired Manager", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-expired-manager", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	require.NoError(t, core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, author.Id, PermMessageManage))
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	expiresAt := message.GetCreatedAt().AsTime().Add(MessageEditWindow)
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, message.Id, "managed edit",
+		withEditMessageAuthorization(),
+		withEditMessageClock(func() time.Time { return expiresAt.Add(time.Nanosecond) }),
+	)
+	require.NoError(t, err)
+	body, err := core.GetMessageBody(ctx, message.Id)
+	require.NoError(t, err)
+	require.Equal(t, "managed edit", body)
+}
+
+func TestEditMessageRejectsExpiredAuthorAfterManageRevocation(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-expired-revoked-manager", "Edit Expired Revoked Manager", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-expired-revoked-manager", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	require.NoError(t, core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, author.Id, PermMessageManage))
+	message, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "original", nil, "", "", nil, false)
+	require.NoError(t, err)
+
+	expiresAt := message.GetCreatedAt().AsTime().Add(MessageEditWindow)
+	hookCalls := 0
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, message.Id, "must not land",
+		withEditMessageAuthorization(),
+		withEditMessageClock(func() time.Time { return expiresAt.Add(time.Nanosecond) }),
+		withEditMessageCommitAuthorization(func(attemptCtx context.Context) error {
+			hookCalls++
+			return core.DenyUserRoomPermission(attemptCtx, SystemActorID, room.Id, author.Id, PermMessageManage)
+		}),
+	)
+	require.ErrorIs(t, err, ErrEditWindowExpired)
+	require.Equal(t, 1, hookCalls)
+	assertNoMessageMutationEvents(t, core, ctx, room.Id)
+}
+
+func TestEditMessageAllowsExpiredManagingAuthorToCreateChannelEcho(t *testing.T) {
+	core, _ := setupTestCore(t)
+	ctx := testContext(t)
+	author, err := core.CreateUser(ctx, SystemActorID, "edit-expired-echo-manager", "Edit Expired Echo Manager", "password123")
+	require.NoError(t, err)
+	room, err := core.CreateRoom(ctx, SystemActorID, KindChannel, "", "edit-expired-echo-manager", "")
+	require.NoError(t, err)
+	_, err = core.JoinRoom(ctx, author.Id, KindChannel, author.Id, room.Id)
+	require.NoError(t, err)
+	require.NoError(t, core.GrantUserRoomPermission(ctx, SystemActorID, room.Id, author.Id, PermMessageManage))
+	root, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "root", nil, "", "", nil, false)
+	require.NoError(t, err)
+	reply, err := core.PostMessage(ctx, KindChannel, room.Id, author.Id, "reply", nil, root.Id, "", nil, false)
+	require.NoError(t, err)
+
+	expiresAt := reply.GetCreatedAt().AsTime().Add(MessageEditWindow)
+	err = core.EditMessage(ctx, author.Id, KindChannel, room.Id, reply.Id, "managed reply edit",
+		WithMessageChannelEcho(true),
+		withEditMessageAuthorization(),
+		withEditMessageClock(func() time.Time { return expiresAt.Add(time.Nanosecond) }),
+	)
+	require.NoError(t, err)
+	echoID, ok := core.roomModel.channelEchoEventID(reply.Id)
+	require.True(t, ok)
+	echoBody, err := core.GetMessageBody(ctx, echoID)
+	require.NoError(t, err)
+	require.Equal(t, "managed reply edit", echoBody)
+}
+
 func TestEditMessageRechecksExactWindowAfterOCCConflict(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
@@ -1170,7 +1275,7 @@ func TestEditMessageRechecksExactWindowAfterOCCConflict(t *testing.T) {
 	clockCalls := 0
 	clock := func() time.Time {
 		clockCalls++
-		if clockCalls <= 2 {
+		if clockCalls <= 3 {
 			return expiresAt
 		}
 		return expiresAt.Add(time.Nanosecond)

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/messages.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/messages.connect.go
@@ -78,9 +78,10 @@ type MessageServiceClient interface {
 	// thread or reject a thread placement that the mode does not allow.
 	CreateMessage(context.Context, *connect.Request[v1.CreateMessageRequest]) (*connect.Response[v1.CreateMessageResponse], error)
 	// Edits a message body. Authors can edit their own messages within the edit
-	// window. Non-authors need message.manage and cannot change channel echo
-	// state. Disabled rooms reject creation of a new channel echo while allowing
-	// an existing echo to be removed. Room membership is also required.
+	// window. Effective message.manage permits edits at any time. Only the
+	// message author can change channel echo state. Disabled rooms reject
+	// creation of a new channel echo while allowing an existing echo to be
+	// removed. Room membership is also required.
 	// Channel-room edits require message.read or a matching thread relationship
 	// with message.read-interactions. DM membership authorizes the DM read.
 	UpdateMessage(context.Context, *connect.Request[v1.UpdateMessageRequest]) (*connect.Response[v1.UpdateMessageResponse], error)
@@ -270,9 +271,10 @@ type MessageServiceHandler interface {
 	// thread or reject a thread placement that the mode does not allow.
 	CreateMessage(context.Context, *connect.Request[v1.CreateMessageRequest]) (*connect.Response[v1.CreateMessageResponse], error)
 	// Edits a message body. Authors can edit their own messages within the edit
-	// window. Non-authors need message.manage and cannot change channel echo
-	// state. Disabled rooms reject creation of a new channel echo while allowing
-	// an existing echo to be removed. Room membership is also required.
+	// window. Effective message.manage permits edits at any time. Only the
+	// message author can change channel echo state. Disabled rooms reject
+	// creation of a new channel echo while allowing an existing echo to be
+	// removed. Room membership is also required.
 	// Channel-room edits require message.read or a matching thread relationship
 	// with message.read-interactions. DM membership authorizes the DM read.
 	UpdateMessage(context.Context, *connect.Request[v1.UpdateMessageRequest]) (*connect.Response[v1.UpdateMessageResponse], error)

--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -1,7 +1,7 @@
 # FDR-002: Replies & Threads
 
 **Status:** Active
-**Last reviewed:** 2026-08-30
+**Last reviewed:** 2026-09-02
 
 ## Overview
 
@@ -27,7 +27,12 @@ Chatto messages can link to one another via reply attribution, and channel-room 
   - **Required** — every new root atomically establishes its thread. The room composer keeps **Post as thread** visible, selected, and locked so the policy is explicit without presenting a false choice. The standard **Reply** action and adjacent **Reply in thread** action keep their usual order; either opens the root's thread, while **Reply** also preserves reply attribution. Inside the thread, **Reply** creates attribution in that thread. The server rejects replies to roots unless they are placed in that root's thread. Automatic root-thread creation needs `message.post`; posting an actual thread reply still needs `message.post-in-thread`.
   - **Encouraged** — both flat and threaded conversation remain valid. The standard **Reply** action opens the root's thread with reply attribution, while the adjacent **Reply in thread** action keeps its usual position. **Reply in room** remains available as a secondary expanded-menu action. **Post as thread** starts selected for each new root draft, but the author may turn it off. If a member can post in the room but cannot post in threads, the standard reply falls back to the room and the composer cannot establish a thread.
   - **Enabled** — the default and unrestricted behavior. Authors may opt into **Post as thread**, and other members may start a thread later.
-  - **Disabled** — new threads, thread replies, thread typing indicators, and new channel echoes from historical thread replies are unavailable and rejected by the server. Ordinary in-room reply attribution remains available. Existing threads and existing channel echoes stay readable, including after a room changes to Disabled; authors may still remove a historical echo during its normal edit window.
+  - **Disabled** — the server rejects new threads, thread replies, thread typing
+    indicators, and new channel echoes from historical thread replies. Ordinary
+    in-room reply attribution remains available. Existing threads and channel
+    echoes stay readable after a room changes to Disabled. Authors can remove a
+    historical echo while they can edit the reply. Effective `message.manage`
+    permits this removal after the normal edit window.
 - Outside Required rooms, a root explicitly posted as a thread is immediately marked as a thread and the author follows it, while the composer remains in the room timeline. If nobody explicitly establishes an ordinary root's thread, the first thread reply establishes one implicitly.
 - Threading Mode changes are prospective: they do not backfill threads for existing roots or remove historical thread state.
 - A successful Threading Mode change appears as an actor-attributed room timeline event. The same ordered realtime update also refreshes room metadata, so open composers and reply actions react immediately.

--- a/docs/fdr/FDR-003-thread-reply-echo.md
+++ b/docs/fdr/FDR-003-thread-reply-echo.md
@@ -1,7 +1,7 @@
 # FDR-003: Thread Reply Echo
 
 **Status:** Active
-**Last reviewed:** 2026-08-25
+**Last reviewed:** 2026-09-02
 
 ## Overview
 
@@ -21,7 +21,13 @@ When posting a reply inside a thread, the user can optionally "also send to chan
 - The thread's reply count is not incremented by the echo; the echo represents the same reply, not an additional one.
 - Mention notifications fire once for the reply, not twice (the echo doesn't re-notify).
 - The main-room composer never shows the echo checkbox — the action only makes sense from inside a thread.
-- During the normal edit window, editing a thread reply shows the same "Also send to channel" checkbox. Saving with it checked creates or keeps the channel echo; saving with it unchecked hides the existing echo from the room timeline while keeping the thread reply readable. A Disabled room cannot gain a new echo from a historical reply, but an existing echo can still be removed.
+- Editing a thread reply shows the same "Also send to channel" checkbox while
+  the author can edit the reply. Effective `message.manage` keeps this action
+  available after the normal edit window. Saving with the checkbox selected
+  creates or keeps the channel echo. Saving with it cleared hides the existing
+  echo from the room timeline and keeps the thread reply readable. A Disabled
+  room cannot gain a new echo from a historical reply, but an existing echo can
+  still be removed.
 
 ## Design Decisions
 
@@ -60,9 +66,14 @@ When posting a reply inside a thread, the user can optionally "also send to chan
 **Decision:** `alsoSendToChannel` is only valid when posting inside a thread. Sending a plain room message with the flag is rejected.
 **Why:** The feature exists to bridge thread visibility back to the room. The reverse (a room message that also shows in some thread) doesn't have a well-defined target.
 
-### 7. Echo state is editable during the edit window
+### 7. Echo state follows author edit permission
 
-**Decision:** The ConnectRPC `MessageService.UpdateMessage` API can optionally reconcile a thread reply's channel echo state during the author's normal edit window through the shared core message model. Omitting the field preserves current echo state for clients that do not intend to change it and for moderation edits.
+**Decision:** The ConnectRPC `MessageService.UpdateMessage` API can optionally
+reconcile a thread reply's channel echo state when the author can edit the
+message through the shared core message model. Effective `message.manage`
+bypasses the normal author edit window. Omitting the field preserves current
+echo state for clients that do not intend to change it and for edits by other
+users.
 **Why:** Users often realize shortly after posting in a thread that the reply should have been visible in the room. Treating the checkbox as edit-time message state keeps the interaction aligned with the composer.
 **Tradeoff:** Echo reconciliation is not a new persisted event type; adding an echo appends the existing echo-shaped `MessagePostedEvent`, and removing one appends a normal `MessageRetractedEvent` for the echo artifact.
 

--- a/docs/fdr/FDR-004-message-editing-and-deletion.md
+++ b/docs/fdr/FDR-004-message-editing-and-deletion.md
@@ -1,15 +1,23 @@
 # FDR-004: Message Editing & Deletion
 
 **Status:** Active
-**Last reviewed:** 2026-09-01
+**Last reviewed:** 2026-09-02
 
 ## Overview
 
-Authors can edit and delete their own messages; users with `message.manage` can edit and delete others' messages. Edits replace the message body; deletes remove the body and attachments and initially leave a "[Message deleted]" placeholder.
+Authors can edit and delete their own messages. Effective `message.manage`
+permits edits at any time and permits edits and deletions of other users'
+messages. Edits replace the message body. Deletes remove the body and
+attachments and initially leave a "[Message deleted]" placeholder.
 
 ## Behavior
 
-- Authors can edit their own messages within a 3-hour window from posting time. After the window closes, only moderators can edit. The window value is queryable via `Server.messageEditWindowSeconds` so the frontend can show countdown timers and disable the edit affordance at exactly the right moment.
+- Authors can edit their own messages within a 3-hour window from posting time.
+  After the window closes, the author needs effective `message.manage` to edit
+  it. This permission also lets a user edit other users' messages at any time.
+  The window value is queryable through `Server.messageEditWindowSeconds` so
+  the frontend can show countdown timers and disable the edit action at the
+  correct time.
 - Editing requires current room membership. In a channel room, it also requires
   broad `message.read`, or `message.read-interactions` with a relationship to
   the message's thread. The operation reads and returns the current message.
@@ -42,7 +50,11 @@ Authors can edit and delete their own messages; users with `message.manage` can 
 
 ### 1. 3-hour edit window for authors
 
-**Decision:** Authors can edit their own messages only within 3 hours of posting. Moderators have no time limit. The 3-hour value is a Go constant (`core.MessageEditWindow`) exposed read-only through the public server-state API.
+**Decision:** Authors can edit their own messages without `message.manage` only
+within 3 hours of posting. Effective `message.manage` permits edits at any
+time, including edits to the permission holder's own messages. The 3-hour value
+is a Go constant (`core.MessageEditWindow`) exposed read-only through the public
+server-state API.
 **Why:** Edits long after the fact (days or weeks later) damage the integrity of the conversation log — readers who already responded would be reacting to text that no longer exists. A short window covers genuine typo-fix cases; the moderation perm covers everything else. Exposing the constant through the API (rather than hardcoding it in the frontend) lets the UI align countdown timers and disable-edit thresholds with the server's actual enforcement.
 **Tradeoff:** Authors who notice a mistake a day later can't fix it themselves. They have to ask a moderator, or live with it. Operators who want a different window currently have to recompile — promoting it to a tunable server config is cheap if demand emerges.
 
@@ -91,12 +103,14 @@ message's thread summary contains a reply.
 
 ## Permissions
 
-- `message.manage` — edit and delete *other* users' messages.
+- `message.manage` — edit messages at any time, and edit and delete other users'
+  messages.
 - `message.read` — read and edit any channel-room message.
 - `message.read-interactions` — read and edit a channel-room message in a
   related thread. DM membership authorizes DM reads without either permission.
   Deletion remains independently authorized by authorship or `message.manage`.
-- (No separate permission for editing/deleting one's own messages — that's gated by authorship and the edit window only.)
+- There is no separate edit-own or delete-own permission. Authorship permits
+  deletion and permits editing within the edit window.
 - Attachment and link-preview removal is author-only; `message.manage` does not grant cross-user removal for those partial message edits.
 
 ## Related

--- a/packages/api-types/src/chatto/api/v1/messages_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/messages_connect.ts
@@ -46,9 +46,10 @@ export const MessageService = {
     },
     /**
      * Edits a message body. Authors can edit their own messages within the edit
-     * window. Non-authors need message.manage and cannot change channel echo
-     * state. Disabled rooms reject creation of a new channel echo while allowing
-     * an existing echo to be removed. Room membership is also required.
+     * window. Effective message.manage permits edits at any time. Only the
+     * message author can change channel echo state. Disabled rooms reject
+     * creation of a new channel echo while allowing an existing echo to be
+     * removed. Room membership is also required.
      * Channel-room edits require message.read or a matching thread relationship
      * with message.read-interactions. DM membership authorizes the DM read.
      *

--- a/proto/chatto/api/v1/messages.proto
+++ b/proto/chatto/api/v1/messages.proto
@@ -211,9 +211,10 @@ service MessageService {
   // thread or reject a thread placement that the mode does not allow.
   rpc CreateMessage(CreateMessageRequest) returns (CreateMessageResponse);
   // Edits a message body. Authors can edit their own messages within the edit
-  // window. Non-authors need message.manage and cannot change channel echo
-  // state. Disabled rooms reject creation of a new channel echo while allowing
-  // an existing echo to be removed. Room membership is also required.
+  // window. Effective message.manage permits edits at any time. Only the
+  // message author can change channel echo state. Disabled rooms reject
+  // creation of a new channel echo while allowing an existing echo to be
+  // removed. Room membership is also required.
   // Channel-room edits require message.read or a matching thread relationship
   // with message.read-interactions. DM membership authorizes the DM read.
   rpc UpdateMessage(UpdateMessageRequest) returns (UpdateMessageResponse);


### PR DESCRIPTION
## Why

Admins, owners, moderators, and custom roles with effective `message.manage`
could edit other users' messages at any time, but the server still rejected
their own messages after the normal author edit window. The bundled client
already exposed the Edit action in this case, so the request failed only after
submission.

## What changed

- let authors with effective `message.manage` edit their own messages after the normal edit window
- recheck the bypass permission during authorized message-mutation attempts
- allow privileged authors to reconcile channel echoes after the edit window while keeping echo changes author-only
- document the behavior in FDR-002, FDR-003, FDR-004, and the public Message API reference

## Compatibility

This is an additive behavioral API change:

- Older client to newer server: existing edits continue to work, and qualified editors gain the bypass.
- Newer client to older server: the server can still return the previous edit-window rejection.
- No protobuf field, persisted event, subject, capability, migration, rollout, security boundary, or operational procedure changes.

## Test plan

- Passed `mise test-cli`.
- Passed `mise lint-cli`.
- Ran `mise codegen-proto` twice; generated output is stable.
- Passed focused ConnectRPC message and API contract tests.
- Passed the focused Go race detector for edit-window, permission-revocation, channel-echo, and OCC-boundary cases.
- Chrome DevTools MCP confirmed the owner Edit action, HTTP 200 from `MessageService.UpdateMessage`, and the edited marker. Deterministic Go clock tests cover the three-hour boundary.
