### PR TITLE
docs(webhooks): clarify room selection and troubleshooting

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/bot-accounts.mdx
@@ -72,6 +72,9 @@ read permission. Posting remains a separate `message.post` or
 
 ## Post from an external webhook
 
+Every request needs a room ID. Put it in the URL or JSON body. The webhook
+credential does not store a default room.
+
 Open the bot's detail page and choose **Create Webhook**. Give the webhook a
 name that identifies its caller. Optionally select a destination channel room.
 Chatto adds its room ID to the URL. The bot must already be a member of that
@@ -93,24 +96,35 @@ cannot read the telemetry.
 Send a JSON request with Slack-compatible `text` and `channel` fields:
 
 ```http
-POST /webhooks/incoming/cht_IW_…
+POST /webhooks/incoming/YOUR_WEBHOOK_CREDENTIAL
 Content-Type: application/json
 
-{"text":"Deployment finished","channel":"R…"}
+{"text":"Deployment finished","channel":"YOUR_ROOM_ID"}
 ```
 
 Chatto also accepts `body` or `message` instead of `text`, and `room_id` instead of
-`channel`. You can put `room_id` in the query string:
+`channel`. For example, send this JSON body:
+
+```json
+{
+  "message": "Deployment finished",
+  "room_id": "YOUR_ROOM_ID"
+}
+```
+
+You can also put `room_id` in the URL query string:
 
 ```http
-POST /webhooks/incoming/cht_IW_…?room_id=R…
+POST /webhooks/incoming/YOUR_WEBHOOK_CREDENTIAL?room_id=YOUR_ROOM_ID
 Content-Type: application/json
 
 {"text":"Deployment finished"}
 ```
 
-If you specify more than one non-empty body or room field, the values must be equal. Use
-a stable room ID, not a room name. Set `"create_thread": true` to start a
+Replace the placeholders with your webhook credential and room ID. If you send
+more than one non-empty message field, their values must match. All non-empty
+room IDs in the URL and JSON body must also match. Use a stable room ID, not a
+room name. Set `"create_thread": true` to start a
 thread in a channel room that supports threads. The bot needs `message.post`
 and `message.post-in-thread` for explicit thread creation. A room that requires
 threads creates one automatically. Direct messages do not support threads.
@@ -134,6 +148,14 @@ The recorded time can be delayed by approximately one minute.
 </Aside>
 
 For Grafana alerts, follow [Send Grafana alerts to Chatto](/guides/integrations/grafana/).
+
+### Webhook troubleshooting
+
+| Response | Check |
+| --- | --- |
+| `400 invalid_payload` | Send valid JSON with a non-empty `message`, `text`, or `body`. Include a room ID in the URL or JSON body. If you supply multiple message fields, their non-empty values must match. All non-empty room IDs must also match. Message size and room policy limits apply. |
+| `404 channel_not_found` | Use the room's ID, not its name. Check that the room exists and the bot is a member. Both the bot and its owner need permission to post there. A missing room, missing membership, or denied permission returns this same error. |
+| `401 invalid_token` | The webhook credential is invalid or revoked. Create a replacement and update the caller's URL. |
 
 ## Activate a bot from Chatto activity
 

--- a/apps/docs-website/src/content/docs/guides/integrations/grafana.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/grafana.mdx
@@ -26,6 +26,11 @@ a custom payload template.
    select the destination room, and create it. Copy the complete URL before
    you close the dialog. The URL includes the destination room ID.
 
+   Check that the URL ends with `?room_id=YOUR_ROOM_ID`. For an existing webhook
+   URL without a room ID, add this suffix and replace `YOUR_ROOM_ID` with the
+   destination room's ID, not its name. If the URL already has other query
+   parameters, use `&room_id=YOUR_ROOM_ID` instead.
+
 3. **Create the contact point in Grafana.**
 
    In Grafana Alerting, open **Contact points** and add a contact point.
@@ -72,11 +77,11 @@ custom payload to use Grafana's default format.
 
 ## Troubleshooting
 
-| Response | Check |
-| --- | --- |
-| `400 invalid_payload` | The request needs a non-empty `message`, `text`, or `body`, and a destination room. All non-empty body aliases must agree; all supplied room IDs must agree. A text-only template such as `slack.default.text` is not a complete JSON payload. Message size and room policy limits also apply. |
-| `404 channel_not_found` | Check the room ID, bot membership, bot posting permissions, and the owner's permissions. |
-| `401 invalid_token` | The webhook credential is invalid or revoked. Create a replacement and update the contact point URL. |
+See [Webhook troubleshooting](/guides/integrations/bot-accounts/#webhook-troubleshooting)
+for response codes and checks for room IDs, membership, and permissions.
+
+Keep **Custom Payload** unset when you use Grafana's default payload. A text-only
+template such as `slack.default.text` is not a complete JSON payload.
 
 <Aside type="caution">
   The webhook URL contains a credential and is shown only once. Keep it out of


### PR DESCRIPTION
## Why

- Missing or incorrect room IDs make webhook setup fail with unclear errors.

## What changed

- Clarify required room IDs, add a JSON example, share troubleshooting guidance, and show how to update existing Grafana webhook URLs.

## API compatibility

- No public API or protocol behaviour changed; client/server compatibility and version requirements are unchanged.

## Test plan

- Passed: `mise x -- pnpm --filter docs-website build`, `git diff --check`, handler comparison, and verification of the built troubleshooting link and target; the build reported a missing `404` content entry.
