### PR TITLE
refactor(frontend): reuse lifecycle timer components

### DIFF
--- a/apps/frontend/src/lib/components/MessageContent.svelte
+++ b/apps/frontend/src/lib/components/MessageContent.svelte
@@ -16,6 +16,7 @@
   import { m } from '$lib/i18n/messages';
   import { formatDateTime, type TimeFormatSettings } from '$lib/utils/formatTime';
   import { SvelteDate } from 'svelte/reactivity';
+  import Interval from '$lib/lifecycle/Interval.svelte';
 
   const fallbackTimestampSettings: TimeFormatSettings = {
     get effectiveTimezone() {
@@ -65,19 +66,6 @@
       ? formatRelativeMessageTimestamp(activeTimestamp.date, activeTimestampLocale, liveNow)
       : ''
   );
-
-  $effect(() => {
-    if (!activeTimestamp) return;
-
-    liveNow.setTime(Date.now());
-    const interval = window.setInterval(() => {
-      liveNow.setTime(Date.now());
-    }, 1000);
-
-    return () => {
-      window.clearInterval(interval);
-    };
-  });
 
   function injectMessageStateMarkers(
     html: string,
@@ -168,6 +156,7 @@
       if (!Number.isSafeInteger(epochSeconds)) return;
       event.preventDefault();
       const rect = timestamp.getBoundingClientRect();
+      liveNow.setTime(Date.now());
       activeTimestamp = {
         epochSeconds,
         date: new Date(epochSeconds * 1000),
@@ -232,6 +221,7 @@
 </div>
 
 {#if activeTimestamp}
+  <Interval milliseconds={1000} ontick={() => liveNow.setTime(Date.now())} />
   <ContextMenu
     anchor={activeTimestamp.anchor}
     role="dialog"

--- a/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/MessageContent.svelte.spec.ts
@@ -491,7 +491,7 @@ describe('MessageContent component', () => {
 
   it('updates the relative timestamp detail while the popover is open', async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2025-04-27T14:29:59Z'));
+    vi.setSystemTime(new Date('2025-04-27T14:28:59Z'));
     const { container } = render(MessageContent, {
       props: {
         body: 'Call at <t:1745764200:F>',
@@ -501,6 +501,8 @@ describe('MessageContent component', () => {
     });
 
     await expect.poll(() => q(container, 'button.message-timestamp')).toBeTruthy();
+    // Opening the details must use the current time, even after an idle minute.
+    await vi.advanceTimersByTimeAsync(60_000);
     (q(container, 'button.message-timestamp') as HTMLButtonElement).click();
 
     await expect

--- a/apps/frontend/src/lib/components/UserCustomStatusBadge.svelte
+++ b/apps/frontend/src/lib/components/UserCustomStatusBadge.svelte
@@ -11,8 +11,7 @@ independent of presence and hides itself after its expiry timestamp.
 <script lang="ts">
   import type { CustomUserStatus } from '$lib/state/userProfiles.svelte';
   import { formatCustomStatusText } from '$lib/customStatusTemplates';
-
-  const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
+  import Deadline from '$lib/lifecycle/Deadline.svelte';
 
   let {
     status,
@@ -36,31 +35,12 @@ independent of presence and hides itself after its expiry timestamp.
   const title = $derived(
     activeStatus ? `${activeStatus.emoji}${displayText ? ` ${displayText}` : ''}` : undefined
   );
-
-  $effect(() => {
-    const expiresAt = status?.expiresAt;
-    if (!expiresAt) return;
-    let timeout: ReturnType<typeof setTimeout> | undefined;
-
-    const schedule = () => {
-      const expiresAtMs = new Date(expiresAt).getTime();
-      if (Number.isNaN(expiresAtMs)) return;
-      const delay = expiresAtMs - Date.now();
-      if (delay <= 0) {
-        expiryTick += 1;
-        return;
-      }
-      timeout = setTimeout(schedule, Math.min(delay, MAX_TIMEOUT_DELAY_MS));
-    };
-
-    schedule();
-    return () => {
-      if (timeout) clearTimeout(timeout);
-    };
-  });
 </script>
 
 {#if activeStatus}
+  {#if activeStatus.expiresAt}
+    <Deadline at={activeStatus.expiresAt} onreached={() => (expiryTick += 1)} />
+  {/if}
   <span
     class={[
       'inline-flex min-w-0 shrink-0 items-center align-middle leading-none',

--- a/apps/frontend/src/lib/components/UserCustomStatusBadge.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/UserCustomStatusBadge.svelte.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import UserCustomStatusBadge from './UserCustomStatusBadge.svelte';
+
+describe('custom status expiry', () => {
+  beforeEach(() => {
+    // Keep animation frames real so Svelte's async tick can finish during rerender.
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    vi.setSystemTime(new Date('2026-09-05T12:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('hides a status when its deadline is reached', async () => {
+    const rendered = render(UserCustomStatusBadge, {
+      props: {
+        status: {
+          emoji: '🌴',
+          text: 'On holiday',
+          expiresAt: new Date(Date.now() + 1000).toISOString()
+        },
+        showText: true
+      }
+    });
+
+    await expect.element(rendered.getByText('On holiday')).toBeVisible();
+    await vi.advanceTimersByTimeAsync(999);
+    await expect.element(rendered.getByText('On holiday')).toBeVisible();
+    await vi.advanceTimersByTimeAsync(1);
+    await expect.element(rendered.getByText('On holiday')).not.toBeInTheDocument();
+  });
+
+  it('uses a replacement status deadline and supports removal of expiry', async () => {
+    const initialTime = Date.now();
+    const rendered = render(UserCustomStatusBadge, {
+      props: {
+        status: {
+          emoji: '🌴',
+          text: 'On holiday',
+          expiresAt: new Date(initialTime + 1000).toISOString()
+        },
+        showText: true
+      }
+    });
+
+    await rendered.rerender({
+      status: {
+        emoji: '🌴',
+        text: 'On holiday',
+        expiresAt: new Date(initialTime + 2000).toISOString()
+      }
+    });
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect.element(rendered.getByText('On holiday')).toBeVisible();
+    await vi.advanceTimersByTimeAsync(1000);
+    await expect.element(rendered.getByText('On holiday')).not.toBeInTheDocument();
+
+    await rendered.rerender({
+      status: {
+        emoji: '🌴',
+        text: 'On holiday',
+        expiresAt: new Date(Date.now() + 1000).toISOString()
+      }
+    });
+    await rendered.rerender({ status: { emoji: '🌴', text: 'On holiday' } });
+    await vi.advanceTimersByTimeAsync(2000);
+    await expect.element(rendered.getByText('On holiday')).toBeVisible();
+  });
+
+  it.each(['2026-09-05T11:59:59Z', 'invalid'])(
+    'does not display a status with expiry %s',
+    async (expiresAt) => {
+      const rendered = render(UserCustomStatusBadge, {
+        props: { status: { emoji: '🌴', text: 'On holiday', expiresAt }, showText: true }
+      });
+      await expect.element(rendered.getByText('On holiday')).not.toBeInTheDocument();
+    }
+  );
+});

--- a/apps/frontend/src/routes/chat/modals/ImageViewerModal.svelte
+++ b/apps/frontend/src/routes/chat/modals/ImageViewerModal.svelte
@@ -11,6 +11,7 @@
   import { assetUrlForServer } from '$lib/assets/assetUrls';
   import { serverConnectionManager } from '$lib/state/server/serverConnection.svelte';
   import ImageModal from '$lib/ui/ImageModal.svelte';
+  import Interval from '$lib/lifecycle/Interval.svelte';
 
   let {
     modal,
@@ -90,16 +91,14 @@
     });
   }
 
-  $effect(() => {
-    const interval = window.setInterval(() => {
-      refreshUrls().catch((error: unknown) => {
-        console.warn('Failed to refresh image viewer URLs', error);
-      });
-    }, URL_REFRESH_MS);
-
-    return () => window.clearInterval(interval);
-  });
+  function refreshImageUrls(): void {
+    void refreshUrls().catch((error: unknown) => {
+      console.warn('Failed to refresh image viewer URLs', error);
+    });
+  }
 </script>
+
+<Interval milliseconds={URL_REFRESH_MS} ontick={refreshImageUrls} />
 
 {#if modal.imageItems.length > 0}
   <ImageModal items={modal.imageItems} bind:index={currentIndex} {onclose} />

--- a/apps/frontend/src/routes/chat/modals/ImageViewerModal.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/modals/ImageViewerModal.svelte.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import type { ImageViewerModalState } from '$lib/modal';
+
+const mocks = vi.hoisted(() => ({
+  refreshUrls: vi.fn(async () => new Map()),
+  getAPI: vi.fn(() => ({})),
+  replaceState: vi.fn(),
+  page: { state: {} }
+}));
+
+vi.mock('$lib/state/server/registry.svelte', () => ({
+  serverRegistry: { getServer: () => undefined }
+}));
+vi.mock('$app/state', () => ({ page: mocks.page }));
+vi.mock('$app/navigation', () => ({ replaceState: mocks.replaceState }));
+vi.mock('$lib/state/server/serverConnection.svelte', () => ({
+  serverConnectionManager: { getClient: () => ({ getAPI: mocks.getAPI }) }
+}));
+vi.mock('$lib/attachments/attachmentUrls', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('$lib/attachments/attachmentUrls')>()),
+  refreshAttachmentUrlsForAssets: mocks.refreshUrls
+}));
+
+import ImageViewerModal from './ImageViewerModal.svelte';
+
+const refreshInterval = 22 * 60 * 60 * 1000;
+
+describe('image viewer URL refresh', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('refreshes attachment URLs periodically and stops after unmount', async () => {
+    vi.useFakeTimers();
+    const modal: ImageViewerModalState = {
+      type: 'imageViewer',
+      serverId: 'origin',
+      roomId: 'room-1',
+      eventId: 'event-1',
+      imageIndex: 0,
+      imageItems: [
+        {
+          id: 'image-1',
+          src: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7',
+          alt: 'Test image'
+        }
+      ]
+    };
+    const rendered = render(ImageViewerModal, { props: { modal, onclose: vi.fn() } });
+
+    await expect.element(rendered.getByRole('img', { name: 'Test image' })).toBeVisible();
+    await vi.advanceTimersByTimeAsync(refreshInterval - 1);
+    expect(mocks.refreshUrls).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(mocks.refreshUrls).toHaveBeenCalledOnce();
+    expect(mocks.refreshUrls).toHaveBeenLastCalledWith(
+      {},
+      'room-1',
+      ['image-1'],
+      expect.any(Object)
+    );
+    await vi.advanceTimersByTimeAsync(refreshInterval);
+    expect(mocks.refreshUrls).toHaveBeenCalledTimes(2);
+
+    await rendered.unmount();
+    await vi.advanceTimersByTimeAsync(refreshInterval);
+    expect(mocks.refreshUrls).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Why

Three frontend components repeat timer setup and cleanup that the shared lifecycle components already provide. Use those components to keep timer ownership consistent and preserve the current behavior.

## Changes

- Use `Deadline` for custom status expiry, including deadlines beyond the browser timeout limit.
- Use `Interval` for timestamp details while the popup is open. Update the clock immediately when the user opens the popup.
- Use `Interval` for the image viewer's 22-hour URL refresh. Preserve refresh error handling and modal identity checks.
- Add browser component coverage for status expiry, replacement deadlines, removal of expiry, invalid dates, periodic image refresh, and cancellation on unmount. Extend the timestamp test to open the popup after an idle minute.

## Test plan

Passed:

- `mise x -- pnpm --filter chatto-frontend exec vitest --run --project=client src/lib/lifecycle/timers.svelte.spec.ts src/lib/components/UserCustomStatusBadge.svelte.spec.ts src/lib/components/MessageContent.svelte.spec.ts -t 'lifecycle timers|custom status expiry|timestamp'` — 15 passed; 71 unrelated tests skipped.
- `mise x -- pnpm --filter chatto-frontend exec vitest --run --project=client src/routes/chat/modals/ImageViewerModal.svelte.spec.ts` — 1 passed.
- `mise lint-frontend` — Svelte check: zero errors and warnings; ESLint and design-system checks passed.
- `mise license-check` and `git diff --check`.
- Svelte autofixer on all three changed components: no issues. It reported an existing navigation suppression as potentially unused in `MessageContent`; repository ESLint passed with that suppression retained.
- Chrome DevTools: mounted the actual badge and message components in an isolated local browser surface. Confirmed badge expiry and live relative timestamp updates, with no console warnings or errors. Stopped the development stack after verification.

The full frontend and end-to-end suites were not run. The 22-hour image refresh was checked with fake timers and a mocked attachment refresh boundary.
