### PR TITLE
fix(assets): increase upload chunks to 10 MiB

### DIFF
--- a/apps/docs-website/src/content/docs/guides/infrastructure/media-attachments.mdx
+++ b/apps/docs-website/src/content/docs/guides/infrastructure/media-attachments.mdx
@@ -22,6 +22,13 @@ Members can attach files through drag-and-drop, paste, or the file picker when t
 
 Default upload limits are 25 MB for non-video files and 100 MB for videos when video uploads are enabled.
 
+Message attachments use upload chunks of up to 10 MiB. The browser uses the chunk
+limit returned by the server. This limit is fixed and reduces the number of
+requests on connections with high latency. If you set a reverse proxy request
+body limit, allow at least 11 MiB for each attachment upload request to include
+the chunk and request metadata. Avatar and branding uploads can need larger
+request bodies.
+
 ## Permission And Access Model
 
 File attachments require:

--- a/cli/internal/connectapi/api.go
+++ b/cli/internal/connectapi/api.go
@@ -213,9 +213,5 @@ func uploadRequestMaxBytes(maxUploadSize int64) int {
 
 func assetUploadRequestMaxBytes() int {
 	const protobufOverhead = 64 * 1024
-	return defaultAssetUploadChunkSizeForConnect() + protobufOverhead
-}
-
-func defaultAssetUploadChunkSizeForConnect() int {
-	return 512 * 1024
+	return core.DefaultAssetUploadChunkSize + protobufOverhead
 }

--- a/cli/internal/connectapi/message_services_test.go
+++ b/cli/internal/connectapi/message_services_test.go
@@ -19,6 +19,7 @@ import (
 	"hmans.de/chatto/internal/core"
 	"hmans.de/chatto/internal/core/linkpreview"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+	"hmans.de/chatto/internal/pb/chatto/api/v1/apiv1connect"
 	evtv1 "hmans.de/chatto/internal/pb/chatto/core/evt/v1"
 )
 
@@ -967,12 +968,23 @@ func TestAssetUploadServiceChunkResumeCompleteAndCancel(t *testing.T) {
 	env := newConnectAPITestEnv(t)
 	room := env.createJoinedRoom("asset-upload-flow")
 	ctx := withCaller(env.ctx, env.viewer)
-	content := []byte("first chunk and second chunk")
-	first := content[:11]
-	second := content[11:]
+	// Exercise the production request limit as well as the stored session limit.
+	mux := http.NewServeMux()
+	for _, handler := range env.api.Handlers() {
+		mux.Handle(handler.ServicePath, handler.Handler)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r.WithContext(withCaller(r.Context(), env.viewer)))
+	}))
+	t.Cleanup(server.Close)
+	client := apiv1connect.NewAssetUploadServiceClient(server.Client(), server.URL)
+	const chunkSize = 10 * 1024 * 1024
+	content := append(bytes.Repeat([]byte("a"), chunkSize), []byte("second chunk")...)
+	first := content[:chunkSize]
+	second := content[chunkSize:]
 	sum := sha256.Sum256(content)
 
-	created, err := env.assetUploads.CreateUpload(ctx, connect.NewRequest(&apiv1.CreateUploadRequest{
+	created, err := client.CreateUpload(ctx, connect.NewRequest(&apiv1.CreateUploadRequest{
 		RoomId:      room.Id,
 		Filename:    "note.txt",
 		ContentType: "text/plain",
@@ -983,12 +995,21 @@ func TestAssetUploadServiceChunkResumeCompleteAndCancel(t *testing.T) {
 		t.Fatalf("CreateUpload: %v", err)
 	}
 	uploadID := created.Msg.GetUpload().GetUploadId()
-	if uploadID == "" || created.Msg.GetUpload().GetMaxChunkSize() <= 0 {
+	if uploadID == "" || created.Msg.GetUpload().GetMaxChunkSize() != chunkSize {
 		t.Fatalf("created upload = %+v, want id and limits", created.Msg.GetUpload())
+	}
+	oversized := content[:chunkSize+1]
+	oversizedSum := sha256.Sum256(oversized)
+	if _, err := client.UploadChunk(ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
+		UploadId:    uploadID,
+		Content:     oversized,
+		ChunkSha256: hex.EncodeToString(oversizedSum[:]),
+	})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+		t.Fatalf("oversized chunk code = %v, want invalid_argument", connect.CodeOf(err))
 	}
 
 	firstSum := sha256.Sum256(first)
-	chunkResp, err := env.assetUploads.UploadChunk(ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
+	chunkResp, err := client.UploadChunk(ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
 		UploadId:    uploadID,
 		Content:     first,
 		ChunkSha256: hex.EncodeToString(firstSum[:]),
@@ -999,7 +1020,7 @@ func TestAssetUploadServiceChunkResumeCompleteAndCancel(t *testing.T) {
 	if got := chunkResp.Msg.GetUpload().GetCommittedOffset(); got != int64(len(first)) {
 		t.Fatalf("committed offset after first chunk = %d, want %d", got, len(first))
 	}
-	resume, err := env.assetUploads.GetUpload(ctx, connect.NewRequest(&apiv1.GetUploadRequest{UploadId: uploadID}))
+	resume, err := client.GetUpload(ctx, connect.NewRequest(&apiv1.GetUploadRequest{UploadId: uploadID}))
 	if err != nil {
 		t.Fatalf("GetUpload: %v", err)
 	}
@@ -1008,7 +1029,7 @@ func TestAssetUploadServiceChunkResumeCompleteAndCancel(t *testing.T) {
 	}
 
 	secondSum := sha256.Sum256(second)
-	if _, err := env.assetUploads.UploadChunk(ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
+	if _, err := client.UploadChunk(ctx, connect.NewRequest(&apiv1.UploadChunkRequest{
 		UploadId:    uploadID,
 		Offset:      int64(len(first)),
 		Content:     second,
@@ -1016,7 +1037,7 @@ func TestAssetUploadServiceChunkResumeCompleteAndCancel(t *testing.T) {
 	})); err != nil {
 		t.Fatalf("UploadChunk second: %v", err)
 	}
-	completed, err := env.assetUploads.CompleteUpload(ctx, connect.NewRequest(&apiv1.CompleteUploadRequest{UploadId: uploadID}))
+	completed, err := client.CompleteUpload(ctx, connect.NewRequest(&apiv1.CompleteUploadRequest{UploadId: uploadID}))
 	if err != nil {
 		t.Fatalf("CompleteUpload: %v", err)
 	}

--- a/cli/internal/core/asset_uploads.go
+++ b/cli/internal/core/asset_uploads.go
@@ -26,10 +26,15 @@ const (
 	assetUploadTempObjectPrefix      = "asset-upload."
 	defaultAssetUploadSessionTTL     = 15 * time.Minute
 	defaultPendingAttachmentAssetTTL = 24 * time.Hour
-	defaultAssetUploadChunkSize      = 512 * 1024
 	assetUploadCleanupInterval       = 5 * time.Minute
 	assetUploadOrphanChunkMaxAge     = defaultAssetUploadSessionTTL + time.Hour
 )
+
+// DefaultAssetUploadChunkSize is the maximum chunk size in bytes for new
+// upload sessions. Larger chunks reduce acknowledgement waits on high-latency
+// connections. Transports must allow this payload plus request metadata.
+// Existing sessions retain the limit stored when they were created.
+const DefaultAssetUploadChunkSize = 10 * 1024 * 1024
 
 type AssetUploadStatus string
 
@@ -122,7 +127,7 @@ func (m *AssetUploadModel) CreateUpload(ctx context.Context, input AssetUploadCr
 		Size:         input.Size,
 		SHA256:       strings.ToLower(input.SHA256),
 		Status:       AssetUploadStatusOpen,
-		MaxChunkSize: defaultAssetUploadChunkSize,
+		MaxChunkSize: DefaultAssetUploadChunkSize,
 		ExpiresAt:    now.Add(defaultAssetUploadSessionTTL),
 	}
 	value, err := json.Marshal(session)

--- a/docs/fdr/FDR-008-file-attachments-and-video.md
+++ b/docs/fdr/FDR-008-file-attachments-and-video.md
@@ -1,7 +1,7 @@
 # FDR-008: File Attachments & Video Processing
 
 **Status:** Active
-**Last reviewed:** 2026-09-03
+**Last reviewed:** 2026-09-05
 
 ## Overview
 
@@ -36,6 +36,8 @@ Users can attach files to messages — images, videos, documents — via drag-an
 ### 1. Attachment uploads use chunked ConnectRPC sessions
 
 **Decision:** Public message attachment uploads use `AssetUploadService`: `CreateUpload`, `UploadChunk`, `GetUpload`, `CompleteUpload`, and `CancelUpload`. Chunks are bounded unary ConnectRPC requests instead of browser client-streaming RPCs. Each upload declares the final file size and lowercase SHA-256 digest, each chunk carries its offset and chunk SHA-256, and `CompleteUpload` verifies the assembled digest before creating the durable asset. `CreateMessage` accepts only completed, live, room-matching asset IDs uploaded by the caller and atomically attaches each asset exclusively to the message.
+New sessions accept chunks up to 10 MiB. Clients use the limit returned by the server. The limit is fixed; operators do not need to configure it. Larger chunks reduce the number of acknowledgement waits on connections with high latency. Each request needs more memory, and a failed chunk can require more bytes to be sent again.
+
 **Why:** Attachments should remain inside the protobuf/ConnectRPC API surface instead of introducing a second REST upload endpoint. Unary chunks work with the current browser Connect stack and give resumable progress through the committed offset.
 **Tradeoff:** Clients must hash the full file before completion and issue several RPCs for larger files. Temporary chunks and open sessions need cleanup if the browser disappears before completion. Retrying a send after the first attempt actually committed must hydrate the created message rather than attach the same asset to a second message.
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -17,7 +17,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-08-30 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-08-27 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-09-04 |
-| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-09-01 |
+| [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-09-05 |
 | [FDR-009](FDR-009-link-previews.md) | Link Previews | Active | 2026-08-27 |
 | [FDR-010](FDR-010-typing-indicators.md) | Typing Indicators | Active | 2026-08-25 |
 | [FDR-011](FDR-011-user-presence.md) | User Presence | Active | 2026-09-01 |


### PR DESCRIPTION
Attachment uploads wait for each chunk to be stored and acknowledged before sending the next chunk. The 512 KiB limit causes frequent waits on connections with high latency. Increase the limit for new sessions to 10 MiB and derive the Connect request limit from the same constant. The browser already uses the server-advertised limit.

Keep the limit fixed. Existing sessions retain their stored limits, and no schema or data migration is required. Larger chunks need more memory per request and can require more bytes to be sent again after a failure. The operator guide documents the reverse proxy body limit. See [FDR-008](https://github.com/chattocorp/chatto/blob/3be4f61affa08e93c30bc0b96f79ef494b80dfe6/docs/fdr/FDR-008-file-attachments-and-video.md) for the decision and tradeoff.

Validation:

- Targeted core and Connect upload tests pass. The HTTP integration test covers a full 10 MiB chunk, rejection at one byte over the limit, resume, and completion.
- `mise license-check` and `git diff --check` pass.
- The complete diff was reviewed at `3be4f61affa08e93c30bc0b96f79ef494b80dfe6`; no material findings remain.
- Real-network throughput has not been measured.
