### PR TITLE
refactor(frontend): share voice participant card markup

### DIFF
--- a/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte
+++ b/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte
@@ -245,6 +245,9 @@ Room sidebar panel for voice/video calls.
         const index = speakingCards.indexOf(entry);
         if (index !== -1) speakingCards.splice(index, 1);
         stopSpeakingIndicatorLoopIfIdle();
+        node.style.removeProperty('--call-speaking-ring-opacity');
+        node.style.removeProperty('--call-speaking-ring-strength');
+        delete node.dataset.callSpeaking;
       };
     };
   }
@@ -418,63 +421,39 @@ Room sidebar panel for voice/video calls.
   {@const showVideo = mode === 'video' && hasVideo(participant)}
   {@const showVoiceActions = isInThisCall && !showVideo}
   {@const actions = showVideo ? 'media' : showVoiceActions ? 'voice' : 'none'}
-  {#if isInThisCall}
-    <div
-      class={[
-        callTileCardClass,
-        mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
-      ]}
-      {@attach speakingCard(participant.key)}
-      title={participantTitle(participant)}
-      data-testid="call-participant-card"
-      data-speaking-ring
-      data-call-media-card={showVideo ? true : undefined}
-    >
-      {@render participantHeader(participant, participant.displayName, actions)}
+  <div
+    class={[
+      callTileCardClass,
+      mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
+    ]}
+    {@attach isInThisCall && speakingCard(participant.key)}
+    title={participantTitle(participant)}
+    data-testid="call-participant-card"
+    data-speaking-ring={isInThisCall ? true : undefined}
+    data-call-media-card={showVideo ? true : undefined}
+  >
+    {@render participantHeader(
+      participant,
+      participant.displayName,
+      isInThisCall ? actions : 'none',
+      isInThisCall
+    )}
 
-      {#if showVideo}
-        <button
-          type="button"
-          class={callTileMediaButtonClass}
-          onclick={(e) => showUserMenu(participant, e)}
-        >
-          <VideoThumbnail
-            track={participant.videoTrack!}
-            name={participant.displayName}
-            user={participant.avatarUser}
-            showIdentityOverlay={false}
-          />
-        </button>
-      {/if}
-    </div>
-  {:else}
-    <div
-      class={[
-        callTileCardClass,
-        mode === 'video' ? 'participant-card-video' : 'participant-card-compact'
-      ]}
-      title={participantTitle(participant)}
-      data-testid="call-participant-card"
-      data-call-media-card={showVideo ? true : undefined}
-    >
-      {@render participantHeader(participant, participant.displayName, 'none', false)}
-
-      {#if showVideo}
-        <button
-          type="button"
-          class={callTileMediaButtonClass}
-          onclick={(e) => showUserMenu(participant, e)}
-        >
-          <VideoThumbnail
-            track={participant.videoTrack!}
-            name={participant.displayName}
-            user={participant.avatarUser}
-            showIdentityOverlay={false}
-          />
-        </button>
-      {/if}
-    </div>
-  {/if}
+    {#if showVideo}
+      <button
+        type="button"
+        class={callTileMediaButtonClass}
+        onclick={(e) => showUserMenu(participant, e)}
+      >
+        <VideoThumbnail
+          track={participant.videoTrack!}
+          name={participant.displayName}
+          user={participant.avatarUser}
+          showIdentityOverlay={false}
+        />
+      </button>
+    {/if}
+  </div>
 {/snippet}
 
 {#snippet screenShareCard(participant: DisplayParticipant)}

--- a/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/voice/VoiceCallPanel.svelte.spec.ts
@@ -1,0 +1,37 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { flushSync } from 'svelte';
+import { serverRegistry } from '$lib/state/server/registry.svelte';
+import VoiceCallPanelStoryHarness from './VoiceCallPanelStoryHarness.svelte';
+
+afterEach(() => vi.restoreAllMocks());
+
+it('clears speaking styles and participant controls when a call becomes observed', async () => {
+  const screen = render(VoiceCallPanelStoryHarness, {
+    props: { layout: 'sidebar', scenario: 'voice' }
+  });
+  await expect.element(screen.getByTestId('call-participant-panel')).toBeInTheDocument();
+  const store = serverRegistry.getStore(serverRegistry.originServer!.id);
+  vi.spyOn(store.voiceCall, 'getAudioLevel').mockReturnValue({ isSpeaking: true, audioLevel: 0.5 });
+  vi.spyOn(store.activeCallRooms, 'has').mockReturnValue(true);
+  vi.spyOn(store.activeCallRooms, 'getParticipants').mockReturnValue([
+    { userId: 'bob', login: 'bob', displayName: 'Bob', avatarUrl: null, isBot: false }
+  ]);
+  const bob = screen.container.querySelector<HTMLElement>('[title="Bob"]')!;
+  await expect.poll(() => bob.style.getPropertyValue('--call-speaking-ring-opacity')).not.toBe('0');
+  await expect.poll(() => bob.dataset.callSpeaking).toBe('true');
+
+  flushSync(() => {
+    store.voiceCall.connected = false;
+    store.voiceCall.roomId = null;
+  });
+
+  await expect.element(screen.getByTestId('call-observer-panel')).toBeInTheDocument();
+  await expect.element(screen.getByTestId('call-join-button')).toBeInTheDocument();
+  expect(screen.container.querySelector('[title="Bob"]')).toBe(bob);
+  expect(bob.style.getPropertyValue('--call-speaking-ring-opacity')).toBe('');
+  expect(bob.style.getPropertyValue('--call-speaking-ring-strength')).toBe('');
+  expect(bob.dataset.callSpeaking).toBeUndefined();
+  expect(bob.hasAttribute('data-speaking-ring')).toBe(false);
+  expect(screen.container.querySelector('[data-testid="call-feed-local-mute-button"]')).toBeNull();
+});


### PR DESCRIPTION
The voice panel duplicated participant cards for joined and observer modes. Share one card and use a conditional speaking attachment, while keeping controls and status indicators specific to each mode.

Clear attachment-owned styles when a joined card becomes an observer card. The DOM node now survives that transition, so leaving those styles would retain a speaking ring.

Validation: Svelte autofixer clean; frontend type/design checks report zero errors or warnings; focused ESLint passed; five existing voice Storybook tests and the new browser regression test passed. Chrome DevTools verified participant and observer rendering, including speaking-style cleanup on the retained card. Existing Storybook fixtures emit a discovery HTTP 502 without a backend; the checks passed.

No public API or documented feature behavior changes.
