### PR TITLE
fix(api): stabilize ban pagination and document page contracts

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -457,3 +457,16 @@ Handle these codes as request failures, not server failures. Wait until the
 cooldown ends before trying the username change again. Correct an unknown
 permission identifier before retrying. No client regeneration or data migration
 is required.
+
+## Pagination contracts in 0.5
+
+Each paginated RPC documents its default limit, maximum limit, and result
+order. For offset lists, an absent page or a zero limit selects the default.
+Valid limits above the RPC maximum are capped; shared `PageRequest` values
+above 500 or below zero return `INVALID_ARGUMENT`.
+
+`RoomService.ListBans` sorts by creation time, newest first, then by ban event
+ID in ascending order. Bans with equal timestamps now keep the same order
+between reads. Offset pages remain live reads: additions, removals, or expiry
+between requests can still shift offsets. No client regeneration or data
+migration is required.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-event-log.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-event-log.mdx
@@ -38,7 +38,7 @@ Request to list durable EVT entries newest-first.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum entries to return. The server clamps this to its diagnostic limit. |
+| `limit` | `int32` | Maximum entries. Zero uses 50; values above 200 use 200. |
 | `before` | `optional string` | Exclusive sequence cursor. Returned entries are older than this sequence. |
 | `filter` | [`AdminEventLogFilter`](/reference/connectrpc-api/types/#chatto-admin-v1-AdminEventLogFilter) | Optional filter. Filtered scans inspect a bounded window per request. |
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-invite-links.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-invite-links.mdx
@@ -38,7 +38,7 @@ Requests a page of invite links, newest first.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | No field description provided. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-admin-v1-ListInviteLinksResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-oauth-clients.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-oauth-clients.mdx
@@ -35,10 +35,11 @@ POST /api/connect/chatto.admin.v1.AdminOAuthClientService/ListOAuthClients
 #### Input: ListOAuthClientsRequest
 
 Lists OAuth clients with recorded authorizations using offset pagination.
+Results use first authorization order, oldest first.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Requested offset and page size. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-admin-v1-ListOAuthClientsResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-users.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-users.mdx
@@ -36,11 +36,13 @@ POST /api/connect/chatto.admin.v1.AdminUserService/ListMembers
 #### Input: ListMembersRequest
 
 Request server-admin member rows.
+Results use creation time, oldest first. Users without a creation time
+appear last, ordered by case-insensitive login.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `search` | `string` | Case-insensitive login/display-name search term. Empty disables search. |
-| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-admin-v1-ListMembersResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/bots.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/bots.mdx
@@ -249,7 +249,7 @@ bot.manage or user.manage-accounts see every bot.
 | Field | Type | Description |
 | --- | --- | --- |
 | `search` | `string` | Optional case-insensitive login or display-name search. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListBotsResponse"></a>
@@ -260,7 +260,7 @@ Page of visible bots.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `bots` | repeated [`Bot`](/reference/connectrpc-api/types/#chatto-api-v1-Bot) | Visible bots. |
+| `bots` | repeated [`Bot`](/reference/connectrpc-api/types/#chatto-api-v1-Bot) | Visible bots by case-insensitive login, then user ID, in ascending order. |
 | `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Page metadata. |
 
 

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/notifications.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/notifications.mdx
@@ -116,7 +116,7 @@ Request for one page of notification occurrences.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 50 results when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListNotificationOccurrencesResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -323,7 +323,7 @@ Request for members of one room.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose effective members should be listed. Existing members and room.manage holders may list a channel room; other nonmembers need both room.list and room.join. |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 250 results when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 250 results when absent or limit is zero. Maximum: 500. |
 
 
 <a id="chatto-api-v1-ListMembersResponse"></a>
@@ -334,7 +334,7 @@ Room member page.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `members` | repeated [`DirectoryMember`](/reference/connectrpc-api/types/#chatto-api-v1-DirectoryMember) | Members in the requested page. |
+| `members` | repeated [`DirectoryMember`](/reference/connectrpc-api/types/#chatto-api-v1-DirectoryMember) | Members by case-insensitive display name, then login, in ascending order. |
 | `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Page metadata. |
 
 
@@ -501,7 +501,7 @@ Request to list active room bans.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Optional channel room filter. Empty lists active bans across all rooms. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults are applied when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListBansResponse"></a>
@@ -512,7 +512,7 @@ Active room bans visible to the current moderator.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `bans` | repeated [`RoomBan`](/reference/connectrpc-api/types/#chatto-api-v1-RoomBan) | Active bans, newest first. |
+| `bans` | repeated [`RoomBan`](/reference/connectrpc-api/types/#chatto-api-v1-RoomBan) | Active bans by creation time, newest first; equal times use ban event ID in ascending order. |
 | `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Page metadata. |
 
 
@@ -540,7 +540,7 @@ Request for room-scoped attachment list pages.
 | --- | --- | --- |
 | `room_id` | `string` | Required room ID. |
 | `thumbnail` | [`ImageTransformOptions`](/reference/connectrpc-api/types/#chatto-api-v1-ImageTransformOptions) | Thumbnail URL options. Defaults are applied when absent. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults are applied when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListRoomAttachmentsResponse"></a>
@@ -577,7 +577,7 @@ Request to list a channel room's current pinned messages.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required channel room ID. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults are applied when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListPinnedMessagesResponse"></a>
@@ -718,7 +718,7 @@ end_cursor to page toward newer events.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose timeline should be loaded. |
-| `limit` | `int32` | Maximum number of events to return. The server may clamp very large limits. |
+| `limit` | `int32` | Maximum events. Values at or below zero use 50; values above 500 use 500. |
 | `cursor.before` | `string` | Return events older than this opaque cursor. |
 | `cursor.after` | `string` | Return events newer than this opaque cursor. |
 
@@ -761,7 +761,7 @@ context around it.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose timeline should be loaded. |
 | `event_id` | `string` | Required. Anchor event ID that should appear in the returned page. |
-| `limit` | `int32` | Maximum number of events to return around the anchor. |
+| `limit` | `int32` | Maximum events around the anchor. Values at or below zero use 50; values above 500 use 500. |
 
 
 <a id="chatto-api-v1-GetRoomEventsAroundResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
@@ -45,7 +45,7 @@ Request for a page of followed threads for the current user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 | `include_direct_message_threads` | `bool` | Include followed direct-message threads. Defaults to false so older clients retain the channel-only result shape. |
 
 
@@ -162,7 +162,7 @@ newer replies without repeating the root message.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
-| `limit` | `int32` | Maximum number of events to return. The server may clamp very large limits. |
+| `limit` | `int32` | Maximum events. Values at or below zero use 50; values above 500 use 500. |
 | `cursor.before` | `string` | Return thread events older than this opaque cursor. |
 | `cursor.after` | `string` | Return thread events newer than this opaque cursor. |
 
@@ -207,7 +207,7 @@ thread context.
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
 | `event_id` | `string` | Required. Anchor event ID inside the thread. The event should belong to the requested thread. |
-| `limit` | `int32` | Maximum number of events to return around the anchor. |
+| `limit` | `int32` | Maximum events around the anchor. Values at or below zero use 50; values above 500 use 500. |
 
 
 <a id="chatto-api-v1-GetThreadEventsAroundResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
@@ -162,7 +162,7 @@ newer replies without repeating the root message.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
-| `limit` | `int32` | Maximum events. Values at or below zero use 50; values above 500 use 500. |
+| `limit` | `int32` | Maximum replies. Values at or below zero use 50; values above 500 use 500. The initial page also includes the root message outside this limit. |
 | `cursor.before` | `string` | Return thread events older than this opaque cursor. |
 | `cursor.after` | `string` | Return thread events newer than this opaque cursor. |
 
@@ -207,7 +207,7 @@ thread context.
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
 | `event_id` | `string` | Required. Anchor event ID inside the thread. The event should belong to the requested thread. |
-| `limit` | `int32` | Maximum events around the anchor. Values at or below zero use 50; values above 500 use 500. |
+| `limit` | `int32` | Maximum replies around the anchor. Values at or below zero use 50; values above 500 use 500. The root message is included outside this limit. |
 
 
 <a id="chatto-api-v1-GetThreadEventsAroundResponse"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -49,11 +49,12 @@ Offset-based page metadata returned by list RPCs.
 ### PageRequest
 
 Offset-based page request for list RPCs whose result order is stable enough
-for simple list browsing.
+for simple list browsing. Pages are live reads, not a fixed snapshot. Changes
+between requests can shift offsets.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum number of items to request. Each RPC defines its default and effective maximum; this shared request shape accepts values up to 500. |
+| `limit` | `int32` | Maximum number of items to request. Each RPC defines its default and effective maximum. Valid values above that maximum are capped. This shared shape rejects values above 500 or below zero. Zero uses the RPC default. |
 | `offset` | `int32` | Zero-based number of matching items to skip. |
 
 <a id="chatto-api-v1-Role"></a>
@@ -533,7 +534,7 @@ window.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `events` | repeated [`RoomTimelineEvent`](#chatto-api-v1-RoomTimelineEvent) | Events in display order. |
+| `events` | repeated [`RoomTimelineEvent`](#chatto-api-v1-RoomTimelineEvent) | Events in chronological display order, oldest first. |
 | `start_cursor` | `string` | Opaque cursor for the first event in the page. |
 | `end_cursor` | `string` | Opaque cursor for the last event in the page. |
 | `has_older` | `bool` | True when older events are available before start_cursor. |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/users.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/users.mdx
@@ -36,11 +36,13 @@ POST /api/connect/chatto.api.v1.UserService/ListUsers
 #### Input: ListUsersRequest
 
 Request for users visible to the authenticated user.
+Results use creation time, oldest first. Users without a creation time
+appear last, ordered by case-insensitive login.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
-| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 500. |
 
 
 <a id="chatto-api-v1-ListUsersResponse"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -77,7 +77,7 @@ Request to list durable EVT entries newest-first.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum entries to return. The server clamps this to its diagnostic limit. |
+| `limit` | `int32` | Maximum entries. Zero uses 50; values above 200 use 200. |
 | `before` | `optional string` | Exclusive sequence cursor. Returned entries are older than this sequence. |
 | `filter` | [`AdminEventLogFilter`](#chatto-admin-v1-AdminEventLogFilter) | Optional filter. Filtered scans inspect a bounded window per request. |
 
@@ -185,7 +185,7 @@ Requests a page of invite links, newest first.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | `chatto.api.v1.PageRequest` | No field description provided. |
+| `page` | `chatto.api.v1.PageRequest` | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-admin-v1-ListInviteLinksResponse"></a>
@@ -526,11 +526,13 @@ POST /api/connect/chatto.admin.v1.AdminUserService/ListMembers
 #### Input: ListMembersRequest
 
 Request server-admin member rows.
+Results use creation time, oldest first. Users without a creation time
+appear last, ordered by case-insensitive login.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `search` | `string` | Case-insensitive login/display-name search term. Empty disables search. |
-| `page` | `chatto.api.v1.PageRequest` | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | `chatto.api.v1.PageRequest` | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-admin-v1-ListMembersResponse"></a>
@@ -840,10 +842,11 @@ POST /api/connect/chatto.admin.v1.AdminOAuthClientService/ListOAuthClients
 #### Input: ListOAuthClientsRequest
 
 Lists OAuth clients with recorded authorizations using offset pagination.
+Results use first authorization order, oldest first.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | `chatto.api.v1.PageRequest` | Requested offset and page size. |
+| `page` | `chatto.api.v1.PageRequest` | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-admin-v1-ListOAuthClientsResponse"></a>

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -506,7 +506,7 @@ Request for members of one room.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose effective members should be listed. Existing members and room.manage holders may list a channel room; other nonmembers need both room.list and room.join. |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 250 results when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 250 results when absent or limit is zero. Maximum: 500. |
 
 
 <a id="chatto-api-v1-ListMembersResponse"></a>
@@ -517,7 +517,7 @@ Room member page.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `members` | repeated [`DirectoryMember`](#chatto-api-v1-DirectoryMember) | Members in the requested page. |
+| `members` | repeated [`DirectoryMember`](#chatto-api-v1-DirectoryMember) | Members by case-insensitive display name, then login, in ascending order. |
 | `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
 
 
@@ -684,7 +684,7 @@ Request to list active room bans.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Optional channel room filter. Empty lists active bans across all rooms. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults are applied when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListBansResponse"></a>
@@ -695,7 +695,7 @@ Active room bans visible to the current moderator.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `bans` | repeated [`RoomBan`](#chatto-api-v1-RoomBan) | Active bans, newest first. |
+| `bans` | repeated [`RoomBan`](#chatto-api-v1-RoomBan) | Active bans by creation time, newest first; equal times use ban event ID in ascending order. |
 | `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
 
 
@@ -723,7 +723,7 @@ Request for room-scoped attachment list pages.
 | --- | --- | --- |
 | `room_id` | `string` | Required room ID. |
 | `thumbnail` | [`ImageTransformOptions`](#chatto-api-v1-ImageTransformOptions) | Thumbnail URL options. Defaults are applied when absent. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults are applied when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListRoomAttachmentsResponse"></a>
@@ -760,7 +760,7 @@ Request to list a channel room's current pinned messages.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required channel room ID. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults are applied when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListPinnedMessagesResponse"></a>
@@ -901,7 +901,7 @@ end_cursor to page toward newer events.
 | Field | Type | Description |
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose timeline should be loaded. |
-| `limit` | `int32` | Maximum number of events to return. The server may clamp very large limits. |
+| `limit` | `int32` | Maximum events. Values at or below zero use 50; values above 500 use 500. |
 | `cursor.before` | `string` | Return events older than this opaque cursor. |
 | `cursor.after` | `string` | Return events newer than this opaque cursor. |
 
@@ -944,7 +944,7 @@ context around it.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room whose timeline should be loaded. |
 | `event_id` | `string` | Required. Anchor event ID that should appear in the returned page. |
-| `limit` | `int32` | Maximum number of events to return around the anchor. |
+| `limit` | `int32` | Maximum events around the anchor. Values at or below zero use 50; values above 500 use 500. |
 
 
 <a id="chatto-api-v1-GetRoomEventsAroundResponse"></a>
@@ -2157,7 +2157,7 @@ bot.manage or user.manage-accounts see every bot.
 | Field | Type | Description |
 | --- | --- | --- |
 | `search` | `string` | Optional case-insensitive login or display-name search. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListBotsResponse"></a>
@@ -2168,7 +2168,7 @@ Page of visible bots.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `bots` | repeated [`Bot`](#chatto-api-v1-Bot) | Visible bots. |
+| `bots` | repeated [`Bot`](#chatto-api-v1-Bot) | Visible bots by case-insensitive login, then user ID, in ascending order. |
 | `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Page metadata. |
 
 
@@ -3152,7 +3152,7 @@ Request for one page of notification occurrences.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 50 results when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 results when absent or limit is zero. Maximum: 100. |
 
 
 <a id="chatto-api-v1-ListNotificationOccurrencesResponse"></a>
@@ -3524,7 +3524,7 @@ Request for a page of followed threads for the current user.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 100. |
 | `include_direct_message_threads` | `bool` | Include followed direct-message threads. Defaults to false so older clients retain the channel-only result shape. |
 
 
@@ -3641,7 +3641,7 @@ newer replies without repeating the root message.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
-| `limit` | `int32` | Maximum number of events to return. The server may clamp very large limits. |
+| `limit` | `int32` | Maximum events. Values at or below zero use 50; values above 500 use 500. |
 | `cursor.before` | `string` | Return thread events older than this opaque cursor. |
 | `cursor.after` | `string` | Return thread events newer than this opaque cursor. |
 
@@ -3686,7 +3686,7 @@ thread context.
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
 | `event_id` | `string` | Required. Anchor event ID inside the thread. The event should belong to the requested thread. |
-| `limit` | `int32` | Maximum number of events to return around the anchor. |
+| `limit` | `int32` | Maximum events around the anchor. Values at or below zero use 50; values above 500 use 500. |
 
 
 <a id="chatto-api-v1-GetThreadEventsAroundResponse"></a>
@@ -3760,11 +3760,13 @@ POST /api/connect/chatto.api.v1.UserService/ListUsers
 #### Input: ListUsersRequest
 
 Request for users visible to the authenticated user.
+Results use creation time, oldest first. Users without a creation time
+appear last, ordered by case-insensitive login.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `search` | `string` | Optional case-insensitive search against login and display name. |
-| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Page request. Defaults to 20 results when absent or limit is zero. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 20 results when absent or limit is zero. Maximum: 500. |
 
 
 <a id="chatto-api-v1-ListUsersResponse"></a>
@@ -4233,11 +4235,12 @@ Offset-based page metadata returned by list RPCs.
 ### PageRequest
 
 Offset-based page request for list RPCs whose result order is stable enough
-for simple list browsing.
+for simple list browsing. Pages are live reads, not a fixed snapshot. Changes
+between requests can shift offsets.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `limit` | `int32` | Maximum number of items to request. Each RPC defines its default and effective maximum; this shared request shape accepts values up to 500. |
+| `limit` | `int32` | Maximum number of items to request. Each RPC defines its default and effective maximum. Valid values above that maximum are capped. This shared shape rejects values above 500 or below zero. Zero uses the RPC default. |
 | `offset` | `int32` | Zero-based number of matching items to skip. |
 
 
@@ -4777,7 +4780,7 @@ window.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `events` | repeated [`RoomTimelineEvent`](#chatto-api-v1-RoomTimelineEvent) | Events in display order. |
+| `events` | repeated [`RoomTimelineEvent`](#chatto-api-v1-RoomTimelineEvent) | Events in chronological display order, oldest first. |
 | `start_cursor` | `string` | Opaque cursor for the first event in the page. |
 | `end_cursor` | `string` | Opaque cursor for the last event in the page. |
 | `has_older` | `bool` | True when older events are available before start_cursor. |

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -3641,7 +3641,7 @@ newer replies without repeating the root message.
 | --- | --- | --- |
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
-| `limit` | `int32` | Maximum events. Values at or below zero use 50; values above 500 use 500. |
+| `limit` | `int32` | Maximum replies. Values at or below zero use 50; values above 500 use 500. The initial page also includes the root message outside this limit. |
 | `cursor.before` | `string` | Return thread events older than this opaque cursor. |
 | `cursor.after` | `string` | Return thread events newer than this opaque cursor. |
 
@@ -3686,7 +3686,7 @@ thread context.
 | `room_id` | `string` | Required. Room containing the thread. |
 | `thread_root_event_id` | `string` | Required. Event ID of the root message for the thread. |
 | `event_id` | `string` | Required. Anchor event ID inside the thread. The event should belong to the requested thread. |
-| `limit` | `int32` | Maximum events around the anchor. Values at or below zero use 50; values above 500 use 500. |
+| `limit` | `int32` | Maximum replies around the anchor. Values at or below zero use 50; values above 500 use 500. The root message is included outside this limit. |
 
 
 <a id="chatto-api-v1-GetThreadEventsAroundResponse"></a>

--- a/cli/internal/core/room_ban_projection.go
+++ b/cli/internal/core/room_ban_projection.go
@@ -115,6 +115,8 @@ func (p *RoomBanProjection) ActiveBan(roomID, userID string, now time.Time) (Roo
 	return ban, true
 }
 
+// ActiveBans returns active bans by creation time descending, then event ID
+// ascending so equal timestamps do not change offset page boundaries.
 func (p *RoomBanProjection) ActiveBans(now time.Time) []RoomBan {
 	p.RLock()
 	defer p.RUnlock()
@@ -127,11 +129,15 @@ func (p *RoomBanProjection) ActiveBans(now time.Time) []RoomBan {
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].EventID < out[j].EventID
+		}
 		return out[i].CreatedAt.After(out[j].CreatedAt)
 	})
 	return out
 }
 
+// ActiveRoomBans uses the same stable order as ActiveBans within one room.
 func (p *RoomBanProjection) ActiveRoomBans(roomID string, now time.Time) []RoomBan {
 	p.RLock()
 	defer p.RUnlock()
@@ -142,6 +148,9 @@ func (p *RoomBanProjection) ActiveRoomBans(roomID string, now time.Time) []RoomB
 		}
 	}
 	sort.Slice(out, func(i, j int) bool {
+		if out[i].CreatedAt.Equal(out[j].CreatedAt) {
+			return out[i].EventID < out[j].EventID
+		}
 		return out[i].CreatedAt.After(out[j].CreatedAt)
 	})
 	return out

--- a/cli/internal/core/room_ban_projection_test.go
+++ b/cli/internal/core/room_ban_projection_test.go
@@ -1,0 +1,50 @@
+package core
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	evtv1 "hmans.de/chatto/internal/pb/chatto/core/evt/v1"
+)
+
+func TestRoomBanProjectionStableOrder(t *testing.T) {
+	now := time.Date(2026, 9, 10, 12, 0, 0, 0, time.UTC)
+	for _, reverse := range []bool{false, true} {
+		t.Run(fmt.Sprintf("reverse_replay_%t", reverse), func(t *testing.T) {
+			p := NewRoomBanProjection()
+			for n := 0; n < 10; n++ {
+				i := n
+				if reverse {
+					i = 9 - n
+				}
+				created := now
+				if i == 9 {
+					created = now.Add(time.Hour)
+				}
+				if i == 0 {
+					created = now.Add(-time.Hour)
+				}
+				require.NoError(t, p.Apply(&evtv1.Event{
+					Id:        fmt.Sprintf("ban-%02d", i),
+					CreatedAt: timestamppb.New(created),
+					Event: &evtv1.Event_RoomMemberBanned{RoomMemberBanned: &evtv1.RoomMemberBannedEvent{
+						RoomId: "room", UserId: fmt.Sprintf("user-%02d", i), Reason: "test",
+					}},
+				}, uint64(n+1)))
+			}
+			// Both list paths must give the same page boundaries on repeated reads.
+			for read := 0; read < 32; read++ {
+				for _, bans := range [][]RoomBan{p.ActiveBans(now), p.ActiveRoomBans("room", now)} {
+					require.Len(t, bans, 10)
+					for i, ban := range bans {
+						want := []int{9, 1, 2, 3, 4, 5, 6, 7, 8, 0}
+						require.Equal(t, fmt.Sprintf("ban-%02d", want[i]), ban.EventID)
+					}
+				}
+			}
+		})
+	}
+}

--- a/cli/internal/pb/chatto/admin/v1/event_log.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/event_log.pb.go
@@ -99,7 +99,7 @@ func (x *AdminEventLogFilter) GetCreatedAtTo() *timestamppb.Timestamp {
 // Request to list durable EVT entries newest-first.
 type ListEventsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Maximum entries to return. The server clamps this to its diagnostic limit.
+	// Maximum entries. Zero uses 50; values above 200 use 200.
 	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Exclusive sequence cursor. Returned entries are older than this sequence.
 	Before *string `protobuf:"bytes,2,opt,name=before,proto3,oneof" json:"before,omitempty"`

--- a/cli/internal/pb/chatto/admin/v1/invitations.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/invitations.pb.go
@@ -194,8 +194,9 @@ func (x *InviteLink) GetRevokedAt() *timestamppb.Timestamp {
 
 // Requests a page of invite links, newest first.
 type ListInviteLinksRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Page          *v1.PageRequest        `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Defaults to 20 results when absent or limit is zero. Maximum: 100.
+	Page          *v1.PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/cli/internal/pb/chatto/admin/v1/members.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/members.pb.go
@@ -129,11 +129,13 @@ func (x *AdminMember) GetUser() *v1.User {
 }
 
 // Request server-admin member rows.
+// Results use creation time, oldest first. Users without a creation time
+// appear last, ordered by case-insensitive login.
 type ListMembersRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Case-insensitive login/display-name search term. Empty disables search.
 	Search string `protobuf:"bytes,1,opt,name=search,proto3" json:"search,omitempty"`
-	// Page request. Defaults to 20 results when absent or limit is zero.
+	// Defaults to 20 results when absent or limit is zero. Maximum: 100.
 	Page          *v1.PageRequest `protobuf:"bytes,4,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cli/internal/pb/chatto/admin/v1/oauth_clients.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/oauth_clients.pb.go
@@ -255,9 +255,10 @@ func (x *OAuthClient) GetAuthorizedUserCount() uint32 {
 }
 
 // Lists OAuth clients with recorded authorizations using offset pagination.
+// Results use first authorization order, oldest first.
 type ListOAuthClientsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Requested offset and page size.
+	// Defaults to 20 results when absent or limit is zero. Maximum: 100.
 	Page          *v1.PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cli/internal/pb/chatto/api/v1/bots.pb.go
+++ b/cli/internal/pb/chatto/api/v1/bots.pb.go
@@ -345,7 +345,7 @@ type ListBotsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional case-insensitive login or display-name search.
 	Search string `protobuf:"bytes,1,opt,name=search,proto3" json:"search,omitempty"`
-	// Page request. Defaults to 20 results when absent or limit is zero.
+	// Defaults to 20 results when absent or limit is zero. Maximum: 100.
 	Page          *PageRequest `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -398,7 +398,7 @@ func (x *ListBotsRequest) GetPage() *PageRequest {
 // Page of visible bots.
 type ListBotsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Visible bots.
+	// Visible bots by case-insensitive login, then user ID, in ascending order.
 	Bots []*Bot `protobuf:"bytes,1,rep,name=bots,proto3" json:"bots,omitempty"`
 	// Page metadata.
 	Page          *PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`

--- a/cli/internal/pb/chatto/api/v1/member_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/member_directory.pb.go
@@ -98,7 +98,7 @@ type ListMembersRequest struct {
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Optional case-insensitive search against login and display name.
 	Search string `protobuf:"bytes,2,opt,name=search,proto3" json:"search,omitempty"`
-	// Page request. Defaults to 250 results when absent or limit is zero.
+	// Defaults to 250 results when absent or limit is zero. Maximum: 500.
 	Page          *PageRequest `protobuf:"bytes,5,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -158,7 +158,7 @@ func (x *ListMembersRequest) GetPage() *PageRequest {
 // Room member page.
 type ListMembersResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Members in the requested page.
+	// Members by case-insensitive display name, then login, in ascending order.
 	Members []*DirectoryMember `protobuf:"bytes,1,rep,name=members,proto3" json:"members,omitempty"`
 	// Page metadata.
 	Page          *PageInfo `protobuf:"bytes,4,opt,name=page,proto3" json:"page,omitempty"`

--- a/cli/internal/pb/chatto/api/v1/notifications.pb.go
+++ b/cli/internal/pb/chatto/api/v1/notifications.pb.go
@@ -1130,7 +1130,7 @@ func (x *NotificationOccurrence) GetAttentionLevel() NotificationAttentionLevel 
 // Request for one page of notification occurrences.
 type ListNotificationOccurrencesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Page request. Defaults to 50 results when absent or limit is zero.
+	// Defaults to 50 results when absent or limit is zero. Maximum: 100.
 	Page          *PageRequest `protobuf:"bytes,1,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cli/internal/pb/chatto/api/v1/pagination.pb.go
+++ b/cli/internal/pb/chatto/api/v1/pagination.pb.go
@@ -23,11 +23,13 @@ const (
 )
 
 // Offset-based page request for list RPCs whose result order is stable enough
-// for simple list browsing.
+// for simple list browsing. Pages are live reads, not a fixed snapshot. Changes
+// between requests can shift offsets.
 type PageRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Maximum number of items to request. Each RPC defines its default and
-	// effective maximum; this shared request shape accepts values up to 500.
+	// effective maximum. Valid values above that maximum are capped. This shared
+	// shape rejects values above 500 or below zero. Zero uses the RPC default.
 	Limit int32 `protobuf:"varint,1,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Zero-based number of matching items to skip.
 	Offset        int32 `protobuf:"varint,2,opt,name=offset,proto3" json:"offset,omitempty"`

--- a/cli/internal/pb/chatto/api/v1/room_timeline.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_timeline.pb.go
@@ -934,7 +934,8 @@ type GetThreadEventsRequest struct {
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Required. Event ID of the root message for the thread.
 	ThreadRootEventId string `protobuf:"bytes,2,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
-	// Maximum events. Values at or below zero use 50; values above 500 use 500.
+	// Maximum replies. Values at or below zero use 50; values above 500 use 500.
+	// The initial page also includes the root message outside this limit.
 	Limit int32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Cursor direction for paging.
 	//
@@ -1100,8 +1101,8 @@ type GetThreadEventsAroundRequest struct {
 	// Required. Anchor event ID inside the thread. The event should belong to the
 	// requested thread.
 	EventId string `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	// Maximum events around the anchor. Values at or below zero use 50;
-	// values above 500 use 500.
+	// Maximum replies around the anchor. Values at or below zero use 50;
+	// values above 500 use 500. The root message is included outside this limit.
 	Limit         int32 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cli/internal/pb/chatto/api/v1/room_timeline.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_timeline.pb.go
@@ -556,7 +556,7 @@ func (*RoomTimelineEvent_CallEnded) isRoomTimelineEvent_Event() {}
 // window.
 type RoomTimelinePage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Events in display order.
+	// Events in chronological display order, oldest first.
 	Events []*RoomTimelineEvent `protobuf:"bytes,1,rep,name=events,proto3" json:"events,omitempty"`
 	// Opaque cursor for the first event in the page.
 	StartCursor string `protobuf:"bytes,2,opt,name=start_cursor,json=startCursor,proto3" json:"start_cursor,omitempty"`
@@ -653,7 +653,7 @@ type GetRoomEventsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required. Room whose timeline should be loaded.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Maximum number of events to return. The server may clamp very large limits.
+	// Maximum events. Values at or below zero use 50; values above 500 use 500.
 	Limit int32 `protobuf:"varint,2,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Cursor direction for paging.
 	//
@@ -809,7 +809,8 @@ type GetRoomEventsAroundRequest struct {
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Required. Anchor event ID that should appear in the returned page.
 	EventId string `protobuf:"bytes,2,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	// Maximum number of events to return around the anchor.
+	// Maximum events around the anchor. Values at or below zero use 50;
+	// values above 500 use 500.
 	Limit         int32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -933,7 +934,7 @@ type GetThreadEventsRequest struct {
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Required. Event ID of the root message for the thread.
 	ThreadRootEventId string `protobuf:"bytes,2,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
-	// Maximum number of events to return. The server may clamp very large limits.
+	// Maximum events. Values at or below zero use 50; values above 500 use 500.
 	Limit int32 `protobuf:"varint,3,opt,name=limit,proto3" json:"limit,omitempty"`
 	// Cursor direction for paging.
 	//
@@ -1099,7 +1100,8 @@ type GetThreadEventsAroundRequest struct {
 	// Required. Anchor event ID inside the thread. The event should belong to the
 	// requested thread.
 	EventId string `protobuf:"bytes,3,opt,name=event_id,json=eventId,proto3" json:"event_id,omitempty"`
-	// Maximum number of events to return around the anchor.
+	// Maximum events around the anchor. Values at or below zero use 50;
+	// values above 500 use 500.
 	Limit         int32 `protobuf:"varint,4,opt,name=limit,proto3" json:"limit,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cli/internal/pb/chatto/api/v1/rooms.pb.go
+++ b/cli/internal/pb/chatto/api/v1/rooms.pb.go
@@ -1644,7 +1644,7 @@ type ListBansRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional channel room filter. Empty lists active bans across all rooms.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Page request. Defaults are applied when absent or limit is zero.
+	// Defaults to 50 results when absent or limit is zero. Maximum: 100.
 	Page          *PageRequest `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1697,7 +1697,8 @@ func (x *ListBansRequest) GetPage() *PageRequest {
 // Active room bans visible to the current moderator.
 type ListBansResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Active bans, newest first.
+	// Active bans by creation time, newest first; equal times use ban event ID
+	// in ascending order.
 	Bans []*RoomBan `protobuf:"bytes,1,rep,name=bans,proto3" json:"bans,omitempty"`
 	// Page metadata.
 	Page          *PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
@@ -1756,7 +1757,7 @@ type ListRoomAttachmentsRequest struct {
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
 	// Thumbnail URL options. Defaults are applied when absent.
 	Thumbnail *ImageTransformOptions `protobuf:"bytes,4,opt,name=thumbnail,proto3" json:"thumbnail,omitempty"`
-	// Page request. Defaults are applied when absent or limit is zero.
+	// Defaults to 50 results when absent or limit is zero. Maximum: 100.
 	Page          *PageRequest `protobuf:"bytes,5,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -1919,7 +1920,7 @@ type ListPinnedMessagesRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Required channel room ID.
 	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
-	// Page request. Defaults are applied when absent or limit is zero.
+	// Defaults to 50 results when absent or limit is zero. Maximum: 100.
 	Page          *PageRequest `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/cli/internal/pb/chatto/api/v1/threads.pb.go
+++ b/cli/internal/pb/chatto/api/v1/threads.pb.go
@@ -374,7 +374,7 @@ func (x *FollowedThread) GetDirectMessageParticipantUserIds() []string {
 // Request for a page of followed threads for the current user.
 type ListFollowedThreadsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Page request. Defaults to 20 results when absent or limit is zero.
+	// Defaults to 20 results when absent or limit is zero. Maximum: 100.
 	Page *PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
 	// Include followed direct-message threads. Defaults to false so older
 	// clients retain the channel-only result shape.

--- a/cli/internal/pb/chatto/api/v1/user_service.pb.go
+++ b/cli/internal/pb/chatto/api/v1/user_service.pb.go
@@ -23,11 +23,13 @@ const (
 )
 
 // Request for users visible to the authenticated user.
+// Results use creation time, oldest first. Users without a creation time
+// appear last, ordered by case-insensitive login.
 type ListUsersRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Optional case-insensitive search against login and display name.
 	Search string `protobuf:"bytes,1,opt,name=search,proto3" json:"search,omitempty"`
-	// Page request. Defaults to 20 results when absent or limit is zero.
+	// Defaults to 20 results when absent or limit is zero. Maximum: 500.
 	Page          *PageRequest `protobuf:"bytes,4,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/packages/api-types/src/chatto/admin/v1/event_log_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/event_log_pb.ts
@@ -78,7 +78,7 @@ export class AdminEventLogFilter extends Message<AdminEventLogFilter> {
  */
 export class ListEventsRequest extends Message<ListEventsRequest> {
   /**
-   * Maximum entries to return. The server clamps this to its diagnostic limit.
+   * Maximum entries. Zero uses 50; values above 200 use 200.
    *
    * @generated from field: int32 limit = 1;
    */

--- a/packages/api-types/src/chatto/admin/v1/invitations_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/invitations_pb.ts
@@ -146,6 +146,8 @@ export class InviteLink extends Message<InviteLink> {
  */
 export class ListInviteLinksRequest extends Message<ListInviteLinksRequest> {
   /**
+   * Defaults to 20 results when absent or limit is zero. Maximum: 100.
+   *
    * @generated from field: chatto.api.v1.PageRequest page = 1;
    */
   page?: PageRequest;

--- a/packages/api-types/src/chatto/admin/v1/members_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/members_pb.ts
@@ -104,6 +104,8 @@ export class AdminMember extends Message<AdminMember> {
 
 /**
  * Request server-admin member rows.
+ * Results use creation time, oldest first. Users without a creation time
+ * appear last, ordered by case-insensitive login.
  *
  * @generated from message chatto.admin.v1.ListMembersRequest
  */
@@ -116,7 +118,7 @@ export class ListMembersRequest extends Message<ListMembersRequest> {
   search = "";
 
   /**
-   * Page request. Defaults to 20 results when absent or limit is zero.
+   * Defaults to 20 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 4;
    */

--- a/packages/api-types/src/chatto/admin/v1/oauth_clients_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/oauth_clients_pb.ts
@@ -191,12 +191,13 @@ export class OAuthClient extends Message<OAuthClient> {
 
 /**
  * Lists OAuth clients with recorded authorizations using offset pagination.
+ * Results use first authorization order, oldest first.
  *
  * @generated from message chatto.admin.v1.ListOAuthClientsRequest
  */
 export class ListOAuthClientsRequest extends Message<ListOAuthClientsRequest> {
   /**
-   * Requested offset and page size.
+   * Defaults to 20 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/bots_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/bots_pb.ts
@@ -295,7 +295,7 @@ export class ListBotsRequest extends Message<ListBotsRequest> {
   search = "";
 
   /**
-   * Page request. Defaults to 20 results when absent or limit is zero.
+   * Defaults to 20 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 2;
    */
@@ -337,7 +337,7 @@ export class ListBotsRequest extends Message<ListBotsRequest> {
  */
 export class ListBotsResponse extends Message<ListBotsResponse> {
   /**
-   * Visible bots.
+   * Visible bots by case-insensitive login, then user ID, in ascending order.
    *
    * @generated from field: repeated chatto.api.v1.Bot bots = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/member_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/member_directory_pb.ts
@@ -90,7 +90,7 @@ export class ListMembersRequest extends Message<ListMembersRequest> {
   search = "";
 
   /**
-   * Page request. Defaults to 250 results when absent or limit is zero.
+   * Defaults to 250 results when absent or limit is zero. Maximum: 500.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 5;
    */
@@ -133,7 +133,7 @@ export class ListMembersRequest extends Message<ListMembersRequest> {
  */
 export class ListMembersResponse extends Message<ListMembersResponse> {
   /**
-   * Members in the requested page.
+   * Members by case-insensitive display name, then login, in ascending order.
    *
    * @generated from field: repeated chatto.api.v1.DirectoryMember members = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/notifications_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/notifications_pb.ts
@@ -885,7 +885,7 @@ export class NotificationOccurrence extends Message<NotificationOccurrence> {
  */
 export class ListNotificationOccurrencesRequest extends Message<ListNotificationOccurrencesRequest> {
   /**
-   * Page request. Defaults to 50 results when absent or limit is zero.
+   * Defaults to 50 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/pagination_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/pagination_pb.ts
@@ -8,14 +8,16 @@ import { Message, proto3, protoInt64 } from "@bufbuild/protobuf";
 
 /**
  * Offset-based page request for list RPCs whose result order is stable enough
- * for simple list browsing.
+ * for simple list browsing. Pages are live reads, not a fixed snapshot. Changes
+ * between requests can shift offsets.
  *
  * @generated from message chatto.api.v1.PageRequest
  */
 export class PageRequest extends Message<PageRequest> {
   /**
    * Maximum number of items to request. Each RPC defines its default and
-   * effective maximum; this shared request shape accepts values up to 500.
+   * effective maximum. Valid values above that maximum are capped. This shared
+   * shape rejects values above 500 or below zero. Zero uses the RPC default.
    *
    * @generated from field: int32 limit = 1;
    */

--- a/packages/api-types/src/chatto/api/v1/room_timeline_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/room_timeline_pb.ts
@@ -415,7 +415,7 @@ export class RoomTimelineEvent extends Message<RoomTimelineEvent> {
  */
 export class RoomTimelinePage extends Message<RoomTimelinePage> {
   /**
-   * Events in display order.
+   * Events in chronological display order, oldest first.
    *
    * @generated from field: repeated chatto.api.v1.RoomTimelineEvent events = 1;
    */
@@ -507,7 +507,7 @@ export class GetRoomEventsRequest extends Message<GetRoomEventsRequest> {
   roomId = "";
 
   /**
-   * Maximum number of events to return. The server may clamp very large limits.
+   * Maximum events. Values at or below zero use 50; values above 500 use 500.
    *
    * @generated from field: int32 limit = 2;
    */
@@ -632,7 +632,8 @@ export class GetRoomEventsAroundRequest extends Message<GetRoomEventsAroundReque
   eventId = "";
 
   /**
-   * Maximum number of events to return around the anchor.
+   * Maximum events around the anchor. Values at or below zero use 50;
+   * values above 500 use 500.
    *
    * @generated from field: int32 limit = 3;
    */
@@ -743,7 +744,7 @@ export class GetThreadEventsRequest extends Message<GetThreadEventsRequest> {
   threadRootEventId = "";
 
   /**
-   * Maximum number of events to return. The server may clamp very large limits.
+   * Maximum events. Values at or below zero use 50; values above 500 use 500.
    *
    * @generated from field: int32 limit = 3;
    */
@@ -877,7 +878,8 @@ export class GetThreadEventsAroundRequest extends Message<GetThreadEventsAroundR
   eventId = "";
 
   /**
-   * Maximum number of events to return around the anchor.
+   * Maximum events around the anchor. Values at or below zero use 50;
+   * values above 500 use 500.
    *
    * @generated from field: int32 limit = 4;
    */

--- a/packages/api-types/src/chatto/api/v1/room_timeline_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/room_timeline_pb.ts
@@ -744,7 +744,8 @@ export class GetThreadEventsRequest extends Message<GetThreadEventsRequest> {
   threadRootEventId = "";
 
   /**
-   * Maximum events. Values at or below zero use 50; values above 500 use 500.
+   * Maximum replies. Values at or below zero use 50; values above 500 use 500.
+   * The initial page also includes the root message outside this limit.
    *
    * @generated from field: int32 limit = 3;
    */
@@ -878,8 +879,8 @@ export class GetThreadEventsAroundRequest extends Message<GetThreadEventsAroundR
   eventId = "";
 
   /**
-   * Maximum events around the anchor. Values at or below zero use 50;
-   * values above 500 use 500.
+   * Maximum replies around the anchor. Values at or below zero use 50;
+   * values above 500 use 500. The root message is included outside this limit.
    *
    * @generated from field: int32 limit = 4;
    */

--- a/packages/api-types/src/chatto/api/v1/rooms_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_pb.ts
@@ -1453,7 +1453,7 @@ export class ListBansRequest extends Message<ListBansRequest> {
   roomId = "";
 
   /**
-   * Page request. Defaults are applied when absent or limit is zero.
+   * Defaults to 50 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 2;
    */
@@ -1495,7 +1495,8 @@ export class ListBansRequest extends Message<ListBansRequest> {
  */
 export class ListBansResponse extends Message<ListBansResponse> {
   /**
-   * Active bans, newest first.
+   * Active bans by creation time, newest first; equal times use ban event ID
+   * in ascending order.
    *
    * @generated from field: repeated chatto.api.v1.RoomBan bans = 1;
    */
@@ -1558,7 +1559,7 @@ export class ListRoomAttachmentsRequest extends Message<ListRoomAttachmentsReque
   thumbnail?: ImageTransformOptions;
 
   /**
-   * Page request. Defaults are applied when absent or limit is zero.
+   * Defaults to 50 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 5;
    */
@@ -1698,7 +1699,7 @@ export class ListPinnedMessagesRequest extends Message<ListPinnedMessagesRequest
   roomId = "";
 
   /**
-   * Page request. Defaults are applied when absent or limit is zero.
+   * Defaults to 50 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 2;
    */

--- a/packages/api-types/src/chatto/api/v1/threads_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/threads_pb.ts
@@ -328,7 +328,7 @@ export class FollowedThread extends Message<FollowedThread> {
  */
 export class ListFollowedThreadsRequest extends Message<ListFollowedThreadsRequest> {
   /**
-   * Page request. Defaults to 20 results when absent or limit is zero.
+   * Defaults to 20 results when absent or limit is zero. Maximum: 100.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 3;
    */

--- a/packages/api-types/src/chatto/api/v1/user_service_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/user_service_pb.ts
@@ -12,6 +12,8 @@ import { User } from "./users_pb.js";
 
 /**
  * Request for users visible to the authenticated user.
+ * Results use creation time, oldest first. Users without a creation time
+ * appear last, ordered by case-insensitive login.
  *
  * @generated from message chatto.api.v1.ListUsersRequest
  */
@@ -24,7 +26,7 @@ export class ListUsersRequest extends Message<ListUsersRequest> {
   search = "";
 
   /**
-   * Page request. Defaults to 20 results when absent or limit is zero.
+   * Defaults to 20 results when absent or limit is zero. Maximum: 500.
    *
    * @generated from field: chatto.api.v1.PageRequest page = 4;
    */

--- a/proto/chatto/admin/v1/event_log.proto
+++ b/proto/chatto/admin/v1/event_log.proto
@@ -19,7 +19,7 @@ message AdminEventLogFilter {
 
 // Request to list durable EVT entries newest-first.
 message ListEventsRequest {
-  // Maximum entries to return. The server clamps this to its diagnostic limit.
+  // Maximum entries. Zero uses 50; values above 200 use 200.
   int32 limit = 1 [(buf.validate.field).int32.gte = 0];
   // Exclusive sequence cursor. Returned entries are older than this sequence.
   optional string before = 2;

--- a/proto/chatto/admin/v1/invitations.proto
+++ b/proto/chatto/admin/v1/invitations.proto
@@ -33,6 +33,7 @@ message InviteLink {
 
 // Requests a page of invite links, newest first.
 message ListInviteLinksRequest {
+  // Defaults to 20 results when absent or limit is zero. Maximum: 100.
   chatto.api.v1.PageRequest page = 1;
 }
 

--- a/proto/chatto/admin/v1/members.proto
+++ b/proto/chatto/admin/v1/members.proto
@@ -37,13 +37,15 @@ message AdminMember {
 }
 
 // Request server-admin member rows.
+// Results use creation time, oldest first. Users without a creation time
+// appear last, ordered by case-insensitive login.
 message ListMembersRequest {
   reserved 2, 3;
   reserved "limit", "offset";
 
   // Case-insensitive login/display-name search term. Empty disables search.
   string search = 1;
-  // Page request. Defaults to 20 results when absent or limit is zero.
+  // Defaults to 20 results when absent or limit is zero. Maximum: 100.
   chatto.api.v1.PageRequest page = 4;
 }
 

--- a/proto/chatto/admin/v1/oauth_clients.proto
+++ b/proto/chatto/admin/v1/oauth_clients.proto
@@ -53,8 +53,9 @@ message OAuthClient {
 }
 
 // Lists OAuth clients with recorded authorizations using offset pagination.
+// Results use first authorization order, oldest first.
 message ListOAuthClientsRequest {
-  // Requested offset and page size.
+  // Defaults to 20 results when absent or limit is zero. Maximum: 100.
   chatto.api.v1.PageRequest page = 1;
 }
 

--- a/proto/chatto/api/v1/bots.proto
+++ b/proto/chatto/api/v1/bots.proto
@@ -77,13 +77,13 @@ message BotIncomingWebhook {
 message ListBotsRequest {
   // Optional case-insensitive login or display-name search.
   string search = 1 [(buf.validate.field).string.max_len = 100];
-  // Page request. Defaults to 20 results when absent or limit is zero.
+  // Defaults to 20 results when absent or limit is zero. Maximum: 100.
   PageRequest page = 2;
 }
 
 // Page of visible bots.
 message ListBotsResponse {
-  // Visible bots.
+  // Visible bots by case-insensitive login, then user ID, in ascending order.
   repeated Bot bots = 1;
   // Page metadata.
   PageInfo page = 2;

--- a/proto/chatto/api/v1/member_directory.proto
+++ b/proto/chatto/api/v1/member_directory.proto
@@ -30,7 +30,7 @@ message ListMembersRequest {
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Optional case-insensitive search against login and display name.
   string search = 2 [(buf.validate.field).string.max_len = 100];
-  // Page request. Defaults to 250 results when absent or limit is zero.
+  // Defaults to 250 results when absent or limit is zero. Maximum: 500.
   PageRequest page = 5;
 }
 
@@ -39,7 +39,7 @@ message ListMembersResponse {
   reserved 2, 3;
   reserved "total_count", "has_more";
 
-  // Members in the requested page.
+  // Members by case-insensitive display name, then login, in ascending order.
   repeated DirectoryMember members = 1;
   // Page metadata.
   PageInfo page = 4;

--- a/proto/chatto/api/v1/notifications.proto
+++ b/proto/chatto/api/v1/notifications.proto
@@ -165,7 +165,7 @@ message NotificationOccurrence {
 
 // Request for one page of notification occurrences.
 message ListNotificationOccurrencesRequest {
-  // Page request. Defaults to 50 results when absent or limit is zero.
+  // Defaults to 50 results when absent or limit is zero. Maximum: 100.
   PageRequest page = 1;
 }
 

--- a/proto/chatto/api/v1/pagination.proto
+++ b/proto/chatto/api/v1/pagination.proto
@@ -5,10 +5,12 @@ package chatto.api.v1;
 import "buf/validate/validate.proto";
 
 // Offset-based page request for list RPCs whose result order is stable enough
-// for simple list browsing.
+// for simple list browsing. Pages are live reads, not a fixed snapshot. Changes
+// between requests can shift offsets.
 message PageRequest {
   // Maximum number of items to request. Each RPC defines its default and
-  // effective maximum; this shared request shape accepts values up to 500.
+  // effective maximum. Valid values above that maximum are capped. This shared
+  // shape rejects values above 500 or below zero. Zero uses the RPC default.
   int32 limit = 1 [(buf.validate.field).int32 = {
     gte: 0,
     lte: 500

--- a/proto/chatto/api/v1/room_timeline.proto
+++ b/proto/chatto/api/v1/room_timeline.proto
@@ -167,7 +167,8 @@ message GetThreadEventsRequest {
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Required. Event ID of the root message for the thread.
   string thread_root_event_id = 2 [(buf.validate.field).string.min_len = 1];
-  // Maximum events. Values at or below zero use 50; values above 500 use 500.
+  // Maximum replies. Values at or below zero use 50; values above 500 use 500.
+  // The initial page also includes the root message outside this limit.
   int32 limit = 3;
   // Cursor direction for paging.
   oneof cursor {
@@ -196,8 +197,8 @@ message GetThreadEventsAroundRequest {
   // Required. Anchor event ID inside the thread. The event should belong to the
   // requested thread.
   string event_id = 3 [(buf.validate.field).string.min_len = 1];
-  // Maximum events around the anchor. Values at or below zero use 50;
-  // values above 500 use 500.
+  // Maximum replies around the anchor. Values at or below zero use 50;
+  // values above 500 use 500. The root message is included outside this limit.
   int32 limit = 4;
 }
 

--- a/proto/chatto/api/v1/room_timeline.proto
+++ b/proto/chatto/api/v1/room_timeline.proto
@@ -95,7 +95,7 @@ message RoomTimelineEvent {
 // has_newer flags tell clients whether another request can extend the current
 // window.
 message RoomTimelinePage {
-  // Events in display order.
+  // Events in chronological display order, oldest first.
   repeated RoomTimelineEvent events = 1;
   // Opaque cursor for the first event in the page.
   string start_cursor = 2;
@@ -117,7 +117,7 @@ message RoomTimelinePage {
 message GetRoomEventsRequest {
   // Required. Room whose timeline should be loaded.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
-  // Maximum number of events to return. The server may clamp very large limits.
+  // Maximum events. Values at or below zero use 50; values above 500 use 500.
   int32 limit = 2;
   // Cursor direction for paging.
   oneof cursor {
@@ -143,7 +143,8 @@ message GetRoomEventsAroundRequest {
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Required. Anchor event ID that should appear in the returned page.
   string event_id = 2 [(buf.validate.field).string.min_len = 1];
-  // Maximum number of events to return around the anchor.
+  // Maximum events around the anchor. Values at or below zero use 50;
+  // values above 500 use 500.
   int32 limit = 3;
 }
 
@@ -166,7 +167,7 @@ message GetThreadEventsRequest {
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Required. Event ID of the root message for the thread.
   string thread_root_event_id = 2 [(buf.validate.field).string.min_len = 1];
-  // Maximum number of events to return. The server may clamp very large limits.
+  // Maximum events. Values at or below zero use 50; values above 500 use 500.
   int32 limit = 3;
   // Cursor direction for paging.
   oneof cursor {
@@ -195,7 +196,8 @@ message GetThreadEventsAroundRequest {
   // Required. Anchor event ID inside the thread. The event should belong to the
   // requested thread.
   string event_id = 3 [(buf.validate.field).string.min_len = 1];
-  // Maximum number of events to return around the anchor.
+  // Maximum events around the anchor. Values at or below zero use 50;
+  // values above 500 use 500.
   int32 limit = 4;
 }
 

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -301,13 +301,14 @@ message RoomBan {
 message ListBansRequest {
   // Optional channel room filter. Empty lists active bans across all rooms.
   string room_id = 1;
-  // Page request. Defaults are applied when absent or limit is zero.
+  // Defaults to 50 results when absent or limit is zero. Maximum: 100.
   PageRequest page = 2;
 }
 
 // Active room bans visible to the current moderator.
 message ListBansResponse {
-  // Active bans, newest first.
+  // Active bans by creation time, newest first; equal times use ban event ID
+  // in ascending order.
   repeated RoomBan bans = 1;
   // Page metadata.
   PageInfo page = 2;
@@ -322,7 +323,7 @@ message ListRoomAttachmentsRequest {
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
   // Thumbnail URL options. Defaults are applied when absent.
   ImageTransformOptions thumbnail = 4;
-  // Page request. Defaults are applied when absent or limit is zero.
+  // Defaults to 50 results when absent or limit is zero. Maximum: 100.
   PageRequest page = 5;
 }
 
@@ -347,7 +348,7 @@ message PinnedMessage {
 message ListPinnedMessagesRequest {
   // Required channel room ID.
   string room_id = 1 [(buf.validate.field).string.min_len = 1];
-  // Page request. Defaults are applied when absent or limit is zero.
+  // Defaults to 50 results when absent or limit is zero. Maximum: 100.
   PageRequest page = 2;
 }
 

--- a/proto/chatto/api/v1/threads.proto
+++ b/proto/chatto/api/v1/threads.proto
@@ -74,7 +74,7 @@ message ListFollowedThreadsRequest {
   reserved 1, 2;
   reserved "limit", "offset";
 
-  // Page request. Defaults to 20 results when absent or limit is zero.
+  // Defaults to 20 results when absent or limit is zero. Maximum: 100.
   PageRequest page = 3;
   // Include followed direct-message threads. Defaults to false so older
   // clients retain the channel-only result shape.

--- a/proto/chatto/api/v1/user_service.proto
+++ b/proto/chatto/api/v1/user_service.proto
@@ -9,13 +9,15 @@ import "chatto/api/v1/pagination.proto";
 import "chatto/api/v1/users.proto";
 
 // Request for users visible to the authenticated user.
+// Results use creation time, oldest first. Users without a creation time
+// appear last, ordered by case-insensitive login.
 message ListUsersRequest {
   reserved 2, 3;
   reserved "limit", "offset";
 
   // Optional case-insensitive search against login and display name.
   string search = 1 [(buf.validate.field).string.max_len = 100];
-  // Page request. Defaults to 20 results when absent or limit is zero.
+  // Defaults to 20 results when absent or limit is zero. Maximum: 500.
   PageRequest page = 4;
 }
 


### PR DESCRIPTION
- Fix `RoomService.ListBans` pagination when bans have equal creation timestamps. Both global and room-scoped lists now sort by creation time descending, then ban event ID ascending, so unchanged results keep stable page boundaries.
- Document existing defaults, caps, and ordering for public/admin paginated RPCs. Clarify that thread limits count replies, with the root included separately on initial and around-anchor pages. Regenerate Go/TypeScript comments and API reference pages.
- Explain live offset-page behavior in the [API compatibility guide](apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx). This is a behavior correction under [ADR-045](docs/adr/ADR-045-public-api-stability-tiers.md), with no schema, stored-data, authorization, or limit changes. No client regeneration or migration is required.
- Verified the ban regression fails before the fix and passes after it, covering repeated reads, reversed replay order, and timestamp priority. Core ban/timeline tests, the full uncached Connect API suite, targeted thread tests, protobuf lint, public and storage compatibility checks, generated TypeScript build, docs build, license check, and whitespace checks pass.
- Final review of `origin/main...a82d59fa8` is clean. Review caught and corrected the thread root/limit documentation. No manual browser testing was needed for this server sorting and API documentation change.
