### PR TITLE
refactor(frontend): share message search presentation

### DIFF
--- a/apps/frontend/src/lib/components/search/SearchAvailability.svelte
+++ b/apps/frontend/src/lib/components/search/SearchAvailability.svelte
@@ -1,0 +1,76 @@
+<!--
+@component
+
+Shows search availability and retry controls. Renders children when search can
+be used. The owner can frame status content and set its loading-state layout.
+Request ownership stays with the caller.
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { ClassValue } from 'svelte/elements';
+  import { MessageSearchState } from '$lib/api-client/messageSearch';
+  import { m } from '$lib/i18n/messages';
+  import { EmptyState } from '$lib/ui';
+  import { Button } from '$lib/ui/form';
+
+  let {
+    state,
+    checking,
+    error,
+    onRetry,
+    checkingClass,
+    frame,
+    children
+  }: {
+    state: MessageSearchState;
+    checking: boolean;
+    error: boolean;
+    onRetry: () => void;
+    checkingClass: ClassValue;
+    /** Optional surface-owned frame for the status message. */
+    frame?: Snippet<[Snippet, boolean]>;
+    children: Snippet;
+  } = $props();
+
+  const unavailable = $derived(error || state === MessageSearchState.UNAVAILABLE);
+  const indexing = $derived(
+    state === MessageSearchState.STARTING || state === MessageSearchState.INDEXING
+  );
+</script>
+
+{#snippet statusContent()}
+  {#if checking}
+    <div class={checkingClass} aria-live="polite">
+      <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"></span>
+      {m('search.checking')}
+    </div>
+  {:else if unavailable}
+    <EmptyState icon="icon-[uil--cloud-slash]" title={m('search.unavailable.title')}>
+      <p>{m('search.unavailable.description')}</p>
+      <div class="mt-4">
+        <Button variant="secondary" onclick={onRetry}>{m('common.retry')}</Button>
+      </div>
+    </EmptyState>
+  {:else if state === MessageSearchState.DISABLED}
+    <EmptyState icon="icon-[uil--search-alt]" title={m('search.disabled.title')}>
+      {m('search.disabled.description')}
+    </EmptyState>
+  {:else if indexing}
+    <EmptyState icon="icon-[uil--database]" title={m('search.indexing.title')}>
+      <p>{m('search.indexing.description')}</p>
+      <div class="mt-4">
+        <Button variant="secondary" onclick={onRetry}>{m('search.check_again')}</Button>
+      </div>
+    </EmptyState>
+  {/if}
+{/snippet}
+
+{#if checking || unavailable || state === MessageSearchState.DISABLED || indexing}
+  {#if frame}
+    {@render frame(statusContent, checking)}
+  {:else}
+    {@render statusContent()}
+  {/if}
+{:else}
+  {@render children()}
+{/if}

--- a/apps/frontend/src/lib/components/search/SearchPresentation.stories.svelte
+++ b/apps/frontend/src/lib/components/search/SearchPresentation.stories.svelte
@@ -1,0 +1,144 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+
+  const { Story } = defineMeta({
+    title: 'Components/Search presentation',
+    tags: ['autodocs']
+  });
+</script>
+
+<script lang="ts">
+  import type { MessageSearchResult } from '$lib/api-client/messageSearch';
+  import { MessageSearchState } from '$lib/api-client/messageSearch';
+  import { RoomKind } from '$lib/api-client/roomDirectory';
+  import { Panel } from '$lib/ui';
+  import { Button } from '$lib/ui/form';
+  import ClampedMessagePreview from '../../../routes/chat/[serverId]/[roomId]/ClampedMessagePreview.svelte';
+  import SearchAvailability from './SearchAvailability.svelte';
+  import SearchResult from './SearchResult.svelte';
+  import { createPresenceCache } from '$lib/state/presenceCache.svelte';
+  import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
+
+  createPresenceCache();
+  createUserProfileCache();
+
+  const timestampSettings = { effectiveTimezone: 'UTC', effectiveHour12: false };
+  const result: MessageSearchResult = {
+    id: 'message-1',
+    roomId: 'room-1',
+    roomName: 'general',
+    roomKind: RoomKind.CHANNEL,
+    actorId: 'user-1',
+    actor: { id: 'user-1', login: 'alex', displayName: 'Alex', avatarUrl: null, deleted: false },
+    body: 'The **release checklist** is ready.\n\nPlease review the changes before Friday.\n\n- Check the upgrade steps.\n- Test the new server.\n- Record the result.\n\nThank you for your help.',
+    createdAt: '2026-09-05T10:00:00Z',
+    threadRootEventId: 'thread-1',
+    attachmentCount: 2,
+    relevanceScore: 1
+  };
+  let availabilityState = $state(MessageSearchState.UNAVAILABLE);
+  let opened = $state(false);
+</script>
+
+<Story name="Availability and retry" asChild>
+  <div class="w-full max-w-2xl">
+    <SearchAvailability
+      state={availabilityState}
+      checking={false}
+      error={false}
+      onRetry={() => (availabilityState = MessageSearchState.READY)}
+      checkingClass="flex min-h-64 items-center justify-center text-muted"
+    >
+      {#snippet frame(content)}<Panel>{@render content()}</Panel>{/snippet}
+      <Panel title="Search query">
+        <p>Search is ready.</p>
+        <Button variant="secondary" onclick={() => (availabilityState = MessageSearchState.UNAVAILABLE)}>
+          Show unavailable state
+        </Button>
+      </Panel>
+    </SearchAvailability>
+  </div>
+</Story>
+
+<Story name="Checking availability" asChild>
+  <div class="w-full max-w-2xl">
+    <SearchAvailability
+      state={MessageSearchState.UNSPECIFIED}
+      checking
+      error={false}
+      onRetry={() => {}}
+      checkingClass="flex min-h-64 items-center justify-center text-muted"
+    >
+      {#snippet frame(content)}<Panel>{@render content()}</Panel>{/snippet}
+      <p>Search is ready.</p>
+    </SearchAvailability>
+  </div>
+</Story>
+
+<Story name="Indexing in sidebar" asChild>
+  <div class="flex h-96 w-80 flex-col">
+    <SearchAvailability
+      state={MessageSearchState.INDEXING}
+      checking={false}
+      error={false}
+      onRetry={() => {}}
+      checkingClass="flex min-h-32 flex-1 items-center justify-center p-4 text-center text-sm text-muted"
+    >
+      {#snippet frame(content)}
+        <div class="flex min-h-0 flex-1 flex-col justify-center p-4">{@render content()}</div>
+      {/snippet}
+      <p>Search is ready.</p>
+    </SearchAvailability>
+  </div>
+</Story>
+
+<Story name="Page result" asChild>
+  <div class="w-full max-w-2xl">
+    <Panel title="Results" noPadding>
+      <ol class="selectable-list gap-4">
+        <li>
+          <SearchResult
+            {result}
+            {timestampSettings}
+            timestampLocale="en-GB"
+            onOpen={() => (opened = true)}
+          >
+            {#snippet headerMeta()}
+              <span class="text-xs text-muted">#general</span>
+              <time class="text-xs text-muted" datetime={result.createdAt}>5 September, 10:00</time>
+            {/snippet}
+          </SearchResult>
+        </li>
+      </ol>
+    </Panel>
+    {#if opened}<p role="status">Result selected.</p>{/if}
+  </div>
+</Story>
+
+<Story name="Sidebar result" asChild>
+  <div class="w-80">
+    <ol class="selectable-list gap-3 py-2">
+      <li>
+        <SearchResult
+          {result}
+          {timestampSettings}
+          timestampLocale="en-GB"
+          class="group/search-result"
+          aria-label={`Alex: ${result.body}`}
+          attachmentClass="text-xs"
+          onOpen={() => (opened = true)}
+        >
+          {#snippet preview(content)}
+            <div class="pointer-events-none" inert>
+              <ClampedMessagePreview>{@render content()}</ClampedMessagePreview>
+            </div>
+          {/snippet}
+          {#snippet headerMeta()}
+            <time class="text-xs text-muted" datetime={result.createdAt}>5 September, 10:00</time>
+          {/snippet}
+        </SearchResult>
+      </li>
+    </ol>
+    {#if opened}<p role="status">Result selected.</p>{/if}
+  </div>
+</Story>

--- a/apps/frontend/src/lib/components/search/SearchResult.svelte
+++ b/apps/frontend/src/lib/components/search/SearchResult.svelte
@@ -1,0 +1,97 @@
+<!--
+@component
+
+Renders one message search result with shared identity and attachment details.
+The owner supplies metadata, optional preview layout, and result navigation.
+Enter activates the result only when the result itself has focus.
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { ClassValue, HTMLAttributes } from 'svelte/elements';
+  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
+  import type { MessageSearchResult } from '$lib/api-client/messageSearch';
+  import type { TimeFormatSettings } from '$lib/utils/formatTime';
+  import MessageView from '$lib/components/messages/MessageView.svelte';
+  import { m } from '$lib/i18n/messages';
+
+  let {
+    result,
+    viewerLogin,
+    timestampSettings,
+    timestampLocale,
+    headerMeta,
+    preview,
+    attachmentClass = 'text-sm',
+    onOpen,
+    class: className,
+    ...attributes
+  }: Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'onclick' | 'onkeydown'> & {
+    result: MessageSearchResult;
+    viewerLogin?: string;
+    timestampSettings: TimeFormatSettings;
+    timestampLocale: string;
+    headerMeta: Snippet;
+    /** Optional wrapper, such as an inert preview with a height limit. */
+    preview?: Snippet<[Snippet]>;
+    attachmentClass?: ClassValue;
+    onOpen: (result: MessageSearchResult) => void;
+  } = $props();
+
+  const actor = $derived(
+    result.actor ? { ...result.actor, presenceStatus: PresenceStatus.OFFLINE } : null
+  );
+  const displayName = $derived(
+    result.actor?.displayName || result.actor?.login || m('common.unknown')
+  );
+
+  function open(event: MouseEvent): void {
+    // The whole result is one target, including links within the preview.
+    event.preventDefault();
+    onOpen(result);
+  }
+
+  function openFromKeyboard(event: KeyboardEvent): void {
+    if (event.target !== event.currentTarget || event.key !== 'Enter') return;
+    event.preventDefault();
+    onOpen(result);
+  }
+</script>
+
+{#snippet message()}
+  <MessageView
+    eventId={result.id}
+    {actor}
+    {displayName}
+    missingActorIsDeleted={false}
+    body={result.body}
+    {viewerLogin}
+    {timestampSettings}
+    {timestampLocale}
+    {headerMeta}
+    rowClass="hover:bg-transparent md:mx-0 md:pe-2"
+  >
+    {#snippet afterBody()}
+      {#if result.attachmentCount > 0}
+        <p class={['inline-flex items-center gap-1 text-muted', attachmentClass]}>
+          <span class="iconify icon-[uil--paperclip]" aria-hidden="true"></span>
+          {m('search.attachments', { count: result.attachmentCount })}
+        </p>
+      {/if}
+    {/snippet}
+  </MessageView>
+{/snippet}
+
+<div
+  {...attributes}
+  role="link"
+  tabindex="0"
+  class={['cursor-pointer selectable-list-item', className]}
+  onclick={open}
+  onkeydown={openFromKeyboard}
+>
+  {#if preview}
+    {@render preview(message)}
+  {:else}
+    {@render message()}
+  {/if}
+</div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -5,13 +5,11 @@ Room-scoped message search for the room sidebar. Its store is retained per room
 so switching rooms cannot leak a query or plaintext results into another room.
 -->
 <script lang="ts">
-  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import type { Attachment } from 'svelte/attachments';
-  import type { MessageSearchResult } from '$lib/api-client/messageSearch';
-  import MessageView from '$lib/components/messages/MessageView.svelte';
+  import SearchResult from '$lib/components/search/SearchResult.svelte';
+  import SearchAvailability from '$lib/components/search/SearchAvailability.svelte';
   import { m } from '$lib/i18n/messages';
   import { getLocale } from '$lib/i18n/runtime';
-  import type { UserAvatarUserView } from '$lib/render/users';
   import {
     MessageSearchOrder,
     MessageSearchState,
@@ -21,7 +19,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
   import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { EmptyState, Hint, ScrollFader } from '$lib/ui';
-  import { Button, TextInput } from '$lib/ui/form';
+  import { TextInput } from '$lib/ui/form';
   import { formatDateTime, timeFormatSettingsFor } from '$lib/utils/formatTime';
   import ClampedMessagePreview from './ClampedMessagePreview.svelte';
 
@@ -54,13 +52,9 @@ so switching rooms cannot leak a query or plaintext results into another room.
     void store.ensureStatus();
   });
 
-  function searchNow(): void {
-    search.submitNow();
-  }
-
   function submit(event: SubmitEvent): void {
     event.preventDefault();
-    searchNow();
+    search.submitNow();
   }
 
   const focusSearchField: Attachment<HTMLFormElement> = (form) => {
@@ -74,61 +68,25 @@ so switching rooms cannot leak a query or plaintext results into another room.
     search.schedule((event.currentTarget as HTMLInputElement).value);
   }
 
-  function resultActor(result: MessageSearchResult): UserAvatarUserView | null {
-    if (!result.actor) return null;
-    return { ...result.actor, presenceStatus: PresenceStatus.OFFLINE };
-  }
-
   function formatTimestamp(value: string): string {
     return value ? formatDateTime(value, userSettings, activeLocale) : '';
   }
-
-  function openResult(event: MouseEvent, result: MessageSearchResult): void {
-    event.preventDefault();
-    onOpenResult?.(result.id, result.threadRootEventId);
-  }
-
-  function openResultFromKeyboard(event: KeyboardEvent, result: MessageSearchResult): void {
-    if (event.target !== event.currentTarget || event.key !== 'Enter') return;
-    event.preventDefault();
-    onOpenResult?.(result.id, result.threadRootEventId);
-  }
 </script>
 
-{#if store.statusLoading && !store.statusLoaded}
-  <div class="flex min-h-32 flex-1 items-center justify-center p-4 text-center text-sm text-muted">
-    <span class="me-2 iconify icon-[uil--spinner-alt] animate-spin" aria-hidden="true"></span>
-    {m('search.checking')}
-  </div>
-{:else if store.statusError || store.status.state === MessageSearchState.UNAVAILABLE}
-  <div class="flex min-h-0 flex-1 flex-col justify-center p-4">
-    <EmptyState icon="icon-[uil--cloud-slash]" title={m('search.unavailable.title')}>
-      <p>{m('search.unavailable.description')}</p>
-      <div class="mt-4">
-        <Button variant="secondary" onclick={() => void store.refreshStatus()}>
-          {m('common.retry')}
-        </Button>
-      </div>
-    </EmptyState>
-  </div>
-{:else if store.status.state === MessageSearchState.DISABLED}
-  <div class="flex min-h-0 flex-1 flex-col justify-center p-4">
-    <EmptyState icon="icon-[uil--search-alt]" title={m('search.disabled.title')}>
-      {m('search.disabled.description')}
-    </EmptyState>
-  </div>
-{:else if store.status.state === MessageSearchState.STARTING || store.status.state === MessageSearchState.INDEXING}
-  <div class="flex min-h-0 flex-1 flex-col justify-center p-4">
-    <EmptyState icon="icon-[uil--database]" title={m('search.indexing.title')}>
-      <p>{m('search.indexing.description')}</p>
-      <div class="mt-4">
-        <Button variant="secondary" onclick={() => void store.refreshStatus()}>
-          {m('search.check_again')}
-        </Button>
-      </div>
-    </EmptyState>
-  </div>
-{:else}
+<SearchAvailability
+  state={store.status.state}
+  checking={store.statusLoading && !store.statusLoaded}
+  error={store.statusError}
+  onRetry={() => void store.refreshStatus()}
+  checkingClass="flex min-h-32 flex-1 items-center justify-center p-4 text-center text-sm text-muted"
+>
+  {#snippet frame(content, checking)}
+    {#if checking}
+      {@render content()}
+    {:else}
+      <div class="flex min-h-0 flex-1 flex-col justify-center p-4">{@render content()}</div>
+    {/if}
+  {/snippet}
   <div class="flex min-h-0 flex-1 flex-col">
     <div class="border-b border-border p-2">
       <form onsubmit={submit} {@attach focusSearchField}>
@@ -158,7 +116,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
           </EmptyState>
         {:else if store.loading && store.results.length === 0}
           <div class="flex min-h-32 flex-1 items-center justify-center p-4 text-sm text-muted">
-            <span class="me-2 iconify icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
+            <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
             ></span>
             {m('search.searching')}
           </div>
@@ -172,50 +130,30 @@ so switching rooms cannot leak a query or plaintext results into another room.
           <ol class="selectable-list gap-3 py-2">
             {#each store.results as result (result.id)}
               <li>
-                <div
-                  role="link"
-                  tabindex="0"
+                <SearchResult
+                  {result}
                   aria-label={`${result.actor?.displayName || result.actor?.login || m('common.unknown')}: ${result.body}`}
                   data-room-search-result-id={result.id}
-                  class="group/search-result cursor-pointer selectable-list-item"
-                  onclick={(event) => openResult(event, result)}
-                  onkeydown={(event) => openResultFromKeyboard(event, result)}
+                  class="group/search-result"
+                  viewerLogin={serverScope.store.currentUser.user?.login}
+                  timestampSettings={userSettings}
+                  timestampLocale={activeLocale}
+                  attachmentClass="text-xs"
+                  onOpen={(result) => onOpenResult?.(result.id, result.threadRootEventId)}
                 >
-                  <div class="pointer-events-none" inert data-room-search-result-preview>
-                    <ClampedMessagePreview>
-                      <MessageView
-                        eventId={result.id}
-                        actor={resultActor(result)}
-                        displayName={result.actor?.displayName ||
-                          result.actor?.login ||
-                          m('common.unknown')}
-                        missingActorIsDeleted={false}
-                        body={result.body}
-                        viewerLogin={serverScope.store.currentUser.user?.login}
-                        timestampSettings={userSettings}
-                        timestampLocale={activeLocale}
-                        rowClass="hover:bg-transparent md:mx-0 md:pe-2"
-                      >
-                        {#snippet headerMeta()}
-                          {#if result.createdAt}
-                            <time class="text-xs text-muted" datetime={result.createdAt}>
-                              {formatTimestamp(result.createdAt)}
-                            </time>
-                          {/if}
-                        {/snippet}
-
-                        {#snippet afterBody()}
-                          {#if result.attachmentCount > 0}
-                            <p class="inline-flex items-center gap-1 text-xs text-muted">
-                              <span class="iconify icon-[uil--paperclip]" aria-hidden="true"></span>
-                              {m('search.attachments', { count: result.attachmentCount })}
-                            </p>
-                          {/if}
-                        {/snippet}
-                      </MessageView>
-                    </ClampedMessagePreview>
-                  </div>
-                </div>
+                  {#snippet preview(content)}
+                    <div class="pointer-events-none" inert data-room-search-result-preview>
+                      <ClampedMessagePreview>{@render content()}</ClampedMessagePreview>
+                    </div>
+                  {/snippet}
+                  {#snippet headerMeta()}
+                    {#if result.createdAt}
+                      <time class="text-xs text-muted" datetime={result.createdAt}>
+                        {formatTimestamp(result.createdAt)}
+                      </time>
+                    {/if}
+                  {/snippet}
+                </SearchResult>
               </li>
             {/each}
           </ol>
@@ -225,7 +163,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
               class="flex h-12 items-center justify-center text-sm text-muted"
             >
               {#if store.loadingMore}
-                <span class="me-2 iconify icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
+                <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
                 ></span>
                 {m('search.loading_more')}
               {/if}
@@ -235,4 +173,4 @@ so switching rooms cannot leak a query or plaintext results into another room.
       </div>
     </ScrollFader>
   </div>
-{/if}
+</SearchAvailability>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -189,8 +189,8 @@ vi.mock('$lib/state/server/registry.svelte', () => ({
 }));
 
 vi.mock('$lib/state/userProfiles.svelte', () => ({
-    getLiveBio: () => null,
-    getLiveTimezone: () => null,
+  getLiveBio: () => null,
+  getLiveTimezone: () => null,
   getLiveAvatarUrl: (_userId: string, fallback: string | null) => fallback,
   getLiveCustomStatus: (_userId: string, fallback: unknown) => fallback,
   getLiveDisplayName: (_userId: string, fallback: string) => fallback,
@@ -437,6 +437,26 @@ describe('RoomSidebar', () => {
     callStore.permissions.canStartDMs = false;
   });
 
+  it('shows search availability and recovers through the sidebar retry action', async () => {
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce({ state: MessageSearchState.UNAVAILABLE, retryAfterMs: null })
+      .mockResolvedValueOnce({ state: MessageSearchState.READY, retryAfterMs: null });
+    const searchStore = new MessageSearchStore({ getStatus, searchMessages: vi.fn() });
+    await searchStore.ensureStatus();
+    const rendered = render(RoomSidebarTestHarness, {
+      props: { activePanel: 'search', roomData: roomData([member(1)], 1, false), searchStore }
+    });
+
+    await expect
+      .element(rendered.getByText('Search is unavailable', { exact: true }))
+      .toBeVisible();
+    await userEvent.click(rendered.getByRole('button', { name: 'Try Again' }));
+    await expect.element(rendered.getByRole('textbox')).toBeVisible();
+    await expect.element(rendered.getByRole('textbox')).toHaveFocus();
+    expect(getStatus).toHaveBeenCalledTimes(2);
+  });
+
   it('automatically searches only the current room and clamps long matching messages', async () => {
     const searchMessages = vi.fn().mockResolvedValue({
       results: [
@@ -521,6 +541,11 @@ describe('RoomSidebar', () => {
     expect(longResult.querySelector('.max-h-40')?.classList).toContain('overflow-hidden');
 
     await userEvent.click(shortResult);
+    expect(onOpenSearchResult).toHaveBeenCalledWith('message-1', 'thread-root');
+    onOpenSearchResult.mockClear();
+    (shortResult as HTMLElement).focus();
+    await userEvent.keyboard('{Enter}');
+    expect(onOpenSearchResult).toHaveBeenCalledOnce();
     expect(onOpenSearchResult).toHaveBeenCalledWith('message-1', 'thread-root');
 
     await userEvent.fill(input, 'roadmap ');

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -6,12 +6,11 @@ in the active server store so browser Back can restore the current search.
 -->
 <script lang="ts">
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import Panel from '$lib/ui/Panel.svelte';
-  import MessageView from '$lib/components/messages/MessageView.svelte';
-  import type { UserAvatarUserView } from '$lib/render/users';
+  import SearchResult from '$lib/components/search/SearchResult.svelte';
+  import SearchAvailability from '$lib/components/search/SearchAvailability.svelte';
   import type { MessageSearchResult } from '$lib/api-client/messageSearch';
   import { RoomKind } from '$lib/api-client/roomDirectory';
   import { serverIdToSegment } from '$lib/navigation';
@@ -30,7 +29,7 @@ in the active server store so browser Back can restore the current search.
     ScrollFader,
     SegmentedControl
   } from '$lib/ui';
-  import { Button, TextInput } from '$lib/ui/form';
+  import { TextInput } from '$lib/ui/form';
   import { m } from '$lib/i18n/messages';
 
   const serverScope = useServerScope();
@@ -74,14 +73,6 @@ in the active server store so browser Back can restore the current search.
     if (store.query.trim()) search.submitNow();
   }
 
-  function resultActor(result: MessageSearchResult): UserAvatarUserView | null {
-    if (!result.actor) return null;
-    return {
-      ...result.actor,
-      presenceStatus: PresenceStatus.OFFLINE
-    };
-  }
-
   function formatTimestamp(value: string): string {
     return value ? formatDateTime(value, timeFormatSettings, activeLocale) : '';
   }
@@ -89,19 +80,6 @@ in the active server store so browser Back can restore the current search.
   function navigateToResult(result: MessageSearchResult): void {
     // eslint-disable-next-line svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route
     void goto(buildMessageLinkPath(serverId, result.roomId, result.id, result.threadRootEventId));
-  }
-
-  function openResult(event: MouseEvent, result: MessageSearchResult): void {
-    // A search result is one navigation target. Links rendered inside the
-    // shared message view are presentation here and must not override it.
-    event.preventDefault();
-    navigateToResult(result);
-  }
-
-  function openResultFromKeyboard(event: KeyboardEvent, result: MessageSearchResult): void {
-    if (event.target !== event.currentTarget || event.key !== 'Enter') return;
-    event.preventDefault();
-    navigateToResult(result);
   }
 </script>
 
@@ -112,43 +90,16 @@ in the active server store so browser Back can restore the current search.
 
   <PaneContent fillHeight>
     <div class="flex min-h-0 flex-1 flex-col gap-6">
-      {#if store.statusLoading && !store.statusLoaded}
-        <Panel>
-          <div class="flex min-h-64 items-center justify-center text-muted" aria-live="polite">
-            <span class="me-2 iconify icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
-            ></span>
-            {m('search.checking')}
-          </div>
-        </Panel>
-      {:else if store.statusError || store.status.state === MessageSearchState.UNAVAILABLE}
-        <Panel>
-          <EmptyState icon="icon-[uil--cloud-slash]" title={m('search.unavailable.title')}>
-            <p>{m('search.unavailable.description')}</p>
-            <div class="mt-4">
-              <Button variant="secondary" onclick={() => void store.refreshStatus()}>
-                {m('common.retry')}
-              </Button>
-            </div>
-          </EmptyState>
-        </Panel>
-      {:else if store.status.state === MessageSearchState.DISABLED}
-        <Panel>
-          <EmptyState icon="icon-[uil--search-alt]" title={m('search.disabled.title')}>
-            {m('search.disabled.description')}
-          </EmptyState>
-        </Panel>
-      {:else if store.status.state === MessageSearchState.STARTING || store.status.state === MessageSearchState.INDEXING}
-        <Panel>
-          <EmptyState icon="icon-[uil--database]" title={m('search.indexing.title')}>
-            <p>{m('search.indexing.description')}</p>
-            <div class="mt-4">
-              <Button variant="secondary" onclick={() => void store.refreshStatus()}>
-                {m('search.check_again')}
-              </Button>
-            </div>
-          </EmptyState>
-        </Panel>
-      {:else}
+      <SearchAvailability
+        state={store.status.state}
+        checking={store.statusLoading && !store.statusLoaded}
+        error={store.statusError}
+        onRetry={() => void store.refreshStatus()}
+        checkingClass="flex min-h-64 items-center justify-center text-muted"
+      >
+        {#snippet frame(content)}
+          <Panel>{@render content()}</Panel>
+        {/snippet}
         <Panel title={m('search.query.label')}>
           <form class="flex flex-wrap items-stretch gap-2" onsubmit={submit}>
             <div class="min-w-64 flex-1">
@@ -197,72 +148,48 @@ in the active server store so browser Back can restore the current search.
                 <ol class="selectable-list gap-4">
                   {#each store.results as result (result.id)}
                     <li>
-                      <div
-                        role="link"
-                        tabindex="0"
+                      <SearchResult
+                        {result}
                         data-search-result-id={result.id}
-                        class="cursor-pointer selectable-list-item"
-                        onclick={(event) => openResult(event, result)}
-                        onkeydown={(event) => openResultFromKeyboard(event, result)}
+                        viewerLogin={serverStore.currentUser.user?.login}
+                        timestampSettings={timeFormatSettings}
+                        timestampLocale={activeLocale}
+                        onOpen={navigateToResult}
                       >
-                        <MessageView
-                          eventId={result.id}
-                          actor={resultActor(result)}
-                          displayName={result.actor?.displayName ||
-                            result.actor?.login ||
-                            m('common.unknown')}
-                          missingActorIsDeleted={false}
-                          body={result.body}
-                          viewerLogin={serverStore.currentUser.user?.login}
-                          timestampSettings={timeFormatSettings}
-                          timestampLocale={activeLocale}
-                          rowClass="hover:bg-transparent md:mx-0 md:pe-2"
-                        >
-                          {#snippet headerMeta()}
+                        {#snippet headerMeta()}
+                          <a
+                            class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
+                            href={resolve('/chat/[serverId]/[roomId]', {
+                              serverId: serverIdToSegment(serverId),
+                              roomId: result.roomId
+                            })}
+                          >
+                            {#if result.roomKind === RoomKind.DM}
+                              {m('room.title.direct_message')}
+                            {:else}
+                              <bdi>#{result.roomName ?? m('search.scope.room')}</bdi>
+                            {/if}
+                          </a>
+                          {#if result.createdAt}
+                            <span class="text-xs text-muted" aria-hidden="true">·</span>
+                            <!-- eslint-disable svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route -->
                             <a
                               class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
-                              href={resolve('/chat/[serverId]/[roomId]', {
-                                serverId: serverIdToSegment(serverId),
-                                roomId: result.roomId
-                              })}
+                              href={buildMessageLinkPath(
+                                serverId,
+                                result.roomId,
+                                result.id,
+                                result.threadRootEventId
+                              )}
                             >
-            {#if result.roomKind === RoomKind.DM}
-              {m('room.title.direct_message')}
-            {:else}
-              <bdi>#{result.roomName ?? m('search.scope.room')}</bdi>
-            {/if}
-                            </a>
-                            {#if result.createdAt}
-                              <span class="text-xs text-muted" aria-hidden="true">·</span>
-                              <!-- eslint-disable svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route -->
-                              <a
-                                class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
-                                href={buildMessageLinkPath(
-                                  serverId,
-                                  result.roomId,
-                                  result.id,
-                                  result.threadRootEventId
-                                )}
+                              <time datetime={result.createdAt}
+                                >{formatTimestamp(result.createdAt)}</time
                               >
-                                <time datetime={result.createdAt}
-                                  >{formatTimestamp(result.createdAt)}</time
-                                >
-                              </a>
-                              <!-- eslint-enable svelte/no-navigation-without-resolve -->
-                            {/if}
-                          {/snippet}
-
-                          {#snippet afterBody()}
-                            {#if result.attachmentCount > 0}
-                              <p class="inline-flex items-center gap-1 text-sm text-muted">
-                                <span class="iconify icon-[uil--paperclip]" aria-hidden="true"
-                                ></span>
-                                {m('search.attachments', { count: result.attachmentCount })}
-                              </p>
-                            {/if}
-                          {/snippet}
-                        </MessageView>
-                      </div>
+                            </a>
+                            <!-- eslint-enable svelte/no-navigation-without-resolve -->
+                          {/if}
+                        {/snippet}
+                      </SearchResult>
                     </li>
                   {/each}
                 </ol>
@@ -273,7 +200,7 @@ in the active server store so browser Back can restore the current search.
                   >
                     {#if store.loadingMore}
                       <span
-                        class="me-2 iconify icon-[uil--spinner-alt] animate-spin"
+                        class="iconify me-2 icon-[uil--spinner-alt] animate-spin"
                         aria-hidden="true"
                       ></span>
                       {m('search.loading_more')}
@@ -284,7 +211,7 @@ in the active server store so browser Back can restore the current search.
             </div>
           </ScrollFader>
         </Panel>
-      {/if}
+      </SearchAvailability>
     </div>
   </PaneContent>
 </div>

--- a/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/search/search.page.svelte.spec.ts
@@ -115,6 +115,57 @@ describe('message search page', () => {
     document.documentElement.dir = 'ltr';
   });
 
+  it.each([
+    [MessageSearchState.UNAVAILABLE, 'Search is unavailable', 'Try Again'],
+    [MessageSearchState.DISABLED, 'Search is disabled', null],
+    [MessageSearchState.STARTING, 'Search is getting ready', 'Check again'],
+    [MessageSearchState.INDEXING, 'Search is getting ready', 'Check again']
+  ] as const)('shows search availability for state %s', async (state, title, action) => {
+    const store = serverStore();
+    store.messageSearch.status.state = state;
+    mocks.serverStores.origin = store;
+    const rendered = render(SearchPageTestHarness);
+
+    await expect.element(rendered.getByText(title, { exact: true })).toBeVisible();
+    await expect.element(rendered.getByRole('textbox')).not.toBeInTheDocument();
+    if (action) {
+      await userEvent.click(rendered.getByRole('button', { name: action }));
+      expect(store.messageSearch.refreshStatus).toHaveBeenCalledOnce();
+    } else {
+      expect(store.messageSearch.refreshStatus).not.toHaveBeenCalled();
+    }
+  });
+
+  it('shows search checking before errors and returns to the form after recovery', async () => {
+    const store = serverStore();
+    store.messageSearch.statusLoading = true;
+    store.messageSearch.statusLoaded = false;
+    store.messageSearch.statusError = true;
+    mocks.serverStores.origin = store;
+    const rendered = render(SearchPageTestHarness);
+
+    await expect.element(rendered.getByText('Checking search availability...')).toBeVisible();
+    store.messageSearch.statusLoading = false;
+    await tick();
+    await expect
+      .element(rendered.getByText('Search is unavailable', { exact: true }))
+      .toBeVisible();
+    store.messageSearch.statusError = false;
+    store.messageSearch.statusLoaded = true;
+    store.messageSearch.status.state = MessageSearchState.DEGRADED;
+    await tick();
+    await expect.element(rendered.getByRole('textbox')).toBeVisible();
+    await expect
+      .element(rendered.getByText('Search is available, but some results may be missing.'))
+      .toBeVisible();
+
+    // A background status read must not unmount an already available search form.
+    const input = rendered.container.querySelector('input');
+    store.messageSearch.statusLoading = true;
+    await tick();
+    expect(rendered.container.querySelector('input')).toBe(input);
+  });
+
   it('mounts as a server page and debounces unscoped searches without a button', async () => {
     const { container } = render(SearchPageTestHarness);
 
@@ -378,7 +429,9 @@ describe('message search page', () => {
         ?.getAttribute('datetime')
     ).toBe('2026-07-22T09:42:00.000Z');
     expect(container.querySelector('[role="article"]')?.textContent).toContain('2');
-    expect(container.querySelector('[role="article"] [class~="icon-[uil--paperclip]"]')).not.toBeNull();
+    expect(
+      container.querySelector('[role="article"] [class~="icon-[uil--paperclip]"]')
+    ).not.toBeNull();
     expect(container.querySelector('[role="article"] button')).toBeNull();
     expect(container.querySelectorAll('[role="article"]')[1]?.textContent).toContain('Unknown');
     expect(container.querySelectorAll('[role="article"]')[1]?.textContent).not.toContain(
@@ -402,5 +455,17 @@ describe('message search page', () => {
     await userEvent.click(firstResult.querySelector('.prose a')!);
     expect(mocks.goto).toHaveBeenCalledOnce();
     expect(mocks.goto).toHaveBeenCalledWith('/chat/origin/room-1/thread-root/m/message-1');
+
+    mocks.goto.mockClear();
+    firstResult.focus();
+    await userEvent.keyboard('{Enter}');
+    expect(mocks.goto).toHaveBeenCalledOnce();
+    expect(mocks.goto).toHaveBeenCalledWith('/chat/origin/room-1/thread-root/m/message-1');
+
+    mocks.goto.mockClear();
+    firstResult
+      .querySelector('a')!
+      .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(mocks.goto).not.toHaveBeenCalled();
   });
 });

--- a/cli/internal/http_server/realtime_test_helpers_test.go
+++ b/cli/internal/http_server/realtime_test_helpers_test.go
@@ -42,7 +42,10 @@ func setupWebSocketTestServerWithTTLs(t testing.TB, accessTokenTTL, cookieSessio
 	t.Helper()
 	gin.SetMode(gin.TestMode)
 
-	_, nc := testutil.StartSharedNATS(t)
+	// Use a separate store for each fixture. JetStream stream deletion includes
+	// background file cleanup, so tests must not reuse the previous store while
+	// that cleanup is still active.
+	_, nc := testutil.StartNATS(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	t.Cleanup(cancel)


### PR DESCRIPTION
## Why

The server search page and room search sidebar repeat availability screens, retry controls, result identity mapping, attachment details, and activation handlers. Keep those behaviors in shared components so the two surfaces remain consistent as search changes.

## Changes

- Add `SearchAvailability` for checking, unavailable, disabled, and indexing states. Owners supply the status frame and retry callback. Available search content stays mounted during background status reads.
- Add `SearchResult` for message presentation, attachment counts, and click/Enter activation. Owners supply navigation and metadata through callbacks and snippets.
- Preserve the server page's room and thread links and the sidebar's inert, clamped preview with an overflow fade. Keep debounce, pagination, query scope, and store ownership with the existing owners.
- Add five Storybook examples and regression coverage for status transitions, retry recovery, focus, and keyboard activation.
- Give each WebSocket test fixture its own NATS server and storage directory. The failed CI run loaded the preceding test's events during bootstrap; separate stores prevent cross-test state reuse during background JetStream file cleanup.

This is a presentation refactor of [FDR-033: Message Search](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-033-message-search.md). The search protocol and provider design in [ADR-055](https://github.com/chattocorp/chatto/blob/main/docs/adr/ADR-055-pluggable-message-search-over-nats.md) do not change.

## Test plan

Passed:

- `mise x -- pnpm --filter chatto-frontend exec vitest --run --project=client 'src/routes/chat/[serverId]/search/search.page.svelte.spec.ts' 'src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts' -t 'message search page|shows search availability|automatically searches only'` — 17 passed; 46 unrelated sidebar tests skipped.
- `mise x -- pnpm --filter chatto-frontend exec vitest --run --project=storybook src/lib/components/search/SearchPresentation.stories.svelte` — 5 passed.
- `mise lint-frontend` — zero Svelte errors or warnings; ESLint and design-system checks passed. `mise x -- pnpm --filter chatto-frontend exec eslint src/lib/components/search` also passed.
- `mise build-frontend` — production build, route bundle budgets, and CSP checks passed.
- `mise license-check`, `git diff --check`, and Svelte autofixer checks on all changed Svelte files.
- Chrome DevTools: inspected page and sidebar stories in light and dark themes, verified result activation and retry, and checked sidebar clamping, inert content, and absence of horizontal overflow. Used direct localhost for the final console check because the HTTPS Storybook proxy had an HMR connection error; only a missing favicon remained. Storybook was stopped after verification.

- `mise test-cli` — passed.
- From `cli/`: `mise x -- go test -tags test_endpoints ./internal/http_server -run '^(TestRealtimeProjectionMapsPinnedMessageChangeThroughKnownServerStateOperation|TestRealtimeWebSocketAuthenticatesWithBearerHello)$' -count=200 -timeout 120s` — all 400 test executions passed.

The full frontend suite and backend end-to-end search tests were not run locally.
