### PR TITLE
refactor(frontend): unify visible pagination attachments

### DIFF
--- a/apps/frontend/src/lib/hooks/loadMoreVisibility.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/loadMoreVisibility.svelte.spec.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { useLoadMoreWhenVisible } from './useLoadMoreWhenVisible.svelte';
+
+const cleanups: Array<() => void> = [];
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+});
+
+it('fills a nested scroller without fetching pages hidden below its edge', async () => {
+  const root = document.createElement('div');
+  root.style.cssText =
+    'position: fixed; top: 20px; left: 20px; height: 100px; width: 200px; overflow: auto;';
+  const content = document.createElement('div');
+  const sentinel = document.createElement('div');
+  sentinel.style.height = '10px';
+  root.append(content, sentinel);
+  document.body.append(root);
+  cleanups.push(() => root.remove());
+  let cursor = 0;
+  const loadMore = vi.fn(async () => {
+    cursor++;
+    const row = document.createElement('div');
+    row.style.height = '60px';
+    content.append(row);
+  });
+  const cleanup = useLoadMoreWhenVisible({
+    getCursor: () => (cursor < 10 ? cursor : null),
+    loadMore
+  })(sentinel);
+  if (cleanup) cleanups.push(cleanup);
+  await vi.waitFor(() => expect(loadMore).toHaveBeenCalledTimes(2));
+  // Allow the native observer to deliver the negative intersection after layout.
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  );
+  expect(loadMore).toHaveBeenCalledTimes(2);
+  expect(sentinel.getBoundingClientRect().top).toBeLessThan(window.innerHeight);
+  expect(sentinel.getBoundingClientRect().top).toBeGreaterThan(root.getBoundingClientRect().bottom);
+
+  root.style.height = '200px';
+  await vi.waitFor(() => expect(loadMore).toHaveBeenCalledTimes(4));
+  await new Promise<void>((resolve) =>
+    requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+  );
+  expect(loadMore).toHaveBeenCalledTimes(4);
+});

--- a/apps/frontend/src/lib/hooks/loadMoreWhenVisible.stories.svelte
+++ b/apps/frontend/src/lib/hooks/loadMoreWhenVisible.stories.svelte
@@ -1,0 +1,38 @@
+<script module lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+
+	const { Story } = defineMeta({
+		title: 'Foundations/Visible pagination',
+		tags: ['autodocs']
+	});
+</script>
+
+<script lang="ts">
+	import ScrollArea from '$lib/ui/ScrollArea.svelte';
+	import Button from '$lib/ui/form/Button.svelte';
+	import { useLoadMoreWhenVisible } from './useLoadMoreWhenVisible.svelte';
+
+	let count = $state(0);
+	let generation = $state(0);
+	const loadMore = useLoadMoreWhenVisible({
+		getCursor: () => count < 30 ? count : null,
+		loadMore: async () => { count += 2; }
+	});
+</script>
+
+<Story name="Nested scroll container" asChild>
+	<div class="flex w-72 flex-col gap-3">
+		<p>{count} of 30 items loaded</p>
+		<Button variant="secondary" onclick={() => { count = 0; generation++; }}>Reset</Button>
+		{#key generation}
+			<ScrollArea fill={false} class="h-40 rounded border border-border" data-testid="pagination-scroll" aria-label="Example items">
+				{#each Array(count) as _, i (i)}
+					<div class="flex h-14 items-center px-3">Item {i + 1}</div>
+				{/each}
+				{#if count < 30}
+					<div class="h-4" {@attach loadMore}></div>
+				{/if}
+			</ScrollArea>
+		{/key}
+	</div>
+</Story>

--- a/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.spec.ts
@@ -1,63 +1,143 @@
+import { tick } from 'svelte';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useLoadMoreWhenVisible } from './useLoadMoreWhenVisible.svelte';
 
 let intersectionCallback: IntersectionObserverCallback;
-const disconnectObserver = vi.fn();
+const observe = vi.fn();
+const unobserve = vi.fn();
+const disconnect = vi.fn();
+const intersect = (visible = true) =>
+  intersectionCallback(
+    [{ isIntersecting: visible } as IntersectionObserverEntry],
+    {} as IntersectionObserver
+  );
 
 beforeEach(() => {
-  disconnectObserver.mockReset();
+  vi.clearAllMocks();
   vi.stubGlobal(
     'IntersectionObserver',
     class {
       constructor(callback: IntersectionObserverCallback) {
         intersectionCallback = callback;
       }
-      observe = vi.fn();
-      disconnect = disconnectObserver;
+      observe = observe;
+      unobserve = unobserve;
+      disconnect = disconnect;
     }
   );
 });
+afterEach(() => vi.unstubAllGlobals());
 
-afterEach(() => {
-  vi.unstubAllGlobals();
-  document.body.replaceChildren();
-});
+function mount(options: Parameters<typeof useLoadMoreWhenVisible>[0]) {
+  const node = document.createElement('div');
+  return useLoadMoreWhenVisible(options)(node);
+}
+
+const settle = async () => {
+  await tick();
+  await tick();
+};
 
 describe('useLoadMoreWhenVisible', () => {
-  it('loads successive pages while the sentinel remains near the viewport', async () => {
-    let cursor: string | null = 'first';
+  it('requests a new visibility measurement after progress, including offset zero', async () => {
+    let cursor: number | null = 0;
     const loadMore = vi.fn(async () => {
-      cursor = cursor === 'first' ? 'second' : null;
+      cursor = cursor === 0 ? 1 : null;
     });
-    const attachment = useLoadMoreWhenVisible({
-      getCursor: () => cursor,
-      loadMore,
-      hasError: () => false
-    });
-    const sentinel = document.createElement('div');
-    document.body.append(sentinel);
-    const cleanup = attachment(sentinel);
-
-    intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as never);
-
-    await vi.waitFor(() => expect(loadMore).toHaveBeenCalledTimes(2));
-    if (typeof cleanup === 'function') cleanup();
-    expect(disconnectObserver).toHaveBeenCalledOnce();
+    mount({ getCursor: () => cursor, loadMore });
+    intersect();
+    await vi.waitFor(() => expect(observe).toHaveBeenCalledTimes(2));
+    expect(unobserve).toHaveBeenCalledOnce();
+    expect(loadMore).toHaveBeenCalledOnce();
+    // Only the browser's next positive intersection starts another page.
+    intersect(false);
+    expect(loadMore).toHaveBeenCalledOnce();
+    intersect();
+    await settle();
+    expect(loadMore).toHaveBeenCalledTimes(2);
+    expect(observe).toHaveBeenCalledTimes(2);
   });
 
-  it('stops when loading does not advance the cursor', async () => {
+  it('does not loop when loading leaves the cursor unchanged', async () => {
     const loadMore = vi.fn(async () => {});
-    const attachment = useLoadMoreWhenVisible({
-      getCursor: () => 'unchanged',
-      loadMore,
-      hasError: () => false
+    mount({ getCursor: () => 'same', loadMore });
+    intersect();
+    await settle();
+    expect(loadMore).toHaveBeenCalledOnce();
+    expect(unobserve).not.toHaveBeenCalled();
+  });
+
+  it('ignores repeated intersections while a request is pending', async () => {
+    let finish!: () => void;
+    const loadMore = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve;
+        })
+    );
+    mount({ getCursor: () => 'first', loadMore });
+    intersect();
+    intersect();
+    intersect();
+    expect(loadMore).toHaveBeenCalledOnce();
+    finish();
+    await settle();
+  });
+
+  it('stops on an error and allows loading after recovery and a new intersection', async () => {
+    let cursor = 1;
+    let error = false;
+    const loadMore = vi.fn(async () => {
+      cursor++;
+      error = true;
     });
-    const sentinel = document.createElement('div');
-    document.body.append(sentinel);
-    attachment(sentinel);
+    mount({ getCursor: () => cursor, loadMore, hasError: () => error });
+    intersect();
+    await settle();
+    expect(observe).toHaveBeenCalledOnce();
+    intersect();
+    expect(loadMore).toHaveBeenCalledOnce();
+    error = false;
+    intersect();
+    await settle();
+    expect(loadMore).toHaveBeenCalledTimes(2);
+  });
 
-    intersectionCallback([{ isIntersecting: true } as IntersectionObserverEntry], {} as never);
+  it('does not load exhausted pages', () => {
+    const loadMore = vi.fn(async () => {});
+    mount({ getCursor: () => null, loadMore });
+    intersect();
+    expect(loadMore).not.toHaveBeenCalled();
+  });
 
-    await vi.waitFor(() => expect(loadMore).toHaveBeenCalledOnce());
+  it('handles rejected loads without an automatic retry', async () => {
+    const loadMore = vi.fn(async () => {
+      throw new Error('request failed');
+    });
+    mount({ getCursor: () => 'first', loadMore });
+    intersect();
+    await settle();
+    expect(loadMore).toHaveBeenCalledOnce();
+    expect(unobserve).not.toHaveBeenCalled();
+  });
+
+  it('discards queued callbacks and late completion after detach', async () => {
+    let finish!: () => void;
+    let cursor = 1;
+    const loadMore = vi.fn(async () => {
+      await new Promise<void>((resolve) => {
+        finish = resolve;
+      });
+      cursor++;
+    });
+    const cleanup = mount({ getCursor: () => cursor, loadMore });
+    intersect();
+    if (cleanup) cleanup();
+    intersect();
+    finish();
+    await settle();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(loadMore).toHaveBeenCalledOnce();
+    expect(observe).toHaveBeenCalledOnce();
   });
 });

--- a/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useLoadMoreWhenVisible.svelte.ts
@@ -2,35 +2,42 @@ import { tick } from 'svelte';
 import type { Attachment } from 'svelte/attachments';
 
 type LoadMoreWhenVisibleOptions = {
-  getCursor: () => string | null;
+  /** Cursor or offset; null means there are no more pages. */
+  getCursor: () => string | number | null;
+  /** The owner reports errors and provides manual retry controls. */
   loadMore: () => Promise<void>;
-  hasError: () => boolean;
+  hasError?: () => boolean;
 };
 
-/** Load successive pages while a trailing sentinel remains near the viewport. */
+/**
+ * Load successive pages while a sentinel intersects the viewport and its scroll
+ * ancestors. Re-observe after each advancing page so the browser checks the new
+ * layout. Detach stops continuation; the owner controls in-flight requests.
+ */
 export function useLoadMoreWhenVisible({
   getCursor,
   loadMore,
-  hasError
+  hasError = () => false
 }: LoadMoreWhenVisibleOptions): Attachment<HTMLElement> {
   return (node) => {
     if (typeof IntersectionObserver === 'undefined') return;
-    let loadingVisiblePages = false;
+    let active = true;
+    let loading = false;
 
     const loadVisiblePages = async (): Promise<void> => {
-      if (loadingVisiblePages) return;
-      loadingVisiblePages = true;
+      const cursor = getCursor();
+      if (!active || loading || cursor === null || hasError()) return;
+      loading = true;
       try {
-        do {
-          const cursor = getCursor();
-          await loadMore();
-          await tick();
-          if (hasError() || getCursor() === cursor) break;
-          const bounds = node.getBoundingClientRect();
-          if (bounds.top > window.innerHeight + 160 || bounds.bottom < -160) break;
-        } while (getCursor() && node.isConnected);
+        await loadMore();
+        await tick();
+        if (!active || hasError() || getCursor() === null || getCursor() === cursor) return;
+        observer.unobserve(node);
+        observer.observe(node);
+      } catch {
+        // A rejected load must not start an automatic retry loop.
       } finally {
-        loadingVisiblePages = false;
+        loading = false;
       }
     };
 
@@ -41,6 +48,9 @@ export function useLoadMoreWhenVisible({
       { rootMargin: '160px 0px' }
     );
     observer.observe(node);
-    return () => observer.disconnect();
+    return () => {
+      active = false;
+      observer.disconnect();
+    };
   };
 }

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
@@ -4,6 +4,7 @@
 Room-scoped file list for the room sidebar.
 -->
 <script lang="ts">
+  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
   import type { RoomFileItem, RoomFilesStore } from '$lib/state/room';
   import { assetUrlForServer } from '$lib/assets/assetUrls';
   import { useExpiringAssetUrlRefresh } from '$lib/attachments/useExpiringAssetUrlRefresh.svelte';
@@ -115,21 +116,10 @@ Room-scoped file list for the room sidebar.
     void store.refreshUrlsForItem(item);
   }
 
-  function loadMoreWhenVisible(node: HTMLElement) {
-    if (typeof IntersectionObserver === 'undefined') return;
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        if (!entries.some((entry) => entry.isIntersecting)) return;
-        if (!store.hasMore || store.isLoadingMore) return;
-        void store.loadMore();
-      },
-      { rootMargin: '160px 0px' }
-    );
-    observer.observe(node);
-
-    return () => observer.disconnect();
-  }
+  const loadMoreWhenVisible = useLoadMoreWhenVisible({
+    getCursor: () => store.hasMore ? store.items.length : null,
+    loadMore: () => store.loadMore()
+  });
 
   function formatTimestamp(value: string): string {
     return formatDateTime(value, userSettings, activeLocale);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomPinsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomPinsPanel.svelte
@@ -5,8 +5,8 @@ Channel pinned messages rendered through the room timeline's canonical
 message presentation. Each message row itself opens the original message.
 -->
 <script lang="ts">
+  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
-  import type { Attachment } from 'svelte/attachments';
   import type { Message } from '@chatto/api-types/api/v1/message_types_pb';
   import MessageView from '$lib/components/messages/MessageView.svelte';
   import { m } from '$lib/i18n/messages';
@@ -83,13 +83,12 @@ message presentation. Each message row itself opens the original message.
     openPin(message);
   }
 
-  const loadMoreWhenVisible: Attachment = (element) => {
-    const observer = new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting && !store.loadMoreError) void store.loadMore();
-    });
-    observer.observe(element);
-    return () => observer.disconnect();
-  };
+  const loadMoreWhenVisible = useLoadMoreWhenVisible({
+    getCursor: () => store.hasMore ? store.items.length : null,
+    loadMore: () => store.loadMore(),
+    hasError: () => store.loadMoreError
+  });
+
 </script>
 
 <ScrollFader top bottom keyboardFocusable={false} class="min-h-0 flex-1">


### PR DESCRIPTION
The shared pagination attachment checked the browser viewport after loading a page, so it could keep fetching items hidden below a nested scroll container. It now re-observes the sentinel after each advancing page and lets IntersectionObserver check the current layout and ancestor clipping.

Files and pins now use the same attachment as search, threads, and notifications. Numeric offsets are supported alongside cursors. Requests remain serialized, and automatic continuation stops on exhaustion, unchanged progress, errors, or detach. Stores retain data loading and retry ownership.

Validation:

- 1,365 Node, 2,045 browser, and 243 Storybook tests passed.
- 18 files/search/threads e2e tests passed with retries disabled.
- Added native nested-scroll coverage and lifecycle/error tests; checked the example in Chrome DevTools.
- Frontend lint, build/bundle/CSP checks, license check, Svelte autofixer, and five performance comparisons passed.

No public protocol, persistence, or migration changes. CI passed on commit `460b0eee6be6aab3a0078f0c05a5b24dd0a532a5` (17 successful checks; two conditional jobs skipped).
