### PR TITLE
refactor(api)!: use explicit sidebar item references

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -415,3 +415,23 @@ marker. Regenerate protobuf clients. The previous timestamp keeps field number
 A stale thread read request reports the retained newer marker as `last_read_at`.
 The previous timestamp is absent on the first read. Stored markers and the
 advance-only write behavior are unchanged.
+
+## Sidebar item references in 0.5
+
+`AdminRoomLayoutService.MoveSidebarItem` and `ReorderSidebarItemsInGroup` use
+explicit item references. Replace the old `kind` and `id` pair with exactly one
+non-empty `roomId` or `sidebarLinkId` in JSON:
+
+```json
+{ "roomId": "room-123" }
+```
+
+```json
+{ "sidebarLinkId": "link-456" }
+```
+
+This applies to `item`, each entry in `items`, and the optional `before`
+reference. Omit `before` to move an item to the end; do not send an empty object.
+Regenerate protobuf clients and remove uses of `AdminRoomLayoutItemKind`.
+The old field names and numbers are reserved. Stored sidebar entries and
+move/reorder authorization are unchanged.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -1684,12 +1684,12 @@ One ordered sidebar item in an admin room group layout.
 
 ### AdminRoomLayoutItemInput
 
-One item reference in a sidebar order replacement.
+One room or sidebar link reference in a move or order replacement.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `kind` | [`AdminRoomLayoutItemKind`](#chatto-admin-v1-AdminRoomLayoutItemKind) | Item kind. |
-| `id` | `string` | Room ID when kind is ROOM, sidebar link ID when kind is SIDEBAR_LINK. |
+| `item.room_id` | `string` | Channel room ID. |
+| `item.sidebar_link_id` | `string` | Sidebar link ID. |
 
 <a id="chatto-admin-v1-Neighbor"></a>
 
@@ -2061,15 +2061,3 @@ Scope tier for permission matrices and write requests.
 | `PERMISSION_SCOPE_KIND_GROUP` | `2` | Room-group tier. |
 | `PERMISSION_SCOPE_KIND_ROOM` | `3` | Room tier. |
 | `PERMISSION_SCOPE_KIND_DM` | `4` | Server-wide direct-message tier. |
-
-<a id="chatto-admin-v1-AdminRoomLayoutItemKind"></a>
-
-### AdminRoomLayoutItemKind
-
-Sidebar item kind used in reorder requests.
-
-| Name | Number | Description |
-| --- | --- | --- |
-| `ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED` | `0` | The item kind was not specified. |
-| `ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM` | `1` | Channel room entry. |
-| `ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK` | `2` | Sidebar link entry. |

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -402,6 +402,9 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ### Navigation and notifications
 
+- Sidebar move and reorder requests now use an explicit room or sidebar-link
+  ID instead of a kind/ID pair. See the [migration guide](/guides/integrations/api-compatibility/#sidebar-item-references-in-05).
+
 - Room and thread read commands now return the same timestamp fields:
   `last_read_at` and `previous_last_read_at`. Thread clients must replace
   `previous_read_at`. See the [migration guide](/guides/integrations/api-compatibility/#read-marker-responses-in-05).

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -2670,12 +2670,12 @@ One ordered sidebar item in an admin room group layout.
 
 ### AdminRoomLayoutItemInput
 
-One item reference in a sidebar order replacement.
+One room or sidebar link reference in a move or order replacement.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `kind` | [`AdminRoomLayoutItemKind`](#chatto-admin-v1-AdminRoomLayoutItemKind) | Item kind. |
-| `id` | `string` | Room ID when kind is ROOM, sidebar link ID when kind is SIDEBAR_LINK. |
+| `item.room_id` | `string` | Channel room ID. |
+| `item.sidebar_link_id` | `string` | Sidebar link ID. |
 
 
 
@@ -2830,16 +2830,3 @@ Scope tier for permission matrices and write requests.
 | `PERMISSION_SCOPE_KIND_GROUP` | `2` | Room-group tier. |
 | `PERMISSION_SCOPE_KIND_ROOM` | `3` | Room tier. |
 | `PERMISSION_SCOPE_KIND_DM` | `4` | Server-wide direct-message tier. |
-
-
-<a id="chatto-admin-v1-AdminRoomLayoutItemKind"></a>
-
-### AdminRoomLayoutItemKind
-
-Sidebar item kind used in reorder requests.
-
-| Name | Number | Description |
-| --- | --- | --- |
-| `ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED` | `0` | The item kind was not specified. |
-| `ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM` | `1` | Channel room entry. |
-| `ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK` | `2` | Sidebar link entry. |

--- a/apps/frontend/e2e/room-layout.test.ts
+++ b/apps/frontend/e2e/room-layout.test.ts
@@ -194,7 +194,7 @@ async function updateRoomLayoutViaAPI(page: Page, groups: RoomGroup[]): Promise<
     if (same) continue;
     await connectPost(page, 'chatto.admin.v1.AdminRoomLayoutService/ReorderSidebarItemsInGroup', {
       groupId: targetId,
-      items: desired.map((id) => ({ kind: 'ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM', id }))
+      items: desired.map((id) => ({ roomId: id }))
     });
   }
 

--- a/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/adminRoomLayout.spec.ts
@@ -1,7 +1,6 @@
 import { Code, ConnectError } from '@connectrpc/connect';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { configureApiClientHooks } from '$lib/api-client/hooks';
-import { AdminRoomLayoutItemKind } from '@chatto/api-types/admin/v1/room_layout_pb';
 import { createAdminRoomLayoutAPI } from '$lib/api-client/adminRoomLayout';
 import { RoomThreadingMode } from '$lib/roomThreading';
 
@@ -224,17 +223,17 @@ describe('createAdminRoomLayoutAPI', () => {
       {
         groupId: 'g2',
         items: [
-          { id: 'room-1', kind: AdminRoomLayoutItemKind.ROOM },
-          { id: 'docs', kind: AdminRoomLayoutItemKind.SIDEBAR_LINK }
+          { item: { case: 'roomId', value: 'room-1' } },
+          { item: { case: 'sidebarLinkId', value: 'docs' } }
         ]
       },
       callOptions
     );
     expect(mocks.moveSidebarItem).toHaveBeenCalledWith(
       {
-        item: { id: 'room-1', kind: AdminRoomLayoutItemKind.ROOM },
+        item: { item: { case: 'roomId', value: 'room-1' } },
         groupId: 'g2',
-        before: { id: 'docs', kind: AdminRoomLayoutItemKind.SIDEBAR_LINK }
+        before: { item: { case: 'sidebarLinkId', value: 'docs' } }
       },
       callOptions
     );

--- a/apps/frontend/src/lib/api-client/adminRoomLayout.ts
+++ b/apps/frontend/src/lib/api-client/adminRoomLayout.ts
@@ -2,7 +2,6 @@ import { updateMask } from './updateMask';
 import { authHeaders, createChattoClient, handleAuthError } from './connect.js';
 import { AdminRoomLayoutService } from '@chatto/api-types/admin/v1/room_layout_connect';
 import {
-  AdminRoomLayoutItemKind,
   type AdminRoomLayoutGroup as APIAdminRoomLayoutGroup,
   type AdminRoomLayoutItem as APIAdminRoomLayoutItem
 } from '@chatto/api-types/admin/v1/room_layout_pb';
@@ -213,13 +212,7 @@ export function createAdminRoomLayoutAPI(config: AdminRoomLayoutAPIConfig) {
         const response = await layout.reorderSidebarItemsInGroup(
           {
             groupId: input.groupId,
-            items: input.items.map((item) => ({
-              id: item.id,
-              kind:
-                item.kind === 'room'
-                  ? AdminRoomLayoutItemKind.ROOM
-                  : AdminRoomLayoutItemKind.SIDEBAR_LINK
-            }))
+            items: input.items.map(adminRoomLayoutItemInput)
           },
           { headers: headers() }
         );
@@ -317,8 +310,9 @@ function mapAdminRoomLayoutGroup(group: APIAdminRoomLayoutGroup): AdminRoomGroup
 
 function adminRoomLayoutItemInput(item: AdminRoomLayoutItemMutationInput) {
   return {
-    id: item.id,
-    kind: item.kind === 'room' ? AdminRoomLayoutItemKind.ROOM : AdminRoomLayoutItemKind.SIDEBAR_LINK
+    item: item.kind === 'room'
+      ? { case: 'roomId' as const, value: item.id }
+      : { case: 'sidebarLinkId' as const, value: item.id }
   };
 }
 

--- a/cli/internal/connectapi/admin_room_layout.go
+++ b/cli/internal/connectapi/admin_room_layout.go
@@ -351,16 +351,7 @@ func apiAdminRoomLayoutGroup(group *evtv1.RoomGroup, roomsByID map[string]*evtv1
 func adminRoomLayoutItemInputsToCore(items []*adminv1.AdminRoomLayoutItemInput) []*evtv1.SidebarGroupEntry {
 	entries := make([]*evtv1.SidebarGroupEntry, 0, len(items))
 	for _, item := range items {
-		var kind evtv1.SidebarGroupEntry_Kind
-		switch item.GetKind() {
-		case adminv1.AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM:
-			kind = evtv1.SidebarGroupEntry_ROOM
-		case adminv1.AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK:
-			kind = evtv1.SidebarGroupEntry_SIDEBAR_LINK
-		default:
-			kind = evtv1.SidebarGroupEntry_KIND_UNSPECIFIED
-		}
-		entries = append(entries, &evtv1.SidebarGroupEntry{Kind: kind, Id: item.GetId()})
+		entries = append(entries, adminRoomLayoutItemInputToCore(item))
 	}
 	return entries
 }
@@ -369,16 +360,14 @@ func adminRoomLayoutItemInputToCore(item *adminv1.AdminRoomLayoutItemInput) *evt
 	if item == nil {
 		return nil
 	}
-	var kind evtv1.SidebarGroupEntry_Kind
-	switch item.GetKind() {
-	case adminv1.AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM:
-		kind = evtv1.SidebarGroupEntry_ROOM
-	case adminv1.AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK:
-		kind = evtv1.SidebarGroupEntry_SIDEBAR_LINK
+	switch target := item.GetItem().(type) {
+	case *adminv1.AdminRoomLayoutItemInput_RoomId:
+		return &evtv1.SidebarGroupEntry{Kind: evtv1.SidebarGroupEntry_ROOM, Id: target.RoomId}
+	case *adminv1.AdminRoomLayoutItemInput_SidebarLinkId:
+		return &evtv1.SidebarGroupEntry{Kind: evtv1.SidebarGroupEntry_SIDEBAR_LINK, Id: target.SidebarLinkId}
 	default:
-		kind = evtv1.SidebarGroupEntry_KIND_UNSPECIFIED
+		return &evtv1.SidebarGroupEntry{}
 	}
-	return &evtv1.SidebarGroupEntry{Kind: kind, Id: item.GetId()}
 }
 
 func sidebarLinkFromAdminRoomLayoutGroup(group *evtv1.RoomGroup, linkID string) *evtv1.SidebarLink {

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -1778,13 +1778,11 @@ func TestAdminRoomLayoutServiceRelativePlacements(t *testing.T) {
 
 	moveResp, err := env.adminLayout.MoveSidebarItem(ctx, connect.NewRequest(&adminv1.MoveSidebarItemRequest{
 		Item: &adminv1.AdminRoomLayoutItemInput{
-			Kind: adminv1.AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK,
-			Id:   linkResp.Msg.GetSidebarLink().GetId(),
+			Item: &adminv1.AdminRoomLayoutItemInput_SidebarLinkId{SidebarLinkId: linkResp.Msg.GetSidebarLink().GetId()},
 		},
 		GroupId: secondGroupID,
 		Before: &adminv1.AdminRoomLayoutItemInput{
-			Kind: adminv1.AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM,
-			Id:   room.GetId(),
+			Item: &adminv1.AdminRoomLayoutItemInput_RoomId{RoomId: room.GetId()},
 		},
 	}))
 	if err != nil {
@@ -1805,5 +1803,42 @@ func TestAdminRoomLayoutServiceRelativePlacements(t *testing.T) {
 	groups := groupMoveResp.Msg.GetGroups()
 	if len(groups) < 2 || groups[0].GetId() != secondGroupID || groups[1].GetId() != firstGroupID {
 		t.Fatalf("moved room groups = %+v, want second group before first", groups)
+	}
+}
+
+// Check the public JSON boundary before any layout mutation can run.
+func TestSidebarItemJSONRejectsInvalidReferences(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	mux := http.NewServeMux()
+	for _, handler := range env.api.Handlers() {
+		mux.Handle(handler.ServicePath, handler.Handler)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r.WithContext(withCaller(r.Context(), env.viewer)))
+	}))
+	t.Cleanup(server.Close)
+	for _, body := range []string{
+		`{"groupId":"group","item":{}}`,
+		`{"groupId":"group","item":{"roomId":""}}`,
+		`{"groupId":"group","item":{"sidebarLinkId":""}}`,
+		`{"groupId":"group","item":{"roomId":"room","sidebarLinkId":"link"}}`,
+		`{"groupId":"group","item":{"roomId":"room"},"before":{}}`,
+	} {
+		t.Run(body, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, server.URL+"/chatto.admin.v1.AdminRoomLayoutService/MoveSidebarItem", strings.NewReader(body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Connect-Protocol-Version", "1")
+			resp, err := server.Client().Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("status = %d, want 400", resp.StatusCode)
+			}
+		})
 	}
 }

--- a/cli/internal/pb/chatto/admin/v1/room_layout.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/room_layout.pb.go
@@ -24,59 +24,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-// Sidebar item kind used in reorder requests.
-type AdminRoomLayoutItemKind int32
-
-const (
-	// The item kind was not specified.
-	AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED AdminRoomLayoutItemKind = 0
-	// Channel room entry.
-	AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM AdminRoomLayoutItemKind = 1
-	// Sidebar link entry.
-	AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK AdminRoomLayoutItemKind = 2
-)
-
-// Enum value maps for AdminRoomLayoutItemKind.
-var (
-	AdminRoomLayoutItemKind_name = map[int32]string{
-		0: "ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED",
-		1: "ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM",
-		2: "ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK",
-	}
-	AdminRoomLayoutItemKind_value = map[string]int32{
-		"ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED":  0,
-		"ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM":         1,
-		"ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK": 2,
-	}
-)
-
-func (x AdminRoomLayoutItemKind) Enum() *AdminRoomLayoutItemKind {
-	p := new(AdminRoomLayoutItemKind)
-	*p = x
-	return p
-}
-
-func (x AdminRoomLayoutItemKind) String() string {
-	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
-}
-
-func (AdminRoomLayoutItemKind) Descriptor() protoreflect.EnumDescriptor {
-	return file_chatto_admin_v1_room_layout_proto_enumTypes[0].Descriptor()
-}
-
-func (AdminRoomLayoutItemKind) Type() protoreflect.EnumType {
-	return &file_chatto_admin_v1_room_layout_proto_enumTypes[0]
-}
-
-func (x AdminRoomLayoutItemKind) Number() protoreflect.EnumNumber {
-	return protoreflect.EnumNumber(x)
-}
-
-// Deprecated: Use AdminRoomLayoutItemKind.Descriptor instead.
-func (AdminRoomLayoutItemKind) EnumDescriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_room_layout_proto_rawDescGZIP(), []int{0}
-}
-
 // One ordered sidebar item in an admin room group layout.
 type AdminRoomLayoutItem struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -549,13 +496,14 @@ func (x *ListRoomGroupsResponse) GetGroups() []*AdminRoomLayoutGroup {
 	return nil
 }
 
-// One item reference in a sidebar order replacement.
+// One room or sidebar link reference in a move or order replacement.
 type AdminRoomLayoutItemInput struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Item kind.
-	Kind AdminRoomLayoutItemKind `protobuf:"varint,1,opt,name=kind,proto3,enum=chatto.admin.v1.AdminRoomLayoutItemKind" json:"kind,omitempty"`
-	// Room ID when kind is ROOM, sidebar link ID when kind is SIDEBAR_LINK.
-	Id            string `protobuf:"bytes,2,opt,name=id,proto3" json:"id,omitempty"`
+	// Types that are valid to be assigned to Item:
+	//
+	//	*AdminRoomLayoutItemInput_RoomId
+	//	*AdminRoomLayoutItemInput_SidebarLinkId
+	Item          isAdminRoomLayoutItemInput_Item `protobuf_oneof:"item"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -590,19 +538,48 @@ func (*AdminRoomLayoutItemInput) Descriptor() ([]byte, []int) {
 	return file_chatto_admin_v1_room_layout_proto_rawDescGZIP(), []int{8}
 }
 
-func (x *AdminRoomLayoutItemInput) GetKind() AdminRoomLayoutItemKind {
+func (x *AdminRoomLayoutItemInput) GetItem() isAdminRoomLayoutItemInput_Item {
 	if x != nil {
-		return x.Kind
+		return x.Item
 	}
-	return AdminRoomLayoutItemKind_ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED
+	return nil
 }
 
-func (x *AdminRoomLayoutItemInput) GetId() string {
+func (x *AdminRoomLayoutItemInput) GetRoomId() string {
 	if x != nil {
-		return x.Id
+		if x, ok := x.Item.(*AdminRoomLayoutItemInput_RoomId); ok {
+			return x.RoomId
+		}
 	}
 	return ""
 }
+
+func (x *AdminRoomLayoutItemInput) GetSidebarLinkId() string {
+	if x != nil {
+		if x, ok := x.Item.(*AdminRoomLayoutItemInput_SidebarLinkId); ok {
+			return x.SidebarLinkId
+		}
+	}
+	return ""
+}
+
+type isAdminRoomLayoutItemInput_Item interface {
+	isAdminRoomLayoutItemInput_Item()
+}
+
+type AdminRoomLayoutItemInput_RoomId struct {
+	// Channel room ID.
+	RoomId string `protobuf:"bytes,3,opt,name=room_id,json=roomId,proto3,oneof"`
+}
+
+type AdminRoomLayoutItemInput_SidebarLinkId struct {
+	// Sidebar link ID.
+	SidebarLinkId string `protobuf:"bytes,4,opt,name=sidebar_link_id,json=sidebarLinkId,proto3,oneof"`
+}
+
+func (*AdminRoomLayoutItemInput_RoomId) isAdminRoomLayoutItemInput_Item() {}
+
+func (*AdminRoomLayoutItemInput_SidebarLinkId) isAdminRoomLayoutItemInput_Item() {}
 
 // Request to create a room group.
 type CreateRoomGroupRequest struct {
@@ -1865,11 +1842,11 @@ const file_chatto_admin_v1_room_layout_proto_rawDesc = "" +
 	"\x1dviewer_can_manage_permissions\x18\x03 \x01(\bR\x1aviewerCanManagePermissions\"\x17\n" +
 	"\x15ListRoomGroupsRequest\"W\n" +
 	"\x16ListRoomGroupsResponse\x12=\n" +
-	"\x06groups\x18\x01 \x03(\v2%.chatto.admin.v1.AdminRoomLayoutGroupR\x06groups\"}\n" +
-	"\x18AdminRoomLayoutItemInput\x12H\n" +
-	"\x04kind\x18\x01 \x01(\x0e2(.chatto.admin.v1.AdminRoomLayoutItemKindB\n" +
-	"\xbaH\a\x82\x01\x04\x10\x01 \x00R\x04kind\x12\x17\n" +
-	"\x02id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x02id\"c\n" +
+	"\x06groups\x18\x01 \x03(\v2%.chatto.admin.v1.AdminRoomLayoutGroupR\x06groups\"\x96\x01\n" +
+	"\x18AdminRoomLayoutItemInput\x12\"\n" +
+	"\aroom_id\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01H\x00R\x06roomId\x121\n" +
+	"\x0fsidebar_link_id\x18\x04 \x01(\tB\a\xbaH\x04r\x02\x10\x01H\x00R\rsidebarLinkIdB\r\n" +
+	"\x04item\x12\x05\xbaH\x02\b\x01J\x04\b\x01\x10\x02J\x04\b\x02\x10\x03R\x04kindR\x02id\"c\n" +
 	"\x16CreateRoomGroupRequest\x12\x1d\n" +
 	"\x04name\x18\x01 \x01(\tB\t\xbaH\x06r\x04\x10\x01\x18PR\x04name\x12*\n" +
 	"\vdescription\x18\x02 \x01(\tB\b\xbaH\x05r\x03\x18\xf4\x03R\vdescription\"V\n" +
@@ -1939,11 +1916,7 @@ const file_chatto_admin_v1_room_layout_proto_rawDesc = "" +
 	"\alink_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06linkId\x12\"\n" +
 	"\bgroup_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\agroupId\"_\n" +
 	"\x1eMoveSidebarLinkToGroupResponse\x12=\n" +
-	"\fsidebar_link\x18\x01 \x01(\v2\x1a.chatto.api.v1.SidebarLinkR\vsidebarLink*\x9a\x01\n" +
-	"\x17AdminRoomLayoutItemKind\x12+\n" +
-	"'ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED\x10\x00\x12$\n" +
-	" ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM\x10\x01\x12,\n" +
-	"(ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK\x10\x022\xb7\f\n" +
+	"\fsidebar_link\x18\x01 \x01(\v2\x1a.chatto.api.v1.SidebarLinkR\vsidebarLink2\xb7\f\n" +
 	"\x16AdminRoomLayoutService\x12L\n" +
 	"\aGetRoom\x12\x1f.chatto.admin.v1.GetRoomRequest\x1a .chatto.admin.v1.GetRoomResponse\x12[\n" +
 	"\fGetRoomGroup\x12$.chatto.admin.v1.GetRoomGroupRequest\x1a%.chatto.admin.v1.GetRoomGroupResponse\x12a\n" +
@@ -1974,105 +1947,102 @@ func file_chatto_admin_v1_room_layout_proto_rawDescGZIP() []byte {
 	return file_chatto_admin_v1_room_layout_proto_rawDescData
 }
 
-var file_chatto_admin_v1_room_layout_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
 var file_chatto_admin_v1_room_layout_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_chatto_admin_v1_room_layout_proto_goTypes = []any{
-	(AdminRoomLayoutItemKind)(0),               // 0: chatto.admin.v1.AdminRoomLayoutItemKind
-	(*AdminRoomLayoutItem)(nil),                // 1: chatto.admin.v1.AdminRoomLayoutItem
-	(*AdminRoomLayoutGroup)(nil),               // 2: chatto.admin.v1.AdminRoomLayoutGroup
-	(*GetRoomRequest)(nil),                     // 3: chatto.admin.v1.GetRoomRequest
-	(*GetRoomResponse)(nil),                    // 4: chatto.admin.v1.GetRoomResponse
-	(*GetRoomGroupRequest)(nil),                // 5: chatto.admin.v1.GetRoomGroupRequest
-	(*GetRoomGroupResponse)(nil),               // 6: chatto.admin.v1.GetRoomGroupResponse
-	(*ListRoomGroupsRequest)(nil),              // 7: chatto.admin.v1.ListRoomGroupsRequest
-	(*ListRoomGroupsResponse)(nil),             // 8: chatto.admin.v1.ListRoomGroupsResponse
-	(*AdminRoomLayoutItemInput)(nil),           // 9: chatto.admin.v1.AdminRoomLayoutItemInput
-	(*CreateRoomGroupRequest)(nil),             // 10: chatto.admin.v1.CreateRoomGroupRequest
-	(*CreateRoomGroupResponse)(nil),            // 11: chatto.admin.v1.CreateRoomGroupResponse
-	(*UpdateRoomGroupRequest)(nil),             // 12: chatto.admin.v1.UpdateRoomGroupRequest
-	(*UpdateRoomGroupResponse)(nil),            // 13: chatto.admin.v1.UpdateRoomGroupResponse
-	(*DeleteRoomGroupRequest)(nil),             // 14: chatto.admin.v1.DeleteRoomGroupRequest
-	(*DeleteRoomGroupResponse)(nil),            // 15: chatto.admin.v1.DeleteRoomGroupResponse
-	(*ReorderRoomGroupsRequest)(nil),           // 16: chatto.admin.v1.ReorderRoomGroupsRequest
-	(*ReorderRoomGroupsResponse)(nil),          // 17: chatto.admin.v1.ReorderRoomGroupsResponse
-	(*MoveRoomGroupRequest)(nil),               // 18: chatto.admin.v1.MoveRoomGroupRequest
-	(*MoveRoomGroupResponse)(nil),              // 19: chatto.admin.v1.MoveRoomGroupResponse
-	(*MoveRoomToGroupRequest)(nil),             // 20: chatto.admin.v1.MoveRoomToGroupRequest
-	(*MoveRoomToGroupResponse)(nil),            // 21: chatto.admin.v1.MoveRoomToGroupResponse
-	(*ReorderSidebarItemsInGroupRequest)(nil),  // 22: chatto.admin.v1.ReorderSidebarItemsInGroupRequest
-	(*ReorderSidebarItemsInGroupResponse)(nil), // 23: chatto.admin.v1.ReorderSidebarItemsInGroupResponse
-	(*MoveSidebarItemRequest)(nil),             // 24: chatto.admin.v1.MoveSidebarItemRequest
-	(*MoveSidebarItemResponse)(nil),            // 25: chatto.admin.v1.MoveSidebarItemResponse
-	(*CreateSidebarLinkRequest)(nil),           // 26: chatto.admin.v1.CreateSidebarLinkRequest
-	(*CreateSidebarLinkResponse)(nil),          // 27: chatto.admin.v1.CreateSidebarLinkResponse
-	(*UpdateSidebarLinkRequest)(nil),           // 28: chatto.admin.v1.UpdateSidebarLinkRequest
-	(*UpdateSidebarLinkResponse)(nil),          // 29: chatto.admin.v1.UpdateSidebarLinkResponse
-	(*DeleteSidebarLinkRequest)(nil),           // 30: chatto.admin.v1.DeleteSidebarLinkRequest
-	(*DeleteSidebarLinkResponse)(nil),          // 31: chatto.admin.v1.DeleteSidebarLinkResponse
-	(*MoveSidebarLinkToGroupRequest)(nil),      // 32: chatto.admin.v1.MoveSidebarLinkToGroupRequest
-	(*MoveSidebarLinkToGroupResponse)(nil),     // 33: chatto.admin.v1.MoveSidebarLinkToGroupResponse
-	(*v1.Room)(nil),                            // 34: chatto.api.v1.Room
-	(*v1.SidebarLink)(nil),                     // 35: chatto.api.v1.SidebarLink
-	(*fieldmaskpb.FieldMask)(nil),              // 36: google.protobuf.FieldMask
+	(*AdminRoomLayoutItem)(nil),                // 0: chatto.admin.v1.AdminRoomLayoutItem
+	(*AdminRoomLayoutGroup)(nil),               // 1: chatto.admin.v1.AdminRoomLayoutGroup
+	(*GetRoomRequest)(nil),                     // 2: chatto.admin.v1.GetRoomRequest
+	(*GetRoomResponse)(nil),                    // 3: chatto.admin.v1.GetRoomResponse
+	(*GetRoomGroupRequest)(nil),                // 4: chatto.admin.v1.GetRoomGroupRequest
+	(*GetRoomGroupResponse)(nil),               // 5: chatto.admin.v1.GetRoomGroupResponse
+	(*ListRoomGroupsRequest)(nil),              // 6: chatto.admin.v1.ListRoomGroupsRequest
+	(*ListRoomGroupsResponse)(nil),             // 7: chatto.admin.v1.ListRoomGroupsResponse
+	(*AdminRoomLayoutItemInput)(nil),           // 8: chatto.admin.v1.AdminRoomLayoutItemInput
+	(*CreateRoomGroupRequest)(nil),             // 9: chatto.admin.v1.CreateRoomGroupRequest
+	(*CreateRoomGroupResponse)(nil),            // 10: chatto.admin.v1.CreateRoomGroupResponse
+	(*UpdateRoomGroupRequest)(nil),             // 11: chatto.admin.v1.UpdateRoomGroupRequest
+	(*UpdateRoomGroupResponse)(nil),            // 12: chatto.admin.v1.UpdateRoomGroupResponse
+	(*DeleteRoomGroupRequest)(nil),             // 13: chatto.admin.v1.DeleteRoomGroupRequest
+	(*DeleteRoomGroupResponse)(nil),            // 14: chatto.admin.v1.DeleteRoomGroupResponse
+	(*ReorderRoomGroupsRequest)(nil),           // 15: chatto.admin.v1.ReorderRoomGroupsRequest
+	(*ReorderRoomGroupsResponse)(nil),          // 16: chatto.admin.v1.ReorderRoomGroupsResponse
+	(*MoveRoomGroupRequest)(nil),               // 17: chatto.admin.v1.MoveRoomGroupRequest
+	(*MoveRoomGroupResponse)(nil),              // 18: chatto.admin.v1.MoveRoomGroupResponse
+	(*MoveRoomToGroupRequest)(nil),             // 19: chatto.admin.v1.MoveRoomToGroupRequest
+	(*MoveRoomToGroupResponse)(nil),            // 20: chatto.admin.v1.MoveRoomToGroupResponse
+	(*ReorderSidebarItemsInGroupRequest)(nil),  // 21: chatto.admin.v1.ReorderSidebarItemsInGroupRequest
+	(*ReorderSidebarItemsInGroupResponse)(nil), // 22: chatto.admin.v1.ReorderSidebarItemsInGroupResponse
+	(*MoveSidebarItemRequest)(nil),             // 23: chatto.admin.v1.MoveSidebarItemRequest
+	(*MoveSidebarItemResponse)(nil),            // 24: chatto.admin.v1.MoveSidebarItemResponse
+	(*CreateSidebarLinkRequest)(nil),           // 25: chatto.admin.v1.CreateSidebarLinkRequest
+	(*CreateSidebarLinkResponse)(nil),          // 26: chatto.admin.v1.CreateSidebarLinkResponse
+	(*UpdateSidebarLinkRequest)(nil),           // 27: chatto.admin.v1.UpdateSidebarLinkRequest
+	(*UpdateSidebarLinkResponse)(nil),          // 28: chatto.admin.v1.UpdateSidebarLinkResponse
+	(*DeleteSidebarLinkRequest)(nil),           // 29: chatto.admin.v1.DeleteSidebarLinkRequest
+	(*DeleteSidebarLinkResponse)(nil),          // 30: chatto.admin.v1.DeleteSidebarLinkResponse
+	(*MoveSidebarLinkToGroupRequest)(nil),      // 31: chatto.admin.v1.MoveSidebarLinkToGroupRequest
+	(*MoveSidebarLinkToGroupResponse)(nil),     // 32: chatto.admin.v1.MoveSidebarLinkToGroupResponse
+	(*v1.Room)(nil),                            // 33: chatto.api.v1.Room
+	(*v1.SidebarLink)(nil),                     // 34: chatto.api.v1.SidebarLink
+	(*fieldmaskpb.FieldMask)(nil),              // 35: google.protobuf.FieldMask
 }
 var file_chatto_admin_v1_room_layout_proto_depIdxs = []int32{
-	34, // 0: chatto.admin.v1.AdminRoomLayoutItem.room:type_name -> chatto.api.v1.Room
-	35, // 1: chatto.admin.v1.AdminRoomLayoutItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
-	1,  // 2: chatto.admin.v1.AdminRoomLayoutGroup.items:type_name -> chatto.admin.v1.AdminRoomLayoutItem
-	34, // 3: chatto.admin.v1.GetRoomResponse.room:type_name -> chatto.api.v1.Room
-	2,  // 4: chatto.admin.v1.GetRoomGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	2,  // 5: chatto.admin.v1.ListRoomGroupsResponse.groups:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	0,  // 6: chatto.admin.v1.AdminRoomLayoutItemInput.kind:type_name -> chatto.admin.v1.AdminRoomLayoutItemKind
-	2,  // 7: chatto.admin.v1.CreateRoomGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	36, // 8: chatto.admin.v1.UpdateRoomGroupRequest.update_mask:type_name -> google.protobuf.FieldMask
-	2,  // 9: chatto.admin.v1.UpdateRoomGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	2,  // 10: chatto.admin.v1.ReorderRoomGroupsResponse.groups:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	2,  // 11: chatto.admin.v1.MoveRoomGroupResponse.groups:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	34, // 12: chatto.admin.v1.MoveRoomToGroupResponse.room:type_name -> chatto.api.v1.Room
-	9,  // 13: chatto.admin.v1.ReorderSidebarItemsInGroupRequest.items:type_name -> chatto.admin.v1.AdminRoomLayoutItemInput
-	2,  // 14: chatto.admin.v1.ReorderSidebarItemsInGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	9,  // 15: chatto.admin.v1.MoveSidebarItemRequest.item:type_name -> chatto.admin.v1.AdminRoomLayoutItemInput
-	9,  // 16: chatto.admin.v1.MoveSidebarItemRequest.before:type_name -> chatto.admin.v1.AdminRoomLayoutItemInput
-	2,  // 17: chatto.admin.v1.MoveSidebarItemResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
-	35, // 18: chatto.admin.v1.CreateSidebarLinkResponse.sidebar_link:type_name -> chatto.api.v1.SidebarLink
-	36, // 19: chatto.admin.v1.UpdateSidebarLinkRequest.update_mask:type_name -> google.protobuf.FieldMask
-	35, // 20: chatto.admin.v1.UpdateSidebarLinkResponse.sidebar_link:type_name -> chatto.api.v1.SidebarLink
-	35, // 21: chatto.admin.v1.MoveSidebarLinkToGroupResponse.sidebar_link:type_name -> chatto.api.v1.SidebarLink
-	3,  // 22: chatto.admin.v1.AdminRoomLayoutService.GetRoom:input_type -> chatto.admin.v1.GetRoomRequest
-	5,  // 23: chatto.admin.v1.AdminRoomLayoutService.GetRoomGroup:input_type -> chatto.admin.v1.GetRoomGroupRequest
-	7,  // 24: chatto.admin.v1.AdminRoomLayoutService.ListRoomGroups:input_type -> chatto.admin.v1.ListRoomGroupsRequest
-	10, // 25: chatto.admin.v1.AdminRoomLayoutService.CreateRoomGroup:input_type -> chatto.admin.v1.CreateRoomGroupRequest
-	12, // 26: chatto.admin.v1.AdminRoomLayoutService.UpdateRoomGroup:input_type -> chatto.admin.v1.UpdateRoomGroupRequest
-	14, // 27: chatto.admin.v1.AdminRoomLayoutService.DeleteRoomGroup:input_type -> chatto.admin.v1.DeleteRoomGroupRequest
-	16, // 28: chatto.admin.v1.AdminRoomLayoutService.ReorderRoomGroups:input_type -> chatto.admin.v1.ReorderRoomGroupsRequest
-	18, // 29: chatto.admin.v1.AdminRoomLayoutService.MoveRoomGroup:input_type -> chatto.admin.v1.MoveRoomGroupRequest
-	20, // 30: chatto.admin.v1.AdminRoomLayoutService.MoveRoomToGroup:input_type -> chatto.admin.v1.MoveRoomToGroupRequest
-	22, // 31: chatto.admin.v1.AdminRoomLayoutService.ReorderSidebarItemsInGroup:input_type -> chatto.admin.v1.ReorderSidebarItemsInGroupRequest
-	24, // 32: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarItem:input_type -> chatto.admin.v1.MoveSidebarItemRequest
-	26, // 33: chatto.admin.v1.AdminRoomLayoutService.CreateSidebarLink:input_type -> chatto.admin.v1.CreateSidebarLinkRequest
-	28, // 34: chatto.admin.v1.AdminRoomLayoutService.UpdateSidebarLink:input_type -> chatto.admin.v1.UpdateSidebarLinkRequest
-	30, // 35: chatto.admin.v1.AdminRoomLayoutService.DeleteSidebarLink:input_type -> chatto.admin.v1.DeleteSidebarLinkRequest
-	32, // 36: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarLinkToGroup:input_type -> chatto.admin.v1.MoveSidebarLinkToGroupRequest
-	4,  // 37: chatto.admin.v1.AdminRoomLayoutService.GetRoom:output_type -> chatto.admin.v1.GetRoomResponse
-	6,  // 38: chatto.admin.v1.AdminRoomLayoutService.GetRoomGroup:output_type -> chatto.admin.v1.GetRoomGroupResponse
-	8,  // 39: chatto.admin.v1.AdminRoomLayoutService.ListRoomGroups:output_type -> chatto.admin.v1.ListRoomGroupsResponse
-	11, // 40: chatto.admin.v1.AdminRoomLayoutService.CreateRoomGroup:output_type -> chatto.admin.v1.CreateRoomGroupResponse
-	13, // 41: chatto.admin.v1.AdminRoomLayoutService.UpdateRoomGroup:output_type -> chatto.admin.v1.UpdateRoomGroupResponse
-	15, // 42: chatto.admin.v1.AdminRoomLayoutService.DeleteRoomGroup:output_type -> chatto.admin.v1.DeleteRoomGroupResponse
-	17, // 43: chatto.admin.v1.AdminRoomLayoutService.ReorderRoomGroups:output_type -> chatto.admin.v1.ReorderRoomGroupsResponse
-	19, // 44: chatto.admin.v1.AdminRoomLayoutService.MoveRoomGroup:output_type -> chatto.admin.v1.MoveRoomGroupResponse
-	21, // 45: chatto.admin.v1.AdminRoomLayoutService.MoveRoomToGroup:output_type -> chatto.admin.v1.MoveRoomToGroupResponse
-	23, // 46: chatto.admin.v1.AdminRoomLayoutService.ReorderSidebarItemsInGroup:output_type -> chatto.admin.v1.ReorderSidebarItemsInGroupResponse
-	25, // 47: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarItem:output_type -> chatto.admin.v1.MoveSidebarItemResponse
-	27, // 48: chatto.admin.v1.AdminRoomLayoutService.CreateSidebarLink:output_type -> chatto.admin.v1.CreateSidebarLinkResponse
-	29, // 49: chatto.admin.v1.AdminRoomLayoutService.UpdateSidebarLink:output_type -> chatto.admin.v1.UpdateSidebarLinkResponse
-	31, // 50: chatto.admin.v1.AdminRoomLayoutService.DeleteSidebarLink:output_type -> chatto.admin.v1.DeleteSidebarLinkResponse
-	33, // 51: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarLinkToGroup:output_type -> chatto.admin.v1.MoveSidebarLinkToGroupResponse
-	37, // [37:52] is the sub-list for method output_type
-	22, // [22:37] is the sub-list for method input_type
-	22, // [22:22] is the sub-list for extension type_name
-	22, // [22:22] is the sub-list for extension extendee
-	0,  // [0:22] is the sub-list for field type_name
+	33, // 0: chatto.admin.v1.AdminRoomLayoutItem.room:type_name -> chatto.api.v1.Room
+	34, // 1: chatto.admin.v1.AdminRoomLayoutItem.sidebar_link:type_name -> chatto.api.v1.SidebarLink
+	0,  // 2: chatto.admin.v1.AdminRoomLayoutGroup.items:type_name -> chatto.admin.v1.AdminRoomLayoutItem
+	33, // 3: chatto.admin.v1.GetRoomResponse.room:type_name -> chatto.api.v1.Room
+	1,  // 4: chatto.admin.v1.GetRoomGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	1,  // 5: chatto.admin.v1.ListRoomGroupsResponse.groups:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	1,  // 6: chatto.admin.v1.CreateRoomGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	35, // 7: chatto.admin.v1.UpdateRoomGroupRequest.update_mask:type_name -> google.protobuf.FieldMask
+	1,  // 8: chatto.admin.v1.UpdateRoomGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	1,  // 9: chatto.admin.v1.ReorderRoomGroupsResponse.groups:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	1,  // 10: chatto.admin.v1.MoveRoomGroupResponse.groups:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	33, // 11: chatto.admin.v1.MoveRoomToGroupResponse.room:type_name -> chatto.api.v1.Room
+	8,  // 12: chatto.admin.v1.ReorderSidebarItemsInGroupRequest.items:type_name -> chatto.admin.v1.AdminRoomLayoutItemInput
+	1,  // 13: chatto.admin.v1.ReorderSidebarItemsInGroupResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	8,  // 14: chatto.admin.v1.MoveSidebarItemRequest.item:type_name -> chatto.admin.v1.AdminRoomLayoutItemInput
+	8,  // 15: chatto.admin.v1.MoveSidebarItemRequest.before:type_name -> chatto.admin.v1.AdminRoomLayoutItemInput
+	1,  // 16: chatto.admin.v1.MoveSidebarItemResponse.group:type_name -> chatto.admin.v1.AdminRoomLayoutGroup
+	34, // 17: chatto.admin.v1.CreateSidebarLinkResponse.sidebar_link:type_name -> chatto.api.v1.SidebarLink
+	35, // 18: chatto.admin.v1.UpdateSidebarLinkRequest.update_mask:type_name -> google.protobuf.FieldMask
+	34, // 19: chatto.admin.v1.UpdateSidebarLinkResponse.sidebar_link:type_name -> chatto.api.v1.SidebarLink
+	34, // 20: chatto.admin.v1.MoveSidebarLinkToGroupResponse.sidebar_link:type_name -> chatto.api.v1.SidebarLink
+	2,  // 21: chatto.admin.v1.AdminRoomLayoutService.GetRoom:input_type -> chatto.admin.v1.GetRoomRequest
+	4,  // 22: chatto.admin.v1.AdminRoomLayoutService.GetRoomGroup:input_type -> chatto.admin.v1.GetRoomGroupRequest
+	6,  // 23: chatto.admin.v1.AdminRoomLayoutService.ListRoomGroups:input_type -> chatto.admin.v1.ListRoomGroupsRequest
+	9,  // 24: chatto.admin.v1.AdminRoomLayoutService.CreateRoomGroup:input_type -> chatto.admin.v1.CreateRoomGroupRequest
+	11, // 25: chatto.admin.v1.AdminRoomLayoutService.UpdateRoomGroup:input_type -> chatto.admin.v1.UpdateRoomGroupRequest
+	13, // 26: chatto.admin.v1.AdminRoomLayoutService.DeleteRoomGroup:input_type -> chatto.admin.v1.DeleteRoomGroupRequest
+	15, // 27: chatto.admin.v1.AdminRoomLayoutService.ReorderRoomGroups:input_type -> chatto.admin.v1.ReorderRoomGroupsRequest
+	17, // 28: chatto.admin.v1.AdminRoomLayoutService.MoveRoomGroup:input_type -> chatto.admin.v1.MoveRoomGroupRequest
+	19, // 29: chatto.admin.v1.AdminRoomLayoutService.MoveRoomToGroup:input_type -> chatto.admin.v1.MoveRoomToGroupRequest
+	21, // 30: chatto.admin.v1.AdminRoomLayoutService.ReorderSidebarItemsInGroup:input_type -> chatto.admin.v1.ReorderSidebarItemsInGroupRequest
+	23, // 31: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarItem:input_type -> chatto.admin.v1.MoveSidebarItemRequest
+	25, // 32: chatto.admin.v1.AdminRoomLayoutService.CreateSidebarLink:input_type -> chatto.admin.v1.CreateSidebarLinkRequest
+	27, // 33: chatto.admin.v1.AdminRoomLayoutService.UpdateSidebarLink:input_type -> chatto.admin.v1.UpdateSidebarLinkRequest
+	29, // 34: chatto.admin.v1.AdminRoomLayoutService.DeleteSidebarLink:input_type -> chatto.admin.v1.DeleteSidebarLinkRequest
+	31, // 35: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarLinkToGroup:input_type -> chatto.admin.v1.MoveSidebarLinkToGroupRequest
+	3,  // 36: chatto.admin.v1.AdminRoomLayoutService.GetRoom:output_type -> chatto.admin.v1.GetRoomResponse
+	5,  // 37: chatto.admin.v1.AdminRoomLayoutService.GetRoomGroup:output_type -> chatto.admin.v1.GetRoomGroupResponse
+	7,  // 38: chatto.admin.v1.AdminRoomLayoutService.ListRoomGroups:output_type -> chatto.admin.v1.ListRoomGroupsResponse
+	10, // 39: chatto.admin.v1.AdminRoomLayoutService.CreateRoomGroup:output_type -> chatto.admin.v1.CreateRoomGroupResponse
+	12, // 40: chatto.admin.v1.AdminRoomLayoutService.UpdateRoomGroup:output_type -> chatto.admin.v1.UpdateRoomGroupResponse
+	14, // 41: chatto.admin.v1.AdminRoomLayoutService.DeleteRoomGroup:output_type -> chatto.admin.v1.DeleteRoomGroupResponse
+	16, // 42: chatto.admin.v1.AdminRoomLayoutService.ReorderRoomGroups:output_type -> chatto.admin.v1.ReorderRoomGroupsResponse
+	18, // 43: chatto.admin.v1.AdminRoomLayoutService.MoveRoomGroup:output_type -> chatto.admin.v1.MoveRoomGroupResponse
+	20, // 44: chatto.admin.v1.AdminRoomLayoutService.MoveRoomToGroup:output_type -> chatto.admin.v1.MoveRoomToGroupResponse
+	22, // 45: chatto.admin.v1.AdminRoomLayoutService.ReorderSidebarItemsInGroup:output_type -> chatto.admin.v1.ReorderSidebarItemsInGroupResponse
+	24, // 46: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarItem:output_type -> chatto.admin.v1.MoveSidebarItemResponse
+	26, // 47: chatto.admin.v1.AdminRoomLayoutService.CreateSidebarLink:output_type -> chatto.admin.v1.CreateSidebarLinkResponse
+	28, // 48: chatto.admin.v1.AdminRoomLayoutService.UpdateSidebarLink:output_type -> chatto.admin.v1.UpdateSidebarLinkResponse
+	30, // 49: chatto.admin.v1.AdminRoomLayoutService.DeleteSidebarLink:output_type -> chatto.admin.v1.DeleteSidebarLinkResponse
+	32, // 50: chatto.admin.v1.AdminRoomLayoutService.MoveSidebarLinkToGroup:output_type -> chatto.admin.v1.MoveSidebarLinkToGroupResponse
+	36, // [36:51] is the sub-list for method output_type
+	21, // [21:36] is the sub-list for method input_type
+	21, // [21:21] is the sub-list for extension type_name
+	21, // [21:21] is the sub-list for extension extendee
+	0,  // [0:21] is the sub-list for field type_name
 }
 
 func init() { file_chatto_admin_v1_room_layout_proto_init() }
@@ -2084,6 +2054,10 @@ func file_chatto_admin_v1_room_layout_proto_init() {
 		(*AdminRoomLayoutItem_Room)(nil),
 		(*AdminRoomLayoutItem_SidebarLink)(nil),
 	}
+	file_chatto_admin_v1_room_layout_proto_msgTypes[8].OneofWrappers = []any{
+		(*AdminRoomLayoutItemInput_RoomId)(nil),
+		(*AdminRoomLayoutItemInput_SidebarLinkId)(nil),
+	}
 	file_chatto_admin_v1_room_layout_proto_msgTypes[11].OneofWrappers = []any{}
 	file_chatto_admin_v1_room_layout_proto_msgTypes[17].OneofWrappers = []any{}
 	file_chatto_admin_v1_room_layout_proto_msgTypes[27].OneofWrappers = []any{}
@@ -2092,14 +2066,13 @@ func file_chatto_admin_v1_room_layout_proto_init() {
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_admin_v1_room_layout_proto_rawDesc), len(file_chatto_admin_v1_room_layout_proto_rawDesc)),
-			NumEnums:      1,
+			NumEnums:      0,
 			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
 		GoTypes:           file_chatto_admin_v1_room_layout_proto_goTypes,
 		DependencyIndexes: file_chatto_admin_v1_room_layout_proto_depIdxs,
-		EnumInfos:         file_chatto_admin_v1_room_layout_proto_enumTypes,
 		MessageInfos:      file_chatto_admin_v1_room_layout_proto_msgTypes,
 	}.Build()
 	File_chatto_admin_v1_room_layout_proto = out.File

--- a/packages/api-types/src/chatto/admin/v1/room_layout_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/room_layout_pb.ts
@@ -9,40 +9,6 @@ import { Room } from "../../api/v1/rooms_pb.js";
 import { SidebarLink } from "../../api/v1/room_directory_pb.js";
 
 /**
- * Sidebar item kind used in reorder requests.
- *
- * @generated from enum chatto.admin.v1.AdminRoomLayoutItemKind
- */
-export enum AdminRoomLayoutItemKind {
-  /**
-   * The item kind was not specified.
-   *
-   * @generated from enum value: ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED = 0;
-   */
-  UNSPECIFIED = 0,
-
-  /**
-   * Channel room entry.
-   *
-   * @generated from enum value: ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM = 1;
-   */
-  ROOM = 1,
-
-  /**
-   * Sidebar link entry.
-   *
-   * @generated from enum value: ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK = 2;
-   */
-  SIDEBAR_LINK = 2,
-}
-// Retrieve enum metadata with: proto3.getEnumType(AdminRoomLayoutItemKind)
-proto3.util.setEnumType(AdminRoomLayoutItemKind, "chatto.admin.v1.AdminRoomLayoutItemKind", [
-  { no: 0, name: "ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED" },
-  { no: 1, name: "ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM" },
-  { no: 2, name: "ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK" },
-]);
-
-/**
  * One ordered sidebar item in an admin room group layout.
  *
  * @generated from message chatto.admin.v1.AdminRoomLayoutItem
@@ -444,24 +410,31 @@ export class ListRoomGroupsResponse extends Message<ListRoomGroupsResponse> {
 }
 
 /**
- * One item reference in a sidebar order replacement.
+ * One room or sidebar link reference in a move or order replacement.
  *
  * @generated from message chatto.admin.v1.AdminRoomLayoutItemInput
  */
 export class AdminRoomLayoutItemInput extends Message<AdminRoomLayoutItemInput> {
   /**
-   * Item kind.
-   *
-   * @generated from field: chatto.admin.v1.AdminRoomLayoutItemKind kind = 1;
+   * @generated from oneof chatto.admin.v1.AdminRoomLayoutItemInput.item
    */
-  kind = AdminRoomLayoutItemKind.UNSPECIFIED;
-
-  /**
-   * Room ID when kind is ROOM, sidebar link ID when kind is SIDEBAR_LINK.
-   *
-   * @generated from field: string id = 2;
-   */
-  id = "";
+  item: {
+    /**
+     * Channel room ID.
+     *
+     * @generated from field: string room_id = 3;
+     */
+    value: string;
+    case: "roomId";
+  } | {
+    /**
+     * Sidebar link ID.
+     *
+     * @generated from field: string sidebar_link_id = 4;
+     */
+    value: string;
+    case: "sidebarLinkId";
+  } | { case: undefined; value?: undefined } = { case: undefined };
 
   constructor(data?: PartialMessage<AdminRoomLayoutItemInput>) {
     super();
@@ -471,8 +444,8 @@ export class AdminRoomLayoutItemInput extends Message<AdminRoomLayoutItemInput> 
   static readonly runtime: typeof proto3 = proto3;
   static readonly typeName = "chatto.admin.v1.AdminRoomLayoutItemInput";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "kind", kind: "enum", T: proto3.getEnumType(AdminRoomLayoutItemKind) },
-    { no: 2, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "item" },
+    { no: 4, name: "sidebar_link_id", kind: "scalar", T: 9 /* ScalarType.STRING */, oneof: "item" },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AdminRoomLayoutItemInput {

--- a/proto/chatto/admin/v1/room_layout.proto
+++ b/proto/chatto/admin/v1/room_layout.proto
@@ -77,25 +77,18 @@ message ListRoomGroupsResponse {
   repeated AdminRoomLayoutGroup groups = 1;
 }
 
-// Sidebar item kind used in reorder requests.
-enum AdminRoomLayoutItemKind {
-  // The item kind was not specified.
-  ADMIN_ROOM_LAYOUT_ITEM_KIND_UNSPECIFIED = 0;
-  // Channel room entry.
-  ADMIN_ROOM_LAYOUT_ITEM_KIND_ROOM = 1;
-  // Sidebar link entry.
-  ADMIN_ROOM_LAYOUT_ITEM_KIND_SIDEBAR_LINK = 2;
-}
-
-// One item reference in a sidebar order replacement.
+// One room or sidebar link reference in a move or order replacement.
 message AdminRoomLayoutItemInput {
-  // Item kind.
-  AdminRoomLayoutItemKind kind = 1 [(buf.validate.field).enum = {
-    defined_only: true
-    not_in: [0]
-  }];
-  // Room ID when kind is ROOM, sidebar link ID when kind is SIDEBAR_LINK.
-  string id = 2 [(buf.validate.field).string.min_len = 1];
+  reserved 1, 2;
+  reserved "kind", "id";
+
+  oneof item {
+    option (buf.validate.oneof).required = true;
+    // Channel room ID.
+    string room_id = 3 [(buf.validate.field).string.min_len = 1];
+    // Sidebar link ID.
+    string sidebar_link_id = 4 [(buf.validate.field).string.min_len = 1];
+  }
 }
 
 // Request to create a room group.


### PR DESCRIPTION
- **What:** Replace sidebar item `kind`/`id` inputs with a required protobuf `oneof`: `room_id` or `sidebar_link_id`. Remove `AdminRoomLayoutItemKind`, reserve the old fields, and update generated clients, frontend adapters, JSON E2E calls, API reference, and release notes.
- **Why:** Move/reorder callers can identify the item directly. Requests now match the explicit alternatives already used by sidebar responses. Both alternatives map to the existing stored sidebar entry type; authorization and move/reorder behavior are unchanged.
- **Migration:** Approved breaking admin API change. Send `{"roomId":"room-123"}` or `{"sidebarLinkId":"link-456"}` in JSON and regenerate protobuf clients. This applies to `item`, `items`, and optional `before`; omit `before` to append. See the [migration guide](apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx#sidebar-item-references-in-05).
- **Verification:** Full Go Connect API tests, mounted JSON rejection tests (missing/empty/both alternatives and empty `before`), 191 frontend adapter tests, frontend checks with zero errors/warnings, two focused E2E tests, protobuf lint, storage compatibility, and the 77-page docs build passed. E2E covered JSON layout reordering and dragging a sidebar link. Buf reports only the approved admin enum/field removals.
