### PR TITLE
fix(frontend): restore room group header hover behaviour

### DIFF
--- a/apps/frontend/src/lib/RoomList.svelte
+++ b/apps/frontend/src/lib/RoomList.svelte
@@ -983,11 +983,6 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
             {@render groupHeaderActions(section.group)}
           {/if}
         {/snippet}
-        {#snippet leadingOverlay()}
-          {#if !isDndShadow(section) && supportsRelativeSidebarMoves && canReorderGroups}
-            {@render groupLeadingOverlay()}
-          {/if}
-        {/snippet}
         <RoomGroupSection
           label={section.label}
           items={section.items}
@@ -999,7 +994,9 @@ rooms are organized into collapsible sections. Otherwise, rooms display alphabet
           containItemDrag
           isDndShadow={isDndShadow(section)}
           {headerActions}
-          {leadingOverlay}
+          leadingOverlay={!isDndShadow(section) && supportsRelativeSidebarMoves && canReorderGroups
+            ? groupLeadingOverlay
+            : undefined}
           separated={i > 0}
         />
       {/each}

--- a/apps/frontend/src/lib/RoomList.svelte.spec.ts
+++ b/apps/frontend/src/lib/RoomList.svelte.spec.ts
@@ -1,7 +1,9 @@
 import { RoomKind } from '@chatto/api-types/api/v1/rooms_pb';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
 import { q } from '$lib/test-utils';
+import '../app.css';
 
 import { NotificationSignalKind } from '$lib/api-client/notifications';
 import type { RoomsListGroup } from '$lib/state/server/rooms.svelte';
@@ -1148,6 +1150,60 @@ describe('RoomList', () => {
       (button) => button.textContent?.trim() === 'Delete Group'
     );
     await expect.element(deleteGroup ?? null).toBeDisabled();
+  });
+
+  it.each([
+    { name: 'without reorder permission', canReorderGroups: false, supportsMoves: true },
+    { name: 'without relative moves', canReorderGroups: true, supportsMoves: false },
+    { name: 'with reorder permission', canReorderGroups: true, supportsMoves: true }
+  ])('keeps a room group indicator visible $name', async ({ name, canReorderGroups, supportsMoves }) => {
+    mocks.store.serverInfo.supportsFeature.mockReturnValue(supportsMoves);
+    mocks.store.navigation.roomGroups = [
+      {
+        id: `indicator-${name}`,
+        name: 'Projects',
+        viewerCanManageGroup: canReorderGroups,
+        viewerCanCreateRoom: canReorderGroups,
+        roomIds: ['channel-1']
+      }
+    ];
+
+    const { container, getByRole } = render(RoomList, { props: { canReorderGroups } });
+    const heading = getByRole('button', { name: 'Projects', exact: true });
+    const icon = q(container, '[data-testid="room-group-disclosure-icon"]')!;
+    const handle = q(container, '[data-testid="room-group-drag-handle"]');
+    const hasOverlay = canReorderGroups && supportsMoves;
+
+    expect(Boolean(handle)).toBe(hasOverlay);
+    await userEvent.unhover(heading);
+    await expect.poll(() => getComputedStyle(icon).opacity).toBe('1');
+    const mutedColour = getComputedStyle(heading.element()).color;
+
+    for (const expanded of [true, false]) {
+      await expect.element(heading).toHaveAttribute('aria-expanded', String(expanded));
+      await userEvent.hover(heading);
+      await expect.poll(() => getComputedStyle(heading.element()).color).not.toBe(mutedColour);
+      await expect.poll(() => getComputedStyle(icon).opacity).toBe(hasOverlay ? '0' : '1');
+      if (handle) await expect.poll(() => getComputedStyle(handle).opacity).toBe('1');
+
+      await userEvent.unhover(heading);
+      heading.element().focus();
+      await userEvent.tab();
+      await userEvent.tab({ shift: true });
+      await expect.element(heading).toHaveFocus();
+      await expect.poll(() => getComputedStyle(heading.element()).color).not.toBe(mutedColour);
+      await expect.poll(() => getComputedStyle(icon).opacity).toBe(hasOverlay ? '0' : '1');
+      if (handle) await expect.poll(() => getComputedStyle(handle).opacity).toBe('1');
+
+      await userEvent.keyboard(' ');
+      await expect.element(heading).toHaveAttribute('aria-expanded', String(!expanded));
+      heading.element().blur();
+    }
+
+    await userEvent.click(heading);
+    await userEvent.unhover(heading);
+    await expect.element(heading).toHaveFocus();
+    await expect.poll(() => getComputedStyle(heading.element()).color).toBe(mutedColour);
   });
 
   it('shows permission-gated drag and creation controls without room or group menu buttons', async () => {

--- a/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte
+++ b/apps/frontend/src/lib/components/chat/RoomGroupSection.svelte
@@ -116,7 +116,7 @@ navigation, member presence groups, and attachment date groups.
 >
   <div class="px-2 py-1.5">
     <div
-      class="group/section-header relative flex min-h-8 w-full min-w-0 items-center rounded-md transition-colors hover:text-text"
+      class="group/section-header relative flex min-h-8 w-full min-w-0 items-center rounded-md text-muted transition-colors hover:text-text"
       {@attach contextMenuTrigger}
     >
       <button
@@ -124,7 +124,7 @@ navigation, member presence groups, and attachment date groups.
         onclick={toggle}
         aria-expanded={!collapsed}
         data-testid={testid}
-        class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-start text-xs font-semibold tracking-wider text-muted uppercase focus-visible:outline-2 focus-visible:outline-action"
+        class="flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-1 py-1 text-start text-xs font-semibold tracking-wider uppercase focus-visible:text-text focus-visible:outline-2 focus-visible:outline-action"
       >
         <span class="relative sidebar-icon">
           <span


### PR DESCRIPTION
## Why

Room group chevrons disappeared on hover when no drag handle was available, and header hover highlighting no longer worked.

## What changed

Only supply the drag overlay when permitted and supported; restore hover and keyboard-focus highlighting while clearing the highlight after a mouse click when the pointer leaves, with browser regression coverage for the [FDR-017 sidebar behaviour](docs/fdr/FDR-017-room-groups-and-sidebar-layout.md).

## API compatibility

- No public API or protocol behaviour changed.
- Older client → newer server: unchanged
- Newer client → older server: chevron remains visible without relative-move support
- Capability discovery or minimum client/server version: unchanged

## Test plan

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/lib/RoomList.svelte.spec.ts src/lib/components/chat/RoomGroupSection.svelte.spec.ts` — 58 passed
- `mise lint-frontend` — passed before the final focus-only adjustment
- `mise x -- pnpm --filter chatto-frontend exec eslint src/lib/RoomList.svelte.spec.ts src/lib/components/chat/RoomGroupSection.svelte` — passed after the final adjustment
- `mise x -- npx @sveltejs/mcp svelte-autofixer ./apps/frontend/src/lib/components/chat/RoomGroupSection.svelte` — no issues or suggestions
- Chrome DevTools MCP, Storybook: hover, keyboard focus, expand/collapse, and click followed by pointer exit verified
- `git diff --check` — passed
- Full frontend suite: not run
