### PR TITLE
fix(events): identify and clean up projection consumers

### DIFF
--- a/apps/docs-website/src/content/docs/guides/operations/server-operations.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/server-operations.mdx
@@ -29,6 +29,24 @@ Owners and permissioned admins use the admin UI for daily operations. Depending 
 
 The system pages expose operational metadata, not conversation content; they do not provide a special endpoint for reading every message or file. The Server Admin System tab includes elected asset-cleanup health, pending retry count/age, and pass timing without exposing asset names, storage keys, or raw cleanup errors. This application boundary does not constrain an infrastructure operator who controls the running process, storage, and encryption keys. See [Encryption at Rest and Data Erasure](/guides/operations/privacy-erasure/) for the threat model.
 
+### NATS Projection Consumers
+
+Use names that start with `projection-` to identify the consumers that maintain
+local read models. Their names have the form
+`projection-<key>-<random>_<generation>`. Each server process needs its own
+projection consumers. The random suffix separates replicas; the generation
+changes when the NATS client replaces a consumer during recovery. NATS consumer
+metadata includes `projection_name` and `projection_description`.
+
+On shutdown, Chatto stops each projector and attempts to delete its consumer.
+If cleanup fails or the process crashes, NATS removes inactive projection
+consumers after five minutes. The timeout also protects active projections
+while slow work temporarily stops requests for more events.
+
+Named durable consumers such as `chatto-asset-cleanup-v1` keep unfinished
+background work across restarts. They remain after shutdown. KV watchers and
+temporary scans also create consumers and do not use the `projection-` prefix.
+
 ## Metrics
 
 Enable the per-process metrics listener when you want Prometheus scraping for one running Chatto process:

--- a/cli/internal/core/asset_processing_runtime.go
+++ b/cli/internal/core/asset_processing_runtime.go
@@ -57,6 +57,9 @@ func NewAssetProcessingRuntime(
 	publisher := evtstream.NewPublisher(js, evt, logger)
 	projection := NewAssetProjection()
 	assets := evtstream.NewProjectionHandle(js, evt, projection, logger.WithPrefix("AssetsProjector"))
+	if err := assets.Projector().ConfigureConsumerIdentity("asset_processing", "Asset processing worker state"); err != nil {
+		return nil, fmt.Errorf("configure asset processing consumer identity: %w", err)
+	}
 
 	workerCore := &ChattoCore{
 		nc:             nc,

--- a/cli/internal/core/projection_wiring.go
+++ b/cli/internal/core/projection_wiring.go
@@ -67,7 +67,10 @@ func registerProjectionHandle[P events.SubjectProjection](
 	identityResolver events.StreamIdentityResolver,
 	estimate func() (int64, int64, []ProjectionAdminMetric),
 	snapshotPolicy projectionSnapshotPolicy,
-) events.ProjectionHandle[P] {
+) (events.ProjectionHandle[P], error) {
+	if err := handle.Projector().ConfigureConsumerIdentity(key, name); err != nil {
+		return events.ProjectionHandle[P]{}, fmt.Errorf("configure %s consumer identity: %w", key, err)
+	}
 	r.registrations = append(r.registrations, projectionRegistration{
 		key:              key,
 		name:             name,
@@ -78,7 +81,7 @@ func registerProjectionHandle[P events.SubjectProjection](
 		identityResolver: identityResolver,
 		estimate:         estimate,
 	})
-	return handle
+	return handle, nil
 }
 
 func registerProjection[T any, P evtstream.ProjectionPointer[T]](
@@ -111,7 +114,7 @@ func registerProjection[T any, P evtstream.ProjectionPointer[T]](
 		evtstream.IdentityFromInfo,
 		estimate,
 		snapshotPolicy,
-	), nil
+	)
 }
 
 func registerPreparedProjection[T any, P evtstream.PreparedProjectionPointer[T]](
@@ -144,7 +147,7 @@ func registerPreparedProjection[T any, P evtstream.PreparedProjectionPointer[T]]
 		evtstream.IdentityFromInfo,
 		estimate,
 		snapshotPolicy,
-	), nil
+	)
 }
 
 func bindContentProjection[T any, P evtstream.ProjectionPointer[T]](
@@ -268,11 +271,14 @@ func initializeCoreProjections(
 		infra.js, notificationProjectionStream, notifications,
 		logger.WithPrefix("core.NotificationsProjector"),
 	)
-	projections.notifications = registerProjectionHandle(
+	projections.notifications, err = registerProjectionHandle(
 		registrar, notificationHandle, notifications, projectionsnapshot.ProjectionNotificationsKey,
 		"Notifications", notificationStreamName,
 		notificationstream.IdentityFromInfo, notifications.adminProjectionEstimate, sharedSnapshots,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	projections.userAuth, err = registerProjection(
 		registrar, userAuth, "user_auth", "User Auth", userAuth.adminProjectionEstimate, coldReplayOnly,

--- a/cli/internal/core/system_test.go
+++ b/cli/internal/core/system_test.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -105,6 +106,20 @@ func TestChattoCore_GetJetStreamStats(t *testing.T) {
 	}
 	if !foundEVT {
 		t.Error("expected EVT stream in stats")
+	}
+	for _, projection := range core.projections {
+		found := false
+		for _, consumer := range stats.Consumers {
+			if consumer.Stream == projection.streamName && strings.HasPrefix(consumer.Name, "projection-"+projection.key+"-") {
+				found = true
+				if consumer.Durable != "" {
+					t.Errorf("projection %s has a durable consumer", projection.key)
+				}
+			}
+		}
+		if !found {
+			t.Errorf("projection %s has no named consumer in diagnostics", projection.key)
+		}
 	}
 }
 

--- a/cli/internal/search/bleve/unit.go
+++ b/cli/internal/search/bleve/unit.go
@@ -69,6 +69,9 @@ func (u Unit) Run(ctx context.Context, env runtimeunit.Env) error {
 
 	projectionHandle := evtstream.NewProjectionHandle(env.JS, evt, projection, env.Logger)
 	projector := projectionHandle.Projector()
+	if err := projector.ConfigureConsumerIdentity("message_search", "Message search index"); err != nil {
+		return err
+	}
 	if err := projector.ConfigureCheckpoint("message_search", evtstream.IdentityFromInfo); err != nil {
 		return err
 	}

--- a/docs/architecture/nats-resources.md
+++ b/docs/architecture/nats-resources.md
@@ -30,6 +30,15 @@ inventories.
 | NATS Core    | `live.sync.>`       | None    | No     | Non-durable `pubsubv1.PubSubEvent` values                                    |
 | Republish    | `live.evt.>`        | None    | No     | Raw committed `EVT` facts republished by JetStream for server-side live delivery |
 
+## Projection consumers
+
+Each projector owns one ephemeral ordered consumer. Chatto uses the name
+`projection-<key>-<random>_<generation>` and stores the owner in consumer
+metadata. On exit, the projector stops consumption and attempts to delete only
+its current consumer. Five-minute inactivity expiry remains the fallback if
+cleanup fails or the process crashes. See the [projection inventory](projections.md)
+for the owners and lifecycle.
+
 ## Durable consumers
 
 | Stream | Consumer | Filter | Ack contract | Owner |

--- a/docs/architecture/projections.md
+++ b/docs/architecture/projections.md
@@ -85,8 +85,16 @@ healthy-looking after an incomplete startup.
 Projection consumers use a five-minute inactivity cleanup threshold. Because
 event application is synchronous and disk-backed commits can temporarily stop
 the pull loop, a shorter broker threshold could delete a live consumer while
-its projection is still applying a batch. Projector shutdown still stops the
-pull subscription; NATS later removes its ephemeral consumer.
+its projection is still applying a batch. On shutdown or failure, the projector
+stops the pull subscription and attempts to delete its current ephemeral
+consumer. The deletion request has an independent two-second timeout. If the
+request fails or the process crashes, inactivity expiry remains the fallback.
+
+Chatto configures names as `projection-<key>-<random>_<generation>` for core,
+asset-processing, and search projectors. Each projector has a unique random
+suffix; the SDK increments the generation when it replaces a consumer.
+Consumer metadata fields `projection_name` and `projection_description` identify
+the owner. These labels do not change snapshot keys or durable worker names.
 
 The projector framework owns JetStream message handling and passes stable
 stream sequence numbers into `Projection.Apply`. Projection implementations do

--- a/pkg/events/README.md
+++ b/pkg/events/README.md
@@ -90,6 +90,9 @@ one mutable state object.
 ```go
 projection := &MyProjection{}
 projector := events.NewDecodedProjector(js, stream, projection, decodeEvent, logger)
+if err := projector.ConfigureConsumerIdentity("my_projection", "Application read model"); err != nil {
+	return err
+}
 
 go projector.Run(ctx) // one Run call per Projector instance
 if err := projector.WaitForStartup(ctx); err != nil {
@@ -98,6 +101,14 @@ if err := projector.WaitForStartup(ctx); err != nil {
 ```
 
 `Run` is single-use. After cancellation or failure, construct a new projector.
+The optional consumer identity gives each consumer a readable name and
+description metadata. Use static labels without personal data or secrets.
+The framework adds a random suffix to separate replicas and the SDK adds a
+generation number for recovery. Labels do not change snapshot contracts.
+On exit, `Run` stops consumption and attempts to delete its current ephemeral
+consumer with an independent two-second request timeout. Deletion failure does
+not replace the run error. Five-minute inactivity expiry remains the fallback
+after a crash or a failed cleanup request. Durable workers keep their consumers.
 Use `WaitFor`, `WaitForCurrent`, or a subject-aware `StreamPosition` when a
 caller needs read-your-writes visibility.
 

--- a/pkg/events/projector.go
+++ b/pkg/events/projector.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"reflect"
@@ -42,6 +43,7 @@ const (
 	// projection Apply is running. Keep their cleanup window comfortably above
 	// slow disk-backed commits so NATS cannot delete a live projector consumer.
 	projectionConsumerInactiveThreshold = 5 * time.Minute
+	projectionConsumerCleanupTimeout    = 2 * time.Second
 )
 
 // MemoryProjection is an embeddable base for projections whose state lives
@@ -335,6 +337,11 @@ type Projector struct {
 	subjects        []string
 	replaySubjects  []string
 	subjectMatchers []compiledSubjectFilter
+
+	// Consumer identity is application-owned diagnostic text, guarded by mu
+	// and frozen by Run.
+	consumerName        string
+	consumerDescription string
 
 	mu        sync.Mutex
 	lastSeq   uint64
@@ -1219,9 +1226,39 @@ func (p *Projector) fail(seq uint64, err error) {
 	p.waiters = nil
 }
 
+// ConfigureConsumerIdentity sets diagnostic labels for this projector's
+// ephemeral consumer. Call it before Run. The name must contain 1 to 64 ASCII
+// letters, digits, hyphens, or underscores. Neither value may contain personal
+// data or secrets. The description is stored in consumer metadata because the
+// ordered-consumer API has no description field.
+//
+// Run adds a random suffix to the name so replicas never share a consumer.
+// These labels do not change snapshot identities or create a durable consumer.
+func (p *Projector) ConfigureConsumerIdentity(name, description string) error {
+	if len(name) == 0 || len(name) > 64 {
+		return fmt.Errorf("projection consumer name must contain 1 to 64 ASCII letters, digits, hyphens, or underscores")
+	}
+	for _, c := range name {
+		if !(c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-' || c == '_') {
+			return fmt.Errorf("projection consumer name must contain only ASCII letters, digits, hyphens, or underscores")
+		}
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.started {
+		return ErrProjectorAlreadyStarted
+	}
+	p.consumerName = name
+	p.consumerDescription = description
+	return nil
+}
+
 // Run starts the consumer + apply loop once. Blocks until ctx is cancelled.
 // Returns ErrProjectorAlreadyStarted for a repeated or concurrent call, and
-// the context's error on shutdown.
+// the context's error on shutdown. On exit it stops consumption and attempts
+// to delete only its own ephemeral consumer. Cleanup failure does not replace
+// the run error; inactivity expiry remains the fallback after a crash or loss
+// of the NATS connection.
 func (p *Projector) Run(ctx context.Context) (runErr error) {
 	defer func() {
 		if runErr != nil && !errors.Is(runErr, ErrProjectorAlreadyStarted) && !errors.Is(runErr, context.Canceled) && !errors.Is(runErr, context.DeadlineExceeded) {
@@ -1235,6 +1272,7 @@ func (p *Projector) Run(ctx context.Context) (runErr error) {
 		return ErrProjectorAlreadyStarted
 	}
 	p.started = true
+	consumerName, consumerDescription := p.consumerName, p.consumerDescription
 	if p.startupStartedAt.IsZero() {
 		p.startupStartedAt = startedAt
 	}
@@ -1257,6 +1295,13 @@ func (p *Projector) Run(ctx context.Context) (runErr error) {
 		DeliverPolicy:     jetstream.DeliverAllPolicy,
 		InactiveThreshold: projectionConsumerInactiveThreshold,
 	}
+	if consumerName != "" {
+		consumerConfig.NamePrefix = "projection-" + consumerName + "-" + rand.Text()
+		consumerConfig.Metadata = map[string]string{
+			"projection_name":        consumerName,
+			"projection_description": consumerDescription,
+		}
+	}
 	p.mu.Lock()
 	restoredSeq := p.restoredSeq
 	p.mu.Unlock()
@@ -1268,6 +1313,9 @@ func (p *Projector) Run(ctx context.Context) (runErr error) {
 	if err != nil {
 		return fmt.Errorf("create ordered consumer: %w", err)
 	}
+	// Registered before Stop so cleanup runs after consumption stops, including
+	// when Consume fails after the physical consumer was created.
+	defer p.deleteProjectionConsumer(cons)
 
 	// Use Consume(handler) — NOT Messages() iterator. The iterator path
 	// has an idle-cost behaviour in the SDK that adds ~5s per process to
@@ -1295,6 +1343,21 @@ func (p *Projector) Run(ctx context.Context) (runErr error) {
 			return err
 		}
 		return ErrProjectionFailed
+	}
+}
+
+// deleteProjectionConsumer reads the current name after Stop: the SDK can
+// replace an ordered consumer during recovery. Never delete by a shared prefix
+// or by the initial name, which may refer to an earlier SDK generation.
+func (p *Projector) deleteProjectionConsumer(consumer jetstream.Consumer) {
+	info := consumer.CachedInfo()
+	if info == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), projectionConsumerCleanupTimeout)
+	defer cancel()
+	if err := p.stream.DeleteConsumer(ctx, info.Name); err != nil && !errors.Is(err, jetstream.ErrConsumerNotFound) && !errors.Is(err, jetstream.ErrStreamNotFound) {
+		p.logger.Warn("Could not delete projection consumer; inactivity expiry remains enabled", "consumer", info.Name, "error", err)
 	}
 }
 

--- a/pkg/events/projector_consumer_test.go
+++ b/pkg/events/projector_consumer_test.go
@@ -1,0 +1,238 @@
+package events_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go/jetstream"
+	. "hmans.de/chatto/pkg/events"
+)
+
+func lifecycleProjector(js jetstream.JetStream, stream jetstream.Stream, decodeErr error) *Projector {
+	return NewDecodedProjector(js, stream, &codecTestProjection{subject: "evt.lifecycle.>"},
+		func(data []byte) (DecodedEvent[codecTestEvent], error) {
+			return DecodedEvent[codecTestEvent]{Event: codecTestEvent{name: string(data)}, ID: string(data)}, decodeErr
+		}, testLogger())
+}
+
+func lifecycleStream(t *testing.T) (jetstream.JetStream, jetstream.Stream) {
+	t.Helper()
+	js, err := jetstream.New(startTestNATS(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	stream, err := js.CreateStream(testContext(t), jetstream.StreamConfig{Name: "LIFECYCLE", Subjects: []string{"evt.lifecycle.>"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return js, stream
+}
+
+func runLifecycleProjector(t *testing.T, p *Projector) (context.CancelFunc, <-chan error) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(testContext(t))
+	t.Cleanup(cancel)
+	done := make(chan error, 1)
+	go func() { done <- p.Run(ctx) }()
+	if err := p.WaitForStartup(ctx); err != nil {
+		t.Fatal(err)
+	}
+	return cancel, done
+}
+
+func awaitLifecycleExit(t *testing.T, done <-chan error, want error) {
+	t.Helper()
+	select {
+	case err := <-done:
+		if !errors.Is(err, want) {
+			t.Fatalf("Run error = %v, want %v", err, want)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("projector did not stop")
+	}
+}
+
+func lifecycleConsumers(t *testing.T, stream jetstream.Stream) map[string]*jetstream.ConsumerInfo {
+	t.Helper()
+	result := make(map[string]*jetstream.ConsumerInfo)
+	list := stream.ListConsumers(testContext(t))
+	for info := range list.Info() {
+		result[info.Name] = info
+	}
+	if err := list.Err(); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestProjectorConsumerIdentityRecoveryAndReplicaIsolation(t *testing.T) {
+	js, stream := lifecycleStream(t)
+	ctx := testContext(t)
+	// A similarly named durable resource must survive projection cleanup.
+	const durable = "projection-content-durable"
+	if _, err := stream.CreateConsumer(ctx, jetstream.ConsumerConfig{Durable: durable, AckPolicy: jetstream.AckExplicitPolicy}); err != nil {
+		t.Fatal(err)
+	}
+	first := lifecycleProjector(js, stream, nil)
+	if err := first.ConfigureConsumerIdentity("content", "Content read model"); err != nil {
+		t.Fatal(err)
+	}
+	stopFirst, firstDone := runLifecycleProjector(t, first)
+	var firstName string
+	for name, info := range lifecycleConsumers(t, stream) {
+		if name == durable {
+			continue
+		}
+		firstName = name
+		if !strings.HasPrefix(name, "projection-content-") || info.Config.Durable != "" || info.Config.InactiveThreshold != 5*time.Minute || info.Config.Metadata["projection_description"] != "Content read model" {
+			t.Fatalf("unexpected projection consumer: %#v", info.Config)
+		}
+	}
+	if firstName == "" {
+		t.Fatal("missing first projection consumer")
+	}
+	if err := first.ConfigureConsumerIdentity("changed", "Changed"); !errors.Is(err, ErrProjectorAlreadyStarted) {
+		t.Fatalf("identity mutation after Run = %v", err)
+	}
+	second := lifecycleProjector(js, stream, nil)
+	if err := second.ConfigureConsumerIdentity("content", "Content read model"); err != nil {
+		t.Fatal(err)
+	}
+	stopSecond, secondDone := runLifecycleProjector(t, second)
+	before := lifecycleConsumers(t, stream)
+	if len(before) != 3 {
+		t.Fatalf("replicas share a consumer: got %d consumers, want 3", len(before))
+	}
+	var secondName string
+	for name := range before {
+		if name != durable && name != firstName {
+			secondName = name
+		}
+	}
+	// Force SDK recovery, then prove both projections still receive events.
+	if err := stream.DeleteConsumer(ctx, firstName); err != nil {
+		t.Fatal(err)
+	}
+	ack, err := js.Publish(ctx, "evt.lifecycle.created", []byte("after-reset"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []*Projector{first, second} {
+		if err := p.WaitFor(ctx, SubjectPosition("evt.lifecycle.created", ack.Sequence)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	after := lifecycleConsumers(t, stream)
+	if len(after) != 3 || after[firstName] != nil {
+		t.Fatalf("unexpected consumers after recovery: %v", after)
+	}
+	for name, info := range after {
+		if name != durable && (info.Config.Metadata["projection_name"] != "content" || !strings.HasPrefix(name, "projection-content-")) {
+			t.Fatalf("identity lost on recovery: %#v", info.Config)
+		}
+	}
+	stopFirst()
+	awaitLifecycleExit(t, firstDone, context.Canceled)
+	after = lifecycleConsumers(t, stream)
+	if len(after) != 2 || after[secondName] == nil || after[durable] == nil {
+		t.Fatalf("cleanup did not isolate the current consumer: %v", after)
+	}
+	stopSecond()
+	awaitLifecycleExit(t, secondDone, context.Canceled)
+	after = lifecycleConsumers(t, stream)
+	if len(after) != 1 || after[durable] == nil {
+		t.Fatalf("cleanup left ephemeral consumers or removed durable state: %v", after)
+	}
+}
+
+func TestProjectorConsumerCleanupOnProjectionFailure(t *testing.T) {
+	js, stream := lifecycleStream(t)
+	failure := errors.New("invalid projection event")
+	p := lifecycleProjector(js, stream, failure)
+	_, done := runLifecycleProjector(t, p)
+	if _, err := js.Publish(testContext(t), "evt.lifecycle.created", []byte("invalid")); err != nil {
+		t.Fatal(err)
+	}
+	awaitLifecycleExit(t, done, failure)
+	if remaining := lifecycleConsumers(t, stream); len(remaining) != 0 {
+		t.Fatalf("failed projector left consumers: %v", remaining)
+	}
+}
+
+// unavailableCleanupStream simulates a broker that does not answer deletion.
+// Consumer creation and delivery still cross the real JetStream boundary.
+type unavailableCleanupStream struct {
+	jetstream.Stream
+	cleanupErr chan error
+}
+
+func (s unavailableCleanupStream) DeleteConsumer(ctx context.Context, _ string) error {
+	<-ctx.Done()
+	s.cleanupErr <- ctx.Err()
+	return ctx.Err()
+}
+
+func TestProjectorConsumerCleanupHasIndependentDeadline(t *testing.T) {
+	js, stream := lifecycleStream(t)
+	wrapper := unavailableCleanupStream{Stream: stream, cleanupErr: make(chan error, 1)}
+	p := lifecycleProjector(js, wrapper, nil)
+	stop, done := runLifecycleProjector(t, p)
+	stop()
+	awaitLifecycleExit(t, done, context.Canceled)
+	if err := <-wrapper.cleanupErr; !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("cleanup reused canceled Run context: %v", err)
+	}
+	if remaining := lifecycleConsumers(t, stream); len(remaining) != 1 {
+		t.Fatalf("expected consumer retained for inactivity expiry: %v", remaining)
+	}
+}
+
+func TestProjectorConsumerIdentityValidation(t *testing.T) {
+	p := lifecycleProjector(nil, nil, nil)
+	for _, name := range []string{"", "has.space", "has space", "has/slash", "has*wildcard", "has>filter", "ümlaut", strings.Repeat("a", 65)} {
+		if err := p.ConfigureConsumerIdentity(name, "Read model"); err == nil {
+			t.Fatalf("accepted invalid name %q", name)
+		}
+	}
+	if err := p.ConfigureConsumerIdentity("content_v2-TEST", "Read model"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// failedConsumeStream creates a real consumer but fails the local pull setup.
+type failedConsumeStream struct {
+	jetstream.Stream
+	failure error
+}
+
+type failedConsumeConsumer struct {
+	jetstream.Consumer
+	failure error
+}
+
+func (s failedConsumeStream) OrderedConsumer(ctx context.Context, cfg jetstream.OrderedConsumerConfig) (jetstream.Consumer, error) {
+	consumer, err := s.Stream.OrderedConsumer(ctx, cfg)
+	if err != nil {
+		return nil, err
+	}
+	return failedConsumeConsumer{Consumer: consumer, failure: s.failure}, nil
+}
+
+func (c failedConsumeConsumer) Consume(jetstream.MessageHandler, ...jetstream.PullConsumeOpt) (jetstream.ConsumeContext, error) {
+	return nil, c.failure
+}
+
+func TestProjectorConsumerCleanupOnConsumeSetupFailure(t *testing.T) {
+	js, stream := lifecycleStream(t)
+	failure := errors.New("pull setup failed")
+	p := lifecycleProjector(js, failedConsumeStream{Stream: stream, failure: failure}, nil)
+	if err := p.Run(testContext(t)); !errors.Is(err, failure) {
+		t.Fatalf("Run error = %v, want setup failure", err)
+	}
+	if remaining := lifecycleConsumers(t, stream); len(remaining) != 0 {
+		t.Fatalf("setup failure left consumers: %v", remaining)
+	}
+}


### PR DESCRIPTION
Frequent server restarts leave projection consumers in NATS until their five-minute inactivity timeout expires, and generated names make their owners hard to identify. Projectors now attempt to delete their current ephemeral consumer when they stop. Core, asset-processing, and search projectors use readable names with unique random suffixes and description metadata.

Cleanup stops consumption first, follows SDK consumer replacements, and uses an independent two-second deletion timeout. Failed cleanup retains the existing inactivity fallback. Durable worker consumers, event bytes, and snapshot contracts are unchanged; no migration is required. Operator and framework documentation describe the lifecycle.

Validation: `mise test-events`, `mise test-cli`, Authling's `mise test`, repeated consumer lifecycle race tests, the core diagnostics integration test, the docs website build, and `mise license-check` all passed. Tests cover replica isolation, SDK recovery, durable-consumer preservation, projection failure, partial startup, and cleanup timeouts. Final full-diff review found no significant issues.

Related: [ADR-056](docs/adr/ADR-056-extractable-nats-event-sourcing-framework.md), [ADR-069](docs/adr/ADR-069-explicit-durable-consumer-lifecycle.md), and the [projection inventory](docs/architecture/projections.md).
