### PR TITLE
fix(tooling): configure pnpm 11 and use Node LTS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-engine-strict=true
+# Set pnpm options in pnpm-workspace.yaml.

--- a/mise.toml
+++ b/mise.toml
@@ -6,7 +6,7 @@ buf = "latest"
 go = "1.26.7"
 goreleaser = "latest"
 node = "lts"
-pnpm = "10.26.0"
+pnpm = "11.25.0"
 uv = "0.11.30"
 
 [env]

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,8 @@ actionlint = "1.7.12"
 buf = "latest"
 go = "1.26.7"
 goreleaser = "latest"
-node = "22"
+node = "lts"
+pnpm = "10.26.0"
 uv = "0.11.30"
 
 [env]

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "license": "AGPL-3.0-or-later",
   "type": "module",
-  "packageManager": "pnpm@10.26.0",
+  "packageManager": "pnpm@11.25.0",
   "scripts": {
     "build:api-types": "pnpm --filter @chatto/api-types build",
     "build:lingua": "pnpm --filter @chatto/lingua build",
@@ -21,15 +21,6 @@
     "test": "pnpm run build:api-types && pnpm run build:lingua && pnpm --recursive --if-present --workspace-concurrency=1 run test",
     "test:lingua": "pnpm --filter @chatto/lingua test",
     "test:frontend": "pnpm run build:api-types && pnpm run build:lingua && pnpm --filter chatto-frontend test:unit:run"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild",
-      "sharp"
-    ],
-    "ignoredBuiltDependencies": [
-      "@tailwindcss/oxide"
-    ]
   },
   "devDependencies": {
     "knip": "^6.22.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,12 @@ packages:
   - apps/*
   - examples/*
   - packages/*
+
+engineStrict: true
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  '@tailwindcss/oxide': false
+  '@google/genai': false
+  protobufjs: false


### PR DESCRIPTION
## Why

`mise setup` can fail because no pnpm version is configured.

## What changed

Select Node LTS instead of Node 22, configure pnpm `11.25.0` in mise and `package.json`, and move engine enforcement and build-script permissions into `pnpm-workspace.yaml` for pnpm 11.
The existing lockfile is unchanged; `@google/genai` and `protobufjs` build scripts remain disabled through explicit permissions.

## API compatibility

- No public API or protocol behaviour changed.

## Test plan

- `CI=true mise x -- pnpm install --frozen-lockfile` — passed
- `mise setup` — passed
- `mise build-frontend` — passed, including bundle and CSP checks
- `mise x -- pnpm run build:docs` — passed
- `mise test-workspace` — passed, including frontend server, browser, and Storybook tests
- `mise license-check` — passed
- `git diff --check` — passed
- Full Go tests, E2E tests, and Docker builds — not run
