### PR TITLE
fix(frontend): gate moderation on effective ban permission

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -40,6 +40,10 @@ The interface updates effective permissions immediately. At expiry, the server
 reconnects the live projection so elevated controls turn off without a page
 reload.
 
+The Moderation link and page are available only when you have active
+server-wide `room.ban-member` permission. If you disable privileged mode while
+the page is open, the page shows an access-denied screen.
+
 The mode activates permissions, not role names. It therefore also covers
 custom roles and direct user grants. It does not add authority: a role removal
 or deny still takes effect while the mode is active.

--- a/apps/frontend/e2e/privileged-mode.test.ts
+++ b/apps/frontend/e2e/privileged-mode.test.ts
@@ -55,3 +55,49 @@ test('owner explicitly activates and deactivates privileged mode', async ({ page
     );
   }
 });
+
+test('Moderation follows effective permission on direct access and mode changes', async ({
+  page
+}) => {
+  const pageErrors: string[] = [];
+  const banRequests: string[] = [];
+  page.on('pageerror', (error) => pageErrors.push(error.message));
+  page.on('request', (request) => {
+    if (request.url().endsWith('/ListBans')) banRequests.push(request.method());
+  });
+  await page.goto(routes.root);
+  await loginAsAdminAndUsePrimaryServer(page, { activatePrivilegedMode: false });
+  await page.goto(routes.serverAdmin('moderation'));
+
+  const moderation = page.getByRole('link', { name: 'Moderation', exact: true });
+  const denied = page.getByText('Access Denied', { exact: true });
+  const emptyBans = page.getByText('No active room bans', { exact: true });
+  const enable = page.getByRole('button', { name: 'Enable privileged mode' });
+  const disable = page.getByRole('button', { name: 'Disable privileged mode' });
+  await expect(denied).toBeVisible();
+  await expect(moderation).not.toBeVisible();
+  expect(banRequests).toHaveLength(0);
+
+  await enable.click();
+  await page
+    .getByRole('dialog', { name: 'Enable privileged mode' })
+    .getByRole('button', { name: 'Enable privileged mode' })
+    .click();
+  await expect(moderation).toBeVisible();
+  await expect(emptyBans).toBeVisible();
+  expect(banRequests.length).toBeGreaterThan(0);
+
+  await disable.click();
+  await expect(denied).toBeVisible();
+  await expect(moderation).not.toBeVisible();
+  await expect(emptyBans).not.toBeVisible();
+
+  await enable.click();
+  await page
+    .getByRole('dialog', { name: 'Enable privileged mode' })
+    .getByRole('button', { name: 'Enable privileged mode' })
+    .click();
+  await expect(moderation).toBeVisible();
+  await expect(emptyBans).toBeVisible();
+  expect(pageErrors).toEqual([]);
+});

--- a/apps/frontend/src/lib/components/chat/Chrome.svelte
+++ b/apps/frontend/src/lib/components/chat/Chrome.svelte
@@ -132,6 +132,7 @@
       canManage: can('server.manage'),
       canManageNeighbors: can('server.manage-neighbors'),
       canManageRooms: can('room.manage'),
+      canModerate: can('room.ban-member'),
       canManageRoles: viewer.canAdminManageRoles,
       canAssignRoles: viewer.canAssignRoles,
       canManageUserAccounts: viewer.canAdminManageAccounts,

--- a/apps/frontend/src/lib/components/chat/adminNav.test.ts
+++ b/apps/frontend/src/lib/components/chat/adminNav.test.ts
@@ -11,6 +11,7 @@ function chrome(overrides: Partial<AdminNavChromePermissions> = {}): AdminNavChr
     canManage: false,
     canManageNeighbors: false,
     canManageRooms: false,
+    canModerate: false,
     canManageRoles: false,
     canAssignRoles: false,
     canManageUserAccounts: false,
@@ -41,6 +42,28 @@ describe('getAdminNavItems', () => {
 
     expect(items.find((item) => item.label === 'Bots')?.href).toBe(
       '/chat/local/manage/server/bots'
+    );
+  });
+
+  it('hides Moderation for admin entitlement and unrelated effective permissions', () => {
+    const items = getAdminNavItems({
+      serverSegment: 'local',
+      chrome: chrome({ canViewAdmin: true, canManage: true }),
+      server: server({ canAdminViewUsers: true })
+    });
+
+    expect(items.some((item) => item.label === 'Moderation')).toBe(false);
+  });
+
+  it('shows Moderation for effective server-wide ban permission', () => {
+    const items = getAdminNavItems({
+      serverSegment: 'local',
+      chrome: chrome({ canModerate: true }),
+      server: server()
+    });
+
+    expect(items.find((item) => item.label === 'Moderation')?.href).toBe(
+      '/chat/local/manage/server/moderation'
     );
   });
 

--- a/apps/frontend/src/lib/components/chat/adminNav.ts
+++ b/apps/frontend/src/lib/components/chat/adminNav.ts
@@ -6,6 +6,8 @@ export type AdminNavChromePermissions = {
   canManage: boolean;
   canManageNeighbors: boolean;
   canManageRooms: boolean;
+  /** Effective server-wide permission to list and manage room bans. */
+  canModerate: boolean;
   canManageRoles: boolean;
   canAssignRoles: boolean;
   canManageUserAccounts: boolean;
@@ -89,7 +91,7 @@ export function getAdminNavItems({
     });
   }
 
-  if (chrome.canViewAdmin) {
+  if (chrome.canModerate) {
     items.push({
       href: resolve('/chat/[serverId]/manage/server/moderation', { serverId: serverSegment }),
       label: m('admin.nav.moderation'),

--- a/apps/frontend/src/lib/state/server/chromePermissions.svelte.ts
+++ b/apps/frontend/src/lib/state/server/chromePermissions.svelte.ts
@@ -5,6 +5,8 @@ export type ChromePermissions = {
   canManage: boolean;
   canManageNeighbors: boolean;
   canManageRooms: boolean;
+  /** Effective server-wide permission to list and manage room bans. */
+  canModerate: boolean;
   canManageRoles: boolean;
   canAssignRoles: boolean;
   canManageUserAccounts: boolean;

--- a/apps/frontend/src/routes/chat/[serverId]/manage/+layout.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/+layout.svelte
@@ -73,9 +73,9 @@
       return () => true;
     }
 
-    // Moderation pages: the resolver enforces server-scope room.ban-member.
+    // The ban list requires effective server-scope room.ban-member.
     if (pathname.startsWith(moderationBase)) {
-      return () => chromePermissions?.canViewAdmin ?? false;
+      return () => chromePermissions?.canModerate ?? false;
     }
 
     // Permissions pages call the server/group role permission matrix APIs,

--- a/docs/fdr/FDR-046-privileged-mode.md
+++ b/docs/fdr/FDR-046-privileged-mode.md
@@ -1,7 +1,7 @@
 # FDR-046: Privileged Mode
 
 **Status:** Active
-**Last reviewed:** 2026-09-03
+**Last reviewed:** 2026-09-05
 
 ## Overview
 
@@ -37,6 +37,9 @@ server session when they need them.
   privileged mode.
 - The admin entry point remains visible to entitled users while the mode is
   inactive. Protected capabilities and actions remain unavailable.
+- The Moderation link and page require effective server-wide
+  `room.ban-member`. Deactivation or permission loss hides the link and removes
+  an open Moderation page. Direct access shows an access-denied screen.
 - A user can edit or delete their own message without privileged mode. Editing
   or deleting another user's message requires active `message.manage`.
 


### PR DESCRIPTION
Moderation used the admin-entry entitlement as its navigation and route gate. Entitled users could therefore open the page while privileged mode was inactive and receive a failed ban-list request.

Gate both surfaces on the existing effective server-wide `room.ban-member` grant. Direct access without that permission shows Access Denied without mounting the ban list. Disabling privileged mode removes an open page; reactivation restores it. No API or migration changes.

Updates [FDR-046](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-046-privileged-mode.md) and the public [permissions guide](https://github.com/chattocorp/chatto/blob/main/apps/docs-website/src/content/docs/guides/operations/permissions.mdx); uses the existing [Privileged Mode](https://github.com/chattocorp/chatto/blob/main/docs/GLOSSARY.md) model.

Validation:

- Navigation tests: 10 passed; both new cases fail with the old predicate.
- Privileged-mode end-to-end tests: 2 passed, including direct access and disable/re-enable behavior.
- Chrome DevTools: verified hidden/denied while inactive and visible/loaded after activation.
- Production build, bundle/CSP checks, Svelte check (zero errors/warnings), targeted ESLint, and REUSE license check passed.
- Complete diff review clean at `9297b4c9ac3e0c4a135c28effa673fc2daed33a1`.
