### PR TITLE
refactor(frontend): simplify welcome banner lifecycle

### DIFF
--- a/apps/frontend/src/lib/components/WelcomeBanner.svelte
+++ b/apps/frontend/src/lib/components/WelcomeBanner.svelte
@@ -34,13 +34,16 @@ Consumes both flags and preserves other URL and page state values.
 			url.searchParams.delete('welcome');
 			const state = { ...page.state };
 			delete state.welcome;
-			replaceState(resolve((url.pathname.slice(base.length) + url.search + url.hash) as '/'), state);
+			// This is the current route; the assertion permits its dynamic pathname.
+			replaceState(
+				resolve((url.pathname.slice(base.length) + url.search + url.hash) as '/'),
+				state
+			);
 		});
 		return () => {
 			mounted = false;
 		};
 	});
-
 </script>
 
 {#if showWelcome}

--- a/apps/frontend/src/lib/components/WelcomeBanner.svelte
+++ b/apps/frontend/src/lib/components/WelcomeBanner.svelte
@@ -5,44 +5,59 @@ Shows a welcome banner to newly verified users. The banner auto-dismisses
 after 5 seconds and can be manually dismissed. When shown, removes the
 `welcome` query parameter from the URL.
 
-Only renders when the `welcome=true` query parameter is present.
+Renders when the `welcome=true` query parameter or page state flag is set.
+Consumes both flags and preserves other URL and page state values.
 -->
 <script lang="ts">
-  import { page } from '$app/state';
-  import { m } from '$lib/i18n/messages';
-  import { Hint } from '$lib/ui';
+	import { onMount, tick } from 'svelte';
+	import { replaceState } from '$app/navigation';
+	import { base, resolve } from '$app/paths';
+	import Deadline from '$lib/lifecycle/Deadline.svelte';
+	import { page } from '$app/state';
+	import { m } from '$lib/i18n/messages';
+	import { Hint } from '$lib/ui';
 
-  let showWelcome = $state(
-    page.url.searchParams.get('welcome') === 'true' || page.state.welcome === true
-  );
+	let showWelcome = $state(
+		page.url.searchParams.get('welcome') === 'true' || page.state.welcome === true
+	);
 
-  function mountWelcomeBanner() {
-    // Remove the query param from URL without navigation.
-    const url = new URL(window.location.href);
-    url.searchParams.delete('welcome');
-    window.history.replaceState({}, '', url.toString());
+	const dismissAt = Date.now() + 5000;
 
-    const timer = setTimeout(() => {
-      showWelcome = false;
-    }, 5000);
-    return () => clearTimeout(timer);
-  }
+	onMount(() => {
+		if (!showWelcome) return;
+
+		let mounted = true;
+		// Let SvelteKit finish its initial render before replacing router state.
+		void tick().then(() => {
+			if (!mounted) return;
+			const url = new URL(page.url);
+			url.searchParams.delete('welcome');
+			const state = { ...page.state };
+			delete state.welcome;
+			replaceState(resolve((url.pathname.slice(base.length) + url.search + url.hash) as '/'), state);
+		});
+		return () => {
+			mounted = false;
+		};
+	});
+
 </script>
 
 {#if showWelcome}
-  <div class="mb-2" {@attach mountWelcomeBanner}>
-    <Hint tone="success">
-      <div class="flex items-start justify-between gap-3">
-        <span>{m('welcome.verified')}</span>
-        <button
-          type="button"
-          class="-m-1 icon-action"
-          onclick={() => (showWelcome = false)}
-          title={m('common.dismiss')}
-        >
-          <span class="iconify icon-[uil--times]"></span>
-        </button>
-      </div>
-    </Hint>
-  </div>
+	<Deadline at={dismissAt} onreached={() => (showWelcome = false)} />
+	<div class="mb-2">
+		<Hint tone="success">
+			<div class="flex items-start justify-between gap-3">
+				<span>{m('welcome.verified')}</span>
+				<button
+					type="button"
+					class="-m-1 icon-action"
+					onclick={() => (showWelcome = false)}
+					title={m('common.dismiss')}
+				>
+					<span class="iconify icon-[uil--times]"></span>
+				</button>
+			</div>
+		</Hint>
+	</div>
 {/if}

--- a/apps/frontend/src/lib/components/WelcomeBanner.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/WelcomeBanner.svelte.spec.ts
@@ -4,14 +4,17 @@ import { render } from 'vitest-browser-svelte';
 
 const mocks = vi.hoisted(() => ({
   page: {
-    url: new URL('https://chatto.test/chat'),
+    url: new URL('https://chatto.test/community/chat'),
     state: {} as App.PageState
   },
   replaceState: vi.fn()
 }));
 
 vi.mock('$app/state', () => ({ page: mocks.page }));
-vi.mock('$app/paths', () => ({ base: '', resolve: (path: string) => path }));
+vi.mock('$app/paths', () => ({
+  base: '/community',
+  resolve: (path: string) => '/community' + path
+}));
 vi.mock('$app/navigation', () => ({ replaceState: mocks.replaceState }));
 vi.mock('$lib/ui', async () => ({ Hint: (await import('$lib/ui/Hint.svelte')).default }));
 vi.mock('$lib/i18n/messages', () => ({ m: (key: string) => key }));
@@ -21,7 +24,7 @@ import WelcomeBanner from './WelcomeBanner.svelte';
 describe('WelcomeBanner', () => {
   beforeEach(() => {
     vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
-    mocks.page.url = new URL('https://chatto.test/chat');
+    mocks.page.url = new URL('https://chatto.test/community/chat');
     mocks.page.state = {};
     mocks.replaceState.mockReset();
   });
@@ -34,7 +37,7 @@ describe('WelcomeBanner', () => {
     'consumes the %s flag and preserves other navigation values',
     async (source) => {
       mocks.page.url = new URL(
-        `https://chatto.test/chat?filter=unread${source !== 'state' ? '&welcome=true' : ''}#latest`
+        `https://chatto.test/community/chat?filter=unread${source !== 'state' ? '&welcome=true' : ''}#latest`
       );
       mocks.page.state = {
         threadFilter: 'unread',
@@ -45,12 +48,24 @@ describe('WelcomeBanner', () => {
       await tick();
       await vi.advanceTimersByTimeAsync(0);
       await expect.element(screen.getByText('welcome.verified')).toBeVisible();
-      expect(mocks.replaceState).toHaveBeenCalledExactlyOnceWith(
-        '/chat?filter=unread#latest',
-        { threadFilter: 'unread' }
-      );
+      expect(mocks.replaceState).toHaveBeenCalledExactlyOnceWith('/community/chat?filter=unread#latest', {
+        threadFilter: 'unread'
+      });
     }
   );
+
+  it('preserves a nonempty base path without duplicating it', async () => {
+    mocks.page.url = new URL(
+      'https://chatto.test/community/chat?welcome=true&filter=unread#latest'
+    );
+    render(WelcomeBanner);
+    await tick();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.replaceState).toHaveBeenCalledExactlyOnceWith(
+      '/community/chat?filter=unread#latest',
+      {}
+    );
+  });
 
   it('does not show or replace navigation state without a true welcome flag', async () => {
     mocks.page.url.searchParams.set('welcome', 'false');

--- a/apps/frontend/src/lib/components/WelcomeBanner.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/WelcomeBanner.svelte.spec.ts
@@ -1,0 +1,110 @@
+import { tick } from 'svelte';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+
+const mocks = vi.hoisted(() => ({
+  page: {
+    url: new URL('https://chatto.test/chat'),
+    state: {} as App.PageState
+  },
+  replaceState: vi.fn()
+}));
+
+vi.mock('$app/state', () => ({ page: mocks.page }));
+vi.mock('$app/paths', () => ({ base: '', resolve: (path: string) => path }));
+vi.mock('$app/navigation', () => ({ replaceState: mocks.replaceState }));
+vi.mock('$lib/ui', async () => ({ Hint: (await import('$lib/ui/Hint.svelte')).default }));
+vi.mock('$lib/i18n/messages', () => ({ m: (key: string) => key }));
+
+import WelcomeBanner from './WelcomeBanner.svelte';
+
+describe('WelcomeBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
+    mocks.page.url = new URL('https://chatto.test/chat');
+    mocks.page.state = {};
+    mocks.replaceState.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each(['query', 'state', 'both'])(
+    'consumes the %s flag and preserves other navigation values',
+    async (source) => {
+      mocks.page.url = new URL(
+        `https://chatto.test/chat?filter=unread${source !== 'state' ? '&welcome=true' : ''}#latest`
+      );
+      mocks.page.state = {
+        threadFilter: 'unread',
+        ...(source !== 'query' ? { welcome: true } : {})
+      };
+
+      const screen = render(WelcomeBanner);
+      await tick();
+      await vi.advanceTimersByTimeAsync(0);
+      await expect.element(screen.getByText('welcome.verified')).toBeVisible();
+      expect(mocks.replaceState).toHaveBeenCalledExactlyOnceWith(
+        '/chat?filter=unread#latest',
+        { threadFilter: 'unread' }
+      );
+    }
+  );
+
+  it('does not show or replace navigation state without a true welcome flag', async () => {
+    mocks.page.url.searchParams.set('welcome', 'false');
+    mocks.page.state = { welcome: false };
+    const screen = render(WelcomeBanner);
+    await tick();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await expect.element(screen.getByText('welcome.verified')).not.toBeInTheDocument();
+    expect(mocks.replaceState).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('dismisses after five seconds', async () => {
+    mocks.page.state = { welcome: true };
+    const screen = render(WelcomeBanner);
+    await tick();
+    await vi.advanceTimersByTimeAsync(0);
+
+    await vi.advanceTimersByTimeAsync(4999);
+    await expect.element(screen.getByText('welcome.verified')).toBeVisible();
+    await vi.advanceTimersByTimeAsync(1);
+    await expect.element(screen.getByText('welcome.verified')).not.toBeInTheDocument();
+  });
+
+  it('cancels the dismissal timer when manually dismissed', async () => {
+    mocks.page.state = { welcome: true };
+    const screen = render(WelcomeBanner);
+    await tick();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    await screen.getByRole('button', { name: 'common.dismiss' }).click();
+    await vi.advanceTimersByTimeAsync(0);
+    await expect.element(screen.getByText('welcome.verified')).not.toBeInTheDocument();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not consume navigation flags after an immediate unmount', async () => {
+    mocks.page.state = { welcome: true };
+    const screen = render(WelcomeBanner);
+    screen.unmount();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(mocks.replaceState).not.toHaveBeenCalled();
+  });
+
+  it('cancels the dismissal timer when unmounted', async () => {
+    mocks.page.state = { welcome: true };
+    const screen = render(WelcomeBanner);
+    await tick();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(vi.getTimerCount()).toBe(1);
+
+    screen.unmount();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});


### PR DESCRIPTION
The verified-account welcome banner cleared the entire browser history state while removing its query flag. It now uses SvelteKit shallow navigation to consume the query and page-state flags while preserving other URL values, page state, and router metadata.

The existing `Deadline` component owns the five-second dismissal timer. URL cleanup waits for the initial render and is cancelled if the banner unmounts before it can run. Manual dismissal keeps the same behavior.

Validation:
- Nine Chromium component tests cover query/state flags, URL and page-state preservation (including a nonempty base path), automatic/manual dismissal, and unmount cleanup.
- REUSE license check passed.
- Svelte check: zero errors and warnings; targeted ESLint and Svelte autofixer passed.
- Chrome DevTools verified a temporary real SvelteKit route: initial loading, query/hash and router-state preservation, state-triggered display, manual dismissal, and five-second dismissal. The fixture and development server were removed/stopped afterward.

No public API, stored protocol, or deployment changes.
