### PR TITLE
refactor(frontend): share timeline mutation subscriptions

### DIFF
--- a/apps/frontend/src/lib/hooks/useTimelineMutations.svelte.spec.ts
+++ b/apps/frontend/src/lib/hooks/useTimelineMutations.svelte.spec.ts
@@ -1,0 +1,71 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { flushSync } from 'svelte';
+import { notifyRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
+import { useTimelineMutations } from './useTimelineMutations.svelte';
+
+let dispose: (() => void) | undefined;
+afterEach(() => dispose?.());
+
+function timeline() {
+  return {
+    applyLocalMessageDeletion: vi.fn(),
+    refreshAnchorForMessageMutation: vi.fn().mockReturnValue('visible-echo'),
+    refreshCurrentWindow: vi.fn().mockResolvedValue(undefined)
+  };
+}
+
+it('filters scope, removes deleted rows, and refreshes only visible mutation anchors', () => {
+  const target = timeline();
+  dispose = $effect.root(() => {
+    useTimelineMutations(() => ({ serverId: 'server-a', roomId: 'room-a', timeline: target }));
+  });
+  flushSync();
+  const mutation = {
+    serverId: 'server-a',
+    roomId: 'room-a',
+    eventId: 'original-message',
+    reason: 'attachment-deleted' as const
+  };
+  notifyRoomMessageMutated({ ...mutation, serverId: 'server-b' });
+  notifyRoomMessageMutated({ ...mutation, roomId: 'room-b' });
+  expect(target.refreshAnchorForMessageMutation).not.toHaveBeenCalled();
+
+  notifyRoomMessageMutated(mutation);
+  expect(target.refreshCurrentWindow).toHaveBeenCalledWith('visible-echo');
+  target.refreshCurrentWindow.mockClear();
+  target.refreshAnchorForMessageMutation.mockReturnValue(null);
+  notifyRoomMessageMutated({ ...mutation, reason: 'link-preview-deleted' });
+  expect(target.refreshCurrentWindow).not.toHaveBeenCalled();
+
+  target.refreshAnchorForMessageMutation.mockClear();
+  notifyRoomMessageMutated({ ...mutation, reason: 'message-deleted' });
+  expect(target.applyLocalMessageDeletion).toHaveBeenCalledWith('original-message');
+  expect(target.refreshAnchorForMessageMutation).not.toHaveBeenCalled();
+});
+
+it('uses the current server, room, and thread target and unsubscribes on disposal', () => {
+  const first = timeline();
+  const second = timeline();
+  const scope = $state({ serverId: 'server-a', roomId: 'room-a' });
+  let selected = $state.raw(first);
+  dispose = $effect.root(() => {
+    useTimelineMutations(() => ({ ...scope, timeline: selected }));
+  });
+  flushSync();
+  const mutation = { ...scope, eventId: 'message', reason: 'message-deleted' as const };
+  Object.assign(scope, { serverId: 'server-b', roomId: 'room-b' });
+  selected = second;
+  // A DOM event can arrive before the next effect flush after route reuse.
+  notifyRoomMessageMutated(mutation);
+  notifyRoomMessageMutated({ ...mutation, ...scope });
+  expect(first.applyLocalMessageDeletion).not.toHaveBeenCalled();
+  expect(second.applyLocalMessageDeletion).toHaveBeenCalledOnce();
+
+  selected = first;
+  notifyRoomMessageMutated({ ...mutation, ...scope });
+  expect(first.applyLocalMessageDeletion).toHaveBeenCalledOnce();
+  dispose();
+  dispose = undefined;
+  notifyRoomMessageMutated({ ...mutation, ...scope });
+  expect(first.applyLocalMessageDeletion).toHaveBeenCalledOnce();
+});

--- a/apps/frontend/src/lib/hooks/useTimelineMutations.svelte.ts
+++ b/apps/frontend/src/lib/hooks/useTimelineMutations.svelte.ts
@@ -1,0 +1,30 @@
+import type { MessagesStore } from '$lib/state/room/messages.svelte';
+import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
+
+type TimelineMutationTarget = Pick<
+  MessagesStore,
+  'applyLocalMessageDeletion' | 'refreshAnchorForMessageMutation' | 'refreshCurrentWindow'
+>;
+
+/**
+ * Reconcile local message mutations while a room or thread timeline is mounted.
+ * Read the current scope and timeline for each event so reused route components
+ * cannot update a previous room or server. The owning effect removes the listener.
+ * Deletions apply directly; other mutations refresh only a visible message or echo.
+ */
+export function useTimelineMutations(
+  getTarget: () => { serverId: string; roomId: string; timeline: TimelineMutationTarget }
+): void {
+  $effect(() =>
+    onRoomMessageMutated((detail) => {
+      const { serverId, roomId, timeline } = getTarget();
+      if (detail.serverId !== serverId || detail.roomId !== roomId) return;
+      if (detail.reason === 'message-deleted') {
+        timeline.applyLocalMessageDeletion(detail.eventId);
+        return;
+      }
+      const anchorEventId = timeline.refreshAnchorForMessageMutation(detail.eventId);
+      if (anchorEventId) void timeline.refreshCurrentWindow(anchorEventId);
+    })
+  );
+}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/Room.svelte
@@ -27,7 +27,7 @@
     createRoomPermissions,
     DEFAULT_ROOM_PERMISSIONS
   } from '$lib/state/room';
-  import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
+  import { useTimelineMutations } from '$lib/hooks/useTimelineMutations.svelte';
   import { getAppUiState, getRoomSidebarPresentation } from '$lib/state/appUi.svelte';
   import { startDMWith } from '$lib/dm/startDM';
   import { useServerScope } from '$lib/state/server/scope.svelte';
@@ -167,18 +167,11 @@
     };
   });
 
-  $effect(() =>
-    onRoomMessageMutated((detail) => {
-      if (detail.serverId !== activeServerId || detail.roomId !== roomId) return;
-      if (detail.reason === 'message-deleted') {
-        roomMessageStore.applyLocalMessageDeletion(detail.eventId);
-        return;
-      }
-      const anchorEventId = roomMessageStore.refreshAnchorForMessageMutation(detail.eventId);
-      if (!anchorEventId) return;
-      void roomMessageStore.refreshCurrentWindow(anchorEventId);
-    })
-  );
+  useTimelineMutations(() => ({
+    serverId: activeServerId,
+    roomId,
+    timeline: roomMessageStore
+  }));
 
   // --- Extracted hooks ---
   const supportsPinnedMessages = $derived(serverInfo.supportsFeature('pinnedMessages'));

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -18,7 +18,7 @@
     createComposerContext,
     type QuoteInsertionRequest
   } from '$lib/state/room';
-  import { onRoomMessageMutated } from '$lib/state/room/messageMutationEvents';
+  import { useTimelineMutations } from '$lib/hooks/useTimelineMutations.svelte';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import HeaderIconButton from '$lib/ui/HeaderIconButton.svelte';
   import { expoOutTransition } from '$lib/ui/motion';
@@ -98,18 +98,11 @@
       mountedStores.releaseMessagesForThread(mountedRoomId, mountedThreadRootEventId, mountedStore);
   });
 
-  $effect(() =>
-    onRoomMessageMutated((detail) => {
-      if (detail.serverId !== activeServerId || detail.roomId !== roomId) return;
-      if (detail.reason === 'message-deleted') {
-        store.applyLocalMessageDeletion(detail.eventId);
-        return;
-      }
-      const anchorEventId = store.refreshAnchorForMessageMutation(detail.eventId);
-      if (!anchorEventId) return;
-      void store.refreshCurrentWindow(anchorEventId);
-    })
-  );
+  useTimelineMutations(() => ({
+    serverId: activeServerId,
+    roomId,
+    timeline: store
+  }));
 
   let threadEvents = $derived(store.threadEvents);
   let updateCounter = $derived(threadEvents.length);


### PR DESCRIPTION
Room and thread panes duplicated local message-mutation subscriptions. Use one lifecycle helper to filter the current server and room, remove deleted messages, and refresh the visible message or channel echo for attachment and preview changes.

The helper reads scope and timeline getters when each event arrives. Reused routes therefore use the current target, including before the next effect flush. Disposal removes the listener. Timeline storage and request cancellation remain with their existing owners.

Validation: 58 browser tests passed across the helper and both panes; the two helper tests passed again after removing test compiler warnings. Frontend type/design checks report zero errors and warnings, focused ESLint passed, and production build, bundle/CSP checks, and REUSE license check passed. Svelte autofixer reported no issues; subscription-effect suggestions were reviewed.

No public API, runtime ownership, or documented feature behavior changes.
