### PR TITLE
refactor(api)!: return empty responses for success-only commands

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -365,3 +365,33 @@ The JSON enum values, such as `OAUTH_CLIENT_POLICY_TRUSTED`, are unchanged.
 Regenerate clients and update type references. RPC paths, request and response
 fields, field numbers, and enum numbers are unchanged. Existing JSON requests
 still work. These naming changes do not change stored data.
+
+## Empty command responses in 0.5
+
+The commands below now return their named response message with no fields.
+A successful JSON response is `{}`. Stop reading the old success flag: a
+resolved RPC means success, and a failed RPC returns a Connect error.
+Regenerate clients from the 0.5 protobuf definitions.
+
+| Service | RPCs | Removed response field |
+| --- | --- | --- |
+| `MyAccountService` | `DeleteMyAccount` | `deleted` |
+| `MyAccountService` | `DisconnectExternalIdentity` | `disconnected` |
+| `MessageService` | `DeleteMessage`, `DeleteAttachment`, `DeleteLinkPreview` | `deleted` |
+| `RoomService` | `LeaveRoom` | `left` |
+| `RoomService` | `RefreshTypingIndicator` | `updated` |
+| `RoomService` | `BanMember` / `UnbanMember` | `banned` / `unbanned` |
+| `PushNotificationService` | `Subscribe` / `Unsubscribe` | `subscribed` / `unsubscribed` |
+| `PushNotificationService` | `SendTestNotification` | `sent` |
+| `AdminUserService` | `DeleteUser` / `ClearUsernameCooldown` | `deleted` / `cleared` |
+| `AdminRoleService` | `DeleteRole` | `deleted` |
+| `AdminRoomLayoutService` | `DeleteRoomGroup`, `DeleteSidebarLink` | `deleted` |
+| `ExternalIdentityAuthService` | `CancelExternalIdentityFlow` | `cancelled` |
+| `PushSubscriptionCleanupService` | `DeleteSubscription` | `completed` |
+
+Fields that report an actual change or state remain. For example,
+`DeleteNotificationOccurrence.deleted` distinguishes deletion from an item that
+was already absent, and `LeaveCall.left` reports whether a leave fact was
+recorded. Counts also remain. Empty responses do not change authorization,
+error codes, idempotency, or stored data. Capability cleanup still does not
+reveal whether a matching subscription existed.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/account.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/account.mdx
@@ -222,10 +222,6 @@ Request to disconnect a linked provider identity from the authenticated user.
 
 Result of disconnecting a provider identity.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `disconnected` | `bool` | True when the identity was disconnected. |
-
 
 <a id="chatto-api-v1-MyAccountService-SetPresence"></a>
 
@@ -385,7 +381,3 @@ Request to permanently delete the authenticated account.
 #### Result: DeleteMyAccountResponse
 
 Result of deleting the authenticated account.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the account was deleted. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-roles.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-roles.mdx
@@ -188,10 +188,6 @@ Request to delete a role.
 
 Result of deleting a role.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the request completed. |
-
 
 <a id="chatto-admin-v1-AdminRoleService-ReorderRoles"></a>
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-room-layout.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-room-layout.mdx
@@ -214,10 +214,6 @@ Request to delete an empty room group.
 
 Result of deleting a room group.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the room group was deleted. |
-
 
 <a id="chatto-admin-v1-AdminRoomLayoutService-ReorderRoomGroups"></a>
 
@@ -486,10 +482,6 @@ Request to delete a sidebar link.
 #### Result: DeleteSidebarLinkResponse
 
 Result of deleting a sidebar link.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the sidebar link was deleted. |
 
 
 <a id="chatto-admin-v1-AdminRoomLayoutService-MoveSidebarLinkToGroup"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-users.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-users.mdx
@@ -299,10 +299,6 @@ Request to clear a user's self-service username-change cooldown.
 
 Result of clearing a user's username-change cooldown.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `cleared` | `bool` | True when the request completed. |
-
 
 <a id="chatto-admin-v1-AdminUserService-DeleteUser"></a>
 
@@ -331,7 +327,3 @@ Request to delete a user account as a server-admin action.
 #### Result: DeleteUserResponse
 
 Result of deleting a user account.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the user was deleted. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/external-identity-auth.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/external-identity-auth.mdx
@@ -154,7 +154,3 @@ Request to cancel a pending external identity flow.
 #### Result: CancelExternalIdentityFlowResponse
 
 Result of cancelling a pending external identity flow.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `cancelled` | `bool` | True when a pending flow was removed or already absent. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/index.mdx
@@ -185,6 +185,8 @@ const viewer = await viewerClient.getViewer({}, {
 
 ## Responses And Errors
 
+Commands that only acknowledge success return a named empty response (`{}` in JSON). Use RPC completion to detect success. Fields that report an actual change, state, or count remain part of the response.
+
 Successful unary JSON calls return the protobuf response message as JSON. Field names use protobuf JSON casing, such as `publicProfile` and `directRegistrationEnabled`.
 
 ProtoJSON integrations that need to tolerate future additive oneof variants must configure their decoder to ignore unknown fields. In particular, Notifications 2.0 may add new `NotificationSignal` variants; strict generated JSON clients must be regenerated before receiving such a variant. Binary protobuf is recommended when forward-compatible unknown-field retention is required.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
@@ -170,10 +170,6 @@ Request to retract a message.
 
 Result of retracting a message.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the delete/retract request was accepted. |
-
 
 <a id="chatto-api-v1-MessageService-DeleteAttachment"></a>
 
@@ -204,10 +200,6 @@ Request to remove one attachment from a message.
 
 Result of removing one attachment from a message.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the attachment removal was accepted. |
-
 
 <a id="chatto-api-v1-MessageService-DeleteLinkPreview"></a>
 
@@ -237,10 +229,6 @@ Request to remove the accepted link preview from a message.
 #### Result: DeleteLinkPreviewResponse
 
 Result of removing a link preview from a message.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the link preview removal was accepted. |
 
 
 <a id="chatto-api-v1-MessageService-GetMessage"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/push-notifications.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/push-notifications.mdx
@@ -55,10 +55,6 @@ Request to store a PushSubscription returned by the browser Push API.
 
 Response from storing a browser push subscription.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `subscribed` | `bool` | True when the subscription was stored. |
-
 
 <a id="chatto-api-v1-PushNotificationService-Unsubscribe"></a>
 
@@ -89,10 +85,6 @@ Request to remove a browser push subscription.
 
 Response from removing a browser push subscription.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `unsubscribed` | `bool` | True when the request completed. |
-
 
 <a id="chatto-api-v1-PushNotificationService-SendTestNotification"></a>
 
@@ -118,7 +110,3 @@ Request to test the current user's registered browser push subscriptions.
 #### Result: SendTestNotificationResponse
 
 Result of sending a test Web Push notification.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `sent` | `bool` | True when the push provider accepted the notification. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/push-subscription-cleanup.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/push-subscription-cleanup.mdx
@@ -51,7 +51,4 @@ Capability-authenticated request to remove an exact push subscription.
 #### Result: DeleteSubscriptionResponse
 
 Response from capability-authenticated subscription cleanup.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `completed` | `bool` | True when the idempotent cleanup request completed. It does not reveal whether a matching subscription existed. |
+Success does not reveal whether a matching subscription existed.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -301,10 +301,6 @@ Request to leave a room as the current user.
 
 Result of leaving a room.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `left` | `bool` | True when the current user is no longer an explicit member after the call. |
-
 
 <a id="chatto-api-v1-RoomService-ListMembers"></a>
 
@@ -695,10 +691,6 @@ Request to refresh the current user's live-only typing indicator.
 
 Result of refreshing a typing indicator.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `updated` | `bool` | True when the typing indicator was accepted for publish. |
-
 
 <a id="chatto-api-v1-RoomService-GetRoomEvents"></a>
 
@@ -858,10 +850,6 @@ Request to ban a member from a channel room.
 
 Result of banning a room member.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `banned` | `bool` | True when the ban operation completed. |
-
 
 <a id="chatto-api-v1-RoomService-UnbanMember"></a>
 
@@ -892,7 +880,3 @@ Request to remove a channel room ban.
 #### Result: UnbanMemberResponse
 
 Result of removing a room ban.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `unbanned` | `bool` | True when the unban operation completed. |

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -402,6 +402,10 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ### Navigation and notifications
 
+- Commands that only reported success now return named empty responses (`{}` in
+  JSON). Clients must use RPC completion and Connect errors instead of the
+  removed success fields. Actual change indicators and counts remain. See the
+  [response migration guide](/guides/integrations/api-compatibility/#empty-command-responses-in-05).
 - Public protobuf request and response types now match their RPC names. OAuth
   admin enum types use `OauthClientSource` and `OauthClientPolicy`. Regenerate
   clients and update type references; RPC paths and JSON values are unchanged.

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -471,10 +471,6 @@ Request to delete a role.
 
 Result of deleting a role.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the request completed. |
-
 
 <a id="chatto-admin-v1-AdminRoleService-ReorderRoles"></a>
 
@@ -793,10 +789,6 @@ Request to clear a user's self-service username-change cooldown.
 
 Result of clearing a user's username-change cooldown.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `cleared` | `bool` | True when the request completed. |
-
 
 <a id="chatto-admin-v1-AdminUserService-DeleteUser"></a>
 
@@ -825,10 +817,6 @@ Request to delete a user account as a server-admin action.
 #### Result: DeleteUserResponse
 
 Result of deleting a user account.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the user was deleted. |
 
 
 <a id="chatto-admin-v1-AdminOAuthClientService"></a>
@@ -1423,10 +1411,6 @@ Request to delete an empty room group.
 
 Result of deleting a room group.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the room group was deleted. |
-
 
 <a id="chatto-admin-v1-AdminRoomLayoutService-ReorderRoomGroups"></a>
 
@@ -1695,10 +1679,6 @@ Request to delete a sidebar link.
 #### Result: DeleteSidebarLinkResponse
 
 Result of deleting a sidebar link.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the sidebar link was deleted. |
 
 
 <a id="chatto-admin-v1-AdminRoomLayoutService-MoveSidebarLinkToGroup"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -484,10 +484,6 @@ Request to leave a room as the current user.
 
 Result of leaving a room.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `left` | `bool` | True when the current user is no longer an explicit member after the call. |
-
 
 <a id="chatto-api-v1-RoomService-ListMembers"></a>
 
@@ -878,10 +874,6 @@ Request to refresh the current user's live-only typing indicator.
 
 Result of refreshing a typing indicator.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `updated` | `bool` | True when the typing indicator was accepted for publish. |
-
 
 <a id="chatto-api-v1-RoomService-GetRoomEvents"></a>
 
@@ -1041,10 +1033,6 @@ Request to ban a member from a channel room.
 
 Result of banning a room member.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `banned` | `bool` | True when the ban operation completed. |
-
 
 <a id="chatto-api-v1-RoomService-UnbanMember"></a>
 
@@ -1075,10 +1063,6 @@ Request to remove a channel room ban.
 #### Result: UnbanMemberResponse
 
 Result of removing a room ban.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `unbanned` | `bool` | True when the unban operation completed. |
 
 
 <a id="chatto-api-v1-RoomDirectoryService"></a>
@@ -1603,10 +1587,6 @@ Request to disconnect a linked provider identity from the authenticated user.
 
 Result of disconnecting a provider identity.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `disconnected` | `bool` | True when the identity was disconnected. |
-
 
 <a id="chatto-api-v1-MyAccountService-SetPresence"></a>
 
@@ -1766,10 +1746,6 @@ Request to permanently delete the authenticated account.
 #### Result: DeleteMyAccountResponse
 
 Result of deleting the authenticated account.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the account was deleted. |
 
 
 <a id="chatto-api-v1-AssetUploadService"></a>
@@ -2743,10 +2719,6 @@ Request to retract a message.
 
 Result of retracting a message.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the delete/retract request was accepted. |
-
 
 <a id="chatto-api-v1-MessageService-DeleteAttachment"></a>
 
@@ -2777,10 +2749,6 @@ Request to remove one attachment from a message.
 
 Result of removing one attachment from a message.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the attachment removal was accepted. |
-
 
 <a id="chatto-api-v1-MessageService-DeleteLinkPreview"></a>
 
@@ -2810,10 +2778,6 @@ Request to remove the accepted link preview from a message.
 #### Result: DeleteLinkPreviewResponse
 
 Result of removing a link preview from a message.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `deleted` | `bool` | True when the link preview removal was accepted. |
 
 
 <a id="chatto-api-v1-MessageService-GetMessage"></a>
@@ -3382,10 +3346,6 @@ Request to store a PushSubscription returned by the browser Push API.
 
 Response from storing a browser push subscription.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `subscribed` | `bool` | True when the subscription was stored. |
-
 
 <a id="chatto-api-v1-PushNotificationService-Unsubscribe"></a>
 
@@ -3416,10 +3376,6 @@ Request to remove a browser push subscription.
 
 Response from removing a browser push subscription.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `unsubscribed` | `bool` | True when the request completed. |
-
 
 <a id="chatto-api-v1-PushNotificationService-SendTestNotification"></a>
 
@@ -3445,10 +3401,6 @@ Request to test the current user's registered browser push subscriptions.
 #### Result: SendTestNotificationResponse
 
 Result of sending a test Web Push notification.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `sent` | `bool` | True when the push provider accepted the notification. |
 
 
 <a id="chatto-api-v1-ServerService"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/auth.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/auth.raw.mdx
@@ -155,10 +155,6 @@ Request to cancel a pending external identity flow.
 
 Result of cancelling a pending external identity flow.
 
-| Field | Type | Description |
-| --- | --- | --- |
-| `cancelled` | `bool` | True when a pending flow was removed or already absent. |
-
 
 <a id="chatto-auth-v1-PushSubscriptionCleanupService"></a>
 
@@ -197,10 +193,7 @@ Capability-authenticated request to remove an exact push subscription.
 #### Result: DeleteSubscriptionResponse
 
 Response from capability-authenticated subscription cleanup.
-
-| Field | Type | Description |
-| --- | --- | --- |
-| `completed` | `bool` | True when the idempotent cleanup request completed. It does not reveal whether a matching subscription existed. |
+Success does not reveal whether a matching subscription existed.
 
 
 

--- a/apps/frontend/e2e/admin.test.ts
+++ b/apps/frontend/e2e/admin.test.ts
@@ -87,12 +87,12 @@ async function createRoleViaConnect(
 }
 
 async function deleteRoleViaConnect(page: Page, name: string): Promise<void> {
-  const data = await connectPost<{ deleted?: boolean }>(
+  const data = await connectPost<Record<string, never>>(
     page,
     'chatto.admin.v1.AdminRoleService/DeleteRole',
     { name }
   );
-  expect(data.deleted).toBe(true);
+  expect(data).toEqual({});
 }
 
 async function getRoleViaConnect(

--- a/apps/frontend/e2e/cross-server-dots.test.ts
+++ b/apps/frontend/e2e/cross-server-dots.test.ts
@@ -206,7 +206,7 @@ test.describe('Cross-instance dots', () => {
       (url) =>
         url.pathname === `/chat/${remoteHostSegment}/${remoteGeneralRoomId}/${remoteRootEventId}`
     );
-    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '# general', exact: true })).toBeVisible();
     await roomPage.expectThreadPaneVisible();
     await roomPage.expectTextInThreadPane(remoteReplyBody);
 
@@ -271,7 +271,7 @@ test.describe('Cross-instance dots', () => {
     await page.waitForURL(
       (url) => url.pathname === `/chat/${remoteHostSegment}/${remoteGeneralRoomId}`
     );
-    await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: '# general', exact: true })).toBeVisible();
 
     const mainRoomTimeline = page.locator('[data-testid="messages-container"]').first();
     await expect(mainRoomTimeline.locator('[role="article"]')).not.toHaveCount(0);
@@ -320,7 +320,7 @@ test.describe('Cross-instance dots', () => {
 
       // Should land on the thread URL (/chat/-/{spaceId}/{roomId}/{threadId}).
       await page.waitForURL(routes.patterns.anyThread);
-      await expect(page.getByRole('heading', { name: '# general' })).toBeVisible();
+      await expect(page.getByRole('heading', { name: '# general', exact: true })).toBeVisible();
       await roomPage.expectThreadPaneVisible();
     });
   });

--- a/apps/frontend/e2e/room-layout.test.ts
+++ b/apps/frontend/e2e/room-layout.test.ts
@@ -207,12 +207,12 @@ async function updateRoomLayoutViaAPI(page: Page, groups: RoomGroup[]): Promise<
     if (desiredSet.has(g.id)) continue;
     const fresh = refreshedRooms.get(g.id) ?? [];
     if (fresh.length > 0) continue;
-    const response = await connectPost<{ deleted?: boolean }>(
+    const response = await connectPost<Record<string, never>>(
       page,
       'chatto.admin.v1.AdminRoomLayoutService/DeleteRoomGroup',
       { groupId: g.id }
     );
-    expect(response.deleted).toBe(true);
+    expect(response).toEqual({});
   }
 
   // Finally, force the layout's group order to match the input.

--- a/apps/frontend/src/lib/api-client-tests/account.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/account.spec.ts
@@ -166,7 +166,7 @@ describe('createAccountAPI', () => {
 
   it('requests and confirms account deletion', async () => {
     mocks.requestAccountDeletion.mockResolvedValue({ confirmationToken: 'AD-token' });
-    mocks.deleteMyAccount.mockResolvedValue({ deleted: true });
+    mocks.deleteMyAccount.mockResolvedValue({});
 
     const api = createAccountAPI({
       baseUrl: '/api/connect',

--- a/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
@@ -99,7 +99,7 @@ describe('createAdminRoomLayoutAPI', () => {
       group: { id: 'g2', name: 'Projects', description: 'Project rooms', items: [] }
     });
     mocks.updateRoomGroup.mockResolvedValue({ group: { id: 'g2', name: 'Renamed', items: [] } });
-    mocks.deleteRoomGroup.mockResolvedValue({ deleted: true });
+    mocks.deleteRoomGroup.mockResolvedValue({});
     mocks.reorderRoomGroups.mockResolvedValue({ groups: [] });
     mocks.moveRoomGroup.mockResolvedValue({ groups: [] });
     mocks.moveRoomToGroup.mockResolvedValue({});
@@ -111,7 +111,7 @@ describe('createAdminRoomLayoutAPI', () => {
     mocks.updateSidebarLink.mockResolvedValue({
       sidebarLink: { id: 'docs', label: 'Docs', url: '/help' }
     });
-    mocks.deleteSidebarLink.mockResolvedValue({ deleted: true });
+    mocks.deleteSidebarLink.mockResolvedValue({});
     mocks.moveSidebarLinkToGroup.mockResolvedValue({});
 
     const api = createAdminRoomLayoutAPI({

--- a/apps/frontend/src/lib/api-client-tests/adminUsers.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/adminUsers.spec.ts
@@ -293,7 +293,7 @@ describe('createAdminUserManagementAPI', () => {
   });
 
   it('clears username cooldown without auth headers when no token is available', async () => {
-    mocks.clearUsernameCooldown.mockResolvedValue({ cleared: true });
+    mocks.clearUsernameCooldown.mockResolvedValue({});
     const api = createAdminUserManagementAPI({ baseUrl: '/api/connect', bearerToken: null });
 
     await expect(api.clearUsernameCooldown('user-1')).resolves.toBe(true);
@@ -341,7 +341,7 @@ describe('createAdminUserManagementAPI', () => {
   });
 
   it('deletes a user with auth headers', async () => {
-    mocks.deleteUser.mockResolvedValue({ deleted: true });
+    mocks.deleteUser.mockResolvedValue({});
     const api = createAdminUserManagementAPI({
       baseUrl: '/api/connect',
       bearerToken: 'token'

--- a/apps/frontend/src/lib/api-client-tests/externalIdentities.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/externalIdentities.spec.ts
@@ -277,7 +277,7 @@ describe('createExternalIdentityAPI', () => {
   });
 
   it('disconnects a linked identity with bearer auth', async () => {
-    mocks.disconnectExternalIdentity.mockResolvedValue({ disconnected: true });
+    mocks.disconnectExternalIdentity.mockResolvedValue({});
 
     const api = createExternalIdentityAPI({
       serverId: 'remote',

--- a/apps/frontend/src/lib/api-client-tests/messages.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/messages.spec.ts
@@ -364,9 +364,9 @@ describe('createMessageAPI', () => {
   });
 
   it('deletes message content through MessageService', async () => {
-    mocks.deleteMessage.mockResolvedValue({ deleted: true });
-    mocks.deleteAttachment.mockResolvedValue({ deleted: true });
-    mocks.deleteLinkPreview.mockResolvedValue({ deleted: true });
+    mocks.deleteMessage.mockResolvedValue({});
+    mocks.deleteAttachment.mockResolvedValue({});
+    mocks.deleteLinkPreview.mockResolvedValue({});
 
     const api = createMessageAPI({
       baseUrl: 'https://remote.example.test/api/connect',

--- a/apps/frontend/src/lib/api-client-tests/pushNotifications.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/pushNotifications.spec.ts
@@ -37,9 +37,9 @@ describe('createPushNotificationAPI', () => {
   });
 
   it('subscribes and unsubscribes with bearer auth', async () => {
-    mocks.subscribe.mockResolvedValue({ subscribed: true });
-    mocks.unsubscribe.mockResolvedValue({ unsubscribed: true });
-    mocks.deleteSubscription.mockResolvedValue({ completed: true });
+    mocks.subscribe.mockResolvedValue({});
+    mocks.unsubscribe.mockResolvedValue({});
+    mocks.deleteSubscription.mockResolvedValue({});
 
     const api = createPushNotificationAPI({
       baseUrl: 'https://origin.test/api/connect',
@@ -101,7 +101,7 @@ describe('createPushNotificationAPI', () => {
   });
 
   it('omits auth headers when no bearer token exists', async () => {
-    mocks.subscribe.mockResolvedValue({ subscribed: true });
+    mocks.subscribe.mockResolvedValue({});
 
     const api = createPushNotificationAPI({
       baseUrl: '/api/connect',

--- a/apps/frontend/src/lib/api-client-tests/roles.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roles.spec.ts
@@ -245,7 +245,7 @@ describe('createRoleAPI', () => {
     mocks.updateRole.mockResolvedValue({
       role: { ...apiRole, role: { ...apiRole.role, displayName: 'Support' } }
     });
-    mocks.deleteRole.mockResolvedValue({ deleted: true });
+    mocks.deleteRole.mockResolvedValue({});
     const api = createRoleAPI({ baseUrl: '/api/connect', bearerToken: 'token' });
 
     await expect(api.createRole(role)).resolves.toEqual(role);

--- a/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/rooms.spec.ts
@@ -254,7 +254,7 @@ describe('createRoomCommandAPI', () => {
   it('uses Connect room and directory membership commands', async () => {
     mocks.joinRoom.mockResolvedValue({ room: { id: 'room-1', name: 'general' } });
     mocks.startDM.mockResolvedValue({ room: { id: 'dm-1', name: '' } });
-    mocks.leaveRoom.mockResolvedValue({ left: true });
+    mocks.leaveRoom.mockResolvedValue({});
     mocks.addMember.mockResolvedValue({
       member: {
         user: {
@@ -308,7 +308,7 @@ describe('createRoomCommandAPI', () => {
   });
 
   it('updates typing indicators through RoomService', async () => {
-    mocks.refreshTypingIndicator.mockResolvedValue({ updated: true });
+    mocks.refreshTypingIndicator.mockResolvedValue({});
 
     const api = createRoomCommandAPI({
       baseUrl: 'https://remote.example.test/api/connect',
@@ -324,8 +324,8 @@ describe('createRoomCommandAPI', () => {
   });
 
   it('sends ban and unban commands through RoomService', async () => {
-    mocks.banMember.mockResolvedValue({ banned: true });
-    mocks.unbanMember.mockResolvedValue({ unbanned: true });
+    mocks.banMember.mockResolvedValue({});
+    mocks.unbanMember.mockResolvedValue({});
 
     const api = createRoomCommandAPI({
       baseUrl: 'https://remote.example.test/api/connect',

--- a/apps/frontend/src/lib/api-client/account.ts
+++ b/apps/frontend/src/lib/api-client/account.ts
@@ -87,14 +87,13 @@ export function createAccountAPI(config: AccountAPIConfig) {
     },
 
     async deleteMyAccount(confirmationToken: string): Promise<boolean> {
-      return (
-        await client.deleteMyAccount(
-          { confirmationToken },
-          {
-            headers: headers()
-          }
-        )
-      ).deleted;
+      await client.deleteMyAccount(
+        { confirmationToken },
+        {
+          headers: headers()
+        }
+      );
+      return true;
     }
   };
 }

--- a/apps/frontend/src/lib/api-client/adminRoomLayout.ts
+++ b/apps/frontend/src/lib/api-client/adminRoomLayout.ts
@@ -163,8 +163,8 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
 
     async deleteRoomGroup(groupId: string): Promise<boolean> {
       try {
-        const response = await layout.deleteRoomGroup({ groupId }, { headers: headers() });
-        return response.deleted;
+        await layout.deleteRoomGroup({ groupId }, { headers: headers() });
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -284,8 +284,8 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
 
     async deleteSidebarLink(linkId: string): Promise<boolean> {
       try {
-        const response = await layout.deleteSidebarLink({ linkId }, { headers: headers() });
-        return response.deleted;
+        await layout.deleteSidebarLink({ linkId }, { headers: headers() });
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }

--- a/apps/frontend/src/lib/api-client/adminUsers.ts
+++ b/apps/frontend/src/lib/api-client/adminUsers.ts
@@ -175,13 +175,13 @@ export function createAdminUserManagementAPI(config: AdminUserManagementAPIConfi
     },
 
     async clearUsernameCooldown(userId: string): Promise<boolean> {
-      const response = await client.clearUsernameCooldown({ userId }, { headers: headers() });
-      return response.cleared;
+      await client.clearUsernameCooldown({ userId }, { headers: headers() });
+      return true;
     },
 
     async deleteUser(input: AdminDeleteUserInput): Promise<boolean> {
-      const response = await client.deleteUser(input, { headers: headers() });
-      return response.deleted;
+      await client.deleteUser(input, { headers: headers() });
+      return true;
     }
   };
 }

--- a/apps/frontend/src/lib/api-client/messages.ts
+++ b/apps/frontend/src/lib/api-client/messages.ts
@@ -125,8 +125,8 @@ export function createMessageAPI(config: MessageAPIConfig) {
 
     async deleteMessage(roomId: string, eventId: string): Promise<boolean> {
       try {
-        const response = await client.deleteMessage({ roomId, eventId }, { headers: headers() });
-        return response.deleted;
+        await client.deleteMessage({ roomId, eventId }, { headers: headers() });
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -138,11 +138,11 @@ export function createMessageAPI(config: MessageAPIConfig) {
       attachmentId: string
     ): Promise<boolean> {
       try {
-        const response = await client.deleteAttachment(
+        await client.deleteAttachment(
           { roomId, eventId, attachmentId },
           { headers: headers() }
         );
-        return response.deleted;
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -150,11 +150,11 @@ export function createMessageAPI(config: MessageAPIConfig) {
 
     async deleteLinkPreview(roomId: string, eventId: string, url: string): Promise<boolean> {
       try {
-        const response = await client.deleteLinkPreview(
+        await client.deleteLinkPreview(
           { roomId, eventId, url },
           { headers: headers() }
         );
-        return response.deleted;
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }

--- a/apps/frontend/src/lib/api-client/pushNotifications.ts
+++ b/apps/frontend/src/lib/api-client/pushNotifications.ts
@@ -37,17 +37,18 @@ export function createPushNotificationAPI(config: PushNotificationAPIConfig) {
       input: SubscribePushInput,
       options: PushRequestOptions = {}
     ): Promise<SubscribePushResult> {
-      const response = await client.subscribe(input, {
+      await client.subscribe(input, {
         headers: headers(),
         ...(options.signal ? { signal: options.signal } : {})
       });
       return {
-        subscribed: response.subscribed
+        subscribed: true
       };
     },
 
     async unsubscribe(endpoint: string): Promise<boolean> {
-      return (await client.unsubscribe({ endpoint }, { headers: headers() })).unsubscribed;
+      await client.unsubscribe({ endpoint }, { headers: headers() });
+      return true;
     },
 
     async deleteByCapability(
@@ -55,11 +56,13 @@ export function createPushNotificationAPI(config: PushNotificationAPIConfig) {
       auth: string,
       cleanupToken: string
     ): Promise<boolean> {
-      return (await cleanupClient.deleteSubscription({ endpoint, auth, cleanupToken })).completed;
+      await cleanupClient.deleteSubscription({ endpoint, auth, cleanupToken });
+      return true;
     },
 
     async sendTestNotification(): Promise<boolean> {
-      return (await client.sendTestNotification({}, { headers: headers() })).sent;
+      await client.sendTestNotification({}, { headers: headers() });
+      return true;
     }
   };
 }

--- a/apps/frontend/src/lib/api-client/roles.ts
+++ b/apps/frontend/src/lib/api-client/roles.ts
@@ -141,11 +141,11 @@ export function createRoleAPI(config: RoleAPIConfig) {
     },
 
     async deleteRole(name: string): Promise<boolean> {
-      const response = await adminClient.deleteRole(
+      await adminClient.deleteRole(
         { name },
         { headers: headers() },
       );
-      return response.deleted;
+      return true;
     },
   };
 }

--- a/apps/frontend/src/lib/api-client/rooms.ts
+++ b/apps/frontend/src/lib/api-client/rooms.ts
@@ -199,8 +199,8 @@ export function createRoomCommandAPI(config: ConnectAPIConfig) {
 
     async leaveRoom(roomId: string): Promise<boolean> {
       try {
-        const response = await rooms.leaveRoom({ roomId }, { headers: headers() });
-        return response.left;
+        await rooms.leaveRoom({ roomId }, { headers: headers() });
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -264,14 +264,14 @@ export function createRoomCommandAPI(config: ConnectAPIConfig) {
       threadRootEventId?: string | null
     ): Promise<boolean> {
       try {
-        const response = await rooms.refreshTypingIndicator(
+        await rooms.refreshTypingIndicator(
           {
             roomId,
             threadRootEventId: threadRootEventId ?? ''
           },
           { headers: headers() }
         );
-        return response.updated;
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -284,7 +284,7 @@ export function createRoomCommandAPI(config: ConnectAPIConfig) {
       expiresAt?: string | null;
     }): Promise<boolean> {
       try {
-        const response = await rooms.banMember(
+        await rooms.banMember(
           {
             roomId: input.roomId,
             userId: input.userId,
@@ -293,7 +293,7 @@ export function createRoomCommandAPI(config: ConnectAPIConfig) {
           },
           { headers: headers() }
         );
-        return response.banned;
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }
@@ -301,10 +301,10 @@ export function createRoomCommandAPI(config: ConnectAPIConfig) {
 
     async unbanMember(input: { roomId: string; userId: string; reason: string }): Promise<boolean> {
       try {
-        const response = await rooms.unbanMember(input, {
+        await rooms.unbanMember(input, {
           headers: headers()
         });
-        return response.unbanned;
+        return true;
       } catch (err) {
         return handleAuthError(config, err);
       }

--- a/cli/internal/connectapi/account.go
+++ b/cli/internal/connectapi/account.go
@@ -141,7 +141,7 @@ func (s *accountService) DeleteMyAccount(ctx context.Context, req *connect.Reque
 	if err := s.api.core.DeleteUser(ctx, caller.UserID, caller.UserID); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.DeleteMyAccountResponse{Deleted: true}), nil
+	return connect.NewResponse(&apiv1.DeleteMyAccountResponse{}), nil
 }
 
 func apiTimeFormatToCore(format apiv1.TimeFormat) evtv1.TimeFormat {

--- a/cli/internal/connectapi/account_server_services_test.go
+++ b/cli/internal/connectapi/account_server_services_test.go
@@ -484,9 +484,7 @@ func TestUserServiceAvatarAndMyAccountServiceDeletion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteMyAccount: %v", err)
 	}
-	if !deleteResp.Msg.GetDeleted() {
-		t.Fatal("Deleted = false, want true")
-	}
+	requireEmptyResponse(t, deleteResp.Msg)
 }
 
 func TestAccountDeletionRequiresDeleteSelfPermission(t *testing.T) {
@@ -524,9 +522,7 @@ func TestAccountDeletionRequiresDeleteSelfPermission(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteMyAccount with restored permission: %v", err)
 	}
-	if !deleteResp.Msg.GetDeleted() {
-		t.Fatal("Deleted = false, want true")
-	}
+	requireEmptyResponse(t, deleteResp.Msg)
 }
 
 func TestAdminUserServiceUpdatesUsersAndClearsCooldown(t *testing.T) {
@@ -733,9 +729,7 @@ func TestAdminUserServiceUpdatesUsersAndClearsCooldown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ClearUsernameCooldown: %v", err)
 	}
-	if !clearResp.Msg.GetCleared() {
-		t.Fatal("Cleared = false, want true")
-	}
+	requireEmptyResponse(t, clearResp.Msg)
 	if _, err := env.core.UpdateUserLogin(env.ctx, target.Id, "target-unblocked"); err != nil {
 		t.Fatalf("self rename after cooldown clear: %v", err)
 	}
@@ -745,9 +739,7 @@ func TestAdminUserServiceUpdatesUsersAndClearsCooldown(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteUser: %v", err)
 	}
-	if !deleteResp.Msg.GetDeleted() {
-		t.Fatal("Deleted = false, want true")
-	}
+	requireEmptyResponse(t, deleteResp.Msg)
 	if _, err := env.core.GetUser(env.ctx, target.Id); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("GetUser after DeleteUser err = %v, want not found", err)
 	}
@@ -774,9 +766,7 @@ func TestAdminUserServiceDeleteUserDoesNotRequireFreshCredential(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteUser with stale credential: %v", err)
 	}
-	if !deleteResp.Msg.GetDeleted() {
-		t.Fatal("Deleted = false, want true")
-	}
+	requireEmptyResponse(t, deleteResp.Msg)
 	if _, err := env.core.GetUser(env.ctx, target.Id); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("GetUser after DeleteUser err = %v, want not found", err)
 	}
@@ -792,9 +782,7 @@ func TestAdminUserServiceDeleteUserPreservesSelfTargetContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("self DeleteUser: %v", err)
 	}
-	if !deleteResp.Msg.GetDeleted() {
-		t.Fatal("Deleted = false, want true")
-	}
+	requireEmptyResponse(t, deleteResp.Msg)
 	if _, err := env.core.GetUser(env.ctx, env.viewer.Id); !errors.Is(err, core.ErrNotFound) {
 		t.Fatalf("GetUser after self DeleteUser err = %v, want not found", err)
 	}

--- a/cli/internal/connectapi/admin_room_layout.go
+++ b/cli/internal/connectapi/admin_room_layout.go
@@ -116,7 +116,7 @@ func (s *adminRoomLayoutService) DeleteRoomGroup(ctx context.Context, req *conne
 	if err := s.api.core.AdminDeleteRoomGroup(ctx, caller.UserID, req.Msg.GetGroupId()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.DeleteRoomGroupResponse{Deleted: true}), nil
+	return connect.NewResponse(&adminv1.DeleteRoomGroupResponse{}), nil
 }
 
 func (s *adminRoomLayoutService) ReorderRoomGroups(ctx context.Context, req *connect.Request[adminv1.ReorderRoomGroupsRequest]) (*connect.Response[adminv1.ReorderRoomGroupsResponse], error) {
@@ -249,7 +249,7 @@ func (s *adminRoomLayoutService) DeleteSidebarLink(ctx context.Context, req *con
 	if err := s.api.core.AdminDeleteSidebarLink(ctx, caller.UserID, req.Msg.GetLinkId()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.DeleteSidebarLinkResponse{Deleted: true}), nil
+	return connect.NewResponse(&adminv1.DeleteSidebarLinkResponse{}), nil
 }
 
 func (s *adminRoomLayoutService) MoveSidebarLinkToGroup(ctx context.Context, req *connect.Request[adminv1.MoveSidebarLinkToGroupRequest]) (*connect.Response[adminv1.MoveSidebarLinkToGroupResponse], error) {

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -374,9 +374,7 @@ func TestExternalIdentityFlowsAndAccountManagement(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DisconnectExternalIdentity: %v", err)
 	}
-	if !disconnected.Msg.GetDisconnected() {
-		t.Fatalf("DisconnectExternalIdentity disconnected = false")
-	}
+	requireEmptyResponse(t, disconnected.Msg)
 	found, err := env.core.GetUserByExternalIdentity(env.ctx, "discord-main", "abc123")
 	if err != nil {
 		t.Fatalf("GetUserByExternalIdentity after disconnect: %v", err)
@@ -1035,9 +1033,7 @@ func TestAdminRoleServiceManagesRoles(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteRole: %v", err)
 	}
-	if !deleteResp.Msg.GetDeleted() {
-		t.Fatal("DeleteRole Deleted = false, want true")
-	}
+	requireEmptyResponse(t, deleteResp.Msg)
 	if _, err := env.roles.DeleteRole(withCaller(env.ctx, env.viewer), connect.NewRequest(&adminv1.DeleteRoleRequest{Name: "triage"})); err != nil {
 		t.Fatalf("DeleteRole triage: %v", err)
 	}

--- a/cli/internal/connectapi/admin_user_management.go
+++ b/cli/internal/connectapi/admin_user_management.go
@@ -235,7 +235,7 @@ func (s *adminUserManagementService) ClearUsernameCooldown(ctx context.Context, 
 	if err := s.api.core.AdminClearLoginChangeCooldown(ctx, caller.UserID, req.Msg.GetUserId()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.ClearUsernameCooldownResponse{Cleared: true}), nil
+	return connect.NewResponse(&adminv1.ClearUsernameCooldownResponse{}), nil
 }
 
 func (s *adminUserManagementService) DeleteUser(ctx context.Context, req *connect.Request[adminv1.DeleteUserRequest]) (*connect.Response[adminv1.DeleteUserResponse], error) {
@@ -256,7 +256,7 @@ func (s *adminUserManagementService) DeleteUser(ctx context.Context, req *connec
 	if err := s.api.core.AdminDeleteUserAs(ctx, caller.UserID, req.Msg.GetUserId()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.DeleteUserResponse{Deleted: true}), nil
+	return connect.NewResponse(&adminv1.DeleteUserResponse{}), nil
 }
 
 func (s *adminUserManagementService) adminMember(ctx context.Context, member core.AdminMember) *adminv1.AdminMember {

--- a/cli/internal/connectapi/api_test_helpers_test.go
+++ b/cli/internal/connectapi/api_test_helpers_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+
 	"connectrpc.com/authn"
 	"connectrpc.com/connect"
 	"github.com/nats-io/nats.go"
@@ -404,4 +407,16 @@ func roomGroupItemsContainSidebarLink(items []*apiv1.RoomGroupItem, linkID strin
 		}
 	}
 	return false
+}
+
+// requireEmptyResponse checks the public JSON acknowledgement contract.
+func requireEmptyResponse(t testing.TB, response proto.Message) {
+	t.Helper()
+	data, err := protojson.Marshal(response)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	if string(data) != "{}" {
+		t.Fatalf("response JSON = %s, want {}", data)
+	}
 }

--- a/cli/internal/connectapi/external_identities.go
+++ b/cli/internal/connectapi/external_identities.go
@@ -160,7 +160,7 @@ func (s *externalIdentityAuthService) CancelExternalIdentityFlow(ctx context.Con
 	if err := s.api.core.DeletePendingExternalIdentityFlow(ctx, req.Msg.GetToken()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&authv1.CancelExternalIdentityFlowResponse{Cancelled: true}), nil
+	return connect.NewResponse(&authv1.CancelExternalIdentityFlowResponse{}), nil
 }
 
 func (s *accountService) ListExternalIdentities(ctx context.Context, _ *connect.Request[apiv1.ListExternalIdentitiesRequest]) (*connect.Response[apiv1.ListExternalIdentitiesResponse], error) {
@@ -214,7 +214,7 @@ func (s *accountService) DisconnectExternalIdentity(ctx context.Context, req *co
 	if err := s.api.core.DisconnectExternalIdentity(ctx, caller.UserID, req.Msg.GetSubjectHash()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.DisconnectExternalIdentityResponse{Disconnected: true}), nil
+	return connect.NewResponse(&apiv1.DisconnectExternalIdentityResponse{}), nil
 }
 
 func apiPendingExternalIdentity(flow *core.PendingExternalIdentityFlow) *authv1.PendingExternalIdentity {

--- a/cli/internal/connectapi/message_services_test.go
+++ b/cli/internal/connectapi/message_services_test.go
@@ -1349,9 +1349,7 @@ func TestMessageServiceDeleteMessageAuthorAndRBAC(t *testing.T) {
 	if err != nil {
 		t.Fatalf("moderator DeleteMessage: %v", err)
 	}
-	if !resp.Msg.Deleted {
-		t.Fatal("moderator DeleteMessage Deleted = false, want true")
-	}
+	requireEmptyResponse(t, resp.Msg)
 	if body, err := env.core.GetMessageBody(env.ctx, target.Id); err != nil || body != "" {
 		t.Fatalf("body after moderator delete = %q, %v; want empty, nil", body, err)
 	}
@@ -1466,9 +1464,7 @@ func TestRoomServiceRefreshTypingIndicatorRequiresMembershipOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("member RefreshTypingIndicator with post denied: %v", err)
 	}
-	if !resp.Msg.Updated {
-		t.Fatal("RefreshTypingIndicator Updated = false, want true")
-	}
+	requireEmptyResponse(t, resp.Msg)
 }
 
 func TestRoomAndThreadTimelineGetRoomEventsPaginatesWithOpaqueCursors(t *testing.T) {

--- a/cli/internal/connectapi/messages.go
+++ b/cli/internal/connectapi/messages.go
@@ -102,7 +102,7 @@ func (s *messageService) DeleteMessage(ctx context.Context, req *connect.Request
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.DeleteMessageResponse{Deleted: true}), nil
+	return connect.NewResponse(&apiv1.DeleteMessageResponse{}), nil
 }
 
 func (s *messageService) DeleteAttachment(ctx context.Context, req *connect.Request[apiv1.DeleteAttachmentRequest]) (*connect.Response[apiv1.DeleteAttachmentResponse], error) {
@@ -119,7 +119,7 @@ func (s *messageService) DeleteAttachment(ctx context.Context, req *connect.Requ
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.DeleteAttachmentResponse{Deleted: true}), nil
+	return connect.NewResponse(&apiv1.DeleteAttachmentResponse{}), nil
 }
 
 func (s *messageService) DeleteLinkPreview(ctx context.Context, req *connect.Request[apiv1.DeleteLinkPreviewRequest]) (*connect.Response[apiv1.DeleteLinkPreviewResponse], error) {
@@ -136,7 +136,7 @@ func (s *messageService) DeleteLinkPreview(ctx context.Context, req *connect.Req
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.DeleteLinkPreviewResponse{Deleted: true}), nil
+	return connect.NewResponse(&apiv1.DeleteLinkPreviewResponse{}), nil
 }
 
 func (s *messageService) hydratePostedEvent(ctx context.Context, viewerID string, kind core.RoomKind, event *evtv1.Event) (*apiv1.RoomTimelineEvent, error) {

--- a/cli/internal/connectapi/push_notifications.go
+++ b/cli/internal/connectapi/push_notifications.go
@@ -31,7 +31,7 @@ func (s *pushNotificationService) SendTestNotification(ctx context.Context, _ *c
 	if err := s.api.core.OnPushTestRequested(ctx, caller.UserID); err != nil {
 		return nil, connect.NewError(connect.CodeUnavailable, errors.New("push notification could not be delivered"))
 	}
-	return connect.NewResponse(&apiv1.SendTestNotificationResponse{Sent: true}), nil
+	return connect.NewResponse(&apiv1.SendTestNotificationResponse{}), nil
 }
 
 func (s *pushNotificationService) Subscribe(ctx context.Context, req *connect.Request[apiv1.SubscribeRequest]) (*connect.Response[apiv1.SubscribeResponse], error) {
@@ -58,7 +58,7 @@ func (s *pushNotificationService) Subscribe(ctx context.Context, req *connect.Re
 		return nil, connectError(err)
 	}
 
-	return connect.NewResponse(&apiv1.SubscribeResponse{Subscribed: true}), nil
+	return connect.NewResponse(&apiv1.SubscribeResponse{}), nil
 }
 
 func (s *pushNotificationService) Unsubscribe(ctx context.Context, req *connect.Request[apiv1.UnsubscribeRequest]) (*connect.Response[apiv1.UnsubscribeResponse], error) {
@@ -71,5 +71,5 @@ func (s *pushNotificationService) Unsubscribe(ctx context.Context, req *connect.
 		return nil, connectError(err)
 	}
 
-	return connect.NewResponse(&apiv1.UnsubscribeResponse{Unsubscribed: true}), nil
+	return connect.NewResponse(&apiv1.UnsubscribeResponse{}), nil
 }

--- a/cli/internal/connectapi/push_subscription_cleanup.go
+++ b/cli/internal/connectapi/push_subscription_cleanup.go
@@ -15,5 +15,5 @@ func (s *pushSubscriptionCleanupService) DeleteSubscription(ctx context.Context,
 	if err := s.api.core.DeletePushSubscriptionByCapability(ctx, req.Msg.GetEndpoint(), req.Msg.GetAuth(), req.Msg.GetCleanupToken()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&authv1.DeleteSubscriptionResponse{Completed: true}), nil
+	return connect.NewResponse(&authv1.DeleteSubscriptionResponse{}), nil
 }

--- a/cli/internal/connectapi/roles.go
+++ b/cli/internal/connectapi/roles.go
@@ -154,7 +154,7 @@ func (s *roleService) DeleteRole(ctx context.Context, req *connect.Request[admin
 	if err := s.api.core.AdminDeleteServerRole(ctx, caller.UserID, req.Msg.GetName()); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.DeleteRoleResponse{Deleted: true}), nil
+	return connect.NewResponse(&adminv1.DeleteRoleResponse{}), nil
 }
 
 func (s *roleService) ReorderRoles(ctx context.Context, req *connect.Request[adminv1.ReorderRolesRequest]) (*connect.Response[adminv1.ReorderRolesResponse], error) {

--- a/cli/internal/connectapi/room_services_test.go
+++ b/cli/internal/connectapi/room_services_test.go
@@ -358,9 +358,7 @@ func TestRoomServiceMembershipAndModerationCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BanMember: %v", err)
 	}
-	if !banResp.Msg.GetBanned() {
-		t.Fatalf("BanMember banned = false, want true")
-	}
+	requireEmptyResponse(t, banResp.Msg)
 	isTargetMember, err := env.core.RoomMembershipExists(env.ctx, core.KindChannel, target.Id, room.Id)
 	if err != nil {
 		t.Fatalf("RoomMembershipExists target after ban: %v", err)
@@ -421,9 +419,7 @@ func TestRoomServiceMembershipAndModerationCommands(t *testing.T) {
 	if err != nil {
 		t.Fatalf("UnbanMember: %v", err)
 	}
-	if !unbanResp.Msg.GetUnbanned() {
-		t.Fatalf("UnbanMember unbanned = false, want true")
-	}
+	requireEmptyResponse(t, unbanResp.Msg)
 	afterUnbanResp, err := env.rooms.ListBans(ctx, connect.NewRequest(&apiv1.ListBansRequest{}))
 	if err != nil {
 		t.Fatalf("ListBans after unban: %v", err)
@@ -2216,9 +2212,7 @@ func TestPushNotificationServiceSubscribeAndUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Subscribe: %v", err)
 	}
-	if !subResp.Msg.GetSubscribed() {
-		t.Fatalf("Subscribe response = %+v, want subscription acknowledgement", subResp.Msg)
-	}
+	requireEmptyResponse(t, subResp.Msg)
 	subs, err := env.core.GetUserPushSubscriptions(env.ctx, env.viewer.Id)
 	if err != nil {
 		t.Fatalf("GetUserPushSubscriptions: %v", err)
@@ -2238,8 +2232,9 @@ func TestPushNotificationServiceSubscribeAndUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SendTestNotification: %v", err)
 	}
-	if !testResp.Msg.GetSent() || testPushCalls != 1 {
-		t.Fatalf("SendTestNotification sent = %v, callback calls = %d", testResp.Msg.GetSent(), testPushCalls)
+	requireEmptyResponse(t, testResp.Msg)
+	if testPushCalls != 1 {
+		t.Fatalf("SendTestNotification callback calls = %d, want 1", testPushCalls)
 	}
 	if _, err := env.push.SendTestNotification(ctx, connect.NewRequest(&apiv1.SendTestNotificationRequest{})); connect.CodeOf(err) != connect.CodeResourceExhausted {
 		t.Fatalf("repeated SendTestNotification code = %v, want resource_exhausted", connect.CodeOf(err))
@@ -2253,9 +2248,7 @@ func TestPushNotificationServiceSubscribeAndUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unsubscribe: %v", err)
 	}
-	if !unsubResp.Msg.GetUnsubscribed() {
-		t.Fatal("Unsubscribe unsubscribed = false, want true")
-	}
+	requireEmptyResponse(t, unsubResp.Msg)
 	subs, err = env.core.GetUserPushSubscriptions(env.ctx, env.viewer.Id)
 	if err != nil {
 		t.Fatalf("GetUserPushSubscriptions after unsubscribe: %v", err)
@@ -2283,9 +2276,7 @@ func TestPushNotificationServiceSubscribeAndUnsubscribe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("capability-authenticated DeleteSubscription: %v", err)
 	}
-	if !cleanupResp.Msg.GetCompleted() {
-		t.Fatal("DeleteSubscription completed = false, want true")
-	}
+	requireEmptyResponse(t, cleanupResp.Msg)
 	if owned, err := env.core.PushSubscriptionOwnedByUser(env.ctx, env.viewer.Id, capabilityEndpoint); err != nil || owned {
 		t.Fatalf("capability cleanup ownership = %t, err = %v", owned, err)
 	}

--- a/cli/internal/connectapi/rooms.go
+++ b/cli/internal/connectapi/rooms.go
@@ -169,7 +169,7 @@ func (s *roomService) LeaveRoom(ctx context.Context, req *connect.Request[apiv1.
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.LeaveRoomResponse{Left: true}), nil
+	return connect.NewResponse(&apiv1.LeaveRoomResponse{}), nil
 }
 
 func (s *roomService) AddMember(ctx context.Context, req *connect.Request[apiv1.AddMemberRequest]) (*connect.Response[apiv1.AddMemberResponse], error) {
@@ -266,7 +266,7 @@ func (s *roomService) RefreshTypingIndicator(ctx context.Context, req *connect.R
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.RefreshTypingIndicatorResponse{Updated: true}), nil
+	return connect.NewResponse(&apiv1.RefreshTypingIndicatorResponse{}), nil
 }
 
 func (s *roomService) BanMember(ctx context.Context, req *connect.Request[apiv1.BanMemberRequest]) (*connect.Response[apiv1.BanMemberResponse], error) {
@@ -289,7 +289,7 @@ func (s *roomService) BanMember(ctx context.Context, req *connect.Request[apiv1.
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.BanMemberResponse{Banned: true}), nil
+	return connect.NewResponse(&apiv1.BanMemberResponse{}), nil
 }
 
 func (s *roomService) UnbanMember(ctx context.Context, req *connect.Request[apiv1.UnbanMemberRequest]) (*connect.Response[apiv1.UnbanMemberResponse], error) {
@@ -305,7 +305,7 @@ func (s *roomService) UnbanMember(ctx context.Context, req *connect.Request[apiv
 	}); err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&apiv1.UnbanMemberResponse{Unbanned: true}), nil
+	return connect.NewResponse(&apiv1.UnbanMemberResponse{}), nil
 }
 
 func (s *roomService) apiRoomBan(ctx context.Context, ban core.RoomBan) (*apiv1.RoomBan, error) {

--- a/cli/internal/http_server/connect_test.go
+++ b/cli/internal/http_server/connect_test.go
@@ -664,7 +664,7 @@ func TestConnectPushSubscriptionCapabilityCleanupIsPublic(t *testing.T) {
 		t.Fatalf("SavePushSubscriptionWithCleanupToken: %v", err)
 	}
 
-	cleanupClient := authv1connect.NewPushSubscriptionCleanupServiceClient(ts.Client(), ts.URL+connectAPIPrefix)
+	cleanupClient := authv1connect.NewPushSubscriptionCleanupServiceClient(ts.Client(), ts.URL+connectAPIPrefix, connect.WithProtoJSON())
 	cleanup, err := cleanupClient.DeleteSubscription(ctx, connect.NewRequest(&authv1.DeleteSubscriptionRequest{
 		Endpoint:     endpoint,
 		Auth:         auth,
@@ -673,8 +673,8 @@ func TestConnectPushSubscriptionCapabilityCleanupIsPublic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unauthenticated DeleteSubscription: %v", err)
 	}
-	if !cleanup.Msg.GetCompleted() {
-		t.Fatal("DeleteSubscription completed = false, want true")
+	if data, err := protojson.Marshal(cleanup.Msg); err != nil || string(data) != "{}" {
+		t.Fatalf("DeleteSubscription JSON = %s, err = %v; want {}", data, err)
 	}
 	if owned, err := s.core.PushSubscriptionOwnedByUser(ctx, user.GetId(), endpoint); err != nil || owned {
 		t.Fatalf("subscription ownership after cleanup = %t, err = %v", owned, err)

--- a/cli/internal/pb/chatto/admin/v1/members.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/members.pb.go
@@ -1040,9 +1040,7 @@ func (x *ClearUsernameCooldownRequest) GetUserId() string {
 
 // Result of clearing a user's username-change cooldown.
 type ClearUsernameCooldownResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the request completed.
-	Cleared       bool `protobuf:"varint,1,opt,name=cleared,proto3" json:"cleared,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1075,13 +1073,6 @@ func (x *ClearUsernameCooldownResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use ClearUsernameCooldownResponse.ProtoReflect.Descriptor instead.
 func (*ClearUsernameCooldownResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_admin_v1_members_proto_rawDescGZIP(), []int{16}
-}
-
-func (x *ClearUsernameCooldownResponse) GetCleared() bool {
-	if x != nil {
-		return x.Cleared
-	}
-	return false
 }
 
 // Request to delete a user account as a server-admin action.
@@ -1132,9 +1123,7 @@ func (x *DeleteUserRequest) GetUserId() string {
 
 // Result of deleting a user account.
 type DeleteUserResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the user was deleted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1167,13 +1156,6 @@ func (x *DeleteUserResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteUserResponse.ProtoReflect.Descriptor instead.
 func (*DeleteUserResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_admin_v1_members_proto_rawDescGZIP(), []int{18}
-}
-
-func (x *DeleteUserResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 var File_chatto_admin_v1_members_proto protoreflect.FileDescriptor
@@ -1247,13 +1229,11 @@ const file_chatto_admin_v1_members_proto_rawDesc = "" +
 	"\x1aChangeUserPasswordResponse\x124\n" +
 	"\x06member\x18\x01 \x01(\v2\x1c.chatto.admin.v1.AdminMemberR\x06member\"@\n" +
 	"\x1cClearUsernameCooldownRequest\x12 \n" +
-	"\auser_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userId\"9\n" +
-	"\x1dClearUsernameCooldownResponse\x12\x18\n" +
-	"\acleared\x18\x01 \x01(\bR\acleared\"M\n" +
+	"\auser_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userId\".\n" +
+	"\x1dClearUsernameCooldownResponseJ\x04\b\x01\x10\x02R\acleared\"M\n" +
 	"\x11DeleteUserRequest\x12 \n" +
-	"\auser_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userIdJ\x04\b\x02\x10\x03R\x10current_password\".\n" +
-	"\x12DeleteUserResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted2\xe9\x06\n" +
+	"\auser_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userIdJ\x04\b\x02\x10\x03R\x10current_password\"#\n" +
+	"\x12DeleteUserResponseJ\x04\b\x01\x10\x02R\adeleted2\xe9\x06\n" +
 	"\x10AdminUserService\x12X\n" +
 	"\vListMembers\x12#.chatto.admin.v1.ListMembersRequest\x1a$.chatto.admin.v1.ListMembersResponse\x12R\n" +
 	"\tGetMember\x12!.chatto.admin.v1.GetMemberRequest\x1a\".chatto.admin.v1.GetMemberResponse\x12d\n" +

--- a/cli/internal/pb/chatto/admin/v1/roles.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/roles.pb.go
@@ -606,9 +606,7 @@ func (x *DeleteRoleRequest) GetName() string {
 
 // Result of deleting a role.
 type DeleteRoleResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the request completed.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -641,13 +639,6 @@ func (x *DeleteRoleResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteRoleResponse.ProtoReflect.Descriptor instead.
 func (*DeleteRoleResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{10}
-}
-
-func (x *DeleteRoleResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 // Request to replace custom role order.
@@ -784,9 +775,8 @@ const file_chatto_admin_v1_roles_proto_rawDesc = "" +
 	"\x12UpdateRoleResponse\x12.\n" +
 	"\x04role\x18\x01 \x01(\v2\x1a.chatto.admin.v1.AdminRoleR\x04role\"0\n" +
 	"\x11DeleteRoleRequest\x12\x1b\n" +
-	"\x04name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04name\".\n" +
-	"\x12DeleteRoleResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"E\n" +
+	"\x04name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04name\"#\n" +
+	"\x12DeleteRoleResponseJ\x04\b\x01\x10\x02R\adeleted\"E\n" +
 	"\x13ReorderRolesRequest\x12.\n" +
 	"\n" +
 	"role_names\x18\x01 \x03(\tB\x0f\xbaH\f\x92\x01\t\x10\xe8\a\"\x04r\x02\x10\x01R\troleNames\"H\n" +

--- a/cli/internal/pb/chatto/admin/v1/room_layout.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/room_layout.pb.go
@@ -876,9 +876,7 @@ func (x *DeleteRoomGroupRequest) GetGroupId() string {
 
 // Result of deleting a room group.
 type DeleteRoomGroupResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the room group was deleted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -911,13 +909,6 @@ func (x *DeleteRoomGroupResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteRoomGroupResponse.ProtoReflect.Descriptor instead.
 func (*DeleteRoomGroupResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_admin_v1_room_layout_proto_rawDescGZIP(), []int{14}
-}
-
-func (x *DeleteRoomGroupResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 // Request to replace the global room group order.
@@ -1709,9 +1700,7 @@ func (x *DeleteSidebarLinkRequest) GetLinkId() string {
 
 // Result of deleting a sidebar link.
 type DeleteSidebarLinkResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the sidebar link was deleted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1744,13 +1733,6 @@ func (x *DeleteSidebarLinkResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteSidebarLinkResponse.ProtoReflect.Descriptor instead.
 func (*DeleteSidebarLinkResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_admin_v1_room_layout_proto_rawDescGZIP(), []int{30}
-}
-
-func (x *DeleteSidebarLinkResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 // Request to move a sidebar link to another room group.
@@ -1904,9 +1886,8 @@ const file_chatto_admin_v1_room_layout_proto_rawDesc = "" +
 	"\x17UpdateRoomGroupResponse\x12;\n" +
 	"\x05group\x18\x01 \x01(\v2%.chatto.admin.v1.AdminRoomLayoutGroupR\x05group\"<\n" +
 	"\x16DeleteRoomGroupRequest\x12\"\n" +
-	"\bgroup_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\agroupId\"3\n" +
-	"\x17DeleteRoomGroupResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"Y\n" +
+	"\bgroup_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\agroupId\"(\n" +
+	"\x17DeleteRoomGroupResponseJ\x04\b\x01\x10\x02R\adeleted\"Y\n" +
 	"\x18ReorderRoomGroupsRequest\x12=\n" +
 	"\x11ordered_group_ids\x18\x01 \x03(\tB\x11\xbaH\x0e\x92\x01\v\b\x01\x10\xe8\a\"\x04r\x02\x10\x01R\x0forderedGroupIds\"Z\n" +
 	"\x19ReorderRoomGroupsResponse\x12=\n" +
@@ -1952,9 +1933,8 @@ const file_chatto_admin_v1_room_layout_proto_rawDesc = "" +
 	"\x19UpdateSidebarLinkResponse\x12=\n" +
 	"\fsidebar_link\x18\x01 \x01(\v2\x1a.chatto.api.v1.SidebarLinkR\vsidebarLink\"<\n" +
 	"\x18DeleteSidebarLinkRequest\x12 \n" +
-	"\alink_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06linkId\"5\n" +
-	"\x19DeleteSidebarLinkResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"e\n" +
+	"\alink_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06linkId\"*\n" +
+	"\x19DeleteSidebarLinkResponseJ\x04\b\x01\x10\x02R\adeleted\"e\n" +
 	"\x1dMoveSidebarLinkToGroupRequest\x12 \n" +
 	"\alink_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06linkId\x12\"\n" +
 	"\bgroup_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\agroupId\"_\n" +

--- a/cli/internal/pb/chatto/api/v1/account.pb.go
+++ b/cli/internal/pb/chatto/api/v1/account.pb.go
@@ -507,9 +507,7 @@ func (x *DeleteMyAccountRequest) GetConfirmationToken() string {
 
 // Result of deleting the authenticated account.
 type DeleteMyAccountResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the account was deleted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -542,13 +540,6 @@ func (x *DeleteMyAccountResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteMyAccountResponse.ProtoReflect.Descriptor instead.
 func (*DeleteMyAccountResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_account_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *DeleteMyAccountResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 var File_chatto_api_v1_account_proto protoreflect.FileDescriptor
@@ -589,9 +580,8 @@ const file_chatto_api_v1_account_proto_rawDesc = "" +
 	"\x1eRequestAccountDeletionResponse\x12-\n" +
 	"\x12confirmation_token\x18\x01 \x01(\tR\x11confirmationToken\"G\n" +
 	"\x16DeleteMyAccountRequest\x12-\n" +
-	"\x12confirmation_token\x18\x01 \x01(\tR\x11confirmationToken\"3\n" +
-	"\x17DeleteMyAccountResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted2\xa8\t\n" +
+	"\x12confirmation_token\x18\x01 \x01(\tR\x11confirmationToken\"(\n" +
+	"\x17DeleteMyAccountResponseJ\x04\b\x01\x10\x02R\adeleted2\xa8\t\n" +
 	"\x10MyAccountService\x12Z\n" +
 	"\rUpdateProfile\x12#.chatto.api.v1.UpdateProfileRequest\x1a$.chatto.api.v1.UpdateProfileResponse\x12]\n" +
 	"\x0eChangePassword\x12$.chatto.api.v1.ChangePasswordRequest\x1a%.chatto.api.v1.ChangePasswordResponse\x12]\n" +

--- a/cli/internal/pb/chatto/api/v1/external_identities.pb.go
+++ b/cli/internal/pb/chatto/api/v1/external_identities.pb.go
@@ -430,9 +430,7 @@ func (x *DisconnectExternalIdentityRequest) GetCurrentPassword() string {
 
 // Result of disconnecting a provider identity.
 type DisconnectExternalIdentityResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the identity was disconnected.
-	Disconnected  bool `protobuf:"varint,1,opt,name=disconnected,proto3" json:"disconnected,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -467,13 +465,6 @@ func (*DisconnectExternalIdentityResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_external_identities_proto_rawDescGZIP(), []int{7}
 }
 
-func (x *DisconnectExternalIdentityResponse) GetDisconnected() bool {
-	if x != nil {
-		return x.Disconnected
-	}
-	return false
-}
-
 var File_chatto_api_v1_external_identities_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_external_identities_proto_rawDesc = "" +
@@ -503,9 +494,8 @@ const file_chatto_api_v1_external_identities_proto_rawDesc = "" +
 	"\tstart_url\x18\x01 \x01(\tR\bstartUrl\"z\n" +
 	"!DisconnectExternalIdentityRequest\x12*\n" +
 	"\fsubject_hash\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\vsubjectHash\x12)\n" +
-	"\x10current_password\x18\x02 \x01(\tR\x0fcurrentPassword\"H\n" +
-	"\"DisconnectExternalIdentityResponse\x12\"\n" +
-	"\fdisconnected\x18\x01 \x01(\bR\fdisconnectedB\xb3\x01\n" +
+	"\x10current_password\x18\x02 \x01(\tR\x0fcurrentPassword\"8\n" +
+	"\"DisconnectExternalIdentityResponseJ\x04\b\x01\x10\x02R\fdisconnectedB\xb3\x01\n" +
 	"\x11com.chatto.api.v1B\x17ExternalIdentitiesProtoP\x01Z/hmans.de/chatto/internal/pb/chatto/api/v1;apiv1\xa2\x02\x03CAX\xaa\x02\rChatto.Api.V1\xca\x02\rChatto\\Api\\V1\xe2\x02\x19Chatto\\Api\\V1\\GPBMetadata\xea\x02\x0fChatto::Api::V1b\x06proto3"
 
 var (

--- a/cli/internal/pb/chatto/api/v1/messages.pb.go
+++ b/cli/internal/pb/chatto/api/v1/messages.pb.go
@@ -373,9 +373,7 @@ func (x *DeleteMessageRequest) GetEventId() string {
 
 // Result of retracting a message.
 type DeleteMessageResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the delete/retract request was accepted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -408,13 +406,6 @@ func (x *DeleteMessageResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteMessageResponse.ProtoReflect.Descriptor instead.
 func (*DeleteMessageResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_messages_proto_rawDescGZIP(), []int{5}
-}
-
-func (x *DeleteMessageResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 // Request to remove one attachment from a message.
@@ -483,9 +474,7 @@ func (x *DeleteAttachmentRequest) GetAttachmentId() string {
 
 // Result of removing one attachment from a message.
 type DeleteAttachmentResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the attachment removal was accepted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -518,13 +507,6 @@ func (x *DeleteAttachmentResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteAttachmentResponse.ProtoReflect.Descriptor instead.
 func (*DeleteAttachmentResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_messages_proto_rawDescGZIP(), []int{7}
-}
-
-func (x *DeleteAttachmentResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 // Request to remove the accepted link preview from a message.
@@ -593,9 +575,7 @@ func (x *DeleteLinkPreviewRequest) GetUrl() string {
 
 // Result of removing a link preview from a message.
 type DeleteLinkPreviewResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the link preview removal was accepted.
-	Deleted       bool `protobuf:"varint,1,opt,name=deleted,proto3" json:"deleted,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -628,13 +608,6 @@ func (x *DeleteLinkPreviewResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use DeleteLinkPreviewResponse.ProtoReflect.Descriptor instead.
 func (*DeleteLinkPreviewResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_messages_proto_rawDescGZIP(), []int{9}
-}
-
-func (x *DeleteLinkPreviewResponse) GetDeleted() bool {
-	if x != nil {
-		return x.Deleted
-	}
-	return false
 }
 
 // Request to read one visible message.
@@ -873,21 +846,18 @@ const file_chatto_api_v1_messages_proto_rawDesc = "" +
 	"\amessage\x18\x02 \x01(\v2\x16.chatto.api.v1.MessageR\amessageJ\x04\b\x01\x10\x02J\x04\b\x03\x10\x04R\aupdatedR\bincludes\"\\\n" +
 	"\x14DeleteMessageRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\"\n" +
-	"\bevent_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aeventId\"1\n" +
-	"\x15DeleteMessageResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"\x8d\x01\n" +
+	"\bevent_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aeventId\"&\n" +
+	"\x15DeleteMessageResponseJ\x04\b\x01\x10\x02R\adeleted\"\x8d\x01\n" +
 	"\x17DeleteAttachmentRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\"\n" +
 	"\bevent_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aeventId\x12,\n" +
-	"\rattachment_id\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\fattachmentId\"4\n" +
-	"\x18DeleteAttachmentResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"{\n" +
+	"\rattachment_id\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\fattachmentId\")\n" +
+	"\x18DeleteAttachmentResponseJ\x04\b\x01\x10\x02R\adeleted\"{\n" +
 	"\x18DeleteLinkPreviewRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\"\n" +
 	"\bevent_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aeventId\x12\x19\n" +
-	"\x03url\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x03url\"5\n" +
-	"\x19DeleteLinkPreviewResponse\x12\x18\n" +
-	"\adeleted\x18\x01 \x01(\bR\adeleted\"j\n" +
+	"\x03url\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x03url\"*\n" +
+	"\x19DeleteLinkPreviewResponseJ\x04\b\x01\x10\x02R\adeleted\"j\n" +
 	"\x11GetMessageRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12\"\n" +
 	"\bevent_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\aeventIdJ\x04\b\x03\x10\x04R\tthumbnail\"V\n" +

--- a/cli/internal/pb/chatto/api/v1/push_notifications.pb.go
+++ b/cli/internal/pb/chatto/api/v1/push_notifications.pb.go
@@ -120,9 +120,7 @@ func (x *SubscribeRequest) GetCleanupToken() string {
 
 // Response from storing a browser push subscription.
 type SubscribeResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the subscription was stored.
-	Subscribed    bool `protobuf:"varint,1,opt,name=subscribed,proto3" json:"subscribed,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -155,13 +153,6 @@ func (x *SubscribeResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use SubscribeResponse.ProtoReflect.Descriptor instead.
 func (*SubscribeResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_push_notifications_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *SubscribeResponse) GetSubscribed() bool {
-	if x != nil {
-		return x.Subscribed
-	}
-	return false
 }
 
 // Request to remove a browser push subscription.
@@ -212,9 +203,7 @@ func (x *UnsubscribeRequest) GetEndpoint() string {
 
 // Response from removing a browser push subscription.
 type UnsubscribeResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the request completed.
-	Unsubscribed  bool `protobuf:"varint,1,opt,name=unsubscribed,proto3" json:"unsubscribed,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -247,13 +236,6 @@ func (x *UnsubscribeResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use UnsubscribeResponse.ProtoReflect.Descriptor instead.
 func (*UnsubscribeResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_push_notifications_proto_rawDescGZIP(), []int{3}
-}
-
-func (x *UnsubscribeResponse) GetUnsubscribed() bool {
-	if x != nil {
-		return x.Unsubscribed
-	}
-	return false
 }
 
 // Request to test the current user's registered browser push subscriptions.
@@ -295,9 +277,7 @@ func (*SendTestNotificationRequest) Descriptor() ([]byte, []int) {
 
 // Result of sending a test Web Push notification.
 type SendTestNotificationResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the push provider accepted the notification.
-	Sent          bool `protobuf:"varint,1,opt,name=sent,proto3" json:"sent,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -332,13 +312,6 @@ func (*SendTestNotificationResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_push_notifications_proto_rawDescGZIP(), []int{5}
 }
 
-func (x *SendTestNotificationResponse) GetSent() bool {
-	if x != nil {
-		return x.Sent
-	}
-	return false
-}
-
 var File_chatto_api_v1_push_notifications_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_push_notifications_proto_rawDesc = "" +
@@ -358,19 +331,15 @@ const file_chatto_api_v1_push_notifications_proto_rawDesc = "" +
 	"clientHost\x12/\n" +
 	"\rcleanup_token\x18\x06 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10 \x18\x80\x01R\fcleanupTokenB\r\n" +
-	"\v_user_agent\"3\n" +
-	"\x11SubscribeResponse\x12\x1e\n" +
-	"\n" +
-	"subscribed\x18\x01 \x01(\bR\n" +
+	"\v_user_agent\"%\n" +
+	"\x11SubscribeResponseJ\x04\b\x01\x10\x02R\n" +
 	"subscribed\"<\n" +
 	"\x12UnsubscribeRequest\x12&\n" +
 	"\bendpoint\x18\x01 \x01(\tB\n" +
-	"\xbaH\ar\x05\x10\x01\x18\x80 R\bendpoint\"9\n" +
-	"\x13UnsubscribeResponse\x12\"\n" +
-	"\funsubscribed\x18\x01 \x01(\bR\funsubscribed\"\x1d\n" +
-	"\x1bSendTestNotificationRequest\"2\n" +
-	"\x1cSendTestNotificationResponse\x12\x12\n" +
-	"\x04sent\x18\x01 \x01(\bR\x04sent2\xb5\x02\n" +
+	"\xbaH\ar\x05\x10\x01\x18\x80 R\bendpoint\")\n" +
+	"\x13UnsubscribeResponseJ\x04\b\x01\x10\x02R\funsubscribed\"\x1d\n" +
+	"\x1bSendTestNotificationRequest\"*\n" +
+	"\x1cSendTestNotificationResponseJ\x04\b\x01\x10\x02R\x04sent2\xb5\x02\n" +
 	"\x17PushNotificationService\x12N\n" +
 	"\tSubscribe\x12\x1f.chatto.api.v1.SubscribeRequest\x1a .chatto.api.v1.SubscribeResponse\x12Y\n" +
 	"\vUnsubscribe\x12!.chatto.api.v1.UnsubscribeRequest\x1a\".chatto.api.v1.UnsubscribeResponse\"\x03\x90\x02\x02\x12o\n" +

--- a/cli/internal/pb/chatto/api/v1/rooms.pb.go
+++ b/cli/internal/pb/chatto/api/v1/rooms.pb.go
@@ -1064,9 +1064,7 @@ func (x *LeaveRoomRequest) GetRoomId() string {
 
 // Result of leaving a room.
 type LeaveRoomResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the current user is no longer an explicit member after the call.
-	Left          bool `protobuf:"varint,1,opt,name=left,proto3" json:"left,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1099,13 +1097,6 @@ func (x *LeaveRoomResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use LeaveRoomResponse.ProtoReflect.Descriptor instead.
 func (*LeaveRoomResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{17}
-}
-
-func (x *LeaveRoomResponse) GetLeft() bool {
-	if x != nil {
-		return x.Left
-	}
-	return false
 }
 
 // Request to add a user to a channel room.
@@ -1385,9 +1376,7 @@ func (x *BanMemberRequest) GetExpiresAt() *timestamppb.Timestamp {
 
 // Result of banning a room member.
 type BanMemberResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the ban operation completed.
-	Banned        bool `protobuf:"varint,1,opt,name=banned,proto3" json:"banned,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1420,13 +1409,6 @@ func (x *BanMemberResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use BanMemberResponse.ProtoReflect.Descriptor instead.
 func (*BanMemberResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{23}
-}
-
-func (x *BanMemberResponse) GetBanned() bool {
-	if x != nil {
-		return x.Banned
-	}
-	return false
 }
 
 // Request to remove a channel room ban.
@@ -1495,9 +1477,7 @@ func (x *UnbanMemberRequest) GetReason() string {
 
 // Result of removing a room ban.
 type UnbanMemberResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the unban operation completed.
-	Unbanned      bool `protobuf:"varint,1,opt,name=unbanned,proto3" json:"unbanned,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1530,13 +1510,6 @@ func (x *UnbanMemberResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use UnbanMemberResponse.ProtoReflect.Descriptor instead.
 func (*UnbanMemberResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{25}
-}
-
-func (x *UnbanMemberResponse) GetUnbanned() bool {
-	if x != nil {
-		return x.Unbanned
-	}
-	return false
 }
 
 // Active channel room ban with optional hydrated room and user references.
@@ -2321,9 +2294,7 @@ func (x *RefreshTypingIndicatorRequest) GetThreadRootEventId() string {
 
 // Result of refreshing a typing indicator.
 type RefreshTypingIndicatorResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the typing indicator was accepted for publish.
-	Updated       bool `protobuf:"varint,1,opt,name=updated,proto3" json:"updated,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2356,13 +2327,6 @@ func (x *RefreshTypingIndicatorResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use RefreshTypingIndicatorResponse.ProtoReflect.Descriptor instead.
 func (*RefreshTypingIndicatorResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_rooms_proto_rawDescGZIP(), []int{39}
-}
-
-func (x *RefreshTypingIndicatorResponse) GetUpdated() bool {
-	if x != nil {
-		return x.Updated
-	}
-	return false
 }
 
 var File_chatto_api_v1_rooms_proto protoreflect.FileDescriptor
@@ -2430,9 +2394,8 @@ const file_chatto_api_v1_rooms_proto_rawDesc = "" +
 	"\x0fStartDMResponse\x12'\n" +
 	"\x04room\x18\x01 \x01(\v2\x13.chatto.api.v1.RoomR\x04room\"4\n" +
 	"\x10LeaveRoomRequest\x12 \n" +
-	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\"'\n" +
-	"\x11LeaveRoomResponse\x12\x12\n" +
-	"\x04left\x18\x01 \x01(\bR\x04left\"V\n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\"\x1f\n" +
+	"\x11LeaveRoomResponseJ\x04\b\x01\x10\x02R\x04left\"V\n" +
 	"\x10AddMemberRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12 \n" +
 	"\auser_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userId\"K\n" +
@@ -2449,16 +2412,14 @@ const file_chatto_api_v1_rooms_proto_rawDesc = "" +
 	"\x06reason\x18\x03 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10\x01\x18\xe8\aR\x06reason\x129\n" +
 	"\n" +
-	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"+\n" +
-	"\x11BanMemberResponse\x12\x16\n" +
-	"\x06banned\x18\x01 \x01(\bR\x06banned\"|\n" +
+	"expires_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\"!\n" +
+	"\x11BanMemberResponseJ\x04\b\x01\x10\x02R\x06banned\"|\n" +
 	"\x12UnbanMemberRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12 \n" +
 	"\auser_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userId\x12\"\n" +
 	"\x06reason\x18\x03 \x01(\tB\n" +
-	"\xbaH\ar\x05\x10\x01\x18\xe8\aR\x06reason\"1\n" +
-	"\x13UnbanMemberResponse\x12\x1a\n" +
-	"\bunbanned\x18\x01 \x01(\bR\bunbanned\"\x97\x03\n" +
+	"\xbaH\ar\x05\x10\x01\x18\xe8\aR\x06reason\"%\n" +
+	"\x13UnbanMemberResponseJ\x04\b\x01\x10\x02R\bunbanned\"\x97\x03\n" +
 	"\aRoomBan\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x17\n" +
 	"\aroom_id\x18\x02 \x01(\tR\x06roomId\x12'\n" +
@@ -2507,9 +2468,8 @@ const file_chatto_api_v1_rooms_proto_rawDesc = "" +
 	"\adeleted\x18\x01 \x01(\bR\adeleted\"r\n" +
 	"\x1dRefreshTypingIndicatorRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x12/\n" +
-	"\x14thread_root_event_id\x18\x02 \x01(\tR\x11threadRootEventId\":\n" +
-	"\x1eRefreshTypingIndicatorResponse\x12\x18\n" +
-	"\aupdated\x18\x01 \x01(\bR\aupdated*N\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tR\x11threadRootEventId\"/\n" +
+	"\x1eRefreshTypingIndicatorResponseJ\x04\b\x01\x10\x02R\aupdated*N\n" +
 	"\bRoomKind\x12\x19\n" +
 	"\x15ROOM_KIND_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11ROOM_KIND_CHANNEL\x10\x01\x12\x10\n" +

--- a/cli/internal/pb/chatto/auth/v1/external_identity_auth.pb.go
+++ b/cli/internal/pb/chatto/auth/v1/external_identity_auth.pb.go
@@ -492,9 +492,7 @@ func (x *CancelExternalIdentityFlowRequest) GetToken() string {
 
 // Result of cancelling a pending external identity flow.
 type CancelExternalIdentityFlowResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when a pending flow was removed or already absent.
-	Cancelled     bool `protobuf:"varint,1,opt,name=cancelled,proto3" json:"cancelled,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -527,13 +525,6 @@ func (x *CancelExternalIdentityFlowResponse) ProtoReflect() protoreflect.Message
 // Deprecated: Use CancelExternalIdentityFlowResponse.ProtoReflect.Descriptor instead.
 func (*CancelExternalIdentityFlowResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_auth_v1_external_identity_auth_proto_rawDescGZIP(), []int{6}
-}
-
-func (x *CancelExternalIdentityFlowResponse) GetCancelled() bool {
-	if x != nil {
-		return x.Cancelled
-	}
-	return false
 }
 
 // Request to confirm a pending provider link using the flow capability token.
@@ -662,9 +653,8 @@ const file_chatto_auth_v1_external_identity_auth_proto_rawDesc = "" +
 	"expires_in\x18\x05 \x01(\x03R\texpiresIn\x127\n" +
 	"\x18refresh_token_expires_in\x18\x06 \x01(\x03R\x15refreshTokenExpiresIn\"B\n" +
 	"!CancelExternalIdentityFlowRequest\x12\x1d\n" +
-	"\x05token\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x05token\"B\n" +
-	"\"CancelExternalIdentityFlowResponse\x12\x1c\n" +
-	"\tcancelled\x18\x01 \x01(\bR\tcancelled\"C\n" +
+	"\x05token\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x05token\"5\n" +
+	"\"CancelExternalIdentityFlowResponseJ\x04\b\x01\x10\x02R\tcancelled\"C\n" +
 	"\"ConfirmExternalIdentityLinkRequest\x12\x1d\n" +
 	"\x05token\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x05token\"u\n" +
 	"#ConfirmExternalIdentityLinkResponse\x12N\n" +

--- a/cli/internal/pb/chatto/auth/v1/push_subscription_cleanup.pb.go
+++ b/cli/internal/pb/chatto/auth/v1/push_subscription_cleanup.pb.go
@@ -89,11 +89,9 @@ func (x *DeleteSubscriptionRequest) GetCleanupToken() string {
 }
 
 // Response from capability-authenticated subscription cleanup.
+// Success does not reveal whether a matching subscription existed.
 type DeleteSubscriptionResponse struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the idempotent cleanup request completed. It does not reveal
-	// whether a matching subscription existed.
-	Completed     bool `protobuf:"varint,1,opt,name=completed,proto3" json:"completed,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -128,13 +126,6 @@ func (*DeleteSubscriptionResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_auth_v1_push_subscription_cleanup_proto_rawDescGZIP(), []int{1}
 }
 
-func (x *DeleteSubscriptionResponse) GetCompleted() bool {
-	if x != nil {
-		return x.Completed
-	}
-	return false
-}
-
 var File_chatto_auth_v1_push_subscription_cleanup_proto protoreflect.FileDescriptor
 
 const file_chatto_auth_v1_push_subscription_cleanup_proto_rawDesc = "" +
@@ -146,9 +137,8 @@ const file_chatto_auth_v1_push_subscription_cleanup_proto_rawDesc = "" +
 	"\x04auth\x18\x02 \x01(\tB\n" +
 	"\xbaH\ar\x05\x10\x01\x18\x80\x01R\x04auth\x12/\n" +
 	"\rcleanup_token\x18\x03 \x01(\tB\n" +
-	"\xbaH\ar\x05\x10 \x18\x80\x01R\fcleanupToken\":\n" +
-	"\x1aDeleteSubscriptionResponse\x12\x1c\n" +
-	"\tcompleted\x18\x01 \x01(\bR\tcompleted2\x92\x01\n" +
+	"\xbaH\ar\x05\x10 \x18\x80\x01R\fcleanupToken\"-\n" +
+	"\x1aDeleteSubscriptionResponseJ\x04\b\x01\x10\x02R\tcompleted2\x92\x01\n" +
 	"\x1ePushSubscriptionCleanupService\x12p\n" +
 	"\x12DeleteSubscription\x12).chatto.auth.v1.DeleteSubscriptionRequest\x1a*.chatto.auth.v1.DeleteSubscriptionResponse\"\x03\x90\x02\x02B\xbf\x01\n" +
 	"\x12com.chatto.auth.v1B\x1cPushSubscriptionCleanupProtoP\x01Z1hmans.de/chatto/internal/pb/chatto/auth/v1;authv1\xa2\x02\x03CAX\xaa\x02\x0eChatto.Auth.V1\xca\x02\x0eChatto\\Auth\\V1\xe2\x02\x1aChatto\\Auth\\V1\\GPBMetadata\xea\x02\x10Chatto::Auth::V1b\x06proto3"

--- a/examples/runling-bot/reply.test.ts
+++ b/examples/runling-bot/reply.test.ts
@@ -51,7 +51,7 @@ function fixture(
       if (path.endsWith("RefreshTypingIndicator")) {
         typing.push(JSON.parse(String(init?.body)));
         return Response.json(
-          { updated: !options.typingFailure },
+          {},
           { status: options.typingFailure ? 503 : 200 },
         );
       }

--- a/packages/api-types/src/chatto/admin/v1/members_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/members_pb.ts
@@ -900,13 +900,6 @@ export class ClearUsernameCooldownRequest extends Message<ClearUsernameCooldownR
  * @generated from message chatto.admin.v1.ClearUsernameCooldownResponse
  */
 export class ClearUsernameCooldownResponse extends Message<ClearUsernameCooldownResponse> {
-  /**
-   * True when the request completed.
-   *
-   * @generated from field: bool cleared = 1;
-   */
-  cleared = false;
-
   constructor(data?: PartialMessage<ClearUsernameCooldownResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -915,7 +908,6 @@ export class ClearUsernameCooldownResponse extends Message<ClearUsernameCooldown
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.admin.v1.ClearUsernameCooldownResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "cleared", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ClearUsernameCooldownResponse {
@@ -982,13 +974,6 @@ export class DeleteUserRequest extends Message<DeleteUserRequest> {
  * @generated from message chatto.admin.v1.DeleteUserResponse
  */
 export class DeleteUserResponse extends Message<DeleteUserResponse> {
-  /**
-   * True when the user was deleted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteUserResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -997,7 +982,6 @@ export class DeleteUserResponse extends Message<DeleteUserResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.admin.v1.DeleteUserResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteUserResponse {

--- a/packages/api-types/src/chatto/admin/v1/roles_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/roles_pb.ts
@@ -531,13 +531,6 @@ export class DeleteRoleRequest extends Message<DeleteRoleRequest> {
  * @generated from message chatto.admin.v1.DeleteRoleResponse
  */
 export class DeleteRoleResponse extends Message<DeleteRoleResponse> {
-  /**
-   * True when the request completed.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteRoleResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -546,7 +539,6 @@ export class DeleteRoleResponse extends Message<DeleteRoleResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.admin.v1.DeleteRoleResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteRoleResponse {

--- a/packages/api-types/src/chatto/admin/v1/room_layout_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/room_layout_pb.ts
@@ -739,13 +739,6 @@ export class DeleteRoomGroupRequest extends Message<DeleteRoomGroupRequest> {
  * @generated from message chatto.admin.v1.DeleteRoomGroupResponse
  */
 export class DeleteRoomGroupResponse extends Message<DeleteRoomGroupResponse> {
-  /**
-   * True when the room group was deleted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteRoomGroupResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -754,7 +747,6 @@ export class DeleteRoomGroupResponse extends Message<DeleteRoomGroupResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.admin.v1.DeleteRoomGroupResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteRoomGroupResponse {
@@ -1482,13 +1474,6 @@ export class DeleteSidebarLinkRequest extends Message<DeleteSidebarLinkRequest> 
  * @generated from message chatto.admin.v1.DeleteSidebarLinkResponse
  */
 export class DeleteSidebarLinkResponse extends Message<DeleteSidebarLinkResponse> {
-  /**
-   * True when the sidebar link was deleted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteSidebarLinkResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1497,7 +1482,6 @@ export class DeleteSidebarLinkResponse extends Message<DeleteSidebarLinkResponse
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.admin.v1.DeleteSidebarLinkResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteSidebarLinkResponse {

--- a/packages/api-types/src/chatto/api/v1/account_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/account_pb.ts
@@ -445,13 +445,6 @@ export class DeleteMyAccountRequest extends Message<DeleteMyAccountRequest> {
  * @generated from message chatto.api.v1.DeleteMyAccountResponse
  */
 export class DeleteMyAccountResponse extends Message<DeleteMyAccountResponse> {
-  /**
-   * True when the account was deleted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteMyAccountResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -460,7 +453,6 @@ export class DeleteMyAccountResponse extends Message<DeleteMyAccountResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.DeleteMyAccountResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteMyAccountResponse {

--- a/packages/api-types/src/chatto/api/v1/external_identities_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/external_identities_pb.ts
@@ -375,13 +375,6 @@ export class DisconnectExternalIdentityRequest extends Message<DisconnectExterna
  * @generated from message chatto.api.v1.DisconnectExternalIdentityResponse
  */
 export class DisconnectExternalIdentityResponse extends Message<DisconnectExternalIdentityResponse> {
-  /**
-   * True when the identity was disconnected.
-   *
-   * @generated from field: bool disconnected = 1;
-   */
-  disconnected = false;
-
   constructor(data?: PartialMessage<DisconnectExternalIdentityResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -390,7 +383,6 @@ export class DisconnectExternalIdentityResponse extends Message<DisconnectExtern
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.DisconnectExternalIdentityResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "disconnected", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DisconnectExternalIdentityResponse {

--- a/packages/api-types/src/chatto/api/v1/messages_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/messages_pb.ts
@@ -324,13 +324,6 @@ export class DeleteMessageRequest extends Message<DeleteMessageRequest> {
  * @generated from message chatto.api.v1.DeleteMessageResponse
  */
 export class DeleteMessageResponse extends Message<DeleteMessageResponse> {
-  /**
-   * True when the delete/retract request was accepted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteMessageResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -339,7 +332,6 @@ export class DeleteMessageResponse extends Message<DeleteMessageResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.DeleteMessageResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteMessageResponse {
@@ -422,13 +414,6 @@ export class DeleteAttachmentRequest extends Message<DeleteAttachmentRequest> {
  * @generated from message chatto.api.v1.DeleteAttachmentResponse
  */
 export class DeleteAttachmentResponse extends Message<DeleteAttachmentResponse> {
-  /**
-   * True when the attachment removal was accepted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteAttachmentResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -437,7 +422,6 @@ export class DeleteAttachmentResponse extends Message<DeleteAttachmentResponse> 
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.DeleteAttachmentResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteAttachmentResponse {
@@ -520,13 +504,6 @@ export class DeleteLinkPreviewRequest extends Message<DeleteLinkPreviewRequest> 
  * @generated from message chatto.api.v1.DeleteLinkPreviewResponse
  */
 export class DeleteLinkPreviewResponse extends Message<DeleteLinkPreviewResponse> {
-  /**
-   * True when the link preview removal was accepted.
-   *
-   * @generated from field: bool deleted = 1;
-   */
-  deleted = false;
-
   constructor(data?: PartialMessage<DeleteLinkPreviewResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -535,7 +512,6 @@ export class DeleteLinkPreviewResponse extends Message<DeleteLinkPreviewResponse
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.DeleteLinkPreviewResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "deleted", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteLinkPreviewResponse {

--- a/packages/api-types/src/chatto/api/v1/push_notifications_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/push_notifications_pb.ts
@@ -98,13 +98,6 @@ export class SubscribeRequest extends Message<SubscribeRequest> {
  * @generated from message chatto.api.v1.SubscribeResponse
  */
 export class SubscribeResponse extends Message<SubscribeResponse> {
-  /**
-   * True when the subscription was stored.
-   *
-   * @generated from field: bool subscribed = 1;
-   */
-  subscribed = false;
-
   constructor(data?: PartialMessage<SubscribeResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -113,7 +106,6 @@ export class SubscribeResponse extends Message<SubscribeResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.SubscribeResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "subscribed", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SubscribeResponse {
@@ -180,13 +172,6 @@ export class UnsubscribeRequest extends Message<UnsubscribeRequest> {
  * @generated from message chatto.api.v1.UnsubscribeResponse
  */
 export class UnsubscribeResponse extends Message<UnsubscribeResponse> {
-  /**
-   * True when the request completed.
-   *
-   * @generated from field: bool unsubscribed = 1;
-   */
-  unsubscribed = false;
-
   constructor(data?: PartialMessage<UnsubscribeResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -195,7 +180,6 @@ export class UnsubscribeResponse extends Message<UnsubscribeResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.UnsubscribeResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "unsubscribed", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UnsubscribeResponse {
@@ -254,13 +238,6 @@ export class SendTestNotificationRequest extends Message<SendTestNotificationReq
  * @generated from message chatto.api.v1.SendTestNotificationResponse
  */
 export class SendTestNotificationResponse extends Message<SendTestNotificationResponse> {
-  /**
-   * True when the push provider accepted the notification.
-   *
-   * @generated from field: bool sent = 1;
-   */
-  sent = false;
-
   constructor(data?: PartialMessage<SendTestNotificationResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -269,7 +246,6 @@ export class SendTestNotificationResponse extends Message<SendTestNotificationRe
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.SendTestNotificationResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "sent", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): SendTestNotificationResponse {

--- a/packages/api-types/src/chatto/api/v1/rooms_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_pb.ts
@@ -931,13 +931,6 @@ export class LeaveRoomRequest extends Message<LeaveRoomRequest> {
  * @generated from message chatto.api.v1.LeaveRoomResponse
  */
 export class LeaveRoomResponse extends Message<LeaveRoomResponse> {
-  /**
-   * True when the current user is no longer an explicit member after the call.
-   *
-   * @generated from field: bool left = 1;
-   */
-  left = false;
-
   constructor(data?: PartialMessage<LeaveRoomResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -946,7 +939,6 @@ export class LeaveRoomResponse extends Message<LeaveRoomResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.LeaveRoomResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "left", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): LeaveRoomResponse {
@@ -1217,13 +1209,6 @@ export class BanMemberRequest extends Message<BanMemberRequest> {
  * @generated from message chatto.api.v1.BanMemberResponse
  */
 export class BanMemberResponse extends Message<BanMemberResponse> {
-  /**
-   * True when the ban operation completed.
-   *
-   * @generated from field: bool banned = 1;
-   */
-  banned = false;
-
   constructor(data?: PartialMessage<BanMemberResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1232,7 +1217,6 @@ export class BanMemberResponse extends Message<BanMemberResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.BanMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "banned", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BanMemberResponse {
@@ -1315,13 +1299,6 @@ export class UnbanMemberRequest extends Message<UnbanMemberRequest> {
  * @generated from message chatto.api.v1.UnbanMemberResponse
  */
 export class UnbanMemberResponse extends Message<UnbanMemberResponse> {
-  /**
-   * True when the unban operation completed.
-   *
-   * @generated from field: bool unbanned = 1;
-   */
-  unbanned = false;
-
   constructor(data?: PartialMessage<UnbanMemberResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1330,7 +1307,6 @@ export class UnbanMemberResponse extends Message<UnbanMemberResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.UnbanMemberResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "unbanned", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UnbanMemberResponse {
@@ -2051,13 +2027,6 @@ export class RefreshTypingIndicatorRequest extends Message<RefreshTypingIndicato
  * @generated from message chatto.api.v1.RefreshTypingIndicatorResponse
  */
 export class RefreshTypingIndicatorResponse extends Message<RefreshTypingIndicatorResponse> {
-  /**
-   * True when the typing indicator was accepted for publish.
-   *
-   * @generated from field: bool updated = 1;
-   */
-  updated = false;
-
   constructor(data?: PartialMessage<RefreshTypingIndicatorResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -2066,7 +2035,6 @@ export class RefreshTypingIndicatorResponse extends Message<RefreshTypingIndicat
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.RefreshTypingIndicatorResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "updated", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RefreshTypingIndicatorResponse {

--- a/packages/api-types/src/chatto/auth/v1/external_identity_auth_pb.ts
+++ b/packages/api-types/src/chatto/auth/v1/external_identity_auth_pb.ts
@@ -416,13 +416,6 @@ export class CancelExternalIdentityFlowRequest extends Message<CancelExternalIde
  * @generated from message chatto.auth.v1.CancelExternalIdentityFlowResponse
  */
 export class CancelExternalIdentityFlowResponse extends Message<CancelExternalIdentityFlowResponse> {
-  /**
-   * True when a pending flow was removed or already absent.
-   *
-   * @generated from field: bool cancelled = 1;
-   */
-  cancelled = false;
-
   constructor(data?: PartialMessage<CancelExternalIdentityFlowResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -431,7 +424,6 @@ export class CancelExternalIdentityFlowResponse extends Message<CancelExternalId
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.auth.v1.CancelExternalIdentityFlowResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "cancelled", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CancelExternalIdentityFlowResponse {

--- a/packages/api-types/src/chatto/auth/v1/push_subscription_cleanup_pb.ts
+++ b/packages/api-types/src/chatto/auth/v1/push_subscription_cleanup_pb.ts
@@ -67,18 +67,11 @@ export class DeleteSubscriptionRequest extends Message<DeleteSubscriptionRequest
 
 /**
  * Response from capability-authenticated subscription cleanup.
+ * Success does not reveal whether a matching subscription existed.
  *
  * @generated from message chatto.auth.v1.DeleteSubscriptionResponse
  */
 export class DeleteSubscriptionResponse extends Message<DeleteSubscriptionResponse> {
-  /**
-   * True when the idempotent cleanup request completed. It does not reveal
-   * whether a matching subscription existed.
-   *
-   * @generated from field: bool completed = 1;
-   */
-  completed = false;
-
   constructor(data?: PartialMessage<DeleteSubscriptionResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -87,7 +80,6 @@ export class DeleteSubscriptionResponse extends Message<DeleteSubscriptionRespon
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.auth.v1.DeleteSubscriptionResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "completed", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteSubscriptionResponse {

--- a/proto/chatto/admin/v1/members.proto
+++ b/proto/chatto/admin/v1/members.proto
@@ -204,8 +204,8 @@ message ClearUsernameCooldownRequest {
 
 // Result of clearing a user's username-change cooldown.
 message ClearUsernameCooldownResponse {
-  // True when the request completed.
-  bool cleared = 1;
+  reserved 1;
+  reserved "cleared";
 }
 
 // Request to delete a user account as a server-admin action.
@@ -219,8 +219,8 @@ message DeleteUserRequest {
 
 // Result of deleting a user account.
 message DeleteUserResponse {
-  // True when the user was deleted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Server-admin user management commands and member-detail reads.

--- a/proto/chatto/admin/v1/roles.proto
+++ b/proto/chatto/admin/v1/roles.proto
@@ -97,8 +97,8 @@ message DeleteRoleRequest {
 
 // Result of deleting a role.
 message DeleteRoleResponse {
-  // True when the request completed.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Request to replace custom role order.

--- a/proto/chatto/admin/v1/room_layout.proto
+++ b/proto/chatto/admin/v1/room_layout.proto
@@ -148,8 +148,8 @@ message DeleteRoomGroupRequest {
 
 // Result of deleting a room group.
 message DeleteRoomGroupResponse {
-  // True when the room group was deleted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Request to replace the global room group order.
@@ -289,8 +289,8 @@ message DeleteSidebarLinkRequest {
 
 // Result of deleting a sidebar link.
 message DeleteSidebarLinkResponse {
-  // True when the sidebar link was deleted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Request to move a sidebar link to another room group.

--- a/proto/chatto/api/v1/account.proto
+++ b/proto/chatto/api/v1/account.proto
@@ -97,8 +97,8 @@ message DeleteMyAccountRequest {
 
 // Result of deleting the authenticated account.
 message DeleteMyAccountResponse {
-  // True when the account was deleted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Self-service account, profile, display preference, presence,

--- a/proto/chatto/api/v1/external_identities.proto
+++ b/proto/chatto/api/v1/external_identities.proto
@@ -72,6 +72,6 @@ message DisconnectExternalIdentityRequest {
 
 // Result of disconnecting a provider identity.
 message DisconnectExternalIdentityResponse {
-  // True when the identity was disconnected.
-  bool disconnected = 1;
+  reserved 1;
+  reserved "disconnected";
 }

--- a/proto/chatto/api/v1/messages.proto
+++ b/proto/chatto/api/v1/messages.proto
@@ -114,8 +114,8 @@ message DeleteMessageRequest {
 
 // Result of retracting a message.
 message DeleteMessageResponse {
-  // True when the delete/retract request was accepted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Request to remove one attachment from a message.
@@ -130,8 +130,8 @@ message DeleteAttachmentRequest {
 
 // Result of removing one attachment from a message.
 message DeleteAttachmentResponse {
-  // True when the attachment removal was accepted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Request to remove the accepted link preview from a message.
@@ -146,8 +146,8 @@ message DeleteLinkPreviewRequest {
 
 // Result of removing a link preview from a message.
 message DeleteLinkPreviewResponse {
-  // True when the link preview removal was accepted.
-  bool deleted = 1;
+  reserved 1;
+  reserved "deleted";
 }
 
 // Request to read one visible message.

--- a/proto/chatto/api/v1/push_notifications.proto
+++ b/proto/chatto/api/v1/push_notifications.proto
@@ -68,8 +68,8 @@ message SubscribeRequest {
 
 // Response from storing a browser push subscription.
 message SubscribeResponse {
-  // True when the subscription was stored.
-  bool subscribed = 1;
+  reserved 1;
+  reserved "subscribed";
 }
 
 // Request to remove a browser push subscription.
@@ -83,8 +83,8 @@ message UnsubscribeRequest {
 
 // Response from removing a browser push subscription.
 message UnsubscribeResponse {
-  // True when the request completed.
-  bool unsubscribed = 1;
+  reserved 1;
+  reserved "unsubscribed";
 }
 
 // Request to test the current user's registered browser push subscriptions.
@@ -92,6 +92,6 @@ message SendTestNotificationRequest {}
 
 // Result of sending a test Web Push notification.
 message SendTestNotificationResponse {
-  // True when the push provider accepted the notification.
-  bool sent = 1;
+  reserved 1;
+  reserved "sent";
 }

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -201,8 +201,8 @@ message LeaveRoomRequest {
 
 // Result of leaving a room.
 message LeaveRoomResponse {
-  // True when the current user is no longer an explicit member after the call.
-  bool left = 1;
+  reserved 1;
+  reserved "left";
 }
 
 // Request to add a user to a channel room.
@@ -250,8 +250,8 @@ message BanMemberRequest {
 
 // Result of banning a room member.
 message BanMemberResponse {
-  // True when the ban operation completed.
-  bool banned = 1;
+  reserved 1;
+  reserved "banned";
 }
 
 // Request to remove a channel room ban.
@@ -269,8 +269,8 @@ message UnbanMemberRequest {
 
 // Result of removing a room ban.
 message UnbanMemberResponse {
-  // True when the unban operation completed.
-  bool unbanned = 1;
+  reserved 1;
+  reserved "unbanned";
 }
 
 // Active channel room ban with optional hydrated room and user references.
@@ -401,8 +401,8 @@ message RefreshTypingIndicatorRequest {
 
 // Result of refreshing a typing indicator.
 message RefreshTypingIndicatorResponse {
-  // True when the typing indicator was accepted for publish.
-  bool updated = 1;
+  reserved 1;
+  reserved "updated";
 }
 
 // Manages room-scoped operations for the current user.

--- a/proto/chatto/auth/v1/external_identity_auth.proto
+++ b/proto/chatto/auth/v1/external_identity_auth.proto
@@ -89,8 +89,8 @@ message CancelExternalIdentityFlowRequest {
 
 // Result of cancelling a pending external identity flow.
 message CancelExternalIdentityFlowResponse {
-  // True when a pending flow was removed or already absent.
-  bool cancelled = 1;
+  reserved 1;
+  reserved "cancelled";
 }
 
 // Request to confirm a pending provider link using the flow capability token.

--- a/proto/chatto/auth/v1/push_subscription_cleanup.proto
+++ b/proto/chatto/auth/v1/push_subscription_cleanup.proto
@@ -39,8 +39,8 @@ message DeleteSubscriptionRequest {
 }
 
 // Response from capability-authenticated subscription cleanup.
+// Success does not reveal whether a matching subscription existed.
 message DeleteSubscriptionResponse {
-  // True when the idempotent cleanup request completed. It does not reveal
-  // whether a matching subscription existed.
-  bool completed = 1;
+  reserved 1;
+  reserved "completed";
 }

--- a/tools/split-connectrpc-docs.mjs
+++ b/tools/split-connectrpc-docs.mjs
@@ -508,6 +508,8 @@ function renderLanding() {
     '',
     '## Responses And Errors',
     '',
+    'Commands that only acknowledge success return a named empty response (`{}` in JSON). Use RPC completion to detect success. Fields that report an actual change, state, or count remain part of the response.',
+    '',
     'Successful unary JSON calls return the protobuf response message as JSON. Field names use protobuf JSON casing, such as `publicProfile` and `directRegistrationEnabled`.',
     '',
     'ProtoJSON integrations that need to tolerate future additive oneof variants must configure their decoder to ignore unknown fields. In particular, Notifications 2.0 may add new `NotificationSignal` variants; strict generated JSON clients must be regenerated before receiving such a variant. Binary protobuf is recommended when forward-compatible unknown-field retention is required.',


### PR DESCRIPTION
- **What:** Replace 19 success-only booleans across the public API, admin, and auth commands with named empty responses (`{}` in JSON). Reserve the removed field names and numbers; update handlers, frontend adapters, bot fixtures, generated clients, and API reference.
- **Why:** RPC completion already reports success. Keep fields that report an actual change, state, or count, including call join/leave results. Authorization, errors, idempotency, and persisted data stay unchanged.
- **Migration:** This is an approved breaking public API change. Regenerate clients and stop reading the removed success fields. The [migration guide](apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx#empty-command-responses-in-05) lists every affected RPC; [0.5 release notes](apps/docs-website/src/content/docs/releases/0-5-0.mdx) also describe the change.
- **CI fixes:** Update end-to-end deletion assertions to expect empty JSON and use exact room heading selectors so thread headings cannot also match. Four targeted end-to-end tests pass locally with retries disabled.
- **Verification:** Go Connect API and HTTP server tests passed, including JSON cleanup; 191 frontend API-client tests and 55 Runling bot tests passed. Frontend checks reported zero errors/warnings; protobuf lint, storage compatibility, and the 77-page docs build passed. Buf reports exactly the 19 approved public field removals. Targeted browser end-to-end tests passed; there are no visual changes.
