### PR TITLE
feat(api): add archive filters to room discovery

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -74,6 +74,14 @@ when `has_message_history` is explicitly false. A new client connected to an
 older server sees no empty DM rows, and it must treat an absent history value
 on a returned DM as unknown rather than false.
 
+Chatto 0.5 adds `archive_filter` to `RoomDirectoryService.ListRooms`. Omit it or
+select `ROOM_ARCHIVE_FILTER_ACTIVE` to keep the active-room list. Select
+`ROOM_ARCHIVE_FILTER_ARCHIVED` for the archive or `ROOM_ARCHIVE_FILTER_ALL` for
+both states. The filter combines with `scope` and preserves room visibility.
+Responses remain complete room snapshots. Existing clients keep their default
+results. Servers without this field do not provide the archive-filter contract;
+clients must use a supporting server release for archive discovery.
+
 The 0.5 authentication boundary also replaces sliding human bearer tokens with
 short-lived access tokens and rotating refresh credentials. A 0.5 server
 rejects bearer records issued before that change, so affected users sign in

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/room-directory.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/room-directory.mdx
@@ -24,9 +24,10 @@ Reads room directory data.
 
 ### ListRooms
 
-Lists rooms visible to the current user. Channel rooms are non-archived
-rooms visible through membership or room.list. DM membership exposes room
-and participant metadata. Message-derived DM state also requires current
+Lists rooms visible to the current user. Defaults to active rooms; use
+archive_filter to discover archived rooms or include both states. Channel
+rooms require membership or room.list. DM membership exposes room and
+participant metadata. Message-derived DM state also requires current
 read permission. Accessible empty DMs are included. Results are returned as a finite
 navigation snapshot.
 
@@ -43,6 +44,7 @@ Request for rooms visible to the current user.
 | Field | Type | Description |
 | --- | --- | --- |
 | `scope` | [`RoomDirectoryScope`](/reference/connectrpc-api/types/#chatto-api-v1-RoomDirectoryScope) | Which room kinds to include. Defaults to all. |
+| `archive_filter` | [`RoomArchiveFilter`](/reference/connectrpc-api/types/#chatto-api-v1-RoomArchiveFilter) | Archive state to include. Defaults to ACTIVE. Combined with scope; this filter does not grant access to hidden rooms. |
 
 
 <a id="chatto-api-v1-ListRoomsResponse"></a>
@@ -53,7 +55,7 @@ Finite snapshot of rooms visible to the current user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `rooms` | repeated [`RoomWithViewerState`](/reference/connectrpc-api/types/#chatto-api-v1-RoomWithViewerState) | Rooms matching the requested scope. |
+| `rooms` | repeated [`RoomWithViewerState`](/reference/connectrpc-api/types/#chatto-api-v1-RoomWithViewerState) | Visible rooms matching both the room-kind scope and archive filter. |
 
 
 <a id="chatto-api-v1-RoomDirectoryService-ListRoomGroups"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -1804,6 +1804,19 @@ Kind of room represented by the public API.
 | `ROOM_KIND_CHANNEL` | `1` | A regular channel governed by server and room permissions. |
 | `ROOM_KIND_DM` | `2` | A direct-message conversation between members. |
 
+<a id="chatto-api-v1-RoomArchiveFilter"></a>
+
+### RoomArchiveFilter
+
+Archive state to include in room directory responses.
+
+| Name | Number | Description |
+| --- | --- | --- |
+| `ROOM_ARCHIVE_FILTER_UNSPECIFIED` | `0` | Include active rooms only. |
+| `ROOM_ARCHIVE_FILTER_ACTIVE` | `1` | Include active rooms only. |
+| `ROOM_ARCHIVE_FILTER_ARCHIVED` | `2` | Include archived rooms only. |
+| `ROOM_ARCHIVE_FILTER_ALL` | `3` | Include both active and archived rooms. |
+
 <a id="chatto-api-v1-RoomDirectoryScope"></a>
 
 ### RoomDirectoryScope
@@ -1812,10 +1825,10 @@ Room kinds to include in directory responses.
 
 | Name | Number | Description |
 | --- | --- | --- |
-| `ROOM_DIRECTORY_SCOPE_UNSPECIFIED` | `0` | Include visible channel rooms and readable active DM rooms. |
-| `ROOM_DIRECTORY_SCOPE_ALL` | `1` | Include visible channel rooms and readable active DM rooms. |
+| `ROOM_DIRECTORY_SCOPE_UNSPECIFIED` | `0` | Include visible channel rooms and the caller's DM rooms. |
+| `ROOM_DIRECTORY_SCOPE_ALL` | `1` | Include visible channel rooms and the caller's DM rooms. |
 | `ROOM_DIRECTORY_SCOPE_CHANNELS` | `2` | Include visible channel rooms only. |
-| `ROOM_DIRECTORY_SCOPE_DMS` | `3` | Include the caller's readable active DM rooms only. |
+| `ROOM_DIRECTORY_SCOPE_DMS` | `3` | Include the caller's DM rooms only. |
 
 <a id="chatto-api-v1-AccountCreationPolicy"></a>
 

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -402,6 +402,10 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ### Navigation and notifications
 
+- Integrations can discover archived rooms with `RoomDirectoryService.ListRooms`
+  by selecting active, archived, or all rooms. The default remains active rooms,
+  and normal room visibility rules apply.
+
 - The desktop room sidebar starts closed in a fresh session and remembers your choice for
   each room while you navigate.
 - Installed-app badges show exact direct-message counts without presenting unrelated channel

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1088,9 +1088,10 @@ Reads room directory data.
 
 ### ListRooms
 
-Lists rooms visible to the current user. Channel rooms are non-archived
-rooms visible through membership or room.list. DM membership exposes room
-and participant metadata. Message-derived DM state also requires current
+Lists rooms visible to the current user. Defaults to active rooms; use
+archive_filter to discover archived rooms or include both states. Channel
+rooms require membership or room.list. DM membership exposes room and
+participant metadata. Message-derived DM state also requires current
 read permission. Accessible empty DMs are included. Results are returned as a finite
 navigation snapshot.
 
@@ -1107,6 +1108,7 @@ Request for rooms visible to the current user.
 | Field | Type | Description |
 | --- | --- | --- |
 | `scope` | [`RoomDirectoryScope`](#chatto-api-v1-RoomDirectoryScope) | Which room kinds to include. Defaults to all. |
+| `archive_filter` | [`RoomArchiveFilter`](#chatto-api-v1-RoomArchiveFilter) | Archive state to include. Defaults to ACTIVE. Combined with scope; this filter does not grant access to hidden rooms. |
 
 
 <a id="chatto-api-v1-ListRoomsResponse"></a>
@@ -1117,7 +1119,7 @@ Finite snapshot of rooms visible to the current user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `rooms` | repeated [`RoomWithViewerState`](#chatto-api-v1-RoomWithViewerState) | Rooms matching the requested scope. |
+| `rooms` | repeated [`RoomWithViewerState`](#chatto-api-v1-RoomWithViewerState) | Visible rooms matching both the room-kind scope and archive filter. |
 
 
 <a id="chatto-api-v1-RoomDirectoryService-ListRoomGroups"></a>
@@ -5674,6 +5676,20 @@ Kind of room represented by the public API.
 | `ROOM_KIND_DM` | `2` | A direct-message conversation between members. |
 
 
+<a id="chatto-api-v1-RoomArchiveFilter"></a>
+
+### RoomArchiveFilter
+
+Archive state to include in room directory responses.
+
+| Name | Number | Description |
+| --- | --- | --- |
+| `ROOM_ARCHIVE_FILTER_UNSPECIFIED` | `0` | Include active rooms only. |
+| `ROOM_ARCHIVE_FILTER_ACTIVE` | `1` | Include active rooms only. |
+| `ROOM_ARCHIVE_FILTER_ARCHIVED` | `2` | Include archived rooms only. |
+| `ROOM_ARCHIVE_FILTER_ALL` | `3` | Include both active and archived rooms. |
+
+
 <a id="chatto-api-v1-RoomDirectoryScope"></a>
 
 ### RoomDirectoryScope
@@ -5682,10 +5698,10 @@ Room kinds to include in directory responses.
 
 | Name | Number | Description |
 | --- | --- | --- |
-| `ROOM_DIRECTORY_SCOPE_UNSPECIFIED` | `0` | Include visible channel rooms and readable active DM rooms. |
-| `ROOM_DIRECTORY_SCOPE_ALL` | `1` | Include visible channel rooms and readable active DM rooms. |
+| `ROOM_DIRECTORY_SCOPE_UNSPECIFIED` | `0` | Include visible channel rooms and the caller's DM rooms. |
+| `ROOM_DIRECTORY_SCOPE_ALL` | `1` | Include visible channel rooms and the caller's DM rooms. |
 | `ROOM_DIRECTORY_SCOPE_CHANNELS` | `2` | Include visible channel rooms only. |
-| `ROOM_DIRECTORY_SCOPE_DMS` | `3` | Include the caller's readable active DM rooms only. |
+| `ROOM_DIRECTORY_SCOPE_DMS` | `3` | Include the caller's DM rooms only. |
 
 
 <a id="chatto-api-v1-AccountCreationPolicy"></a>

--- a/cli/internal/connectapi/room_directory.go
+++ b/cli/internal/connectapi/room_directory.go
@@ -19,11 +19,16 @@ func (s *roomDirectoryService) ListRooms(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, err
 	}
+	archiveFilter, err := coreRoomArchiveFilter(req.Msg.GetArchiveFilter())
+	if err != nil {
+		return nil, connectError(err)
+	}
 
 	rooms, err := s.api.core.RoomDirectoryReads().ListRooms(ctx, caller.UserID, core.RoomDirectoryListOptions{
 		IncludeChannels: roomDirectoryScopeIncludesChannels(req.Msg.GetScope()),
 		IncludeDMs:      roomDirectoryScopeIncludesDMs(req.Msg.GetScope()),
 		IncludeEmptyDMs: true,
+		ArchiveFilter:   archiveFilter,
 	})
 	if err != nil {
 		return nil, connectError(err)
@@ -39,6 +44,19 @@ func (s *roomDirectoryService) ListRooms(ctx context.Context, req *connect.Reque
 	}
 
 	return connect.NewResponse(&apiv1.ListRoomsResponse{Rooms: apiRooms}), nil
+}
+
+func coreRoomArchiveFilter(filter apiv1.RoomArchiveFilter) (core.RoomArchiveFilter, error) {
+	switch filter {
+	case apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_UNSPECIFIED, apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ACTIVE:
+		return core.RoomArchiveActive, nil
+	case apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ARCHIVED:
+		return core.RoomArchiveArchived, nil
+	case apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ALL:
+		return core.RoomArchiveAll, nil
+	default:
+		return 0, core.ErrInvalidArgument
+	}
 }
 
 func (s *roomDirectoryService) ListRoomGroups(ctx context.Context, req *connect.Request[apiv1.ListRoomGroupsRequest]) (*connect.Response[apiv1.ListRoomGroupsResponse], error) {

--- a/cli/internal/connectapi/room_services_test.go
+++ b/cli/internal/connectapi/room_services_test.go
@@ -2687,3 +2687,129 @@ func TestMyAccountServiceUpdatePresence(t *testing.T) {
 		t.Fatalf("explicit online stored presence = %q, want %q", stored, core.PresenceStatusOnline)
 	}
 }
+
+func TestRoomDirectoryServiceArchiveFilters(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	caller, err := env.core.CreateUser(env.ctx, core.SystemActorID, "archive-directory-caller", "Archive Caller", "password")
+	if err != nil {
+		t.Fatalf("CreateUser: %v", err)
+	}
+	ctx := withCaller(env.ctx, caller)
+	createRoom := func(name string) *evtv1.Room {
+		t.Helper()
+		room, err := env.core.CreateRoom(env.ctx, core.SystemActorID, core.KindChannel, "", name, "")
+		if err != nil {
+			t.Fatalf("CreateRoom %s: %v", name, err)
+		}
+		return room
+	}
+	active := createRoom("archive-filter-active")
+	archived := createRoom("archive-filter-archived")
+	memberOnly := createRoom("archive-filter-member")
+	hidden := createRoom("archive-filter-hidden")
+	if _, err := env.core.JoinRoom(env.ctx, caller.Id, core.KindChannel, caller.Id, memberOnly.Id); err != nil {
+		t.Fatalf("JoinRoom: %v", err)
+	}
+	for _, room := range []*evtv1.Room{memberOnly, hidden} {
+		if err := env.core.DenyRoomPermission(env.ctx, core.SystemActorID, room.Id, core.RoleEveryone, core.PermRoomList); err != nil {
+			t.Fatalf("DenyRoomPermission: %v", err)
+		}
+	}
+	for _, room := range []*evtv1.Room{archived, memberOnly, hidden} {
+		if _, err := env.core.ArchiveRoom(env.ctx, core.SystemActorID, core.KindChannel, room.Id); err != nil {
+			t.Fatalf("ArchiveRoom: %v", err)
+		}
+	}
+	dm, _, err := env.core.FindOrCreateDM(env.ctx, caller.Id, []string{env.viewer.Id})
+	if err != nil {
+		t.Fatalf("FindOrCreateDM: %v", err)
+	}
+	otherDM, _, err := env.core.FindOrCreateDM(env.ctx, env.viewer.Id, nil)
+	if err != nil {
+		t.Fatalf("FindOrCreateDM other: %v", err)
+	}
+
+	filters := []struct {
+		name             string
+		value            apiv1.RoomArchiveFilter
+		active, archived bool
+	}{
+		{"default", apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_UNSPECIFIED, true, false},
+		{"active", apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ACTIVE, true, false},
+		{"archived", apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ARCHIVED, false, true},
+		{"all", apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ALL, true, true},
+	}
+	scopes := []struct {
+		name          string
+		value         apiv1.RoomDirectoryScope
+		channels, dms bool
+	}{
+		{"default", apiv1.RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_UNSPECIFIED, true, true},
+		{"all", apiv1.RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_ALL, true, true},
+		{"channels", apiv1.RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_CHANNELS, true, false},
+		{"dms", apiv1.RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_DMS, false, true},
+	}
+	for _, filter := range filters {
+		for _, scope := range scopes {
+			t.Run(filter.name+"/"+scope.name, func(t *testing.T) {
+				response, err := env.directory.ListRooms(ctx, connect.NewRequest(&apiv1.ListRoomsRequest{
+					Scope: scope.value, ArchiveFilter: filter.value,
+				}))
+				if err != nil {
+					t.Fatalf("ListRooms: %v", err)
+				}
+				rooms := directoryRoomsByID(response.Msg.GetRooms())
+				for id, want := range map[string]bool{
+					active.Id:     filter.active && scope.channels,
+					archived.Id:   filter.archived && scope.channels,
+					memberOnly.Id: filter.archived && scope.channels,
+					dm.Id:         filter.active && scope.dms,
+					hidden.Id:     false,
+					otherDM.Id:    false,
+				} {
+					if got := rooms[id] != nil; got != want {
+						t.Fatalf("room %s present = %v, want %v", id, got, want)
+					}
+				}
+				for _, room := range response.Msg.GetRooms() {
+					if room.GetRoom().GetArchived() && !filter.archived || !room.GetRoom().GetArchived() && !filter.active {
+						t.Fatalf("room %s has wrong archive state", room.GetRoom().GetId())
+					}
+				}
+				if room := rooms[memberOnly.Id]; room != nil {
+					if !room.GetViewerState().GetIsMember() || apiRoomPermissionGranted(room, core.PermMessagePost) {
+						t.Fatalf("archived member room has incorrect viewer state: %+v", room)
+					}
+				}
+			})
+		}
+	}
+	for _, id := range []string{archived.Id, memberOnly.Id} {
+		response, err := env.directory.GetRoom(ctx, connect.NewRequest(&apiv1.GetRoomRequest{RoomId: id}))
+		if err != nil || !response.Msg.GetRoom().GetRoom().GetArchived() {
+			t.Fatalf("GetRoom archived %s: %v, %v", id, response, err)
+		}
+	}
+	if _, err := env.core.UnarchiveRoom(env.ctx, core.SystemActorID, core.KindChannel, archived.Id); err != nil {
+		t.Fatalf("UnarchiveRoom: %v", err)
+	}
+	for _, filter := range filters {
+		response, err := env.directory.ListRooms(ctx, connect.NewRequest(&apiv1.ListRoomsRequest{ArchiveFilter: filter.value}))
+		if err != nil {
+			t.Fatalf("ListRooms after unarchive: %v", err)
+		}
+		if got := directoryRoomsByID(response.Msg.GetRooms())[archived.Id] != nil; got != filter.active {
+			t.Fatalf("unarchived room present with %s = %v, want %v", filter.name, got, filter.active)
+		}
+	}
+}
+
+func TestRoomDirectoryServiceRejectsInvalidArchiveFilter(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	for _, filter := range []apiv1.RoomArchiveFilter{-1, 99} {
+		_, err := env.directory.ListRooms(withCaller(env.ctx, env.viewer), connect.NewRequest(&apiv1.ListRoomsRequest{ArchiveFilter: filter}))
+		requireConnectCode(t, err, connect.CodeInvalidArgument)
+	}
+	_, err := env.directory.ListRooms(env.ctx, connect.NewRequest(&apiv1.ListRoomsRequest{ArchiveFilter: apiv1.RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ALL}))
+	requireConnectCode(t, err, connect.CodeUnauthenticated)
+}

--- a/cli/internal/core/room_directory_read_model.go
+++ b/cli/internal/core/room_directory_read_model.go
@@ -20,9 +20,27 @@ type RoomDirectoryReadModel struct {
 	core *ChattoCore
 }
 
+// RoomArchiveFilter selects room archive state without changing visibility.
+type RoomArchiveFilter int
+
+const (
+	// RoomArchiveActive preserves the default active-room navigation snapshot.
+	RoomArchiveActive RoomArchiveFilter = iota
+	// RoomArchiveArchived selects only archived rooms.
+	RoomArchiveArchived
+	// RoomArchiveAll selects both active and archived rooms.
+	RoomArchiveAll
+)
+
+func (filter RoomArchiveFilter) matches(archived bool) bool {
+	return filter == RoomArchiveAll || (filter == RoomArchiveArchived) == archived
+}
+
 type RoomDirectoryListOptions struct {
 	IncludeChannels bool
 	IncludeDMs      bool
+	// ArchiveFilter defaults to active rooms and intersects the room-kind flags.
+	ArchiveFilter RoomArchiveFilter
 	// IncludeEmptyDMs includes accessible DMs before their first message.
 	// Public directory and snapshot reads set this; clients choose whether
 	// to hide empty conversations from navigation.
@@ -77,17 +95,20 @@ func (s *RoomDirectoryReadModel) ListRooms(ctx context.Context, actorID string, 
 	if err := requireAuthenticatedActor(actorID); err != nil {
 		return nil, err
 	}
+	if opts.ArchiveFilter < RoomArchiveActive || opts.ArchiveFilter > RoomArchiveAll {
+		return nil, invalidArgument("unknown room archive filter")
+	}
 
 	rooms := []*DirectoryRoom{}
 	if opts.IncludeChannels {
-		channelRooms, err := s.visibleChannelRooms(ctx, actorID)
+		channelRooms, err := s.visibleChannelRooms(ctx, actorID, opts.ArchiveFilter)
 		if err != nil {
 			return nil, err
 		}
 		rooms = append(rooms, channelRooms...)
 	}
 	if opts.IncludeDMs {
-		dmRooms, err := s.visibleDMRooms(ctx, actorID, opts.IncludeEmptyDMs)
+		dmRooms, err := s.visibleDMRooms(ctx, actorID, opts.IncludeEmptyDMs, opts.ArchiveFilter)
 		if err != nil {
 			return nil, err
 		}
@@ -257,14 +278,14 @@ func (s *RoomDirectoryReadModel) JoinGroup(ctx context.Context, actorID, groupID
 	return joined, nil
 }
 
-func (s *RoomDirectoryReadModel) visibleChannelRooms(ctx context.Context, actorID string) ([]*DirectoryRoom, error) {
+func (s *RoomDirectoryReadModel) visibleChannelRooms(ctx context.Context, actorID string, archiveFilter RoomArchiveFilter) ([]*DirectoryRoom, error) {
 	rooms, err := s.core.ListRooms(ctx, KindChannel)
 	if err != nil {
 		return nil, err
 	}
 	result := make([]*DirectoryRoom, 0, len(rooms))
 	for _, room := range rooms {
-		if room.GetArchived() {
+		if !archiveFilter.matches(room.GetArchived()) {
 			continue
 		}
 		visible, err := s.core.CanSeeRoom(ctx, actorID, KindChannel, room.Id)
@@ -283,7 +304,7 @@ func (s *RoomDirectoryReadModel) visibleChannelRooms(ctx context.Context, actorI
 	return result, nil
 }
 
-func (s *RoomDirectoryReadModel) visibleDMRooms(ctx context.Context, actorID string, includeEmpty bool) ([]*DirectoryRoom, error) {
+func (s *RoomDirectoryReadModel) visibleDMRooms(ctx context.Context, actorID string, includeEmpty bool, archiveFilter RoomArchiveFilter) ([]*DirectoryRoom, error) {
 	rooms, err := s.core.ListMemberRooms(ctx, KindDM, actorID, MemberRoomListOptions{})
 	if err != nil {
 		return nil, err
@@ -294,6 +315,9 @@ func (s *RoomDirectoryReadModel) visibleDMRooms(ctx context.Context, actorID str
 	}
 	visible := make([]visibleDMRoom, 0, len(rooms))
 	for _, room := range rooms {
+		if !archiveFilter.matches(room.GetArchived()) {
+			continue
+		}
 		canAccess, err := s.core.CanAccessRoomMessages(ctx, actorID, KindDM, room.GetId())
 		if err != nil {
 			return nil, err

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/room_directory.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/room_directory.connect.go
@@ -55,9 +55,10 @@ const (
 
 // RoomDirectoryServiceClient is a client for the chatto.api.v1.RoomDirectoryService service.
 type RoomDirectoryServiceClient interface {
-	// Lists rooms visible to the current user. Channel rooms are non-archived
-	// rooms visible through membership or room.list. DM membership exposes room
-	// and participant metadata. Message-derived DM state also requires current
+	// Lists rooms visible to the current user. Defaults to active rooms; use
+	// archive_filter to discover archived rooms or include both states. Channel
+	// rooms require membership or room.list. DM membership exposes room and
+	// participant metadata. Message-derived DM state also requires current
 	// read permission. Accessible empty DMs are included. Results are returned as a finite
 	// navigation snapshot.
 	ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error)
@@ -178,9 +179,10 @@ func (c *roomDirectoryServiceClient) BatchGetRooms(ctx context.Context, req *con
 // RoomDirectoryServiceHandler is an implementation of the chatto.api.v1.RoomDirectoryService
 // service.
 type RoomDirectoryServiceHandler interface {
-	// Lists rooms visible to the current user. Channel rooms are non-archived
-	// rooms visible through membership or room.list. DM membership exposes room
-	// and participant metadata. Message-derived DM state also requires current
+	// Lists rooms visible to the current user. Defaults to active rooms; use
+	// archive_filter to discover archived rooms or include both states. Channel
+	// rooms require membership or room.list. DM membership exposes room and
+	// participant metadata. Message-derived DM state also requires current
 	// read permission. Accessible empty DMs are included. Results are returned as a finite
 	// navigation snapshot.
 	ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error)

--- a/cli/internal/pb/chatto/api/v1/room_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_directory.pb.go
@@ -27,13 +27,13 @@ const (
 type RoomDirectoryScope int32
 
 const (
-	// Include visible channel rooms and readable active DM rooms.
+	// Include visible channel rooms and the caller's DM rooms.
 	RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_UNSPECIFIED RoomDirectoryScope = 0
-	// Include visible channel rooms and readable active DM rooms.
+	// Include visible channel rooms and the caller's DM rooms.
 	RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_ALL RoomDirectoryScope = 1
 	// Include visible channel rooms only.
 	RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_CHANNELS RoomDirectoryScope = 2
-	// Include the caller's readable active DM rooms only.
+	// Include the caller's DM rooms only.
 	RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_DMS RoomDirectoryScope = 3
 )
 
@@ -78,6 +78,63 @@ func (x RoomDirectoryScope) Number() protoreflect.EnumNumber {
 // Deprecated: Use RoomDirectoryScope.Descriptor instead.
 func (RoomDirectoryScope) EnumDescriptor() ([]byte, []int) {
 	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{0}
+}
+
+// Archive state to include in room directory responses.
+type RoomArchiveFilter int32
+
+const (
+	// Include active rooms only.
+	RoomArchiveFilter_ROOM_ARCHIVE_FILTER_UNSPECIFIED RoomArchiveFilter = 0
+	// Include active rooms only.
+	RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ACTIVE RoomArchiveFilter = 1
+	// Include archived rooms only.
+	RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ARCHIVED RoomArchiveFilter = 2
+	// Include both active and archived rooms.
+	RoomArchiveFilter_ROOM_ARCHIVE_FILTER_ALL RoomArchiveFilter = 3
+)
+
+// Enum value maps for RoomArchiveFilter.
+var (
+	RoomArchiveFilter_name = map[int32]string{
+		0: "ROOM_ARCHIVE_FILTER_UNSPECIFIED",
+		1: "ROOM_ARCHIVE_FILTER_ACTIVE",
+		2: "ROOM_ARCHIVE_FILTER_ARCHIVED",
+		3: "ROOM_ARCHIVE_FILTER_ALL",
+	}
+	RoomArchiveFilter_value = map[string]int32{
+		"ROOM_ARCHIVE_FILTER_UNSPECIFIED": 0,
+		"ROOM_ARCHIVE_FILTER_ACTIVE":      1,
+		"ROOM_ARCHIVE_FILTER_ARCHIVED":    2,
+		"ROOM_ARCHIVE_FILTER_ALL":         3,
+	}
+)
+
+func (x RoomArchiveFilter) Enum() *RoomArchiveFilter {
+	p := new(RoomArchiveFilter)
+	*p = x
+	return p
+}
+
+func (x RoomArchiveFilter) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (RoomArchiveFilter) Descriptor() protoreflect.EnumDescriptor {
+	return file_chatto_api_v1_room_directory_proto_enumTypes[1].Descriptor()
+}
+
+func (RoomArchiveFilter) Type() protoreflect.EnumType {
+	return &file_chatto_api_v1_room_directory_proto_enumTypes[1]
+}
+
+func (x RoomArchiveFilter) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use RoomArchiveFilter.Descriptor instead.
+func (RoomArchiveFilter) EnumDescriptor() ([]byte, []int) {
+	return file_chatto_api_v1_room_directory_proto_rawDescGZIP(), []int{1}
 }
 
 // Viewer-specific state and permission decisions for one room.
@@ -510,7 +567,10 @@ func (x *RoomGroup) GetViewerState() *RoomGroupViewerState {
 type ListRoomsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Which room kinds to include. Defaults to all.
-	Scope         RoomDirectoryScope `protobuf:"varint,1,opt,name=scope,proto3,enum=chatto.api.v1.RoomDirectoryScope" json:"scope,omitempty"`
+	Scope RoomDirectoryScope `protobuf:"varint,1,opt,name=scope,proto3,enum=chatto.api.v1.RoomDirectoryScope" json:"scope,omitempty"`
+	// Archive state to include. Defaults to ACTIVE. Combined with scope; this
+	// filter does not grant access to hidden rooms.
+	ArchiveFilter RoomArchiveFilter `protobuf:"varint,2,opt,name=archive_filter,json=archiveFilter,proto3,enum=chatto.api.v1.RoomArchiveFilter" json:"archive_filter,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -552,10 +612,17 @@ func (x *ListRoomsRequest) GetScope() RoomDirectoryScope {
 	return RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_UNSPECIFIED
 }
 
+func (x *ListRoomsRequest) GetArchiveFilter() RoomArchiveFilter {
+	if x != nil {
+		return x.ArchiveFilter
+	}
+	return RoomArchiveFilter_ROOM_ARCHIVE_FILTER_UNSPECIFIED
+}
+
 // Finite snapshot of rooms visible to the current user.
 type ListRoomsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Rooms matching the requested scope.
+	// Visible rooms matching both the room-kind scope and archive filter.
 	Rooms         []*RoomWithViewerState `protobuf:"bytes,1,rep,name=rooms,proto3" json:"rooms,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1085,9 +1152,10 @@ const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x122\n" +
 	"\x05items\x18\x05 \x03(\v2\x1c.chatto.api.v1.RoomGroupItemR\x05items\x12F\n" +
-	"\fviewer_state\x18\x06 \x01(\v2#.chatto.api.v1.RoomGroupViewerStateR\vviewerStateJ\x04\b\x04\x10\x05R\x05rooms\"U\n" +
+	"\fviewer_state\x18\x06 \x01(\v2#.chatto.api.v1.RoomGroupViewerStateR\vviewerStateJ\x04\b\x04\x10\x05R\x05rooms\"\xa8\x01\n" +
 	"\x10ListRoomsRequest\x12A\n" +
-	"\x05scope\x18\x01 \x01(\x0e2!.chatto.api.v1.RoomDirectoryScopeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05scope\"M\n" +
+	"\x05scope\x18\x01 \x01(\x0e2!.chatto.api.v1.RoomDirectoryScopeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05scope\x12Q\n" +
+	"\x0earchive_filter\x18\x02 \x01(\x0e2 .chatto.api.v1.RoomArchiveFilterB\b\xbaH\x05\x82\x01\x02\x10\x01R\rarchiveFilter\"M\n" +
 	"\x11ListRoomsResponse\x128\n" +
 	"\x05rooms\x18\x01 \x03(\v2\".chatto.api.v1.RoomWithViewerStateR\x05rooms\"5\n" +
 	"\x15ListRoomGroupsRequestJ\x04\b\x01\x10\x02R\x16include_archived_rooms\"J\n" +
@@ -1115,7 +1183,12 @@ const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	" ROOM_DIRECTORY_SCOPE_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18ROOM_DIRECTORY_SCOPE_ALL\x10\x01\x12!\n" +
 	"\x1dROOM_DIRECTORY_SCOPE_CHANNELS\x10\x02\x12\x1c\n" +
-	"\x18ROOM_DIRECTORY_SCOPE_DMS\x10\x032\xaf\x04\n" +
+	"\x18ROOM_DIRECTORY_SCOPE_DMS\x10\x03*\x97\x01\n" +
+	"\x11RoomArchiveFilter\x12#\n" +
+	"\x1fROOM_ARCHIVE_FILTER_UNSPECIFIED\x10\x00\x12\x1e\n" +
+	"\x1aROOM_ARCHIVE_FILTER_ACTIVE\x10\x01\x12 \n" +
+	"\x1cROOM_ARCHIVE_FILTER_ARCHIVED\x10\x02\x12\x1b\n" +
+	"\x17ROOM_ARCHIVE_FILTER_ALL\x10\x032\xaf\x04\n" +
 	"\x14RoomDirectoryService\x12N\n" +
 	"\tListRooms\x12\x1f.chatto.api.v1.ListRoomsRequest\x1a .chatto.api.v1.ListRoomsResponse\x12]\n" +
 	"\x0eListRoomGroups\x12$.chatto.api.v1.ListRoomGroupsRequest\x1a%.chatto.api.v1.ListRoomGroupsResponse\x12W\n" +
@@ -1137,66 +1210,68 @@ func file_chatto_api_v1_room_directory_proto_rawDescGZIP() []byte {
 	return file_chatto_api_v1_room_directory_proto_rawDescData
 }
 
-var file_chatto_api_v1_room_directory_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_chatto_api_v1_room_directory_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
 var file_chatto_api_v1_room_directory_proto_msgTypes = make([]protoimpl.MessageInfo, 18)
 var file_chatto_api_v1_room_directory_proto_goTypes = []any{
 	(RoomDirectoryScope)(0),            // 0: chatto.api.v1.RoomDirectoryScope
-	(*RoomViewerState)(nil),            // 1: chatto.api.v1.RoomViewerState
-	(*RoomWithViewerState)(nil),        // 2: chatto.api.v1.RoomWithViewerState
-	(*SidebarLink)(nil),                // 3: chatto.api.v1.SidebarLink
-	(*RoomGroupItem)(nil),              // 4: chatto.api.v1.RoomGroupItem
-	(*RoomGroupViewerState)(nil),       // 5: chatto.api.v1.RoomGroupViewerState
-	(*RoomGroup)(nil),                  // 6: chatto.api.v1.RoomGroup
-	(*ListRoomsRequest)(nil),           // 7: chatto.api.v1.ListRoomsRequest
-	(*ListRoomsResponse)(nil),          // 8: chatto.api.v1.ListRoomsResponse
-	(*ListRoomGroupsRequest)(nil),      // 9: chatto.api.v1.ListRoomGroupsRequest
-	(*ListRoomGroupsResponse)(nil),     // 10: chatto.api.v1.ListRoomGroupsResponse
-	(*GetRoomGroupRequest)(nil),        // 11: chatto.api.v1.GetRoomGroupRequest
-	(*GetRoomGroupResponse)(nil),       // 12: chatto.api.v1.GetRoomGroupResponse
-	(*BatchGetRoomGroupsRequest)(nil),  // 13: chatto.api.v1.BatchGetRoomGroupsRequest
-	(*BatchGetRoomGroupsResponse)(nil), // 14: chatto.api.v1.BatchGetRoomGroupsResponse
-	(*GetRoomRequest)(nil),             // 15: chatto.api.v1.GetRoomRequest
-	(*GetRoomResponse)(nil),            // 16: chatto.api.v1.GetRoomResponse
-	(*BatchGetRoomsRequest)(nil),       // 17: chatto.api.v1.BatchGetRoomsRequest
-	(*BatchGetRoomsResponse)(nil),      // 18: chatto.api.v1.BatchGetRoomsResponse
-	(*PermissionGrant)(nil),            // 19: chatto.api.v1.PermissionGrant
-	(*timestamppb.Timestamp)(nil),      // 20: google.protobuf.Timestamp
-	(*Room)(nil),                       // 21: chatto.api.v1.Room
+	(RoomArchiveFilter)(0),             // 1: chatto.api.v1.RoomArchiveFilter
+	(*RoomViewerState)(nil),            // 2: chatto.api.v1.RoomViewerState
+	(*RoomWithViewerState)(nil),        // 3: chatto.api.v1.RoomWithViewerState
+	(*SidebarLink)(nil),                // 4: chatto.api.v1.SidebarLink
+	(*RoomGroupItem)(nil),              // 5: chatto.api.v1.RoomGroupItem
+	(*RoomGroupViewerState)(nil),       // 6: chatto.api.v1.RoomGroupViewerState
+	(*RoomGroup)(nil),                  // 7: chatto.api.v1.RoomGroup
+	(*ListRoomsRequest)(nil),           // 8: chatto.api.v1.ListRoomsRequest
+	(*ListRoomsResponse)(nil),          // 9: chatto.api.v1.ListRoomsResponse
+	(*ListRoomGroupsRequest)(nil),      // 10: chatto.api.v1.ListRoomGroupsRequest
+	(*ListRoomGroupsResponse)(nil),     // 11: chatto.api.v1.ListRoomGroupsResponse
+	(*GetRoomGroupRequest)(nil),        // 12: chatto.api.v1.GetRoomGroupRequest
+	(*GetRoomGroupResponse)(nil),       // 13: chatto.api.v1.GetRoomGroupResponse
+	(*BatchGetRoomGroupsRequest)(nil),  // 14: chatto.api.v1.BatchGetRoomGroupsRequest
+	(*BatchGetRoomGroupsResponse)(nil), // 15: chatto.api.v1.BatchGetRoomGroupsResponse
+	(*GetRoomRequest)(nil),             // 16: chatto.api.v1.GetRoomRequest
+	(*GetRoomResponse)(nil),            // 17: chatto.api.v1.GetRoomResponse
+	(*BatchGetRoomsRequest)(nil),       // 18: chatto.api.v1.BatchGetRoomsRequest
+	(*BatchGetRoomsResponse)(nil),      // 19: chatto.api.v1.BatchGetRoomsResponse
+	(*PermissionGrant)(nil),            // 20: chatto.api.v1.PermissionGrant
+	(*timestamppb.Timestamp)(nil),      // 21: google.protobuf.Timestamp
+	(*Room)(nil),                       // 22: chatto.api.v1.Room
 }
 var file_chatto_api_v1_room_directory_proto_depIdxs = []int32{
-	19, // 0: chatto.api.v1.RoomViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
-	20, // 1: chatto.api.v1.RoomViewerState.slow_mode_next_post_at:type_name -> google.protobuf.Timestamp
-	21, // 2: chatto.api.v1.RoomWithViewerState.room:type_name -> chatto.api.v1.Room
-	1,  // 3: chatto.api.v1.RoomWithViewerState.viewer_state:type_name -> chatto.api.v1.RoomViewerState
-	2,  // 4: chatto.api.v1.RoomGroupItem.room:type_name -> chatto.api.v1.RoomWithViewerState
-	3,  // 5: chatto.api.v1.RoomGroupItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
-	19, // 6: chatto.api.v1.RoomGroupViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
-	4,  // 7: chatto.api.v1.RoomGroup.items:type_name -> chatto.api.v1.RoomGroupItem
-	5,  // 8: chatto.api.v1.RoomGroup.viewer_state:type_name -> chatto.api.v1.RoomGroupViewerState
+	20, // 0: chatto.api.v1.RoomViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
+	21, // 1: chatto.api.v1.RoomViewerState.slow_mode_next_post_at:type_name -> google.protobuf.Timestamp
+	22, // 2: chatto.api.v1.RoomWithViewerState.room:type_name -> chatto.api.v1.Room
+	2,  // 3: chatto.api.v1.RoomWithViewerState.viewer_state:type_name -> chatto.api.v1.RoomViewerState
+	3,  // 4: chatto.api.v1.RoomGroupItem.room:type_name -> chatto.api.v1.RoomWithViewerState
+	4,  // 5: chatto.api.v1.RoomGroupItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
+	20, // 6: chatto.api.v1.RoomGroupViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
+	5,  // 7: chatto.api.v1.RoomGroup.items:type_name -> chatto.api.v1.RoomGroupItem
+	6,  // 8: chatto.api.v1.RoomGroup.viewer_state:type_name -> chatto.api.v1.RoomGroupViewerState
 	0,  // 9: chatto.api.v1.ListRoomsRequest.scope:type_name -> chatto.api.v1.RoomDirectoryScope
-	2,  // 10: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
-	6,  // 11: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	6,  // 12: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
-	6,  // 13: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	2,  // 14: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.RoomWithViewerState
-	2,  // 15: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
-	7,  // 16: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
-	9,  // 17: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
-	11, // 18: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
-	13, // 19: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
-	15, // 20: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
-	17, // 21: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
-	8,  // 22: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
-	10, // 23: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
-	12, // 24: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
-	14, // 25: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
-	16, // 26: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
-	18, // 27: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
-	22, // [22:28] is the sub-list for method output_type
-	16, // [16:22] is the sub-list for method input_type
-	16, // [16:16] is the sub-list for extension type_name
-	16, // [16:16] is the sub-list for extension extendee
-	0,  // [0:16] is the sub-list for field type_name
+	1,  // 10: chatto.api.v1.ListRoomsRequest.archive_filter:type_name -> chatto.api.v1.RoomArchiveFilter
+	3,  // 11: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
+	7,  // 12: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	7,  // 13: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
+	7,  // 14: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	3,  // 15: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.RoomWithViewerState
+	3,  // 16: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
+	8,  // 17: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
+	10, // 18: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
+	12, // 19: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
+	14, // 20: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
+	16, // 21: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
+	18, // 22: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
+	9,  // 23: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
+	11, // 24: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
+	13, // 25: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
+	15, // 26: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
+	17, // 27: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
+	19, // 28: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
+	23, // [23:29] is the sub-list for method output_type
+	17, // [17:23] is the sub-list for method input_type
+	17, // [17:17] is the sub-list for extension type_name
+	17, // [17:17] is the sub-list for extension extendee
+	0,  // [0:17] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_room_directory_proto_init() }
@@ -1216,7 +1291,7 @@ func file_chatto_api_v1_room_directory_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_room_directory_proto_rawDesc), len(file_chatto_api_v1_room_directory_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      2,
 			NumMessages:   18,
 			NumExtensions: 0,
 			NumServices:   1,

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -90,6 +90,13 @@ Owner reassignment validates stable request-time authorization inputs and uses
 user-family OCC. This boundary serializes reassignment with deletion of the bot
 or either human owner.
 
+`RoomDirectoryService.ListRooms` intersects the room-kind scope with an archive
+filter. The default returns active rooms; callers can select archived rooms or
+both states. The read uses the existing room catalog, visibility checks, and
+canonical room response. Archive discovery does not change membership or
+permissions. Room-group and realtime navigation snapshots keep their default
+active-room scope.
+
 `RoomService.AddMember` and `RemoveMember` accept room managers, account
 managers, bot owners, and human bot managers. `room.manage` for the room or
 `user.manage-accounts` overrides the target account's missing `room.join`.

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-019: Room Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-08-30
+**Last reviewed:** 2026-09-09
 
 ## Overview
 
@@ -22,6 +22,11 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
   Archived rooms vanish from the sidebar, server Overview, and search results.
   Membership and history stay intact, but the room is read-only until an
   administrator unarchives it.
+- **Archive discovery** — API clients can list active rooms, archived rooms,
+  or both. The default room list still includes only active rooms. Archive
+  discovery keeps the normal membership and visibility rules; it does not give
+  access to hidden rooms or another user's DMs. Room-group navigation still
+  omits archived rooms.
 - **Unarchive** — same permission, flips the flag back. The room reappears in the sidebar and discovery surfaces.
 - **Manage members** — `room.manage` holders can list, inspect, add, or remove members of channel rooms, including when they are not themselves members or eligible to join. Adding can bring a user into a private room even when that user could not self-join through `room.join`. Active room bans still block adding; the user must be unbanned first. DM membership remains visible only to its participants.
 - **Ban member** — `room.ban-member` holders can ban a user from a channel room with a required reason and optional expiry. The banned user loses room read/write/live access immediately and cannot rejoin until the ban is removed or expires.
@@ -52,6 +57,10 @@ A channel room goes through a lifecycle of create, edit, archive, unarchive, and
 **Decision:** Archive is one boolean in the room projection. Durable room
 archive and unarchive facts change it. The room keeps its event history and
 members; active-room discovery filters on `archived: false`.
+`RoomDirectoryService.ListRooms` accepts an explicit archive filter for clients
+that need the archive. The room-kind scope and archive filter both apply.
+The list retains its complete navigation-snapshot response; it does not
+introduce a page limit that would truncate existing callers' room lists.
 **Why:** Archive's purpose is "stop showing this room everywhere, but don't lose the history". A full archived-rooms-elsewhere migration would mean different code paths for archived rooms, divergent reads, and a hard road back to active state. A flag is enough.
 **Tradeoff:** Every "show me rooms" query needs to remember to filter on `archived`. Centralised in the resolver layer.
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -28,7 +28,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-08-20 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-08-29 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-08-28 |
-| [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-08-30 |
+| [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-09-09 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-08-30 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-08-27 |
 | [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-08-30 |

--- a/packages/api-types/src/chatto/api/v1/room_directory_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/room_directory_connect.ts
@@ -15,9 +15,10 @@ export const RoomDirectoryService = {
   typeName: "chatto.api.v1.RoomDirectoryService",
   methods: {
     /**
-     * Lists rooms visible to the current user. Channel rooms are non-archived
-     * rooms visible through membership or room.list. DM membership exposes room
-     * and participant metadata. Message-derived DM state also requires current
+     * Lists rooms visible to the current user. Defaults to active rooms; use
+     * archive_filter to discover archived rooms or include both states. Channel
+     * rooms require membership or room.list. DM membership exposes room and
+     * participant metadata. Message-derived DM state also requires current
      * read permission. Accessible empty DMs are included. Results are returned as a finite
      * navigation snapshot.
      *

--- a/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
@@ -15,14 +15,14 @@ import { Room } from "./rooms_pb.js";
  */
 export enum RoomDirectoryScope {
   /**
-   * Include visible channel rooms and readable active DM rooms.
+   * Include visible channel rooms and the caller's DM rooms.
    *
    * @generated from enum value: ROOM_DIRECTORY_SCOPE_UNSPECIFIED = 0;
    */
   UNSPECIFIED = 0,
 
   /**
-   * Include visible channel rooms and readable active DM rooms.
+   * Include visible channel rooms and the caller's DM rooms.
    *
    * @generated from enum value: ROOM_DIRECTORY_SCOPE_ALL = 1;
    */
@@ -36,7 +36,7 @@ export enum RoomDirectoryScope {
   CHANNELS = 2,
 
   /**
-   * Include the caller's readable active DM rooms only.
+   * Include the caller's DM rooms only.
    *
    * @generated from enum value: ROOM_DIRECTORY_SCOPE_DMS = 3;
    */
@@ -48,6 +48,48 @@ proto3.util.setEnumType(RoomDirectoryScope, "chatto.api.v1.RoomDirectoryScope", 
   { no: 1, name: "ROOM_DIRECTORY_SCOPE_ALL" },
   { no: 2, name: "ROOM_DIRECTORY_SCOPE_CHANNELS" },
   { no: 3, name: "ROOM_DIRECTORY_SCOPE_DMS" },
+]);
+
+/**
+ * Archive state to include in room directory responses.
+ *
+ * @generated from enum chatto.api.v1.RoomArchiveFilter
+ */
+export enum RoomArchiveFilter {
+  /**
+   * Include active rooms only.
+   *
+   * @generated from enum value: ROOM_ARCHIVE_FILTER_UNSPECIFIED = 0;
+   */
+  UNSPECIFIED = 0,
+
+  /**
+   * Include active rooms only.
+   *
+   * @generated from enum value: ROOM_ARCHIVE_FILTER_ACTIVE = 1;
+   */
+  ACTIVE = 1,
+
+  /**
+   * Include archived rooms only.
+   *
+   * @generated from enum value: ROOM_ARCHIVE_FILTER_ARCHIVED = 2;
+   */
+  ARCHIVED = 2,
+
+  /**
+   * Include both active and archived rooms.
+   *
+   * @generated from enum value: ROOM_ARCHIVE_FILTER_ALL = 3;
+   */
+  ALL = 3,
+}
+// Retrieve enum metadata with: proto3.getEnumType(RoomArchiveFilter)
+proto3.util.setEnumType(RoomArchiveFilter, "chatto.api.v1.RoomArchiveFilter", [
+  { no: 0, name: "ROOM_ARCHIVE_FILTER_UNSPECIFIED" },
+  { no: 1, name: "ROOM_ARCHIVE_FILTER_ACTIVE" },
+  { no: 2, name: "ROOM_ARCHIVE_FILTER_ARCHIVED" },
+  { no: 3, name: "ROOM_ARCHIVE_FILTER_ALL" },
 ]);
 
 /**
@@ -423,6 +465,14 @@ export class ListRoomsRequest extends Message<ListRoomsRequest> {
    */
   scope = RoomDirectoryScope.UNSPECIFIED;
 
+  /**
+   * Archive state to include. Defaults to ACTIVE. Combined with scope; this
+   * filter does not grant access to hidden rooms.
+   *
+   * @generated from field: chatto.api.v1.RoomArchiveFilter archive_filter = 2;
+   */
+  archiveFilter = RoomArchiveFilter.UNSPECIFIED;
+
   constructor(data?: PartialMessage<ListRoomsRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -432,6 +482,7 @@ export class ListRoomsRequest extends Message<ListRoomsRequest> {
   static readonly typeName = "chatto.api.v1.ListRoomsRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "scope", kind: "enum", T: proto3.getEnumType(RoomDirectoryScope) },
+    { no: 2, name: "archive_filter", kind: "enum", T: proto3.getEnumType(RoomArchiveFilter) },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListRoomsRequest {
@@ -458,7 +509,7 @@ export class ListRoomsRequest extends Message<ListRoomsRequest> {
  */
 export class ListRoomsResponse extends Message<ListRoomsResponse> {
   /**
-   * Rooms matching the requested scope.
+   * Visible rooms matching both the room-kind scope and archive filter.
    *
    * @generated from field: repeated chatto.api.v1.RoomWithViewerState rooms = 1;
    */

--- a/proto/chatto/api/v1/room_directory.proto
+++ b/proto/chatto/api/v1/room_directory.proto
@@ -23,14 +23,26 @@ message RoomViewerState {
 
 // Room kinds to include in directory responses.
 enum RoomDirectoryScope {
-  // Include visible channel rooms and readable active DM rooms.
+  // Include visible channel rooms and the caller's DM rooms.
   ROOM_DIRECTORY_SCOPE_UNSPECIFIED = 0;
-  // Include visible channel rooms and readable active DM rooms.
+  // Include visible channel rooms and the caller's DM rooms.
   ROOM_DIRECTORY_SCOPE_ALL = 1;
   // Include visible channel rooms only.
   ROOM_DIRECTORY_SCOPE_CHANNELS = 2;
-  // Include the caller's readable active DM rooms only.
+  // Include the caller's DM rooms only.
   ROOM_DIRECTORY_SCOPE_DMS = 3;
+}
+
+// Archive state to include in room directory responses.
+enum RoomArchiveFilter {
+  // Include active rooms only.
+  ROOM_ARCHIVE_FILTER_UNSPECIFIED = 0;
+  // Include active rooms only.
+  ROOM_ARCHIVE_FILTER_ACTIVE = 1;
+  // Include archived rooms only.
+  ROOM_ARCHIVE_FILTER_ARCHIVED = 2;
+  // Include both active and archived rooms.
+  ROOM_ARCHIVE_FILTER_ALL = 3;
 }
 
 // Room metadata plus state and capabilities resolved for the authenticated
@@ -99,11 +111,14 @@ message RoomGroup {
 message ListRoomsRequest {
   // Which room kinds to include. Defaults to all.
   RoomDirectoryScope scope = 1 [(buf.validate.field).enum.defined_only = true];
+  // Archive state to include. Defaults to ACTIVE. Combined with scope; this
+  // filter does not grant access to hidden rooms.
+  RoomArchiveFilter archive_filter = 2 [(buf.validate.field).enum.defined_only = true];
 }
 
 // Finite snapshot of rooms visible to the current user.
 message ListRoomsResponse {
-  // Rooms matching the requested scope.
+  // Visible rooms matching both the room-kind scope and archive filter.
   repeated RoomWithViewerState rooms = 1;
 }
 
@@ -189,9 +204,10 @@ message BatchGetRoomsResponse {
 
 // Reads room directory data.
 service RoomDirectoryService {
-  // Lists rooms visible to the current user. Channel rooms are non-archived
-  // rooms visible through membership or room.list. DM membership exposes room
-  // and participant metadata. Message-derived DM state also requires current
+  // Lists rooms visible to the current user. Defaults to active rooms; use
+  // archive_filter to discover archived rooms or include both states. Channel
+  // rooms require membership or room.list. DM membership exposes room and
+  // participant metadata. Message-derived DM state also requires current
   // read permission. Accessible empty DMs are included. Results are returned as a finite
   // navigation snapshot.
   rpc ListRooms(ListRoomsRequest) returns (ListRoomsResponse);


### PR DESCRIPTION
`RoomDirectoryService.ListRooms` can now discover archived rooms. Clients can select active, archived, or all rooms; omitted filters keep the existing active-room list.

- **What:** Add `archive_filter`, combine it with the room-kind scope, and regenerate Go/TypeScript clients and API reference pages. Keep existing visibility rules and complete snapshot responses.
- **Why:** Integrations need a clear way to discover archived rooms without knowing their IDs. This additive public API change requires no stored-data migration. Pagination remains separate.
- **Documentation:** Update [FDR-019](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-019-room-lifecycle.md), the [interface inventory](https://github.com/chattocorp/chatto/blob/main/docs/architecture/interfaces.md), compatibility guidance, and 0.5 release notes. Compatibility checks follow [ADR-045](https://github.com/chattocorp/chatto/blob/main/docs/adr/ADR-045-public-api-stability-tiers.md).
- **Verification:** Full ConnectRPC package tests, room-directory core tests, Go vet, TypeScript API build, public protobuf compatibility, storage protocol compatibility, and whitespace checks passed. New tests cover every archive-filter/room-kind combination, hidden rooms, membership-only rooms, DM outsiders, unarchive transitions, invalid values, and authentication. Restoring the previous handler makes the new archive-filter regression test fail.
