### PR TITLE
fix(frontend): backport iOS video safe-area fix to 0.4

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -40,6 +40,7 @@ runs:
     - name: Setup mise
       uses: jdx/mise-action@v4
       with:
+        version: 2026.9.2
         experimental: true
 
     # pnpm is not available as a mise plugin, so install via npm (comes with Node)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
       - name: Setup mise
         uses: jdx/mise-action@v4
         with:
+          version: 2026.9.2
           experimental: true
 
       - name: Check license metadata

--- a/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte
+++ b/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte
@@ -73,7 +73,8 @@
     onfullscreenchange={handleFullscreenChange}
   >
     <button
-      class="absolute top-4 right-4 z-10 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
+      type="button"
+      class="absolute top-[calc(env(safe-area-inset-top,0px)+1rem)] right-[calc(env(safe-area-inset-right,0px)+1rem)] z-10 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full bg-white/10 text-white transition-colors hover:bg-white/20"
       onclick={close}
       aria-label={m['media.close_fullscreen_video']()}
     >

--- a/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/FullscreenVideoOverlay.svelte.spec.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { fullscreenVideo } from '$lib/state/globals.svelte';
+import FullscreenVideoOverlay from './FullscreenVideoOverlay.svelte';
+
+afterEach(() => {
+  fullscreenVideo.close();
+});
+
+describe('FullscreenVideoOverlay', () => {
+  it('keeps the close button inside iOS safe areas', async () => {
+    fullscreenVideo.open('https://chat.example.test/clip.mp4', null, 0);
+    const { container } = render(FullscreenVideoOverlay);
+
+    await expect.poll(() => container.querySelector('button')).toBeTruthy();
+    const closeButton = container.querySelector<HTMLButtonElement>('button')!;
+
+    expect(closeButton.className).toContain('safe-area-inset-top');
+    expect(closeButton.className).toContain('safe-area-inset-right');
+    expect(closeButton.type).toBe('button');
+
+    closeButton.click();
+    expect(fullscreenVideo.isOpen).toBe(false);
+  });
+});


### PR DESCRIPTION
Backport #1618 to `release-0.4`. On an iPhone PWA, the fullscreen video close button can overlap the system status area. Place it 1rem inside the top and right safe-area boundaries and set `type="button"`.

Cherry-picked `cf4210a1df577c6e4b99b83c84006e972b09f3bc` with `-x`, including the original regression test. No application API, dependency, translation, or player changes.

Pin both CI mise-action entry points to `2026.9.2`. Automatic version selection requested `2026.9.3`, whose Linux download returned 404 and prevented all nine checks from running.

Validation:
- All nine CI checks passed, including frontend, backend, protobuf drift, license metadata, four E2E shards, and media E2E. Image publication jobs are skipped for this PR.
- Svelte autofixer: no issues or suggestions.
- `mise lint-frontend`: passed; Svelte check reported zero errors and warnings.
- Focused fullscreen overlay browser test: passed (1 test), including a rerun in the original workspace.
- `mise license-check`: passed.
- Chrome DevTools MCP: mounted the actual overlay with a placeholder media URL at 393×852 and 1440×900; checked button geometry and hit target, clicked Close, and confirmed the overlay was removed. This checks layout and dismissal, not video playback.
- Actual iPhone PWA safe-area behavior remains unverified; Chrome uses zero device safe-area insets.
