### PR TITLE
refactor(api)!: use canonical thread follow response state

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -395,3 +395,11 @@ was already absent, and `LeaveCall.left` reports whether a leave fact was
 recorded. Counts also remain. Empty responses do not change authorization,
 error codes, idempotency, or stored data. Capability cleanup still does not
 reveal whether a matching subscription existed.
+
+## Thread follow responses in 0.5
+
+`ThreadService.FollowThread` and `ThreadService.UnfollowThread` no longer return
+the top-level `following` field. Read `state.following` instead. The `state`
+message contains the room ID, thread root event ID, and current follow state.
+Regenerate clients from the 0.5 protobuf definitions. Requests, authorization,
+and stored follow state are unchanged.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
@@ -95,7 +95,6 @@ Result of following a thread.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `following` | `bool` | True when the current user follows the thread after the operation. |
 | `state` | [`ThreadFollowState`](/reference/connectrpc-api/types/#chatto-api-v1-ThreadFollowState) | Current follow state after the operation. |
 
 
@@ -132,7 +131,6 @@ Result of unfollowing a thread.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `following` | `bool` | True when the current user follows the thread after the operation. |
 | `state` | [`ThreadFollowState`](/reference/connectrpc-api/types/#chatto-api-v1-ThreadFollowState) | Current follow state after the operation. |
 
 

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -402,6 +402,10 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ### Navigation and notifications
 
+- Thread follow and unfollow responses now expose follow state only in `state`.
+  Read `state.following` instead of the removed top-level `following` field. See
+  the [migration guide](/guides/integrations/api-compatibility/#thread-follow-responses-in-05).
+
 - Commands that only reported success now return named empty responses (`{}` in
   JSON). Clients must use RPC completion and Connect errors instead of the
   removed success fields. Actual change indicators and counts remain. See the

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -3574,7 +3574,6 @@ Result of following a thread.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `following` | `bool` | True when the current user follows the thread after the operation. |
 | `state` | [`ThreadFollowState`](#chatto-api-v1-ThreadFollowState) | Current follow state after the operation. |
 
 
@@ -3611,7 +3610,6 @@ Result of unfollowing a thread.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `following` | `bool` | True when the current user follows the thread after the operation. |
 | `state` | [`ThreadFollowState`](#chatto-api-v1-ThreadFollowState) | Current follow state after the operation. |
 
 

--- a/apps/frontend/src/lib/api-client-tests/threads.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/threads.spec.ts
@@ -206,7 +206,6 @@ describe('createThreadAPI', () => {
 
   it('follows a thread with bearer auth', async () => {
     mocks.followThread.mockResolvedValue({
-      following: true,
       state: { roomId: 'room-1', threadRootEventId: 'root-1', following: true }
     });
 
@@ -234,14 +233,12 @@ describe('createThreadAPI', () => {
       }
     );
     expect(result).toEqual({
-      following: true,
       state: { roomId: 'room-1', threadRootEventId: 'root-1', following: true }
     });
   });
 
   it('unfollows a thread without auth headers when no token is available', async () => {
     mocks.unfollowThread.mockResolvedValue({
-      following: false,
       state: { roomId: 'room-1', threadRootEventId: 'root-1', following: false }
     });
 
@@ -264,7 +261,6 @@ describe('createThreadAPI', () => {
       }
     );
     expect(result).toEqual({
-      following: false,
       state: { roomId: 'room-1', threadRootEventId: 'root-1', following: false }
     });
   });

--- a/apps/frontend/src/lib/api-client/threads.ts
+++ b/apps/frontend/src/lib/api-client/threads.ts
@@ -40,7 +40,6 @@ export type ThreadFollowState = {
 };
 
 export type ThreadFollowResult = {
-  following: boolean;
   state: ThreadFollowState | null;
 };
 
@@ -120,7 +119,6 @@ export function createThreadAPI(config: ConnectAPIConfig) {
           headers: headers()
         });
         return {
-          following: response.following,
           state: response.state ? mapThreadFollowState(response.state) : null
         };
       } catch (err) {
@@ -137,7 +135,6 @@ export function createThreadAPI(config: ConnectAPIConfig) {
           headers: headers()
         });
         return {
-          following: response.following,
           state: response.state ? mapThreadFollowState(response.state) : null
         };
       } catch (err) {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.spec.ts
@@ -1,4 +1,5 @@
 import { flushSync } from 'svelte';
+import type { ThreadFollowResult } from '$lib/api-client/threads';
 import { describe, expect, it, onTestFinished, vi } from 'vitest';
 import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
 import { ThreadFollowState, type ThreadFollowSnapshot } from './threadFollowState.svelte';
@@ -26,8 +27,8 @@ function setup(
     following: false
   }
 ) {
-  const followRequest = deferred<{ following: boolean }>();
-  const unfollowRequest = deferred<{ following: boolean }>();
+  const followRequest = deferred<ThreadFollowResult>();
+  const unfollowRequest = deferred<ThreadFollowResult>();
   const api = {
     followThread: vi.fn(() => followRequest.promise),
     unfollowThread: vi.fn(() => unfollowRequest.promise)
@@ -83,12 +84,23 @@ describe('ThreadFollowState', () => {
       threadRootEventId: 'thread-1'
     });
 
-    followRequest.resolve({ following: true });
+    followRequest.resolve({ state: { roomId: 'room-1', threadRootEventId: 'thread-1', following: true } });
     await request;
 
     expect(state.following).toBe(true);
     expect(state.pending).toBe(false);
     expect(commit).toHaveBeenCalledWith({ roomId: 'room-1', threadRootEventId: 'thread-1' }, true);
+  });
+
+  it('rolls back when the response has no follow state', async () => {
+    const { followRequest, rollback, commit, state } = setup();
+    const request = state.toggle();
+    followRequest.resolve({ state: null });
+    await request;
+    expect(state.following).toBe(false);
+    expect(state.pending).toBe(false);
+    expect(rollback).toHaveBeenCalledOnce();
+    expect(commit).not.toHaveBeenCalled();
   });
 
   it('rolls an optimistic update back when the request fails', async () => {
@@ -133,7 +145,7 @@ describe('ThreadFollowState', () => {
     expect(state.following).toBe(false);
     expect(api.unfollowThread).toHaveBeenCalledOnce();
 
-    unfollowRequest.resolve({ following: false });
+    unfollowRequest.resolve({ state: { roomId: 'room-1', threadRootEventId: 'thread-1', following: false } });
     await request;
     expect(state.following).toBe(false);
     expect(state.pending).toBe(false);
@@ -143,7 +155,7 @@ describe('ThreadFollowState', () => {
     const { followRequest, setSnapshot, state } = setup();
 
     const request = state.toggle();
-    followRequest.resolve({ following: true });
+    followRequest.resolve({ state: { roomId: 'room-1', threadRootEventId: 'thread-1', following: true } });
     await request;
 
     setSnapshot({
@@ -182,7 +194,7 @@ describe('ThreadFollowState', () => {
     expect(state.pending).toBe(false);
     expect(rollback).toHaveBeenCalledOnce();
 
-    followRequest.resolve({ following: true });
+    followRequest.resolve({ state: { roomId: 'room-1', threadRootEventId: 'thread-1', following: true } });
     await request;
 
     expect(state.following).toBe(true);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/threadFollowState.svelte.ts
@@ -39,10 +39,11 @@ export class ThreadFollowState {
       const api = this.#options.getConnection().getAPI(createThreadAPI);
       const result = await (wasFollowing ? api.unfollowThread : api.followThread)(target);
       if (requestId !== this.#request.id) return;
+      if (!result.state) throw new Error('Thread follow response has no state');
       this.#request.optimistic = undefined;
       this.pending = false;
-      this.following = result.following;
-      this.#options.commit?.(target, result.following);
+      this.following = result.state.following;
+      this.#options.commit?.(target, result.state.following);
     } catch {
       if (requestId !== this.#request.id) return;
       this.pending = false;

--- a/cli/internal/connectapi/threads.go
+++ b/cli/internal/connectapi/threads.go
@@ -44,8 +44,7 @@ func (s *threadService) FollowThread(ctx context.Context, req *connect.Request[a
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.FollowThreadResponse{
-		Following: true,
-		State:     threadFollowState(req.Msg.RoomId, req.Msg.ThreadRootEventId, true),
+		State: threadFollowState(req.Msg.RoomId, req.Msg.ThreadRootEventId, true),
 	}), nil
 }
 
@@ -58,8 +57,7 @@ func (s *threadService) UnfollowThread(ctx context.Context, req *connect.Request
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&apiv1.UnfollowThreadResponse{
-		Following: false,
-		State:     threadFollowState(req.Msg.RoomId, req.Msg.ThreadRootEventId, false),
+		State: threadFollowState(req.Msg.RoomId, req.Msg.ThreadRootEventId, false),
 	}), nil
 }
 

--- a/cli/internal/connectapi/timeline_thread_services_test.go
+++ b/cli/internal/connectapi/timeline_thread_services_test.go
@@ -955,9 +955,6 @@ func TestThreadServiceRequiresMembershipAndTogglesFollowState(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FollowThread: %v", err)
 	}
-	if !followResp.Msg.Following {
-		t.Fatalf("FollowThread following = false, want true")
-	}
 	if state := followResp.Msg.GetState(); state.GetRoomId() != room.Id || state.GetThreadRootEventId() != root.Id || !state.GetFollowing() {
 		t.Fatalf("FollowThread state = %+v, want current followed thread", state)
 	}
@@ -975,9 +972,6 @@ func TestThreadServiceRequiresMembershipAndTogglesFollowState(t *testing.T) {
 	}))
 	if err != nil {
 		t.Fatalf("UnfollowThread: %v", err)
-	}
-	if unfollowResp.Msg.Following {
-		t.Fatalf("UnfollowThread following = true, want false")
 	}
 	if state := unfollowResp.Msg.GetState(); state.GetRoomId() != room.Id || state.GetThreadRootEventId() != root.Id || state.GetFollowing() {
 		t.Fatalf("UnfollowThread state = %+v, want current unfollowed thread", state)

--- a/cli/internal/pb/chatto/api/v1/threads.pb.go
+++ b/cli/internal/pb/chatto/api/v1/threads.pb.go
@@ -144,8 +144,6 @@ func (x *FollowThreadRequest) GetThreadRootEventId() string {
 // Result of following a thread.
 type FollowThreadResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the current user follows the thread after the operation.
-	Following bool `protobuf:"varint,1,opt,name=following,proto3" json:"following,omitempty"`
 	// Current follow state after the operation.
 	State         *ThreadFollowState `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -180,13 +178,6 @@ func (x *FollowThreadResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use FollowThreadResponse.ProtoReflect.Descriptor instead.
 func (*FollowThreadResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_threads_proto_rawDescGZIP(), []int{2}
-}
-
-func (x *FollowThreadResponse) GetFollowing() bool {
-	if x != nil {
-		return x.Following
-	}
-	return false
 }
 
 func (x *FollowThreadResponse) GetState() *ThreadFollowState {
@@ -254,8 +245,6 @@ func (x *UnfollowThreadRequest) GetThreadRootEventId() string {
 // Result of unfollowing a thread.
 type UnfollowThreadResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// True when the current user follows the thread after the operation.
-	Following bool `protobuf:"varint,1,opt,name=following,proto3" json:"following,omitempty"`
 	// Current follow state after the operation.
 	State         *ThreadFollowState `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`
 	unknownFields protoimpl.UnknownFields
@@ -290,13 +279,6 @@ func (x *UnfollowThreadResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use UnfollowThreadResponse.ProtoReflect.Descriptor instead.
 func (*UnfollowThreadResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_threads_proto_rawDescGZIP(), []int{4}
-}
-
-func (x *UnfollowThreadResponse) GetFollowing() bool {
-	if x != nil {
-		return x.Following
-	}
-	return false
 }
 
 func (x *UnfollowThreadResponse) GetState() *ThreadFollowState {
@@ -521,16 +503,14 @@ const file_chatto_api_v1_threads_proto_rawDesc = "" +
 	"\tfollowing\x18\x03 \x01(\bR\tfollowing\"q\n" +
 	"\x13FollowThreadRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x128\n" +
-	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\"l\n" +
-	"\x14FollowThreadResponse\x12\x1c\n" +
-	"\tfollowing\x18\x01 \x01(\bR\tfollowing\x126\n" +
-	"\x05state\x18\x02 \x01(\v2 .chatto.api.v1.ThreadFollowStateR\x05state\"s\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\"_\n" +
+	"\x14FollowThreadResponse\x126\n" +
+	"\x05state\x18\x02 \x01(\v2 .chatto.api.v1.ThreadFollowStateR\x05stateJ\x04\b\x01\x10\x02R\tfollowing\"s\n" +
 	"\x15UnfollowThreadRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x128\n" +
-	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\"n\n" +
-	"\x16UnfollowThreadResponse\x12\x1c\n" +
-	"\tfollowing\x18\x01 \x01(\bR\tfollowing\x126\n" +
-	"\x05state\x18\x02 \x01(\v2 .chatto.api.v1.ThreadFollowStateR\x05state\"\x98\x03\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\"a\n" +
+	"\x16UnfollowThreadResponse\x126\n" +
+	"\x05state\x18\x02 \x01(\v2 .chatto.api.v1.ThreadFollowStateR\x05stateJ\x04\b\x01\x10\x02R\tfollowing\"\x98\x03\n" +
 	"\x0eFollowedThread\x129\n" +
 	"\froot_message\x18\x04 \x01(\v2\x16.chatto.api.v1.MessageR\vrootMessage\x12.\n" +
 	"\x04room\x18\b \x01(\v2\x1a.chatto.api.v1.RoomSummaryR\x04room\x124\n" +

--- a/packages/api-types/src/chatto/api/v1/threads_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/threads_pb.ts
@@ -123,13 +123,6 @@ export class FollowThreadRequest extends Message<FollowThreadRequest> {
  */
 export class FollowThreadResponse extends Message<FollowThreadResponse> {
   /**
-   * True when the current user follows the thread after the operation.
-   *
-   * @generated from field: bool following = 1;
-   */
-  following = false;
-
-  /**
    * Current follow state after the operation.
    *
    * @generated from field: chatto.api.v1.ThreadFollowState state = 2;
@@ -144,7 +137,6 @@ export class FollowThreadResponse extends Message<FollowThreadResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.FollowThreadResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "following", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 2, name: "state", kind: "message", T: ThreadFollowState },
   ]);
 
@@ -221,13 +213,6 @@ export class UnfollowThreadRequest extends Message<UnfollowThreadRequest> {
  */
 export class UnfollowThreadResponse extends Message<UnfollowThreadResponse> {
   /**
-   * True when the current user follows the thread after the operation.
-   *
-   * @generated from field: bool following = 1;
-   */
-  following = false;
-
-  /**
    * Current follow state after the operation.
    *
    * @generated from field: chatto.api.v1.ThreadFollowState state = 2;
@@ -242,7 +227,6 @@ export class UnfollowThreadResponse extends Message<UnfollowThreadResponse> {
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.UnfollowThreadResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "following", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 2, name: "state", kind: "message", T: ThreadFollowState },
   ]);
 

--- a/proto/chatto/api/v1/threads.proto
+++ b/proto/chatto/api/v1/threads.proto
@@ -29,8 +29,8 @@ message FollowThreadRequest {
 
 // Result of following a thread.
 message FollowThreadResponse {
-  // True when the current user follows the thread after the operation.
-  bool following = 1;
+  reserved 1;
+  reserved "following";
   // Current follow state after the operation.
   ThreadFollowState state = 2;
 }
@@ -45,8 +45,8 @@ message UnfollowThreadRequest {
 
 // Result of unfollowing a thread.
 message UnfollowThreadResponse {
-  // True when the current user follows the thread after the operation.
-  bool following = 1;
+  reserved 1;
+  reserved "following";
   // Current follow state after the operation.
   ThreadFollowState state = 2;
 }


### PR DESCRIPTION
- **What:** Remove the duplicate top-level `following` field from `FollowThreadResponse` and `UnfollowThreadResponse`. Keep the canonical `ThreadFollowState` in `state`, reserve the removed name and tag, and update generated clients and API reference.
- **Why:** Clients should read one source of follow state: `state.following`. Update the frontend adapter and optimistic UI helper accordingly, including rollback if a response has no state. Requests, authorization, errors, and stored data are unchanged.
- **Migration:** Approved breaking public API change. Regenerate clients and replace top-level `following` reads with `state.following`. See the [migration guide](apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx#thread-follow-responses-in-05) and [0.5 release notes](apps/docs-website/src/content/docs/releases/0-5-0.mdx).
- **Verification:** Go Connect API tests, 191 frontend API adapter tests, seven browser-backed UI state tests, frontend checks (zero errors/warnings), protobuf lint, storage compatibility, and docs build passed. Updated UI fixtures failed against the old helper and pass after the fix. Buf reports only the two approved public field removals. No manual browser inspection was needed for this response-shape change.
