### PR TITLE
fix(frontend): adapt dialog width to footer actions

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -104,15 +104,17 @@ plane, or a footer divider inside this structure.
 
 Pass footer buttons directly to the `Dialog` footer snippet. `Dialog` owns the
 horizontal, end-aligned layout. The actions always stay in one row. A button
-label truncates when the viewport cannot show the full label. Put Cancel
-first. Use `secondary` for Cancel, `action` for the recommended path, and a
-semantic tone such as `danger` only when the action has that meaning. Use an
-action-specific icon on the committing action. Do not add an icon to Cancel by
-default.
+label can expand the dialog beyond its baseline size when the viewport has
+room. The label truncates only when the viewport cannot show the full action
+row. Put Cancel first. Use `secondary` for Cancel, `action` for the recommended
+path, and a semantic tone such as `danger` only when the action has that
+meaning. Use an action-specific icon on the committing action. Do not add an
+icon to Cancel by default.
 
-Use the `sm` size for short confirmations, `md` for ordinary custom dialogs,
-and `lg` for dense content such as screen selection. Keep the standard
-viewport gutter. Do not add a feature-specific width to a task dialog.
+Use the `sm` baseline size for short confirmations, `md` for ordinary custom
+dialogs, and `lg` for dense content such as screen selection. Footer actions
+can make each size wider. Keep the standard viewport gutter. Do not add a
+feature-specific width to a task dialog.
 
 `ImageModal`, fullscreen video, `QuickSwitcher`, popovers, and `BottomSheet`
 are specialized overlays. They can use their own geometry because they do not

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -311,9 +311,13 @@
   @apply max-w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap;
 }
 
-/* Dialog actions form one stable row. Buttons can surrender label width in a
- * narrow viewport, but they never wrap or force a second action row. */
+/* Dialog actions form one stable row. Their natural width can expand the
+ * dialog, while the viewport limit makes buttons surrender label width on a
+ * narrow screen. Actions never wrap or force a second row. */
 @utility dialog-actions {
+  width: max-content;
+  max-width: 100%;
+  align-self: flex-end;
   @apply mt-6 flex min-w-0 shrink-0 flex-nowrap justify-end gap-2;
 
   & > :is(button, a) {

--- a/apps/frontend/src/lib/ui/Dialog.stories.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.stories.svelte
@@ -28,7 +28,7 @@
   let dialogWithFooterVisible = $state(false);
   let referenceDialogVisible = $state(false);
   let longDialogVisible = $state(false);
-  let narrowDialogVisible = $state(false);
+  let adaptiveDialogVisible = $state(false);
 </script>
 
 <Story
@@ -118,30 +118,33 @@
 </Story>
 
 <Story
-  name="Narrow action truncation"
+  name="Adaptive action width"
   asChild
   parameters={{
     docs: {
       description: {
         story:
-          'Resize the canvas to a narrow viewport. Actions stay in one row and long labels truncate before the row can wrap.'
+          'German action labels expand the dialog when space is available. Resize the canvas to a narrow viewport to see labels truncate without wrapping the action row.'
       }
     }
   }}
 >
-  <Button onclick={() => (narrowDialogVisible = true)}>Open narrow dialog</Button>
+  <Button onclick={() => (adaptiveDialogVisible = true)}>Open adaptive dialog</Button>
 
-  <Dialog bind:visible={narrowDialogVisible} title="Choose Destination" size="md">
-    <p class="text-muted">Choose where Chatto should post this message.</p>
+  <Dialog bind:visible={adaptiveDialogVisible} title="Im vorherigen Thread fortfahren?" size="md">
+    <p class="text-muted">
+      Deine vorherige Nachricht hat bereits einen Thread. Wohin soll diese Nachricht gesendet
+      werden?
+    </p>
 
     {#snippet footer()}
-      <Button variant="secondary" onclick={() => (narrowDialogVisible = false)}>Cancel</Button>
-      <Button variant="secondary" onclick={() => (narrowDialogVisible = false)}>
-        Post as a Completely New Message
+      <Button variant="secondary" onclick={() => (adaptiveDialogVisible = false)}>Abbrechen</Button>
+      <Button variant="secondary" onclick={() => (adaptiveDialogVisible = false)}>
+        Als neue Nachricht senden
       </Button>
-      <Button defaultAction onclick={() => (narrowDialogVisible = false)}>
+      <Button defaultAction onclick={() => (adaptiveDialogVisible = false)}>
         <span class="iconify icon-[uil--comment-alt-lines]"></span>
-        Continue in the Existing Thread
+        Im Thread fortfahren
       </Button>
     {/snippet}
   </Dialog>
@@ -222,9 +225,7 @@
     </p>
 
     {#snippet footer()}
-      <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
-        Cancel
-      </Button>
+      <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>Cancel</Button>
       <Button variant="secondary" onclick={() => (dialogWithFooterVisible = false)}>
         Post as new message
       </Button>

--- a/apps/frontend/src/lib/ui/Dialog.svelte
+++ b/apps/frontend/src/lib/ui/Dialog.svelte
@@ -5,7 +5,9 @@ The standard task-dialog shell. It owns the framed tray, inset work plane,
 fixed header and footer, scrollable body, focus behavior, and dismissal.
 
 Pass footer actions as direct children of the `footer` snippet. The dialog
-owns their single-line, end-aligned layout and truncates labels when needed.
+owns their single-line, end-aligned layout. The selected size is the baseline
+width. Footer actions can make the dialog wider when the viewport has room;
+labels truncate only after the dialog reaches its viewport limit.
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
@@ -47,10 +49,10 @@ owns their single-line, end-aligned layout and truncates labels when needed.
   const dialogId = $props.id();
   const titleId = `${dialogId}-title`;
 
-  const sizeClasses = {
-    sm: 'w-100 max-w-[calc(100vw-2rem)]',
-    md: 'w-150 max-w-[calc(100vw-2rem)]',
-    lg: 'w-200 max-w-[calc(100vw-2rem)]'
+  const sizeWidths = {
+    sm: '400px',
+    md: '600px',
+    lg: '800px'
   };
 
   function getDefaultAction(node: ParentNode): HTMLButtonElement | null {
@@ -107,12 +109,7 @@ owns their single-line, end-aligned layout and truncates labels when needed.
   }
 
   function handleKeydown(event: KeyboardEvent) {
-    if (
-      event.key !== 'Enter' ||
-      event.defaultPrevented ||
-      event.isComposing ||
-      event.repeat
-    ) {
+    if (event.key !== 'Enter' || event.defaultPrevented || event.isComposing || event.repeat) {
       return;
     }
 
@@ -168,7 +165,7 @@ owns their single-line, end-aligned layout and truncates labels when needed.
       close();
     }
   }}
-  class="m-auto bg-transparent backdrop:bg-black/50 {sizeClasses[size]}"
+  class="m-auto w-fit max-w-[calc(100vw-2rem)] bg-transparent backdrop:bg-black/50"
   class:closing
   aria-labelledby={title ? titleId : undefined}
   aria-describedby={describedBy}
@@ -183,16 +180,22 @@ owns their single-line, end-aligned layout and truncates labels when needed.
   -->
   {#if visible || closing}
     <div
-      class="flex max-h-[calc(100dvh-2rem)] flex-col overflow-hidden rounded-lg border border-text/10 bg-surface p-2 shadow-xl sm:max-h-[78vh]"
+      class="dialog-frame flex max-h-[calc(100dvh-2rem)] w-max max-w-full flex-col overflow-hidden rounded-lg border border-text/10 bg-surface p-2 shadow-xl sm:max-h-[78vh]"
+      style:--dialog-baseline-width={sizeWidths[size]}
     >
-      <div class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-md bg-background p-3">
+      <div
+        class="flex min-h-0 w-max max-w-full min-w-full flex-1 flex-col overflow-hidden rounded-md bg-background p-3"
+      >
         <!--
           Header row holds the title (if any) and the close button, so
           they share a baseline and the title is not indented relative to
           the body content.
         -->
         <header
-          class={['flex shrink-0 items-center justify-between gap-3', title ? 'mb-4' : 'mb-2']}
+          class={[
+            'flex w-0 min-w-full shrink-0 items-center justify-between gap-3',
+            title ? 'mb-4' : 'mb-2'
+          ]}
         >
           {#if title}
             <h2 id={titleId} class="text-xl font-semibold text-balance text-text-top">{title}</h2>
@@ -209,7 +212,7 @@ owns their single-line, end-aligned layout and truncates labels when needed.
           </button>
         </header>
 
-        <div class="min-h-0 overflow-y-auto text-text">
+        <div class="min-h-0 w-0 min-w-full overflow-y-auto text-text">
           {@render children()}
         </div>
 
@@ -224,6 +227,15 @@ owns their single-line, end-aligned layout and truncates labels when needed.
 </dialog>
 
 <style>
+  dialog {
+    border: 0;
+    padding: 0;
+  }
+
+  .dialog-frame {
+    min-width: min(var(--dialog-baseline-width), calc(100vw - 2rem));
+  }
+
   dialog[open] {
     animation: fade-in 100ms ease-out;
   }

--- a/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/Dialog.svelte.spec.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import '../../app.css';
+import { page } from 'vitest/browser';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { flushSync } from 'svelte';
 import Dialog from './Dialog.svelte';
@@ -18,6 +20,10 @@ const FRAME = 'dialog > div';
 const WELL = `${FRAME} > div`;
 
 describe('Dialog', () => {
+  beforeEach(async () => {
+    await page.viewport(1280, 720);
+  });
+
   describe('dialog element', () => {
     it('renders a dialog element', async () => {
       const { container } = renderDialog({
@@ -63,34 +69,84 @@ describe('Dialog', () => {
   });
 
   describe('size classes', () => {
-    it('applies medium size class by default', async () => {
+    it('uses the medium size as its default baseline', async () => {
       const { container } = renderDialog({
         visible: true,
         children: testSnippet('<span>Content</span>')
       });
 
-      await expect.element(q(container, 'dialog')).toHaveClass('w-150');
+      expect(q(container, FRAME)?.style.getPropertyValue('--dialog-baseline-width')).toBe(
+        '600px'
+      );
     });
 
-    it('applies small size class when size is sm', async () => {
+    it('uses the small size as its baseline when size is sm', async () => {
       const { container } = renderDialog({
         visible: true,
         size: 'sm',
         children: testSnippet('<span>Content</span>')
       });
 
-      await expect.element(q(container, 'dialog')).toHaveClass('w-100');
+      expect(q(container, FRAME)?.style.getPropertyValue('--dialog-baseline-width')).toBe('400px');
       await expect.element(q(container, 'dialog')).toHaveClass('max-w-[calc(100vw-2rem)]');
     });
 
-    it('applies large size class when size is lg', async () => {
+    it('uses the large size as its baseline when size is lg', async () => {
       const { container } = renderDialog({
         visible: true,
         size: 'lg',
         children: testSnippet('<span>Content</span>')
       });
 
-      await expect.element(q(container, 'dialog')).toHaveClass('w-200');
+      expect(q(container, FRAME)?.style.getPropertyValue('--dialog-baseline-width')).toBe('800px');
+    });
+
+    it('keeps a short-action medium dialog at its baseline width', () => {
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span>Content</span>'),
+        footer: testSnippet('<button>Continue</button>')
+      });
+
+      expect(q(container, FRAME)?.offsetWidth).toBe(600);
+    });
+
+    it('expands beyond its baseline to show long footer actions', () => {
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span>Content</span>'),
+        footer: testSnippet(
+          '<button><span class="button-content">Im vorherigen außergewöhnlich langen Diskussionsthread mit allen bisherigen Nachrichten fortfahren</span></button>'
+        )
+      });
+
+      const dialog = q(container, 'dialog') as HTMLDialogElement;
+      const footer = dialog.querySelector('footer') as HTMLElement;
+      expect(dialog.offsetWidth).toBeGreaterThan(600);
+      for (const label of footer.querySelectorAll('button > span')) {
+        expect(label.scrollWidth).toBe(label.clientWidth);
+      }
+    });
+
+    it('clamps to the viewport and truncates long actions on narrow screens', async () => {
+      await page.viewport(425, 720);
+      const { container } = renderDialog({
+        visible: true,
+        children: testSnippet('<span>Content</span>'),
+        footer: testSnippet(
+          '<button><span class="button-content">Im vorherigen außergewöhnlich langen Diskussionsthread mit allen bisherigen Nachrichten fortfahren</span></button>'
+        )
+      });
+
+      const dialog = q(container, 'dialog') as HTMLDialogElement;
+      const footer = dialog.querySelector('footer') as HTMLElement;
+      const label = footer.querySelector('button > span') as HTMLElement;
+      const viewportGutter = 2 * Number.parseFloat(getComputedStyle(document.documentElement).fontSize);
+      expect(dialog.offsetWidth).toBe(window.innerWidth - viewportGutter);
+      expect(getComputedStyle(footer).flexWrap).toBe('nowrap');
+      expect(getComputedStyle(label).overflow).toBe('hidden');
+      expect(getComputedStyle(label).textOverflow).toBe('ellipsis');
+      expect(getComputedStyle(label).whiteSpace).toBe('nowrap');
     });
   });
 
@@ -169,6 +225,11 @@ describe('Dialog', () => {
       await expect.element(footer).not.toHaveClass('flex-wrap');
       expect(footer?.querySelectorAll('button')).toHaveLength(1);
       expect(getComputedStyle(footer!).flexWrap).toBe('nowrap');
+      expect(getComputedStyle(footer!).maxWidth).toBe('100%');
+      expect(getComputedStyle(footer!).alignSelf).toBe('flex-end');
+      expect(footer!.getBoundingClientRect().width).toBeLessThan(
+        q(container, WELL)!.getBoundingClientRect().width
+      );
     });
   });
 
@@ -208,7 +269,9 @@ describe('Dialog', () => {
       const defaultAction = vi.fn();
       q(container, '[data-dialog-default]')?.addEventListener('click', defaultAction);
 
-      q(container, 'dialog')?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+      q(container, 'dialog')?.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+      );
 
       expect(defaultAction).toHaveBeenCalledOnce();
     });
@@ -244,7 +307,9 @@ describe('Dialog', () => {
       const defaultAction = vi.fn();
       q(container, '[data-dialog-default]')?.addEventListener('click', defaultAction);
 
-      q(container, 'dialog')?.dispatchEvent(new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' }));
+      q(container, 'dialog')?.dispatchEvent(
+        new KeyboardEvent('keydown', { bubbles: true, key: 'Enter' })
+      );
 
       expect(defaultAction).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
## Why

Localized dialog actions can exceed the fixed baseline width and truncate even when the viewport has room.

## What changed

- Standard dialogs now treat `sm`, `md`, and `lg` as baseline widths, expand to fit footer actions, and retain the viewport clamp and single-row fallback.
- Dialog tests, the German Storybook example, and design-system guidance cover the adaptive behavior.

## API compatibility

- No public API or protocol behaviour changed.

Older client → newer server: Not applicable.

Newer client → older server: Not applicable.

Capability discovery or minimum client/server version: Not applicable.

## Test plan

- `mise lint-frontend` passed with zero errors and warnings; `mise test-frontend` passed 1,363 server tests, 2,017 browser tests, 236 Storybook tests, and 5 performance-comparison tests.
- Chrome DevTools confirmed complete German labels at 1000 px and a 15 px gutter, one action row, and label truncation at 375 px.
