### PR TITLE
refactor(api)!: align room and thread read-marker responses

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -403,3 +403,15 @@ the top-level `following` field. Read `state.following` instead. The `state`
 message contains the room ID, thread root event ID, and current follow state.
 Regenerate clients from the 0.5 protobuf definitions. Requests, authorization,
 and stored follow state are unchanged.
+
+## Read-marker responses in 0.5
+
+`MarkRoomAsRead` and `MarkThreadAsRead` both return `last_read_at` and
+`previous_last_read_at`. For thread responses, replace `previousReadAt` with
+`previousLastReadAt` in JSON clients and use `lastReadAt` for the resulting
+marker. Regenerate protobuf clients. The previous timestamp keeps field number
+1; the new resulting timestamp uses field number 2.
+
+A stale thread read request reports the retained newer marker as `last_read_at`.
+The previous timestamp is absent on the first read. Stored markers and the
+advance-only write behavior are unchanged.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
@@ -255,4 +255,5 @@ Result of marking a message thread as read.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `previous_read_at` | `google.protobuf.Timestamp` | Previous thread read timestamp, when one existed. |
+| `previous_last_read_at` | `google.protobuf.Timestamp` | Previous thread read timestamp, when one existed. |
+| `last_read_at` | `google.protobuf.Timestamp` | Resulting thread read timestamp. A stale request retains the newer marker. Absent when no marker exists. |

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -402,6 +402,10 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ### Navigation and notifications
 
+- Room and thread read commands now return the same timestamp fields:
+  `last_read_at` and `previous_last_read_at`. Thread clients must replace
+  `previous_read_at`. See the [migration guide](/guides/integrations/api-compatibility/#read-marker-responses-in-05).
+
 - Thread follow and unfollow responses now expose follow state only in `state`.
   Read `state.following` instead of the removed top-level `following` field. See
   the [migration guide](/guides/integrations/api-compatibility/#thread-follow-responses-in-05).

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -3734,7 +3734,8 @@ Result of marking a message thread as read.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `previous_read_at` | `google.protobuf.Timestamp` | Previous thread read timestamp, when one existed. |
+| `previous_last_read_at` | `google.protobuf.Timestamp` | Previous thread read timestamp, when one existed. |
+| `last_read_at` | `google.protobuf.Timestamp` | Resulting thread read timestamp. A stale request retains the newer marker. Absent when no marker exists. |
 
 
 <a id="chatto-api-v1-UserService"></a>

--- a/apps/frontend/src/lib/api-client-tests/readState.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/readState.spec.ts
@@ -77,7 +77,8 @@ describe('createReadStateAPI', () => {
 
   it('marks a thread read without auth headers when no token is available', async () => {
     mocks.markThreadAsRead.mockResolvedValue({
-      previousReadAt: Timestamp.fromDate(new Date('2026-06-01T10:00:00Z'))
+      lastReadAt: Timestamp.fromDate(new Date('2026-06-01T12:00:00Z')),
+      previousLastReadAt: Timestamp.fromDate(new Date('2026-06-01T10:00:00Z'))
     });
 
     const api = createReadStateAPI({
@@ -100,7 +101,8 @@ describe('createReadStateAPI', () => {
       }
     );
     expect(result).toEqual({
-      previousReadAt: '2026-06-01T10:00:00.000Z'
+      lastReadAt: '2026-06-01T12:00:00.000Z',
+      previousLastReadAt: '2026-06-01T10:00:00.000Z'
     });
   });
 

--- a/apps/frontend/src/lib/api-client/readState.ts
+++ b/apps/frontend/src/lib/api-client/readState.ts
@@ -13,7 +13,8 @@ export type MarkRoomAsReadResult = {
 };
 
 export type MarkThreadAsReadResult = {
-  previousReadAt: string | null;
+  lastReadAt: string | null;
+  previousLastReadAt: string | null;
 };
 
 export function createReadStateAPI(config: ConnectAPIConfig) {
@@ -69,7 +70,8 @@ export function createReadStateAPI(config: ConnectAPIConfig) {
           }
         );
         return {
-          previousReadAt: response.previousReadAt?.toDate().toISOString() ?? null
+          lastReadAt: response.lastReadAt?.toDate().toISOString() ?? null,
+          previousLastReadAt: response.previousLastReadAt?.toDate().toISOString() ?? null
         };
       } catch (err) {
         return handleAuthError(config, err);

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte
@@ -110,7 +110,7 @@
   const unread = useUnreadMarker(() => threadRootEventId, {
     markAsRead: markThreadAsRead,
     markerWindowFromReadResult: (result, markedAtMs) =>
-      result.previousReadAt ? { afterTime: result.previousReadAt, beforeTime: markedAtMs } : null,
+      result.previousLastReadAt ? { afterTime: result.previousLastReadAt, beforeTime: markedAtMs } : null,
     getMarkerEvents: () => threadEvents,
     getMarkerSkipActorId: () => currentUser.user?.id ?? null,
     onMarkAsReadError: (error) => console.error('Failed to mark thread as read:', error)

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/ThreadPane.svelte.spec.ts
@@ -201,7 +201,7 @@ describe('ThreadPane', () => {
     mocks.appState.isPresent = true;
     mocks.unreadMarkerEventId = null;
     mocks.markThreadAsRead.mockResolvedValue({
-      previousReadAt: null,
+      previousLastReadAt: null,
       lastReadAt: '2026-07-04T13:00:00Z'
     });
     mocks.followThread.mockResolvedValue({

--- a/cli/internal/connectapi/read_state.go
+++ b/cli/internal/connectapi/read_state.go
@@ -41,8 +41,11 @@ func (s *threadService) MarkThreadAsRead(ctx context.Context, req *connect.Reque
 	}
 
 	resp := &apiv1.MarkThreadAsReadResponse{}
-	if !result.PreviousReadAt.IsZero() {
-		resp.PreviousReadAt = timestamppb.New(result.PreviousReadAt)
+	if !result.LastReadAt.IsZero() {
+		resp.LastReadAt = timestamppb.New(result.LastReadAt)
+	}
+	if !result.PreviousLastReadAt.IsZero() {
+		resp.PreviousLastReadAt = timestamppb.New(result.PreviousLastReadAt)
 	}
 	return connect.NewResponse(resp), nil
 }

--- a/cli/internal/connectapi/timeline_thread_services_test.go
+++ b/cli/internal/connectapi/timeline_thread_services_test.go
@@ -797,12 +797,15 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	if err != nil {
 		t.Fatalf("MarkThreadAsRead reply2: %v", err)
 	}
-	if resp.Msg.PreviousReadAt != nil {
-		t.Fatalf("first previous read at = %v, want nil", resp.Msg.PreviousReadAt)
+	if resp.Msg.PreviousLastReadAt != nil {
+		t.Fatalf("first previous read at = %v, want nil", resp.Msg.PreviousLastReadAt)
 	}
 	marker2, err := env.core.GetThreadLastOpened(env.ctx, core.KindChannel, reader.Id, room.Id, root.Id)
 	if err != nil {
 		t.Fatalf("GetThreadLastOpened after reply2: %v", err)
+	}
+	if resp.Msg.LastReadAt == nil || !resp.Msg.LastReadAt.AsTime().Equal(marker2) {
+		t.Fatalf("first last_read_at = %v, want %v", resp.Msg.LastReadAt, marker2)
 	}
 	assertAPINotificationStates(t, env, ctx,
 		[]string{futureThreadNotification.Id, otherThreadNotification.Id, roomNotification.Id},
@@ -817,12 +820,15 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	if err != nil {
 		t.Fatalf("MarkThreadAsRead stale reply1: %v", err)
 	}
-	if resp.Msg.PreviousReadAt == nil {
+	if resp.Msg.PreviousLastReadAt == nil {
 		t.Fatalf("second previous read at = nil, want previous marker")
 	}
 	markerAfter, err := env.core.GetThreadLastOpened(env.ctx, core.KindChannel, reader.Id, room.Id, root.Id)
 	if err != nil {
 		t.Fatalf("GetThreadLastOpened after stale reply1: %v", err)
+	}
+	if resp.Msg.LastReadAt == nil || !resp.Msg.LastReadAt.AsTime().Equal(marker2) || !resp.Msg.PreviousLastReadAt.AsTime().Equal(marker2) {
+		t.Fatalf("stale response = %+v, want previous and current %v", resp.Msg, marker2)
 	}
 	if !markerAfter.Equal(marker2) {
 		t.Fatalf("thread marker regressed from %v to %v", marker2, markerAfter)
@@ -861,6 +867,15 @@ func TestRoomAndThreadServicesMarkThreadAsReadAnchorsAndDoesNotRegress(t *testin
 	if !markerAfterMissing.Equal(marker2) {
 		t.Fatalf("thread marker changed after missing anchor from %v to %v", marker2, markerAfterMissing)
 	}
+	// An omitted anchor advances to the latest reply and reports the retained pair.
+	resp, err = env.threads.MarkThreadAsRead(ctx, connect.NewRequest(&apiv1.MarkThreadAsReadRequest{RoomId: room.Id, ThreadRootEventId: root.Id}))
+	if err != nil {
+		t.Fatalf("MarkThreadAsRead latest: %v", err)
+	}
+	if resp.Msg.LastReadAt == nil || !resp.Msg.LastReadAt.AsTime().Equal(reply3.CreatedAt.AsTime()) || !resp.Msg.PreviousLastReadAt.AsTime().Equal(marker2) {
+		t.Fatalf("latest response = %+v, want previous %v and current %v", resp.Msg, marker2, reply3.CreatedAt)
+	}
+
 }
 
 func createReadTestOccurrence(t *testing.T, env *connectAPITestEnv, recipientID, actorID, roomID string, event *evtv1.Event, threadRootID string, reason notificationTestSignalKind) *notificationv1.NotificationOccurrence {

--- a/cli/internal/core/read_state_model.go
+++ b/cli/internal/core/read_state_model.go
@@ -17,7 +17,10 @@ type MarkRoomAsReadResult struct {
 // MarkThreadAsReadResult describes the timestamp response for a thread-level
 // read marker update.
 type MarkThreadAsReadResult struct {
-	PreviousReadAt time.Time
+	// LastReadAt is the retained marker after this operation. Zero means no marker.
+	LastReadAt time.Time
+	// PreviousLastReadAt is the marker observed by the successful advance decision.
+	PreviousLastReadAt time.Time
 }
 
 // ReadState returns the operation-level model for user-facing read marker
@@ -167,7 +170,7 @@ func (s *ReadStateModel) MarkThreadAsRead(ctx context.Context, actorID, roomID, 
 		}
 	}
 
-	previousReadAt, err := s.core.SetThreadLastReadEventID(ctx, kind, actorID, room.Id, threadRootEventID, markerEventID)
+	result, err := s.core.advanceThreadLastReadEventID(ctx, kind, actorID, room.Id, threadRootEventID, markerEventID)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +180,7 @@ func (s *ReadStateModel) MarkThreadAsRead(ctx context.Context, actorID, roomID, 
 		}
 		s.core.NotifyNotificationUnreadStateChanged(ctx, actorID, actorID, room.Id, threadRootEventID)
 	}
-	return &MarkThreadAsReadResult{PreviousReadAt: previousReadAt}, nil
+	return result, nil
 }
 
 func (s *ReadStateModel) roomReadAnchor(ctx context.Context, actorID string, kind RoomKind, roomID, eventID string) (eventIDOut string, ts time.Time, found bool, err error) {

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -307,70 +307,80 @@ func (c *ChattoCore) GetThreadLastOpened(ctx context.Context, kind RoomKind, use
 // has seen, but only if it is newer than the existing marker (advance-only).
 // Returns the previous marker time (zero if never opened before).
 func (c *ChattoCore) SetThreadLastReadEventID(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID, eventID string) (time.Time, error) {
+	result, err := c.advanceThreadLastReadEventID(ctx, kind, userID, roomID, threadRootEventID, eventID)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return result.PreviousLastReadAt, nil
+}
+
+// advanceThreadLastReadEventID returns the timestamps from the successful CAS
+// decision, including the retained marker when the request does not advance it.
+func (c *ChattoCore) advanceThreadLastReadEventID(ctx context.Context, kind RoomKind, userID, roomID, threadRootEventID, eventID string) (*MarkThreadAsReadResult, error) {
 	bucket := c.storage.runtimeStateKV
 	key := threadLastOpenedKey(userID, roomID, threadRootEventID)
 
 	nextTime, err := c.GetEventTimestamp(ctx, kind, roomID, eventID)
 	if err != nil {
-		return time.Time{}, err
+		return nil, err
 	}
 
 	for attempt := 0; attempt < maxReadMarkerUpdateRetries; attempt++ {
 		var previousTime time.Time
 		entry, exists, err := c.readStateModel.index.threadMarker(ctx, userID, roomID, threadRootEventID)
 		if err != nil {
-			return time.Time{}, fmt.Errorf("read thread marker index: %w", err)
+			return nil, fmt.Errorf("read thread marker index: %w", err)
 		}
 		if !exists {
 			if nextTime.IsZero() {
-				return time.Time{}, nil
+				return &MarkThreadAsReadResult{}, nil
 			}
 			revision, err := bucket.Create(ctx, key, []byte(eventID))
 			if err != nil {
 				if jetstreamutil.IsSequenceConflict(err) {
 					if waitErr := c.readStateModel.index.waitForRevisionAfter(ctx, key, entry.revision); waitErr != nil {
-						return time.Time{}, fmt.Errorf("wait for conflicting thread marker: %w", waitErr)
+						return nil, fmt.Errorf("wait for conflicting thread marker: %w", waitErr)
 					}
 					continue
 				}
-				return time.Time{}, fmt.Errorf("failed to create thread last opened: %w", err)
+				return nil, fmt.Errorf("failed to create thread last opened: %w", err)
 			}
 			if err := c.readStateModel.index.waitForRevision(ctx, key, revision); err != nil {
-				return time.Time{}, fmt.Errorf("wait for created thread marker: %w", err)
+				return nil, fmt.Errorf("wait for created thread marker: %w", err)
 			}
 			c.logger.Debug("Set thread last read event", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "event_id", eventID)
 			c.publishThreadViewerStateChangedEvent(ctx, userID, kind, roomID, threadRootEventID, c.roomModel.threadFollowState(userID, roomID, threadRootEventID) == ThreadFollowStateFollowing)
-			return previousTime, nil
+			return &MarkThreadAsReadResult{PreviousLastReadAt: previousTime, LastReadAt: nextTime}, nil
 		}
 
 		previousTime, err = c.threadReadMarkerTime(ctx, kind, roomID, entry.value)
 		if err != nil {
-			return time.Time{}, err
+			return nil, err
 		}
 		if nextTime.IsZero() || !nextTime.After(previousTime) {
-			return previousTime, nil
+			return &MarkThreadAsReadResult{PreviousLastReadAt: previousTime, LastReadAt: previousTime}, nil
 		}
 
 		revision, err := bucket.Update(ctx, key, []byte(eventID), entry.revision)
 		if err != nil {
 			if jetstreamutil.IsSequenceConflict(err) {
 				if waitErr := c.readStateModel.index.waitForRevisionAfter(ctx, key, entry.revision); waitErr != nil {
-					return time.Time{}, fmt.Errorf("wait for conflicting thread marker: %w", waitErr)
+					return nil, fmt.Errorf("wait for conflicting thread marker: %w", waitErr)
 				}
 				continue
 			}
-			return time.Time{}, fmt.Errorf("failed to set thread last opened: %w", err)
+			return nil, fmt.Errorf("failed to set thread last opened: %w", err)
 		}
 		if err := c.readStateModel.index.waitForRevision(ctx, key, revision); err != nil {
-			return time.Time{}, fmt.Errorf("wait for updated thread marker: %w", err)
+			return nil, fmt.Errorf("wait for updated thread marker: %w", err)
 		}
 
 		c.logger.Debug("Set thread last read event", "user_id", userID, "room_id", roomID, "thread_root_event_id", threadRootEventID, "previous", previousTime, "event_id", eventID)
 		c.publishThreadViewerStateChangedEvent(ctx, userID, kind, roomID, threadRootEventID, c.roomModel.threadFollowState(userID, roomID, threadRootEventID) == ThreadFollowStateFollowing)
-		return previousTime, nil
+		return &MarkThreadAsReadResult{PreviousLastReadAt: previousTime, LastReadAt: nextTime}, nil
 	}
 
-	return time.Time{}, fmt.Errorf("thread read marker update failed after %d retries", maxReadMarkerUpdateRetries)
+	return nil, fmt.Errorf("thread read marker update failed after %d retries", maxReadMarkerUpdateRetries)
 }
 
 // SetThreadLastOpenedAt is retained for timestamp-based callers/tests. It

--- a/cli/internal/pb/chatto/api/v1/read_state.pb.go
+++ b/cli/internal/pb/chatto/api/v1/read_state.pb.go
@@ -207,9 +207,12 @@ func (x *MarkThreadAsReadRequest) GetUpToEventId() string {
 type MarkThreadAsReadResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Previous thread read timestamp, when one existed.
-	PreviousReadAt *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=previous_read_at,json=previousReadAt,proto3" json:"previous_read_at,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	PreviousLastReadAt *timestamppb.Timestamp `protobuf:"bytes,1,opt,name=previous_last_read_at,json=previousLastReadAt,proto3" json:"previous_last_read_at,omitempty"`
+	// Resulting thread read timestamp. A stale request retains the newer marker.
+	// Absent when no marker exists.
+	LastReadAt    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_read_at,json=lastReadAt,proto3" json:"last_read_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *MarkThreadAsReadResponse) Reset() {
@@ -242,9 +245,16 @@ func (*MarkThreadAsReadResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{3}
 }
 
-func (x *MarkThreadAsReadResponse) GetPreviousReadAt() *timestamppb.Timestamp {
+func (x *MarkThreadAsReadResponse) GetPreviousLastReadAt() *timestamppb.Timestamp {
 	if x != nil {
-		return x.PreviousReadAt
+		return x.PreviousLastReadAt
+	}
+	return nil
+}
+
+func (x *MarkThreadAsReadResponse) GetLastReadAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastReadAt
 	}
 	return nil
 }
@@ -264,9 +274,11 @@ const file_chatto_api_v1_read_state_proto_rawDesc = "" +
 	"\x17MarkThreadAsReadRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x128\n" +
 	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\x12#\n" +
-	"\x0eup_to_event_id\x18\x03 \x01(\tR\vupToEventId\"`\n" +
-	"\x18MarkThreadAsReadResponse\x12D\n" +
-	"\x10previous_read_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x0epreviousReadAtB\xaa\x01\n" +
+	"\x0eup_to_event_id\x18\x03 \x01(\tR\vupToEventId\"\xb9\x01\n" +
+	"\x18MarkThreadAsReadResponse\x12M\n" +
+	"\x15previous_last_read_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x12previousLastReadAt\x12<\n" +
+	"\flast_read_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"lastReadAtR\x10previous_read_atB\xaa\x01\n" +
 	"\x11com.chatto.api.v1B\x0eReadStateProtoP\x01Z/hmans.de/chatto/internal/pb/chatto/api/v1;apiv1\xa2\x02\x03CAX\xaa\x02\rChatto.Api.V1\xca\x02\rChatto\\Api\\V1\xe2\x02\x19Chatto\\Api\\V1\\GPBMetadata\xea\x02\x0fChatto::Api::V1b\x06proto3"
 
 var (
@@ -292,12 +304,13 @@ var file_chatto_api_v1_read_state_proto_goTypes = []any{
 var file_chatto_api_v1_read_state_proto_depIdxs = []int32{
 	4, // 0: chatto.api.v1.MarkRoomAsReadResponse.last_read_at:type_name -> google.protobuf.Timestamp
 	4, // 1: chatto.api.v1.MarkRoomAsReadResponse.previous_last_read_at:type_name -> google.protobuf.Timestamp
-	4, // 2: chatto.api.v1.MarkThreadAsReadResponse.previous_read_at:type_name -> google.protobuf.Timestamp
-	3, // [3:3] is the sub-list for method output_type
-	3, // [3:3] is the sub-list for method input_type
-	3, // [3:3] is the sub-list for extension type_name
-	3, // [3:3] is the sub-list for extension extendee
-	0, // [0:3] is the sub-list for field type_name
+	4, // 2: chatto.api.v1.MarkThreadAsReadResponse.previous_last_read_at:type_name -> google.protobuf.Timestamp
+	4, // 3: chatto.api.v1.MarkThreadAsReadResponse.last_read_at:type_name -> google.protobuf.Timestamp
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_read_state_proto_init() }

--- a/docs/architecture/runtime-state.md
+++ b/docs/architecture/runtime-state.md
@@ -115,6 +115,10 @@ local index when read-your-writes is required. Create-only membership
 initialization cannot replace a marker concurrently advanced by the user or
 another replica.
 
+The thread read command returns its previous and resulting marker timestamps
+from the successful KV advance decision. A stale anchor returns the retained
+marker time; the response does not need a separate index read.
+
 Token HMAC keys are derived with `[core].secret_key` and the credential purpose as a domain separator. Backups include `RUNTIME_STATE`, so sessions and pending links survive restore only when the same `core.secret_key` is kept; backup archives do not contain raw bearer access or refresh credentials, cookie credential handles, or raw link/code values. Backups also include wrapped app DEK records, but those records cannot decrypt content without the KEKs in `ENCRYPTION_KEYS` or an external KMS.
 
 **MEMORY_CACHE keys:**

--- a/packages/api-types/src/chatto/api/v1/read_state_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/read_state_pb.ts
@@ -176,9 +176,17 @@ export class MarkThreadAsReadResponse extends Message<MarkThreadAsReadResponse> 
   /**
    * Previous thread read timestamp, when one existed.
    *
-   * @generated from field: google.protobuf.Timestamp previous_read_at = 1;
+   * @generated from field: google.protobuf.Timestamp previous_last_read_at = 1;
    */
-  previousReadAt?: Timestamp;
+  previousLastReadAt?: Timestamp;
+
+  /**
+   * Resulting thread read timestamp. A stale request retains the newer marker.
+   * Absent when no marker exists.
+   *
+   * @generated from field: google.protobuf.Timestamp last_read_at = 2;
+   */
+  lastReadAt?: Timestamp;
 
   constructor(data?: PartialMessage<MarkThreadAsReadResponse>) {
     super();
@@ -188,7 +196,8 @@ export class MarkThreadAsReadResponse extends Message<MarkThreadAsReadResponse> 
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.api.v1.MarkThreadAsReadResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "previous_read_at", kind: "message", T: Timestamp },
+    { no: 1, name: "previous_last_read_at", kind: "message", T: Timestamp },
+    { no: 2, name: "last_read_at", kind: "message", T: Timestamp },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): MarkThreadAsReadResponse {

--- a/proto/chatto/api/v1/read_state.proto
+++ b/proto/chatto/api/v1/read_state.proto
@@ -39,6 +39,11 @@ message MarkThreadAsReadRequest {
 
 // Result of marking a message thread as read.
 message MarkThreadAsReadResponse {
+  reserved "previous_read_at";
+
   // Previous thread read timestamp, when one existed.
-  google.protobuf.Timestamp previous_read_at = 1;
+  google.protobuf.Timestamp previous_last_read_at = 1;
+  // Resulting thread read timestamp. A stale request retains the newer marker.
+  // Absent when no marker exists.
+  google.protobuf.Timestamp last_read_at = 2;
 }


### PR DESCRIPTION
- **What:** Align room and thread read-command responses on `last_read_at` and `previous_last_read_at`. Rename the thread response's previous timestamp at its existing tag, reserve the old name, and add the resulting timestamp at tag 2. Update generated clients, frontend consumers, API reference, and release notes.
- **Why:** Clients can use the same response shape for rooms and threads. Return the thread timestamp pair from the existing successful marker-advance decision; stale requests report the retained newer marker. Keep the existing lower-level helper contract, storage format, authorization, notification behavior, and concurrency controls.
- **Migration:** Approved public API break: replace JSON `previousReadAt` with `previousLastReadAt` and regenerate clients. See the [migration guide](apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx#read-marker-responses-in-05) and [runtime-state documentation](docs/architecture/runtime-state.md).
- **Verification:** Full Go Connect API suite; first/stale/latest thread response assertions; existing core stale-marker regression under the race detector; 191 frontend API adapter tests; focused ThreadPane content-cursor test; frontend checks with zero errors/warnings; protobuf lint, storage compatibility, and 77-page docs build all passed. Buf reports only the approved field and JSON-name change. No manual browser inspection was performed.
