### PR TITLE
fix(frontend): give bot avatars a friendly adaptive robot badge

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
@@ -189,7 +189,8 @@ Authorization: Bearer cht_BK_…
 The request is authorized as the bot user. For example, posting a message
 requires an explicit effective `message.post` allow and normal room access.
 The canonical `User.is_bot` field identifies bot authors to API clients;
-the bundled client also shows a robot marker on their avatars.
+the bundled client also shows a robot marker on their avatars. The marker uses
+soft shading and changes its colours to match the light or dark theme.
 
 A bot API key can update its own login, display name, and bio through
 `MyAccountService.UpdateProfile`. It can upload or delete its own avatar through

--- a/apps/frontend/src/lib/assets/bot.svg
+++ b/apps/frontend/src/lib/assets/bot.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <!-- SPDX-FileCopyrightText: 2026 ChattoCorp GmbH -->
+  <!-- SPDX-License-Identifier: Apache-2.0 -->
+  <!-- Embedded SVG images inherit the host's colour scheme. Keep the same
+       silhouette and face contrast in both themes; only the shell changes. -->
+  <style>
+    :root { --top: #E4F5F2; --middle: #AFD6D4; --bottom: #6FA5AF; --edge: #427582; }
+    @media (prefers-color-scheme: dark) {
+      :root { --top: #D3EDE8; --middle: #9FCAC9; --bottom: #6095A2; --edge: #A4D2D1; }
+    }
+  </style>
+  <defs>
+    <linearGradient id="shell" x1="10" y1="9" x2="22" y2="30" gradientUnits="userSpaceOnUse">
+      <stop stop-color="var(--top)"/>
+      <stop offset=".5" stop-color="var(--middle)"/>
+      <stop offset="1" stop-color="var(--bottom)"/>
+    </linearGradient>
+  </defs>
+  <path d="M16 9V4" stroke="#608D99" stroke-width="2.5"/>
+  <circle cx="16" cy="3.5" r="2.5" fill="var(--middle)" stroke="var(--edge)" stroke-width=".75"/>
+  <rect x="1" y="16" width="6" height="9" rx="3" fill="#608D99"/>
+  <rect x="25" y="16" width="6" height="9" rx="3" fill="#608D99"/>
+  <rect x="4.5" y="8.5" width="23" height="21" rx="7" fill="url(#shell)" stroke="var(--edge)"/>
+  <rect x="9" y="15" width="4" height="6" rx="2" fill="#214353"/>
+  <rect x="19" y="15" width="4" height="6" rx="2" fill="#214353"/>
+  <path d="M14 24q2 1.5 4 0" stroke="#214353" stroke-width="1.5" stroke-linecap="round"/>
+</svg>

--- a/apps/frontend/src/lib/components/UserAvatar.stories.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.stories.svelte
@@ -2,6 +2,8 @@
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import type { UserAvatarUserView } from '$lib/render/users';
+  import imageAvatar from '$lib/assets/chatto-icon-maskable.png';
+  import botIcon from '$lib/assets/bot.svg';
   import UserAvatar from './UserAvatar.svelte';
 
   const { Story } = defineMeta({
@@ -11,7 +13,7 @@
     parameters: {
       docs: {
         description: {
-          component: 'Circular user avatar rendering with optional presence dots.'
+          component: 'Circular user avatars with optional presence dots and coloured bot icons.'
         }
       }
     }
@@ -61,5 +63,64 @@
     <UserAvatar user={onlineUser} size="xs" />
     <UserAvatar user={awayUser} size="sm" />
     <UserAvatar user={dndUser} size="md" />
+  </div>
+</Story>
+
+<Story name="Bot accounts" asChild>
+  <div class="flex flex-wrap items-center gap-6 rounded-md bg-surface p-6">
+    {#each ['xs', 'sm', 'md', 'message', 'lg', 'xl'] as const as size (size)}
+      <div class="flex flex-col items-center gap-3">
+        <UserAvatar user={{ ...onlineUser, displayName: 'Assistant', isBot: true }} {size} />
+        <span class="text-xs text-muted">{size}</span>
+      </div>
+    {/each}
+  </div>
+</Story>
+
+<Story name="Bots with status" asChild>
+  <div class="flex items-center gap-6 rounded-md bg-surface p-6">
+    <UserAvatar
+      user={{ ...onlineUser, displayName: 'Assistant', isBot: true }}
+      size="sm"
+      showPresence
+    />
+    <UserAvatar
+      user={{
+        ...onlineUser,
+        displayName: 'Assistant',
+        isBot: true,
+        customStatus: { emoji: '🔧', text: 'Building', expiresAt: null }
+      }}
+      size="message"
+      showPresence
+      showStatus
+    />
+    <UserAvatar user={onlineUser} size="message" showPresence />
+  </div>
+</Story>
+
+<Story name="Robot artwork" asChild>
+  <div class="flex max-w-2xl items-center justify-center gap-16 rounded-xl bg-surface px-10 py-12">
+    <img src={botIcon} alt="Chatto robot" class="size-40 outline-none" />
+    <div class="flex flex-col items-center gap-6">
+      <div class="flex items-center gap-6">
+        <UserAvatar user={{ ...onlineUser, displayName: 'Assistant', isBot: true }} size="sm" />
+        <UserAvatar
+          user={{ ...onlineUser, displayName: 'Assistant', isBot: true }}
+          size="message"
+          showPresence
+        />
+        <UserAvatar user={{ ...onlineUser, displayName: 'Assistant', isBot: true }} size="xl" />
+      </div>
+      <div class="flex items-center gap-6">
+        {#each ['xs', 'sm', 'message'] as const as size (size)}
+          <UserAvatar
+            user={{ ...onlineUser, displayName: 'Assistant', isBot: true, avatarUrl: imageAvatar }}
+            {size}
+          />
+        {/each}
+      </div>
+      <span class="text-sm text-muted">Actual avatar sizes</span>
+    </div>
   </div>
 </Story>

--- a/apps/frontend/src/lib/components/UserAvatar.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { PresenceStatus } from '@chatto/api-types/api/v1/presence_pb';
   import { untrack } from 'svelte';
+  import botIcon from '$lib/assets/bot.svg';
   import { m } from '$lib/i18n/messages';
   import type { UserAvatarUserView } from '$lib/render/users';
   import { getLiveAvatarUrl, getLiveCustomStatus } from '$lib/state/userProfiles.svelte';
@@ -166,14 +167,14 @@
     {#if showBotBadge}
       <span
         class={[
-          size === 'xs' ? 'h-3 w-3 text-[8px]' : 'h-4 w-4 text-[11px]',
-          'pointer-events-none absolute top-0 left-0 grid -translate-x-1/4 -translate-y-1/4 place-items-center rounded-full border border-surface bg-neutral-action text-on-neutral-action shadow-sm'
+          size === 'xs' ? 'h-3.5 w-3.5' : 'h-5 w-5',
+          'pointer-events-none absolute top-0 left-0 grid -translate-x-1/4 -translate-y-1/4 place-items-center rounded-full'
         ]}
         data-testid="bot-badge"
         role="img"
         aria-label={m('settings.bots.singular')}
       >
-        <span class="iconify icon-[uil--robot]" aria-hidden="true"></span>
+        <img src={botIcon} alt="" class="h-full w-full outline-none" aria-hidden="true" />
       </span>
     {/if}
     {#if showCustomStatusBadge}

--- a/apps/frontend/src/lib/components/UserCustomStatusBadge.svelte
+++ b/apps/frontend/src/lib/components/UserCustomStatusBadge.svelte
@@ -48,6 +48,7 @@ independent of presence and hides itself after its expiry timestamp.
       className
     ]}
     {title}
+    role="img"
     aria-label={title}
   >
     <span aria-hidden="true">{activeStatus.emoji}</span>


### PR DESCRIPTION
Replace the dense outline robot badge with a custom SVG that stays clear at small avatar sizes. The robot uses a simple face, soft shading, and a muted blue-green shell whose colours and edge contrast adapt to the app theme. Circular avatars and accessible bot labels remain in place.

Add Storybook examples for all avatar sizes, image avatars, and presence/status overlays. Fix the missing accessible role on custom-status badges, exposed by the new Storybook accessibility coverage. Update the [bot account guide](apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx). This preserves the bot identity behaviour in [FDR-038](docs/fdr/FDR-038-bot-accounts.md); no API, data migration, or deployment changes are required.

Validation:
- All 13 avatar/custom-status browser component tests and all 5 avatar Storybook accessibility tests pass. The status story reproduced the missing-role failure before the fix.
- Frontend Svelte/type and design-system checks pass with no errors or warnings.
- Targeted ESLint and Svelte autofixer checks pass.
- REUSE license check and SVG XML validation pass.
- Chrome DevTools visual review covers light/dark themes, actual badge sizes, and image avatars.
- [CI run 33970879913](https://github.com/chattocorp/chatto/actions/runs/33970879913) passed on `74fc3c83c`, including workspace tests/checks, CLI tests, all four end-to-end shards, media/performance tests, desktop checks, and docs checks. Full frontend suite and production build were not run locally.
