### PR TITLE
refactor(frontend): share scroll edge tracking attachment

### DIFF
--- a/apps/frontend/e2e/messages.test.ts
+++ b/apps/frontend/e2e/messages.test.ts
@@ -766,9 +766,16 @@ test('image lightbox supports keyboard navigation with multiple images', async (
 
   const gallery = page.getByTestId('message-image-gallery');
   await expect(gallery).toBeVisible();
-  await expect.poll(() => gallery.evaluate((el) => getComputedStyle(el).columnGap)).toBe('12px');
   const galleryImages = gallery.locator('button[aria-label^="View"]');
   await expect(galleryImages).toHaveCount(5);
+  await expect
+    .poll(() =>
+      galleryImages.evaluateAll(
+        ([first, second]) =>
+          second.getBoundingClientRect().left - first.getBoundingClientRect().right
+      )
+    )
+    .toBe(12);
   await expect.poll(() => gallery.evaluate((el) => el.scrollWidth > el.clientWidth)).toBe(true);
   await gallery.evaluate((el) => {
     el.scrollLeft = 0;

--- a/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/PermissionMatrix.svelte.spec.ts
@@ -294,7 +294,7 @@ describe('PermissionMatrix', () => {
     const stickyBody = panel.querySelector('tbody th[scope="row"].sticky') as HTMLElement;
     const surfaceColor = getComputedStyle(panel).backgroundColor;
     const headerColor = getComputedStyle(tableHeader).backgroundColor;
-    const viewport = panel.querySelector('table')?.parentElement?.parentElement as HTMLElement;
+    const viewport = panel.querySelector<HTMLElement>('.data-table-viewport')!;
     const inset = panel.querySelector(':scope > div:last-child > div') as HTMLElement;
     const frame = inset.parentElement as HTMLElement;
 
@@ -309,10 +309,10 @@ describe('PermissionMatrix', () => {
     expect(frame.className).toContain('pb-1');
     expect(viewport.className).toContain('data-table-viewport');
     expect(viewport.className).not.toContain('rounded-md');
-    expect((panel.querySelector('table')?.parentElement as HTMLElement).className).toContain(
+    expect((viewport.querySelector('.overflow-y-auto') as HTMLElement).className).toContain(
       'overflow-y-auto'
     );
-    expect((panel.querySelector('table')?.parentElement as HTMLElement).className).toContain(
+    expect((viewport.querySelector('.overflow-y-auto') as HTMLElement).className).toContain(
       'overflow-x-auto'
     );
     expect(getComputedStyle(tableHeader).backgroundColor).toBe(headerColor);

--- a/apps/frontend/src/lib/ui/DataTable.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/DataTable.svelte.spec.ts
@@ -157,20 +157,19 @@ describe('DataTable.hoverable', () => {
       }
     });
     const table = container.querySelector('table') as HTMLTableElement;
-    const viewport = table.parentElement?.parentElement as HTMLElement;
+    const viewport = table.closest('.data-table-viewport') as HTMLElement;
     const header = container.querySelector('thead') as HTMLElement;
 
     expect(viewport.className).toContain('data-table-viewport');
     expect(viewport.className).toContain('max-h-[70dvh]');
-    expect((table.parentElement as HTMLElement).className).toContain('overflow-y-auto');
-    expect((table.parentElement as HTMLElement).className).toContain('overflow-x-auto');
+    expect((table.parentElement?.parentElement as HTMLElement).className).toContain('overflow-y-auto');
+    expect((table.parentElement?.parentElement as HTMLElement).className).toContain('overflow-x-auto');
     expect(header.className).toContain('sticky');
   });
 
   it('fills a flex parent instead of using the sticky-header viewport cap when requested', () => {
     const { container } = renderTable({ stickyHeader: true, fillHeight: true });
-    const viewport = (container.querySelector('table') as HTMLTableElement).parentElement
-      ?.parentElement as HTMLElement;
+    const viewport = container.querySelector<HTMLElement>('.data-table-viewport')!;
 
     expect(viewport.className).toContain('flex-1');
     expect(viewport.className).not.toContain('max-h-[70dvh]');

--- a/apps/frontend/src/lib/ui/PaneContent.svelte
+++ b/apps/frontend/src/lib/ui/PaneContent.svelte
@@ -15,7 +15,8 @@
 </script>
 
 <ScrollFader top bottom bind:scrollEl={scrollContainer}>
-  <div class={['w-full max-w-5xl p-6', fillHeight && 'flex h-full min-h-0 flex-col']}>
+  <!-- A zero-length basis keeps tall children bounded inside the min-height content wrapper. -->
+  <div class={['w-full max-w-5xl p-6', fillHeight && 'flex min-h-0 flex-1 basis-0 flex-col']}>
     {@render children()}
   </div>
 </ScrollFader>

--- a/apps/frontend/src/lib/ui/PaneContent.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/PaneContent.svelte.spec.ts
@@ -1,3 +1,4 @@
+import '../../app.css';
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
 import { testSnippet } from '$lib/test-utils';
@@ -10,7 +11,7 @@ describe('PaneContent', () => {
     });
     const fader = container.firstElementChild as HTMLElement;
     const scrollArea = fader.firstElementChild as HTMLElement;
-    const content = scrollArea.firstElementChild as HTMLElement;
+    const content = container.querySelector('[data-testid="content"]')!.parentElement!;
 
     expect(scrollArea.className).toContain('overflow-y-auto');
     expect(fader.className).toContain('relative');
@@ -20,11 +21,40 @@ describe('PaneContent', () => {
 
   it('can give a primary child the available page height', () => {
     const { container } = render(PaneContent, {
-      props: { fillHeight: true, children: testSnippet('<div>Content</div>') }
+      props: {
+        fillHeight: true,
+        children: testSnippet('<div class="flex-1" data-testid="primary">Content</div>')
+      }
     });
-    const content = container.firstElementChild?.firstElementChild?.firstElementChild as HTMLElement;
+    container.style.cssText = 'display: flex; flex-direction: column; height: 240px; width: 400px;';
+    const primary = container.querySelector<HTMLElement>('[data-testid="primary"]')!;
+    const content = primary.parentElement!;
+    const viewport = container.querySelector<HTMLElement>('.overflow-y-auto')!;
+    const style = getComputedStyle(content);
 
-    expect(content.className).toContain('h-full');
-    expect(content.className).toContain('flex');
+    expect(viewport.clientHeight).toBe(240);
+    expect(content.getBoundingClientRect().height).toBe(viewport.clientHeight);
+    expect(primary.getBoundingClientRect().height).toBe(
+      viewport.clientHeight -
+        Number.parseFloat(style.paddingTop) -
+        Number.parseFloat(style.paddingBottom)
+    );
+  });
+  it('bounds an overflowing primary child to the available page height', () => {
+    const { container } = render(PaneContent, {
+      props: {
+        fillHeight: true,
+        children: testSnippet(
+          '<div class="min-h-0 flex-1 overflow-y-auto" data-testid="primary"><div style="height: 600px">Tall content</div></div>'
+        )
+      }
+    });
+    container.style.cssText = 'display: flex; flex-direction: column; height: 240px; width: 400px;';
+    const primary = container.querySelector<HTMLElement>('[data-testid="primary"]')!;
+    const content = primary.parentElement!;
+    const viewport = container.querySelector<HTMLElement>('.overflow-y-auto')!;
+    expect(content.getBoundingClientRect().height).toBe(viewport.clientHeight);
+    expect(primary.scrollHeight).toBe(600);
+    expect(primary.clientHeight).toBeLessThan(viewport.clientHeight);
   });
 });

--- a/apps/frontend/src/lib/ui/ScrollArea.svelte
+++ b/apps/frontend/src/lib/ui/ScrollArea.svelte
@@ -4,7 +4,9 @@
 Reusable scroll viewport. It owns the relative outer wrapper, native vertical
 and optional horizontal scrolling, and exposes its inner element for consumers
 such as virtualizers and infinite-scroll observers. `ScrollFader` composes this
-primitive when a scroll viewport also needs edge fades.
+primitive when a scroll viewport also needs edge fades. A stable inner flex
+column sizes to its content and fills short viewports, including bottom-aligned
+timelines. Attach content size observers to that wrapper.
 -->
 <script lang="ts">
   import type { Snippet } from 'svelte';
@@ -24,8 +26,8 @@ primitive when a scroll viewport also needs edge fades.
     scrollClass?: string;
     /** Bound to the inner scroll container for imperative integrations. */
     scrollEl?: HTMLDivElement;
-    /** Optional lifecycle attachment for the inner scroll container. */
-    scrollAttachment?: Attachment<HTMLDivElement>;
+    /** Optional lifecycle attachment for the stable content wrapper. */
+    contentAttachment?: Attachment<HTMLDivElement>;
     /** Keep the scroll viewport in the tab order for keyboard scrolling. */
     keyboardFocusable?: boolean;
     [key: string]: unknown;
@@ -39,7 +41,7 @@ primitive when a scroll viewport also needs edge fades.
     class: className = '',
     scrollClass = '',
     scrollEl = $bindable(),
-    scrollAttachment,
+    contentAttachment,
     keyboardFocusable = true,
     ...rest
   }: Props = $props();
@@ -52,17 +54,18 @@ primitive when a scroll viewport also needs edge fades.
   <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <div
     bind:this={scrollEl}
-    {@attach scrollAttachment}
     role={keyboardFocusable ? 'region' : undefined}
     tabindex={keyboardFocusable ? 0 : undefined}
     class={[
-      'flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto',
+      'min-h-0 min-w-0 flex-1 overflow-y-auto',
       scrollX ? 'overflow-x-auto' : 'overflow-x-hidden',
       scrollClass
     ]}
     {...rest}
   >
-    {@render children()}
+    <div class="flex min-h-full flex-col" {@attach contentAttachment}>
+      {@render children()}
+    </div>
   </div>
   {@render overlay?.()}
 </div>

--- a/apps/frontend/src/lib/ui/ScrollFader.stories.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.stories.svelte
@@ -52,7 +52,8 @@ access to native attributes / events.
 ### Edge detection
 
 The fade visibility is driven by a Svelte attachment that listens to
-the scroll container's \`scroll\` event plus a \`ResizeObserver\`. The
+the scroll container's \`scroll\` event. A \`ResizeObserver\` watches the viewport
+and a stable inner content wrapper. Content changes need no mutation observer. The
 fades use \`transition-opacity\` so the show/hide is animated.
 `.trim();
 
@@ -66,6 +67,10 @@ fades use \`transition-opacity\` so the show/hide is animated.
       }
     }
   });
+</script>
+
+<script lang="ts">
+  let expanded = $state(false);
 </script>
 
 <Story
@@ -232,5 +237,23 @@ fades use \`transition-opacity\` so the show/hide is animated.
         {/each}
       </div>
     </ScrollFader>
+  </div>
+</Story>
+
+
+<Story name="Growing content" asChild>
+  <div class="flex w-64 flex-col gap-3">
+    <button class="btn btn-secondary cursor-pointer" onclick={() => { expanded = !expanded; }}>
+      {expanded ? 'Show short content' : 'Show long content'}
+    </button>
+    <div class="flex h-52 flex-col border border-border bg-background">
+      <ScrollFader top bottom>
+        <div class="mt-auto flex flex-col gap-2 p-3">
+          {#each Array(expanded ? 20 : 2) as _, i (i)}
+            <div class="rounded-md bg-surface px-3 py-2">Item {i + 1}</div>
+          {/each}
+        </div>
+      </ScrollFader>
+    </div>
   </div>
 </Story>

--- a/apps/frontend/src/lib/ui/ScrollFader.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.svelte
@@ -17,6 +17,7 @@ scroll container; children render inside the scroll container.
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import ScrollArea from './ScrollArea.svelte';
+  import { readScrollEdges, trackScrollEdges } from './scrollEdges';
 
   type Props = {
     children: Snippet;
@@ -64,48 +65,18 @@ scroll container; children render inside the scroll container.
   let scrolledFromTop = $state(false);
   let scrolledFromBottom = $state(false);
 
-  function updateScrollEdges(el: HTMLElement) {
-    const maxScrollTop = Math.max(0, el.scrollHeight - el.clientHeight);
-    const scrollTop = Math.min(Math.max(el.scrollTop, 0), maxScrollTop);
-    const canScroll = maxScrollTop > 1;
-
-    scrolledFromTop = canScroll && scrollTop > 1;
-    scrolledFromBottom = canScroll && maxScrollTop - scrollTop > 1;
+  function setScrollEdges(edges: { start: boolean; end: boolean }) {
+    scrolledFromTop = edges.start;
+    scrolledFromBottom = edges.end;
   }
 
-  function trackScrollEdges(el: HTMLElement) {
-    const update = () => {
-      updateScrollEdges(el);
-    };
-
-    update();
-    el.addEventListener('scroll', update, { passive: true });
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    for (const child of el.children) {
-      if (child instanceof HTMLElement) ro.observe(child);
-    }
-    const mo = new MutationObserver(() => {
-      ro.disconnect();
-      ro.observe(el);
-      for (const child of el.children) {
-        if (child instanceof HTMLElement) ro.observe(child);
-      }
-      update();
-    });
-    mo.observe(el, { childList: true });
-    return () => {
-      el.removeEventListener('scroll', update);
-      mo.disconnect();
-      ro.disconnect();
-    };
-  }
+  const observeScrollEdges = trackScrollEdges('y', setScrollEdges);
 
   export function refresh() {
     if (!scrollEl) return;
 
     requestAnimationFrame(() => {
-      if (scrollEl) updateScrollEdges(scrollEl);
+      if (scrollEl) setScrollEdges(readScrollEdges(scrollEl, 'y'));
     });
   }
 </script>
@@ -143,7 +114,7 @@ scroll container; children render inside the scroll container.
   {scrollClass}
   bind:scrollEl
   {keyboardFocusable}
-  scrollAttachment={trackScrollEdges}
+  scrollAttachment={observeScrollEdges}
   overlay={fades}
   {...rest}
 >

--- a/apps/frontend/src/lib/ui/ScrollFader.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFader.svelte
@@ -17,7 +17,7 @@ scroll container; children render inside the scroll container.
 <script lang="ts">
   import type { Snippet } from 'svelte';
   import ScrollArea from './ScrollArea.svelte';
-  import { readScrollEdges, trackScrollEdges } from './scrollEdges';
+  import { readScrollEdges, trackScrollEdges, type ScrollEdges } from './scrollEdges';
 
   type Props = {
     children: Snippet;
@@ -62,21 +62,16 @@ scroll container; children render inside the scroll container.
     ...rest
   }: Props = $props();
 
-  let scrolledFromTop = $state(false);
-  let scrolledFromBottom = $state(false);
-
-  function setScrollEdges(edges: { start: boolean; end: boolean }) {
-    scrolledFromTop = edges.start;
-    scrolledFromBottom = edges.end;
-  }
-
-  const observeScrollEdges = trackScrollEdges('y', setScrollEdges);
+  let edges = $state<ScrollEdges>({ start: false, end: false });
+  const observeScrollEdges = trackScrollEdges('y', (value) => {
+    edges = value;
+  });
 
   export function refresh() {
     if (!scrollEl) return;
 
     requestAnimationFrame(() => {
-      if (scrollEl) setScrollEdges(readScrollEdges(scrollEl, 'y'));
+      if (scrollEl) edges = readScrollEdges(scrollEl, 'y');
     });
   }
 </script>
@@ -90,7 +85,7 @@ scroll container; children render inside the scroll container.
         fadeColorClass,
         topFadeOffset,
         fadeHeight,
-        !scrolledFromTop && 'opacity-0'
+        !edges.start && 'opacity-0'
       ]}
     ></div>
   {/if}
@@ -101,7 +96,7 @@ scroll container; children render inside the scroll container.
         'pointer-events-none absolute inset-x-0 bottom-0 z-30 bg-gradient-to-t to-transparent transition-opacity',
         fadeColorClass,
         fadeHeight,
-        !scrolledFromBottom && 'opacity-0'
+        !edges.end && 'opacity-0'
       ]}
     ></div>
   {/if}
@@ -114,7 +109,7 @@ scroll container; children render inside the scroll container.
   {scrollClass}
   bind:scrollEl
   {keyboardFocusable}
-  scrollAttachment={observeScrollEdges}
+  contentAttachment={observeScrollEdges}
   overlay={fades}
   {...rest}
 >

--- a/apps/frontend/src/lib/ui/ScrollFader.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ScrollFader.svelte.spec.ts
@@ -1,6 +1,6 @@
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import ScrollFaderTestHarness from './ScrollFaderTestHarness.svelte';
 
 async function nextFrame() {
@@ -83,6 +83,9 @@ describe('ScrollFader', () => {
     await Promise.resolve();
     flushSync();
 
-    expect(getBottomFade(container).classList.contains('opacity-0')).toBe(true);
+    await vi.waitFor(() => {
+      flushSync();
+      expect(getBottomFade(container).classList.contains('opacity-0')).toBe(true);
+    });
   });
 });

--- a/apps/frontend/src/lib/ui/ScrollFaderLayout.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/ScrollFaderLayout.svelte.spec.ts
@@ -1,0 +1,65 @@
+import '../../app.css';
+import { flushSync } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import { describe, expect, it, vi } from 'vitest';
+import Harness from './ScrollFaderLayoutHarness.svelte';
+
+function layout(container: HTMLElement) {
+  const viewport = container.querySelector<HTMLElement>('[data-testid="layout-scroll"]')!;
+  const content = container.querySelector<HTMLElement>('[data-testid="layout-content"]')!;
+  const fades = () =>
+    [...viewport.parentElement!.querySelectorAll<HTMLElement>('[aria-hidden="true"]')].map(
+      (fade) => !fade.classList.contains('opacity-0')
+    );
+  return { viewport, content, fades };
+}
+
+describe('ScrollFader content layout', () => {
+  it('bottom-aligns short content and tracks growth, scrolling, and shrinkage', async () => {
+    const { container, component } = render(Harness);
+    const { viewport, content, fades } = layout(container);
+    expect(viewport.clientHeight).toBe(200);
+    expect(content.getBoundingClientRect().bottom).toBe(viewport.getBoundingClientRect().bottom);
+    expect(viewport.scrollHeight).toBe(200);
+    component.resizeContent(500);
+    flushSync();
+    await vi.waitFor(() => expect(fades()).toEqual([false, true]));
+    viewport.scrollTop = viewport.scrollHeight;
+    await vi.waitFor(() => expect(fades()).toEqual([true, false]));
+    component.resizeContent(60);
+    flushSync();
+    await vi.waitFor(() => expect(fades()).toEqual([false, false]));
+    expect(viewport.scrollHeight).toBe(200);
+  });
+
+  it('updates fades when only the viewport size changes', async () => {
+    const { container, component } = render(Harness);
+    const { fades } = layout(container);
+    component.resizeContent(300);
+    flushSync();
+    await vi.waitFor(() => expect(fades()).toEqual([false, true]));
+    component.resizeViewport(400);
+    flushSync();
+    await vi.waitFor(() => expect(fades()).toEqual([false, false]));
+  });
+
+  it('measures intrinsic content and caps taller previews', async () => {
+    const { container, component } = render(Harness, { intrinsic: true });
+    const { viewport, fades } = layout(container);
+    expect(viewport.clientHeight).toBe(60);
+    component.resizeContent(500);
+    flushSync();
+    await vi.waitFor(() => expect(fades()).toEqual([false, true]));
+    expect(viewport.clientHeight).toBe(Number.parseFloat(getComputedStyle(viewport).maxHeight));
+  });
+
+  it('updates fades after an image gains its natural height', async () => {
+    const { container, component } = render(Harness);
+    const { viewport, fades } = layout(container);
+    component.loadImage();
+    flushSync();
+    await container.querySelector('img')!.decode();
+    await vi.waitFor(() => expect(fades()).toEqual([false, true]));
+    expect(viewport.scrollHeight).toBe(460);
+  });
+});

--- a/apps/frontend/src/lib/ui/ScrollFaderLayoutHarness.svelte
+++ b/apps/frontend/src/lib/ui/ScrollFaderLayoutHarness.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import ScrollFader from './ScrollFader.svelte';
+
+  let { intrinsic = false }: { intrinsic?: boolean } = $props();
+  let height = $state(60);
+  let viewportHeight = $state(200);
+  let image = $state<string>();
+
+  export function resizeContent(value: number) {
+    height = value;
+  }
+  export function resizeViewport(value: number) {
+    viewportHeight = value;
+  }
+  export function loadImage() {
+    image =
+      'data:image/svg+xml,' +
+      encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="100" height="400"></svg>');
+  }
+</script>
+
+<div class="flex w-64 flex-col" style:height={intrinsic ? undefined : `${viewportHeight}px`}>
+  <ScrollFader
+    top
+    bottom
+    fill={!intrinsic}
+    scrollClass={intrinsic ? 'max-h-52' : ''}
+    data-testid="layout-scroll"
+  >
+    <div class="mt-auto shrink-0" data-testid="layout-content" style:height={`${height}px`}></div>
+    {#if image}<img src={image} alt="" class="w-[100px] shrink-0" />{/if}
+  </ScrollFader>
+</div>

--- a/apps/frontend/src/lib/ui/scrollEdges.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/scrollEdges.svelte.spec.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { readScrollEdges, trackScrollEdges } from './scrollEdges';
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+function viewport() {
+  const element = document.createElement('div');
+  element.style.cssText = 'width: 100px; height: 100px; overflow: auto; position: fixed;';
+  const child = document.createElement('div');
+  child.style.cssText = 'width: 300px; height: 300px;';
+  element.append(child);
+  document.body.append(element);
+  cleanups.push(() => element.remove());
+  return { element, child };
+}
+
+describe('scroll edge attachment', () => {
+  it.each(['x', 'y'] as const)('tracks both edges on the %s axis', async (axis) => {
+    const { element } = viewport();
+    const changed = vi.fn();
+    const cleanup = trackScrollEdges(axis, changed)(element);
+    if (cleanup) cleanups.push(cleanup);
+    expect(changed).toHaveBeenLastCalledWith({ start: false, end: true });
+
+    element.scrollTo(50, 50);
+    await vi.waitFor(() => expect(changed).toHaveBeenLastCalledWith({ start: true, end: true }));
+    element.scrollTo(1000, 1000);
+    await vi.waitFor(() => expect(changed).toHaveBeenLastCalledWith({ start: true, end: false }));
+  });
+
+  it('tracks replacement children and their later size changes', async () => {
+    const { element } = viewport();
+    const changed = vi.fn();
+    const cleanup = trackScrollEdges('y', changed)(element);
+    if (cleanup) cleanups.push(cleanup);
+    const replacement = document.createElement('div');
+    replacement.style.height = '50px';
+    element.replaceChildren(replacement);
+    await vi.waitFor(() => expect(changed).toHaveBeenLastCalledWith({ start: false, end: false }));
+    replacement.style.height = '300px';
+    await vi.waitFor(() => expect(changed).toHaveBeenLastCalledWith({ start: false, end: true }));
+  });
+
+  it('stops reporting scroll and layout changes after detach', async () => {
+    const { element, child } = viewport();
+    const changed = vi.fn();
+    const cleanup = trackScrollEdges('y', changed)(element);
+    if (cleanup) cleanup();
+    changed.mockClear();
+    element.dispatchEvent(new Event('scroll'));
+    child.style.height = '50px';
+    element.replaceChildren(document.createElement('div'));
+    // Let native mutation and resize deliveries run before checking cleanup.
+    await new Promise<void>((resolve) =>
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    );
+    expect(changed).not.toHaveBeenCalled();
+  });
+
+  it('clamps overscroll and ignores one-pixel rounding differences', () => {
+    const { element } = viewport();
+    Object.defineProperties(element, {
+      scrollTop: { value: -20, configurable: true },
+      scrollHeight: { value: 300, configurable: true },
+      clientHeight: { value: 100 }
+    });
+    expect(readScrollEdges(element, 'y')).toEqual({ start: false, end: true });
+    Object.defineProperty(element, 'scrollTop', { value: 220 });
+    expect(readScrollEdges(element, 'y')).toEqual({ start: true, end: false });
+    Object.defineProperty(element, 'scrollHeight', { value: 101 });
+    expect(readScrollEdges(element, 'y')).toEqual({ start: false, end: false });
+  });
+});

--- a/apps/frontend/src/lib/ui/scrollEdges.svelte.spec.ts
+++ b/apps/frontend/src/lib/ui/scrollEdges.svelte.spec.ts
@@ -9,19 +9,22 @@ afterEach(() => {
 function viewport() {
   const element = document.createElement('div');
   element.style.cssText = 'width: 100px; height: 100px; overflow: auto; position: fixed;';
+  const content = document.createElement('div');
+  content.style.cssText = 'display: flow-root; width: max-content; min-width: 100%;';
   const child = document.createElement('div');
   child.style.cssText = 'width: 300px; height: 300px;';
-  element.append(child);
+  content.append(child);
+  element.append(content);
   document.body.append(element);
   cleanups.push(() => element.remove());
-  return { element, child };
+  return { element, content, child };
 }
 
 describe('scroll edge attachment', () => {
   it.each(['x', 'y'] as const)('tracks both edges on the %s axis', async (axis) => {
-    const { element } = viewport();
+    const { element, content } = viewport();
     const changed = vi.fn();
-    const cleanup = trackScrollEdges(axis, changed)(element);
+    const cleanup = trackScrollEdges(axis, changed)(content);
     if (cleanup) cleanups.push(cleanup);
     expect(changed).toHaveBeenLastCalledWith({ start: false, end: true });
 
@@ -32,27 +35,27 @@ describe('scroll edge attachment', () => {
   });
 
   it('tracks replacement children and their later size changes', async () => {
-    const { element } = viewport();
+    const { content } = viewport();
     const changed = vi.fn();
-    const cleanup = trackScrollEdges('y', changed)(element);
+    const cleanup = trackScrollEdges('y', changed)(content);
     if (cleanup) cleanups.push(cleanup);
     const replacement = document.createElement('div');
     replacement.style.height = '50px';
-    element.replaceChildren(replacement);
+    content.replaceChildren(replacement);
     await vi.waitFor(() => expect(changed).toHaveBeenLastCalledWith({ start: false, end: false }));
     replacement.style.height = '300px';
     await vi.waitFor(() => expect(changed).toHaveBeenLastCalledWith({ start: false, end: true }));
   });
 
   it('stops reporting scroll and layout changes after detach', async () => {
-    const { element, child } = viewport();
+    const { element, content, child } = viewport();
     const changed = vi.fn();
-    const cleanup = trackScrollEdges('y', changed)(element);
+    const cleanup = trackScrollEdges('y', changed)(content);
     if (cleanup) cleanup();
     changed.mockClear();
     element.dispatchEvent(new Event('scroll'));
     child.style.height = '50px';
-    element.replaceChildren(document.createElement('div'));
+    content.replaceChildren(document.createElement('div'));
     // Let native mutation and resize deliveries run before checking cleanup.
     await new Promise<void>((resolve) =>
       requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
@@ -60,7 +63,7 @@ describe('scroll edge attachment', () => {
     expect(changed).not.toHaveBeenCalled();
   });
 
-  it('clamps overscroll and ignores one-pixel rounding differences', () => {
+  it('handles overscroll and ignores one-pixel rounding differences', () => {
     const { element } = viewport();
     Object.defineProperties(element, {
       scrollTop: { value: -20, configurable: true },

--- a/apps/frontend/src/lib/ui/scrollEdges.ts
+++ b/apps/frontend/src/lib/ui/scrollEdges.ts
@@ -1,0 +1,58 @@
+import type { Attachment } from 'svelte/attachments';
+
+/** Whether content extends past each edge of a physical scroll axis. */
+export type ScrollEdges = { start: boolean; end: boolean };
+
+/** Read edge visibility with a one-pixel tolerance and clamp browser overscroll. */
+export function readScrollEdges(element: HTMLElement, axis: 'x' | 'y'): ScrollEdges {
+  const maximum = Math.max(
+    0,
+    axis === 'x'
+      ? element.scrollWidth - element.clientWidth
+      : element.scrollHeight - element.clientHeight
+  );
+  const position = Math.min(
+    Math.max(axis === 'x' ? element.scrollLeft : element.scrollTop, 0),
+    maximum
+  );
+  return {
+    start: maximum > 1 && position > 1,
+    end: maximum > 1 && maximum - position > 1
+  };
+}
+
+/**
+ * Report edges on mount, scroll, and viewport or direct-child size changes.
+ * Track replacement children and release listeners and observers on detach.
+ */
+export function trackScrollEdges(
+  axis: 'x' | 'y',
+  onchange: (edges: ScrollEdges) => void
+): Attachment<HTMLElement> {
+  return (element) => {
+    const update = () => onchange(readScrollEdges(element, axis));
+    const resizeObserver = new ResizeObserver(update);
+    const observeChildren = () => {
+      resizeObserver.disconnect();
+      resizeObserver.observe(element);
+      for (const child of element.children) {
+        if (child instanceof HTMLElement) resizeObserver.observe(child);
+      }
+    };
+    const mutationObserver = new MutationObserver(() => {
+      observeChildren();
+      update();
+    });
+
+    update();
+    element.addEventListener('scroll', update, { passive: true });
+    observeChildren();
+    mutationObserver.observe(element, { childList: true });
+
+    return () => {
+      element.removeEventListener('scroll', update);
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+    };
+  };
+}

--- a/apps/frontend/src/lib/ui/scrollEdges.ts
+++ b/apps/frontend/src/lib/ui/scrollEdges.ts
@@ -3,18 +3,13 @@ import type { Attachment } from 'svelte/attachments';
 /** Whether content extends past each edge of a physical scroll axis. */
 export type ScrollEdges = { start: boolean; end: boolean };
 
-/** Read edge visibility with a one-pixel tolerance and clamp browser overscroll. */
+/** Read edge visibility with a one-pixel tolerance, including browser overscroll. */
 export function readScrollEdges(element: HTMLElement, axis: 'x' | 'y'): ScrollEdges {
-  const maximum = Math.max(
-    0,
+  const maximum =
     axis === 'x'
       ? element.scrollWidth - element.clientWidth
-      : element.scrollHeight - element.clientHeight
-  );
-  const position = Math.min(
-    Math.max(axis === 'x' ? element.scrollLeft : element.scrollTop, 0),
-    maximum
-  );
+      : element.scrollHeight - element.clientHeight;
+  const position = axis === 'x' ? element.scrollLeft : element.scrollTop;
   return {
     start: maximum > 1 && position > 1,
     end: maximum > 1 && maximum - position > 1
@@ -22,37 +17,26 @@ export function readScrollEdges(element: HTMLElement, axis: 'x' | 'y'): ScrollEd
 }
 
 /**
- * Report edges on mount, scroll, and viewport or direct-child size changes.
- * Track replacement children and release listeners and observers on detach.
+ * Attach to a stable content wrapper directly inside its scroll viewport.
+ * The wrapper must size to its content on the tracked axis. Observe both
+ * elements so content and viewport resizing update the edges without DOM watches.
  */
 export function trackScrollEdges(
   axis: 'x' | 'y',
   onchange: (edges: ScrollEdges) => void
 ): Attachment<HTMLElement> {
-  return (element) => {
-    const update = () => onchange(readScrollEdges(element, axis));
-    const resizeObserver = new ResizeObserver(update);
-    const observeChildren = () => {
-      resizeObserver.disconnect();
-      resizeObserver.observe(element);
-      for (const child of element.children) {
-        if (child instanceof HTMLElement) resizeObserver.observe(child);
-      }
-    };
-    const mutationObserver = new MutationObserver(() => {
-      observeChildren();
-      update();
-    });
-
+  return (content) => {
+    const viewport = content.parentElement!;
+    const update = () => onchange(readScrollEdges(viewport, axis));
+    const observer = new ResizeObserver(update);
+    observer.observe(viewport);
+    observer.observe(content);
+    viewport.addEventListener('scroll', update, { passive: true });
     update();
-    element.addEventListener('scroll', update, { passive: true });
-    observeChildren();
-    mutationObserver.observe(element, { childList: true });
 
     return () => {
-      element.removeEventListener('scroll', update);
-      mutationObserver.disconnect();
-      resizeObserver.disconnect();
+      viewport.removeEventListener('scroll', update);
+      observer.disconnect();
     };
   };
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { trackScrollEdges } from '$lib/ui/scrollEdges';
+  import { trackScrollEdges, type ScrollEdges } from '$lib/ui/scrollEdges';
   import type { MessageAttachmentView } from '$lib/render/messageAttachments';
   import type { ImageItem } from '$lib/ui/ImageModal.svelte';
 
@@ -58,8 +58,7 @@
   let refreshPromise: Promise<Map<string, RefreshedAttachmentUrls>> | null = null;
   const failedAssetRefreshKeys = new SvelteSet<string>();
   const retainAssetUrl = createAssetUrlRetainer();
-  let galleryScrolledFromLeft = $state(false);
-  let galleryScrolledFromRight = $state(false);
+  let galleryEdges = $state<ScrollEdges>({ start: false, end: false });
 
   function normalizeAssetUrl(value: ExpiringAssetUrl | null | undefined): ExpiringAssetUrl | null {
     if (!value) return null;
@@ -236,8 +235,7 @@
   }
 
   const trackGalleryScrollEdges = trackScrollEdges('x', (edges) => {
-    galleryScrolledFromLeft = edges.start;
-    galleryScrolledFromRight = edges.end;
+    galleryEdges = edges;
   });
 
   const imageAttachments = $derived(attachments.filter(isGalleryImageAttachment));
@@ -611,20 +609,21 @@
     <div class="mt-2 flex min-w-0 flex-col gap-2 first:mt-0">
       <div class="relative w-full max-w-full min-w-0">
         <div
-          {@attach trackGalleryScrollEdges}
-          class="flex w-full gap-3 overflow-x-auto overscroll-x-contain p-1"
+          class="w-full overflow-x-auto overscroll-x-contain"
           data-testid="message-image-gallery"
         >
-          {#each imageAttachments as attachment (attachment.id)}
-            {@render imageAttachmentButton(attachment, 'gallery')}
-          {/each}
+          <div class="flex w-max min-w-full gap-3 p-1" {@attach trackGalleryScrollEdges}>
+            {#each imageAttachments as attachment (attachment.id)}
+              {@render imageAttachmentButton(attachment, 'gallery')}
+            {/each}
+          </div>
         </div>
         <div
           aria-hidden="true"
           data-testid="message-image-gallery-left-fade"
           class={[
             'pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-background to-transparent transition-opacity',
-            !galleryScrolledFromLeft && 'opacity-0'
+            !galleryEdges.start && 'opacity-0'
           ]}
         ></div>
         <div
@@ -632,7 +631,7 @@
           data-testid="message-image-gallery-right-fade"
           class={[
             'pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-background to-transparent transition-opacity',
-            !galleryScrolledFromRight && 'opacity-0'
+            !galleryEdges.end && 'opacity-0'
           ]}
         ></div>
       </div>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { trackScrollEdges } from '$lib/ui/scrollEdges';
   import type { MessageAttachmentView } from '$lib/render/messageAttachments';
   import type { ImageItem } from '$lib/ui/ImageModal.svelte';
 
@@ -234,43 +235,10 @@
     return attachment.thumbnailUrl ?? attachment.url;
   }
 
-  function updateGalleryScrollEdges(el: HTMLElement) {
-    const maxScrollLeft = Math.max(0, el.scrollWidth - el.clientWidth);
-    const scrollLeft = Math.min(Math.max(el.scrollLeft, 0), maxScrollLeft);
-    const canScroll = maxScrollLeft > 1;
-
-    galleryScrolledFromLeft = canScroll && scrollLeft > 1;
-    galleryScrolledFromRight = canScroll && maxScrollLeft - scrollLeft > 1;
-  }
-
-  function trackGalleryScrollEdges(el: HTMLElement) {
-    const update = () => updateGalleryScrollEdges(el);
-
-    update();
-    el.addEventListener('scroll', update, { passive: true });
-
-    const ro = new ResizeObserver(update);
-    ro.observe(el);
-    for (const child of el.children) {
-      if (child instanceof HTMLElement) ro.observe(child);
-    }
-
-    const mo = new MutationObserver(() => {
-      ro.disconnect();
-      ro.observe(el);
-      for (const child of el.children) {
-        if (child instanceof HTMLElement) ro.observe(child);
-      }
-      update();
-    });
-    mo.observe(el, { childList: true });
-
-    return () => {
-      el.removeEventListener('scroll', update);
-      mo.disconnect();
-      ro.disconnect();
-    };
-  }
+  const trackGalleryScrollEdges = trackScrollEdges('x', (edges) => {
+    galleryScrolledFromLeft = edges.start;
+    galleryScrolledFromRight = edges.end;
+  });
 
   const imageAttachments = $derived(attachments.filter(isGalleryImageAttachment));
   const hasImageGallery = $derived(imageAttachments.length > 1);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/MessageAttachments.svelte.spec.ts
@@ -1,3 +1,4 @@
+import '../../../../app.css';
 import { ImageFitMode } from '@chatto/api-types/api/v1/common_pb';
 import { tick } from 'svelte';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -448,6 +449,23 @@ describe('MessageAttachments', () => {
     });
   });
 
+  it('updates gallery fades as its viewport scrolls and resizes', async () => {
+    const { container } = renderAttachments([
+      imageAttachment({ id: 'first', width: 1600, height: 900 }),
+      imageAttachment({ id: 'second', width: 1600, height: 900 })
+    ]);
+    const gallery = container.querySelector<HTMLElement>('[data-testid="message-image-gallery"]')!;
+    const fades = () => ['left', 'right'].map((edge) =>
+      !container.querySelector(`[data-testid="message-image-gallery-${edge}-fade"]`)!.classList.contains('opacity-0')
+    );
+    gallery.style.width = '200px';
+    await vi.waitFor(() => expect(fades()).toEqual([false, true]));
+    gallery.scrollLeft = gallery.scrollWidth;
+    await vi.waitFor(() => expect(fades()).toEqual([true, false]));
+    gallery.style.width = '1000px';
+    await vi.waitFor(() => expect(fades()).toEqual([false, false]));
+  });
+
   it('renders multiple images inside a horizontal gallery with equal-height frames', () => {
     const { container } = renderAttachments([
       imageAttachment({
@@ -468,8 +486,8 @@ describe('MessageAttachments', () => {
     expect(gallery).not.toBeNull();
     expect(gallery!.className).toContain('overflow-x-auto');
     expect(gallery!.className).toContain('overscroll-x-contain');
-    expect(gallery!.className).toContain('gap-3');
-    expect(gallery!.className).toContain('p-1');
+    expect(gallery!.firstElementChild!.className).toContain('gap-3');
+    expect(gallery!.firstElementChild!.className).toContain('p-1');
     expect(gallery!.parentElement?.className).toContain('w-full');
     expect(gallery!.parentElement?.getAttribute('style')).toBeNull();
     expect(


### PR DESCRIPTION
## Why

ScrollFader and image galleries duplicate scroll-edge observation and cleanup. Both previously watched each content child and rebuilt their resize observations after DOM mutations. Share the edge tracking and simplify its lifecycle with a stable content wrapper.

## Changes

- Add one content wrapper inside each scroll viewport. Observe only the viewport and wrapper with one ResizeObserver; remove the MutationObserver and per-child tracking.
- Share edge measurement and attachment cleanup across vertical fades and horizontal galleries. Remove redundant overscroll clamping and store the edge flags together.
- Keep the existing scroll element for Virtua, native events, keyboard access, and explicit refresh. The vertical content wrapper fills short viewports to preserve bottom alignment and sizes to longer content. Gallery padding and gaps move into a wrapper that sizes to its contents.
- Give PaneContent a zero-length flex basis so both short and overflowing primary children fill the available height through the new wrapper. Test the resulting geometry instead of relying on parent depth.
- Replace ScrollArea's internal `scrollAttachment` prop with `contentAttachment` at its sole caller. Public protocols and persisted data do not change.
- Add a growing-content story and browser coverage for content growth/shrinkage, replacement children, image sizing, viewport resizing, intrinsic previews, gallery scrolling, and observer cleanup.

## Validation

- `mise test-frontend`: passed the full suite — 1,365 Node tests, 2,039 Chromium component tests, 242 Storybook tests, and 5 performance-comparison tests.
- `mise test-e2e -- e2e/auto-scroll.test.ts e2e/virtualizer-stability.test.ts --retries=0`: all 15 passed, including bottom alignment, room switching, incoming messages, auto-scroll, and fade resets.
- Gallery keyboard-navigation e2e test: passed with retries disabled; verifies actual image spacing and horizontal scrolling through the new wrapper.
- `mise lint-frontend`: passed, zero Svelte errors or warnings.
- `mise build-frontend`: passed, including bundle budgets and CSP checks.
- `mise license-check` and `git diff --check`: passed. Svelte autofixer reported no issues; ScrollArea retains `bind:this` because its viewport is exposed to callers.
- Chrome DevTools: verified growing/shrinking content, fade states, bottom alignment, and a sticky table during horizontal and vertical scrolling. No console warnings or errors. Storybook was stopped.

All applicable CI checks passed for commit `6dbe5aed0`, including workspace tests, all four e2e shards, media and performance tests, CLI, desktop, and compatibility/code-generation checks. Main-branch image build and publish jobs are skipped for this PR.
