### PR TITLE
refactor(frontend): share canvas lifecycle observers

### DIFF
--- a/apps/frontend/src/lib/attachments/observeCanvas.svelte.spec.ts
+++ b/apps/frontend/src/lib/attachments/observeCanvas.svelte.spec.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { observeCanvas } from './observeCanvas';
+
+let intersect: IntersectionObserverCallback;
+let resize: ResizeObserverCallback;
+let motion: EventTarget & { matches: boolean };
+const disconnectResize = vi.fn();
+const disconnectIntersection = vi.fn();
+const cleanups: Array<() => void> = [];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  motion = Object.assign(new EventTarget(), { matches: false });
+  vi.spyOn(window, 'matchMedia').mockReturnValue(motion as MediaQueryList);
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(callback: ResizeObserverCallback) {
+        resize = callback;
+      }
+      observe() {}
+      disconnect = disconnectResize;
+    }
+  );
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback: IntersectionObserverCallback) {
+        intersect = callback;
+      }
+      observe() {}
+      disconnect = disconnectIntersection;
+    }
+  );
+});
+
+afterEach(() => {
+  for (const cleanup of cleanups.splice(0)) cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function setup() {
+  const onResize = vi.fn();
+  const onVisibilityChange = vi.fn();
+  const onMotionChange = vi.fn();
+  const lifecycle = observeCanvas(document.createElement('canvas'), {
+    onResize,
+    onVisibilityChange,
+    onMotionChange
+  });
+  cleanups.push(lifecycle.destroy);
+  return { lifecycle, onResize, onVisibilityChange, onMotionChange };
+}
+
+function setIntersection(visible: boolean) {
+  intersect([{ isIntersecting: visible } as IntersectionObserverEntry], {} as IntersectionObserver);
+}
+
+it('combines tab and element visibility without resuming an offscreen canvas', () => {
+  const { lifecycle, onVisibilityChange } = setup();
+  expect(lifecycle.visible).toBe(true);
+  expect(onVisibilityChange).not.toHaveBeenCalled();
+  setIntersection(false);
+  expect(lifecycle.visible).toBe(false);
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+  document.dispatchEvent(new Event('visibilitychange'));
+  setIntersection(true);
+  expect(lifecycle.visible).toBe(false);
+  setIntersection(false);
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+  document.dispatchEvent(new Event('visibilitychange'));
+  expect(lifecycle.visible).toBe(false);
+  setIntersection(true);
+  expect(lifecycle.visible).toBe(true);
+  expect(onVisibilityChange).toHaveBeenCalledTimes(6);
+});
+
+it('reads initial reduced motion and reports preference and size changes', () => {
+  motion.matches = true;
+  const { lifecycle, onMotionChange, onResize } = setup();
+  expect(lifecycle.reducedMotion).toBe(true);
+  motion.matches = false;
+  motion.dispatchEvent(new Event('change'));
+  expect(lifecycle.reducedMotion).toBe(false);
+  expect(onMotionChange).toHaveBeenCalledOnce();
+  resize([], {} as ResizeObserver);
+  expect(onResize).toHaveBeenCalledOnce();
+});
+
+it('disconnects and discards queued callbacks after cleanup', () => {
+  const { lifecycle, onResize, onVisibilityChange, onMotionChange } = setup();
+  lifecycle.destroy();
+  expect(lifecycle.visible).toBe(false);
+  expect(disconnectResize).toHaveBeenCalledOnce();
+  expect(disconnectIntersection).toHaveBeenCalledOnce();
+  resize([], {} as ResizeObserver);
+  setIntersection(true);
+  document.dispatchEvent(new Event('visibilitychange'));
+  motion.dispatchEvent(new Event('change'));
+  expect(onResize).not.toHaveBeenCalled();
+  expect(onVisibilityChange).not.toHaveBeenCalled();
+  expect(onMotionChange).not.toHaveBeenCalled();
+});

--- a/apps/frontend/src/lib/attachments/observeCanvas.ts
+++ b/apps/frontend/src/lib/attachments/observeCanvas.ts
@@ -1,0 +1,59 @@
+type CanvasObservers = {
+  /** Resize the drawing buffer or schedule a new frame. */
+  onResize: () => void;
+  /** Start or pause drawing after tab or intersection visibility changes. */
+  onVisibilityChange: () => void;
+  /** Apply the current motion preference and redraw. */
+  onMotionChange: () => void;
+  /** Use a containing control when it defines the visible drawing surface. */
+  visibilityTarget?: Element;
+};
+
+/**
+ * Observe a mounted canvas. Callbacks run on browser events, not during setup.
+ * The caller owns the initial draw and cancels scheduled work on detach.
+ */
+export function observeCanvas(
+  canvas: HTMLCanvasElement,
+  { onResize, onVisibilityChange, onMotionChange, visibilityTarget = canvas }: CanvasObservers
+) {
+  const motion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let active = true;
+  let inViewport = true;
+  const resize = new ResizeObserver(() => {
+    if (active) onResize();
+  });
+  const intersection = new IntersectionObserver(([entry]) => {
+    if (!active) return;
+    inViewport = entry?.isIntersecting ?? true;
+    onVisibilityChange();
+  });
+  const visibilityChanged = () => {
+    if (active) onVisibilityChange();
+  };
+  const motionChanged = () => {
+    if (active) onMotionChange();
+  };
+  resize.observe(canvas);
+  intersection.observe(visibilityTarget);
+  document.addEventListener('visibilitychange', visibilityChanged);
+  motion.addEventListener('change', motionChanged);
+
+  return {
+    /** Visibility is optimistic until the first intersection notification. */
+    get visible() {
+      return active && inViewport && !document.hidden;
+    },
+    get reducedMotion() {
+      return motion.matches;
+    },
+    /** Disconnect observers and ignore notifications already queued by the browser. */
+    destroy() {
+      active = false;
+      resize.disconnect();
+      intersection.disconnect();
+      document.removeEventListener('visibilitychange', visibilityChanged);
+      motion.removeEventListener('change', motionChanged);
+    }
+  };
+}

--- a/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte
+++ b/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { untrack } from 'svelte';
+  import { observeCanvas } from '$lib/attachments/observeCanvas';
   import { m } from '$lib/i18n/messages';
   import {
     ballisticDisplacement,
@@ -147,7 +148,7 @@
   let canvasWidth = 0;
   let canvasHeight = 0;
   let animationFrame: number | undefined;
-  let canvasInViewport = true;
+  let canvasLifecycle: ReturnType<typeof observeCanvas> | undefined;
   let lastDrawnAt = Number.NEGATIVE_INFINITY;
   let lastSortedRotateX = Number.NaN;
   let lastSortedRotateY = Number.NaN;
@@ -185,8 +186,6 @@
     canvasContext = canvas.getContext('2d');
     constructionStartedAt = performance.now();
     hudNow = constructionStartedAt;
-    const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    reducedMotion = motionQuery.matches;
 
     function resizeCanvas() {
       const bounds = canvas.getBoundingClientRect();
@@ -203,7 +202,7 @@
     }
 
     function handleMotionPreference() {
-      reducedMotion = motionQuery.matches;
+      reducedMotion = lifecycle.reducedMotion;
       if (reducedMotion) {
         currentRotateX = targetRotateX;
         currentRotateY = targetRotateY;
@@ -211,37 +210,27 @@
       requestDraw();
     }
 
-    function handleVisibilityChange() {
-      if (document.hidden) {
-        if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
-        animationFrame = undefined;
-        return;
-      }
-      requestDraw();
-    }
-
-    const resizeObserver = new ResizeObserver(resizeCanvas);
-    const intersectionObserver = new IntersectionObserver(([entry]) => {
-      canvasInViewport = entry?.isIntersecting ?? true;
-      if (canvasInViewport) {
-        lastDrawnAt = Number.NEGATIVE_INFINITY;
-        requestDraw();
-      } else if (animationFrame !== undefined) {
-        cancelAnimationFrame(animationFrame);
-        animationFrame = undefined;
-      }
+    const lifecycle = observeCanvas(canvas, {
+      onResize: resizeCanvas,
+      onMotionChange: handleMotionPreference,
+      onVisibilityChange: () => {
+        if (canvasLifecycle?.visible) {
+          lastDrawnAt = Number.NEGATIVE_INFINITY;
+          requestDraw();
+        } else if (animationFrame !== undefined) {
+          cancelAnimationFrame(animationFrame);
+          animationFrame = undefined;
+        }
+      },
+      visibilityTarget: canvas.parentElement ?? canvas
     });
-    resizeObserver.observe(canvas);
-    intersectionObserver.observe(canvas.parentElement ?? canvas);
-    motionQuery.addEventListener('change', handleMotionPreference);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
+    canvasLifecycle = lifecycle;
+    reducedMotion = lifecycle.reducedMotion;
     resizeCanvas();
 
     return () => {
-      resizeObserver.disconnect();
-      intersectionObserver.disconnect();
-      motionQuery.removeEventListener('change', handleMotionPreference);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      canvasLifecycle?.destroy();
+      canvasLifecycle = undefined;
       if (animationFrame !== undefined) cancelAnimationFrame(animationFrame);
       animationFrame = undefined;
       canvasContext = null;
@@ -251,7 +240,7 @@
   }
 
   function requestDraw() {
-    if (animationFrame === undefined && !document.hidden && canvasInViewport) {
+    if (animationFrame === undefined && canvasLifecycle?.visible) {
       animationFrame = requestAnimationFrame(draw);
     }
   }

--- a/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/SimulatedChattoWordmark.svelte.spec.ts
@@ -628,3 +628,50 @@ describe('SimulatedChattoWordmark', () => {
     expect(smokeFrame(850, 0)?.opacity).toBeLessThan(0.1);
   });
 });
+
+it('cancels wordmark frames when hidden or detached and resumes only when visible', async () => {
+  let intersect!: IntersectionObserverCallback;
+  const frames = new Map<number, FrameRequestCallback>();
+  let nextFrame = 0;
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+  vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+    frames.set(++nextFrame, callback);
+    return nextFrame;
+  });
+  vi.spyOn(window, 'cancelAnimationFrame').mockImplementation((id) => { frames.delete(id); });
+  vi.stubGlobal('IntersectionObserver', class {
+    constructor(callback: IntersectionObserverCallback) { intersect = callback; }
+    observe() {}
+    disconnect() {}
+  });
+  vi.stubGlobal('ResizeObserver', class { observe() {} disconnect() {} });
+  const view = render(SimulatedChattoWordmark);
+  let mounted = true;
+  try {
+    const intersection = (visible: boolean) => intersect(
+      [{ isIntersecting: visible } as IntersectionObserverEntry], {} as IntersectionObserver
+    );
+    expect(frames.size).toBe(1);
+    intersection(false);
+    expect(frames.size).toBe(0);
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(frames.size).toBe(0);
+    intersection(true);
+    expect(frames.size).toBe(1);
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(frames.size).toBe(0);
+    vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(frames.size).toBe(1);
+    await view.unmount();
+    mounted = false;
+    expect(frames.size).toBe(0);
+    intersection(true);
+    expect(frames.size).toBe(0);
+  } finally {
+    if (mounted) await view.unmount();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  }
+});

--- a/apps/frontend/src/lib/components/chat/VideoProcessingAnimation.svelte
+++ b/apps/frontend/src/lib/components/chat/VideoProcessingAnimation.svelte
@@ -101,6 +101,7 @@
 </script>
 
 <script lang="ts">
+  import { observeCanvas } from '$lib/attachments/observeCanvas';
   let {
     label,
     progress = null
@@ -118,16 +119,14 @@
 
       const texture = getCloudTexture();
       const startedAt = performance.now();
-      const motionQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
       let timer: ReturnType<typeof setTimeout> | undefined;
-      let inViewport = true;
 
       function effectiveProgress(now: number) {
         const suppliedProgress = getProgress();
         if (suppliedProgress !== null) {
           return Math.min(1, Math.max(0, suppliedProgress));
         }
-        if (motionQuery.matches) return 0.72;
+        if (lifecycle.reducedMotion) return 0.72;
         return Math.min(1, (now - startedAt) / 1000 / AMBIENT_REFINEMENT_SECONDS);
       }
 
@@ -153,7 +152,7 @@
         const sourceHeight = Math.min(TEXTURE_HEIGHT - 16, sourceWidth * aspectRatio);
         const travelX = TEXTURE_WIDTH - sourceWidth;
         const travelY = TEXTURE_HEIGHT - sourceHeight;
-        const elapsed = motionQuery.matches ? 2.4 : (now - startedAt) / 1000;
+        const elapsed = lifecycle.reducedMotion ? 2.4 : (now - startedAt) / 1000;
         const sourceX = travelX * (0.5 + Math.sin(elapsed * 0.071) * 0.36);
         const sourceY = travelY * (0.5 + Math.cos(elapsed * 0.053) * 0.36);
 
@@ -170,14 +169,14 @@
           rows
         );
 
-        if (!motionQuery.matches && inViewport && !document.hidden) {
+        if (!lifecycle.reducedMotion && lifecycle.visible) {
           const interval = fidelity >= 1 ? RESOLVED_FRAME_INTERVAL : ACTIVE_FRAME_INTERVAL;
           timer = setTimeout(draw, interval);
         }
       }
 
       function scheduleDraw() {
-        if (timer === undefined && inViewport && !document.hidden) {
+        if (timer === undefined && lifecycle.visible) {
           timer = setTimeout(draw, 0);
         }
       }
@@ -187,27 +186,17 @@
         timer = undefined;
       }
 
-      function handleVisibilityChange() {
-        if (document.hidden) pause();
-        else scheduleDraw();
-      }
-
-      function handleMotionChange() {
-        pause();
-        scheduleDraw();
-      }
-
-      const resizeObserver = new ResizeObserver(scheduleDraw);
-      const intersectionObserver = new IntersectionObserver(([entry]) => {
-        inViewport = entry?.isIntersecting ?? true;
-        if (inViewport) scheduleDraw();
-        else pause();
+      const lifecycle = observeCanvas(canvas, {
+        onResize: scheduleDraw,
+        onVisibilityChange: () => {
+          if (lifecycle.visible) scheduleDraw();
+          else pause();
+        },
+        onMotionChange: () => {
+          pause();
+          scheduleDraw();
+        }
       });
-
-      resizeObserver.observe(canvas);
-      intersectionObserver.observe(canvas);
-      document.addEventListener('visibilitychange', handleVisibilityChange);
-      motionQuery.addEventListener('change', handleMotionChange);
       scheduleDraw();
 
       $effect(() => {
@@ -217,10 +206,7 @@
 
       return () => {
         pause();
-        resizeObserver.disconnect();
-        intersectionObserver.disconnect();
-        document.removeEventListener('visibilitychange', handleVisibilityChange);
-        motionQuery.removeEventListener('change', handleMotionChange);
+        lifecycle.destroy();
       };
     };
   }

--- a/apps/frontend/src/lib/components/chat/VideoProcessingAnimation.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/VideoProcessingAnimation.svelte.spec.ts
@@ -1,0 +1,69 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { tick } from 'svelte';
+import VideoProcessingAnimation from './VideoProcessingAnimation.svelte';
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+it('pauses offscreen and hidden, redraws with reduced motion, and cancels on unmount', async () => {
+  let intersect!: IntersectionObserverCallback;
+  const motion = Object.assign(new EventTarget(), { matches: false });
+  vi.spyOn(window, 'matchMedia').mockReturnValue(motion as MediaQueryList);
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+  vi.stubGlobal(
+    'IntersectionObserver',
+    class {
+      constructor(callback: IntersectionObserverCallback) {
+        intersect = callback;
+      }
+      observe() {}
+      disconnect() {}
+    }
+  );
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe() {}
+      disconnect() {}
+    }
+  );
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+  const draw = vi.spyOn(CanvasRenderingContext2D.prototype, 'drawImage');
+  const view = render(VideoProcessingAnimation, { label: 'Processing' });
+  await tick();
+  await vi.advanceTimersByTimeAsync(1);
+  const first = draw.mock.calls.length;
+  expect(first).toBeGreaterThan(0);
+  const intersection = (visible: boolean) =>
+    intersect(
+      [{ isIntersecting: visible } as IntersectionObserverEntry],
+      {} as IntersectionObserver
+    );
+  intersection(false);
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(draw).toHaveBeenCalledTimes(first);
+  document.dispatchEvent(new Event('visibilitychange'));
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(draw).toHaveBeenCalledTimes(first);
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(true);
+  intersection(true);
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(draw).toHaveBeenCalledTimes(first);
+  vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+  document.dispatchEvent(new Event('visibilitychange'));
+  await vi.advanceTimersByTimeAsync(1);
+  expect(draw).toHaveBeenCalledTimes(first + 1);
+  motion.matches = true;
+  motion.dispatchEvent(new Event('change'));
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(draw).toHaveBeenCalledTimes(first + 2);
+  motion.matches = false;
+  motion.dispatchEvent(new Event('change'));
+  await view.unmount();
+  await vi.advanceTimersByTimeAsync(1000);
+  expect(draw).toHaveBeenCalledTimes(first + 2);
+});


### PR DESCRIPTION
The wordmark and video-processing canvas repeated observer and browser-listener setup. Both now use `observeCanvas` for resize, intersection visibility, tab visibility, reduced-motion readings, and cleanup.

Each component retains its renderer and scheduling policy. The helper ignores queued notifications after cleanup and combines tab and element visibility before drawing can resume.

Validation:

- 32 focused browser tests and four existing Storybook cases passed.
- Tests cover hidden/offscreen interleavings, motion changes, queued callbacks, and cancellation on unmount for both canvases.
- Chrome DevTools confirmed drawing stops offscreen and resumes onscreen, with no console warnings or errors.
- Frontend lint/type checks, build/bundle/CSP checks, license checks, and Svelte autofixer passed.

No public protocol, persistence, or migration changes. CI passed on `04275a3afd963b6768c4d49cf62543530ba87f4a`: 17 successful checks, four conditional jobs skipped.
