### PR TITLE
fix(auth): decouple bot permission ceilings from privilege arming

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
@@ -44,11 +44,21 @@ move the integration to it, and revoke the affected key.
 
 Bots do not inherit `everyone`, named roles, or the owner's roles. The bot
 matrix exposes a simple enabled/disabled allowlist. A configured permission is
-effective only while the owner currently has sufficient effective authority at
+effective only while the owner has sufficient RBAC entitlement at
 that scope; a lock marks one currently blocked by this owner ceiling. The matrix
 lists only rooms visible to both the bot owner and the person managing it,
 while retaining the directory's complete group layout so permissions such as
 `room.create` remain configurable for an empty group.
+
+The owner ceiling and the bot's displayed permissions do not depend on any
+human session's privileged mode. Bots can use their effective permissions
+while their owner is signed out or has privileged mode inactive. If the owner
+loses a required RBAC permission, the bot also loses that effective permission.
+
+Before granting an elevation-required permission, activate privileged mode.
+You must have that permission active at the target scope, even when you manage
+another user's bot. Removing a grant uses the normal bot management checks and
+does not require activation of that permission.
 
 Channel-room membership alone does not expose messages to a bot. Grant
 `message.read` for broad room access. Grant `message.read-interactions` when

--- a/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
+++ b/apps/docs-website/src/content/docs/guides/operations/permissions.mdx
@@ -52,7 +52,12 @@ The initial elevation-required set includes message moderation, room creation
 and management, role and user administration, server management, invite and
 bot administration, audit access, and owner-only system diagnostics. Normal
 message use and editing or deleting your own messages do not require the mode.
-Bot API keys do not use privileged mode.
+Bot API keys do not use privileged mode. Bot permissions are limited by their
+explicit grants and their owner's current RBAC entitlement. Human session
+activation does not change this ceiling or the bot's displayed permissions.
+Granting an elevation-required permission to a bot requires you to have that
+permission active at the target scope. Removing a grant does not require
+activation of that permission.
 
 The event log records each successful activation and explicit deactivation.
 An activation entry includes its deadline, which also records when automatic

--- a/cli/internal/core/bots.go
+++ b/cli/internal/core/bots.go
@@ -988,22 +988,34 @@ func (c *ChattoCore) setBotUserPermissionState(ctx context.Context, actorID, bot
 			return err
 		}
 		if state == PermissionStateAllow {
-			var decision DecisionKind
+			kind, roomID, groupID := KindChannel, "", ""
 			switch normalized.Kind {
 			case MatrixScopeDM:
-				decision, err = c.PermResolver().Resolve(ctx, currentBot.GetBotOwnerUserId(), KindDM, "", perm)
+				kind = KindDM
 			case MatrixScopeGroup:
-				decision, err = c.PermResolver().ResolveGroup(ctx, currentBot.GetBotOwnerUserId(), KindChannel, normalized.ID, perm)
+				groupID = normalized.ID
 			case MatrixScopeRoom:
-				decision, err = c.PermResolver().Resolve(ctx, currentBot.GetBotOwnerUserId(), KindChannel, normalized.ID, perm)
-			default:
-				decision, err = c.PermResolver().Resolve(ctx, currentBot.GetBotOwnerUserId(), KindChannel, "", perm)
+				roomID = normalized.ID
 			}
+			decision, err := c.PermResolver().resolveEntitlement(ctx, currentBot.GetBotOwnerUserId(), kind, roomID, groupID, perm)
 			if err != nil {
 				return err
 			}
 			if decision != DecisionAllow {
 				return ErrBotOwnerPermissionCeiling
+			}
+			// Delegating elevated authority requires the acting human to hold
+			// it actively at this scope, independently of the owner's ceiling.
+			if metadata, known := GetPermissionMetadata(perm); known && metadata.RequiresPrivilegedMode {
+				decision, err := c.PermResolver().resolveInContentView(ctx, func(readCtx context.Context) (DecisionKind, error) {
+					return c.PermResolver().resolveWithGroup(readCtx, actorID, kind, roomID, groupID, perm)
+				})
+				if err != nil {
+					return err
+				}
+				if decision != DecisionAllow {
+					return ErrPermissionDenied
+				}
 			}
 		}
 		return nil

--- a/cli/internal/core/permission_management.go
+++ b/cli/internal/core/permission_management.go
@@ -69,10 +69,13 @@ type PermissionMatrixScope struct {
 }
 
 type PermissionMatrixCell struct {
-	Permission     string
-	ScopeID        string
-	Override       MatrixDecision
-	Effective      MatrixDecision
+	Permission string
+	ScopeID    string
+	Override   MatrixDecision
+	Effective  MatrixDecision
+	// AllowPermitted reports the bot owner's RBAC entitlement at this scope.
+	// It does not include the acting human's session activation or edit authority.
+	// Nil means that the cell does not use a bot owner ceiling.
 	AllowPermitted *bool
 }
 
@@ -734,13 +737,13 @@ func (c *ChattoCore) botOwnerAllowsAtMatrixScope(ctx context.Context, ownerID st
 	)
 	switch scope.Kind {
 	case MatrixScopeServer:
-		decision, err = c.PermResolver().Resolve(ctx, ownerID, KindChannel, "", perm)
+		decision, err = c.PermResolver().resolveEntitlement(ctx, ownerID, KindChannel, "", "", perm)
 	case MatrixScopeDM:
-		decision, err = c.PermResolver().Resolve(ctx, ownerID, KindDM, "", perm)
+		decision, err = c.PermResolver().resolveEntitlement(ctx, ownerID, KindDM, "", "", perm)
 	case MatrixScopeGroup:
-		decision, err = c.PermResolver().ResolveGroup(ctx, ownerID, KindChannel, scopeRefID(scope.ID, "group:"), perm)
+		decision, err = c.PermResolver().resolveEntitlement(ctx, ownerID, KindChannel, "", scopeRefID(scope.ID, "group:"), perm)
 	case MatrixScopeRoom:
-		decision, err = c.PermResolver().Resolve(ctx, ownerID, KindChannel, scopeRefID(scope.ID, "room:"), perm)
+		decision, err = c.PermResolver().resolveEntitlement(ctx, ownerID, KindChannel, scopeRefID(scope.ID, "room:"), "", perm)
 	default:
 		return false, fmt.Errorf("%w: unknown scope kind %q", ErrInvalidArgument, scope.Kind)
 	}

--- a/cli/internal/core/permission_resolver.go
+++ b/cli/internal/core/permission_resolver.go
@@ -114,6 +114,10 @@ func (r *PermissionResolver) resolveWithGroup(ctx context.Context, userID string
 	if err != nil || decision != DecisionAllow {
 		return decision, err
 	}
+	// A bot subject has no human session to arm, including during inspection.
+	if isBot, _, exists := r.core.userModel.isBotAndOwner(userID); exists && isBot {
+		return decision, nil
+	}
 	metadata, known := GetPermissionMetadata(perm)
 	if !known || !metadata.RequiresPrivilegedMode {
 		return decision, nil
@@ -135,6 +139,14 @@ func privilegedModeAllows(ctx context.Context, userID string, now time.Time) boo
 		return false
 	}
 	return now.Before(credential.PrivilegedModeExpiresAt)
+}
+
+// resolveEntitlement reads assigned authority in a consistent content view,
+// without applying the inspecting human's session activation state.
+func (r *PermissionResolver) resolveEntitlement(ctx context.Context, userID string, kind RoomKind, roomID, groupID string, perm Permission) (DecisionKind, error) {
+	return r.resolveInContentView(ctx, func(readCtx context.Context) (DecisionKind, error) {
+		return r.resolveEntitlementWithGroup(readCtx, userID, kind, roomID, groupID, perm)
+	})
 }
 
 // resolveEntitlementWithGroup resolves durable RBAC entitlement without the
@@ -199,7 +211,7 @@ func (r *PermissionResolver) resolveBotWithGroup(ctx context.Context, botUserID,
 	if delegated != DecisionAllow {
 		return DecisionDeny, nil
 	}
-	ownerDecision, err := r.resolveWithGroup(ctx, ownerUserID, kind, roomID, groupID, perm)
+	ownerDecision, err := r.resolveEntitlementWithGroup(ctx, ownerUserID, kind, roomID, groupID, perm)
 	if err != nil {
 		return DecisionNone, err
 	}

--- a/cli/internal/core/privileged_mode_test.go
+++ b/cli/internal/core/privileged_mode_test.go
@@ -215,3 +215,168 @@ func TestChattoCore_CookiePrivilegedModeRejectsRevokedSession(t *testing.T) {
 		t.Fatalf("SetCookiePrivilegedMode error = %v, want ErrCookieSessionNotFound", err)
 	}
 }
+
+// Bot inspection must report the same authority as unattended API requests.
+func TestBotPermissionsIndependentOfInspectorPrivilegedMode(t *testing.T) {
+	for _, ownerRole := range []string{RoleOwner, RoleAdmin} {
+		t.Run(ownerRole, func(t *testing.T) {
+			c, _ := setupTestCore(t)
+			ctx := testContext(t)
+			owner, err := c.CreateUser(ctx, SystemActorID, "ceiling-owner", "Owner", "password123")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := c.AssignServerRoleToExistingUser(ctx, SystemActorID, owner.Id, ownerRole); err != nil {
+				t.Fatal(err)
+			}
+			// Make the named role's entitlement explicit instead of relying on defaults.
+			if err := c.GrantServerPermission(ctx, SystemActorID, RoleAdmin, PermMessageManage); err != nil {
+				t.Fatal(err)
+			}
+			group, err := c.CreateRoomGroup(ctx, SystemActorID, "Automation", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			room, err := c.CreateRoom(ctx, SystemActorID, KindChannel, group.Id, "automation", "")
+			if err != nil {
+				t.Fatal(err)
+			}
+			scopes := []struct {
+				name                      string
+				target                    PermissionTargetScope
+				kind                      RoomKind
+				roomID, groupID, matrixID string
+			}{
+				{"server", PermissionTargetScope{Kind: MatrixScopeServer}, KindChannel, "", "", "server"},
+				{"group", PermissionTargetScope{Kind: MatrixScopeGroup, ID: group.Id}, KindChannel, "", group.Id, "group:" + group.Id},
+				{"room", PermissionTargetScope{Kind: MatrixScopeRoom, ID: room.Id}, KindChannel, room.Id, "", "room:" + room.Id},
+				{"dm", PermissionTargetScope{Kind: MatrixScopeDM}, KindDM, "", "", "dm"},
+			}
+			for _, scope := range scopes {
+				t.Run(scope.name, func(t *testing.T) {
+					bot, err := c.CreateBot(ctx, owner.Id, scope.name+"_bot", "Bot")
+					if err != nil {
+						t.Fatal(err)
+					}
+					contexts := []struct {
+						name       string
+						credential authctx.RuntimeCredential
+					}{
+						{"inactive", authctx.RuntimeCredential{Handle: "test-session", Kind: authctx.RuntimeCredentialKindBearerToken, UserID: owner.Id}},
+						{"active", authctx.RuntimeCredential{Handle: "test-session", Kind: authctx.RuntimeCredentialKindBearerToken, UserID: owner.Id, PrivilegedModeExpiresAt: time.Now().Add(time.Minute)}},
+						{"expired", authctx.RuntimeCredential{Handle: "test-session", Kind: authctx.RuntimeCredentialKindBearerToken, UserID: owner.Id, PrivilegedModeExpiresAt: time.Now().Add(-time.Minute)}},
+						{"unrelated", authctx.RuntimeCredential{Handle: "test-session", Kind: authctx.RuntimeCredentialKindBearerToken, UserID: "other", PrivilegedModeExpiresAt: time.Now().Add(time.Minute)}},
+						{"bot", authctx.RuntimeCredential{Handle: "test-session", Kind: authctx.RuntimeCredentialKindBotAPIKey, UserID: bot.User.Id}},
+					}
+					check := func(want DecisionKind) {
+						t.Helper()
+						for _, session := range contexts {
+							readCtx := authctx.WithCredential(ctx, session.credential)
+							var got DecisionKind
+							var err error
+							if scope.groupID != "" {
+								got, err = c.PermResolver().ResolveGroup(readCtx, bot.User.Id, scope.kind, scope.groupID, PermMessageManage)
+							} else {
+								got, err = c.PermResolver().Resolve(readCtx, bot.User.Id, scope.kind, scope.roomID, PermMessageManage)
+							}
+							if err != nil || got != want {
+								t.Fatalf("%s resolve = %s, %v; want %s", session.name, got, err, want)
+							}
+							// Room inspection also exercises inherited group grants.
+							explainRoom := scope.roomID
+							if scope.groupID != "" {
+								explainRoom = room.Id
+							}
+							exp, err := c.PermResolver().ExplainRoomPermission(readCtx, bot.User.Id, scope.kind, explainRoom, PermMessageManage)
+							if err != nil || exp.State != want {
+								t.Fatalf("%s explanation = %s, %v; want %s", session.name, exp.State, err, want)
+							}
+						}
+					}
+					check(DecisionDeny)
+					if err := c.SetUserPermissionState(ctx, owner.Id, bot.User.Id, scope.target, PermMessageManage, PermissionStateAllow); err != nil {
+						t.Fatal(err)
+					}
+					check(DecisionAllow)
+					for _, session := range contexts[:3] {
+						matrix, err := c.GetUserPermissionMatrixIncludingDM(authctx.WithCredential(ctx, session.credential), owner.Id, bot.User.Id, true)
+						if err != nil {
+							t.Fatal(err)
+						}
+						found := false
+						for _, cell := range matrix.Cells {
+							if cell.ScopeID == scope.matrixID && cell.Permission == string(PermMessageManage) {
+								found = true
+								if cell.Effective != MatrixDecisionAllow || cell.AllowPermitted == nil || !*cell.AllowPermitted {
+									t.Fatalf("%s matrix cell = %+v", session.name, cell)
+								}
+							}
+						}
+						if !found {
+							t.Fatalf("missing matrix cell %s", scope.matrixID)
+						}
+					}
+					if err := c.RevokeServerRole(ctx, SystemActorID, owner.Id, ownerRole); err != nil {
+						t.Fatal(err)
+					}
+					if err := c.DenyUserPermission(ctx, SystemActorID, owner.Id, PermMessageManage); err != nil {
+						t.Fatal(err)
+					}
+					check(DecisionDeny)
+					if err := c.AssignServerRoleToExistingUser(ctx, SystemActorID, owner.Id, ownerRole); err != nil {
+						t.Fatal(err)
+					}
+					if err := c.ClearUserPermissionState(ctx, SystemActorID, owner.Id, PermMessageManage); err != nil {
+						t.Fatal(err)
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestBotElevatedGrantRequiresActiveActorAuthority(t *testing.T) {
+	c, _ := setupTestCore(t)
+	ctx := testContext(t)
+	owner, err := c.CreateUser(ctx, SystemActorID, "grant-owner", "Owner", "password123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.AssignOwnerRole(ctx, owner.Id); err != nil {
+		t.Fatal(err)
+	}
+	manager, err := c.CreateUser(ctx, SystemActorID, "grant-manager", "Manager", "password123")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.GrantUserPermission(ctx, SystemActorID, manager.Id, PermBotManage); err != nil {
+		t.Fatal(err)
+	}
+	bot, err := c.CreateBot(ctx, owner.Id, "grant_bot", "Bot")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := PermissionTargetScope{Kind: MatrixScopeServer}
+	session := func(userID string, active bool) context.Context {
+		deadline := time.Time{}
+		if active {
+			deadline = time.Now().Add(time.Minute)
+		}
+		return authctx.WithCredential(ctx, authctx.RuntimeCredential{Handle: "test-session", Kind: authctx.RuntimeCredentialKindBearerToken, UserID: userID, PrivilegedModeExpiresAt: deadline})
+	}
+	if err := c.SetUserPermissionState(session(owner.Id, false), owner.Id, bot.User.Id, scope, PermRoomCreate, PermissionStateAllow); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("unarmed grant: %v", err)
+	}
+	if err := c.SetUserPermissionState(session(manager.Id, true), manager.Id, bot.User.Id, scope, PermRoomCreate, PermissionStateAllow); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("manager without target permission: %v", err)
+	}
+	if err := c.GrantUserPermission(ctx, SystemActorID, manager.Id, PermRoomCreate); err != nil {
+		t.Fatal(err)
+	}
+	if err := c.SetUserPermissionState(session(manager.Id, true), manager.Id, bot.User.Id, scope, PermRoomCreate, PermissionStateAllow); err != nil {
+		t.Fatalf("armed manager with unarmed owner: %v", err)
+	}
+	if err := c.SetUserPermissionState(session(owner.Id, false), owner.Id, bot.User.Id, scope, PermRoomCreate, PermissionStateNone); err != nil {
+		t.Fatalf("unarmed removal: %v", err)
+	}
+}

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -1,7 +1,7 @@
 # FDR-001: Roles & Permissions (RBAC)
 
 **Status:** Active
-**Last reviewed:** 2026-09-04
+**Last reviewed:** 2026-09-09
 
 ## Overview
 
@@ -51,7 +51,7 @@ Chatto controls who can do what through role-based access control. Every authent
 
 ### 2. Named subjects with an `everyone` baseline
 
-**Decision:** For non-owner human users, select the nearest room/group/server decision independently for the direct user and every explicitly assigned named role. Denies win across those decisions. Select `everyone`'s nearest decision as the scoped baseline; a direct-user or named-role allow overrides an `everyone` deny only at the same or a nearer scope. If nothing applies, the result is denied at the API boundary. Bots instead use only explicit direct-user allows, further bounded by their owner's current effective permissions.
+**Decision:** For non-owner human users, select the nearest room/group/server decision independently for the direct user and every explicitly assigned named role. Denies win across those decisions. Select `everyone`'s nearest decision as the scoped baseline; a direct-user or named-role allow overrides an `everyone` deny only at the same or a nearer scope. If nothing applies, the result is denied at the API boundary. Bots instead use only explicit direct-user allows, further bounded by their owner's current RBAC entitlement.
 **Why:** Operators can express an allowlist by denying the `everyone` baseline and granting a named role, while a named restriction role such as `suspended` still reliably denies. Role position remains irrelevant to authorization. See ADR-052.
 **Tradeoff:** An `everyone` deny can be overridden deliberately at its own scope or a nearer one. A restriction role's deny beats other subjects' grants, but a nearer allow configured on that same role replaces its broader deny. Direct-user decisions follow the same nearest-scope rule. ADR-052 records the compatibility audit.
 

--- a/docs/fdr/FDR-038-bot-accounts.md
+++ b/docs/fdr/FDR-038-bot-accounts.md
@@ -1,7 +1,7 @@
 # FDR-038: Bot Accounts
 
 **Status:** Experimental
-**Last reviewed:** 2026-09-08
+**Last reviewed:** 2026-09-09
 
 ## Overview
 
@@ -111,8 +111,12 @@ exercise more authority than its human owner currently possesses.
   message permissions.
 - Bot permissions are granted explicitly at their applicable server, room
   group, or room scope. The bot's effective permission is allowed only when
-  both the bot's allowlist and its owner's current effective permissions allow
-  it at that scope.
+  both the bot's allowlist and its owner's current RBAC entitlement allow
+  it at that scope. The owner ceiling does not depend on privileged mode in
+  any human session. Bot permission inspection uses the same rule.
+- Granting an elevation-required permission requires the acting human to have
+  that permission active at the target scope. Clearing a grant uses the normal
+  bot management checks and does not require activation of that permission.
 - Bot permission mutations accept only allow or clear; explicit denials are
   rejected. The editor therefore presents each applicable permission as
   enabled or disabled instead of exposing RBAC's general three-state control.

--- a/docs/fdr/FDR-046-privileged-mode.md
+++ b/docs/fdr/FDR-046-privileged-mode.md
@@ -1,7 +1,7 @@
 # FDR-046: Privileged Mode
 
 **Status:** Active
-**Last reviewed:** 2026-09-05
+**Last reviewed:** 2026-09-09
 
 ## Overview
 
@@ -34,7 +34,10 @@ server session when they need them.
   expiry does not add a second event because the deadline is already durable.
 - Each connected server has independent state.
 - Bot API keys keep their current direct permission behavior. Bots do not use
-  privileged mode.
+  privileged mode. Their owner ceiling uses current RBAC entitlement, independent
+  of human session activation. Granting an elevation-required permission to a
+  bot requires the acting human to have it active at the target scope. Clearing
+  a grant does not require activation of that permission.
 - The admin entry point remains visible to entitled users while the mode is
   inactive. Protected capabilities and actions remain unavailable.
 - The Moderation link and page require effective server-wide

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -10,7 +10,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
-| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-09-04 |
+| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-09-09 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-09-04 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-09-04 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-25 |
@@ -47,7 +47,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-035](FDR-035-slow-mode.md) | Slow Mode | Active | 2026-08-30 |
 | [FDR-036](FDR-036-invite-links.md) | Invite Links | Active | 2026-08-11 |
 | [FDR-037](FDR-037-pinned-messages.md) | Pinned Messages | Active | 2026-09-01 |
-| [FDR-038](FDR-038-bot-accounts.md) | Bot Accounts | Experimental | 2026-09-05 |
+| [FDR-038](FDR-038-bot-accounts.md) | Bot Accounts | Experimental | 2026-09-09 |
 | [FDR-039](FDR-039-message-access-and-interactions.md) | Message Access & Interactions | Experimental | 2026-09-04 |
 | [FDR-040](FDR-040-backup-and-restore.md) | Backup and Restore | Active | 2026-08-27 |
 | [FDR-041](FDR-041-transactional-email-delivery.md) | Transactional Email Delivery | Active | 2026-08-28 |
@@ -55,4 +55,4 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-043](FDR-043-model-context-protocol-integration.md) | Model Context Protocol Integration | Experimental | 2026-08-30 |
 | [FDR-044](FDR-044-my-threads.md) | My Threads | Active | 2026-09-04 |
 | [FDR-045](FDR-045-realtime-event-stream.md) | Realtime Event Stream | Experimental | 2026-09-05 |
-| [FDR-046](FDR-046-privileged-mode.md) | Privileged Mode | Active | 2026-09-03 |
+| [FDR-046](FDR-046-privileged-mode.md) | Privileged Mode | Active | 2026-09-09 |


### PR DESCRIPTION
- **What changed:** Bot permissions and the bot permission matrix now intersect explicit bot grants with the owner's current RBAC entitlement, independent of human session arming. Elevated grant edits separately require the acting human to hold the permission actively at the target scope. Removing a grant retains the existing management checks.
- **Why:** Viewing a bot from a human session could mark elevated permissions unavailable even though bot API-key requests already bypass privilege arming. The owner ceiling must reflect assigned authority, while deliberate delegation remains protected.
- **Verification:** `mise test-cli` passed, including the new session-state, scope, owner-revocation, and delegation regression tests. Chrome DevTools verification confirmed that `room.create` remains enabled after disarming and reloading, and can be removed while unarmed. The local test grant was cleared and the dev stack stopped. Full diff review of `a36f8230a8b7aef5ceca0bc2050d32c3f8104cf8` found no significant issues.
- **Documentation and compatibility:** Updated [FDR-001](https://github.com/chattocorp/chatto/blob/hmans/fix-bot-privilege-arming/docs/fdr/FDR-001-roles-and-permissions.md), [FDR-038](https://github.com/chattocorp/chatto/blob/hmans/fix-bot-privilege-arming/docs/fdr/FDR-038-bot-accounts.md), [FDR-046](https://github.com/chattocorp/chatto/blob/hmans/fix-bot-privilege-arming/docs/fdr/FDR-046-privileged-mode.md), and the public bot and permissions guides. No protobuf changes or data migration. Bot allowlists, current owner permission loss, and DM membership restrictions remain in force.
