### PR TITLE
refactor(frontend): share settings draft reconciliation

### DIFF
--- a/apps/frontend/src/lib/components/settings/DraftField.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/settings/DraftField.svelte.spec.ts
@@ -1,0 +1,63 @@
+import { flushSync } from 'svelte';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DraftField } from './DraftField.svelte';
+
+let dispose: (() => void) | undefined;
+afterEach(() => dispose?.());
+
+describe('DraftField', () => {
+  it('adopts pristine fields and preserves dirty fields across remote refreshes', () => {
+    let remote = $state({ name: 'Original', description: 'Before' });
+    let name!: DraftField<string>;
+    let description!: DraftField<string>;
+    dispose = $effect.root(() => {
+      name = new DraftField(() => remote.name);
+      description = new DraftField(() => remote.description);
+    });
+    flushSync();
+    name.value = 'Local';
+    flushSync(() => {
+      remote = { name: 'Remote', description: 'After' };
+    });
+    expect(name.value).toBe('Local');
+    expect(name.original).toBe('Remote');
+    expect(description.value).toBe('After');
+    expect(description.original).toBe('After');
+
+    // Returning to the latest remote value makes this field pristine again.
+    name.value = 'Remote';
+    flushSync(() => {
+      remote.name = 'Later';
+    });
+    expect(name.value).toBe('Later');
+  });
+
+  it('preserves raw text edits and handles numeric and boolean fields', () => {
+    let remote = $state({ name: 'Name', interval: 10, enabled: false });
+    let name!: DraftField<string>;
+    let interval!: DraftField<number>;
+    let enabled!: DraftField<boolean>;
+    dispose = $effect.root(() => {
+      name = new DraftField(() => remote.name);
+      interval = new DraftField(() => remote.interval);
+      enabled = new DraftField(() => remote.enabled);
+    });
+    flushSync();
+    name.value = 'Name ';
+    interval.value = 20;
+    flushSync(() => {
+      remote = { name: 'Renamed', interval: 30, enabled: true };
+    });
+    expect(name.value).toBe('Name ');
+    expect(interval.value).toBe(20);
+    expect(interval.original).toBe(30);
+    expect(enabled.value).toBe(true);
+
+    dispose?.();
+    flushSync(() => {
+      remote.enabled = false;
+    });
+    expect(enabled.value).toBe(true);
+    dispose = undefined;
+  });
+});

--- a/apps/frontend/src/lib/components/settings/DraftField.svelte.ts
+++ b/apps/frontend/src/lib/components/settings/DraftField.svelte.ts
@@ -1,0 +1,25 @@
+import { untrack } from 'svelte';
+
+/**
+ * Keeps a scalar draft when a remote field changes. Create it during component
+ * initialization so its subscription ends with the editor. The owner must reset
+ * the editor when the resource changes or a save succeeds.
+ */
+export class DraftField<T extends string | number | boolean> {
+  /** Current input value, including unsaved edits. */
+  value = $state<T>() as T;
+  /** Latest remote value used to build a sparse update. */
+  original = $state<T>() as T;
+
+  constructor(read: () => T) {
+    this.value = this.original = untrack(read);
+    $effect(() => {
+      const next = read();
+      untrack(() => {
+        const pristine = this.value === this.original;
+        this.original = next;
+        if (pristine) this.value = next;
+      });
+    });
+  }
+}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupGeneralSettingsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/room-groups/[groupId]/RoomGroupGeneralSettingsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { DraftField } from '$lib/components/settings/DraftField.svelte';
   import type { AdminRoomGroup } from '$lib/api-client/adminRoomLayout';
   import Panel from '$lib/ui/Panel.svelte';
   import { Button, TextArea, TextInput } from '$lib/ui/form';
@@ -17,37 +17,21 @@
   } = $props();
 
   // The parent keys this editor by group identity and successful save revision.
-  let originalName = $state(untrack(() => group.name));
-  let originalDescription = $state(untrack(() => group.description ?? ''));
-  let name = $state(untrack(() => group.name));
-  let description = $state(untrack(() => group.description ?? ''));
+  const name = new DraftField(() => group.name);
+  const description = new DraftField(() => group.description ?? '');
 
-  // Query snapshots may refresh while this editor is mounted. Adopt each remote
-  // field only when that field is pristine, preserving unrelated local edits.
-  $effect(() => {
-    const nextName = group.name;
-    const nextDescription = group.description ?? '';
-    untrack(() => {
-      const nameWasPristine = name === originalName;
-      const descriptionWasPristine = description === originalDescription;
-      originalName = nextName;
-      originalDescription = nextDescription;
-      if (nameWasPristine) name = nextName;
-      if (descriptionWasPristine) description = nextDescription;
-    });
-  });
   const changed = $derived(
-    name.trim() !== originalName || description.trim() !== originalDescription
+    name.value.trim() !== name.original || description.value.trim() !== description.original
   );
 
   function save(event: SubmitEvent): void {
     event.preventDefault();
-    if (saving || !name.trim() || !changed) return;
+    if (saving || !name.value.trim() || !changed) return;
     onSave(
       buildRoomGroupSettingsUpdate(
         group.id,
-        { name, description },
-        { name: originalName, description: originalDescription }
+        { name: name.value, description: description.value },
+        { name: name.original, description: description.original }
       )
     );
   }
@@ -58,7 +42,7 @@
     <TextInput
       id="room-group-settings-name"
       label={m('admin.rooms_admin.group_name')}
-      bind:value={name}
+      bind:value={name.value}
       required
       maxlength={80}
       disabled={saving}
@@ -66,13 +50,13 @@
     <TextArea
       id="room-group-settings-description"
       label={m('rbac.role_form.description')}
-      bind:value={description}
+      bind:value={description.value}
       rows={3}
       maxlength={500}
       disabled={saving}
     />
     <div class="flex justify-end">
-      <Button type="submit" loading={saving} disabled={!name.trim() || !changed}>
+      <Button type="submit" loading={saving} disabled={!name.value.trim() || !changed}>
         {m('admin.permissions.save_changes')}
       </Button>
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomGeneralSettingsPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/RoomGeneralSettingsPanel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { untrack } from 'svelte';
+  import { DraftField } from '$lib/components/settings/DraftField.svelte';
   import type { AdminManagedRoom } from '$lib/api-client/adminRoomLayout';
   import Panel from '$lib/ui/Panel.svelte';
   import { Button, Checkbox, Select, TextArea, TextInput } from '$lib/ui/form';
@@ -23,49 +23,17 @@
   } = $props();
 
   // The parent keys this editor by room identity and successful save revision.
-  let originalName = $state(untrack(() => room.name));
-  let originalDescription = $state(untrack(() => room.description ?? ''));
-  let originalUniversal = $state(untrack(() => room.isUniversal));
-  let originalSlowModeSeconds = $state(untrack(() => room.slowModeSeconds));
-  let originalThreadingMode = $state(untrack(() => room.threadingMode));
-  let name = $state(untrack(() => room.name));
-  let description = $state(untrack(() => room.description ?? ''));
-  let universal = $state(untrack(() => room.isUniversal));
-  let slowModeSeconds = $state(untrack(() => String(room.slowModeSeconds)));
-  let threadingMode = $state(untrack(() => String(room.threadingMode)));
+  const name = new DraftField(() => room.name);
+  const description = new DraftField(() => room.description ?? '');
+  const universal = new DraftField(() => room.isUniversal);
+  const slowModeSeconds = new DraftField(() => room.slowModeSeconds);
+  const threadingMode = new DraftField(() => room.threadingMode);
 
-  // Query snapshots may refresh while this editor is mounted. Adopt each remote
-  // field only when that field is pristine, preserving unrelated local edits.
-  $effect(() => {
-    const nextName = room.name;
-    const nextDescription = room.description ?? '';
-    const nextUniversal = room.isUniversal;
-    const nextSlowModeSeconds = room.slowModeSeconds;
-    const nextThreadingMode = room.threadingMode;
-    untrack(() => {
-      const nameWasPristine = name === originalName;
-      const descriptionWasPristine = description === originalDescription;
-      const universalWasPristine = universal === originalUniversal;
-      const slowModeWasPristine = Number(slowModeSeconds) === originalSlowModeSeconds;
-      const threadingModeWasPristine = Number(threadingMode) === originalThreadingMode;
-      originalName = nextName;
-      originalDescription = nextDescription;
-      originalUniversal = nextUniversal;
-      originalSlowModeSeconds = nextSlowModeSeconds;
-      originalThreadingMode = nextThreadingMode;
-      if (nameWasPristine) name = nextName;
-      if (descriptionWasPristine) description = nextDescription;
-      if (universalWasPristine) universal = nextUniversal;
-      if (slowModeWasPristine) slowModeSeconds = String(nextSlowModeSeconds);
-      if (threadingModeWasPristine) threadingMode = String(nextThreadingMode);
-    });
-  });
-
-  const normalizedName = $derived(normalizeRoomName(name));
+  const normalizedName = $derived(normalizeRoomName(name.value));
   const nameError = $derived.by(() => {
-    if (!name) return undefined;
-    if (name.trim() === '') return m('admin.rooms_admin.room_name_empty');
-    if (name !== name.trim()) return m('admin.rooms_admin.room_name_trim');
+    if (!name.value) return undefined;
+    if (name.value.trim() === '') return m('admin.rooms_admin.room_name_empty');
+    if (name.value !== name.value.trim()) return m('admin.rooms_admin.room_name_trim');
     const validationError = roomNameValidationError(normalizedName);
     if (validationError === 'empty') return m('admin.rooms_admin.room_name_empty');
     if (validationError === 'too_long') {
@@ -75,11 +43,11 @@
     return undefined;
   });
   const changed = $derived(
-    normalizedName !== originalName ||
-      description.trim() !== originalDescription ||
-      universal !== originalUniversal ||
-      Number(slowModeSeconds) !== originalSlowModeSeconds ||
-      Number(threadingMode) !== originalThreadingMode
+    normalizedName !== name.original ||
+      description.value.trim() !== description.original ||
+      universal.value !== universal.original ||
+      slowModeSeconds.value !== slowModeSeconds.original ||
+      threadingMode.value !== threadingMode.original
   );
   const slowModeOptions = $derived.by(() => {
     const locale = getLocale();
@@ -90,7 +58,7 @@
           ? m('admin.rooms_admin.slow_mode_off')
           : formatSlowModeInterval(seconds, locale)
     }));
-    const current = Number(slowModeSeconds);
+    const current = slowModeSeconds.value;
     if (!SLOW_MODE_PRESETS.some((seconds) => seconds === current)) {
       options.splice(1, 0, {
         value: String(current),
@@ -126,23 +94,23 @@
 
   function save(event: SubmitEvent): void {
     event.preventDefault();
-    if (saving || nameError || !name.trim() || !changed) return;
+    if (saving || nameError || !name.value.trim() || !changed) return;
     onSave(
       buildRoomSettingsUpdate(
         room.id,
         {
-          name,
-          description,
-          universal,
-          slowModeSeconds: Number(slowModeSeconds),
-          threadingMode: Number(threadingMode) as RoomThreadingMode
+          name: name.value,
+          description: description.value,
+          universal: universal.value,
+          slowModeSeconds: slowModeSeconds.value,
+          threadingMode: threadingMode.value
         },
         {
-          name: originalName,
-          description: originalDescription,
-          universal: originalUniversal,
-          slowModeSeconds: originalSlowModeSeconds,
-          threadingMode: originalThreadingMode
+          name: name.original,
+          description: description.original,
+          universal: universal.original,
+          slowModeSeconds: slowModeSeconds.original,
+          threadingMode: threadingMode.original
         }
       )
     );
@@ -154,7 +122,7 @@
     <TextInput
       id="room-settings-name"
       label={m('rbac.role_form.name')}
-      bind:value={name}
+      bind:value={name.value}
       required
       disabled={saving}
       error={nameError}
@@ -162,21 +130,23 @@
     <TextArea
       id="room-settings-description"
       label={m('rbac.role_form.description')}
-      bind:value={description}
+      bind:value={description.value}
       rows={3}
       disabled={saving}
       placeholder={m('admin.rooms_admin.room_description_placeholder')}
     />
     <Checkbox
       id="room-settings-universal"
-      bind:checked={universal}
+      bind:checked={universal.value}
       disabled={saving}
       label={m('admin.rooms_admin.universal_room')}
       description={UNIVERSAL_ROOM_HELP_TEXT}
     />
     <Select
       id="room-settings-slow-mode"
-      bind:value={slowModeSeconds}
+      bind:value={
+        () => String(slowModeSeconds.value), (value) => (slowModeSeconds.value = Number(value))
+      }
       disabled={saving}
       label={m('admin.rooms_admin.slow_mode')}
       description={m('admin.rooms_admin.slow_mode_description')}
@@ -197,15 +167,19 @@
           <ChoiceRow
             label={option.label}
             description={option.description}
-            selected={threadingMode === option.value}
+            selected={String(threadingMode.value) === option.value}
             disabled={saving}
-            onclick={() => (threadingMode = option.value)}
+            onclick={() => (threadingMode.value = Number(option.value))}
           />
         {/each}
       </div>
     </div>
     <div class="flex justify-end">
-      <Button type="submit" loading={saving} disabled={!name.trim() || !!nameError || !changed}>
+      <Button
+        type="submit"
+        loading={saving}
+        disabled={!name.value.trim() || !!nameError || !changed}
+      >
         {m('admin.permissions.save_changes')}
       </Button>
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/rooms/[roomId]/room-management.page.svelte.spec.ts
@@ -330,6 +330,27 @@ describe('room management page identity and realtime authority', () => {
     });
   });
 
+  it('saves a numeric slow-mode selection as a sparse patch', async () => {
+    mocks.getRoom.mockResolvedValue(managedRoom('general'));
+    const { container } = render(RoomManagementPage);
+    await settle();
+
+    const select = container.querySelector('#room-settings-slow-mode') as HTMLSelectElement;
+    select.value = '10';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    flushSync();
+    const submit = container.querySelector('form button[type="submit"]') as HTMLButtonElement;
+    expect(submit.disabled).toBe(false);
+    submit.click();
+
+    await vi.waitFor(() => {
+      expect(mocks.updateRoom).toHaveBeenCalledWith({
+        roomId: 'shared-room',
+        slowModeSeconds: 10
+      });
+    });
+  });
+
   it('saves a threading mode selected from the explanatory radio choices', async () => {
     mocks.getRoom.mockResolvedValue(managedRoom('general'));
     mocks.updateRoom.mockResolvedValueOnce({


### PR DESCRIPTION
Room and room-group settings repeated the logic that keeps local edits while query snapshots refresh. Share that logic in `DraftField`: pristine fields adopt remote values, dirty fields retain their input, and the latest remote value remains the baseline for sparse updates.

The forms still own validation, normalization, and patch construction. Their parent pages still own resource identity, save revisions, and conflict handling. Numeric controls use typed draft values with a Svelte function binding at the select boundary.

Validation: 25 browser tests passed across the new helper tests and existing room and room-group page suites, including a new sparse slow-mode update test. `mise lint-frontend` passed with no Svelte errors or warnings; Svelte autofixer reported no issues. `mise license-check` passed. No public API, protocol, or documented user behavior changes.
