### PR TITLE
fix(runling): deliver one final reply from validated agent outcomes

### DIFF
--- a/apps/frontend/e2e/runling-bot.test.ts
+++ b/apps/frontend/e2e/runling-bot.test.ts
@@ -50,7 +50,7 @@ test.describe('Runling webhook bot', () => {
           if (!context.thread?.some(message => message.body === context.message)) {
             throw new Error('Mention context did not include the current message');
           }
-          await context.sender.send(${JSON.stringify(replyBody)});
+          await context.sender.sendFinal(${JSON.stringify(replyBody)});
         })
       } } });
     `
@@ -159,7 +159,7 @@ test.describe('Runling webhook bot', () => {
         roomId: string,
         rootId: string,
         sourceId: string,
-        expectedBody = replyBody
+        expectedBodies = [replyBody]
       ) {
         await expect
           .poll(
@@ -169,6 +169,7 @@ test.describe('Runling webhook bot', () => {
                 'chatto.api.v1.ThreadService/GetThreadEvents',
                 { roomId, threadRootEventId: rootId, limit: 20 }
               );
+              const replies: Array<{ body?: string; root?: string }> = [];
               for (const event of timeline.page?.events ?? []) {
                 const result = await connectPost<{
                   message?: {
@@ -179,14 +180,17 @@ test.describe('Runling webhook bot', () => {
                   };
                 }>(page, 'chatto.api.v1.MessageService/GetMessage', { roomId, eventId: event.id });
                 if (result.message?.actorId === botId && result.message.inReplyTo === sourceId) {
-                  return { body: result.message.body, root: result.message.threadRootEventId };
+                  replies.push({
+                    body: result.message.body,
+                    root: result.message.threadRootEventId
+                  });
                 }
               }
-              return null;
+              return replies;
             },
             { timeout: 15_000 }
           )
-          .toEqual({ body: expectedBody, root: rootId });
+          .toEqual(expectedBodies.map((body) => ({ body, root: rootId })));
       }
       const rootId = await postMessageViaConnect(page, roomId, '@test_bot Hello Runling');
       await expectReply(roomId, rootId, rootId);
@@ -213,12 +217,9 @@ test.describe('Runling webhook bot', () => {
         'Trigger test model failure',
         dmId
       );
-      await expectReply(
-        dm.room.id,
-        dmId,
-        failedId,
+      await expectReply(dm.room.id, dmId, failedId, [
         "Sorry, I couldn't generate a reply. Please try again."
-      );
+      ]);
     } finally {
       if (bot.exitCode === null && bot.signalCode === null) bot.kill('SIGTERM');
       const timer = setTimeout(() => bot.kill('SIGKILL'), 5_000);

--- a/docs/architecture/runtime-components.md
+++ b/docs/architecture/runtime-components.md
@@ -158,15 +158,21 @@ addresses, checks redirect destinations, and bounds response size and time.
 The prompt directs Chatto questions to `https://docs.chatto.run/` and requires
 source citations. Channel mentions and DMs preload all thread pages into the agent
 prompt on each delivery. A separate workflow
-step starts the live typing indicator, which refreshes during context loading
-and composition. The agent sends chat text through `send_reply`, which calls the public API
-with a fixed destination. The example’s `sender.ts` owns the confirmed message ID and one attempt per
-run, shared by the agent and error fallback. `typing.ts` owns refresh and stop
-behavior. A
-successful send determines delivery success even if the subsequent Runling
-outcome report is missing. Outcome reporting is enabled after the send attempt. If context loading or
-composition fails before any reply POST, a separate workflow step sends a
-fixed error notification in the same thread. The run remains failed; an
-ambiguous send attempt never triggers a second POST.
+step starts the live typing indicator, which refreshes during context loading,
+composition, and final-answer delivery. Intermediate assistant text, thinking,
+and tool output stay out of the chat. Runling's local history is available for
+diagnostics. Its `report_outcome` tool remains available throughout the run.
+The validated report supplies one complete final answer from `details`, or
+from `summary` when details are empty.
+The example's `sender.ts` owns one POST attempt per run, shared by the final
+answer and error notification, and the confirmed final-answer ID. A failed or
+uncertain POST is never retried. The workflow waits for delivery before
+finishing. `typing.ts` owns refresh and stop behavior.
+Success requires a completed Runling outcome and confirmed final-answer
+delivery. Valid blocked or failed reports are delivered but keep the workflow
+failed. If context loading or composition fails before a reply POST, a separate
+workflow step sends a fixed error notification. A previous POST attempt
+suppresses that notification. The agent is disposed and typing refreshes stop
+on exit.
 `OPENROUTER_API_KEY` supplies model credentials. It has no realtime connection. Its local run history is stored under
 `examples/runling-bot/.runling`. This process is not part of server releases.

--- a/examples/runling-bot/README.md
+++ b/examples/runling-bot/README.md
@@ -71,23 +71,39 @@ For Chatto questions, the system prompt requires the agent to fetch
 `https://docs.chatto.run/`, follow relevant documentation links, and cite the
 source pages. Fetched content is reference data, not instructions. If the docs
 are unavailable or incomplete, the bot must say so instead of inventing an
-answer. It uses
-`send_reply` to post the exact chat text through the API. The room and reply
-thread are fixed by the workflow. Outcome reporting becomes available after
-the send attempt and is internal bookkeeping. A missing report after a
-successful send does not fail delivery. Repeated tool calls share one HTTP
-attempt, including a failed attempt; this protection applies within one run
-only. The workflow disposes the agent session after it finishes. A separate **Start typing** step sends a typing
-indicator in that thread. The indicator refreshes every three seconds during
-context loading and composition. Refreshes stop on success or failure; the
-indicator then expires through Chatto’s normal typing timeout. Typing errors
-do not fail delivery. Model turns have a
-two-minute timeout. Missing model credentials and model errors fail the run. If context loading or
-composition fails before any reply POST, a separate **Send error reply** step
-sends a fixed failure message to the same thread. It contains no raw error
-text. The run remains failed in Runling. No fallback is sent after a reply POST
-was attempted, because its delivery can be uncertain. Error notifications are
-best effort and are not retried.
+answer.
+
+The workflow posts one final answer per delivery. Intermediate assistant text,
+thinking, tool calls, and tool results are not posted to Chatto. Runling's
+local history remains available for diagnostics. The typing indicator shows
+that the bot is working.
+
+The agent finishes with Runling's `report_outcome` tool, which stays available
+throughout the run, including recovery prompts. `outcome` is the status:
+`completed`, `blocked`, or `failed`; it must not contain answer text. The
+workflow posts the full answer from `details`, or `summary` when `details` is
+empty. The report must contain the complete answer without relying on earlier
+assistant text.
+
+The room and reply thread are fixed by the workflow. The sender allows one
+HTTP POST attempt per run, shared by final-answer delivery and the error
+notification. A failed or uncertain POST is never retried. This protection
+applies within one run only. The workflow waits for delivery and disposes the
+agent session on exit. Success requires a completed Runling outcome and
+confirmed final-answer delivery. The workflow's `replyId` identifies that
+answer. Valid blocked or failed reports are posted but keep the run failed.
+A missing report is a failure even if the agent produced intermediate text.
+
+A separate **Start typing** step sends a typing indicator in that thread. The
+indicator refreshes every three seconds through context loading, composition,
+and delivery. Refreshes stop on success or failure; the indicator then expires
+through Chatto's normal typing timeout. Typing errors do not fail delivery.
+Model runs have a two-minute timeout. Missing model credentials and model
+errors fail the run. If context loading or composition fails before a reply
+POST, a **Send error reply** step sends a fixed failure message. It contains
+no raw error text. The run remains failed in Runling. A previous POST attempt
+suppresses this notification because delivery can be uncertain. Error
+notifications are best effort and are not retried.
 
 The current message and any requested thread context are sent to OpenRouter.
 Credentials are not included in prompts or tool results. Agent text is omitted
@@ -112,20 +128,22 @@ mise test-runling-bot
 ```
 
 The tests cover new and existing threads, bot identity, bot-message loops, and
-failed reply requests. They make no network or model calls. The end-to-end test injects a fixed
-answer while testing real webhook delivery and Chatto API calls.
+failed reply requests. They make no network or model calls. Agent integration
+tests use the real Runling and Pi runtime with synthetic provider responses.
+They check the outbound prompt and tools, report validation, recovery, and
+suppression of intermediate text. The end-to-end test injects a fixed answer
+while testing real webhook delivery and Chatto API calls.
 
 ## Code layout
 
 - `reply.ts` defines the webhook schema, inline Chatto API calls, thread loading,
   and workflow steps.
-- `agent.ts` defines the chat prompt and tools. It reads delivery status from
-  the workflow's sender.
-- `sender.ts` owns the single reply attempt and error fallback for each run.
+- `agent.ts` defines the chat prompt, read-only tools, and final-report delivery.
+- `sender.ts` owns the single delivery attempt and error fallback for each run.
 - `typing.ts` owns best-effort typing refreshes and shutdown.
 - `web-fetch.ts` contains the public-network fetch protections.
 
-Helper tests cover sender and typing lifecycles. Agent tests cover tool order
-and delivery status. Workflow tests cover authentication, thread context,
-replies, and error notifications. The browser integration test covers real
+Helper tests cover sender and typing lifecycles. Agent tests cover event
+filtering, outcome reports, recovery prompts, and delivery status. Workflow
+tests cover authentication, thread context, replies, and error notifications. The browser integration test covers real
 webhook delivery and API calls without a paid model request.

--- a/examples/runling-bot/agent.integration.test.ts
+++ b/examples/runling-bot/agent.integration.test.ts
@@ -1,0 +1,166 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import { createRunling } from "runling";
+import { generateReply } from "./agent.ts";
+import { createReplySender } from "./sender.ts";
+
+/** A provider response still passes through Runling, Pi, and tool validation. */
+function completion(delta: object, finishReason: "stop" | "tool_calls") {
+  const chunk = {
+    id: "synthetic-completion",
+    object: "chat.completion.chunk",
+    created: 0,
+    model: "google/gemini-2.5-flash-lite",
+    choices: [
+      {
+        index: 0,
+        delta: { role: "assistant", ...delta },
+        finish_reason: finishReason,
+      },
+    ],
+  };
+  return new Response(`data: ${JSON.stringify(chunk)}\n\ndata: [DONE]\n\n`, {
+    headers: { "Content-Type": "text/event-stream" },
+  });
+}
+
+for (const recover of [false, true]) {
+  test(`real Runling validates and delivers an outcome, recovery=${recover}`, async (t) => {
+    const cwd = await mkdtemp(path.join(os.tmpdir(), "chatto-agent-test-"));
+    const env = {
+      OPENROUTER_API_KEY: "test-only",
+      PI_CODING_AGENT_DIR: cwd,
+      PI_OFFLINE: "1",
+    };
+    const previous = Object.fromEntries(
+      Object.keys(env).map((key) => [key, process.env[key]]),
+    );
+    Object.assign(process.env, env);
+    let requests = 0;
+    const requestErrors: unknown[] = [];
+    const posts: string[] = [];
+    // Mock only the provider transport. No agent, extension, or event mocks.
+    // Fail closed: an unexpected URL must never reach a real service.
+    t.mock.method(
+      globalThis,
+      "fetch",
+      async (url: string | URL | Request, init?: RequestInit) => {
+        try {
+          assert.equal(
+            String(url),
+            "https://openrouter.ai/api/v1/chat/completions",
+          );
+          const body = JSON.parse(String(init?.body));
+          const system = body.messages.find(
+            (message: { role: string }) => message.role === "system",
+          ).content;
+          assert.match(system, /outcome is a status, never the answer text/);
+          for (const status of ["completed", "blocked", "failed"]) {
+            assert.ok(system.includes(`"${status}"`));
+          }
+          assert.ok(
+            system.includes('{"outcome":"completed","summary":"Hello!"}'),
+          );
+          assert.deepEqual(
+            body.tools
+              .map((tool: { function: { name: string } }) => tool.function.name)
+              .sort(),
+            ["read_thread", "report_outcome", "web_fetch"],
+          );
+          const report = body.tools.find(
+            (tool: { function: { name: string } }) =>
+              tool.function.name === "report_outcome",
+          );
+          assert.deepEqual(
+            report.function.parameters.properties.outcome.anyOf,
+            ["completed", "blocked", "failed"].map((value) => ({
+              const: value,
+              type: "string",
+            })),
+          );
+          assert.deepEqual(
+            posts,
+            [],
+            "No message is posted before the final report",
+          );
+          requests++;
+          if (recover && requests === 2) {
+            assert.ok(
+              body.messages.some(
+                (message: { role: string; content?: string }) =>
+                  message.role === "tool" &&
+                  message.content?.includes("Validation failed"),
+              ),
+            );
+            return completion({ content: "Interim update" }, "stop");
+          }
+          if (recover && requests === 3) {
+            assert.match(
+              JSON.stringify(body.messages.at(-1).content),
+              /calling report_outcome with the truthful outcome/,
+            );
+          }
+          const invalid = recover && requests === 1;
+          return completion(
+            {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: `report-${requests}`,
+                  type: "function",
+                  function: {
+                    name: "report_outcome",
+                    arguments: JSON.stringify({
+                      outcome: invalid ? "Hello!" : "completed",
+                      summary: "Hello!",
+                    }),
+                  },
+                },
+              ],
+            },
+            "tool_calls",
+          );
+        } catch (error) {
+          requestErrors.push(error);
+          // Avoid provider retry delays when an assertion fails.
+          return new Response(
+            '{"error":{"message":"Synthetic request assertion failed"}}',
+            { status: 400 },
+          );
+        }
+      },
+    );
+    try {
+      const r = createRunling({ cwd, prompt: "", verbose: false });
+      const sender = createReplySender(async (text) => {
+        posts.push(text);
+        return `message-${posts.length}`;
+      });
+      let runError: unknown;
+      try {
+        await generateReply(r, {
+          message: "Hello",
+          readThread: async () => [],
+          sender,
+        });
+      } catch (error) {
+        runError = error;
+      }
+      assert.deepEqual(requestErrors, []);
+      assert.equal(runError, undefined);
+      assert.equal(requests, recover ? 3 : 1);
+      assert.deepEqual(posts, ["Hello!"]);
+      assert.equal(sender.id, `message-${posts.length}`);
+    } finally {
+      t.mock.restoreAll();
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+      await rm(cwd, { recursive: true, force: true });
+    }
+  });
+}

--- a/examples/runling-bot/agent.test.ts
+++ b/examples/runling-bot/agent.test.ts
@@ -4,96 +4,208 @@ import {
   createRunling,
   type AgentExtensionAPI,
   type RunlingAgent,
+  type Runling,
 } from "runling";
 import { createReplySender } from "./sender.ts";
 import { generateReply } from "./agent.ts";
 
-test("delivery, not the outcome report, determines success", async () => {
+type Options = Parameters<Runling["agent"]>[0];
+type Event = Parameters<NonNullable<Options["onEvent"]>>[0];
+
+/** Exercise the event boundary without a model request or credentials. */
+async function fixture(
+  run: (
+    emit: (event: object) => void,
+    restart: () => Promise<void>,
+  ) => Promise<object>,
+  post: (text: string) => Promise<string> = async () => "reply",
+) {
   const previous = process.env.OPENROUTER_API_KEY;
   process.env.OPENROUTER_API_KEY = "test-only";
+  let disposed = false;
+  const posted: string[] = [];
+  const sender = createReplySender(async (text) => {
+    posted.push(text);
+    return post(text);
+  });
+  const r = {
+    ...createRunling({ cwd: process.cwd(), prompt: "", verbose: false }),
+  };
+  r.agent = async (options) => {
+    assert.equal(options.model, "openrouter/google/gemini-2.5-flash-lite");
+    assert.equal(options.thinkingLevel, "off");
+    assert.deepEqual(options.tools, ["read_thread", "web_fetch"]);
+    assert.deepEqual(options.resources, {
+      extensions: false,
+      skills: false,
+      promptTemplates: false,
+      themes: false,
+      contextFiles: false,
+    });
+    let beforeStart: (() => Promise<{ systemPrompt: string }>) | undefined;
+    const extension = options.extensions?.[0];
+    assert.equal(typeof extension, "function");
+    const registered: string[] = [];
+    await (extension as (api: AgentExtensionAPI) => unknown)({
+      on(name: string, handler: typeof beforeStart) {
+        if (name === "before_agent_start") beforeStart = handler;
+      },
+      setActiveTools() {
+        assert.fail(
+          "Do not override Runling's tool availability on any prompt",
+        );
+      },
+      registerTool(tool: { name: string }) {
+        registered.push(tool.name);
+      },
+    } as unknown as AgentExtensionAPI);
+    assert.deepEqual(registered, ["read_thread"]);
+    const restart = async () => {
+      const result = await beforeStart!();
+      assert.match(result.systemPrompt, /report_outcome/);
+      assert.doesNotMatch(result.systemPrompt, /send_reply/);
+    };
+    return {
+      async runOutcome() {
+        await restart();
+        return run((event) => options.onEvent!(event as Event), restart);
+      },
+      dispose() {
+        disposed = true;
+      },
+    } as unknown as RunlingAgent;
+  };
+  let error: unknown;
   try {
-    for (const mode of [
-      "success",
-      "missing-report",
-      "late-error",
-      "no-send",
-      "send-failure",
-    ]) {
-      let disposed = false;
-      const posted: string[] = [];
-      const r = {
-        ...createRunling({ cwd: process.cwd(), prompt: "", verbose: false }),
-      };
-      r.agent = async (options) => {
-        assert.equal(options.model, "openrouter/google/gemini-2.5-flash-lite");
-        assert.equal(options.thinkingLevel, "off");
-        assert.deepEqual(options.tools, [
-          "read_thread",
-          "web_fetch",
-          "send_reply",
-        ]);
-        let send:
-          | ((id: string, args: { text: string }) => Promise<unknown>)
-          | undefined;
-        const extension = options.extensions?.[0];
-        if (typeof extension !== "function")
-          throw new Error("Missing chat extension");
-        let beforeStart: (() => Promise<unknown>) | undefined;
-        const activeTools: string[][] = [];
-        await extension({
-          on(name: string, handler: () => Promise<unknown>) {
-            if (name === "before_agent_start") beforeStart = handler;
-          },
-          setActiveTools(names: string[]) {
-            activeTools.push(names);
-          },
-          registerTool(tool: { name: string; execute: typeof send }) {
-            if (tool.name === "send_reply") send = tool.execute;
-          },
-        } as unknown as AgentExtensionAPI);
-        return {
-          async runOutcome() {
-            await beforeStart!();
-            assert.deepEqual(activeTools[0], [
-              "read_thread",
-              "web_fetch",
-              "send_reply",
-            ]);
-            if (mode !== "no-send") await send!("call", { text: " Hey! " });
-            if (mode !== "no-send")
-              assert.deepEqual(activeTools.at(-1), ["report_outcome"]);
-            if (mode === "late-error")
-              throw new Error("Model disconnected after sending");
-            return {
-              outcome: mode === "missing-report" ? "failed" : "completed",
-              summary: "Internal report",
-            };
-          },
-          dispose() {
-            disposed = true;
-          },
-        } as unknown as RunlingAgent;
-      };
-      const result = generateReply(r, {
-        message: "sup",
-        readThread: async () => [],
-        sender: createReplySender(async (text) => {
-          if (mode === "send-failure") throw new Error("HTTP failed");
-          posted.push(text);
-          return "reply-id";
-        }),
-      });
-      if (mode === "no-send" || mode === "send-failure") {
-        await assert.rejects(result, /did not send|HTTP failed/);
-        assert.deepEqual(posted, []);
-      } else {
-        await result;
-        assert.deepEqual(posted, ["Hey!"]);
-      }
-      assert.equal(disposed, true);
-    }
+    await generateReply(r, {
+      message: "Hello",
+      readThread: async () => [],
+      sender,
+    });
+  } catch (caught) {
+    error = caught;
   } finally {
     if (previous === undefined) delete process.env.OPENROUTER_API_KEY;
     else process.env.OPENROUTER_API_KEY = previous;
   }
+  assert.equal(disposed, true);
+  return { posted, sender, error };
+}
+
+const textEvent = (text: string) => ({
+  type: "message_end",
+  message: { role: "assistant", content: [{ type: "text", text }] },
+});
+const reportEvent = {
+  type: "tool_execution_end",
+  toolName: "report_outcome",
+  isError: false,
+};
+
+for (const details of ["Full answer", undefined, "   "]) {
+  test(`ignores intermediate text and posts only final ${JSON.stringify(details)}`, async () => {
+    const result = await fixture(async (emit) => {
+      emit({
+        type: "message_update",
+        assistantMessageEvent: { type: "text_delta", delta: "partial" },
+      });
+      emit({
+        type: "message_end",
+        message: { role: "user", content: "private input" },
+      });
+      emit({
+        type: "message_end",
+        message: {
+          role: "toolResult",
+          content: [{ type: "text", text: "tool output" }],
+        },
+      });
+      emit({
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "private reasoning" },
+            { type: "toolCall", name: "web_fetch", arguments: {} },
+            { type: "text", text: "First update" },
+          ],
+        },
+      });
+      emit(textEvent("  "));
+      emit(textEvent("Second update"));
+      emit(reportEvent);
+      return { outcome: "completed", summary: "Short answer", details };
+    });
+    assert.equal(result.error, undefined);
+    assert.deepEqual(result.posted, [details?.trim() || "Short answer"]);
+    assert.equal(result.sender.id, "reply");
+  });
+}
+
+test("recovery prompts preserve reporting and do not replay interim messages", async () => {
+  const result = await fixture(async (emit, restart) => {
+    emit(textEvent("Interim update"));
+    await restart(); // Runling's missing-report recovery calls session.prompt again.
+    emit(reportEvent);
+    return { outcome: "completed", summary: "Final answer" };
+  });
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.posted, ["Final answer"]);
+});
+
+test("final text is posted once even when the agent emitted it earlier", async () => {
+  const result = await fixture(async (emit) => {
+    emit(textEvent("The answer"));
+    emit(reportEvent);
+    return { outcome: "completed", summary: "The answer" };
+  });
+  assert.equal(result.error, undefined);
+  assert.deepEqual(result.posted, ["The answer"]);
+  assert.equal(result.sender.id, "reply");
+});
+
+for (const outcome of ["blocked", "failed"]) {
+  test(`delivers a valid ${outcome} answer without a second error notification`, async () => {
+    const result = await fixture(async (emit) => {
+      emit(reportEvent);
+      return { outcome, summary: "Please supply the missing information" };
+    });
+    assert.match(String(result.error), new RegExp(outcome));
+    await result.sender.notifyFailure();
+    assert.deepEqual(result.posted, ["Please supply the missing information"]);
+  });
+}
+
+for (const mode of ["missing", "invalid", "exception"]) {
+  test(`${mode} report hides intermediate text and sends only an error`, async () => {
+    const result = await fixture(async (emit) => {
+      emit(textEvent("Interim update"));
+      if (mode === "exception") throw new Error("Model disconnected");
+      if (mode === "invalid") emit({ ...reportEvent, isError: true });
+      return { outcome: "failed", summary: "Internal missing-report error" };
+    });
+    assert.ok(result.error);
+    assert.equal(result.sender.id, undefined);
+    await result.sender.notifyFailure();
+    assert.deepEqual(result.posted, [
+      "Sorry, I couldn't generate a reply. Please try again.",
+    ]);
+  });
+}
+
+test("does not retry a failed final POST and disposes", async () => {
+  const result = await fixture(
+    async (emit) => {
+      emit(textEvent("First update"));
+      emit(textEvent("Second update"));
+      emit(reportEvent);
+      return { outcome: "completed", summary: "Final answer" };
+    },
+    async () => {
+      throw new Error("HTTP failed");
+    },
+  );
+  assert.match(String(result.error), /HTTP failed/);
+  await result.sender.notifyFailure();
+  assert.deepEqual(result.posted, ["Final answer"]);
 });

--- a/examples/runling-bot/agent.ts
+++ b/examples/runling-bot/agent.ts
@@ -8,13 +8,18 @@ The prompt contains the complete current thread. Use it to answer the latest mes
 
 For Chatto questions, fetch https://docs.chatto.run/ and follow relevant documentation links before answering. Cite the specific source pages. Use web_fetch for other current public information when useful. State when sources are unavailable or insufficient. Do not send credentials or private conversation text to websites.
 
-Answer by calling send_reply with the exact message for the user, not a description of your answer. Use native tool calls; text that resembles code does not execute tools. Send one reply, then call report_outcome for internal bookkeeping. If sending fails, report failed. Only the available tools can perform actions. Do not repeat the @test_bot mention.`;
+Only your final report is posted to Chatto. Intermediate assistant text is not shown to the user. Put the complete answer in the final report; do not rely on earlier text. Finish with a native report_outcome tool call. Its fields have distinct purposes:
+- outcome is a status, never the answer text. Use exactly "completed" when you have answered the user, "blocked" when you need external input or access, or "failed" when you could not complete the task.
+- summary is a required, nonempty, single-line answer or concise result, at most 500 characters.
+- details is optional and contains the full user-facing answer in Markdown, at most 20000 characters. Omit it when summary already contains the complete answer.
+For a greeting, a valid final call is {"outcome":"completed","summary":"Hello!"}.
+The workflow posts details, or summary when details is absent, to the user. Do not put internal bookkeeping in either field. Use native tool calls; text that resembles code does not execute tools. Only the available tools can perform actions. Do not repeat the @test_bot mention.`;
 
 /** Context is restricted by the workflow to the webhook's current thread. */
 export interface ReplyContext {
   message: string;
 
-  /** The workflow owns the single reply attempt and its result. */
+  /** The workflow owns the single final-answer or error-notification attempt. */
   sender: ReplySender;
 
   /** Fresh complete history supplied automatically for mentions and DMs. */
@@ -23,7 +28,7 @@ export interface ReplyContext {
   readThread: () => Promise<Array<{ role: "bot" | "human"; body: string }>>;
 }
 
-/** Let the agent send a reply; a successful HTTP send determines success. */
+/** Post only the validated final Runling report to the current thread. */
 export async function generateReply(
   r: Runling,
   context: ReplyContext,
@@ -36,40 +41,9 @@ export async function generateReply(
     // Replace Pi's coding-agent identity for this chat session. Appending role
     // instructions leaves conflicting defaults in place for lightweight models.
     pi.on("before_agent_start", async () => {
-      pi.setActiveTools(["read_thread", "web_fetch", "send_reply"]);
       return {
         systemPrompt: SYSTEM_PROMPT,
       };
-    });
-
-    pi.registerTool({
-      name: "send_reply",
-      label: "Send reply to Chatto",
-      description:
-        "Send the exact user-facing chat message now. This is the only way to answer the user. The destination is fixed to the triggering message's thread. Call once, then report_outcome.",
-      parameters: Type.Object({ text: Type.String({ minLength: 1 }) }),
-      async execute(_id, { text }) {
-        if (!text.trim()) {
-          throw new Error("The reply must not be empty");
-        }
-
-        try {
-          await context.sender.send(text.trim());
-        } finally {
-          // After the single send attempt, only internal reporting remains.
-          pi.setActiveTools(["report_outcome"]);
-        }
-
-        return {
-          content: [
-            {
-              type: "text",
-              text: "Reply sent. Finish with report_outcome; do not send again.",
-            },
-          ],
-          details: {},
-        };
-      },
     });
 
     pi.registerTool({
@@ -91,10 +65,22 @@ export async function generateReply(
   // Runling reports agent text to its logger by default. Keep chat content out
   // of process logs; the local Runling run history still contains workflow data.
   return r.log.withDestination("silent", async () => {
+    let reported = false;
     const agent = await r.agent({
       model: "openrouter/google/gemini-2.5-flash-lite",
       thinkingLevel: "off",
-      tools: ["read_thread", "web_fetch", "send_reply"],
+      tools: ["read_thread", "web_fetch"],
+      onEvent(event) {
+        // runOutcome also returns a synthetic failed result when reporting is
+        // missing. Only a successful report tool call supplies a user answer.
+        if (
+          event.type === "tool_execution_end" &&
+          event.toolName === "report_outcome" &&
+          !event.isError
+        ) {
+          reported = true;
+        }
+      },
       // Keep local coding tools and project instructions out of this chat agent.
       resources: {
         extensions: false,
@@ -108,7 +94,7 @@ export async function generateReply(
 
     try {
       const prompt =
-        "Read the conversation below. For Chatto questions, fetch the relevant docs first. Then CALL send_reply with your answer to the current message. Do not finish until you have called send_reply.\n\n" +
+        "Read the conversation below. For Chatto questions, fetch the relevant docs first. Call report_outcome with your complete answer to the current message. Only this final report is shown to the user.\n\n" +
         JSON.stringify({
           thread: context.thread,
           currentMessage: context.message,
@@ -116,15 +102,12 @@ export async function generateReply(
 
       const signal = AbortSignal.timeout(120_000);
 
-      try {
-        await agent.runOutcome(prompt, { signal });
-      } catch (error) {
-        // Delivery is already complete even if subsequent model bookkeeping fails.
-        if (!context.sender.id) throw error;
-      }
+      const result = await agent.runOutcome(prompt, { signal });
+      if (!reported) throw new Error("The agent did not report an outcome");
 
-      if (!context.sender.id) {
-        throw new Error("The agent did not send a chat reply");
+      await context.sender.sendFinal(result.details?.trim() || result.summary);
+      if (result.outcome !== "completed") {
+        throw new Error(`The agent reported ${result.outcome}`);
       }
     } finally {
       agent.dispose();

--- a/examples/runling-bot/reply.test.ts
+++ b/examples/runling-bot/reply.test.ts
@@ -22,9 +22,10 @@ function fixture(
     postStatus?: number;
     modelFailure?: boolean;
     typingFailure?: boolean;
-    duplicateSend?: boolean;
+    duplicateFinal?: boolean;
     noSend?: boolean;
     failAfterSend?: boolean;
+    duringComposition?: () => Promise<void>;
   } = {},
 ) {
   const posts: object[] = [];
@@ -89,17 +90,21 @@ function fixture(
       contexts.push(context.thread);
       if (options.noSend) return;
       if (options.modelFailure) throw new Error("Model unavailable");
-      if (options.duplicateSend) {
-        await Promise.allSettled([
-          context.sender.send("First reply"),
-          context.sender.send("Second reply"),
+      await options.duringComposition?.();
+      if (options.duplicateFinal) {
+        await Promise.all([
+          context.sender.sendFinal("First reply"),
+          context.sender.sendFinal("Second reply"),
         ]);
         return;
       }
-      await context.sender.send(
+      if (options.failAfterSend) {
+        await context.sender.sendFinal("Final answer");
+        throw new Error("Late model failure");
+      }
+      await context.sender.sendFinal(
         "Hello from Runling! I received your webhook and replied through the Chatto API.",
       );
-      if (options.failAfterSend) throw new Error("Late model failure");
     },
   );
   return { workflow, posts, contexts, typing };
@@ -227,9 +232,9 @@ test("typing failures do not prevent a reply", async () => {
   assert.equal(posts.length, 1);
 });
 
-test("duplicate tool calls share one HTTP attempt even when it fails", async () => {
+test("repeated final delivery shares one POST even when it fails", async () => {
   for (const postStatus of [200, 503]) {
-    const { workflow, posts } = fixture({ duplicateSend: true, postStatus });
+    const { workflow, posts } = fixture({ duplicateFinal: true, postStatus });
     assert.equal(
       (await runWorkflow(workflow, { input })).ok,
       postStatus === 200,
@@ -284,13 +289,16 @@ test("notifies an existing DM thread when the agent finishes without sending", a
   ]);
 });
 
-test("does not send an error message after a reply attempt", async () => {
-  for (const options of [{ failAfterSend: true }, { postStatus: 503 }]) {
-    const { workflow, posts } = fixture(options);
-    assert.equal((await runWorkflow(workflow, { input })).ok, false);
-    assert.equal(posts.length, 1);
-    assert.match((posts[0] as { body: string }).body, /^Hello from Runling/);
-  }
+test("does not notify after a final answer or failed POST", async () => {
+  const partial = fixture({ failAfterSend: true });
+  assert.equal((await runWorkflow(partial.workflow, { input })).ok, false);
+  assert.deepEqual(
+    partial.posts.map((post) => (post as { body: string }).body),
+    ["Final answer"],
+  );
+  const failed = fixture({ postStatus: 503 });
+  assert.equal((await runWorkflow(failed.workflow, { input })).ok, false);
+  assert.equal(failed.posts.length, 1);
 });
 
 test("does not retry a failed error notification", async () => {
@@ -298,3 +306,22 @@ test("does not retry a failed error notification", async () => {
   assert.equal((await runWorkflow(workflow, { input })).ok, false);
   assert.equal(posts.length, 1);
 });
+
+for (const fails of [false, true]) {
+  test(`typing continues during composition and stops on failure=${fails}`, async (t) => {
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const { workflow, posts, typing } = fixture({
+      duringComposition: async () => {
+        assert.equal(posts.length, 0);
+        t.mock.timers.tick(3000);
+        assert.equal(typing.length, 2);
+        if (fails) throw new Error("Model disconnected");
+      },
+    });
+    assert.equal((await runWorkflow(workflow, { input })).ok, !fails);
+    const stoppedAt = typing.length;
+    t.mock.timers.tick(30_000);
+    assert.equal(typing.length, stoppedAt);
+    assert.equal(posts.length, 1);
+  });
+}

--- a/examples/runling-bot/reply.ts
+++ b/examples/runling-bot/reply.ts
@@ -209,7 +209,7 @@ export function createReplyWorkflow(
         ),
       );
 
-      // Both the agent and the error fallback use this single reply attempt.
+      // Each run owns one final-answer or error-notification attempt.
       const sender = createReplySender((text, stepName) =>
         r.step(stepName, async () => {
           const result = await rpc<{ message?: { id?: string } }>(
@@ -225,7 +225,6 @@ export function createReplyWorkflow(
           const id = result.message?.id;
           if (!id) throw new Error("Chatto did not return a reply ID");
 
-          stopTyping();
           return id;
         }),
       );
@@ -243,7 +242,7 @@ export function createReplyWorkflow(
         );
 
         if (!sender.id) {
-          throw new Error("The agent did not send a chat reply");
+          throw new Error("The agent did not send a final answer");
         }
       } catch (error) {
         // Notify the user if possible, but keep the run marked as failed.

--- a/examples/runling-bot/sender.test.ts
+++ b/examples/runling-bot/sender.test.ts
@@ -2,41 +2,55 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 import { createReplySender } from "./sender.ts";
 
-test("concurrent sends and fallback share one attempt, including failure", async () => {
-  for (const fails of [false, true]) {
+for (const fails of [false, true]) {
+  test(`concurrent final answers share one POST, failure=${fails}`, async () => {
     const posts: string[] = [];
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
     const sender = createReplySender(async (text) => {
       posts.push(text);
+      await gate;
       if (fails) throw new Error("Response lost");
       return "reply";
     });
-    const first = sender.send("First");
-    assert.equal(sender.send("Second"), first);
-    await Promise.allSettled([first]);
+    const first = sender.sendFinal("First");
+    assert.equal(sender.sendFinal("Second"), first);
     await sender.notifyFailure();
     assert.deepEqual(posts, ["First"]);
+    assert.equal(sender.id, undefined);
+    release();
+    if (fails) await assert.rejects(first, /Response lost/);
+    else assert.equal(await first, "reply");
+    await sender.notifyFailure();
+    assert.equal(posts.length, 1);
     assert.equal(sender.id, fails ? undefined : "reply");
-  }
-});
-
-test("fallback sends once and contains no original error details", async () => {
-  const posts: object[] = [];
-  const sender = createReplySender(async (text, stepName) => {
-    posts.push({ text, stepName });
-    return "notification";
   });
-  await sender.notifyFailure();
-  await sender.notifyFailure();
-  assert.deepEqual(posts, [
-    {
-      text: "Sorry, I couldn't generate a reply. Please try again.",
-      stepName: "Send error reply",
-    },
-  ]);
-});
+}
+
+for (const fails of [false, true]) {
+  test(`error notification gets one attempt, failure=${fails}`, async () => {
+    const posts: object[] = [];
+    const sender = createReplySender(async (text, stepName) => {
+      posts.push({ text, stepName });
+      if (fails) throw new Error("HTTP failed");
+      return "notification";
+    });
+    await Promise.all([sender.notifyFailure(), sender.notifyFailure()]);
+    await sender.notifyFailure();
+    assert.deepEqual(posts, [
+      {
+        text: "Sorry, I couldn't generate a reply. Please try again.",
+        stepName: "Send error reply",
+      },
+    ]);
+    assert.equal(sender.id, undefined);
+  });
+}
 
 test("empty text does not consume the reply attempt", async () => {
   const sender = createReplySender(async () => "reply");
-  await assert.rejects(sender.send("  "), /empty/);
-  assert.equal(await sender.send("Hello"), "reply");
+  await assert.rejects(sender.sendFinal("  "), /empty/);
+  assert.equal(await sender.sendFinal("Hello"), "reply");
 });

--- a/examples/runling-bot/sender.ts
+++ b/examples/runling-bot/sender.ts
@@ -1,36 +1,36 @@
 const ERROR_REPLY = "Sorry, I couldn't generate a reply. Please try again.";
 
-/** One delivery's reply attempt, shared by the agent and the error fallback. */
+/** One final answer or error notification per webhook run. */
 export interface ReplySender {
-  /** Confirmed Chatto message ID; absent until the HTTP request succeeds. */
+  /** Confirmed final-answer ID; error notifications do not complete delivery. */
   readonly id: string | undefined;
 
-  /** Repeated calls share the first attempt, including a failed attempt. */
-  send(text: string): Promise<string>;
+  /** Send the final answer. Repeated calls share the first POST attempt. */
+  sendFinal(text: string): Promise<string>;
 
-  /** Best-effort error notification, only if no reply attempt was started. */
+  /** Send a fixed error only if no answer or notification POST was attempted. */
   notifyFailure(): Promise<void>;
 }
 
-/** Prevent duplicate POSTs within a run, including after ambiguous HTTP failures. */
+/** Share one POST attempt, including failures whose delivery may be uncertain. */
 export function createReplySender(
   post: (text: string, stepName: string) => Promise<string>,
 ): ReplySender {
   let id: string | undefined;
   let attempt: Promise<string> | undefined;
 
-  function send(text: string, stepName: string): Promise<string> {
-    if (!text.trim()) {
-      return Promise.reject(new Error("The reply must not be empty"));
-    }
+  function send(text: string, finalAnswer: boolean): Promise<string> {
+    const body = text.trim();
+    if (!body) return Promise.reject(new Error("The reply must not be empty"));
 
-    // Store the promise before starting the POST, so concurrent calls share it.
-    // Keep failed attempts too: Chatto may have accepted the message even if
-    // its response did not reach us. A second POST could send a duplicate.
+    // Store the attempt before starting I/O. Never retry an uncertain POST.
     return (attempt ??= Promise.resolve().then(async () => {
-      id = await post(text, stepName);
-
-      return id;
+      const messageId = await post(
+        body,
+        finalAnswer ? "Send final answer" : "Send error reply",
+      );
+      if (finalAnswer) id = messageId;
+      return messageId;
     }));
   }
 
@@ -38,19 +38,13 @@ export function createReplySender(
     get id() {
       return id;
     },
-
-    send: (text) => send(text, "Send reply to Chatto"),
-
+    sendFinal: (text) => send(text, true),
     async notifyFailure() {
-      // The fallback is safe only when no message send has been attempted.
-      if (attempt) {
-        return;
-      }
-
+      if (attempt) return;
       try {
-        await send(ERROR_REPLY, "Send error reply");
+        await send(ERROR_REPLY, false);
       } catch {
-        // Preserve the original failure; the send step records this one.
+        // Preserve the original failure. Notifications are best effort.
       }
     },
   };


### PR DESCRIPTION
## Why

- Fix TestBot failures caused by hidden outcome reporting and ambiguous status instructions, and prevent intermediate output from becoming duplicate chat replies.

## What changed

- Replace `send_reply` and tool switching with one reply from the validated final report; retain one POST attempt, error fallback, typing through delivery, and agent disposal; add real Runling/Pi recovery coverage and update the [example guide](https://github.com/chattocorp/chatto/blob/hmans/fix-runling-report-outcome/examples/runling-bot/README.md) and [runtime inventory](https://github.com/chattocorp/chatto/blob/hmans/fix-runling-report-outcome/docs/architecture/runtime-components.md).

## API compatibility

- No public API or protocol behaviour changed; older/newer client-server combinations, capability discovery, and minimum versions are unaffected; no migration required.

## Test plan

- Passed: `mise test-runling-bot` — 55 tests, including real Runling/Pi execution with synthetic provider responses
- Passed: `mise test-e2e -- e2e/runling-bot.test.ts --workers=1 --retries=0` — root mentions, thread mentions, DMs, and error replies
- Passed: `mise x -- node apps/frontend/node_modules/typescript/bin/tsc --noEmit --skipLibCheck --strict --target es2023 --module nodenext --allowImportingTsExtensions examples/runling-bot/*.ts`
- Passed: `mise license-check` and `git diff --check`
- Passed: live-model reply through a temporary Chatto server, inspected with Chrome DevTools; temporary server stopped; no checks outstanding for this scope
