### PR TITLE
fix(frontend): hide bot badges on tiny avatars

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
@@ -189,7 +189,8 @@ Authorization: Bearer cht_BK_…
 The request is authorized as the bot user. For example, posting a message
 requires an explicit effective `message.post` allow and normal room access.
 The canonical `User.is_bot` field identifies bot authors to API clients;
-the bundled client also shows a robot marker on their avatars. The marker uses
+the bundled client also shows a robot marker on their avatars, except on
+extra-small avatars such as thread participants. The marker uses
 soft shading and changes its colours to match the light or dark theme.
 
 A bot API key can update its own login, display name, and bio through

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -716,7 +716,7 @@ describe('RoomList', () => {
     expect(pulseIcon?.classList.contains('animate-ping')).toBe(true);
     expect(dmRow?.querySelector('[data-testid="room-call-participants"]')).not.toBeNull();
     expect(dmRow?.querySelectorAll('[data-testid="room-call-participant-avatar"]')).toHaveLength(1);
-    expect(dmRow?.querySelector('[data-testid="bot-badge"]')).not.toBeNull();
+    expect(dmRow?.querySelector('[data-testid="bot-badge"]')).toBeNull();
     expect(dmRow!.querySelector('[data-testid="room-call-participants"]')?.nextElementSibling).toBe(
       icon
     );

--- a/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/QuickSwitcher.svelte.spec.ts
@@ -436,7 +436,7 @@ describe('QuickSwitcher', () => {
     expect(mocks.recents.record).toHaveBeenCalledWith('/chat/-/dm-new');
   });
 
-  it('marks bot user results', async () => {
+  it('shows bot user results without a badge on tiny avatars', async () => {
     mocks.listUsers.mockResolvedValue({
       members: [user('user-helper', 'helper_bot', 'Helper', true)],
       totalCount: 1,
@@ -447,7 +447,8 @@ describe('QuickSwitcher', () => {
     setSearch(container, 'helper');
     await waitForDebouncedUserSearch('helper');
     await vi.waitFor(() => {
-      expect(container.querySelector('[data-testid="bot-badge"]')).not.toBeNull();
+      expect(container.querySelector('[aria-label="helper_bot"]')).not.toBeNull();
+      expect(container.querySelector('[data-testid="bot-badge"]')).toBeNull();
     });
   });
 

--- a/apps/frontend/src/lib/components/UserAvatar.stories.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.stories.svelte
@@ -13,7 +13,8 @@
     parameters: {
       docs: {
         description: {
-          component: 'Circular user avatars with optional presence dots and coloured bot icons.'
+          component:
+            'Circular user avatars with optional presence dots. Bot icons appear on all sizes except xs.'
         }
       }
     }

--- a/apps/frontend/src/lib/components/UserAvatar.svelte
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte
@@ -121,7 +121,7 @@
   );
   const showCustomStatusBadge = $derived(!!user && showStatus && !user.deleted);
   const showPresenceDot = $derived(!!presence && showPresence && size !== 'xs');
-  const showBotBadge = $derived(!!user && !user.deleted && user.isBot === true);
+  const showBotBadge = $derived(!!user && !user.deleted && user.isBot === true && size !== 'xs');
   const hasOverlay = $derived(showCustomStatusBadge || showPresenceDot || showBotBadge);
   const wrapperClass = $derived(
     [sizeClasses[size], 'inline-grid shrink-0 rounded-full', hasOverlay && 'relative', className]
@@ -166,10 +166,7 @@
     {/if}
     {#if showBotBadge}
       <span
-        class={[
-          size === 'xs' ? 'h-3.5 w-3.5' : 'h-5 w-5',
-          'pointer-events-none absolute top-0 left-0 grid -translate-x-1/4 -translate-y-1/4 place-items-center rounded-full'
-        ]}
+        class="pointer-events-none absolute top-0 left-0 grid h-5 w-5 -translate-x-1/4 -translate-y-1/4 place-items-center rounded-full"
         data-testid="bot-badge"
         role="img"
         aria-label={m('settings.bots.singular')}

--- a/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/UserAvatar.svelte.spec.ts
@@ -81,14 +81,24 @@ describe('UserAvatar', () => {
     expect(q(container, '[aria-label="Online"]')).toBeFalsy();
   });
 
-  it('marks bot accounts with a robot badge', () => {
-    const { container } = render(UserAvatarTestHarness, {
-      size: 'md',
-      isBot: true
-    });
+  it('keeps extra-small bot avatars free of robot badges', () => {
+    const { container } = render(UserAvatarTestHarness, { size: 'xs', isBot: true });
 
-    expect(q(container, '[data-testid="bot-badge"][aria-label="bot"]')).toBeTruthy();
+    expect(q(container, '[aria-label="alice"]')).toBeTruthy();
+    expect(q(container, '[data-testid="bot-badge"]')).toBeFalsy();
   });
+
+  it.each(['sm', 'md', 'message', 'lg', 'xl'] as const)(
+    'marks %s bot avatars with a robot badge',
+    (size) => {
+      const { container } = render(UserAvatarTestHarness, {
+        size,
+        isBot: true
+      });
+
+      expect(q(container, '[data-testid="bot-badge"][aria-label="bot"]')).toBeTruthy();
+    }
+  );
 
   it('renders static directory identities without app-level live caches', () => {
     const { container } = render(UserAvatar, {

--- a/apps/frontend/src/lib/components/UserAvatarTestHarness.svelte
+++ b/apps/frontend/src/lib/components/UserAvatarTestHarness.svelte
@@ -5,7 +5,7 @@
   import { createUserProfileCache } from '$lib/state/userProfiles.svelte';
   import UserAvatar from './UserAvatar.svelte';
 
-  type Size = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
+  type Size = 'xs' | 'sm' | 'md' | 'message' | 'lg' | 'xl';
 
   let {
     size = 'md',

--- a/apps/frontend/src/lib/components/composer/MentionAutocomplete.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MentionAutocomplete.svelte.spec.ts
@@ -89,11 +89,12 @@ describe('MentionAutocomplete', () => {
       expect(container.querySelector('bdi:not([dir])')?.textContent).toBe('Alice Wonderland');
     });
 
-    it('marks bot mention targets with the shared avatar badge', () => {
+    it('shows bot mention targets without a badge on tiny avatars', () => {
       const bot = { ...member('helper_bot', 'Helper Bot'), isBot: true };
       const { container } = renderAutocomplete({ query: 'helper', members: [bot] });
 
-      expect(container.querySelector('[data-testid="bot-badge"]')).not.toBeNull();
+      expect(visibleLogins(container)).toEqual(['helper_bot']);
+      expect(container.querySelector('[data-testid="bot-badge"]')).toBeNull();
     });
 
     it('does not render deleted members as mention targets', () => {

--- a/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/users/UserCombobox.svelte.spec.ts
@@ -118,7 +118,7 @@ describe('UserCombobox', () => {
     expect(second.container.textContent).toContain('Alice Admin');
   });
 
-  it('marks bot results', async () => {
+  it('shows bot results without a badge on tiny avatars', async () => {
     mocks.listUsers.mockResolvedValue({
       members: [
         {
@@ -145,7 +145,8 @@ describe('UserCombobox', () => {
     await vi.advanceTimersByTimeAsync(220);
     await settle();
 
-    expect(view.container.querySelector('[data-testid="bot-badge"]')).not.toBeNull();
+    expect(view.container.querySelector('[aria-label="helper_bot"]')).not.toBeNull();
+    expect(view.container.querySelector('[data-testid="bot-badge"]')).toBeNull();
   });
 
   it('omits bot accounts when restricted to human users', async () => {

--- a/docs/fdr/FDR-038-bot-accounts.md
+++ b/docs/fdr/FDR-038-bot-accounts.md
@@ -1,7 +1,7 @@
 # FDR-038: Bot Accounts
 
 **Status:** Experimental
-**Last reviewed:** 2026-09-04
+**Last reviewed:** 2026-09-05
 
 ## Overview
 
@@ -258,7 +258,9 @@ their keys.
 ### 8. Bot identity is visible on canonical user surfaces
 
 **Decision:** Public user representations identify bot accounts, and clients
-render an accessible bot marker anywhere user identity is presented.
+render an accessible bot marker on user identity surfaces. The bundled client
+omits this marker from extra-small avatars to keep them clear. Larger avatars
+keep the marker.
 **Why:** People should know when messages or other actions come from automation.
 Using the canonical user representation keeps the distinction consistent
 across existing and future surfaces.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -47,7 +47,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-035](FDR-035-slow-mode.md) | Slow Mode | Active | 2026-08-11 |
 | [FDR-036](FDR-036-invite-links.md) | Invite Links | Active | 2026-08-11 |
 | [FDR-037](FDR-037-pinned-messages.md) | Pinned Messages | Active | 2026-08-25 |
-| [FDR-038](FDR-038-bot-accounts.md) | Bot Accounts | Experimental | 2026-09-04 |
+| [FDR-038](FDR-038-bot-accounts.md) | Bot Accounts | Experimental | 2026-09-05 |
 | [FDR-039](FDR-039-message-access-and-interactions.md) | Message Access & Interactions | Experimental | 2026-09-04 |
 | [FDR-040](FDR-040-backup-and-restore.md) | Backup and Restore | Active | 2026-08-27 |
 | [FDR-041](FDR-041-transactional-email-delivery.md) | Transactional Email Delivery | Active | 2026-08-28 |


### PR DESCRIPTION
Tiny thread participant avatars can be obscured by the robot badge. Hide that badge on shared `xs` avatars and keep it on all larger sizes.

Update the avatar story, the [bot account guide](apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx), and [FDR-038](docs/fdr/FDR-038-bot-accounts.md) to describe the size exception.

Validation: 99 component tests across avatar and affected surfaces passed; frontend lint and type checks, Svelte autofixer, and REUSE license check passed. Verified all avatar sizes in light and dark themes through Chrome DevTools and Storybook. Final complete diff review found no outstanding issues.
