### PR TITLE
refactor(frontend): share message search result states

### DIFF
--- a/apps/frontend/src/lib/components/search/SearchPresentation.stories.svelte
+++ b/apps/frontend/src/lib/components/search/SearchPresentation.stories.svelte
@@ -16,6 +16,17 @@
   import ClampedMessagePreview from '../../../routes/chat/[serverId]/[roomId]/ClampedMessagePreview.svelte';
   import SearchAvailability from './SearchAvailability.svelte';
   import SearchResult from './SearchResult.svelte';
+  import SearchResults from './SearchResults.svelte';
+
+  const resultsState = {
+    error: false,
+    loading: false,
+    loadingMore: false,
+    hasSearched: false,
+    results: [],
+    nextCursor: null,
+    loadMore: async () => {}
+  };
   import { createPresenceCache } from '$lib/state/presenceCache.svelte';
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
 
@@ -52,7 +63,10 @@
       {#snippet frame(content)}<Panel>{@render content()}</Panel>{/snippet}
       <Panel title="Search query">
         <p>Search is ready.</p>
-        <Button variant="secondary" onclick={() => (availabilityState = MessageSearchState.UNAVAILABLE)}>
+        <Button
+          variant="secondary"
+          onclick={() => (availabilityState = MessageSearchState.UNAVAILABLE)}
+        >
           Show unavailable state
         </Button>
       </Panel>
@@ -140,5 +154,26 @@
       </li>
     </ol>
     {#if opened}<p role="status">Result selected.</p>{/if}
+  </div>
+</Story>
+
+<Story name="Result states" asChild>
+  <div class="grid w-full max-w-4xl gap-4 md:grid-cols-2">
+    <Panel title="Page prompt" noPadding>
+      <SearchResults store={resultsState}><span>Result</span></SearchResults>
+    </Panel>
+    <Panel title="Sidebar loading" noPadding>
+      <SearchResults store={{ ...resultsState, loading: true }} compact
+        ><span>Result</span></SearchResults
+      >
+    </Panel>
+    <Panel title="Empty results" noPadding>
+      <SearchResults store={{ ...resultsState, hasSearched: true }}
+        ><span>Result</span></SearchResults
+      >
+    </Panel>
+    <Panel title="Search error" noPadding>
+      <SearchResults store={{ ...resultsState, error: true }}><span>Result</span></SearchResults>
+    </Panel>
   </div>
 </Story>

--- a/apps/frontend/src/lib/components/search/SearchResults.svelte
+++ b/apps/frontend/src/lib/components/search/SearchResults.svelte
@@ -31,6 +31,8 @@ mode preserves the sidebar's loading indicator, spacing, and shorter prompt.
   });
 </script>
 
+{#snippet promptDescription()}{m('search.prompt.description')}{/snippet}
+
 <div class="flex min-h-full flex-col" aria-live="polite">
   {#if store.error}
     <EmptyState icon="icon-[uil--exclamation-triangle]" title={m('search.error.title')}>
@@ -46,9 +48,11 @@ mode preserves the sidebar's loading indicator, spacing, and shorter prompt.
       {m('search.no_results.description')}
     </EmptyState>
   {:else if !store.hasSearched}
-    <EmptyState icon="icon-[uil--search]" title={m('search.prompt.title')}>
-      {#if !compact}{m('search.prompt.description')}{/if}
-    </EmptyState>
+    <EmptyState
+      icon="icon-[uil--search]"
+      title={m('search.prompt.title')}
+      children={compact ? undefined : promptDescription}
+    />
   {:else}
     <ol class={['selectable-list', compact ? 'gap-3 py-2' : 'gap-4']}>
       {#each store.results as result (result.id)}

--- a/apps/frontend/src/lib/components/search/SearchResults.svelte
+++ b/apps/frontend/src/lib/components/search/SearchResults.svelte
@@ -1,0 +1,70 @@
+<!-- @component
+Renders search states and loads more results at the scroll edge. The owner
+supplies each result and keeps navigation and the scroll container. Compact
+mode preserves the sidebar's loading indicator, spacing, and shorter prompt.
+-->
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import type { MessageSearchResult } from '$lib/api-client/messageSearch';
+  import type { MessageSearchStore } from '$lib/state/server/messageSearch.svelte';
+  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
+  import { EmptyState } from '$lib/ui';
+  import { m } from '$lib/i18n/messages';
+
+  let {
+    store,
+    compact = false,
+    children
+  }: {
+    store: Pick<
+      MessageSearchStore,
+      'error' | 'loading' | 'loadingMore' | 'hasSearched' | 'results' | 'nextCursor' | 'loadMore'
+    >;
+    compact?: boolean;
+    children: Snippet<[MessageSearchResult]>;
+  } = $props();
+
+  const loadMoreWhenVisible = useLoadMoreWhenVisible({
+    getCursor: () => store.nextCursor,
+    loadMore: () => store.loadMore(),
+    hasError: () => store.error
+  });
+</script>
+
+<div class="flex min-h-full flex-col" aria-live="polite">
+  {#if store.error}
+    <EmptyState icon="icon-[uil--exclamation-triangle]" title={m('search.error.title')}>
+      {m('search.error.description')}
+    </EmptyState>
+  {:else if compact && store.loading && store.results.length === 0}
+    <div class="flex min-h-32 flex-1 items-center justify-center p-4 text-sm text-muted">
+      <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"></span>
+      {m('search.searching')}
+    </div>
+  {:else if store.hasSearched && !store.loading && store.results.length === 0 && !store.nextCursor}
+    <EmptyState icon="icon-[uil--search-minus]" title={m('search.no_results.title')}>
+      {m('search.no_results.description')}
+    </EmptyState>
+  {:else if !store.hasSearched}
+    <EmptyState icon="icon-[uil--search]" title={m('search.prompt.title')}>
+      {#if !compact}{m('search.prompt.description')}{/if}
+    </EmptyState>
+  {:else}
+    <ol class={['selectable-list', compact ? 'gap-3 py-2' : 'gap-4']}>
+      {#each store.results as result (result.id)}
+        <li>{@render children(result)}</li>
+      {/each}
+    </ol>
+    {#if store.nextCursor}
+      <div
+        {@attach loadMoreWhenVisible}
+        class={['flex h-12 items-center justify-center text-muted', compact && 'text-sm']}
+      >
+        {#if store.loadingMore}
+          <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"></span>
+          {m('search.loading_more')}
+        {/if}
+      </div>
+    {/if}
+  {/if}
+</div>

--- a/apps/frontend/src/lib/components/search/SearchResults.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/search/SearchResults.svelte.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRawSnippet } from 'svelte';
+import { render } from 'vitest-browser-svelte';
+import type { ComponentProps } from 'svelte';
+import SearchResults from './SearchResults.svelte';
+import { m } from '$lib/i18n/messages';
+
+type SearchStore = ComponentProps<typeof SearchResults>['store'];
+
+function searchStore(overrides: Partial<SearchStore> = {}): SearchStore {
+  return {
+    error: false,
+    loading: false,
+    loadingMore: false,
+    hasSearched: false,
+    results: [],
+    nextCursor: null,
+    loadMore: vi.fn().mockResolvedValue(undefined),
+    ...overrides
+  };
+}
+
+const children = createRawSnippet(() => ({ render: () => '<span>Search result</span>' }));
+
+describe('SearchResults', () => {
+  it('preserves the full page prompt and the shorter sidebar prompt', async () => {
+    const view = render(SearchResults, { store: searchStore(), children });
+    await expect.element(view.getByText(m('search.prompt.description'))).toBeVisible();
+    await view.rerender({ compact: true });
+    await expect.element(view.getByText(m('search.prompt.title'))).toBeVisible();
+    await expect.element(view.getByText(m('search.prompt.description'))).not.toBeInTheDocument();
+  });
+
+  it('shows loading before empty results in the sidebar and errors before loading', async () => {
+    const view = render(SearchResults, {
+      store: searchStore({ hasSearched: true, loading: true }),
+      compact: true,
+      children
+    });
+    await expect.element(view.getByText(m('search.searching'))).toBeVisible();
+    await expect.element(view.getByText(m('search.no_results.title'))).not.toBeInTheDocument();
+    await view.rerender({ store: searchStore({ hasSearched: true, loading: true, error: true }) });
+    await expect.element(view.getByText(m('search.error.title'))).toBeVisible();
+    await expect.element(view.getByText(m('search.searching'))).not.toBeInTheDocument();
+  });
+
+  it('loads a visible continuation even when the first page has no visible results', async () => {
+    const store = searchStore({ hasSearched: true, nextCursor: 'next-page' });
+    const view = render(SearchResults, { store, children });
+    await expect.poll(() => vi.mocked(store.loadMore).mock.calls.length).toBe(1);
+    await expect.element(view.getByText(m('search.no_results.title'))).not.toBeInTheDocument();
+    await view.rerender({ store: searchStore({ hasSearched: true }) });
+    await expect.element(view.getByText(m('search.no_results.title'))).toBeVisible();
+  });
+});

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -16,9 +16,9 @@ so switching rooms cannot leak a query or plaintext results into another room.
     type MessageSearchStore
   } from '$lib/state/server/messageSearch.svelte';
   import { useDebouncedMessageSearch } from '$lib/hooks/useDebouncedMessageSearch.svelte';
-  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
+  import SearchResults from '$lib/components/search/SearchResults.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import { EmptyState, Hint, ScrollFader } from '$lib/ui';
+  import { Hint, ScrollFader } from '$lib/ui';
   import { TextInput } from '$lib/ui/form';
   import { formatDateTime, timeFormatSettingsFor } from '$lib/utils/formatTime';
   import ClampedMessagePreview from './ClampedMessagePreview.svelte';
@@ -41,11 +41,6 @@ so switching rooms cannot leak a query or plaintext results into another room.
   const search = useDebouncedMessageSearch({
     getStore: () => store,
     getInput: (query) => ({ query, roomId, order: MessageSearchOrder.RELEVANCE })
-  });
-  const loadMoreWhenVisible = useLoadMoreWhenVisible({
-    getCursor: () => store.nextCursor,
-    loadMore: () => store.loadMore(),
-    hasError: () => store.error
   });
 
   $effect(() => {
@@ -109,68 +104,34 @@ so switching rooms cannot leak a query or plaintext results into another room.
     </div>
 
     <ScrollFader top bottom keyboardFocusable={false} class="min-h-0 flex-1">
-      <div class="flex min-h-full flex-col" aria-live="polite">
-        {#if store.error}
-          <EmptyState icon="icon-[uil--exclamation-triangle]" title={m('search.error.title')}>
-            {m('search.error.description')}
-          </EmptyState>
-        {:else if store.loading && store.results.length === 0}
-          <div class="flex min-h-32 flex-1 items-center justify-center p-4 text-sm text-muted">
-            <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
-            ></span>
-            {m('search.searching')}
-          </div>
-        {:else if store.hasSearched && store.results.length === 0 && !store.nextCursor}
-          <EmptyState icon="icon-[uil--search-minus]" title={m('search.no_results.title')}>
-            {m('search.no_results.description')}
-          </EmptyState>
-        {:else if !store.hasSearched}
-          <EmptyState icon="icon-[uil--search]" title={m('search.prompt.title')} />
-        {:else}
-          <ol class="selectable-list gap-3 py-2">
-            {#each store.results as result (result.id)}
-              <li>
-                <SearchResult
-                  {result}
-                  aria-label={`${result.actor?.displayName || result.actor?.login || m('common.unknown')}: ${result.body}`}
-                  data-room-search-result-id={result.id}
-                  class="group/search-result"
-                  viewerLogin={serverScope.store.currentUser.user?.login}
-                  timestampSettings={userSettings}
-                  timestampLocale={activeLocale}
-                  attachmentClass="text-xs"
-                  onOpen={(result) => onOpenResult?.(result.id, result.threadRootEventId)}
-                >
-                  {#snippet preview(content)}
-                    <div class="pointer-events-none" inert data-room-search-result-preview>
-                      <ClampedMessagePreview>{@render content()}</ClampedMessagePreview>
-                    </div>
-                  {/snippet}
-                  {#snippet headerMeta()}
-                    {#if result.createdAt}
-                      <time class="text-xs text-muted" datetime={result.createdAt}>
-                        {formatTimestamp(result.createdAt)}
-                      </time>
-                    {/if}
-                  {/snippet}
-                </SearchResult>
-              </li>
-            {/each}
-          </ol>
-          {#if store.nextCursor}
-            <div
-              {@attach loadMoreWhenVisible}
-              class="flex h-12 items-center justify-center text-sm text-muted"
-            >
-              {#if store.loadingMore}
-                <span class="iconify me-2 icon-[uil--spinner-alt] animate-spin" aria-hidden="true"
-                ></span>
-                {m('search.loading_more')}
+      <SearchResults {store} compact>
+        {#snippet children(result)}
+          <SearchResult
+            {result}
+            aria-label={`${result.actor?.displayName || result.actor?.login || m('common.unknown')}: ${result.body}`}
+            data-room-search-result-id={result.id}
+            class="group/search-result"
+            viewerLogin={serverScope.store.currentUser.user?.login}
+            timestampSettings={userSettings}
+            timestampLocale={activeLocale}
+            attachmentClass="text-xs"
+            onOpen={(result) => onOpenResult?.(result.id, result.threadRootEventId)}
+          >
+            {#snippet preview(content)}
+              <div class="pointer-events-none" inert data-room-search-result-preview>
+                <ClampedMessagePreview>{@render content()}</ClampedMessagePreview>
+              </div>
+            {/snippet}
+            {#snippet headerMeta()}
+              {#if result.createdAt}
+                <time class="text-xs text-muted" datetime={result.createdAt}>
+                  {formatTimestamp(result.createdAt)}
+                </time>
               {/if}
-            </div>
-          {/if}
-        {/if}
-      </div>
+            {/snippet}
+          </SearchResult>
+        {/snippet}
+      </SearchResults>
     </ScrollFader>
   </div>
 </SearchAvailability>

--- a/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/search/+page.svelte
@@ -17,18 +17,10 @@ in the active server store so browser Back can restore the current search.
   import { MessageSearchOrder, MessageSearchState } from '$lib/state/server/messageSearch.svelte';
   import { getLocale } from '$lib/i18n/runtime';
   import { useDebouncedMessageSearch } from '$lib/hooks/useDebouncedMessageSearch.svelte';
-  import { useLoadMoreWhenVisible } from '$lib/hooks/useLoadMoreWhenVisible.svelte';
+  import SearchResults from '$lib/components/search/SearchResults.svelte';
   import { buildMessageLinkPath } from '$lib/messageLinks';
   import { formatDateTime, timeFormatSettingsFor } from '$lib/utils/formatTime';
-  import {
-    EmptyState,
-    Hint,
-    PageTitle,
-    PaneContent,
-    PaneHeader,
-    ScrollFader,
-    SegmentedControl
-  } from '$lib/ui';
+  import { Hint, PageTitle, PaneContent, PaneHeader, ScrollFader, SegmentedControl } from '$lib/ui';
   import { TextInput } from '$lib/ui/form';
   import { m } from '$lib/i18n/messages';
 
@@ -48,11 +40,6 @@ in the active server store so browser Back can restore the current search.
   const search = useDebouncedMessageSearch({
     getStore: () => store,
     getInput: (query) => ({ query, order: store.order })
-  });
-  const loadMoreWhenVisible = useLoadMoreWhenVisible({
-    getCursor: () => store.nextCursor,
-    loadMore: () => store.loadMore(),
-    hasError: () => store.error
   });
   $effect(() => {
     void store.ensureStatus();
@@ -131,84 +118,50 @@ in the active server store so browser Back can restore the current search.
 
         <Panel title={m('search.results')} noPadding fillHeight>
           <ScrollFader top bottom keyboardFocusable={false} class="min-h-0 flex-1">
-            <div class="flex min-h-full flex-col" aria-live="polite">
-              {#if store.error}
-                <EmptyState icon="icon-[uil--exclamation-triangle]" title={m('search.error.title')}>
-                  {m('search.error.description')}
-                </EmptyState>
-              {:else if store.hasSearched && !store.loading && store.results.length === 0 && !store.nextCursor}
-                <EmptyState icon="icon-[uil--search-minus]" title={m('search.no_results.title')}>
-                  {m('search.no_results.description')}
-                </EmptyState>
-              {:else if !store.hasSearched}
-                <EmptyState icon="icon-[uil--search]" title={m('search.prompt.title')}>
-                  {m('search.prompt.description')}
-                </EmptyState>
-              {:else}
-                <ol class="selectable-list gap-4">
-                  {#each store.results as result (result.id)}
-                    <li>
-                      <SearchResult
-                        {result}
-                        data-search-result-id={result.id}
-                        viewerLogin={serverStore.currentUser.user?.login}
-                        timestampSettings={timeFormatSettings}
-                        timestampLocale={activeLocale}
-                        onOpen={navigateToResult}
+            <SearchResults {store}>
+              {#snippet children(result)}
+                <SearchResult
+                  {result}
+                  data-search-result-id={result.id}
+                  viewerLogin={serverStore.currentUser.user?.login}
+                  timestampSettings={timeFormatSettings}
+                  timestampLocale={activeLocale}
+                  onOpen={navigateToResult}
+                >
+                  {#snippet headerMeta()}
+                    <a
+                      class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
+                      href={resolve('/chat/[serverId]/[roomId]', {
+                        serverId: serverIdToSegment(serverId),
+                        roomId: result.roomId
+                      })}
+                    >
+                      {#if result.roomKind === RoomKind.DM}
+                        {m('room.title.direct_message')}
+                      {:else}
+                        <bdi>#{result.roomName ?? m('search.scope.room')}</bdi>
+                      {/if}
+                    </a>
+                    {#if result.createdAt}
+                      <span class="text-xs text-muted" aria-hidden="true">·</span>
+                      <!-- eslint-disable svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route -->
+                      <a
+                        class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
+                        href={buildMessageLinkPath(
+                          serverId,
+                          result.roomId,
+                          result.id,
+                          result.threadRootEventId
+                        )}
                       >
-                        {#snippet headerMeta()}
-                          <a
-                            class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
-                            href={resolve('/chat/[serverId]/[roomId]', {
-                              serverId: serverIdToSegment(serverId),
-                              roomId: result.roomId
-                            })}
-                          >
-                            {#if result.roomKind === RoomKind.DM}
-                              {m('room.title.direct_message')}
-                            {:else}
-                              <bdi>#{result.roomName ?? m('search.scope.room')}</bdi>
-                            {/if}
-                          </a>
-                          {#if result.createdAt}
-                            <span class="text-xs text-muted" aria-hidden="true">·</span>
-                            <!-- eslint-disable svelte/no-navigation-without-resolve -- buildMessageLinkPath() returns a resolved app route -->
-                            <a
-                              class="min-w-0 truncate text-xs text-muted hover:text-text hover:underline"
-                              href={buildMessageLinkPath(
-                                serverId,
-                                result.roomId,
-                                result.id,
-                                result.threadRootEventId
-                              )}
-                            >
-                              <time datetime={result.createdAt}
-                                >{formatTimestamp(result.createdAt)}</time
-                              >
-                            </a>
-                            <!-- eslint-enable svelte/no-navigation-without-resolve -->
-                          {/if}
-                        {/snippet}
-                      </SearchResult>
-                    </li>
-                  {/each}
-                </ol>
-                {#if store.nextCursor}
-                  <div
-                    {@attach loadMoreWhenVisible}
-                    class="flex h-12 items-center justify-center text-muted"
-                  >
-                    {#if store.loadingMore}
-                      <span
-                        class="iconify me-2 icon-[uil--spinner-alt] animate-spin"
-                        aria-hidden="true"
-                      ></span>
-                      {m('search.loading_more')}
+                        <time datetime={result.createdAt}>{formatTimestamp(result.createdAt)}</time>
+                      </a>
+                      <!-- eslint-enable svelte/no-navigation-without-resolve -->
                     {/if}
-                  </div>
-                {/if}
-              {/if}
-            </div>
+                  {/snippet}
+                </SearchResult>
+              {/snippet}
+            </SearchResults>
           </ScrollFader>
         </Panel>
       </SearchAvailability>


### PR DESCRIPTION
The server search page and room search sidebar repeated result states and automatic pagination. Both now use `SearchResults`, with a Svelte snippet for each result. The owners keep navigation, result metadata, preview content, and scrolling.

Compact mode preserves the sidebar loading indicator, shorter prompt, and spacing. Search data and request lifecycles remain in the existing stores. This implements a UI cleanup for [FDR-033](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-033-message-search.md); it makes no public API, persisted data, or deployment changes.

Validation:

- Three browser component tests pass, including error/loading priority and continuation from an empty page.
- `mise lint-frontend`: passes with zero Svelte errors or warnings.
- `mise build-frontend`: passes, including bundle and CSP checks.
- Storybook build and `mise license-check`: pass.
- Svelte autofixer reports no issues; existing route lifecycle suggestions were reviewed.
- Chrome DevTools review of the new story: prompt, loading, empty, and error states at wide and narrow widths in dark theme, and at narrow width in light theme. Full backend search E2E was not run locally.

CI is green on `460244ca4`: all applicable checks passed, including all four E2E shards, media and performance E2E, workspace tests, and desktop builds.
