### PR TITLE
fix(frontend): synchronize PWA chrome with display theme

### DIFF
--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -2,6 +2,7 @@
 <html lang="en" dir="ltr" style="color-scheme: light">
   <head>
     <meta charset="utf-8" />
+    <meta name="theme-color" content="#e5e7eb" />
     <script>
       // Resolve and apply shell preferences as early as possible — before CSS
       // loads — so:
@@ -40,6 +41,9 @@
           // Pre-CSS background hint, mirrors --color-background.
           root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
           root.style.colorScheme = effective;
+          document
+            .querySelector('meta[name="theme-color"]')
+            ?.setAttribute('content', effective === 'dark' ? '#262626' : '#e5e7eb');
         }
 
         function applyLocale() {
@@ -73,8 +77,6 @@
       content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content"
     />
     <meta name="description" content="Real-time chat application" />
-    <meta name="theme-color" media="(prefers-color-scheme: light)" content="#e5e7eb" />
-    <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#262626" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.webmanifest" />

--- a/apps/frontend/src/appHtml.spec.ts
+++ b/apps/frontend/src/appHtml.spec.ts
@@ -12,13 +12,14 @@ const themeScript = appHtml.match(/<script>\s*([\s\S]*?)\s*<\/script>/i)?.[1];
 
 type WebAppManifest = {
   icons?: Array<{ src?: string; sizes?: string; type?: string; purpose?: string }>;
+  theme_color?: string;
 };
 
-function metaContent(name: string, mediaFragment: string): string | null {
-  const tag = appHtml.match(
-    new RegExp(`<meta\\s+[^>]*name="${name}"[^>]*media="[^"]*${mediaFragment}[^"]*"[^>]*>`, 'i')
-  )?.[0];
+function metaTags(name: string): string[] {
+  return appHtml.match(new RegExp(`<meta\\s+[^>]*name="${name}"[^>]*>`, 'gi')) ?? [];
+}
 
+function metaContent(tag: string): string | null {
   return tag?.match(/\bcontent="([^"]+)"/i)?.[1] ?? null;
 }
 
@@ -81,9 +82,19 @@ function runThemeScript({
     lang?: string;
     dir?: string;
   } = { dataset: {}, style: {} };
+  const themeColor = {
+    content: '#e5e7eb',
+    setAttribute: (_name: string, value: string) => {
+      themeColor.content = value;
+    }
+  };
 
   runInNewContext(themeScript, {
-    document: { documentElement: root },
+    document: {
+      documentElement: root,
+      querySelector: (selector: string) =>
+        selector === 'meta[name="theme-color"]' ? themeColor : null
+    },
     localStorage: {
       getItem: (key: string) => storage.get(key) ?? null
     },
@@ -104,6 +115,7 @@ function runThemeScript({
 
   return {
     root,
+    themeColor,
     changeSystemTheme(systemTheme: 'light' | 'dark') {
       dark = systemTheme === 'dark';
       changeHandler?.();
@@ -112,9 +124,13 @@ function runThemeScript({
 }
 
 describe('app.html metadata', () => {
-  it('defines theme colors matching the outer frame background colors', () => {
-    expect(metaContent('theme-color', 'light')).toBe('#e5e7eb');
-    expect(metaContent('theme-color', 'dark')).toBe('#262626');
+  it('defines one document-controlled theme color without a manifest override', () => {
+    const tags = metaTags('theme-color');
+
+    expect(tags).toHaveLength(1);
+    expect(metaContent(tags[0])).toBe('#e5e7eb');
+    expect(tags[0]).not.toMatch(/\bmedia=/i);
+    expect(manifest.theme_color).toBeUndefined();
   });
 
   it('declares the Safari apple touch icon with an explicit size', () => {
@@ -177,7 +193,7 @@ describe('app.html metadata', () => {
 
 describe('app.html theme bootstrap', () => {
   it('reads chatto:preferences.displayTheme before legacy localStorage.theme', () => {
-    const { root } = runThemeScript({
+    const { root, themeColor } = runThemeScript({
       preferences: { displayTheme: 'light' },
       legacyTheme: 'dark',
       systemDark: true
@@ -186,28 +202,32 @@ describe('app.html theme bootstrap', () => {
     expect(root.dataset.theme).toBe('light');
     expect(root.style.backgroundColor).toBe('#f3f4f6');
     expect(root.style.colorScheme).toBe('light');
+    expect(themeColor.content).toBe('#e5e7eb');
   });
 
   it('uses legacy localStorage.theme when no display preference exists', () => {
-    const { root } = runThemeScript({ legacyTheme: 'dark', systemDark: false });
+    const { root, themeColor } = runThemeScript({ legacyTheme: 'dark', systemDark: false });
     expect(root.dataset.theme).toBe('dark');
     expect(root.style.colorScheme).toBe('dark');
+    expect(themeColor.content).toBe('#262626');
   });
 
   it('follows prefers-color-scheme when the display preference is system', () => {
-    const { root } = runThemeScript({
+    const { root, themeColor } = runThemeScript({
       preferences: { displayTheme: 'system' },
       systemDark: true
     });
 
     expect(root.dataset.theme).toBe('dark');
     expect(root.style.colorScheme).toBe('dark');
+    expect(themeColor.content).toBe('#262626');
   });
 
   it('follows prefers-color-scheme when no display preference exists', () => {
-    const { root } = runThemeScript({ systemDark: true });
+    const { root, themeColor } = runThemeScript({ systemDark: true });
     expect(root.dataset.theme).toBe('dark');
     expect(root.style.colorScheme).toBe('dark');
+    expect(themeColor.content).toBe('#262626');
   });
 
   it('only reacts to system theme changes while the display preference is system', () => {
@@ -217,6 +237,7 @@ describe('app.html theme bootstrap', () => {
     });
     system.changeSystemTheme('dark');
     expect(system.root.dataset.theme).toBe('dark');
+    expect(system.themeColor.content).toBe('#262626');
 
     const explicit = runThemeScript({
       preferences: { displayTheme: 'light' },
@@ -224,6 +245,7 @@ describe('app.html theme bootstrap', () => {
     });
     explicit.changeSystemTheme('dark');
     expect(explicit.root.dataset.theme).toBe('light');
+    expect(explicit.themeColor.content).toBe('#e5e7eb');
   });
 });
 

--- a/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.spec.ts
@@ -28,6 +28,7 @@ describe('UserPreferencesState', () => {
     delete document.documentElement.dataset.theme;
     document.documentElement.style.backgroundColor = '';
     document.documentElement.style.colorScheme = '';
+    document.head.innerHTML = '<meta name="theme-color" content="#e5e7eb" />';
   });
 
   describe('initial state', () => {
@@ -183,21 +184,24 @@ describe('UserPreferencesState', () => {
       {
         displayTheme: 'light' as const,
         effectiveTheme: 'light' as const,
-        background: 'rgb(243, 244, 246)'
+        background: 'rgb(243, 244, 246)',
+        themeColor: '#e5e7eb'
       },
       {
         displayTheme: 'dark' as const,
         effectiveTheme: 'dark' as const,
-        background: 'rgb(23, 23, 23)'
+        background: 'rgb(23, 23, 23)',
+        themeColor: '#262626'
       },
       {
         displayTheme: 'system' as const,
         effectiveTheme: 'dark' as const,
-        background: 'rgb(23, 23, 23)'
+        background: 'rgb(23, 23, 23)',
+        themeColor: '#262626'
       }
     ])(
       'updates, persists, and applies the $displayTheme display theme',
-      ({ displayTheme, effectiveTheme, background }) => {
+      ({ displayTheme, effectiveTheme, background, themeColor }) => {
         mockSystemTheme('dark');
         const state = new UserPreferencesState();
 
@@ -207,6 +211,9 @@ describe('UserPreferencesState', () => {
         expect(document.documentElement.dataset.theme).toBe(effectiveTheme);
         expect(document.documentElement.style.backgroundColor).toBe(background);
         expect(document.documentElement.style.colorScheme).toBe(effectiveTheme);
+        expect(document.querySelector<HTMLMetaElement>('meta[name="theme-color"]')?.content).toBe(
+          themeColor
+        );
 
         const stored = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '{}');
         expect(stored.displayTheme).toBe(displayTheme);

--- a/apps/frontend/src/lib/state/userPreferences.svelte.ts
+++ b/apps/frontend/src/lib/state/userPreferences.svelte.ts
@@ -81,6 +81,9 @@ export function applyDisplayTheme(theme: DisplayTheme): void {
   root.dataset.theme = effective;
   root.style.backgroundColor = effective === 'dark' ? '#171717' : '#f3f4f6';
   root.style.colorScheme = effective;
+  document
+    .querySelector<HTMLMetaElement>('meta[name="theme-color"]')
+    ?.setAttribute('content', effective === 'dark' ? '#262626' : '#e5e7eb');
 }
 
 function normalizeNotificationSoundFilters(value: unknown): NotificationSoundFilters {

--- a/apps/frontend/static/manifest.webmanifest
+++ b/apps/frontend/static/manifest.webmanifest
@@ -10,7 +10,6 @@
   "display": "standalone",
   "display_override": ["standalone", "browser"],
   "background_color": "#f3f4f6",
-  "theme_color": "#e5e7eb",
   "categories": ["communication", "social", "productivity"],
   "prefer_related_applications": false,
   "icons": [


### PR DESCRIPTION
## Why

Chrome 152 can prefer the installed WebAPK manifest theme colour over media-qualified document tags. This makes the Android PWA status area light even when Chatto uses its dark display theme.

This backports #2286 to the 0.4 release line.

## What changed

- Remove the fixed manifest theme colour while keeping the installation splash background colour.
- Replace the two media-qualified theme-colour tags with one document-controlled tag before the bootstrap script.
- Synchronize that tag with the effective light or dark theme during bootstrap and runtime preference changes.
- Add metadata, bootstrap, and preference-store coverage for the synchronized colour.
- Keep viewport, safe-area, and layout behaviour unchanged.

## Test plan

- Svelte autofixer: passed with no issues or suggestions.
- Targeted metadata and preference tests: 40 passed.
- `mise test-frontend`: 195 files and 2,032 tests passed. The first run was invalidated by a one-time Vite dependency re-optimization after switching branches; the warmed rerun passed.
- Chrome DevTools mobile emulation in dark mode: verified one unqualified theme-colour tag with `#262626`; verified that the manifest has no theme colour and retains `background_color: #f3f4f6`.

## Rollout

Installed Android PWAs may need reinstallation before cached WebAPK manifest metadata is replaced immediately. No data migration, public API change, or security impact.