### PR TITLE
fix(frontend): synchronize PWA chrome with display theme

### DIFF
--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     %sveltekit.head%
+    <meta name="theme-color" content="#e5e7eb" />
     <script>
       // Resolve and apply shell preferences as early as possible — before CSS
       // loads — so:
@@ -41,6 +42,9 @@
           // Pre-CSS background hint, mirrors --color-background.
           root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
           root.style.colorScheme = effective;
+          document
+            .querySelector('meta[name="theme-color"]')
+            ?.setAttribute('content', effective === 'dark' ? '#262626' : '#e5e7eb');
         }
 
         function textDirection(locale) {
@@ -181,8 +185,6 @@
       content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="description" content="Real-time chat application" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#e5e7eb" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#262626" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/apps/frontend/src/appHtml.spec.ts
+++ b/apps/frontend/src/appHtml.spec.ts
@@ -18,13 +18,14 @@ const directionFunction = themeScript?.match(
 
 type WebAppManifest = {
   icons?: Array<{ src?: string; sizes?: string; type?: string; purpose?: string }>;
+  theme_color?: string;
 };
 
-function metaContent(name: string, mediaFragment: string): string | null {
-  const tag = appHtml.match(
-    new RegExp(`<meta\\s+[^>]*name="${name}"[^>]*media="[^"]*${mediaFragment}[^"]*"[^>]*>`, 'i')
-  )?.[0];
+function metaTags(name: string): string[] {
+  return appHtml.match(new RegExp(`<meta\\s+[^>]*name="${name}"[^>]*>`, 'gi')) ?? [];
+}
 
+function metaContent(tag: string): string | null {
   return tag?.match(/\bcontent="([^"]+)"/i)?.[1] ?? null;
 }
 
@@ -92,9 +93,19 @@ function runThemeScript({
     lang?: string;
     dir?: string;
   } = { dataset: {}, style: {} };
+  const themeColor = {
+    content: '#e5e7eb',
+    setAttribute: (_name: string, value: string) => {
+      themeColor.content = value;
+    }
+  };
 
   runInNewContext(themeScript, {
-    document: { documentElement: root },
+    document: {
+      documentElement: root,
+      querySelector: (selector: string) =>
+        selector === 'meta[name="theme-color"]' ? themeColor : null
+    },
     localStorage: {
       getItem: (key: string) => storage.get(key) ?? null,
       setItem: (key: string, value: string) => storage.set(key, value),
@@ -117,6 +128,7 @@ function runThemeScript({
 
   return {
     root,
+    themeColor,
     storedLocale: () => storage.get('chatto:locale'),
     legacyStoredLocale: () => storage.get('PARAGLIDE_LOCALE'),
     changeSystemTheme(systemTheme: 'light' | 'dark') {
@@ -137,9 +149,13 @@ function firstPaintDirection(locale: string): string {
 }
 
 describe('app.html metadata', () => {
-  it('defines theme colors matching the outer frame background colors', () => {
-    expect(metaContent('theme-color', 'light')).toBe('#e5e7eb');
-    expect(metaContent('theme-color', 'dark')).toBe('#262626');
+  it('defines one document-controlled theme color without a manifest override', () => {
+    const tags = metaTags('theme-color');
+
+    expect(tags).toHaveLength(1);
+    expect(metaContent(tags[0])).toBe('#e5e7eb');
+    expect(tags[0]).not.toMatch(/\bmedia=/i);
+    expect(manifest.theme_color).toBeUndefined();
   });
 
   it('declares the Safari apple touch icon with an explicit size', () => {
@@ -202,7 +218,7 @@ describe('app.html metadata', () => {
 
 describe('app.html theme bootstrap', () => {
   it('reads chatto:preferences.displayTheme before legacy localStorage.theme', () => {
-    const { root } = runThemeScript({
+    const { root, themeColor } = runThemeScript({
       preferences: { displayTheme: 'light' },
       legacyTheme: 'dark',
       systemDark: true
@@ -211,28 +227,32 @@ describe('app.html theme bootstrap', () => {
     expect(root.dataset.theme).toBe('light');
     expect(root.style.backgroundColor).toBe('#f3f4f6');
     expect(root.style.colorScheme).toBe('light');
+    expect(themeColor.content).toBe('#e5e7eb');
   });
 
   it('uses legacy localStorage.theme when no display preference exists', () => {
-    const { root } = runThemeScript({ legacyTheme: 'dark', systemDark: false });
+    const { root, themeColor } = runThemeScript({ legacyTheme: 'dark', systemDark: false });
     expect(root.dataset.theme).toBe('dark');
     expect(root.style.colorScheme).toBe('dark');
+    expect(themeColor.content).toBe('#262626');
   });
 
   it('follows prefers-color-scheme when the display preference is system', () => {
-    const { root } = runThemeScript({
+    const { root, themeColor } = runThemeScript({
       preferences: { displayTheme: 'system' },
       systemDark: true
     });
 
     expect(root.dataset.theme).toBe('dark');
     expect(root.style.colorScheme).toBe('dark');
+    expect(themeColor.content).toBe('#262626');
   });
 
   it('follows prefers-color-scheme when no display preference exists', () => {
-    const { root } = runThemeScript({ systemDark: true });
+    const { root, themeColor } = runThemeScript({ systemDark: true });
     expect(root.dataset.theme).toBe('dark');
     expect(root.style.colorScheme).toBe('dark');
+    expect(themeColor.content).toBe('#262626');
   });
 
   it('only reacts to system theme changes while the display preference is system', () => {
@@ -242,6 +262,7 @@ describe('app.html theme bootstrap', () => {
     });
     system.changeSystemTheme('dark');
     expect(system.root.dataset.theme).toBe('dark');
+    expect(system.themeColor.content).toBe('#262626');
 
     const explicit = runThemeScript({
       preferences: { displayTheme: 'light' },
@@ -249,6 +270,7 @@ describe('app.html theme bootstrap', () => {
     });
     explicit.changeSystemTheme('dark');
     expect(explicit.root.dataset.theme).toBe('light');
+    expect(explicit.themeColor.content).toBe('#e5e7eb');
   });
 });
 

--- a/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
@@ -31,6 +31,7 @@ describe('UserPreferencesState', () => {
     delete document.documentElement.dataset.theme;
     document.documentElement.style.backgroundColor = '';
     document.documentElement.style.colorScheme = '';
+    document.head.innerHTML = '<meta name="theme-color" content="#e5e7eb" />';
   });
 
   it('uses the product defaults when no preferences are stored', () => {
@@ -94,19 +95,45 @@ describe('UserPreferencesState', () => {
     }
   );
 
-  it('updates, persists, and applies the display theme', () => {
-    const state = new UserPreferencesState();
+  it.each([
+    {
+      displayTheme: 'light' as const,
+      effectiveTheme: 'light' as const,
+      background: 'rgb(243, 244, 246)',
+      themeColor: '#e5e7eb'
+    },
+    {
+      displayTheme: 'dark' as const,
+      effectiveTheme: 'dark' as const,
+      background: 'rgb(23, 23, 23)',
+      themeColor: '#262626'
+    },
+    {
+      displayTheme: 'system' as const,
+      effectiveTheme: 'dark' as const,
+      background: 'rgb(23, 23, 23)',
+      themeColor: '#262626'
+    }
+  ])(
+    'updates, persists, and applies the $displayTheme display theme',
+    ({ displayTheme, effectiveTheme, background, themeColor }) => {
+      mockSystemTheme('dark');
+      const state = new UserPreferencesState();
 
-    state.displayTheme = 'dark';
+      state.displayTheme = displayTheme;
 
-    expect(state.displayTheme).toBe('dark');
-    expect(document.documentElement.dataset.theme).toBe('dark');
-    expect(document.documentElement.style.backgroundColor).toBe('rgb(23, 23, 23)');
-    expect(document.documentElement.style.colorScheme).toBe('dark');
-    expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')).toMatchObject({
-      displayTheme: 'dark'
-    });
-  });
+      expect(state.displayTheme).toBe(displayTheme);
+      expect(document.documentElement.dataset.theme).toBe(effectiveTheme);
+      expect(document.documentElement.style.backgroundColor).toBe(background);
+      expect(document.documentElement.style.colorScheme).toBe(effectiveTheme);
+      expect(document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.content).toBe(
+        themeColor
+      );
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}')).toMatchObject({
+        displayTheme
+      });
+    }
+  );
 
   it('updates and persists composer choices', () => {
     const state = new UserPreferencesState();

--- a/apps/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.ts
@@ -113,6 +113,9 @@ export function applyDisplayTheme(theme: DisplayTheme): void {
   root.dataset.theme = effective;
   root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
   root.style.colorScheme = effective;
+  document
+    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    ?.setAttribute('content', effective === 'dark' ? '#262626' : '#e5e7eb');
 }
 
 function normalizeNotificationSoundFilters(value: unknown): NotificationSoundFilters {

--- a/apps/frontend/static/manifest.webmanifest
+++ b/apps/frontend/static/manifest.webmanifest
@@ -10,7 +10,6 @@
   "display": "standalone",
   "display_override": ["standalone", "browser"],
   "background_color": "#f3f4f6",
-  "theme_color": "#e5e7eb",
   "categories": ["communication", "social", "productivity"],
   "prefer_related_applications": false,
   "icons": [


### PR DESCRIPTION
## Why

Chrome 152 on Android can show Chatto’s light manifest colour above a dark installed PWA. The manifest and document currently provide competing theme-colour sources. This forward-port keeps main aligned with the release-0.4 fix and makes the active document theme authoritative.

## What changed

- removed `theme_color` from the manifest while retaining `background_color` for the installation splash fallback
- replaced two media-qualified tags with one unqualified `theme-color` tag before the bootstrap script
- synchronously set the tag to `#e5e7eb` for light or `#262626` for dark during bootstrap
- update the same tag when the display preference changes at runtime
- added metadata, system-theme, explicit-override, and runtime-preference coverage
- preserved main’s newer locale bootstrap and made no viewport, safe-area, layout, protocol, or persisted-data changes

## Test plan

- Svelte autofixer: clean
- targeted metadata and preference-store tests: 2 files and 66 tests passed
- `mise test-frontend`: server (150 files, 1,363 tests), client (190 files, 2,014 tests), Storybook (82 files, 236 tests), and performance comparison (5 tests) passed
- Chrome DevTools mobile emulation at 412 × 915 and DPR 2.625: all four system-theme/Chatto-theme combinations produced one unqualified tag with the expected value; the served manifest contained no `theme_color`
- outstanding device check: deploy to Chrome 152 for Android, reinstall the PWA so WebAPK metadata is replaced immediately, and verify all four combinations

## Rollout

The manifest field is optional and the document supplies its replacement before first paint. Existing installations can receive the document fix normally; reinstalling is recommended for immediate WebAPK metadata replacement.

## Related PR

- Release 0.4 fix: #2285