### PR TITLE
fix(frontend): unify sidebar drop target frames

### DIFF
--- a/apps/frontend/e2e/room-layout.test.ts
+++ b/apps/frontend/e2e/room-layout.test.ts
@@ -401,6 +401,21 @@ async function dragWithPointer(
   await page.mouse.move(targetX, targetY, { steps: 12 });
 }
 
+async function expectActiveSidebarDropTarget(target: Locator): Promise<void> {
+  await expect(target).toHaveClass(/sidebar-drop-target-active/);
+  await expect(target).toHaveCSS('outline-width', '2px');
+  await expect(target).toHaveCSS('outline-offset', '-2px');
+  await expect(target).toHaveCSS('outline-style', 'dashed');
+  await expect(target).toHaveCSS('border-radius', '6px');
+  await expect(target).toHaveCSS('transition-property', 'outline-color');
+  await expect(target).toHaveCSS('transition-duration', '0.12s');
+}
+
+async function expectInactiveSidebarDropTarget(target: Locator): Promise<void> {
+  await expect(target).not.toHaveClass(/sidebar-drop-target-active/);
+  await expect(target).toHaveCSS('outline-color', 'rgba(0, 0, 0, 0)');
+}
+
 // ============================================================================
 // Tests
 // ============================================================================
@@ -585,9 +600,10 @@ test.describe('Room Layout', () => {
         0.8
       );
 
-      await expect(
-        sidebarGroup(page, 'Projects').getByTestId('room-group-items-dropzone')
-      ).toHaveCSS('outline-style', 'dashed');
+      const projectsDropTarget = sidebarGroup(page, 'Projects').getByTestId(
+        'room-group-items-dropzone'
+      );
+      await expectActiveSidebarDropTarget(projectsDropTarget);
       await expect(
         sidebarGroup(page, 'Projects').locator('[data-is-dnd-shadow-item-hint="true"]')
       ).toHaveCount(1);
@@ -595,6 +611,7 @@ test.describe('Room Layout', () => {
       await expect(sidebarGroup(page, 'Main')).toBeVisible();
       await expect(sidebarGroup(page, 'Projects')).toBeVisible();
       await page.mouse.up();
+      await expectInactiveSidebarDropTarget(projectsDropTarget);
 
       await expect(async () => {
         const layout = await getAdminRoomLayoutViaAPI(page);
@@ -702,7 +719,10 @@ test.describe('Room Layout', () => {
         0.01
       );
 
-      await expect(landingIndicator).toHaveCSS('outline-style', 'dashed');
+      await expectActiveSidebarDropTarget(landingIndicator);
+      await page.emulateMedia({ reducedMotion: 'reduce' });
+      await expect(landingIndicator).toHaveCSS('transition-duration', '0s');
+      await page.emulateMedia({ reducedMotion: 'no-preference' });
       await expect(
         landingIndicator.locator(':scope > [data-is-dnd-shadow-item-hint="true"]')
       ).toHaveCount(1);
@@ -716,6 +736,7 @@ test.describe('Room Layout', () => {
         'true'
       );
       await page.mouse.up();
+      await expectInactiveSidebarDropTarget(landingIndicator);
 
       await expect(async () => {
         const layout = await getAdminRoomLayoutViaAPI(page);

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -797,6 +797,25 @@
   @apply ring-2 ring-text;
 }
 
+/* Sidebar drag targets keep their frame mounted so outline-colour changes can
+ * fade both in and out when svelte-dnd-action toggles the active class. */
+.sidebar-drop-target {
+  border-radius: 0.375rem;
+  outline: 2px dashed transparent;
+  outline-offset: -2px;
+  transition: outline-color 120ms ease;
+}
+
+.sidebar-drop-target-active {
+  outline-color: var(--color-action);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sidebar-drop-target {
+    transition: none;
+  }
+}
+
 /* Make ServerLogo slightly smaller inside server-icon to leave room for the ring */
 .server-icon > div {
   @apply h-11 w-11;

--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -130,14 +130,17 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 
   const dndHandleAttachment = fromAction(dragHandle);
 
+  // The empty style disables the library's solid default. The global classes
+  // keep the frame mounted so its colour can fade in both directions.
+  const sidebarDropTargetOptions = {
+    dropTargetStyle: {},
+    dropTargetClasses: ['sidebar-drop-target-active']
+  };
+
   const groupDragZoneAttachment = fromAction(dragHandleZone, () => ({
     items: renderManagedSections,
     flipDurationMs: 160,
-    dropTargetStyle: {
-      outline: '1px dashed var(--color-action)',
-      'outline-offset': '-1px',
-      'border-radius': '0.375rem'
-    },
+    ...sidebarDropTargetOptions,
     type: 'sidebar-room-groups'
   }));
 
@@ -187,11 +190,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
     const zoneAttachment = fromAction(dragHandleZone, () => ({
       items: managedSections.find((section) => section.group.id === groupId)?.items ?? [],
       flipDurationMs: 160,
-      dropTargetStyle: {
-        outline: '2px dashed var(--color-action)',
-        'outline-offset': '-2px',
-        'border-radius': '0.375rem'
-      },
+      ...sidebarDropTargetOptions,
       type: 'sidebar-room-items'
     }));
     const attachment: Attachment<HTMLDivElement> = (node) => {
@@ -972,6 +971,7 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
 {:else}
   <nav class="room-list md:w-full">
     <div
+      class={supportsRelativeSidebarMoves && canReorderGroups ? 'sidebar-drop-target' : undefined}
       data-testid={supportsRelativeSidebarMoves && canReorderGroups
         ? 'room-groups-dropzone'
         : undefined}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -1211,6 +1211,7 @@ describe('RoomList', () => {
     expect(control.previousElementSibling?.getAttribute('data-testid')).toBe(
       'room-groups-dropzone'
     );
+    expect(control.previousElementSibling?.classList).toContain('sidebar-drop-target');
     expect(control.nextElementSibling?.getAttribute('data-testid')).toBe('room-group-section');
   });
 

--- a/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte
+++ b/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte
@@ -155,7 +155,11 @@ navigation, member presence groups, and attachment date groups.
 
     {#if visibleItems.length > 0 || (itemsAttachment && !collapsed)}
       <div
-        class={['flex flex-col gap-0.5', visibleItems.length === 0 ? 'min-h-8' : '']}
+        class={[
+          'flex flex-col gap-0.5',
+          visibleItems.length === 0 ? 'min-h-8' : '',
+          itemsAttachment ? 'sidebar-drop-target' : ''
+        ]}
         data-testid={itemsAttachment ? 'room-group-items-dropzone' : undefined}
         {@attach itemsAttachment}
       >

--- a/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte.spec.ts
@@ -82,6 +82,7 @@ describe('RoomGroupSection', () => {
     const dropzone = q(container, '[data-testid="room-group-items-dropzone"]');
     await expect.element(dropzone).toBeInTheDocument();
     expect(dropzone?.classList).toContain('min-h-8');
+    expect(dropzone?.classList).toContain('sidebar-drop-target');
     expect(itemsAttachment).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Why

Room-group drop targets looked thinner than room drop targets, and both frames appeared and disappeared abruptly.

## What changed

- Unified both sidebar drop targets on one 2px dashed, inset, rounded frame.
- Added a 120ms outline-colour fade in both directions and disabled it for reduced motion.
- Expanded component and end-to-end coverage for frame geometry, transitions, and inactive state.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `mise lint-frontend` — passed with no errors or warnings.
- Focused Vitest component tests — 55 passed.
- Targeted room-layout Playwright tests — 2 passed.
- Production frontend build, bundle checks, and CSP check — passed through the E2E setup.
- Chrome DevTools inspection in light and dark themes — passed, including fade timing.
