### PR TITLE
refactor(api)!: rename call token creation RPC

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -435,3 +435,13 @@ reference. Omit `before` to move an item to the end; do not send an empty object
 Regenerate protobuf clients and remove uses of `AdminRoomLayoutItemKind`.
 The old field names and numbers are reserved. Stored sidebar entries and
 move/reorder authorization are unchanged.
+
+## Call token creation in 0.5
+
+`VoiceCallService.GetCallToken` is now `VoiceCallService.CreateCallToken`.
+The request and response types are now `CreateCallTokenRequest` and
+`CreateCallTokenResponse`. Regenerate clients and update JSON request paths to
+`/api/connect/chatto.api.v1.VoiceCallService/CreateCallToken`.
+The old route is removed. Request fields, token contents, authorization, and
+error behavior are unchanged. The name now matches the credential-creation
+operation `CreateCallMediaPublisherToken`.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/calls.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/calls.mdx
@@ -195,9 +195,9 @@ Response from recording a join intent.
 | `joined` | `bool` | True when a join fact was recorded. |
 
 
-<a id="chatto-api-v1-VoiceCallService-GetCallToken"></a>
+<a id="chatto-api-v1-VoiceCallService-CreateCallToken"></a>
 
-### GetCallToken
+### CreateCallToken
 
 Issues a LiveKit token for joining the room's active call.
 
@@ -207,12 +207,12 @@ caller is not a room member, and FAILED_PRECONDITION when no call is active
 or voice and video calls are not configured.
 
 ```http
-POST /api/connect/chatto.api.v1.VoiceCallService/GetCallToken
+POST /api/connect/chatto.api.v1.VoiceCallService/CreateCallToken
 ```
 
-<a id="chatto-api-v1-GetCallTokenRequest"></a>
+<a id="chatto-api-v1-CreateCallTokenRequest"></a>
 
-#### Input: GetCallTokenRequest
+#### Input: CreateCallTokenRequest
 
 Request for a LiveKit token for a room call.
 
@@ -221,9 +221,9 @@ Request for a LiveKit token for a room call.
 | `room_id` | `string` | Required. Room whose active call should be joined. |
 
 
-<a id="chatto-api-v1-GetCallTokenResponse"></a>
+<a id="chatto-api-v1-CreateCallTokenResponse"></a>
 
-#### Result: GetCallTokenResponse
+#### Result: CreateCallTokenResponse
 
 LiveKit token details for joining a room call.
 

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -402,6 +402,10 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
 
 ### Navigation and notifications
 
+- `VoiceCallService.GetCallToken` is now `CreateCallToken`, matching its purpose
+  of issuing a credential. Update clients and JSON request paths; token behavior
+  is unchanged. See the [migration guide](/guides/integrations/api-compatibility/#call-token-creation-in-05).
+
 - Sidebar move and reorder requests now use an explicit room or sidebar-link
   ID instead of a kind/ID pair. See the [migration guide](/guides/integrations/api-compatibility/#sidebar-item-references-in-05).
 

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -4098,9 +4098,9 @@ Response from recording a join intent.
 | `joined` | `bool` | True when a join fact was recorded. |
 
 
-<a id="chatto-api-v1-VoiceCallService-GetCallToken"></a>
+<a id="chatto-api-v1-VoiceCallService-CreateCallToken"></a>
 
-### GetCallToken
+### CreateCallToken
 
 Issues a LiveKit token for joining the room's active call.
 
@@ -4110,12 +4110,12 @@ caller is not a room member, and FAILED_PRECONDITION when no call is active
 or voice and video calls are not configured.
 
 ```http
-POST /api/connect/chatto.api.v1.VoiceCallService/GetCallToken
+POST /api/connect/chatto.api.v1.VoiceCallService/CreateCallToken
 ```
 
-<a id="chatto-api-v1-GetCallTokenRequest"></a>
+<a id="chatto-api-v1-CreateCallTokenRequest"></a>
 
-#### Input: GetCallTokenRequest
+#### Input: CreateCallTokenRequest
 
 Request for a LiveKit token for a room call.
 
@@ -4124,9 +4124,9 @@ Request for a LiveKit token for a room call.
 | `room_id` | `string` | Required. Room whose active call should be joined. |
 
 
-<a id="chatto-api-v1-GetCallTokenResponse"></a>
+<a id="chatto-api-v1-CreateCallTokenResponse"></a>
 
-#### Result: GetCallTokenResponse
+#### Result: CreateCallTokenResponse
 
 LiveKit token details for joining a room call.
 

--- a/apps/frontend/e2e/voice-call.spec.ts
+++ b/apps/frontend/e2e/voice-call.spec.ts
@@ -48,7 +48,7 @@ interface LeaveCallResponse {
   left?: boolean;
 }
 
-interface GetCallTokenResponse {
+interface CreateCallTokenResponse {
   token?: string;
   e2eeKey?: string;
   callId?: string;
@@ -90,8 +90,8 @@ async function leaveCallViaConnect(page: Page, roomId: string): Promise<boolean>
   return data.left ?? false;
 }
 
-async function getCallTokenViaConnect(page: Page, roomId: string): Promise<GetCallTokenResponse> {
-  return connectPost<GetCallTokenResponse>(page, 'chatto.api.v1.VoiceCallService/GetCallToken', {
+async function createCallTokenViaConnect(page: Page, roomId: string): Promise<CreateCallTokenResponse> {
+  return connectPost<CreateCallTokenResponse>(page, 'chatto.api.v1.VoiceCallService/CreateCallToken', {
     roomId
   });
 }
@@ -157,7 +157,7 @@ test.describe('Voice calls', () => {
 
     await expect(joinCallViaConnect(page, roomId)).resolves.toBe(true);
 
-    const token = await getCallTokenViaConnect(page, roomId);
+    const token = await createCallTokenViaConnect(page, roomId);
     expect(token.token).toBeTruthy();
     expect(token.e2eeKey).toBeTruthy();
     expect(token.callId).toBeTruthy();
@@ -182,7 +182,7 @@ test.describe('Voice calls', () => {
     await withServerUser(browser!, serverURL, async ({ page: page2 }) => {
       const response = await connectPostResponse(
         page2,
-        'chatto.api.v1.VoiceCallService/GetCallToken',
+        'chatto.api.v1.VoiceCallService/CreateCallToken',
         { roomId }
       );
       expect(response.ok()).toBe(false);

--- a/apps/frontend/src/lib/api-client-tests/voiceCalls.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/voiceCalls.spec.ts
@@ -5,7 +5,7 @@ const mocks = vi.hoisted(() => ({
   createClient: vi.fn(),
   createConnectTransport: vi.fn(),
   joinCall: vi.fn(),
-  getCallToken: vi.fn(),
+  createCallToken: vi.fn(),
   createCallMediaPublisherToken: vi.fn(),
   leaveCall: vi.fn()
 }));
@@ -27,13 +27,13 @@ describe('createVoiceCallAPI', () => {
     mocks.createClient.mockReset();
     mocks.createConnectTransport.mockReset();
     mocks.joinCall.mockReset();
-    mocks.getCallToken.mockReset();
+    mocks.createCallToken.mockReset();
     mocks.createCallMediaPublisherToken.mockReset();
     mocks.leaveCall.mockReset();
     mocks.createConnectTransport.mockReturnValue({ kind: 'transport' });
     mocks.createClient.mockReturnValue({
       joinCall: mocks.joinCall,
-      getCallToken: mocks.getCallToken,
+      createCallToken: mocks.createCallToken,
       createCallMediaPublisherToken: mocks.createCallMediaPublisherToken,
       leaveCall: mocks.leaveCall
     });
@@ -42,7 +42,7 @@ describe('createVoiceCallAPI', () => {
   it('maps call commands without auth headers', async () => {
     mocks.joinCall.mockResolvedValue({ joined: true });
     mocks.leaveCall.mockResolvedValue({ left: true });
-    mocks.getCallToken.mockResolvedValue({ token: 'jwt', e2eeKey: 'key', callId: 'call-1' });
+    mocks.createCallToken.mockResolvedValue({ token: 'jwt', e2eeKey: 'key', callId: 'call-1' });
     mocks.createCallMediaPublisherToken.mockResolvedValue({
       token: 'publisher-jwt',
       e2eeKey: 'key',
@@ -52,7 +52,7 @@ describe('createVoiceCallAPI', () => {
     const api = createVoiceCallAPI({ baseUrl: '/api/connect', bearerToken: null });
 
     await expect(api.joinCall('room-1')).resolves.toBe(true);
-    await expect(api.getCallToken('room-1')).resolves.toEqual({
+    await expect(api.createCallToken('room-1')).resolves.toEqual({
       token: 'jwt',
       e2eeKey: 'key',
       callId: 'call-1'
@@ -65,7 +65,7 @@ describe('createVoiceCallAPI', () => {
     await expect(api.leaveCall('room-1')).resolves.toBe(true);
 
     expect(mocks.joinCall).toHaveBeenCalledWith({ roomId: 'room-1' }, { headers: undefined });
-    expect(mocks.getCallToken).toHaveBeenCalledWith({ roomId: 'room-1' }, { headers: undefined });
+    expect(mocks.createCallToken).toHaveBeenCalledWith({ roomId: 'room-1' }, { headers: undefined });
     expect(mocks.leaveCall).toHaveBeenCalledWith({ roomId: 'room-1' }, { headers: undefined });
   });
 });

--- a/apps/frontend/src/lib/api-client/voiceCalls.ts
+++ b/apps/frontend/src/lib/api-client/voiceCalls.ts
@@ -23,8 +23,8 @@ export function createVoiceCallAPI(config: VoiceCallAPIConfig) {
       return (await client.joinCall({ roomId }, { headers: headers() })).joined;
     },
 
-    async getCallToken(roomId: string): Promise<VoiceCallToken | null> {
-      const response = await client.getCallToken({ roomId }, { headers: headers() });
+    async createCallToken(roomId: string): Promise<VoiceCallToken | null> {
+      const response = await client.createCallToken({ roomId }, { headers: headers() });
       if (!response.token || !response.e2eeKey || !response.callId) return null;
       return {
         token: response.token,

--- a/apps/frontend/src/lib/state/server/store.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.spec.ts
@@ -91,7 +91,7 @@ const { soundMocks, apiMocks, cacheMocks } = vi.hoisted(() => ({
       })
     ),
     joinCall: vi.fn(() => Promise.resolve(true)),
-    getCallToken: vi.fn(() => Promise.resolve(null)),
+    createCallToken: vi.fn(() => Promise.resolve(null)),
     leaveCall: vi.fn(() => Promise.resolve(true)),
     activatePrivilegedMode: vi.fn(() =>
       Promise.resolve({
@@ -232,7 +232,7 @@ vi.mock('$lib/api-client/memberDirectory', () => ({
 vi.mock('$lib/api-client/voiceCalls', () => ({
   createVoiceCallAPI: vi.fn(() => ({
     joinCall: apiMocks.joinCall,
-    getCallToken: apiMocks.getCallToken,
+    createCallToken: apiMocks.createCallToken,
     leaveCall: apiMocks.leaveCall
   }))
 }));
@@ -517,7 +517,7 @@ beforeEach(() => {
   apiMocks.refreshAssetUrls.mockReset();
   apiMocks.refreshAssetUrls.mockResolvedValue(new Map());
   apiMocks.joinCall.mockResolvedValue(true);
-  apiMocks.getCallToken.mockResolvedValue(null);
+  apiMocks.createCallToken.mockResolvedValue(null);
   apiMocks.leaveCall.mockResolvedValue(true);
   apiMocks.activatePrivilegedMode.mockReset();
   apiMocks.activatePrivilegedMode.mockResolvedValue({

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.spec.ts
@@ -241,7 +241,7 @@ vi.mock('livekit-client/e2ee-worker?worker', () => ({
 function createVoiceCallClient(overrides: Partial<VoiceCallAPI> = {}): VoiceCallAPI {
   return {
     joinCall: vi.fn(async () => true),
-    getCallToken: vi.fn(async () => ({
+    createCallToken: vi.fn(async () => ({
       token: 'livekit-token',
       e2eeKey: 'shared-e2ee-key',
       callId: 'call-1'
@@ -411,7 +411,7 @@ describe('VoiceCallState', () => {
     );
 
     expect(client.joinCall).not.toHaveBeenCalled();
-    expect(client.getCallToken).not.toHaveBeenCalled();
+    expect(client.createCallToken).not.toHaveBeenCalled();
     expect(state.isInAnyCall).toBe(false);
     expect(soundMocks.playCallSound).not.toHaveBeenCalled();
   });
@@ -434,7 +434,7 @@ describe('VoiceCallState', () => {
     ]);
 
     expect(client.joinCall).toHaveBeenCalledTimes(1);
-    expect(client.getCallToken).toHaveBeenCalledTimes(1);
+    expect(client.createCallToken).toHaveBeenCalledTimes(1);
     expect(calls.filter((call) => call === 'connect')).toHaveLength(1);
   });
 

--- a/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
+++ b/apps/frontend/src/lib/state/server/voiceCall.svelte.ts
@@ -395,8 +395,8 @@ export class VoiceCallState {
       await this.#api.joinCall(roomId);
       joinIntentRecorded = true;
 
-      // Get token from server (pure query, no side effects)
-      const tokenResponse = await this.#api.getCallToken(roomId);
+      // Request a credential for the active call.
+      const tokenResponse = await this.#api.createCallToken(roomId);
       if (!tokenResponse) {
         throw new Error('Failed to get voice call token');
       }

--- a/cli/internal/connectapi/room_services_test.go
+++ b/cli/internal/connectapi/room_services_test.go
@@ -2345,10 +2345,10 @@ func TestVoiceCallServiceRecordsAndListsCalls(t *testing.T) {
 	if len(disabledBatch.Msg.GetCalls()) != 0 {
 		t.Fatalf("disabled BatchGetActiveCalls calls = %+v, want none", disabledBatch.Msg.GetCalls())
 	}
-	if _, err := env.voice.GetCallToken(ctx, connect.NewRequest(&apiv1.GetCallTokenRequest{
+	if _, err := env.voice.CreateCallToken(ctx, connect.NewRequest(&apiv1.CreateCallTokenRequest{
 		RoomId: room.Id,
 	})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
-		t.Fatalf("disabled GetCallToken code = %v, want failed_precondition", connect.CodeOf(err))
+		t.Fatalf("disabled CreateCallToken code = %v, want failed_precondition", connect.CodeOf(err))
 	}
 
 	env.api.config.LiveKit = config.LiveKitConfig{
@@ -2438,14 +2438,14 @@ func TestVoiceCallServiceRecordsAndListsCalls(t *testing.T) {
 		t.Fatalf("participants = %+v, want viewer participant with call metadata", participants)
 	}
 
-	tokenResp, err := env.voice.GetCallToken(ctx, connect.NewRequest(&apiv1.GetCallTokenRequest{
+	tokenResp, err := env.voice.CreateCallToken(ctx, connect.NewRequest(&apiv1.CreateCallTokenRequest{
 		RoomId: room.Id,
 	}))
 	if err != nil {
-		t.Fatalf("GetCallToken: %v", err)
+		t.Fatalf("CreateCallToken: %v", err)
 	}
 	if tokenResp.Msg.GetToken() == "" || tokenResp.Msg.GetE2EeKey() == "" || tokenResp.Msg.GetCallId() != participants[0].GetCallId() {
-		t.Fatalf("GetCallToken response = %+v, want token/e2ee key/call id", tokenResp.Msg)
+		t.Fatalf("CreateCallToken response = %+v, want token/e2ee key/call id", tokenResp.Msg)
 	}
 	publisherResp, err := env.voice.CreateCallMediaPublisherToken(ctx, connect.NewRequest(&apiv1.CreateCallMediaPublisherTokenRequest{
 		RoomId: room.Id,
@@ -2481,10 +2481,10 @@ func TestVoiceCallServiceRecordsAndListsCalls(t *testing.T) {
 	})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("GetActiveCall after leave code = %v, want not_found", connect.CodeOf(err))
 	}
-	if _, err := env.voice.GetCallToken(ctx, connect.NewRequest(&apiv1.GetCallTokenRequest{
+	if _, err := env.voice.CreateCallToken(ctx, connect.NewRequest(&apiv1.CreateCallTokenRequest{
 		RoomId: room.Id,
 	})); connect.CodeOf(err) != connect.CodeFailedPrecondition {
-		t.Fatalf("GetCallToken after leave code = %v, want failed_precondition", connect.CodeOf(err))
+		t.Fatalf("CreateCallToken after leave code = %v, want failed_precondition", connect.CodeOf(err))
 	}
 	if _, err := env.voice.CreateCallMediaPublisherToken(ctx, connect.NewRequest(&apiv1.CreateCallMediaPublisherTokenRequest{
 		RoomId: room.Id,
@@ -2624,10 +2624,10 @@ func TestVoiceCallServiceRoomRemovalClearsCallParticipant(t *testing.T) {
 	})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("GetActiveCall after removal code = %v, want not_found", connect.CodeOf(err))
 	}
-	if _, err := env.voice.GetCallToken(withCaller(env.ctx, target), connect.NewRequest(&apiv1.GetCallTokenRequest{
+	if _, err := env.voice.CreateCallToken(withCaller(env.ctx, target), connect.NewRequest(&apiv1.CreateCallTokenRequest{
 		RoomId: room.Id,
 	})); connect.CodeOf(err) != connect.CodePermissionDenied {
-		t.Fatalf("removed member GetCallToken code = %v, want permission_denied", connect.CodeOf(err))
+		t.Fatalf("removed member CreateCallToken code = %v, want permission_denied", connect.CodeOf(err))
 	}
 }
 

--- a/cli/internal/connectapi/voice_calls.go
+++ b/cli/internal/connectapi/voice_calls.go
@@ -137,7 +137,7 @@ func (s *voiceCallService) JoinCall(ctx context.Context, req *connect.Request[ap
 	return connect.NewResponse(&apiv1.JoinCallResponse{Joined: true}), nil
 }
 
-func (s *voiceCallService) GetCallToken(ctx context.Context, req *connect.Request[apiv1.GetCallTokenRequest]) (*connect.Response[apiv1.GetCallTokenResponse], error) {
+func (s *voiceCallService) CreateCallToken(ctx context.Context, req *connect.Request[apiv1.CreateCallTokenRequest]) (*connect.Response[apiv1.CreateCallTokenResponse], error) {
 	caller, err := requireCaller(ctx)
 	if err != nil {
 		return nil, err
@@ -180,7 +180,7 @@ func (s *voiceCallService) GetCallToken(ctx context.Context, req *connect.Reques
 		return nil, connectError(err)
 	}
 
-	return connect.NewResponse(&apiv1.GetCallTokenResponse{
+	return connect.NewResponse(&apiv1.CreateCallTokenResponse{
 		Token:   token.Token,
 		E2EeKey: token.E2EEKey,
 		CallId:  token.CallID,

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/voice_calls.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/voice_calls.connect.go
@@ -48,9 +48,9 @@ const (
 	// VoiceCallServiceJoinCallProcedure is the fully-qualified name of the VoiceCallService's JoinCall
 	// RPC.
 	VoiceCallServiceJoinCallProcedure = "/chatto.api.v1.VoiceCallService/JoinCall"
-	// VoiceCallServiceGetCallTokenProcedure is the fully-qualified name of the VoiceCallService's
-	// GetCallToken RPC.
-	VoiceCallServiceGetCallTokenProcedure = "/chatto.api.v1.VoiceCallService/GetCallToken"
+	// VoiceCallServiceCreateCallTokenProcedure is the fully-qualified name of the VoiceCallService's
+	// CreateCallToken RPC.
+	VoiceCallServiceCreateCallTokenProcedure = "/chatto.api.v1.VoiceCallService/CreateCallToken"
 	// VoiceCallServiceCreateCallMediaPublisherTokenProcedure is the fully-qualified name of the
 	// VoiceCallService's CreateCallMediaPublisherToken RPC.
 	VoiceCallServiceCreateCallMediaPublisherTokenProcedure = "/chatto.api.v1.VoiceCallService/CreateCallMediaPublisherToken"
@@ -96,7 +96,7 @@ type VoiceCallServiceClient interface {
 	// Returns NOT_FOUND when the room does not exist, PERMISSION_DENIED when the
 	// caller is not a room member, and FAILED_PRECONDITION when no call is active
 	// or voice and video calls are not configured.
-	GetCallToken(context.Context, *connect.Request[v1.GetCallTokenRequest]) (*connect.Response[v1.GetCallTokenResponse], error)
+	CreateCallToken(context.Context, *connect.Request[v1.CreateCallTokenRequest]) (*connect.Response[v1.CreateCallTokenResponse], error)
 	// Issues a short-lived LiveKit token for a native companion publisher owned
 	// by the caller. Companion publishers contribute media to the caller's
 	// logical participant without becoming call participants themselves.
@@ -152,10 +152,10 @@ func NewVoiceCallServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(voiceCallServiceMethods.ByName("JoinCall")),
 			connect.WithClientOptions(opts...),
 		),
-		getCallToken: connect.NewClient[v1.GetCallTokenRequest, v1.GetCallTokenResponse](
+		createCallToken: connect.NewClient[v1.CreateCallTokenRequest, v1.CreateCallTokenResponse](
 			httpClient,
-			baseURL+VoiceCallServiceGetCallTokenProcedure,
-			connect.WithSchema(voiceCallServiceMethods.ByName("GetCallToken")),
+			baseURL+VoiceCallServiceCreateCallTokenProcedure,
+			connect.WithSchema(voiceCallServiceMethods.ByName("CreateCallToken")),
 			connect.WithClientOptions(opts...),
 		),
 		createCallMediaPublisherToken: connect.NewClient[v1.CreateCallMediaPublisherTokenRequest, v1.CreateCallMediaPublisherTokenResponse](
@@ -180,7 +180,7 @@ type voiceCallServiceClient struct {
 	batchGetActiveCalls           *connect.Client[v1.BatchGetActiveCallsRequest, v1.BatchGetActiveCallsResponse]
 	listCallParticipants          *connect.Client[v1.ListCallParticipantsRequest, v1.ListCallParticipantsResponse]
 	joinCall                      *connect.Client[v1.JoinCallRequest, v1.JoinCallResponse]
-	getCallToken                  *connect.Client[v1.GetCallTokenRequest, v1.GetCallTokenResponse]
+	createCallToken               *connect.Client[v1.CreateCallTokenRequest, v1.CreateCallTokenResponse]
 	createCallMediaPublisherToken *connect.Client[v1.CreateCallMediaPublisherTokenRequest, v1.CreateCallMediaPublisherTokenResponse]
 	leaveCall                     *connect.Client[v1.LeaveCallRequest, v1.LeaveCallResponse]
 }
@@ -210,9 +210,9 @@ func (c *voiceCallServiceClient) JoinCall(ctx context.Context, req *connect.Requ
 	return c.joinCall.CallUnary(ctx, req)
 }
 
-// GetCallToken calls chatto.api.v1.VoiceCallService.GetCallToken.
-func (c *voiceCallServiceClient) GetCallToken(ctx context.Context, req *connect.Request[v1.GetCallTokenRequest]) (*connect.Response[v1.GetCallTokenResponse], error) {
-	return c.getCallToken.CallUnary(ctx, req)
+// CreateCallToken calls chatto.api.v1.VoiceCallService.CreateCallToken.
+func (c *voiceCallServiceClient) CreateCallToken(ctx context.Context, req *connect.Request[v1.CreateCallTokenRequest]) (*connect.Response[v1.CreateCallTokenResponse], error) {
+	return c.createCallToken.CallUnary(ctx, req)
 }
 
 // CreateCallMediaPublisherToken calls chatto.api.v1.VoiceCallService.CreateCallMediaPublisherToken.
@@ -262,7 +262,7 @@ type VoiceCallServiceHandler interface {
 	// Returns NOT_FOUND when the room does not exist, PERMISSION_DENIED when the
 	// caller is not a room member, and FAILED_PRECONDITION when no call is active
 	// or voice and video calls are not configured.
-	GetCallToken(context.Context, *connect.Request[v1.GetCallTokenRequest]) (*connect.Response[v1.GetCallTokenResponse], error)
+	CreateCallToken(context.Context, *connect.Request[v1.CreateCallTokenRequest]) (*connect.Response[v1.CreateCallTokenResponse], error)
 	// Issues a short-lived LiveKit token for a native companion publisher owned
 	// by the caller. Companion publishers contribute media to the caller's
 	// logical participant without becoming call participants themselves.
@@ -314,10 +314,10 @@ func NewVoiceCallServiceHandler(svc VoiceCallServiceHandler, opts ...connect.Han
 		connect.WithSchema(voiceCallServiceMethods.ByName("JoinCall")),
 		connect.WithHandlerOptions(opts...),
 	)
-	voiceCallServiceGetCallTokenHandler := connect.NewUnaryHandler(
-		VoiceCallServiceGetCallTokenProcedure,
-		svc.GetCallToken,
-		connect.WithSchema(voiceCallServiceMethods.ByName("GetCallToken")),
+	voiceCallServiceCreateCallTokenHandler := connect.NewUnaryHandler(
+		VoiceCallServiceCreateCallTokenProcedure,
+		svc.CreateCallToken,
+		connect.WithSchema(voiceCallServiceMethods.ByName("CreateCallToken")),
 		connect.WithHandlerOptions(opts...),
 	)
 	voiceCallServiceCreateCallMediaPublisherTokenHandler := connect.NewUnaryHandler(
@@ -344,8 +344,8 @@ func NewVoiceCallServiceHandler(svc VoiceCallServiceHandler, opts ...connect.Han
 			voiceCallServiceListCallParticipantsHandler.ServeHTTP(w, r)
 		case VoiceCallServiceJoinCallProcedure:
 			voiceCallServiceJoinCallHandler.ServeHTTP(w, r)
-		case VoiceCallServiceGetCallTokenProcedure:
-			voiceCallServiceGetCallTokenHandler.ServeHTTP(w, r)
+		case VoiceCallServiceCreateCallTokenProcedure:
+			voiceCallServiceCreateCallTokenHandler.ServeHTTP(w, r)
 		case VoiceCallServiceCreateCallMediaPublisherTokenProcedure:
 			voiceCallServiceCreateCallMediaPublisherTokenHandler.ServeHTTP(w, r)
 		case VoiceCallServiceLeaveCallProcedure:
@@ -379,8 +379,8 @@ func (UnimplementedVoiceCallServiceHandler) JoinCall(context.Context, *connect.R
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.VoiceCallService.JoinCall is not implemented"))
 }
 
-func (UnimplementedVoiceCallServiceHandler) GetCallToken(context.Context, *connect.Request[v1.GetCallTokenRequest]) (*connect.Response[v1.GetCallTokenResponse], error) {
-	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.VoiceCallService.GetCallToken is not implemented"))
+func (UnimplementedVoiceCallServiceHandler) CreateCallToken(context.Context, *connect.Request[v1.CreateCallTokenRequest]) (*connect.Response[v1.CreateCallTokenResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.VoiceCallService.CreateCallToken is not implemented"))
 }
 
 func (UnimplementedVoiceCallServiceHandler) CreateCallMediaPublisherToken(context.Context, *connect.Request[v1.CreateCallMediaPublisherTokenRequest]) (*connect.Response[v1.CreateCallMediaPublisherTokenResponse], error) {

--- a/cli/internal/pb/chatto/api/v1/voice_calls.pb.go
+++ b/cli/internal/pb/chatto/api/v1/voice_calls.pb.go
@@ -652,7 +652,7 @@ func (x *JoinCallResponse) GetJoined() bool {
 }
 
 // Request for a LiveKit token for a room call.
-type GetCallTokenRequest struct {
+type CreateCallTokenRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. Room whose active call should be joined.
 	RoomId        string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
@@ -660,20 +660,20 @@ type GetCallTokenRequest struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetCallTokenRequest) Reset() {
-	*x = GetCallTokenRequest{}
+func (x *CreateCallTokenRequest) Reset() {
+	*x = CreateCallTokenRequest{}
 	mi := &file_chatto_api_v1_voice_calls_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetCallTokenRequest) String() string {
+func (x *CreateCallTokenRequest) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetCallTokenRequest) ProtoMessage() {}
+func (*CreateCallTokenRequest) ProtoMessage() {}
 
-func (x *GetCallTokenRequest) ProtoReflect() protoreflect.Message {
+func (x *CreateCallTokenRequest) ProtoReflect() protoreflect.Message {
 	mi := &file_chatto_api_v1_voice_calls_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -685,12 +685,12 @@ func (x *GetCallTokenRequest) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetCallTokenRequest.ProtoReflect.Descriptor instead.
-func (*GetCallTokenRequest) Descriptor() ([]byte, []int) {
+// Deprecated: Use CreateCallTokenRequest.ProtoReflect.Descriptor instead.
+func (*CreateCallTokenRequest) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_voice_calls_proto_rawDescGZIP(), []int{12}
 }
 
-func (x *GetCallTokenRequest) GetRoomId() string {
+func (x *CreateCallTokenRequest) GetRoomId() string {
 	if x != nil {
 		return x.RoomId
 	}
@@ -698,7 +698,7 @@ func (x *GetCallTokenRequest) GetRoomId() string {
 }
 
 // LiveKit token details for joining a room call.
-type GetCallTokenResponse struct {
+type CreateCallTokenResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// LiveKit JWT token.
 	Token string `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`
@@ -710,20 +710,20 @@ type GetCallTokenResponse struct {
 	sizeCache     protoimpl.SizeCache
 }
 
-func (x *GetCallTokenResponse) Reset() {
-	*x = GetCallTokenResponse{}
+func (x *CreateCallTokenResponse) Reset() {
+	*x = CreateCallTokenResponse{}
 	mi := &file_chatto_api_v1_voice_calls_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
 
-func (x *GetCallTokenResponse) String() string {
+func (x *CreateCallTokenResponse) String() string {
 	return protoimpl.X.MessageStringOf(x)
 }
 
-func (*GetCallTokenResponse) ProtoMessage() {}
+func (*CreateCallTokenResponse) ProtoMessage() {}
 
-func (x *GetCallTokenResponse) ProtoReflect() protoreflect.Message {
+func (x *CreateCallTokenResponse) ProtoReflect() protoreflect.Message {
 	mi := &file_chatto_api_v1_voice_calls_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
@@ -735,26 +735,26 @@ func (x *GetCallTokenResponse) ProtoReflect() protoreflect.Message {
 	return mi.MessageOf(x)
 }
 
-// Deprecated: Use GetCallTokenResponse.ProtoReflect.Descriptor instead.
-func (*GetCallTokenResponse) Descriptor() ([]byte, []int) {
+// Deprecated: Use CreateCallTokenResponse.ProtoReflect.Descriptor instead.
+func (*CreateCallTokenResponse) Descriptor() ([]byte, []int) {
 	return file_chatto_api_v1_voice_calls_proto_rawDescGZIP(), []int{13}
 }
 
-func (x *GetCallTokenResponse) GetToken() string {
+func (x *CreateCallTokenResponse) GetToken() string {
 	if x != nil {
 		return x.Token
 	}
 	return ""
 }
 
-func (x *GetCallTokenResponse) GetE2EeKey() string {
+func (x *CreateCallTokenResponse) GetE2EeKey() string {
 	if x != nil {
 		return x.E2EeKey
 	}
 	return ""
 }
 
-func (x *GetCallTokenResponse) GetCallId() string {
+func (x *CreateCallTokenResponse) GetCallId() string {
 	if x != nil {
 		return x.CallId
 	}
@@ -1005,10 +1005,10 @@ const file_chatto_api_v1_voice_calls_proto_rawDesc = "" +
 	"\x0fJoinCallRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\"*\n" +
 	"\x10JoinCallResponse\x12\x16\n" +
-	"\x06joined\x18\x01 \x01(\bR\x06joined\"7\n" +
-	"\x13GetCallTokenRequest\x12 \n" +
-	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\"`\n" +
-	"\x14GetCallTokenResponse\x12\x14\n" +
+	"\x06joined\x18\x01 \x01(\bR\x06joined\":\n" +
+	"\x16CreateCallTokenRequest\x12 \n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\"c\n" +
+	"\x17CreateCallTokenResponse\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12\x19\n" +
 	"\be2ee_key\x18\x02 \x01(\tR\ae2eeKey\x12\x17\n" +
 	"\acall_id\x18\x03 \x01(\tR\x06callId\"\x8f\x01\n" +
@@ -1026,14 +1026,14 @@ const file_chatto_api_v1_voice_calls_proto_rawDesc = "" +
 	"\x04left\x18\x01 \x01(\bR\x04left*m\n" +
 	"\x16CallMediaPublisherKind\x12)\n" +
 	"%CALL_MEDIA_PUBLISHER_KIND_UNSPECIFIED\x10\x00\x12(\n" +
-	"$CALL_MEDIA_PUBLISHER_KIND_GAME_SHARE\x10\x012\xb2\x06\n" +
+	"$CALL_MEDIA_PUBLISHER_KIND_GAME_SHARE\x10\x012\xbb\x06\n" +
 	"\x10VoiceCallService\x12`\n" +
 	"\x0fListActiveCalls\x12%.chatto.api.v1.ListActiveCallsRequest\x1a&.chatto.api.v1.ListActiveCallsResponse\x12Z\n" +
 	"\rGetActiveCall\x12#.chatto.api.v1.GetActiveCallRequest\x1a$.chatto.api.v1.GetActiveCallResponse\x12l\n" +
 	"\x13BatchGetActiveCalls\x12).chatto.api.v1.BatchGetActiveCallsRequest\x1a*.chatto.api.v1.BatchGetActiveCallsResponse\x12o\n" +
 	"\x14ListCallParticipants\x12*.chatto.api.v1.ListCallParticipantsRequest\x1a+.chatto.api.v1.ListCallParticipantsResponse\x12K\n" +
-	"\bJoinCall\x12\x1e.chatto.api.v1.JoinCallRequest\x1a\x1f.chatto.api.v1.JoinCallResponse\x12W\n" +
-	"\fGetCallToken\x12\".chatto.api.v1.GetCallTokenRequest\x1a#.chatto.api.v1.GetCallTokenResponse\x12\x8a\x01\n" +
+	"\bJoinCall\x12\x1e.chatto.api.v1.JoinCallRequest\x1a\x1f.chatto.api.v1.JoinCallResponse\x12`\n" +
+	"\x0fCreateCallToken\x12%.chatto.api.v1.CreateCallTokenRequest\x1a&.chatto.api.v1.CreateCallTokenResponse\x12\x8a\x01\n" +
 	"\x1dCreateCallMediaPublisherToken\x123.chatto.api.v1.CreateCallMediaPublisherTokenRequest\x1a4.chatto.api.v1.CreateCallMediaPublisherTokenResponse\x12N\n" +
 	"\tLeaveCall\x12\x1f.chatto.api.v1.LeaveCallRequest\x1a .chatto.api.v1.LeaveCallResponseB\xab\x01\n" +
 	"\x11com.chatto.api.v1B\x0fVoiceCallsProtoP\x01Z/hmans.de/chatto/internal/pb/chatto/api/v1;apiv1\xa2\x02\x03CAX\xaa\x02\rChatto.Api.V1\xca\x02\rChatto\\Api\\V1\xe2\x02\x19Chatto\\Api\\V1\\GPBMetadata\xea\x02\x0fChatto::Api::V1b\x06proto3"
@@ -1066,8 +1066,8 @@ var file_chatto_api_v1_voice_calls_proto_goTypes = []any{
 	(*CallParticipant)(nil),                       // 10: chatto.api.v1.CallParticipant
 	(*JoinCallRequest)(nil),                       // 11: chatto.api.v1.JoinCallRequest
 	(*JoinCallResponse)(nil),                      // 12: chatto.api.v1.JoinCallResponse
-	(*GetCallTokenRequest)(nil),                   // 13: chatto.api.v1.GetCallTokenRequest
-	(*GetCallTokenResponse)(nil),                  // 14: chatto.api.v1.GetCallTokenResponse
+	(*CreateCallTokenRequest)(nil),                // 13: chatto.api.v1.CreateCallTokenRequest
+	(*CreateCallTokenResponse)(nil),               // 14: chatto.api.v1.CreateCallTokenResponse
 	(*CreateCallMediaPublisherTokenRequest)(nil),  // 15: chatto.api.v1.CreateCallMediaPublisherTokenRequest
 	(*CreateCallMediaPublisherTokenResponse)(nil), // 16: chatto.api.v1.CreateCallMediaPublisherTokenResponse
 	(*LeaveCallRequest)(nil),                      // 17: chatto.api.v1.LeaveCallRequest
@@ -1091,7 +1091,7 @@ var file_chatto_api_v1_voice_calls_proto_depIdxs = []int32{
 	6,  // 11: chatto.api.v1.VoiceCallService.BatchGetActiveCalls:input_type -> chatto.api.v1.BatchGetActiveCallsRequest
 	8,  // 12: chatto.api.v1.VoiceCallService.ListCallParticipants:input_type -> chatto.api.v1.ListCallParticipantsRequest
 	11, // 13: chatto.api.v1.VoiceCallService.JoinCall:input_type -> chatto.api.v1.JoinCallRequest
-	13, // 14: chatto.api.v1.VoiceCallService.GetCallToken:input_type -> chatto.api.v1.GetCallTokenRequest
+	13, // 14: chatto.api.v1.VoiceCallService.CreateCallToken:input_type -> chatto.api.v1.CreateCallTokenRequest
 	15, // 15: chatto.api.v1.VoiceCallService.CreateCallMediaPublisherToken:input_type -> chatto.api.v1.CreateCallMediaPublisherTokenRequest
 	17, // 16: chatto.api.v1.VoiceCallService.LeaveCall:input_type -> chatto.api.v1.LeaveCallRequest
 	2,  // 17: chatto.api.v1.VoiceCallService.ListActiveCalls:output_type -> chatto.api.v1.ListActiveCallsResponse
@@ -1099,7 +1099,7 @@ var file_chatto_api_v1_voice_calls_proto_depIdxs = []int32{
 	7,  // 19: chatto.api.v1.VoiceCallService.BatchGetActiveCalls:output_type -> chatto.api.v1.BatchGetActiveCallsResponse
 	9,  // 20: chatto.api.v1.VoiceCallService.ListCallParticipants:output_type -> chatto.api.v1.ListCallParticipantsResponse
 	12, // 21: chatto.api.v1.VoiceCallService.JoinCall:output_type -> chatto.api.v1.JoinCallResponse
-	14, // 22: chatto.api.v1.VoiceCallService.GetCallToken:output_type -> chatto.api.v1.GetCallTokenResponse
+	14, // 22: chatto.api.v1.VoiceCallService.CreateCallToken:output_type -> chatto.api.v1.CreateCallTokenResponse
 	16, // 23: chatto.api.v1.VoiceCallService.CreateCallMediaPublisherToken:output_type -> chatto.api.v1.CreateCallMediaPublisherTokenResponse
 	18, // 24: chatto.api.v1.VoiceCallService.LeaveCall:output_type -> chatto.api.v1.LeaveCallResponse
 	17, // [17:25] is the sub-list for method output_type

--- a/docs/architecture/subjects-and-events.md
+++ b/docs/architecture/subjects-and-events.md
@@ -462,7 +462,7 @@ Listing failures increment the shared
 end projected calls only after three consecutive failed elected reconciliation
 cycles. A successful elected pass deletes the counter.
 
-`VoiceCallService.GetActiveCall`, `BatchGetActiveCalls`, `GetCallToken`, and
+`VoiceCallService.GetActiveCall`, `BatchGetActiveCalls`, `CreateCallToken`, and
 `ListCallParticipants` expose the active call ID to integrations and command
 flows. The bundled frontend receives complete authorized active-call state
 with semantic call events and infers one-shot join, leave, and end presentation

--- a/packages/api-types/src/chatto/api/v1/voice_calls_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/voice_calls_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { BatchGetActiveCallsRequest, BatchGetActiveCallsResponse, CreateCallMediaPublisherTokenRequest, CreateCallMediaPublisherTokenResponse, GetActiveCallRequest, GetActiveCallResponse, GetCallTokenRequest, GetCallTokenResponse, JoinCallRequest, JoinCallResponse, LeaveCallRequest, LeaveCallResponse, ListActiveCallsRequest, ListActiveCallsResponse, ListCallParticipantsRequest, ListCallParticipantsResponse } from "./voice_calls_pb.js";
+import { BatchGetActiveCallsRequest, BatchGetActiveCallsResponse, CreateCallMediaPublisherTokenRequest, CreateCallMediaPublisherTokenResponse, CreateCallTokenRequest, CreateCallTokenResponse, GetActiveCallRequest, GetActiveCallResponse, JoinCallRequest, JoinCallResponse, LeaveCallRequest, LeaveCallResponse, ListActiveCallsRequest, ListActiveCallsResponse, ListCallParticipantsRequest, ListCallParticipantsResponse } from "./voice_calls_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -96,12 +96,12 @@ export const VoiceCallService = {
      * caller is not a room member, and FAILED_PRECONDITION when no call is active
      * or voice and video calls are not configured.
      *
-     * @generated from rpc chatto.api.v1.VoiceCallService.GetCallToken
+     * @generated from rpc chatto.api.v1.VoiceCallService.CreateCallToken
      */
-    getCallToken: {
-      name: "GetCallToken",
-      I: GetCallTokenRequest,
-      O: GetCallTokenResponse,
+    createCallToken: {
+      name: "CreateCallToken",
+      I: CreateCallTokenRequest,
+      O: CreateCallTokenResponse,
       kind: MethodKind.Unary,
     },
     /**

--- a/packages/api-types/src/chatto/api/v1/voice_calls_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/voice_calls_pb.ts
@@ -553,9 +553,9 @@ export class JoinCallResponse extends Message<JoinCallResponse> {
 /**
  * Request for a LiveKit token for a room call.
  *
- * @generated from message chatto.api.v1.GetCallTokenRequest
+ * @generated from message chatto.api.v1.CreateCallTokenRequest
  */
-export class GetCallTokenRequest extends Message<GetCallTokenRequest> {
+export class CreateCallTokenRequest extends Message<CreateCallTokenRequest> {
   /**
    * Required. Room whose active call should be joined.
    *
@@ -563,40 +563,40 @@ export class GetCallTokenRequest extends Message<GetCallTokenRequest> {
    */
   roomId = "";
 
-  constructor(data?: PartialMessage<GetCallTokenRequest>) {
+  constructor(data?: PartialMessage<CreateCallTokenRequest>) {
     super();
     proto3.util.initPartial(data, this);
   }
 
   static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "chatto.api.v1.GetCallTokenRequest";
+  static readonly typeName = "chatto.api.v1.CreateCallTokenRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetCallTokenRequest {
-    return new GetCallTokenRequest().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateCallTokenRequest {
+    return new CreateCallTokenRequest().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetCallTokenRequest {
-    return new GetCallTokenRequest().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): CreateCallTokenRequest {
+    return new CreateCallTokenRequest().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetCallTokenRequest {
-    return new GetCallTokenRequest().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): CreateCallTokenRequest {
+    return new CreateCallTokenRequest().fromJsonString(jsonString, options);
   }
 
-  static equals(a: GetCallTokenRequest | PlainMessage<GetCallTokenRequest> | undefined, b: GetCallTokenRequest | PlainMessage<GetCallTokenRequest> | undefined): boolean {
-    return proto3.util.equals(GetCallTokenRequest, a, b);
+  static equals(a: CreateCallTokenRequest | PlainMessage<CreateCallTokenRequest> | undefined, b: CreateCallTokenRequest | PlainMessage<CreateCallTokenRequest> | undefined): boolean {
+    return proto3.util.equals(CreateCallTokenRequest, a, b);
   }
 }
 
 /**
  * LiveKit token details for joining a room call.
  *
- * @generated from message chatto.api.v1.GetCallTokenResponse
+ * @generated from message chatto.api.v1.CreateCallTokenResponse
  */
-export class GetCallTokenResponse extends Message<GetCallTokenResponse> {
+export class CreateCallTokenResponse extends Message<CreateCallTokenResponse> {
   /**
    * LiveKit JWT token.
    *
@@ -618,33 +618,33 @@ export class GetCallTokenResponse extends Message<GetCallTokenResponse> {
    */
   callId = "";
 
-  constructor(data?: PartialMessage<GetCallTokenResponse>) {
+  constructor(data?: PartialMessage<CreateCallTokenResponse>) {
     super();
     proto3.util.initPartial(data, this);
   }
 
   static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "chatto.api.v1.GetCallTokenResponse";
+  static readonly typeName = "chatto.api.v1.CreateCallTokenResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "token", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "e2ee_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "call_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetCallTokenResponse {
-    return new GetCallTokenResponse().fromBinary(bytes, options);
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateCallTokenResponse {
+    return new CreateCallTokenResponse().fromBinary(bytes, options);
   }
 
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetCallTokenResponse {
-    return new GetCallTokenResponse().fromJson(jsonValue, options);
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): CreateCallTokenResponse {
+    return new CreateCallTokenResponse().fromJson(jsonValue, options);
   }
 
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetCallTokenResponse {
-    return new GetCallTokenResponse().fromJsonString(jsonString, options);
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): CreateCallTokenResponse {
+    return new CreateCallTokenResponse().fromJsonString(jsonString, options);
   }
 
-  static equals(a: GetCallTokenResponse | PlainMessage<GetCallTokenResponse> | undefined, b: GetCallTokenResponse | PlainMessage<GetCallTokenResponse> | undefined): boolean {
-    return proto3.util.equals(GetCallTokenResponse, a, b);
+  static equals(a: CreateCallTokenResponse | PlainMessage<CreateCallTokenResponse> | undefined, b: CreateCallTokenResponse | PlainMessage<CreateCallTokenResponse> | undefined): boolean {
+    return proto3.util.equals(CreateCallTokenResponse, a, b);
   }
 }
 

--- a/proto/chatto/api/v1/voice_calls.proto
+++ b/proto/chatto/api/v1/voice_calls.proto
@@ -49,7 +49,7 @@ service VoiceCallService {
   // Returns NOT_FOUND when the room does not exist, PERMISSION_DENIED when the
   // caller is not a room member, and FAILED_PRECONDITION when no call is active
   // or voice and video calls are not configured.
-  rpc GetCallToken(GetCallTokenRequest) returns (GetCallTokenResponse);
+  rpc CreateCallToken(CreateCallTokenRequest) returns (CreateCallTokenResponse);
 
   // Issues a short-lived LiveKit token for a native companion publisher owned
   // by the caller. Companion publishers contribute media to the caller's
@@ -153,13 +153,13 @@ message JoinCallResponse {
 }
 
 // Request for a LiveKit token for a room call.
-message GetCallTokenRequest {
+message CreateCallTokenRequest {
   // Required. Room whose active call should be joined.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
 }
 
 // LiveKit token details for joining a room call.
-message GetCallTokenResponse {
+message CreateCallTokenResponse {
   // LiveKit JWT token.
   string token = 1;
   // Shared E2EE key for this active call.


### PR DESCRIPTION
- **What:** Rename `VoiceCallService.GetCallToken` to `CreateCallToken`, including request/response types, generated clients, frontend state, tests, and API documentation.
- **Why:** The RPC issues a credential. Its name now matches the existing `CreateCallMediaPublisherToken` operation. Token contents, fields, authorization, and error behavior are unchanged.
- **Migration:** Approved breaking public API change. Regenerate clients and use `/api/connect/chatto.api.v1.VoiceCallService/CreateCallToken` for JSON requests. The old route is removed. See the [migration guide](apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx#call-token-creation-in-05) and [call architecture](docs/architecture/subjects-and-events.md).
- **Verification:** Go Connect API suite, 191 frontend adapter tests, 80 frontend state tests, two focused E2E tests (valid token and membership denial), frontend checks, Svelte checks, protobuf lint, storage compatibility, and the 77-page docs build passed. Buf reports only the approved old RPC/type removals.
