### PR TITLE
feat(api): expose complete relationships and read markers

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
@@ -200,3 +200,26 @@ support inline timestamps.
     description="Trusted local automation over the operator socket."
   />
 </CardGrid>
+
+## Read Complete Relationships and Read Positions
+
+Use `MessageService.ListReactionUsers` to list all user IDs for one emoji on a
+message. Use `ThreadService.ListThreadParticipants` to list distinct authors
+of current thread replies. The root author appears only if they also replied.
+Retracted replies and erased authors do not contribute to the participant list.
+Both calls return IDs in ascending order, with 50 items by default and at most
+100 per page. Use `UserService.BatchGetUsers` when you also need user profiles.
+Message previews remain bounded; their preview IDs are not complete lists.
+Pages are live reads, so concurrent changes can shift offsets.
+
+Use `RoomService.GetRoomReadState` or `ThreadService.GetThreadReadState` to
+read your stored position. Their `BatchGetRoomReadStates` and
+`BatchGetThreadReadStates` counterparts accept at most 100 targets. Batches
+remove duplicates in first-seen order and omit missing or inaccessible targets.
+All these calls require the same access as the corresponding read-marker update.
+
+A returned state without `marker` means no non-empty position is stored. The
+read does not initialize a position or mark anything as read. When a marker
+exists, it contains `lastReadEventId` and, when available, the referenced event's
+`lastReadAt` timestamp. This timestamp is the event time, not the time you read
+it. Stored read positions are separate from notification attention.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/messages.mdx
@@ -20,6 +20,45 @@ Shared message and enum definitions are documented in [Shared Types And Enums](/
 
 Creates messages in room and thread timelines.
 
+<a id="chatto-api-v1-MessageService-ListReactionUsers"></a>
+
+### ListReactionUsers
+
+Lists all users with the requested reaction. Requires room membership and
+permission to read the message. A missing reaction returns an empty page;
+a missing or hidden message returns NOT_FOUND or PERMISSION_DENIED.
+
+```http
+POST /api/connect/chatto.api.v1.MessageService/ListReactionUsers
+```
+
+<a id="chatto-api-v1-ListReactionUsersRequest"></a>
+
+#### Input: ListReactionUsersRequest
+
+Request all users with one emoji reaction on a message. Echo IDs resolve to
+the original message. Users are ordered by user ID ascending.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room containing the message. |
+| `message_event_id` | `string` | Message or channel echo ID. |
+| `emoji` | `string` | Emoji shortcode, such as "thumbsup". |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 results. Maximum: 100. Zero uses the default. |
+
+
+<a id="chatto-api-v1-ListReactionUsersResponse"></a>
+
+#### Result: ListReactionUsersResponse
+
+Complete reaction membership is available by paging this collection.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `user_ids` | `repeated string` | User IDs in this page. Use UserService.BatchGetUsers for profiles. |
+| `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Count and continuation for the matching reaction users. |
+
+
 <a id="chatto-api-v1-MessageService-FetchLinkPreview"></a>
 
 ### FetchLinkPreview

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -26,6 +26,73 @@ room read state, attachments, and live typing. Resource-specific services
 should still be preferred when an operation is not naturally room-scoped or
 when the resource needs an independent CRUD/batch surface.
 
+<a id="chatto-api-v1-RoomService-GetRoomReadState"></a>
+
+### GetRoomReadState
+
+Reads the current viewer's stored marker without changing it. Requires the
+same membership and read access as MarkRoomAsRead. Missing resources
+return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+
+```http
+POST /api/connect/chatto.api.v1.RoomService/GetRoomReadState
+```
+
+<a id="chatto-api-v1-GetRoomReadStateRequest"></a>
+
+#### Input: GetRoomReadStateRequest
+
+Request current room read state without changing it.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+
+
+<a id="chatto-api-v1-GetRoomReadStateResponse"></a>
+
+#### Result: GetRoomReadStateResponse
+
+Current room read state, including an absent marker when none is stored.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `state` | [`RoomReadState`](/reference/connectrpc-api/types/#chatto-api-v1-RoomReadState) | State for the requested room and viewer. |
+
+
+<a id="chatto-api-v1-RoomService-BatchGetRoomReadStates"></a>
+
+### BatchGetRoomReadStates
+
+Reads up to 100 states under the same authorization as GetRoomReadState.
+Missing and inaccessible resources are omitted; duplicates use first-seen order.
+
+```http
+POST /api/connect/chatto.api.v1.RoomService/BatchGetRoomReadStates
+```
+
+<a id="chatto-api-v1-BatchGetRoomReadStatesRequest"></a>
+
+#### Input: BatchGetRoomReadStatesRequest
+
+Request room read states. Duplicates are removed in first-seen order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_ids` | `repeated string` | Up to 100 room IDs. Missing or inaccessible rooms are omitted. |
+
+
+<a id="chatto-api-v1-BatchGetRoomReadStatesResponse"></a>
+
+#### Result: BatchGetRoomReadStatesResponse
+
+Accessible room read states in first-seen request order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `states` | repeated [`RoomReadState`](/reference/connectrpc-api/types/#chatto-api-v1-RoomReadState) | States for the current viewer. An absent marker does not omit the state. |
+
+
 <a id="chatto-api-v1-RoomService-CreateRoom"></a>
 
 ### CreateRoom

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/threads.mdx
@@ -20,6 +20,111 @@ Shared message and enum definitions are documented in [Shared Types And Enums](/
 
 Manages thread follow state for the current user.
 
+<a id="chatto-api-v1-ThreadService-GetThreadReadState"></a>
+
+### GetThreadReadState
+
+Reads the current viewer's stored marker without changing it. Requires the
+same membership and read access as MarkThreadAsRead. Missing resources
+return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+
+```http
+POST /api/connect/chatto.api.v1.ThreadService/GetThreadReadState
+```
+
+<a id="chatto-api-v1-GetThreadReadStateRequest"></a>
+
+#### Input: GetThreadReadStateRequest
+
+Request current thread read state without changing it.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `thread_root_event_id` | `string` | Root message ID. |
+
+
+<a id="chatto-api-v1-GetThreadReadStateResponse"></a>
+
+#### Result: GetThreadReadStateResponse
+
+Current thread read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `state` | [`ThreadReadState`](/reference/connectrpc-api/types/#chatto-api-v1-ThreadReadState) | State for the requested thread and viewer. |
+
+
+<a id="chatto-api-v1-ThreadService-BatchGetThreadReadStates"></a>
+
+### BatchGetThreadReadStates
+
+Reads up to 100 states under the same authorization as GetThreadReadState.
+Missing and inaccessible resources are omitted; duplicates use first-seen order.
+
+```http
+POST /api/connect/chatto.api.v1.ThreadService/BatchGetThreadReadStates
+```
+
+<a id="chatto-api-v1-BatchGetThreadReadStatesRequest"></a>
+
+#### Input: BatchGetThreadReadStatesRequest
+
+Request thread read states. Duplicates are removed in first-seen order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `targets` | repeated [`ThreadReadStateTarget`](/reference/connectrpc-api/types/#chatto-api-v1-ThreadReadStateTarget) | Up to 100 room/thread targets. Missing or inaccessible targets are omitted. |
+
+
+<a id="chatto-api-v1-BatchGetThreadReadStatesResponse"></a>
+
+#### Result: BatchGetThreadReadStatesResponse
+
+Accessible thread read states in first-seen request order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `states` | repeated [`ThreadReadState`](/reference/connectrpc-api/types/#chatto-api-v1-ThreadReadState) | States for the current viewer. An absent marker does not omit the state. |
+
+
+<a id="chatto-api-v1-ThreadService-ListThreadParticipants"></a>
+
+### ListThreadParticipants
+
+Lists distinct authors of non-retracted replies, excluding erased users.
+The root author is included only if they also replied. Requires the same
+membership and message-read access as GetThreadEvents.
+
+```http
+POST /api/connect/chatto.api.v1.ThreadService/ListThreadParticipants
+```
+
+<a id="chatto-api-v1-ListThreadParticipantsRequest"></a>
+
+#### Input: ListThreadParticipantsRequest
+
+Request a complete thread participant collection, ordered by user ID ascending.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room containing the thread. |
+| `thread_root_event_id` | `string` | Root message ID. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 results. Maximum: 100. Zero uses the default. |
+
+
+<a id="chatto-api-v1-ListThreadParticipantsResponse"></a>
+
+#### Result: ListThreadParticipantsResponse
+
+A page of distinct reply authors. An empty thread returns an empty page.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `user_ids` | `repeated string` | User IDs in this page. Use UserService.BatchGetUsers for profiles. |
+| `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Count and continuation for all current participants. |
+
+
 <a id="chatto-api-v1-ThreadService-ListFollowedThreads"></a>
 
 ### ListFollowedThreads

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -457,6 +457,52 @@ surfaces.
 | `roles` | `repeated string` | Explicit roles assigned to the user. Member listings include the virtual `everyone` role for parity with Chatto's permission model. |
 | `created_at` | `google.protobuf.Timestamp` | Account creation time when known. |
 
+<a id="chatto-api-v1-ReadMarker"></a>
+
+### ReadMarker
+
+Current stored read position. Its event can later be retracted. The timestamp
+is absent if the event can no longer be resolved. This is not Badge attention.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `last_read_event_id` | `string` | Last-read event ID, to locate the boundary in a timeline. |
+| `last_read_at` | `google.protobuf.Timestamp` | Creation time of the last-read event, when available. |
+
+<a id="chatto-api-v1-RoomReadState"></a>
+
+### RoomReadState
+
+Current viewer's stored room read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `marker` | [`ReadMarker`](#chatto-api-v1-ReadMarker) | Absent when no non-empty marker has been stored. Reading never initializes it. |
+
+<a id="chatto-api-v1-ThreadReadState"></a>
+
+### ThreadReadState
+
+Current viewer's stored thread read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `thread_root_event_id` | `string` | Root message ID. |
+| `marker` | [`ReadMarker`](#chatto-api-v1-ReadMarker) | Absent when no non-empty marker has been stored. Reading never advances it. |
+
+<a id="chatto-api-v1-ThreadReadStateTarget"></a>
+
+### ThreadReadStateTarget
+
+Room and root identity for one thread read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `thread_root_event_id` | `string` | Root message ID. |
+
 <a id="chatto-api-v1-RoomMessagePosted"></a>
 
 ### RoomMessagePosted

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -209,6 +209,73 @@ room read state, attachments, and live typing. Resource-specific services
 should still be preferred when an operation is not naturally room-scoped or
 when the resource needs an independent CRUD/batch surface.
 
+<a id="chatto-api-v1-RoomService-GetRoomReadState"></a>
+
+### GetRoomReadState
+
+Reads the current viewer's stored marker without changing it. Requires the
+same membership and read access as MarkRoomAsRead. Missing resources
+return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+
+```http
+POST /api/connect/chatto.api.v1.RoomService/GetRoomReadState
+```
+
+<a id="chatto-api-v1-GetRoomReadStateRequest"></a>
+
+#### Input: GetRoomReadStateRequest
+
+Request current room read state without changing it.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+
+
+<a id="chatto-api-v1-GetRoomReadStateResponse"></a>
+
+#### Result: GetRoomReadStateResponse
+
+Current room read state, including an absent marker when none is stored.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `state` | [`RoomReadState`](#chatto-api-v1-RoomReadState) | State for the requested room and viewer. |
+
+
+<a id="chatto-api-v1-RoomService-BatchGetRoomReadStates"></a>
+
+### BatchGetRoomReadStates
+
+Reads up to 100 states under the same authorization as GetRoomReadState.
+Missing and inaccessible resources are omitted; duplicates use first-seen order.
+
+```http
+POST /api/connect/chatto.api.v1.RoomService/BatchGetRoomReadStates
+```
+
+<a id="chatto-api-v1-BatchGetRoomReadStatesRequest"></a>
+
+#### Input: BatchGetRoomReadStatesRequest
+
+Request room read states. Duplicates are removed in first-seen order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_ids` | `repeated string` | Up to 100 room IDs. Missing or inaccessible rooms are omitted. |
+
+
+<a id="chatto-api-v1-BatchGetRoomReadStatesResponse"></a>
+
+#### Result: BatchGetRoomReadStatesResponse
+
+Accessible room read states in first-seen request order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `states` | repeated [`RoomReadState`](#chatto-api-v1-RoomReadState) | States for the current viewer. An absent marker does not omit the state. |
+
+
 <a id="chatto-api-v1-RoomService-CreateRoom"></a>
 
 ### CreateRoom
@@ -2569,6 +2636,45 @@ disappear between page requests while the index advances.
 
 Creates messages in room and thread timelines.
 
+<a id="chatto-api-v1-MessageService-ListReactionUsers"></a>
+
+### ListReactionUsers
+
+Lists all users with the requested reaction. Requires room membership and
+permission to read the message. A missing reaction returns an empty page;
+a missing or hidden message returns NOT_FOUND or PERMISSION_DENIED.
+
+```http
+POST /api/connect/chatto.api.v1.MessageService/ListReactionUsers
+```
+
+<a id="chatto-api-v1-ListReactionUsersRequest"></a>
+
+#### Input: ListReactionUsersRequest
+
+Request all users with one emoji reaction on a message. Echo IDs resolve to
+the original message. Users are ordered by user ID ascending.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room containing the message. |
+| `message_event_id` | `string` | Message or channel echo ID. |
+| `emoji` | `string` | Emoji shortcode, such as "thumbsup". |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 results. Maximum: 100. Zero uses the default. |
+
+
+<a id="chatto-api-v1-ListReactionUsersResponse"></a>
+
+#### Result: ListReactionUsersResponse
+
+Complete reaction membership is available by paging this collection.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `user_ids` | `repeated string` | User IDs in this page. Use UserService.BatchGetUsers for profiles. |
+| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Count and continuation for the matching reaction users. |
+
+
 <a id="chatto-api-v1-MessageService-FetchLinkPreview"></a>
 
 ### FetchLinkPreview
@@ -3498,6 +3604,111 @@ Authenticated server runtime configuration response.
 ## ThreadService
 
 Manages thread follow state for the current user.
+
+<a id="chatto-api-v1-ThreadService-GetThreadReadState"></a>
+
+### GetThreadReadState
+
+Reads the current viewer's stored marker without changing it. Requires the
+same membership and read access as MarkThreadAsRead. Missing resources
+return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+
+```http
+POST /api/connect/chatto.api.v1.ThreadService/GetThreadReadState
+```
+
+<a id="chatto-api-v1-GetThreadReadStateRequest"></a>
+
+#### Input: GetThreadReadStateRequest
+
+Request current thread read state without changing it.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `thread_root_event_id` | `string` | Root message ID. |
+
+
+<a id="chatto-api-v1-GetThreadReadStateResponse"></a>
+
+#### Result: GetThreadReadStateResponse
+
+Current thread read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `state` | [`ThreadReadState`](#chatto-api-v1-ThreadReadState) | State for the requested thread and viewer. |
+
+
+<a id="chatto-api-v1-ThreadService-BatchGetThreadReadStates"></a>
+
+### BatchGetThreadReadStates
+
+Reads up to 100 states under the same authorization as GetThreadReadState.
+Missing and inaccessible resources are omitted; duplicates use first-seen order.
+
+```http
+POST /api/connect/chatto.api.v1.ThreadService/BatchGetThreadReadStates
+```
+
+<a id="chatto-api-v1-BatchGetThreadReadStatesRequest"></a>
+
+#### Input: BatchGetThreadReadStatesRequest
+
+Request thread read states. Duplicates are removed in first-seen order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `targets` | repeated [`ThreadReadStateTarget`](#chatto-api-v1-ThreadReadStateTarget) | Up to 100 room/thread targets. Missing or inaccessible targets are omitted. |
+
+
+<a id="chatto-api-v1-BatchGetThreadReadStatesResponse"></a>
+
+#### Result: BatchGetThreadReadStatesResponse
+
+Accessible thread read states in first-seen request order.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `states` | repeated [`ThreadReadState`](#chatto-api-v1-ThreadReadState) | States for the current viewer. An absent marker does not omit the state. |
+
+
+<a id="chatto-api-v1-ThreadService-ListThreadParticipants"></a>
+
+### ListThreadParticipants
+
+Lists distinct authors of non-retracted replies, excluding erased users.
+The root author is included only if they also replied. Requires the same
+membership and message-read access as GetThreadEvents.
+
+```http
+POST /api/connect/chatto.api.v1.ThreadService/ListThreadParticipants
+```
+
+<a id="chatto-api-v1-ListThreadParticipantsRequest"></a>
+
+#### Input: ListThreadParticipantsRequest
+
+Request a complete thread participant collection, ordered by user ID ascending.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room containing the thread. |
+| `thread_root_event_id` | `string` | Root message ID. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 results. Maximum: 100. Zero uses the default. |
+
+
+<a id="chatto-api-v1-ListThreadParticipantsResponse"></a>
+
+#### Result: ListThreadParticipantsResponse
+
+A page of distinct reply authors. An empty thread returns an empty page.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `user_ids` | `repeated string` | User IDs in this page. Use UserService.BatchGetUsers for profiles. |
+| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Count and continuation for all current participants. |
+
 
 <a id="chatto-api-v1-ThreadService-ListFollowedThreads"></a>
 
@@ -4692,6 +4903,60 @@ surfaces.
 | `user` | [`User`](#chatto-api-v1-User) | Public user fields. |
 | `roles` | `repeated string` | Explicit roles assigned to the user. Member listings include the virtual `everyone` role for parity with Chatto's permission model. |
 | `created_at` | `google.protobuf.Timestamp` | Account creation time when known. |
+
+
+
+<a id="chatto-api-v1-ReadMarker"></a>
+
+### ReadMarker
+
+Current stored read position. Its event can later be retracted. The timestamp
+is absent if the event can no longer be resolved. This is not Badge attention.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `last_read_event_id` | `string` | Last-read event ID, to locate the boundary in a timeline. |
+| `last_read_at` | `google.protobuf.Timestamp` | Creation time of the last-read event, when available. |
+
+
+
+<a id="chatto-api-v1-RoomReadState"></a>
+
+### RoomReadState
+
+Current viewer's stored room read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `marker` | [`ReadMarker`](#chatto-api-v1-ReadMarker) | Absent when no non-empty marker has been stored. Reading never initializes it. |
+
+
+
+<a id="chatto-api-v1-ThreadReadState"></a>
+
+### ThreadReadState
+
+Current viewer's stored thread read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `thread_root_event_id` | `string` | Root message ID. |
+| `marker` | [`ReadMarker`](#chatto-api-v1-ReadMarker) | Absent when no non-empty marker has been stored. Reading never advances it. |
+
+
+
+<a id="chatto-api-v1-ThreadReadStateTarget"></a>
+
+### ThreadReadStateTarget
+
+Room and root identity for one thread read state.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `room_id` | `string` | Room ID. |
+| `thread_root_event_id` | `string` | Root message ID. |
 
 
 

--- a/cli/internal/connectapi/integration_reads_test.go
+++ b/cli/internal/connectapi/integration_reads_test.go
@@ -1,0 +1,172 @@
+package connectapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	"hmans.de/chatto/internal/core"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+)
+
+func TestIntegrationRelationshipReads(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("relationship-reads")
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	ctx := withCaller(env.ctx, env.viewer)
+	var ids []string
+	for i := 0; i < 7; i++ {
+		user, err := env.core.CreateUser(env.ctx, core.SystemActorID, fmt.Sprintf("relationship-reader-%d", i), "Reader", "password")
+		require.NoError(t, err)
+		_, err = env.core.JoinRoom(env.ctx, user.Id, core.KindChannel, user.Id, room.Id)
+		require.NoError(t, err)
+		ids = append(ids, user.Id)
+		env.post(room.Id, user.Id, "reply", root.Id)
+		_, err = env.messages.AddReaction(withCaller(env.ctx, user), connect.NewRequest(&apiv1.AddReactionRequest{RoomId: room.Id, MessageEventId: root.Id, Emoji: "thumbsup"}))
+		require.NoError(t, err)
+	}
+	slices.Sort(ids)
+	for _, offset := range []int32{0, 4, 7} {
+		page := &apiv1.PageRequest{Limit: 4, Offset: offset}
+		reactions, err := env.messages.ListReactionUsers(ctx, connect.NewRequest(&apiv1.ListReactionUsersRequest{RoomId: room.Id, MessageEventId: root.Id, Emoji: "thumbsup", Page: page}))
+		require.NoError(t, err)
+		participants, err := env.threads.ListThreadParticipants(ctx, connect.NewRequest(&apiv1.ListThreadParticipantsRequest{RoomId: room.Id, ThreadRootEventId: root.Id, Page: page}))
+		require.NoError(t, err)
+		want := ids[int(offset):min(int(offset)+4, len(ids))]
+		require.Equal(t, want, reactions.Msg.UserIds)
+		require.Equal(t, want, participants.Msg.UserIds)
+		require.EqualValues(t, 7, reactions.Msg.Page.TotalCount)
+		require.EqualValues(t, 7, participants.Msg.Page.TotalCount)
+		require.Equal(t, offset == 0, reactions.Msg.Page.HasMore)
+		require.Equal(t, offset == 0, participants.Msg.Page.HasMore)
+	}
+	empty, err := env.messages.ListReactionUsers(ctx, connect.NewRequest(&apiv1.ListReactionUsersRequest{RoomId: room.Id, MessageEventId: root.Id, Emoji: "heart"}))
+	require.NoError(t, err)
+	require.Empty(t, empty.Msg.UserIds)
+	outsider, err := env.core.CreateUser(env.ctx, core.SystemActorID, "relationship-outsider", "Outsider", "password")
+	require.NoError(t, err)
+	_, err = env.messages.ListReactionUsers(withCaller(env.ctx, outsider), connect.NewRequest(&apiv1.ListReactionUsersRequest{RoomId: room.Id, MessageEventId: root.Id, Emoji: "thumbsup"}))
+	require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+	_, err = env.threads.ListThreadParticipants(withCaller(env.ctx, outsider), connect.NewRequest(&apiv1.ListThreadParticipantsRequest{RoomId: room.Id, ThreadRootEventId: root.Id}))
+	require.Equal(t, connect.CodePermissionDenied, connect.CodeOf(err))
+}
+
+func TestIntegrationReadMarkers(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room, err := env.core.CreateRoom(env.ctx, env.viewer.Id, core.KindChannel, "", "marker-reads", "", core.WithUniversalRoom(true))
+	require.NoError(t, err)
+	_, err = env.core.JoinRoom(env.ctx, env.viewer.Id, core.KindChannel, env.viewer.Id, room.Id)
+	require.NoError(t, err)
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	reply := env.post(room.Id, env.viewer.Id, "reply", root.Id)
+	reader, err := env.core.CreateUser(env.ctx, core.SystemActorID, "marker-reader", "Reader", "password")
+	require.NoError(t, err)
+	ctx := withCaller(env.ctx, reader)
+	roomReq := connect.NewRequest(&apiv1.GetRoomReadStateRequest{RoomId: room.Id})
+	threadReq := connect.NewRequest(&apiv1.GetThreadReadStateRequest{RoomId: room.Id, ThreadRootEventId: root.Id})
+	roomState, err := env.rooms.GetRoomReadState(ctx, roomReq)
+	require.NoError(t, err)
+	require.Nil(t, roomState.Msg.State.Marker)
+	_, exists, err := env.core.PeekLastReadEventID(env.ctx, reader.Id, room.Id)
+	require.NoError(t, err)
+	require.False(t, exists, "reading must not initialize a marker")
+	threadState, err := env.threads.GetThreadReadState(ctx, threadReq)
+	require.NoError(t, err)
+	require.Nil(t, threadState.Msg.State.Marker)
+	_, err = env.rooms.MarkRoomAsRead(ctx, connect.NewRequest(&apiv1.MarkRoomAsReadRequest{RoomId: room.Id, UpToEventId: root.Id}))
+	require.NoError(t, err)
+	_, err = env.threads.MarkThreadAsRead(ctx, connect.NewRequest(&apiv1.MarkThreadAsReadRequest{RoomId: room.Id, ThreadRootEventId: root.Id, UpToEventId: reply.Id}))
+	require.NoError(t, err)
+	roomState, err = env.rooms.GetRoomReadState(ctx, roomReq)
+	require.NoError(t, err)
+	require.Equal(t, root.Id, roomState.Msg.State.Marker.LastReadEventId)
+	require.NotNil(t, roomState.Msg.State.Marker.LastReadAt)
+	threadState, err = env.threads.GetThreadReadState(ctx, threadReq)
+	require.NoError(t, err)
+	require.Equal(t, reply.Id, threadState.Msg.State.Marker.LastReadEventId)
+	require.NotNil(t, threadState.Msg.State.Marker.LastReadAt)
+	private := env.createJoinedRoom("marker-private")
+	rooms, err := env.rooms.BatchGetRoomReadStates(ctx, connect.NewRequest(&apiv1.BatchGetRoomReadStatesRequest{RoomIds: []string{private.Id, room.Id, "missing", room.Id}}))
+	require.NoError(t, err)
+	require.Len(t, rooms.Msg.States, 1)
+	require.Equal(t, room.Id, rooms.Msg.States[0].RoomId)
+	target := &apiv1.ThreadReadStateTarget{RoomId: room.Id, ThreadRootEventId: root.Id}
+	threads, err := env.threads.BatchGetThreadReadStates(ctx, connect.NewRequest(&apiv1.BatchGetThreadReadStatesRequest{Targets: []*apiv1.ThreadReadStateTarget{{RoomId: private.Id, ThreadRootEventId: root.Id}, target, {RoomId: room.Id, ThreadRootEventId: "missing"}, target}}))
+	require.NoError(t, err)
+	require.Len(t, threads.Msg.States, 1)
+	require.Equal(t, reply.Id, threads.Msg.States[0].Marker.LastReadEventId)
+}
+
+func TestIntegrationReactionAliasesAndRetractions(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("relationship-alias")
+	ctx := withCaller(env.ctx, env.viewer)
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	reply, err := env.core.PostMessage(env.ctx, core.KindChannel, room.Id, env.viewer.Id, "reply", nil, root.Id, root.Id, nil, true)
+	require.NoError(t, err)
+	echo, ok := env.core.ChannelEchoEventID(reply.Id)
+	require.True(t, ok)
+	_, err = env.messages.AddReaction(ctx, connect.NewRequest(&apiv1.AddReactionRequest{RoomId: room.Id, MessageEventId: echo, Emoji: "thumbsup"}))
+	require.NoError(t, err)
+	for _, id := range []string{reply.Id, echo} {
+		result, err := env.messages.ListReactionUsers(ctx, connect.NewRequest(&apiv1.ListReactionUsersRequest{RoomId: room.Id, MessageEventId: id, Emoji: "thumbsup"}))
+		require.NoError(t, err)
+		require.Equal(t, []string{env.viewer.Id}, result.Msg.UserIds)
+	}
+	require.NoError(t, env.core.DeleteMessage(env.ctx, env.viewer.Id, core.KindChannel, room.Id, reply.Id))
+	_, err = env.messages.ListReactionUsers(ctx, connect.NewRequest(&apiv1.ListReactionUsersRequest{RoomId: room.Id, MessageEventId: reply.Id, Emoji: "thumbsup"}))
+	require.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	participants, err := env.threads.ListThreadParticipants(ctx, connect.NewRequest(&apiv1.ListThreadParticipantsRequest{RoomId: room.Id, ThreadRootEventId: root.Id}))
+	require.NoError(t, err)
+	require.Empty(t, participants.Msg.UserIds)
+}
+
+func TestIntegrationReadsThroughJSON(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	room := env.createJoinedRoom("json-reads")
+	root := env.post(room.Id, env.viewer.Id, "root", "")
+	mux := http.NewServeMux()
+	for _, handler := range env.api.Handlers() {
+		mux.Handle(handler.ServicePath, handler.Handler)
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux.ServeHTTP(w, r.WithContext(withCaller(r.Context(), env.viewer)))
+	}))
+	t.Cleanup(server.Close)
+	cases := []struct {
+		method string
+		body   any
+		status int
+	}{
+		{"MessageService/ListReactionUsers", map[string]any{"roomId": room.Id, "messageEventId": root.Id, "emoji": "heart"}, 200},
+		{"ThreadService/ListThreadParticipants", map[string]any{"roomId": room.Id, "threadRootEventId": root.Id}, 200},
+		{"RoomService/GetRoomReadState", map[string]any{"roomId": room.Id}, 200},
+		{"ThreadService/GetThreadReadState", map[string]any{"roomId": room.Id, "threadRootEventId": root.Id}, 200},
+		{"RoomService/BatchGetRoomReadStates", map[string]any{"roomIds": []string{room.Id}}, 200},
+		{"ThreadService/BatchGetThreadReadStates", map[string]any{"targets": []any{map[string]any{"roomId": room.Id, "threadRootEventId": root.Id}}}, 200},
+		{"RoomService/BatchGetRoomReadStates", map[string]any{"roomIds": slices.Repeat([]string{room.Id}, 101)}, 400},
+		{"ThreadService/BatchGetThreadReadStates", map[string]any{"targets": []any{map[string]any{"roomId": room.Id}}}, 400},
+		{"MessageService/ListReactionUsers", map[string]any{"roomId": room.Id, "messageEventId": root.Id, "emoji": "heart", "page": map[string]any{"limit": 501}}, 400},
+		{"ThreadService/ListThreadParticipants", map[string]any{"roomId": room.Id, "threadRootEventId": root.Id, "page": map[string]any{"offset": -1}}, 400},
+	}
+	for _, tc := range cases {
+		t.Run(tc.method+fmt.Sprint(tc.status), func(t *testing.T) {
+			data, err := json.Marshal(tc.body)
+			require.NoError(t, err)
+			req, err := http.NewRequest(http.MethodPost, server.URL+"/chatto.api.v1."+tc.method, bytes.NewReader(data))
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Connect-Protocol-Version", "1")
+			resp, err := server.Client().Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, tc.status, resp.StatusCode)
+		})
+	}
+}

--- a/cli/internal/connectapi/interaction_reads.go
+++ b/cli/internal/connectapi/interaction_reads.go
@@ -1,0 +1,33 @@
+package connectapi
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+)
+
+func (s *messageService) ListReactionUsers(ctx context.Context, req *connect.Request[apiv1.ListReactionUsersRequest]) (*connect.Response[apiv1.ListReactionUsersResponse], error) {
+	caller, err := requireCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	limit, offset := apiPagination(req.Msg.GetPage(), 50, 100)
+	page, err := s.api.core.RoomTimelineReads().ListReactionUsers(ctx, caller.UserID, req.Msg.GetRoomId(), req.Msg.GetMessageEventId(), req.Msg.GetEmoji(), limit, offset)
+	if err != nil {
+		return nil, connectError(err)
+	}
+	return connect.NewResponse(&apiv1.ListReactionUsersResponse{UserIds: page.UserIDs, Page: apiPageInfo(page.TotalCount, page.HasMore)}), nil
+}
+
+func (s *threadService) ListThreadParticipants(ctx context.Context, req *connect.Request[apiv1.ListThreadParticipantsRequest]) (*connect.Response[apiv1.ListThreadParticipantsResponse], error) {
+	caller, err := requireCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	limit, offset := apiPagination(req.Msg.GetPage(), 50, 100)
+	page, err := s.api.core.RoomTimelineReads().ListThreadParticipants(ctx, caller.UserID, req.Msg.GetRoomId(), req.Msg.GetThreadRootEventId(), limit, offset)
+	if err != nil {
+		return nil, connectError(err)
+	}
+	return connect.NewResponse(&apiv1.ListThreadParticipantsResponse{UserIds: page.UserIDs, Page: apiPageInfo(page.TotalCount, page.HasMore)}), nil
+}

--- a/cli/internal/connectapi/read_marker_reads.go
+++ b/cli/internal/connectapi/read_marker_reads.go
@@ -1,0 +1,92 @@
+package connectapi
+
+import (
+	"connectrpc.com/connect"
+	"context"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"hmans.de/chatto/internal/core"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+)
+
+func apiReadMarker(marker *core.ReadMarker) *apiv1.ReadMarker {
+	if marker == nil {
+		return nil
+	}
+	result := &apiv1.ReadMarker{LastReadEventId: marker.EventID}
+	if !marker.LastReadAt.IsZero() {
+		result.LastReadAt = timestamppb.New(marker.LastReadAt)
+	}
+	return result
+}
+
+func (s *roomService) GetRoomReadState(ctx context.Context, req *connect.Request[apiv1.GetRoomReadStateRequest]) (*connect.Response[apiv1.GetRoomReadStateResponse], error) {
+	caller, err := requireCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	marker, err := s.api.core.ReadState().GetRoomReadMarker(ctx, caller.UserID, req.Msg.GetRoomId())
+	if err != nil {
+		return nil, connectError(err)
+	}
+	return connect.NewResponse(&apiv1.GetRoomReadStateResponse{State: &apiv1.RoomReadState{RoomId: req.Msg.GetRoomId(), Marker: apiReadMarker(marker)}}), nil
+}
+
+func (s *roomService) BatchGetRoomReadStates(ctx context.Context, req *connect.Request[apiv1.BatchGetRoomReadStatesRequest]) (*connect.Response[apiv1.BatchGetRoomReadStatesResponse], error) {
+	if _, err := requireCaller(ctx); err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool)
+	result := &apiv1.BatchGetRoomReadStatesResponse{}
+	for _, target := range req.Msg.GetRoomIds() {
+		key := target
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		response, err := s.GetRoomReadState(ctx, connect.NewRequest(&apiv1.GetRoomReadStateRequest{RoomId: target}))
+		if err != nil {
+			if connect.CodeOf(err) == connect.CodeNotFound || connect.CodeOf(err) == connect.CodePermissionDenied {
+				continue
+			}
+			return nil, err
+		}
+		result.States = append(result.States, response.Msg.State)
+	}
+	return connect.NewResponse(result), nil
+}
+
+func (s *threadService) GetThreadReadState(ctx context.Context, req *connect.Request[apiv1.GetThreadReadStateRequest]) (*connect.Response[apiv1.GetThreadReadStateResponse], error) {
+	caller, err := requireCaller(ctx)
+	if err != nil {
+		return nil, err
+	}
+	marker, err := s.api.core.ReadState().GetThreadReadMarker(ctx, caller.UserID, req.Msg.GetRoomId(), req.Msg.GetThreadRootEventId())
+	if err != nil {
+		return nil, connectError(err)
+	}
+	return connect.NewResponse(&apiv1.GetThreadReadStateResponse{State: &apiv1.ThreadReadState{RoomId: req.Msg.GetRoomId(), ThreadRootEventId: req.Msg.GetThreadRootEventId(), Marker: apiReadMarker(marker)}}), nil
+}
+
+func (s *threadService) BatchGetThreadReadStates(ctx context.Context, req *connect.Request[apiv1.BatchGetThreadReadStatesRequest]) (*connect.Response[apiv1.BatchGetThreadReadStatesResponse], error) {
+	if _, err := requireCaller(ctx); err != nil {
+		return nil, err
+	}
+	seen := make(map[[2]string]bool)
+	result := &apiv1.BatchGetThreadReadStatesResponse{}
+	for _, target := range req.Msg.GetTargets() {
+		key := [2]string{target.GetRoomId(), target.GetThreadRootEventId()}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		response, err := s.GetThreadReadState(ctx, connect.NewRequest(&apiv1.GetThreadReadStateRequest{RoomId: target.GetRoomId(), ThreadRootEventId: target.GetThreadRootEventId()}))
+		if err != nil {
+			if connect.CodeOf(err) == connect.CodeNotFound || connect.CodeOf(err) == connect.CodePermissionDenied {
+				continue
+			}
+			return nil, err
+		}
+		result.States = append(result.States, response.Msg.State)
+	}
+	return connect.NewResponse(result), nil
+}

--- a/cli/internal/connectapi/room_timeline_assembler.go
+++ b/cli/internal/connectapi/room_timeline_assembler.go
@@ -295,7 +295,7 @@ func (h *timelineHydrator) messagePosted(ctx context.Context, event *core.RoomEv
 				thread.LastReplyAt = timestamppb.New(*metadata.LastReplyAt)
 			}
 			thread.ParticipantPreviewUserIds = firstN(metadata.ParticipantIDs, 5)
-			thread.ParticipantCount = int32(len(metadata.ParticipantIDs))
+			thread.ParticipantCount = int32(metadata.ParticipantCount)
 			h.addUserIDs(thread.ParticipantPreviewUserIds)
 			following, err := h.api.core.IsFollowingThread(ctx, h.kind, h.viewerID, payload.GetRoomId(), event.Id)
 			if err != nil {

--- a/cli/internal/connectapi/thread_assembler.go
+++ b/cli/internal/connectapi/thread_assembler.go
@@ -123,7 +123,7 @@ func followedThreadsResponse(ctx context.Context, api *API, viewerID string, pag
 				ReplyCount:                int32(thread.ReplyCount),
 				LastReplyAt:               lastReplyAt,
 				ParticipantPreviewUserIds: participantPreviewUserIDs,
-				ParticipantCount:          int32(len(thread.ParticipantIDs)),
+				ParticipantCount:          int32(thread.ParticipantCount),
 				ViewerState:               apiThreadViewerState(following, thread.HasUnreadReplies),
 			},
 		}, nil

--- a/cli/internal/core/interaction_reads.go
+++ b/cli/internal/core/interaction_reads.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"context"
+	"sort"
+)
+
+// InteractionUserPage is a bounded set of user references. TotalCount counts
+// relationships before pagination; clients can hydrate profiles separately.
+type InteractionUserPage struct {
+	UserIDs    []string
+	TotalCount int
+	HasMore    bool
+}
+
+func interactionUserPage(ids []string, limit, offset int) *InteractionUserPage {
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	sort.Strings(ids)
+	page, total, more := paginateCoreSlice(ids, limit, offset)
+	return &InteractionUserPage{UserIDs: page, TotalCount: total, HasMore: more}
+}
+
+// ListReactionUsers returns complete reaction membership under the same read
+// authorization as the message. A channel echo is an alias for its reply.
+func (s *RoomTimelineReadModel) ListReactionUsers(ctx context.Context, actorID, roomID, eventID, emoji string, limit, offset int) (*InteractionUserPage, error) {
+	if _, _, err := s.core.requireMessageReader(ctx, actorID, roomID, eventID); err != nil {
+		return nil, err
+	}
+	canonical, err := s.core.canonicalReactionMessageEventID(roomID, eventID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.timelineMessageEntry(roomID, canonical, false); err != nil {
+		return nil, err
+	}
+	name, err := resolveEmojiInput(emoji)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.core.roomModel.waitForReactionsCurrent(ctx, s.core.EventPublisher, roomID); err != nil {
+		return nil, err
+	}
+	for _, reaction := range s.core.roomModel.reactionsForMessage(canonical) {
+		if reaction.Emoji == name {
+			return interactionUserPage(append([]string(nil), reaction.UserIDs...), limit, offset), nil
+		}
+	}
+	return interactionUserPage(nil, limit, offset), nil
+}
+
+// ListThreadParticipants returns distinct authors of current visible replies.
+// It excludes the root author unless they replied, matching thread summaries.
+func (s *RoomTimelineReadModel) ListThreadParticipants(ctx context.Context, actorID, roomID, rootID string, limit, offset int) (*InteractionUserPage, error) {
+	_, kind, err := s.core.requireThreadMessageReader(ctx, actorID, roomID, rootID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.core.requireThreadRoot(ctx, kind, roomID, rootID); err != nil {
+		return nil, err
+	}
+	if _, err := s.timelineMessageEntry(roomID, rootID, false); err != nil {
+		return nil, err
+	}
+	ids, err := s.core.roomModel.threadParticipantIDs(ctx, rootID)
+	if err != nil {
+		return nil, err
+	}
+	return interactionUserPage(ids, limit, offset), nil
+}

--- a/cli/internal/core/read_state_model.go
+++ b/cli/internal/core/read_state_model.go
@@ -30,7 +30,7 @@ func (c *ChattoCore) ReadState() *ReadStateModel {
 	return c.readStateModel
 }
 
-// ReadStateModel owns user-facing read marker mutations. Lower-level marker
+// ReadStateModel owns user-facing read marker reads and mutations. Lower-level marker
 // helpers stay available for trusted/internal callers, while this model keeps
 // public API authorization and anchor semantics in one place.
 type ReadStateModel struct {
@@ -236,4 +236,54 @@ func (s *ReadStateModel) threadReadAnchor(ctx context.Context, kind RoomKind, ro
 		return "", invalidArgument("up_to_event_id must identify a message in the thread")
 	}
 	return event.Id, nil
+}
+
+// ReadMarker is a stored position, independent of notification attention.
+// A nil result means that no non-empty marker has been stored.
+type ReadMarker struct {
+	EventID    string
+	LastReadAt time.Time
+}
+
+// GetRoomReadMarker reads only; it never performs lazy marker initialization.
+func (s *ReadStateModel) GetRoomReadMarker(ctx context.Context, actorID, roomID string) (*ReadMarker, error) {
+	_, kind, err := s.core.requireRoomMessageReader(ctx, actorID, roomID)
+	if err != nil {
+		return nil, err
+	}
+	id, _, err := s.core.PeekLastReadEventID(ctx, actorID, roomID)
+	if err != nil {
+		return nil, err
+	}
+	return s.readMarker(ctx, kind, roomID, id)
+}
+
+// GetThreadReadMarker reads only after checking access to the thread root.
+func (s *ReadStateModel) GetThreadReadMarker(ctx context.Context, actorID, roomID, rootID string) (*ReadMarker, error) {
+	_, kind, err := s.core.requireThreadMessageReader(ctx, actorID, roomID, rootID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err := s.core.requireThreadRoot(ctx, kind, roomID, rootID); err != nil {
+		return nil, err
+	}
+	entry, exists, err := s.index.threadMarker(ctx, actorID, roomID, rootID)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	return s.readMarker(ctx, kind, roomID, string(entry.value))
+}
+
+func (s *ReadStateModel) readMarker(ctx context.Context, kind RoomKind, roomID, eventID string) (*ReadMarker, error) {
+	if eventID == "" {
+		return nil, nil
+	}
+	at, err := s.core.GetEventTimestamp(ctx, kind, roomID, eventID)
+	if err != nil {
+		return nil, err
+	}
+	return &ReadMarker{EventID: eventID, LastReadAt: at}, nil
 }

--- a/cli/internal/core/room_model.go
+++ b/cli/internal/core/room_model.go
@@ -418,3 +418,11 @@ func (m *RoomModel) appendTimelineEventually(ctx context.Context, pub *evtstream
 	}
 	return pos, nil
 }
+
+// threadParticipantIDs waits for current thread state before reading the full set.
+func (m *RoomModel) threadParticipantIDs(ctx context.Context, rootID string) ([]string, error) {
+	if err := m.threads.Projector().WaitForCurrent(ctx); err != nil {
+		return nil, err
+	}
+	return m.threads.Projection().ParticipantIDs(rootID), nil
+}

--- a/cli/internal/core/thread_projection.go
+++ b/cli/internal/core/thread_projection.go
@@ -562,6 +562,7 @@ func (p *ThreadProjection) ThreadMetadata(rootEventID string) *ThreadMetadata {
 		ReplyCount:         summary.replyCount,
 		LatestReplyEventID: summary.latestReplyEventID,
 		ParticipantIDs:     append([]string(nil), summary.participantIDs...),
+		ParticipantCount:   len(summary.participantCounts),
 	}
 	if summary.lastReplyAt != nil {
 		at := *summary.lastReplyAt
@@ -696,4 +697,22 @@ func (p *ThreadProjection) Stats() (threads int, entries int, replies int) {
 		}
 	}
 	return threads, entries, replies
+}
+
+// ParticipantIDs returns the complete current reply-author set, independent of
+// the bounded display preview. Retractions and key shredding update this set.
+func (p *ThreadProjection) ParticipantIDs(rootEventID string) []string {
+	p.RLock()
+	defer p.RUnlock()
+	summary := p.summaryByThread[rootEventID]
+	if summary == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(summary.participantCounts))
+	for id, count := range summary.participantCounts {
+		if count > 0 {
+			ids = append(ids, id)
+		}
+	}
+	return ids
 }

--- a/cli/internal/core/thread_projection_test.go
+++ b/cli/internal/core/thread_projection_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"bytes"
+	"fmt"
 	"slices"
 	"strings"
 	"testing"
@@ -625,5 +626,49 @@ func TestThreadProjection_SubjectFilter(t *testing.T) {
 	}
 	if slices.Contains(subjects, evtstream.RoomSubjectFilter()) {
 		t.Errorf("unexpected broad room subject filter %q", evtstream.RoomSubjectFilter())
+	}
+}
+
+func TestThreadParticipantsExceedPreviewAndSurviveRestore(t *testing.T) {
+	p := NewThreadProjection()
+	events := []*evtv1.Event{
+		roomCreatedTimelineEvent("ROOM", "R1", "room", 1),
+		postedEvent(postedOpts{envelopeID: "ROOT", eventID: "ROOT", roomID: "R1", actorID: "AUTHOR", at: 2}),
+		threadCreatedEvent("THREAD", "R1", "ROOT", "AUTHOR", 1),
+	}
+	for i := 0; i < 60; i++ {
+		id := fmt.Sprintf("REPLY-%02d", i)
+		events = append(events, postedEvent(postedOpts{envelopeID: id, eventID: id, roomID: "R1", actorID: fmt.Sprintf("U%02d", i), inThread: "ROOT", at: i + 3}))
+	}
+	applyAll(t, p, events)
+	if got := len(p.ParticipantIDs("ROOT")); got != 60 {
+		t.Fatalf("participants = %d, want 60", got)
+	}
+	if got := p.ThreadMetadata("ROOT"); got.ParticipantCount != 60 || len(got.ParticipantIDs) != 50 {
+		t.Fatalf("metadata count=%d preview=%d", got.ParticipantCount, len(got.ParticipantIDs))
+	}
+	snapshot, err := p.Snapshot()
+	if err != nil {
+		t.Fatal(err)
+	}
+	restored := NewThreadProjection()
+	if err := restored.Restore(snapshot); err != nil {
+		t.Fatal(err)
+	}
+	if got := len(restored.ParticipantIDs("ROOT")); got != 60 {
+		t.Fatalf("restored participants = %d, want 60", got)
+	}
+	if err := restored.Apply(retractedEvent("RETRACT", "REPLY-59", "R1", "U59", "removed", 70), 64); err != nil {
+		t.Fatal(err)
+	}
+	if err := restored.Apply(userKeyShreddedSnapshotTestEvent("SHRED", "U58"), 65); err != nil {
+		t.Fatal(err)
+	}
+	ids := restored.ParticipantIDs("ROOT")
+	if len(ids) != 58 || slices.Contains(ids, "U59") || slices.Contains(ids, "U58") || slices.Contains(ids, "AUTHOR") {
+		t.Fatalf("participants after removal = %v", ids)
+	}
+	if restored.ThreadMetadata("ROOT").ParticipantCount != 58 {
+		t.Fatal("participant count did not follow removals")
 	}
 }

--- a/cli/internal/core/threads.go
+++ b/cli/internal/core/threads.go
@@ -26,18 +26,22 @@ type ThreadMetadata struct {
 	LastReplyAt        *time.Time
 	LatestReplyEventID string
 	ParticipantIDs     []string
+	// ParticipantCount counts all current reply authors, beyond the preview limit.
+	ParticipantCount int
 }
 
 // FollowedThread represents a thread the user is following, enriched with metadata for display.
 type FollowedThread struct {
-	SpaceID            string
-	RoomID             string
-	ThreadRootEventID  string
-	Exists             bool
-	ReplyCount         int
-	LastReplyAt        *time.Time
-	ActivityAt         *time.Time
-	ParticipantIDs     []string
+	SpaceID           string
+	RoomID            string
+	ThreadRootEventID string
+	Exists            bool
+	ReplyCount        int
+	LastReplyAt       *time.Time
+	ActivityAt        *time.Time
+	ParticipantIDs    []string
+	// ParticipantCount counts all current reply authors, beyond the preview limit.
+	ParticipantCount   int
 	LatestReplyEventID string
 	HasUnreadReplies   bool
 }
@@ -50,7 +54,7 @@ type FollowedThreadsPage struct {
 	HasMore    bool
 }
 
-// maxThreadParticipants is the maximum number of participant IDs tracked per thread.
+// maxThreadParticipants bounds the display preview; the full author set is retained.
 const maxThreadParticipants = 50
 
 // GetThreadEvents returns the root message followed by every reply
@@ -796,6 +800,7 @@ func (c *ChattoCore) listFollowedThreadsInSpace(ctx context.Context, userID stri
 			ActivityAt:         activityAt,
 			LatestReplyEventID: metadata.LatestReplyEventID,
 			ParticipantIDs:     metadata.ParticipantIDs,
+			ParticipantCount:   metadata.ParticipantCount,
 		})
 	}
 

--- a/cli/internal/http_server/connect_json_smoke_test.go
+++ b/cli/internal/http_server/connect_json_smoke_test.go
@@ -1,0 +1,112 @@
+package http_server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"hmans.de/chatto/internal/config"
+	"hmans.de/chatto/internal/core"
+)
+
+// TestConnectJSONIntegrationSmoke exercises a client workflow through the real
+// HTTP auth and Connect routes. Keep procedure names, JSON fields, enum values,
+// and error codes literal so generated clients cannot hide contract changes.
+func TestConnectJSONIntegrationSmoke(t *testing.T) {
+	s, server := setupConnectTestServer(t, config.AuthConfig{})
+	ctx := context.Background()
+	// Provision the human credential out of band, as an integration would
+	// obtain it from OAuth. Every workflow operation below uses HTTP JSON.
+	owner, err := s.core.CreateUser(ctx, core.SystemActorID, "json-smoke", "JSON Smoke", "password")
+	require.NoError(t, err)
+	token, err := s.core.CreateAuthToken(ctx, owner.GetId())
+	require.NoError(t, err)
+
+	call := func(credential, procedure, body string, status int) map[string]any {
+		t.Helper()
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, server.URL+"/api/connect/"+procedure, strings.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Connect-Protocol-Version", "1")
+		if credential != "" {
+			req.Header.Set("Authorization", "Bearer "+credential)
+		}
+		resp, err := server.Client().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		// Do not include response bodies: credential-creation responses contain secrets.
+		require.Equal(t, status, resp.StatusCode, "procedure %s", procedure)
+		require.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+		var result map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&result))
+		return result
+	}
+	object := func(value any) map[string]any {
+		t.Helper()
+		result, ok := value.(map[string]any)
+		require.True(t, ok, "expected JSON object")
+		return result
+	}
+	const viewer = "chatto.api.v1.ViewerService/GetViewer"
+	const account = "chatto.api.v1.MyAccountService/"
+	const bots = "chatto.api.v1.BotService/"
+
+	discovery := call("", "chatto.discovery.v1.ServerDiscoveryService/GetServer", "{}", 200)
+	require.Equal(t, "1.2.3", object(discovery["profile"])["version"])
+	require.Equal(t, "/oauth/authorize", object(discovery["login"])["authorizeUrl"])
+	require.Equal(t, "unauthenticated", call("", viewer, "{}", 401)["code"])
+	require.Equal(t, "unauthenticated", call("invalid-credential", viewer, "{}", 401)["code"])
+	current := call(token, viewer, "{}", 200)
+	require.Equal(t, owner.GetId(), object(object(current["user"])["profile"])["id"])
+
+	// Create out of sort order; authenticate with a credential returned in JSON.
+	for _, login := range []string{"smoke_c_bot", "smoke_a_bot", "smoke_b_bot"} {
+		created := call(token, bots+"CreateBot", `{"login":"`+login+`","displayName":"Smoke Bot"}`, 200)
+		user := object(object(created["bot"])["user"])
+		require.Equal(t, login, user["login"])
+		key, ok := created["apiKey"].(string)
+		require.True(t, ok)
+		require.NotEmpty(t, key)
+		authenticated := call(key, viewer, "{}", 200)
+		require.Equal(t, user["id"], object(object(authenticated["user"])["profile"])["id"])
+	}
+
+	// A comma-separated camelCase FieldMask can reset null/false while
+	// preserving an unselected value. Verify through a separate public read.
+	call(token, account+"UpdateSettings", `{"timezone":"Europe/Berlin","shareTimezone":true,"timeFormat":"TIME_FORMAT_24_HOUR","updateMask":"timezone,shareTimezone,timeFormat"}`, 200)
+	call(token, account+"UpdateSettings", `{"timezone":null,"shareTimezone":false,"updateMask":"timezone,shareTimezone"}`, 200)
+	current = call(token, viewer, "{}", 200)
+	settings := object(object(current["user"])["settings"])
+	require.NotContains(t, settings, "timezone")
+	require.Equal(t, false, settings["shareTimezone"])
+	require.Equal(t, "TIME_FORMAT_24_HOUR", settings["timeFormat"])
+
+	first := call(token, bots+"ListBots", `{"search":"smoke_","page":{"limit":2}}`, 200)
+	second := call(token, bots+"ListBots", `{"search":"smoke_","page":{"limit":2,"offset":2}}`, 200)
+	var logins []string
+	for _, page := range []map[string]any{first, second} {
+		rows, ok := page["bots"].([]any)
+		require.True(t, ok)
+		for _, row := range rows {
+			logins = append(logins, object(object(row)["user"])["login"].(string))
+		}
+		// ProtoJSON encodes int64 counts as decimal strings.
+		require.Equal(t, "3", object(page["page"])["totalCount"])
+	}
+	require.Len(t, first["bots"], 2)
+	require.Len(t, second["bots"], 1)
+	require.Equal(t, []string{"smoke_a_bot", "smoke_b_bot", "smoke_c_bot"}, logins)
+	require.Equal(t, true, object(first["page"])["hasMore"])
+	// ProtoJSON omits non-optional false scalars.
+	require.NotContains(t, object(second["page"]), "hasMore")
+
+	require.Equal(t, "invalid_argument", call(token, account+"UpdateSettings", `{"updateMask":"unknownField"}`, 400)["code"])
+	require.Equal(t, "invalid_argument", call(token, bots+"ListBots", `{"page":{"limit":501}}`, 400)["code"])
+	require.Equal(t, "not_found", call(token, "chatto.api.v1.UserService/GetUser", `{"userId":"missing-user"}`, 404)["code"])
+	require.Equal(t, "permission_denied", call(token, "chatto.admin.v1.AdminServerService/UpdateBlockedUsernames", `{"blockedUsernames":["blocked"],"updateMask":"blockedUsernames"}`, 403)["code"])
+	call(token, account+"UpdateProfile", `{"login":"json-smoke-renamed","updateMask":"login"}`, 200)
+	require.Equal(t, "failed_precondition", call(token, account+"UpdateProfile", `{"login":"json-smoke-again","updateMask":"login"}`, 400)["code"])
+}

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/messages.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/messages.connect.go
@@ -33,6 +33,9 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
+	// MessageServiceListReactionUsersProcedure is the fully-qualified name of the MessageService's
+	// ListReactionUsers RPC.
+	MessageServiceListReactionUsersProcedure = "/chatto.api.v1.MessageService/ListReactionUsers"
 	// MessageServiceFetchLinkPreviewProcedure is the fully-qualified name of the MessageService's
 	// FetchLinkPreview RPC.
 	MessageServiceFetchLinkPreviewProcedure = "/chatto.api.v1.MessageService/FetchLinkPreview"
@@ -67,6 +70,10 @@ const (
 
 // MessageServiceClient is a client for the chatto.api.v1.MessageService service.
 type MessageServiceClient interface {
+	// Lists all users with the requested reaction. Requires room membership and
+	// permission to read the message. A missing reaction returns an empty page;
+	// a missing or hidden message returns NOT_FOUND or PERMISSION_DENIED.
+	ListReactionUsers(context.Context, *connect.Request[v1.ListReactionUsersRequest]) (*connect.Response[v1.ListReactionUsersResponse], error)
 	// Fetches and caches metadata for a composer URL. Authentication is required
 	// to avoid exposing the preview fetcher as an unauthenticated network proxy.
 	// Successful responses include a short-lived token accepted by CreateMessage.
@@ -129,6 +136,12 @@ func NewMessageServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 	baseURL = strings.TrimRight(baseURL, "/")
 	messageServiceMethods := v1.File_chatto_api_v1_messages_proto.Services().ByName("MessageService").Methods()
 	return &messageServiceClient{
+		listReactionUsers: connect.NewClient[v1.ListReactionUsersRequest, v1.ListReactionUsersResponse](
+			httpClient,
+			baseURL+MessageServiceListReactionUsersProcedure,
+			connect.WithSchema(messageServiceMethods.ByName("ListReactionUsers")),
+			connect.WithClientOptions(opts...),
+		),
 		fetchLinkPreview: connect.NewClient[v1.FetchLinkPreviewRequest, v1.FetchLinkPreviewResponse](
 			httpClient,
 			baseURL+MessageServiceFetchLinkPreviewProcedure,
@@ -194,6 +207,7 @@ func NewMessageServiceClient(httpClient connect.HTTPClient, baseURL string, opts
 
 // messageServiceClient implements MessageServiceClient.
 type messageServiceClient struct {
+	listReactionUsers *connect.Client[v1.ListReactionUsersRequest, v1.ListReactionUsersResponse]
 	fetchLinkPreview  *connect.Client[v1.FetchLinkPreviewRequest, v1.FetchLinkPreviewResponse]
 	createMessage     *connect.Client[v1.CreateMessageRequest, v1.CreateMessageResponse]
 	updateMessage     *connect.Client[v1.UpdateMessageRequest, v1.UpdateMessageResponse]
@@ -204,6 +218,11 @@ type messageServiceClient struct {
 	batchGetMessages  *connect.Client[v1.BatchGetMessagesRequest, v1.BatchGetMessagesResponse]
 	addReaction       *connect.Client[v1.AddReactionRequest, v1.AddReactionResponse]
 	removeReaction    *connect.Client[v1.RemoveReactionRequest, v1.RemoveReactionResponse]
+}
+
+// ListReactionUsers calls chatto.api.v1.MessageService.ListReactionUsers.
+func (c *messageServiceClient) ListReactionUsers(ctx context.Context, req *connect.Request[v1.ListReactionUsersRequest]) (*connect.Response[v1.ListReactionUsersResponse], error) {
+	return c.listReactionUsers.CallUnary(ctx, req)
 }
 
 // FetchLinkPreview calls chatto.api.v1.MessageService.FetchLinkPreview.
@@ -258,6 +277,10 @@ func (c *messageServiceClient) RemoveReaction(ctx context.Context, req *connect.
 
 // MessageServiceHandler is an implementation of the chatto.api.v1.MessageService service.
 type MessageServiceHandler interface {
+	// Lists all users with the requested reaction. Requires room membership and
+	// permission to read the message. A missing reaction returns an empty page;
+	// a missing or hidden message returns NOT_FOUND or PERMISSION_DENIED.
+	ListReactionUsers(context.Context, *connect.Request[v1.ListReactionUsersRequest]) (*connect.Response[v1.ListReactionUsersResponse], error)
 	// Fetches and caches metadata for a composer URL. Authentication is required
 	// to avoid exposing the preview fetcher as an unauthenticated network proxy.
 	// Successful responses include a short-lived token accepted by CreateMessage.
@@ -316,6 +339,12 @@ type MessageServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewMessageServiceHandler(svc MessageServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	messageServiceMethods := v1.File_chatto_api_v1_messages_proto.Services().ByName("MessageService").Methods()
+	messageServiceListReactionUsersHandler := connect.NewUnaryHandler(
+		MessageServiceListReactionUsersProcedure,
+		svc.ListReactionUsers,
+		connect.WithSchema(messageServiceMethods.ByName("ListReactionUsers")),
+		connect.WithHandlerOptions(opts...),
+	)
 	messageServiceFetchLinkPreviewHandler := connect.NewUnaryHandler(
 		MessageServiceFetchLinkPreviewProcedure,
 		svc.FetchLinkPreview,
@@ -378,6 +407,8 @@ func NewMessageServiceHandler(svc MessageServiceHandler, opts ...connect.Handler
 	)
 	return "/chatto.api.v1.MessageService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case MessageServiceListReactionUsersProcedure:
+			messageServiceListReactionUsersHandler.ServeHTTP(w, r)
 		case MessageServiceFetchLinkPreviewProcedure:
 			messageServiceFetchLinkPreviewHandler.ServeHTTP(w, r)
 		case MessageServiceCreateMessageProcedure:
@@ -406,6 +437,10 @@ func NewMessageServiceHandler(svc MessageServiceHandler, opts ...connect.Handler
 
 // UnimplementedMessageServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedMessageServiceHandler struct{}
+
+func (UnimplementedMessageServiceHandler) ListReactionUsers(context.Context, *connect.Request[v1.ListReactionUsersRequest]) (*connect.Response[v1.ListReactionUsersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.MessageService.ListReactionUsers is not implemented"))
+}
 
 func (UnimplementedMessageServiceHandler) FetchLinkPreview(context.Context, *connect.Request[v1.FetchLinkPreviewRequest]) (*connect.Response[v1.FetchLinkPreviewResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.MessageService.FetchLinkPreview is not implemented"))

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
@@ -33,6 +33,12 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
+	// RoomServiceGetRoomReadStateProcedure is the fully-qualified name of the RoomService's
+	// GetRoomReadState RPC.
+	RoomServiceGetRoomReadStateProcedure = "/chatto.api.v1.RoomService/GetRoomReadState"
+	// RoomServiceBatchGetRoomReadStatesProcedure is the fully-qualified name of the RoomService's
+	// BatchGetRoomReadStates RPC.
+	RoomServiceBatchGetRoomReadStatesProcedure = "/chatto.api.v1.RoomService/BatchGetRoomReadStates"
 	// RoomServiceCreateRoomProcedure is the fully-qualified name of the RoomService's CreateRoom RPC.
 	RoomServiceCreateRoomProcedure = "/chatto.api.v1.RoomService/CreateRoom"
 	// RoomServiceUpdateRoomProcedure is the fully-qualified name of the RoomService's UpdateRoom RPC.
@@ -97,6 +103,13 @@ const (
 
 // RoomServiceClient is a client for the chatto.api.v1.RoomService service.
 type RoomServiceClient interface {
+	// Reads the current viewer's stored marker without changing it. Requires the
+	// same membership and read access as MarkRoomAsRead. Missing resources
+	// return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+	GetRoomReadState(context.Context, *connect.Request[v1.GetRoomReadStateRequest]) (*connect.Response[v1.GetRoomReadStateResponse], error)
+	// Reads up to 100 states under the same authorization as GetRoomReadState.
+	// Missing and inaccessible resources are omitted; duplicates use first-seen order.
+	BatchGetRoomReadStates(context.Context, *connect.Request[v1.BatchGetRoomReadStatesRequest]) (*connect.Response[v1.BatchGetRoomReadStatesResponse], error)
 	// Creates a new channel room in a room group. The caller must be allowed to
 	// create rooms in the target group.
 	CreateRoom(context.Context, *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error)
@@ -206,6 +219,18 @@ func NewRoomServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 	baseURL = strings.TrimRight(baseURL, "/")
 	roomServiceMethods := v1.File_chatto_api_v1_rooms_proto.Services().ByName("RoomService").Methods()
 	return &roomServiceClient{
+		getRoomReadState: connect.NewClient[v1.GetRoomReadStateRequest, v1.GetRoomReadStateResponse](
+			httpClient,
+			baseURL+RoomServiceGetRoomReadStateProcedure,
+			connect.WithSchema(roomServiceMethods.ByName("GetRoomReadState")),
+			connect.WithClientOptions(opts...),
+		),
+		batchGetRoomReadStates: connect.NewClient[v1.BatchGetRoomReadStatesRequest, v1.BatchGetRoomReadStatesResponse](
+			httpClient,
+			baseURL+RoomServiceBatchGetRoomReadStatesProcedure,
+			connect.WithSchema(roomServiceMethods.ByName("BatchGetRoomReadStates")),
+			connect.WithClientOptions(opts...),
+		),
 		createRoom: connect.NewClient[v1.CreateRoomRequest, v1.CreateRoomResponse](
 			httpClient,
 			baseURL+RoomServiceCreateRoomProcedure,
@@ -355,6 +380,8 @@ func NewRoomServiceClient(httpClient connect.HTTPClient, baseURL string, opts ..
 
 // roomServiceClient implements RoomServiceClient.
 type roomServiceClient struct {
+	getRoomReadState       *connect.Client[v1.GetRoomReadStateRequest, v1.GetRoomReadStateResponse]
+	batchGetRoomReadStates *connect.Client[v1.BatchGetRoomReadStatesRequest, v1.BatchGetRoomReadStatesResponse]
 	createRoom             *connect.Client[v1.CreateRoomRequest, v1.CreateRoomResponse]
 	updateRoom             *connect.Client[v1.UpdateRoomRequest, v1.UpdateRoomResponse]
 	archiveRoom            *connect.Client[v1.ArchiveRoomRequest, v1.ArchiveRoomResponse]
@@ -379,6 +406,16 @@ type roomServiceClient struct {
 	markRoomAsRead         *connect.Client[v1.MarkRoomAsReadRequest, v1.MarkRoomAsReadResponse]
 	banMember              *connect.Client[v1.BanMemberRequest, v1.BanMemberResponse]
 	unbanMember            *connect.Client[v1.UnbanMemberRequest, v1.UnbanMemberResponse]
+}
+
+// GetRoomReadState calls chatto.api.v1.RoomService.GetRoomReadState.
+func (c *roomServiceClient) GetRoomReadState(ctx context.Context, req *connect.Request[v1.GetRoomReadStateRequest]) (*connect.Response[v1.GetRoomReadStateResponse], error) {
+	return c.getRoomReadState.CallUnary(ctx, req)
+}
+
+// BatchGetRoomReadStates calls chatto.api.v1.RoomService.BatchGetRoomReadStates.
+func (c *roomServiceClient) BatchGetRoomReadStates(ctx context.Context, req *connect.Request[v1.BatchGetRoomReadStatesRequest]) (*connect.Response[v1.BatchGetRoomReadStatesResponse], error) {
+	return c.batchGetRoomReadStates.CallUnary(ctx, req)
 }
 
 // CreateRoom calls chatto.api.v1.RoomService.CreateRoom.
@@ -503,6 +540,13 @@ func (c *roomServiceClient) UnbanMember(ctx context.Context, req *connect.Reques
 
 // RoomServiceHandler is an implementation of the chatto.api.v1.RoomService service.
 type RoomServiceHandler interface {
+	// Reads the current viewer's stored marker without changing it. Requires the
+	// same membership and read access as MarkRoomAsRead. Missing resources
+	// return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+	GetRoomReadState(context.Context, *connect.Request[v1.GetRoomReadStateRequest]) (*connect.Response[v1.GetRoomReadStateResponse], error)
+	// Reads up to 100 states under the same authorization as GetRoomReadState.
+	// Missing and inaccessible resources are omitted; duplicates use first-seen order.
+	BatchGetRoomReadStates(context.Context, *connect.Request[v1.BatchGetRoomReadStatesRequest]) (*connect.Response[v1.BatchGetRoomReadStatesResponse], error)
 	// Creates a new channel room in a room group. The caller must be allowed to
 	// create rooms in the target group.
 	CreateRoom(context.Context, *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error)
@@ -608,6 +652,18 @@ type RoomServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewRoomServiceHandler(svc RoomServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	roomServiceMethods := v1.File_chatto_api_v1_rooms_proto.Services().ByName("RoomService").Methods()
+	roomServiceGetRoomReadStateHandler := connect.NewUnaryHandler(
+		RoomServiceGetRoomReadStateProcedure,
+		svc.GetRoomReadState,
+		connect.WithSchema(roomServiceMethods.ByName("GetRoomReadState")),
+		connect.WithHandlerOptions(opts...),
+	)
+	roomServiceBatchGetRoomReadStatesHandler := connect.NewUnaryHandler(
+		RoomServiceBatchGetRoomReadStatesProcedure,
+		svc.BatchGetRoomReadStates,
+		connect.WithSchema(roomServiceMethods.ByName("BatchGetRoomReadStates")),
+		connect.WithHandlerOptions(opts...),
+	)
 	roomServiceCreateRoomHandler := connect.NewUnaryHandler(
 		RoomServiceCreateRoomProcedure,
 		svc.CreateRoom,
@@ -754,6 +810,10 @@ func NewRoomServiceHandler(svc RoomServiceHandler, opts ...connect.HandlerOption
 	)
 	return "/chatto.api.v1.RoomService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case RoomServiceGetRoomReadStateProcedure:
+			roomServiceGetRoomReadStateHandler.ServeHTTP(w, r)
+		case RoomServiceBatchGetRoomReadStatesProcedure:
+			roomServiceBatchGetRoomReadStatesHandler.ServeHTTP(w, r)
 		case RoomServiceCreateRoomProcedure:
 			roomServiceCreateRoomHandler.ServeHTTP(w, r)
 		case RoomServiceUpdateRoomProcedure:
@@ -810,6 +870,14 @@ func NewRoomServiceHandler(svc RoomServiceHandler, opts ...connect.HandlerOption
 
 // UnimplementedRoomServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedRoomServiceHandler struct{}
+
+func (UnimplementedRoomServiceHandler) GetRoomReadState(context.Context, *connect.Request[v1.GetRoomReadStateRequest]) (*connect.Response[v1.GetRoomReadStateResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.RoomService.GetRoomReadState is not implemented"))
+}
+
+func (UnimplementedRoomServiceHandler) BatchGetRoomReadStates(context.Context, *connect.Request[v1.BatchGetRoomReadStatesRequest]) (*connect.Response[v1.BatchGetRoomReadStatesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.RoomService.BatchGetRoomReadStates is not implemented"))
+}
 
 func (UnimplementedRoomServiceHandler) CreateRoom(context.Context, *connect.Request[v1.CreateRoomRequest]) (*connect.Response[v1.CreateRoomResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.RoomService.CreateRoom is not implemented"))

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/threads.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/threads.connect.go
@@ -33,6 +33,15 @@ const (
 // reflection-formatted method names, remove the leading slash and convert the remaining slash to a
 // period.
 const (
+	// ThreadServiceGetThreadReadStateProcedure is the fully-qualified name of the ThreadService's
+	// GetThreadReadState RPC.
+	ThreadServiceGetThreadReadStateProcedure = "/chatto.api.v1.ThreadService/GetThreadReadState"
+	// ThreadServiceBatchGetThreadReadStatesProcedure is the fully-qualified name of the ThreadService's
+	// BatchGetThreadReadStates RPC.
+	ThreadServiceBatchGetThreadReadStatesProcedure = "/chatto.api.v1.ThreadService/BatchGetThreadReadStates"
+	// ThreadServiceListThreadParticipantsProcedure is the fully-qualified name of the ThreadService's
+	// ListThreadParticipants RPC.
+	ThreadServiceListThreadParticipantsProcedure = "/chatto.api.v1.ThreadService/ListThreadParticipants"
 	// ThreadServiceListFollowedThreadsProcedure is the fully-qualified name of the ThreadService's
 	// ListFollowedThreads RPC.
 	ThreadServiceListFollowedThreadsProcedure = "/chatto.api.v1.ThreadService/ListFollowedThreads"
@@ -55,6 +64,17 @@ const (
 
 // ThreadServiceClient is a client for the chatto.api.v1.ThreadService service.
 type ThreadServiceClient interface {
+	// Reads the current viewer's stored marker without changing it. Requires the
+	// same membership and read access as MarkThreadAsRead. Missing resources
+	// return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+	GetThreadReadState(context.Context, *connect.Request[v1.GetThreadReadStateRequest]) (*connect.Response[v1.GetThreadReadStateResponse], error)
+	// Reads up to 100 states under the same authorization as GetThreadReadState.
+	// Missing and inaccessible resources are omitted; duplicates use first-seen order.
+	BatchGetThreadReadStates(context.Context, *connect.Request[v1.BatchGetThreadReadStatesRequest]) (*connect.Response[v1.BatchGetThreadReadStatesResponse], error)
+	// Lists distinct authors of non-retracted replies, excluding erased users.
+	// The root author is included only if they also replied. Requires the same
+	// membership and message-read access as GetThreadEvents.
+	ListThreadParticipants(context.Context, *connect.Request[v1.ListThreadParticipantsRequest]) (*connect.Response[v1.ListThreadParticipantsResponse], error)
 	// Returns followed threads in rooms where the current user is a member.
 	// All threads also require message.read or an active relationship with
 	// message.read-interactions. Direct-message threads are returned only when
@@ -103,6 +123,24 @@ func NewThreadServiceClient(httpClient connect.HTTPClient, baseURL string, opts 
 	baseURL = strings.TrimRight(baseURL, "/")
 	threadServiceMethods := v1.File_chatto_api_v1_threads_proto.Services().ByName("ThreadService").Methods()
 	return &threadServiceClient{
+		getThreadReadState: connect.NewClient[v1.GetThreadReadStateRequest, v1.GetThreadReadStateResponse](
+			httpClient,
+			baseURL+ThreadServiceGetThreadReadStateProcedure,
+			connect.WithSchema(threadServiceMethods.ByName("GetThreadReadState")),
+			connect.WithClientOptions(opts...),
+		),
+		batchGetThreadReadStates: connect.NewClient[v1.BatchGetThreadReadStatesRequest, v1.BatchGetThreadReadStatesResponse](
+			httpClient,
+			baseURL+ThreadServiceBatchGetThreadReadStatesProcedure,
+			connect.WithSchema(threadServiceMethods.ByName("BatchGetThreadReadStates")),
+			connect.WithClientOptions(opts...),
+		),
+		listThreadParticipants: connect.NewClient[v1.ListThreadParticipantsRequest, v1.ListThreadParticipantsResponse](
+			httpClient,
+			baseURL+ThreadServiceListThreadParticipantsProcedure,
+			connect.WithSchema(threadServiceMethods.ByName("ListThreadParticipants")),
+			connect.WithClientOptions(opts...),
+		),
 		listFollowedThreads: connect.NewClient[v1.ListFollowedThreadsRequest, v1.ListFollowedThreadsResponse](
 			httpClient,
 			baseURL+ThreadServiceListFollowedThreadsProcedure,
@@ -144,12 +182,30 @@ func NewThreadServiceClient(httpClient connect.HTTPClient, baseURL string, opts 
 
 // threadServiceClient implements ThreadServiceClient.
 type threadServiceClient struct {
-	listFollowedThreads   *connect.Client[v1.ListFollowedThreadsRequest, v1.ListFollowedThreadsResponse]
-	followThread          *connect.Client[v1.FollowThreadRequest, v1.FollowThreadResponse]
-	unfollowThread        *connect.Client[v1.UnfollowThreadRequest, v1.UnfollowThreadResponse]
-	getThreadEvents       *connect.Client[v1.GetThreadEventsRequest, v1.GetThreadEventsResponse]
-	getThreadEventsAround *connect.Client[v1.GetThreadEventsAroundRequest, v1.GetThreadEventsAroundResponse]
-	markThreadAsRead      *connect.Client[v1.MarkThreadAsReadRequest, v1.MarkThreadAsReadResponse]
+	getThreadReadState       *connect.Client[v1.GetThreadReadStateRequest, v1.GetThreadReadStateResponse]
+	batchGetThreadReadStates *connect.Client[v1.BatchGetThreadReadStatesRequest, v1.BatchGetThreadReadStatesResponse]
+	listThreadParticipants   *connect.Client[v1.ListThreadParticipantsRequest, v1.ListThreadParticipantsResponse]
+	listFollowedThreads      *connect.Client[v1.ListFollowedThreadsRequest, v1.ListFollowedThreadsResponse]
+	followThread             *connect.Client[v1.FollowThreadRequest, v1.FollowThreadResponse]
+	unfollowThread           *connect.Client[v1.UnfollowThreadRequest, v1.UnfollowThreadResponse]
+	getThreadEvents          *connect.Client[v1.GetThreadEventsRequest, v1.GetThreadEventsResponse]
+	getThreadEventsAround    *connect.Client[v1.GetThreadEventsAroundRequest, v1.GetThreadEventsAroundResponse]
+	markThreadAsRead         *connect.Client[v1.MarkThreadAsReadRequest, v1.MarkThreadAsReadResponse]
+}
+
+// GetThreadReadState calls chatto.api.v1.ThreadService.GetThreadReadState.
+func (c *threadServiceClient) GetThreadReadState(ctx context.Context, req *connect.Request[v1.GetThreadReadStateRequest]) (*connect.Response[v1.GetThreadReadStateResponse], error) {
+	return c.getThreadReadState.CallUnary(ctx, req)
+}
+
+// BatchGetThreadReadStates calls chatto.api.v1.ThreadService.BatchGetThreadReadStates.
+func (c *threadServiceClient) BatchGetThreadReadStates(ctx context.Context, req *connect.Request[v1.BatchGetThreadReadStatesRequest]) (*connect.Response[v1.BatchGetThreadReadStatesResponse], error) {
+	return c.batchGetThreadReadStates.CallUnary(ctx, req)
+}
+
+// ListThreadParticipants calls chatto.api.v1.ThreadService.ListThreadParticipants.
+func (c *threadServiceClient) ListThreadParticipants(ctx context.Context, req *connect.Request[v1.ListThreadParticipantsRequest]) (*connect.Response[v1.ListThreadParticipantsResponse], error) {
+	return c.listThreadParticipants.CallUnary(ctx, req)
 }
 
 // ListFollowedThreads calls chatto.api.v1.ThreadService.ListFollowedThreads.
@@ -184,6 +240,17 @@ func (c *threadServiceClient) MarkThreadAsRead(ctx context.Context, req *connect
 
 // ThreadServiceHandler is an implementation of the chatto.api.v1.ThreadService service.
 type ThreadServiceHandler interface {
+	// Reads the current viewer's stored marker without changing it. Requires the
+	// same membership and read access as MarkThreadAsRead. Missing resources
+	// return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+	GetThreadReadState(context.Context, *connect.Request[v1.GetThreadReadStateRequest]) (*connect.Response[v1.GetThreadReadStateResponse], error)
+	// Reads up to 100 states under the same authorization as GetThreadReadState.
+	// Missing and inaccessible resources are omitted; duplicates use first-seen order.
+	BatchGetThreadReadStates(context.Context, *connect.Request[v1.BatchGetThreadReadStatesRequest]) (*connect.Response[v1.BatchGetThreadReadStatesResponse], error)
+	// Lists distinct authors of non-retracted replies, excluding erased users.
+	// The root author is included only if they also replied. Requires the same
+	// membership and message-read access as GetThreadEvents.
+	ListThreadParticipants(context.Context, *connect.Request[v1.ListThreadParticipantsRequest]) (*connect.Response[v1.ListThreadParticipantsResponse], error)
 	// Returns followed threads in rooms where the current user is a member.
 	// All threads also require message.read or an active relationship with
 	// message.read-interactions. Direct-message threads are returned only when
@@ -228,6 +295,24 @@ type ThreadServiceHandler interface {
 // and JSON codecs. They also support gzip compression.
 func NewThreadServiceHandler(svc ThreadServiceHandler, opts ...connect.HandlerOption) (string, http.Handler) {
 	threadServiceMethods := v1.File_chatto_api_v1_threads_proto.Services().ByName("ThreadService").Methods()
+	threadServiceGetThreadReadStateHandler := connect.NewUnaryHandler(
+		ThreadServiceGetThreadReadStateProcedure,
+		svc.GetThreadReadState,
+		connect.WithSchema(threadServiceMethods.ByName("GetThreadReadState")),
+		connect.WithHandlerOptions(opts...),
+	)
+	threadServiceBatchGetThreadReadStatesHandler := connect.NewUnaryHandler(
+		ThreadServiceBatchGetThreadReadStatesProcedure,
+		svc.BatchGetThreadReadStates,
+		connect.WithSchema(threadServiceMethods.ByName("BatchGetThreadReadStates")),
+		connect.WithHandlerOptions(opts...),
+	)
+	threadServiceListThreadParticipantsHandler := connect.NewUnaryHandler(
+		ThreadServiceListThreadParticipantsProcedure,
+		svc.ListThreadParticipants,
+		connect.WithSchema(threadServiceMethods.ByName("ListThreadParticipants")),
+		connect.WithHandlerOptions(opts...),
+	)
 	threadServiceListFollowedThreadsHandler := connect.NewUnaryHandler(
 		ThreadServiceListFollowedThreadsProcedure,
 		svc.ListFollowedThreads,
@@ -266,6 +351,12 @@ func NewThreadServiceHandler(svc ThreadServiceHandler, opts ...connect.HandlerOp
 	)
 	return "/chatto.api.v1.ThreadService/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
+		case ThreadServiceGetThreadReadStateProcedure:
+			threadServiceGetThreadReadStateHandler.ServeHTTP(w, r)
+		case ThreadServiceBatchGetThreadReadStatesProcedure:
+			threadServiceBatchGetThreadReadStatesHandler.ServeHTTP(w, r)
+		case ThreadServiceListThreadParticipantsProcedure:
+			threadServiceListThreadParticipantsHandler.ServeHTTP(w, r)
 		case ThreadServiceListFollowedThreadsProcedure:
 			threadServiceListFollowedThreadsHandler.ServeHTTP(w, r)
 		case ThreadServiceFollowThreadProcedure:
@@ -286,6 +377,18 @@ func NewThreadServiceHandler(svc ThreadServiceHandler, opts ...connect.HandlerOp
 
 // UnimplementedThreadServiceHandler returns CodeUnimplemented from all methods.
 type UnimplementedThreadServiceHandler struct{}
+
+func (UnimplementedThreadServiceHandler) GetThreadReadState(context.Context, *connect.Request[v1.GetThreadReadStateRequest]) (*connect.Response[v1.GetThreadReadStateResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.ThreadService.GetThreadReadState is not implemented"))
+}
+
+func (UnimplementedThreadServiceHandler) BatchGetThreadReadStates(context.Context, *connect.Request[v1.BatchGetThreadReadStatesRequest]) (*connect.Response[v1.BatchGetThreadReadStatesResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.ThreadService.BatchGetThreadReadStates is not implemented"))
+}
+
+func (UnimplementedThreadServiceHandler) ListThreadParticipants(context.Context, *connect.Request[v1.ListThreadParticipantsRequest]) (*connect.Response[v1.ListThreadParticipantsResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.ThreadService.ListThreadParticipants is not implemented"))
+}
 
 func (UnimplementedThreadServiceHandler) ListFollowedThreads(context.Context, *connect.Request[v1.ListFollowedThreadsRequest]) (*connect.Response[v1.ListFollowedThreadsResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.api.v1.ThreadService.ListFollowedThreads is not implemented"))

--- a/cli/internal/pb/chatto/api/v1/messages.pb.go
+++ b/cli/internal/pb/chatto/api/v1/messages.pb.go
@@ -868,8 +868,9 @@ const file_chatto_api_v1_messages_proto_rawDesc = "" +
 	"\tevent_ids\x18\x02 \x03(\tB\x10\xbaH\r\x92\x01\n" +
 	"\b\x01\x10d\"\x04r\x02\x10\x01R\beventIdsJ\x04\b\x03\x10\x04R\tthumbnail\"^\n" +
 	"\x18BatchGetMessagesResponse\x122\n" +
-	"\bmessages\x18\x01 \x03(\v2\x16.chatto.api.v1.MessageR\bmessagesJ\x04\b\x02\x10\x03R\bincludes2\xc3\a\n" +
-	"\x0eMessageService\x12c\n" +
+	"\bmessages\x18\x01 \x03(\v2\x16.chatto.api.v1.MessageR\bmessagesJ\x04\b\x02\x10\x03R\bincludes2\xab\b\n" +
+	"\x0eMessageService\x12f\n" +
+	"\x11ListReactionUsers\x12'.chatto.api.v1.ListReactionUsersRequest\x1a(.chatto.api.v1.ListReactionUsersResponse\x12c\n" +
 	"\x10FetchLinkPreview\x12&.chatto.api.v1.FetchLinkPreviewRequest\x1a'.chatto.api.v1.FetchLinkPreviewResponse\x12Z\n" +
 	"\rCreateMessage\x12#.chatto.api.v1.CreateMessageRequest\x1a$.chatto.api.v1.CreateMessageResponse\x12Z\n" +
 	"\rUpdateMessage\x12#.chatto.api.v1.UpdateMessageRequest\x1a$.chatto.api.v1.UpdateMessageResponse\x12Z\n" +
@@ -913,12 +914,14 @@ var file_chatto_api_v1_messages_proto_goTypes = []any{
 	(*BatchGetMessagesResponse)(nil),  // 13: chatto.api.v1.BatchGetMessagesResponse
 	(*Message)(nil),                   // 14: chatto.api.v1.Message
 	(*fieldmaskpb.FieldMask)(nil),     // 15: google.protobuf.FieldMask
-	(*FetchLinkPreviewRequest)(nil),   // 16: chatto.api.v1.FetchLinkPreviewRequest
-	(*AddReactionRequest)(nil),        // 17: chatto.api.v1.AddReactionRequest
-	(*RemoveReactionRequest)(nil),     // 18: chatto.api.v1.RemoveReactionRequest
-	(*FetchLinkPreviewResponse)(nil),  // 19: chatto.api.v1.FetchLinkPreviewResponse
-	(*AddReactionResponse)(nil),       // 20: chatto.api.v1.AddReactionResponse
-	(*RemoveReactionResponse)(nil),    // 21: chatto.api.v1.RemoveReactionResponse
+	(*ListReactionUsersRequest)(nil),  // 16: chatto.api.v1.ListReactionUsersRequest
+	(*FetchLinkPreviewRequest)(nil),   // 17: chatto.api.v1.FetchLinkPreviewRequest
+	(*AddReactionRequest)(nil),        // 18: chatto.api.v1.AddReactionRequest
+	(*RemoveReactionRequest)(nil),     // 19: chatto.api.v1.RemoveReactionRequest
+	(*ListReactionUsersResponse)(nil), // 20: chatto.api.v1.ListReactionUsersResponse
+	(*FetchLinkPreviewResponse)(nil),  // 21: chatto.api.v1.FetchLinkPreviewResponse
+	(*AddReactionResponse)(nil),       // 22: chatto.api.v1.AddReactionResponse
+	(*RemoveReactionResponse)(nil),    // 23: chatto.api.v1.RemoveReactionResponse
 }
 var file_chatto_api_v1_messages_proto_depIdxs = []int32{
 	14, // 0: chatto.api.v1.CreateMessageResponse.message:type_name -> chatto.api.v1.Message
@@ -926,28 +929,30 @@ var file_chatto_api_v1_messages_proto_depIdxs = []int32{
 	14, // 2: chatto.api.v1.UpdateMessageResponse.message:type_name -> chatto.api.v1.Message
 	14, // 3: chatto.api.v1.GetMessageResponse.message:type_name -> chatto.api.v1.Message
 	14, // 4: chatto.api.v1.BatchGetMessagesResponse.messages:type_name -> chatto.api.v1.Message
-	16, // 5: chatto.api.v1.MessageService.FetchLinkPreview:input_type -> chatto.api.v1.FetchLinkPreviewRequest
-	0,  // 6: chatto.api.v1.MessageService.CreateMessage:input_type -> chatto.api.v1.CreateMessageRequest
-	2,  // 7: chatto.api.v1.MessageService.UpdateMessage:input_type -> chatto.api.v1.UpdateMessageRequest
-	4,  // 8: chatto.api.v1.MessageService.DeleteMessage:input_type -> chatto.api.v1.DeleteMessageRequest
-	6,  // 9: chatto.api.v1.MessageService.DeleteAttachment:input_type -> chatto.api.v1.DeleteAttachmentRequest
-	8,  // 10: chatto.api.v1.MessageService.DeleteLinkPreview:input_type -> chatto.api.v1.DeleteLinkPreviewRequest
-	10, // 11: chatto.api.v1.MessageService.GetMessage:input_type -> chatto.api.v1.GetMessageRequest
-	12, // 12: chatto.api.v1.MessageService.BatchGetMessages:input_type -> chatto.api.v1.BatchGetMessagesRequest
-	17, // 13: chatto.api.v1.MessageService.AddReaction:input_type -> chatto.api.v1.AddReactionRequest
-	18, // 14: chatto.api.v1.MessageService.RemoveReaction:input_type -> chatto.api.v1.RemoveReactionRequest
-	19, // 15: chatto.api.v1.MessageService.FetchLinkPreview:output_type -> chatto.api.v1.FetchLinkPreviewResponse
-	1,  // 16: chatto.api.v1.MessageService.CreateMessage:output_type -> chatto.api.v1.CreateMessageResponse
-	3,  // 17: chatto.api.v1.MessageService.UpdateMessage:output_type -> chatto.api.v1.UpdateMessageResponse
-	5,  // 18: chatto.api.v1.MessageService.DeleteMessage:output_type -> chatto.api.v1.DeleteMessageResponse
-	7,  // 19: chatto.api.v1.MessageService.DeleteAttachment:output_type -> chatto.api.v1.DeleteAttachmentResponse
-	9,  // 20: chatto.api.v1.MessageService.DeleteLinkPreview:output_type -> chatto.api.v1.DeleteLinkPreviewResponse
-	11, // 21: chatto.api.v1.MessageService.GetMessage:output_type -> chatto.api.v1.GetMessageResponse
-	13, // 22: chatto.api.v1.MessageService.BatchGetMessages:output_type -> chatto.api.v1.BatchGetMessagesResponse
-	20, // 23: chatto.api.v1.MessageService.AddReaction:output_type -> chatto.api.v1.AddReactionResponse
-	21, // 24: chatto.api.v1.MessageService.RemoveReaction:output_type -> chatto.api.v1.RemoveReactionResponse
-	15, // [15:25] is the sub-list for method output_type
-	5,  // [5:15] is the sub-list for method input_type
+	16, // 5: chatto.api.v1.MessageService.ListReactionUsers:input_type -> chatto.api.v1.ListReactionUsersRequest
+	17, // 6: chatto.api.v1.MessageService.FetchLinkPreview:input_type -> chatto.api.v1.FetchLinkPreviewRequest
+	0,  // 7: chatto.api.v1.MessageService.CreateMessage:input_type -> chatto.api.v1.CreateMessageRequest
+	2,  // 8: chatto.api.v1.MessageService.UpdateMessage:input_type -> chatto.api.v1.UpdateMessageRequest
+	4,  // 9: chatto.api.v1.MessageService.DeleteMessage:input_type -> chatto.api.v1.DeleteMessageRequest
+	6,  // 10: chatto.api.v1.MessageService.DeleteAttachment:input_type -> chatto.api.v1.DeleteAttachmentRequest
+	8,  // 11: chatto.api.v1.MessageService.DeleteLinkPreview:input_type -> chatto.api.v1.DeleteLinkPreviewRequest
+	10, // 12: chatto.api.v1.MessageService.GetMessage:input_type -> chatto.api.v1.GetMessageRequest
+	12, // 13: chatto.api.v1.MessageService.BatchGetMessages:input_type -> chatto.api.v1.BatchGetMessagesRequest
+	18, // 14: chatto.api.v1.MessageService.AddReaction:input_type -> chatto.api.v1.AddReactionRequest
+	19, // 15: chatto.api.v1.MessageService.RemoveReaction:input_type -> chatto.api.v1.RemoveReactionRequest
+	20, // 16: chatto.api.v1.MessageService.ListReactionUsers:output_type -> chatto.api.v1.ListReactionUsersResponse
+	21, // 17: chatto.api.v1.MessageService.FetchLinkPreview:output_type -> chatto.api.v1.FetchLinkPreviewResponse
+	1,  // 18: chatto.api.v1.MessageService.CreateMessage:output_type -> chatto.api.v1.CreateMessageResponse
+	3,  // 19: chatto.api.v1.MessageService.UpdateMessage:output_type -> chatto.api.v1.UpdateMessageResponse
+	5,  // 20: chatto.api.v1.MessageService.DeleteMessage:output_type -> chatto.api.v1.DeleteMessageResponse
+	7,  // 21: chatto.api.v1.MessageService.DeleteAttachment:output_type -> chatto.api.v1.DeleteAttachmentResponse
+	9,  // 22: chatto.api.v1.MessageService.DeleteLinkPreview:output_type -> chatto.api.v1.DeleteLinkPreviewResponse
+	11, // 23: chatto.api.v1.MessageService.GetMessage:output_type -> chatto.api.v1.GetMessageResponse
+	13, // 24: chatto.api.v1.MessageService.BatchGetMessages:output_type -> chatto.api.v1.BatchGetMessagesResponse
+	22, // 25: chatto.api.v1.MessageService.AddReaction:output_type -> chatto.api.v1.AddReactionResponse
+	23, // 26: chatto.api.v1.MessageService.RemoveReaction:output_type -> chatto.api.v1.RemoveReactionResponse
+	16, // [16:27] is the sub-list for method output_type
+	5,  // [5:16] is the sub-list for method input_type
 	5,  // [5:5] is the sub-list for extension type_name
 	5,  // [5:5] is the sub-list for extension extendee
 	0,  // [0:5] is the sub-list for field type_name

--- a/cli/internal/pb/chatto/api/v1/reactions.pb.go
+++ b/cli/internal/pb/chatto/api/v1/reactions.pb.go
@@ -273,11 +273,140 @@ func (x *RemoveReactionResponse) GetReaction() *MessageReaction {
 	return nil
 }
 
+// Request all users with one emoji reaction on a message. Echo IDs resolve to
+// the original message. Users are ordered by user ID ascending.
+type ListReactionUsersRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room containing the message.
+	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	// Message or channel echo ID.
+	MessageEventId string `protobuf:"bytes,2,opt,name=message_event_id,json=messageEventId,proto3" json:"message_event_id,omitempty"`
+	// Emoji shortcode, such as "thumbsup".
+	Emoji string `protobuf:"bytes,3,opt,name=emoji,proto3" json:"emoji,omitempty"`
+	// Defaults to 50 results. Maximum: 100. Zero uses the default.
+	Page          *PageRequest `protobuf:"bytes,4,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListReactionUsersRequest) Reset() {
+	*x = ListReactionUsersRequest{}
+	mi := &file_chatto_api_v1_reactions_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListReactionUsersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListReactionUsersRequest) ProtoMessage() {}
+
+func (x *ListReactionUsersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_reactions_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListReactionUsersRequest.ProtoReflect.Descriptor instead.
+func (*ListReactionUsersRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_reactions_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ListReactionUsersRequest) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *ListReactionUsersRequest) GetMessageEventId() string {
+	if x != nil {
+		return x.MessageEventId
+	}
+	return ""
+}
+
+func (x *ListReactionUsersRequest) GetEmoji() string {
+	if x != nil {
+		return x.Emoji
+	}
+	return ""
+}
+
+func (x *ListReactionUsersRequest) GetPage() *PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+// Complete reaction membership is available by paging this collection.
+type ListReactionUsersResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// User IDs in this page. Use UserService.BatchGetUsers for profiles.
+	UserIds []string `protobuf:"bytes,1,rep,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty"`
+	// Count and continuation for the matching reaction users.
+	Page          *PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListReactionUsersResponse) Reset() {
+	*x = ListReactionUsersResponse{}
+	mi := &file_chatto_api_v1_reactions_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListReactionUsersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListReactionUsersResponse) ProtoMessage() {}
+
+func (x *ListReactionUsersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_reactions_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListReactionUsersResponse.ProtoReflect.Descriptor instead.
+func (*ListReactionUsersResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_reactions_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *ListReactionUsersResponse) GetUserIds() []string {
+	if x != nil {
+		return x.UserIds
+	}
+	return nil
+}
+
+func (x *ListReactionUsersResponse) GetPage() *PageInfo {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
 var File_chatto_api_v1_reactions_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_reactions_proto_rawDesc = "" +
 	"\n" +
-	"\x1dchatto/api/v1/reactions.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a!chatto/api/v1/message_types.proto\"\x88\x01\n" +
+	"\x1dchatto/api/v1/reactions.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a!chatto/api/v1/message_types.proto\x1a\x1echatto/api/v1/pagination.proto\"\x88\x01\n" +
 	"\x12AddReactionRequest\x12 \n" +
 	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x121\n" +
 	"\x10message_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x0emessageEventId\x12\x1d\n" +
@@ -291,7 +420,15 @@ const file_chatto_api_v1_reactions_proto_rawDesc = "" +
 	"\x05emoji\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x05emoji\"n\n" +
 	"\x16RemoveReactionResponse\x12\x18\n" +
 	"\aremoved\x18\x01 \x01(\bR\aremoved\x12:\n" +
-	"\breaction\x18\x02 \x01(\v2\x1e.chatto.api.v1.MessageReactionR\breactionB\xaa\x01\n" +
+	"\breaction\x18\x02 \x01(\v2\x1e.chatto.api.v1.MessageReactionR\breaction\"\xbe\x01\n" +
+	"\x18ListReactionUsersRequest\x12 \n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x121\n" +
+	"\x10message_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x0emessageEventId\x12\x1d\n" +
+	"\x05emoji\x18\x03 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x05emoji\x12.\n" +
+	"\x04page\x18\x04 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\"c\n" +
+	"\x19ListReactionUsersResponse\x12\x19\n" +
+	"\buser_ids\x18\x01 \x03(\tR\auserIds\x12+\n" +
+	"\x04page\x18\x02 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04pageB\xaa\x01\n" +
 	"\x11com.chatto.api.v1B\x0eReactionsProtoP\x01Z/hmans.de/chatto/internal/pb/chatto/api/v1;apiv1\xa2\x02\x03CAX\xaa\x02\rChatto.Api.V1\xca\x02\rChatto\\Api\\V1\xe2\x02\x19Chatto\\Api\\V1\\GPBMetadata\xea\x02\x0fChatto::Api::V1b\x06proto3"
 
 var (
@@ -306,22 +443,28 @@ func file_chatto_api_v1_reactions_proto_rawDescGZIP() []byte {
 	return file_chatto_api_v1_reactions_proto_rawDescData
 }
 
-var file_chatto_api_v1_reactions_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_chatto_api_v1_reactions_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_chatto_api_v1_reactions_proto_goTypes = []any{
-	(*AddReactionRequest)(nil),     // 0: chatto.api.v1.AddReactionRequest
-	(*AddReactionResponse)(nil),    // 1: chatto.api.v1.AddReactionResponse
-	(*RemoveReactionRequest)(nil),  // 2: chatto.api.v1.RemoveReactionRequest
-	(*RemoveReactionResponse)(nil), // 3: chatto.api.v1.RemoveReactionResponse
-	(*MessageReaction)(nil),        // 4: chatto.api.v1.MessageReaction
+	(*AddReactionRequest)(nil),        // 0: chatto.api.v1.AddReactionRequest
+	(*AddReactionResponse)(nil),       // 1: chatto.api.v1.AddReactionResponse
+	(*RemoveReactionRequest)(nil),     // 2: chatto.api.v1.RemoveReactionRequest
+	(*RemoveReactionResponse)(nil),    // 3: chatto.api.v1.RemoveReactionResponse
+	(*ListReactionUsersRequest)(nil),  // 4: chatto.api.v1.ListReactionUsersRequest
+	(*ListReactionUsersResponse)(nil), // 5: chatto.api.v1.ListReactionUsersResponse
+	(*MessageReaction)(nil),           // 6: chatto.api.v1.MessageReaction
+	(*PageRequest)(nil),               // 7: chatto.api.v1.PageRequest
+	(*PageInfo)(nil),                  // 8: chatto.api.v1.PageInfo
 }
 var file_chatto_api_v1_reactions_proto_depIdxs = []int32{
-	4, // 0: chatto.api.v1.AddReactionResponse.reaction:type_name -> chatto.api.v1.MessageReaction
-	4, // 1: chatto.api.v1.RemoveReactionResponse.reaction:type_name -> chatto.api.v1.MessageReaction
-	2, // [2:2] is the sub-list for method output_type
-	2, // [2:2] is the sub-list for method input_type
-	2, // [2:2] is the sub-list for extension type_name
-	2, // [2:2] is the sub-list for extension extendee
-	0, // [0:2] is the sub-list for field type_name
+	6, // 0: chatto.api.v1.AddReactionResponse.reaction:type_name -> chatto.api.v1.MessageReaction
+	6, // 1: chatto.api.v1.RemoveReactionResponse.reaction:type_name -> chatto.api.v1.MessageReaction
+	7, // 2: chatto.api.v1.ListReactionUsersRequest.page:type_name -> chatto.api.v1.PageRequest
+	8, // 3: chatto.api.v1.ListReactionUsersResponse.page:type_name -> chatto.api.v1.PageInfo
+	4, // [4:4] is the sub-list for method output_type
+	4, // [4:4] is the sub-list for method input_type
+	4, // [4:4] is the sub-list for extension type_name
+	4, // [4:4] is the sub-list for extension extendee
+	0, // [0:4] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_reactions_proto_init() }
@@ -330,13 +473,14 @@ func file_chatto_api_v1_reactions_proto_init() {
 		return
 	}
 	file_chatto_api_v1_message_types_proto_init()
+	file_chatto_api_v1_pagination_proto_init()
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_reactions_proto_rawDesc), len(file_chatto_api_v1_reactions_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/api/v1/read_state.pb.go
+++ b/cli/internal/pb/chatto/api/v1/read_state.pb.go
@@ -259,6 +259,613 @@ func (x *MarkThreadAsReadResponse) GetLastReadAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// Current stored read position. Its event can later be retracted. The timestamp
+// is absent if the event can no longer be resolved. This is not Badge attention.
+type ReadMarker struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Last-read event ID, to locate the boundary in a timeline.
+	LastReadEventId string `protobuf:"bytes,1,opt,name=last_read_event_id,json=lastReadEventId,proto3" json:"last_read_event_id,omitempty"`
+	// Creation time of the last-read event, when available.
+	LastReadAt    *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=last_read_at,json=lastReadAt,proto3" json:"last_read_at,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ReadMarker) Reset() {
+	*x = ReadMarker{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ReadMarker) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ReadMarker) ProtoMessage() {}
+
+func (x *ReadMarker) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ReadMarker.ProtoReflect.Descriptor instead.
+func (*ReadMarker) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *ReadMarker) GetLastReadEventId() string {
+	if x != nil {
+		return x.LastReadEventId
+	}
+	return ""
+}
+
+func (x *ReadMarker) GetLastReadAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.LastReadAt
+	}
+	return nil
+}
+
+// Current viewer's stored room read state.
+type RoomReadState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room ID.
+	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	// Absent when no non-empty marker has been stored. Reading never initializes it.
+	Marker        *ReadMarker `protobuf:"bytes,2,opt,name=marker,proto3" json:"marker,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RoomReadState) Reset() {
+	*x = RoomReadState{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RoomReadState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RoomReadState) ProtoMessage() {}
+
+func (x *RoomReadState) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RoomReadState.ProtoReflect.Descriptor instead.
+func (*RoomReadState) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *RoomReadState) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *RoomReadState) GetMarker() *ReadMarker {
+	if x != nil {
+		return x.Marker
+	}
+	return nil
+}
+
+// Current viewer's stored thread read state.
+type ThreadReadState struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room ID.
+	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	// Root message ID.
+	ThreadRootEventId string `protobuf:"bytes,2,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
+	// Absent when no non-empty marker has been stored. Reading never advances it.
+	Marker        *ReadMarker `protobuf:"bytes,3,opt,name=marker,proto3" json:"marker,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ThreadReadState) Reset() {
+	*x = ThreadReadState{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ThreadReadState) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ThreadReadState) ProtoMessage() {}
+
+func (x *ThreadReadState) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ThreadReadState.ProtoReflect.Descriptor instead.
+func (*ThreadReadState) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *ThreadReadState) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *ThreadReadState) GetThreadRootEventId() string {
+	if x != nil {
+		return x.ThreadRootEventId
+	}
+	return ""
+}
+
+func (x *ThreadReadState) GetMarker() *ReadMarker {
+	if x != nil {
+		return x.Marker
+	}
+	return nil
+}
+
+// Request current room read state without changing it.
+type GetRoomReadStateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room ID.
+	RoomId        string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRoomReadStateRequest) Reset() {
+	*x = GetRoomReadStateRequest{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[7]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRoomReadStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRoomReadStateRequest) ProtoMessage() {}
+
+func (x *GetRoomReadStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[7]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRoomReadStateRequest.ProtoReflect.Descriptor instead.
+func (*GetRoomReadStateRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *GetRoomReadStateRequest) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+// Current room read state, including an absent marker when none is stored.
+type GetRoomReadStateResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// State for the requested room and viewer.
+	State         *RoomReadState `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetRoomReadStateResponse) Reset() {
+	*x = GetRoomReadStateResponse{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetRoomReadStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetRoomReadStateResponse) ProtoMessage() {}
+
+func (x *GetRoomReadStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetRoomReadStateResponse.ProtoReflect.Descriptor instead.
+func (*GetRoomReadStateResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *GetRoomReadStateResponse) GetState() *RoomReadState {
+	if x != nil {
+		return x.State
+	}
+	return nil
+}
+
+// Request room read states. Duplicates are removed in first-seen order.
+type BatchGetRoomReadStatesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Up to 100 room IDs. Missing or inaccessible rooms are omitted.
+	RoomIds       []string `protobuf:"bytes,1,rep,name=room_ids,json=roomIds,proto3" json:"room_ids,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGetRoomReadStatesRequest) Reset() {
+	*x = BatchGetRoomReadStatesRequest{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGetRoomReadStatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGetRoomReadStatesRequest) ProtoMessage() {}
+
+func (x *BatchGetRoomReadStatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGetRoomReadStatesRequest.ProtoReflect.Descriptor instead.
+func (*BatchGetRoomReadStatesRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *BatchGetRoomReadStatesRequest) GetRoomIds() []string {
+	if x != nil {
+		return x.RoomIds
+	}
+	return nil
+}
+
+// Accessible room read states in first-seen request order.
+type BatchGetRoomReadStatesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// States for the current viewer. An absent marker does not omit the state.
+	States        []*RoomReadState `protobuf:"bytes,1,rep,name=states,proto3" json:"states,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGetRoomReadStatesResponse) Reset() {
+	*x = BatchGetRoomReadStatesResponse{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGetRoomReadStatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGetRoomReadStatesResponse) ProtoMessage() {}
+
+func (x *BatchGetRoomReadStatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGetRoomReadStatesResponse.ProtoReflect.Descriptor instead.
+func (*BatchGetRoomReadStatesResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *BatchGetRoomReadStatesResponse) GetStates() []*RoomReadState {
+	if x != nil {
+		return x.States
+	}
+	return nil
+}
+
+// Request current thread read state without changing it.
+type GetThreadReadStateRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room ID.
+	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	// Root message ID.
+	ThreadRootEventId string `protobuf:"bytes,2,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *GetThreadReadStateRequest) Reset() {
+	*x = GetThreadReadStateRequest{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[11]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetThreadReadStateRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetThreadReadStateRequest) ProtoMessage() {}
+
+func (x *GetThreadReadStateRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[11]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetThreadReadStateRequest.ProtoReflect.Descriptor instead.
+func (*GetThreadReadStateRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{11}
+}
+
+func (x *GetThreadReadStateRequest) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *GetThreadReadStateRequest) GetThreadRootEventId() string {
+	if x != nil {
+		return x.ThreadRootEventId
+	}
+	return ""
+}
+
+// Current thread read state.
+type GetThreadReadStateResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// State for the requested thread and viewer.
+	State         *ThreadReadState `protobuf:"bytes,1,opt,name=state,proto3" json:"state,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetThreadReadStateResponse) Reset() {
+	*x = GetThreadReadStateResponse{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[12]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetThreadReadStateResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetThreadReadStateResponse) ProtoMessage() {}
+
+func (x *GetThreadReadStateResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[12]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetThreadReadStateResponse.ProtoReflect.Descriptor instead.
+func (*GetThreadReadStateResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{12}
+}
+
+func (x *GetThreadReadStateResponse) GetState() *ThreadReadState {
+	if x != nil {
+		return x.State
+	}
+	return nil
+}
+
+// Request thread read states. Duplicates are removed in first-seen order.
+type BatchGetThreadReadStatesRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Up to 100 room/thread targets. Missing or inaccessible targets are omitted.
+	Targets       []*ThreadReadStateTarget `protobuf:"bytes,1,rep,name=targets,proto3" json:"targets,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGetThreadReadStatesRequest) Reset() {
+	*x = BatchGetThreadReadStatesRequest{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[13]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGetThreadReadStatesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGetThreadReadStatesRequest) ProtoMessage() {}
+
+func (x *BatchGetThreadReadStatesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[13]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGetThreadReadStatesRequest.ProtoReflect.Descriptor instead.
+func (*BatchGetThreadReadStatesRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{13}
+}
+
+func (x *BatchGetThreadReadStatesRequest) GetTargets() []*ThreadReadStateTarget {
+	if x != nil {
+		return x.Targets
+	}
+	return nil
+}
+
+// Accessible thread read states in first-seen request order.
+type BatchGetThreadReadStatesResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// States for the current viewer. An absent marker does not omit the state.
+	States        []*ThreadReadState `protobuf:"bytes,1,rep,name=states,proto3" json:"states,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BatchGetThreadReadStatesResponse) Reset() {
+	*x = BatchGetThreadReadStatesResponse{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[14]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BatchGetThreadReadStatesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BatchGetThreadReadStatesResponse) ProtoMessage() {}
+
+func (x *BatchGetThreadReadStatesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[14]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BatchGetThreadReadStatesResponse.ProtoReflect.Descriptor instead.
+func (*BatchGetThreadReadStatesResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{14}
+}
+
+func (x *BatchGetThreadReadStatesResponse) GetStates() []*ThreadReadState {
+	if x != nil {
+		return x.States
+	}
+	return nil
+}
+
+// Room and root identity for one thread read state.
+type ThreadReadStateTarget struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room ID.
+	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	// Root message ID.
+	ThreadRootEventId string `protobuf:"bytes,2,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
+	unknownFields     protoimpl.UnknownFields
+	sizeCache         protoimpl.SizeCache
+}
+
+func (x *ThreadReadStateTarget) Reset() {
+	*x = ThreadReadStateTarget{}
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[15]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ThreadReadStateTarget) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ThreadReadStateTarget) ProtoMessage() {}
+
+func (x *ThreadReadStateTarget) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_read_state_proto_msgTypes[15]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ThreadReadStateTarget.ProtoReflect.Descriptor instead.
+func (*ThreadReadStateTarget) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_read_state_proto_rawDescGZIP(), []int{15}
+}
+
+func (x *ThreadReadStateTarget) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *ThreadReadStateTarget) GetThreadRootEventId() string {
+	if x != nil {
+		return x.ThreadRootEventId
+	}
+	return ""
+}
+
 var File_chatto_api_v1_read_state_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_read_state_proto_rawDesc = "" +
@@ -278,7 +885,41 @@ const file_chatto_api_v1_read_state_proto_rawDesc = "" +
 	"\x18MarkThreadAsReadResponse\x12M\n" +
 	"\x15previous_last_read_at\x18\x01 \x01(\v2\x1a.google.protobuf.TimestampR\x12previousLastReadAt\x12<\n" +
 	"\flast_read_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
-	"lastReadAtR\x10previous_read_atB\xaa\x01\n" +
+	"lastReadAtR\x10previous_read_at\"w\n" +
+	"\n" +
+	"ReadMarker\x12+\n" +
+	"\x12last_read_event_id\x18\x01 \x01(\tR\x0flastReadEventId\x12<\n" +
+	"\flast_read_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
+	"lastReadAt\"[\n" +
+	"\rRoomReadState\x12\x17\n" +
+	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x121\n" +
+	"\x06marker\x18\x02 \x01(\v2\x19.chatto.api.v1.ReadMarkerR\x06marker\"\x8e\x01\n" +
+	"\x0fThreadReadState\x12\x17\n" +
+	"\aroom_id\x18\x01 \x01(\tR\x06roomId\x12/\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tR\x11threadRootEventId\x121\n" +
+	"\x06marker\x18\x03 \x01(\v2\x19.chatto.api.v1.ReadMarkerR\x06marker\";\n" +
+	"\x17GetRoomReadStateRequest\x12 \n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\"N\n" +
+	"\x18GetRoomReadStateResponse\x122\n" +
+	"\x05state\x18\x01 \x01(\v2\x1c.chatto.api.v1.RoomReadStateR\x05state\"L\n" +
+	"\x1dBatchGetRoomReadStatesRequest\x12+\n" +
+	"\broom_ids\x18\x01 \x03(\tB\x10\xbaH\r\x92\x01\n" +
+	"\b\x01\x10d\"\x04r\x02\x10\x01R\aroomIds\"V\n" +
+	"\x1eBatchGetRoomReadStatesResponse\x124\n" +
+	"\x06states\x18\x01 \x03(\v2\x1c.chatto.api.v1.RoomReadStateR\x06states\"w\n" +
+	"\x19GetThreadReadStateRequest\x12 \n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x128\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\"R\n" +
+	"\x1aGetThreadReadStateResponse\x124\n" +
+	"\x05state\x18\x01 \x01(\v2\x1e.chatto.api.v1.ThreadReadStateR\x05state\"m\n" +
+	"\x1fBatchGetThreadReadStatesRequest\x12J\n" +
+	"\atargets\x18\x01 \x03(\v2$.chatto.api.v1.ThreadReadStateTargetB\n" +
+	"\xbaH\a\x92\x01\x04\b\x01\x10dR\atargets\"Z\n" +
+	" BatchGetThreadReadStatesResponse\x126\n" +
+	"\x06states\x18\x01 \x03(\v2\x1e.chatto.api.v1.ThreadReadStateR\x06states\"s\n" +
+	"\x15ThreadReadStateTarget\x12 \n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x128\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventIdB\xaa\x01\n" +
 	"\x11com.chatto.api.v1B\x0eReadStateProtoP\x01Z/hmans.de/chatto/internal/pb/chatto/api/v1;apiv1\xa2\x02\x03CAX\xaa\x02\rChatto.Api.V1\xca\x02\rChatto\\Api\\V1\xe2\x02\x19Chatto\\Api\\V1\\GPBMetadata\xea\x02\x0fChatto::Api::V1b\x06proto3"
 
 var (
@@ -293,24 +934,44 @@ func file_chatto_api_v1_read_state_proto_rawDescGZIP() []byte {
 	return file_chatto_api_v1_read_state_proto_rawDescData
 }
 
-var file_chatto_api_v1_read_state_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_chatto_api_v1_read_state_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_chatto_api_v1_read_state_proto_goTypes = []any{
-	(*MarkRoomAsReadRequest)(nil),    // 0: chatto.api.v1.MarkRoomAsReadRequest
-	(*MarkRoomAsReadResponse)(nil),   // 1: chatto.api.v1.MarkRoomAsReadResponse
-	(*MarkThreadAsReadRequest)(nil),  // 2: chatto.api.v1.MarkThreadAsReadRequest
-	(*MarkThreadAsReadResponse)(nil), // 3: chatto.api.v1.MarkThreadAsReadResponse
-	(*timestamppb.Timestamp)(nil),    // 4: google.protobuf.Timestamp
+	(*MarkRoomAsReadRequest)(nil),            // 0: chatto.api.v1.MarkRoomAsReadRequest
+	(*MarkRoomAsReadResponse)(nil),           // 1: chatto.api.v1.MarkRoomAsReadResponse
+	(*MarkThreadAsReadRequest)(nil),          // 2: chatto.api.v1.MarkThreadAsReadRequest
+	(*MarkThreadAsReadResponse)(nil),         // 3: chatto.api.v1.MarkThreadAsReadResponse
+	(*ReadMarker)(nil),                       // 4: chatto.api.v1.ReadMarker
+	(*RoomReadState)(nil),                    // 5: chatto.api.v1.RoomReadState
+	(*ThreadReadState)(nil),                  // 6: chatto.api.v1.ThreadReadState
+	(*GetRoomReadStateRequest)(nil),          // 7: chatto.api.v1.GetRoomReadStateRequest
+	(*GetRoomReadStateResponse)(nil),         // 8: chatto.api.v1.GetRoomReadStateResponse
+	(*BatchGetRoomReadStatesRequest)(nil),    // 9: chatto.api.v1.BatchGetRoomReadStatesRequest
+	(*BatchGetRoomReadStatesResponse)(nil),   // 10: chatto.api.v1.BatchGetRoomReadStatesResponse
+	(*GetThreadReadStateRequest)(nil),        // 11: chatto.api.v1.GetThreadReadStateRequest
+	(*GetThreadReadStateResponse)(nil),       // 12: chatto.api.v1.GetThreadReadStateResponse
+	(*BatchGetThreadReadStatesRequest)(nil),  // 13: chatto.api.v1.BatchGetThreadReadStatesRequest
+	(*BatchGetThreadReadStatesResponse)(nil), // 14: chatto.api.v1.BatchGetThreadReadStatesResponse
+	(*ThreadReadStateTarget)(nil),            // 15: chatto.api.v1.ThreadReadStateTarget
+	(*timestamppb.Timestamp)(nil),            // 16: google.protobuf.Timestamp
 }
 var file_chatto_api_v1_read_state_proto_depIdxs = []int32{
-	4, // 0: chatto.api.v1.MarkRoomAsReadResponse.last_read_at:type_name -> google.protobuf.Timestamp
-	4, // 1: chatto.api.v1.MarkRoomAsReadResponse.previous_last_read_at:type_name -> google.protobuf.Timestamp
-	4, // 2: chatto.api.v1.MarkThreadAsReadResponse.previous_last_read_at:type_name -> google.protobuf.Timestamp
-	4, // 3: chatto.api.v1.MarkThreadAsReadResponse.last_read_at:type_name -> google.protobuf.Timestamp
-	4, // [4:4] is the sub-list for method output_type
-	4, // [4:4] is the sub-list for method input_type
-	4, // [4:4] is the sub-list for extension type_name
-	4, // [4:4] is the sub-list for extension extendee
-	0, // [0:4] is the sub-list for field type_name
+	16, // 0: chatto.api.v1.MarkRoomAsReadResponse.last_read_at:type_name -> google.protobuf.Timestamp
+	16, // 1: chatto.api.v1.MarkRoomAsReadResponse.previous_last_read_at:type_name -> google.protobuf.Timestamp
+	16, // 2: chatto.api.v1.MarkThreadAsReadResponse.previous_last_read_at:type_name -> google.protobuf.Timestamp
+	16, // 3: chatto.api.v1.MarkThreadAsReadResponse.last_read_at:type_name -> google.protobuf.Timestamp
+	16, // 4: chatto.api.v1.ReadMarker.last_read_at:type_name -> google.protobuf.Timestamp
+	4,  // 5: chatto.api.v1.RoomReadState.marker:type_name -> chatto.api.v1.ReadMarker
+	4,  // 6: chatto.api.v1.ThreadReadState.marker:type_name -> chatto.api.v1.ReadMarker
+	5,  // 7: chatto.api.v1.GetRoomReadStateResponse.state:type_name -> chatto.api.v1.RoomReadState
+	5,  // 8: chatto.api.v1.BatchGetRoomReadStatesResponse.states:type_name -> chatto.api.v1.RoomReadState
+	6,  // 9: chatto.api.v1.GetThreadReadStateResponse.state:type_name -> chatto.api.v1.ThreadReadState
+	15, // 10: chatto.api.v1.BatchGetThreadReadStatesRequest.targets:type_name -> chatto.api.v1.ThreadReadStateTarget
+	6,  // 11: chatto.api.v1.BatchGetThreadReadStatesResponse.states:type_name -> chatto.api.v1.ThreadReadState
+	12, // [12:12] is the sub-list for method output_type
+	12, // [12:12] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_read_state_proto_init() }
@@ -324,7 +985,7 @@ func file_chatto_api_v1_read_state_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_read_state_proto_rawDesc), len(file_chatto_api_v1_read_state_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/cli/internal/pb/chatto/api/v1/rooms.pb.go
+++ b/cli/internal/pb/chatto/api/v1/rooms.pb.go
@@ -2474,8 +2474,10 @@ const file_chatto_api_v1_rooms_proto_rawDesc = "" +
 	"\bRoomKind\x12\x19\n" +
 	"\x15ROOM_KIND_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11ROOM_KIND_CHANNEL\x10\x01\x12\x10\n" +
-	"\fROOM_KIND_DM\x10\x022\xa1\x11\n" +
-	"\vRoomService\x12Q\n" +
+	"\fROOM_KIND_DM\x10\x022\xfd\x12\n" +
+	"\vRoomService\x12c\n" +
+	"\x10GetRoomReadState\x12&.chatto.api.v1.GetRoomReadStateRequest\x1a'.chatto.api.v1.GetRoomReadStateResponse\x12u\n" +
+	"\x16BatchGetRoomReadStates\x12,.chatto.api.v1.BatchGetRoomReadStatesRequest\x1a-.chatto.api.v1.BatchGetRoomReadStatesResponse\x12Q\n" +
 	"\n" +
 	"CreateRoom\x12 .chatto.api.v1.CreateRoomRequest\x1a!.chatto.api.v1.CreateRoomResponse\x12Q\n" +
 	"\n" +
@@ -2570,18 +2572,22 @@ var file_chatto_api_v1_rooms_proto_goTypes = []any{
 	(*ImageTransformOptions)(nil),          // 47: chatto.api.v1.ImageTransformOptions
 	(*RoomAttachmentListItem)(nil),         // 48: chatto.api.v1.RoomAttachmentListItem
 	(*Message)(nil),                        // 49: chatto.api.v1.Message
-	(*ListMembersRequest)(nil),             // 50: chatto.api.v1.ListMembersRequest
-	(*GetMemberRequest)(nil),               // 51: chatto.api.v1.GetMemberRequest
-	(*BatchGetMembersRequest)(nil),         // 52: chatto.api.v1.BatchGetMembersRequest
-	(*GetRoomEventsRequest)(nil),           // 53: chatto.api.v1.GetRoomEventsRequest
-	(*GetRoomEventsAroundRequest)(nil),     // 54: chatto.api.v1.GetRoomEventsAroundRequest
-	(*MarkRoomAsReadRequest)(nil),          // 55: chatto.api.v1.MarkRoomAsReadRequest
-	(*ListMembersResponse)(nil),            // 56: chatto.api.v1.ListMembersResponse
-	(*GetMemberResponse)(nil),              // 57: chatto.api.v1.GetMemberResponse
-	(*BatchGetMembersResponse)(nil),        // 58: chatto.api.v1.BatchGetMembersResponse
-	(*GetRoomEventsResponse)(nil),          // 59: chatto.api.v1.GetRoomEventsResponse
-	(*GetRoomEventsAroundResponse)(nil),    // 60: chatto.api.v1.GetRoomEventsAroundResponse
-	(*MarkRoomAsReadResponse)(nil),         // 61: chatto.api.v1.MarkRoomAsReadResponse
+	(*GetRoomReadStateRequest)(nil),        // 50: chatto.api.v1.GetRoomReadStateRequest
+	(*BatchGetRoomReadStatesRequest)(nil),  // 51: chatto.api.v1.BatchGetRoomReadStatesRequest
+	(*ListMembersRequest)(nil),             // 52: chatto.api.v1.ListMembersRequest
+	(*GetMemberRequest)(nil),               // 53: chatto.api.v1.GetMemberRequest
+	(*BatchGetMembersRequest)(nil),         // 54: chatto.api.v1.BatchGetMembersRequest
+	(*GetRoomEventsRequest)(nil),           // 55: chatto.api.v1.GetRoomEventsRequest
+	(*GetRoomEventsAroundRequest)(nil),     // 56: chatto.api.v1.GetRoomEventsAroundRequest
+	(*MarkRoomAsReadRequest)(nil),          // 57: chatto.api.v1.MarkRoomAsReadRequest
+	(*GetRoomReadStateResponse)(nil),       // 58: chatto.api.v1.GetRoomReadStateResponse
+	(*BatchGetRoomReadStatesResponse)(nil), // 59: chatto.api.v1.BatchGetRoomReadStatesResponse
+	(*ListMembersResponse)(nil),            // 60: chatto.api.v1.ListMembersResponse
+	(*GetMemberResponse)(nil),              // 61: chatto.api.v1.GetMemberResponse
+	(*BatchGetMembersResponse)(nil),        // 62: chatto.api.v1.BatchGetMembersResponse
+	(*GetRoomEventsResponse)(nil),          // 63: chatto.api.v1.GetRoomEventsResponse
+	(*GetRoomEventsAroundResponse)(nil),    // 64: chatto.api.v1.GetRoomEventsAroundResponse
+	(*MarkRoomAsReadResponse)(nil),         // 65: chatto.api.v1.MarkRoomAsReadResponse
 }
 var file_chatto_api_v1_rooms_proto_depIdxs = []int32{
 	0,  // 0: chatto.api.v1.Room.kind:type_name -> chatto.api.v1.RoomKind
@@ -2615,56 +2621,60 @@ var file_chatto_api_v1_rooms_proto_depIdxs = []int32{
 	32, // 28: chatto.api.v1.ListPinnedMessagesResponse.pinned_messages:type_name -> chatto.api.v1.PinnedMessage
 	46, // 29: chatto.api.v1.ListPinnedMessagesResponse.page:type_name -> chatto.api.v1.PageInfo
 	32, // 30: chatto.api.v1.CreatePinnedMessageResponse.pinned_message:type_name -> chatto.api.v1.PinnedMessage
-	3,  // 31: chatto.api.v1.RoomService.CreateRoom:input_type -> chatto.api.v1.CreateRoomRequest
-	5,  // 32: chatto.api.v1.RoomService.UpdateRoom:input_type -> chatto.api.v1.UpdateRoomRequest
-	7,  // 33: chatto.api.v1.RoomService.ArchiveRoom:input_type -> chatto.api.v1.ArchiveRoomRequest
-	9,  // 34: chatto.api.v1.RoomService.UnarchiveRoom:input_type -> chatto.api.v1.UnarchiveRoomRequest
-	11, // 35: chatto.api.v1.RoomService.JoinRoom:input_type -> chatto.api.v1.JoinRoomRequest
-	13, // 36: chatto.api.v1.RoomService.JoinRoomGroup:input_type -> chatto.api.v1.JoinRoomGroupRequest
-	15, // 37: chatto.api.v1.RoomService.StartDM:input_type -> chatto.api.v1.StartDMRequest
-	17, // 38: chatto.api.v1.RoomService.LeaveRoom:input_type -> chatto.api.v1.LeaveRoomRequest
-	50, // 39: chatto.api.v1.RoomService.ListMembers:input_type -> chatto.api.v1.ListMembersRequest
-	51, // 40: chatto.api.v1.RoomService.GetMember:input_type -> chatto.api.v1.GetMemberRequest
-	52, // 41: chatto.api.v1.RoomService.BatchGetMembers:input_type -> chatto.api.v1.BatchGetMembersRequest
-	19, // 42: chatto.api.v1.RoomService.AddMember:input_type -> chatto.api.v1.AddMemberRequest
-	21, // 43: chatto.api.v1.RoomService.RemoveMember:input_type -> chatto.api.v1.RemoveMemberRequest
-	28, // 44: chatto.api.v1.RoomService.ListBans:input_type -> chatto.api.v1.ListBansRequest
-	30, // 45: chatto.api.v1.RoomService.ListRoomAttachments:input_type -> chatto.api.v1.ListRoomAttachmentsRequest
-	33, // 46: chatto.api.v1.RoomService.ListPinnedMessages:input_type -> chatto.api.v1.ListPinnedMessagesRequest
-	35, // 47: chatto.api.v1.RoomService.CreatePinnedMessage:input_type -> chatto.api.v1.CreatePinnedMessageRequest
-	37, // 48: chatto.api.v1.RoomService.DeletePinnedMessage:input_type -> chatto.api.v1.DeletePinnedMessageRequest
-	39, // 49: chatto.api.v1.RoomService.RefreshTypingIndicator:input_type -> chatto.api.v1.RefreshTypingIndicatorRequest
-	53, // 50: chatto.api.v1.RoomService.GetRoomEvents:input_type -> chatto.api.v1.GetRoomEventsRequest
-	54, // 51: chatto.api.v1.RoomService.GetRoomEventsAround:input_type -> chatto.api.v1.GetRoomEventsAroundRequest
-	55, // 52: chatto.api.v1.RoomService.MarkRoomAsRead:input_type -> chatto.api.v1.MarkRoomAsReadRequest
-	23, // 53: chatto.api.v1.RoomService.BanMember:input_type -> chatto.api.v1.BanMemberRequest
-	25, // 54: chatto.api.v1.RoomService.UnbanMember:input_type -> chatto.api.v1.UnbanMemberRequest
-	4,  // 55: chatto.api.v1.RoomService.CreateRoom:output_type -> chatto.api.v1.CreateRoomResponse
-	6,  // 56: chatto.api.v1.RoomService.UpdateRoom:output_type -> chatto.api.v1.UpdateRoomResponse
-	8,  // 57: chatto.api.v1.RoomService.ArchiveRoom:output_type -> chatto.api.v1.ArchiveRoomResponse
-	10, // 58: chatto.api.v1.RoomService.UnarchiveRoom:output_type -> chatto.api.v1.UnarchiveRoomResponse
-	12, // 59: chatto.api.v1.RoomService.JoinRoom:output_type -> chatto.api.v1.JoinRoomResponse
-	14, // 60: chatto.api.v1.RoomService.JoinRoomGroup:output_type -> chatto.api.v1.JoinRoomGroupResponse
-	16, // 61: chatto.api.v1.RoomService.StartDM:output_type -> chatto.api.v1.StartDMResponse
-	18, // 62: chatto.api.v1.RoomService.LeaveRoom:output_type -> chatto.api.v1.LeaveRoomResponse
-	56, // 63: chatto.api.v1.RoomService.ListMembers:output_type -> chatto.api.v1.ListMembersResponse
-	57, // 64: chatto.api.v1.RoomService.GetMember:output_type -> chatto.api.v1.GetMemberResponse
-	58, // 65: chatto.api.v1.RoomService.BatchGetMembers:output_type -> chatto.api.v1.BatchGetMembersResponse
-	20, // 66: chatto.api.v1.RoomService.AddMember:output_type -> chatto.api.v1.AddMemberResponse
-	22, // 67: chatto.api.v1.RoomService.RemoveMember:output_type -> chatto.api.v1.RemoveMemberResponse
-	29, // 68: chatto.api.v1.RoomService.ListBans:output_type -> chatto.api.v1.ListBansResponse
-	31, // 69: chatto.api.v1.RoomService.ListRoomAttachments:output_type -> chatto.api.v1.ListRoomAttachmentsResponse
-	34, // 70: chatto.api.v1.RoomService.ListPinnedMessages:output_type -> chatto.api.v1.ListPinnedMessagesResponse
-	36, // 71: chatto.api.v1.RoomService.CreatePinnedMessage:output_type -> chatto.api.v1.CreatePinnedMessageResponse
-	38, // 72: chatto.api.v1.RoomService.DeletePinnedMessage:output_type -> chatto.api.v1.DeletePinnedMessageResponse
-	40, // 73: chatto.api.v1.RoomService.RefreshTypingIndicator:output_type -> chatto.api.v1.RefreshTypingIndicatorResponse
-	59, // 74: chatto.api.v1.RoomService.GetRoomEvents:output_type -> chatto.api.v1.GetRoomEventsResponse
-	60, // 75: chatto.api.v1.RoomService.GetRoomEventsAround:output_type -> chatto.api.v1.GetRoomEventsAroundResponse
-	61, // 76: chatto.api.v1.RoomService.MarkRoomAsRead:output_type -> chatto.api.v1.MarkRoomAsReadResponse
-	24, // 77: chatto.api.v1.RoomService.BanMember:output_type -> chatto.api.v1.BanMemberResponse
-	26, // 78: chatto.api.v1.RoomService.UnbanMember:output_type -> chatto.api.v1.UnbanMemberResponse
-	55, // [55:79] is the sub-list for method output_type
-	31, // [31:55] is the sub-list for method input_type
+	50, // 31: chatto.api.v1.RoomService.GetRoomReadState:input_type -> chatto.api.v1.GetRoomReadStateRequest
+	51, // 32: chatto.api.v1.RoomService.BatchGetRoomReadStates:input_type -> chatto.api.v1.BatchGetRoomReadStatesRequest
+	3,  // 33: chatto.api.v1.RoomService.CreateRoom:input_type -> chatto.api.v1.CreateRoomRequest
+	5,  // 34: chatto.api.v1.RoomService.UpdateRoom:input_type -> chatto.api.v1.UpdateRoomRequest
+	7,  // 35: chatto.api.v1.RoomService.ArchiveRoom:input_type -> chatto.api.v1.ArchiveRoomRequest
+	9,  // 36: chatto.api.v1.RoomService.UnarchiveRoom:input_type -> chatto.api.v1.UnarchiveRoomRequest
+	11, // 37: chatto.api.v1.RoomService.JoinRoom:input_type -> chatto.api.v1.JoinRoomRequest
+	13, // 38: chatto.api.v1.RoomService.JoinRoomGroup:input_type -> chatto.api.v1.JoinRoomGroupRequest
+	15, // 39: chatto.api.v1.RoomService.StartDM:input_type -> chatto.api.v1.StartDMRequest
+	17, // 40: chatto.api.v1.RoomService.LeaveRoom:input_type -> chatto.api.v1.LeaveRoomRequest
+	52, // 41: chatto.api.v1.RoomService.ListMembers:input_type -> chatto.api.v1.ListMembersRequest
+	53, // 42: chatto.api.v1.RoomService.GetMember:input_type -> chatto.api.v1.GetMemberRequest
+	54, // 43: chatto.api.v1.RoomService.BatchGetMembers:input_type -> chatto.api.v1.BatchGetMembersRequest
+	19, // 44: chatto.api.v1.RoomService.AddMember:input_type -> chatto.api.v1.AddMemberRequest
+	21, // 45: chatto.api.v1.RoomService.RemoveMember:input_type -> chatto.api.v1.RemoveMemberRequest
+	28, // 46: chatto.api.v1.RoomService.ListBans:input_type -> chatto.api.v1.ListBansRequest
+	30, // 47: chatto.api.v1.RoomService.ListRoomAttachments:input_type -> chatto.api.v1.ListRoomAttachmentsRequest
+	33, // 48: chatto.api.v1.RoomService.ListPinnedMessages:input_type -> chatto.api.v1.ListPinnedMessagesRequest
+	35, // 49: chatto.api.v1.RoomService.CreatePinnedMessage:input_type -> chatto.api.v1.CreatePinnedMessageRequest
+	37, // 50: chatto.api.v1.RoomService.DeletePinnedMessage:input_type -> chatto.api.v1.DeletePinnedMessageRequest
+	39, // 51: chatto.api.v1.RoomService.RefreshTypingIndicator:input_type -> chatto.api.v1.RefreshTypingIndicatorRequest
+	55, // 52: chatto.api.v1.RoomService.GetRoomEvents:input_type -> chatto.api.v1.GetRoomEventsRequest
+	56, // 53: chatto.api.v1.RoomService.GetRoomEventsAround:input_type -> chatto.api.v1.GetRoomEventsAroundRequest
+	57, // 54: chatto.api.v1.RoomService.MarkRoomAsRead:input_type -> chatto.api.v1.MarkRoomAsReadRequest
+	23, // 55: chatto.api.v1.RoomService.BanMember:input_type -> chatto.api.v1.BanMemberRequest
+	25, // 56: chatto.api.v1.RoomService.UnbanMember:input_type -> chatto.api.v1.UnbanMemberRequest
+	58, // 57: chatto.api.v1.RoomService.GetRoomReadState:output_type -> chatto.api.v1.GetRoomReadStateResponse
+	59, // 58: chatto.api.v1.RoomService.BatchGetRoomReadStates:output_type -> chatto.api.v1.BatchGetRoomReadStatesResponse
+	4,  // 59: chatto.api.v1.RoomService.CreateRoom:output_type -> chatto.api.v1.CreateRoomResponse
+	6,  // 60: chatto.api.v1.RoomService.UpdateRoom:output_type -> chatto.api.v1.UpdateRoomResponse
+	8,  // 61: chatto.api.v1.RoomService.ArchiveRoom:output_type -> chatto.api.v1.ArchiveRoomResponse
+	10, // 62: chatto.api.v1.RoomService.UnarchiveRoom:output_type -> chatto.api.v1.UnarchiveRoomResponse
+	12, // 63: chatto.api.v1.RoomService.JoinRoom:output_type -> chatto.api.v1.JoinRoomResponse
+	14, // 64: chatto.api.v1.RoomService.JoinRoomGroup:output_type -> chatto.api.v1.JoinRoomGroupResponse
+	16, // 65: chatto.api.v1.RoomService.StartDM:output_type -> chatto.api.v1.StartDMResponse
+	18, // 66: chatto.api.v1.RoomService.LeaveRoom:output_type -> chatto.api.v1.LeaveRoomResponse
+	60, // 67: chatto.api.v1.RoomService.ListMembers:output_type -> chatto.api.v1.ListMembersResponse
+	61, // 68: chatto.api.v1.RoomService.GetMember:output_type -> chatto.api.v1.GetMemberResponse
+	62, // 69: chatto.api.v1.RoomService.BatchGetMembers:output_type -> chatto.api.v1.BatchGetMembersResponse
+	20, // 70: chatto.api.v1.RoomService.AddMember:output_type -> chatto.api.v1.AddMemberResponse
+	22, // 71: chatto.api.v1.RoomService.RemoveMember:output_type -> chatto.api.v1.RemoveMemberResponse
+	29, // 72: chatto.api.v1.RoomService.ListBans:output_type -> chatto.api.v1.ListBansResponse
+	31, // 73: chatto.api.v1.RoomService.ListRoomAttachments:output_type -> chatto.api.v1.ListRoomAttachmentsResponse
+	34, // 74: chatto.api.v1.RoomService.ListPinnedMessages:output_type -> chatto.api.v1.ListPinnedMessagesResponse
+	36, // 75: chatto.api.v1.RoomService.CreatePinnedMessage:output_type -> chatto.api.v1.CreatePinnedMessageResponse
+	38, // 76: chatto.api.v1.RoomService.DeletePinnedMessage:output_type -> chatto.api.v1.DeletePinnedMessageResponse
+	40, // 77: chatto.api.v1.RoomService.RefreshTypingIndicator:output_type -> chatto.api.v1.RefreshTypingIndicatorResponse
+	63, // 78: chatto.api.v1.RoomService.GetRoomEvents:output_type -> chatto.api.v1.GetRoomEventsResponse
+	64, // 79: chatto.api.v1.RoomService.GetRoomEventsAround:output_type -> chatto.api.v1.GetRoomEventsAroundResponse
+	65, // 80: chatto.api.v1.RoomService.MarkRoomAsRead:output_type -> chatto.api.v1.MarkRoomAsReadResponse
+	24, // 81: chatto.api.v1.RoomService.BanMember:output_type -> chatto.api.v1.BanMemberResponse
+	26, // 82: chatto.api.v1.RoomService.UnbanMember:output_type -> chatto.api.v1.UnbanMemberResponse
+	57, // [57:83] is the sub-list for method output_type
+	31, // [31:57] is the sub-list for method input_type
 	31, // [31:31] is the sub-list for extension type_name
 	31, // [31:31] is the sub-list for extension extendee
 	0,  // [0:31] is the sub-list for field type_name

--- a/cli/internal/pb/chatto/api/v1/threads.pb.go
+++ b/cli/internal/pb/chatto/api/v1/threads.pb.go
@@ -492,6 +492,125 @@ func (x *ListFollowedThreadsResponse) GetPage() *PageInfo {
 	return nil
 }
 
+// Request a complete thread participant collection, ordered by user ID ascending.
+type ListThreadParticipantsRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Room containing the thread.
+	RoomId string `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`
+	// Root message ID.
+	ThreadRootEventId string `protobuf:"bytes,2,opt,name=thread_root_event_id,json=threadRootEventId,proto3" json:"thread_root_event_id,omitempty"`
+	// Defaults to 50 results. Maximum: 100. Zero uses the default.
+	Page          *PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListThreadParticipantsRequest) Reset() {
+	*x = ListThreadParticipantsRequest{}
+	mi := &file_chatto_api_v1_threads_proto_msgTypes[8]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListThreadParticipantsRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListThreadParticipantsRequest) ProtoMessage() {}
+
+func (x *ListThreadParticipantsRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_threads_proto_msgTypes[8]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListThreadParticipantsRequest.ProtoReflect.Descriptor instead.
+func (*ListThreadParticipantsRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_threads_proto_rawDescGZIP(), []int{8}
+}
+
+func (x *ListThreadParticipantsRequest) GetRoomId() string {
+	if x != nil {
+		return x.RoomId
+	}
+	return ""
+}
+
+func (x *ListThreadParticipantsRequest) GetThreadRootEventId() string {
+	if x != nil {
+		return x.ThreadRootEventId
+	}
+	return ""
+}
+
+func (x *ListThreadParticipantsRequest) GetPage() *PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+// A page of distinct reply authors. An empty thread returns an empty page.
+type ListThreadParticipantsResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// User IDs in this page. Use UserService.BatchGetUsers for profiles.
+	UserIds []string `protobuf:"bytes,1,rep,name=user_ids,json=userIds,proto3" json:"user_ids,omitempty"`
+	// Count and continuation for all current participants.
+	Page          *PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ListThreadParticipantsResponse) Reset() {
+	*x = ListThreadParticipantsResponse{}
+	mi := &file_chatto_api_v1_threads_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ListThreadParticipantsResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListThreadParticipantsResponse) ProtoMessage() {}
+
+func (x *ListThreadParticipantsResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_api_v1_threads_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListThreadParticipantsResponse.ProtoReflect.Descriptor instead.
+func (*ListThreadParticipantsResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_api_v1_threads_proto_rawDescGZIP(), []int{9}
+}
+
+func (x *ListThreadParticipantsResponse) GetUserIds() []string {
+	if x != nil {
+		return x.UserIds
+	}
+	return nil
+}
+
+func (x *ListThreadParticipantsResponse) GetPage() *PageInfo {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
 var File_chatto_api_v1_threads_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_threads_proto_rawDesc = "" +
@@ -525,8 +644,18 @@ const file_chatto_api_v1_threads_proto_rawDesc = "" +
 	"\x1bListFollowedThreadsResponse\x127\n" +
 	"\athreads\x18\x01 \x03(\v2\x1d.chatto.api.v1.FollowedThreadR\athreads\x12?\n" +
 	"\bincludes\x18\x04 \x01(\v2#.chatto.api.v1.RoomTimelineIncludesR\bincludes\x12+\n" +
-	"\x04page\x18\x05 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04pageJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vtotal_countR\bhas_more2\xf0\x04\n" +
-	"\rThreadService\x12l\n" +
+	"\x04page\x18\x05 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04pageJ\x04\b\x02\x10\x03J\x04\b\x03\x10\x04R\vtotal_countR\bhas_more\"\xab\x01\n" +
+	"\x1dListThreadParticipantsRequest\x12 \n" +
+	"\aroom_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06roomId\x128\n" +
+	"\x14thread_root_event_id\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x11threadRootEventId\x12.\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\"h\n" +
+	"\x1eListThreadParticipantsResponse\x12\x19\n" +
+	"\buser_ids\x18\x01 \x03(\tR\auserIds\x12+\n" +
+	"\x04page\x18\x02 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page2\xcf\a\n" +
+	"\rThreadService\x12i\n" +
+	"\x12GetThreadReadState\x12(.chatto.api.v1.GetThreadReadStateRequest\x1a).chatto.api.v1.GetThreadReadStateResponse\x12{\n" +
+	"\x18BatchGetThreadReadStates\x12..chatto.api.v1.BatchGetThreadReadStatesRequest\x1a/.chatto.api.v1.BatchGetThreadReadStatesResponse\x12u\n" +
+	"\x16ListThreadParticipants\x12,.chatto.api.v1.ListThreadParticipantsRequest\x1a-.chatto.api.v1.ListThreadParticipantsResponse\x12l\n" +
 	"\x13ListFollowedThreads\x12).chatto.api.v1.ListFollowedThreadsRequest\x1a*.chatto.api.v1.ListFollowedThreadsResponse\x12W\n" +
 	"\fFollowThread\x12\".chatto.api.v1.FollowThreadRequest\x1a#.chatto.api.v1.FollowThreadResponse\x12]\n" +
 	"\x0eUnfollowThread\x12$.chatto.api.v1.UnfollowThreadRequest\x1a%.chatto.api.v1.UnfollowThreadResponse\x12`\n" +
@@ -547,57 +676,71 @@ func file_chatto_api_v1_threads_proto_rawDescGZIP() []byte {
 	return file_chatto_api_v1_threads_proto_rawDescData
 }
 
-var file_chatto_api_v1_threads_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
+var file_chatto_api_v1_threads_proto_msgTypes = make([]protoimpl.MessageInfo, 10)
 var file_chatto_api_v1_threads_proto_goTypes = []any{
-	(*ThreadFollowState)(nil),             // 0: chatto.api.v1.ThreadFollowState
-	(*FollowThreadRequest)(nil),           // 1: chatto.api.v1.FollowThreadRequest
-	(*FollowThreadResponse)(nil),          // 2: chatto.api.v1.FollowThreadResponse
-	(*UnfollowThreadRequest)(nil),         // 3: chatto.api.v1.UnfollowThreadRequest
-	(*UnfollowThreadResponse)(nil),        // 4: chatto.api.v1.UnfollowThreadResponse
-	(*FollowedThread)(nil),                // 5: chatto.api.v1.FollowedThread
-	(*ListFollowedThreadsRequest)(nil),    // 6: chatto.api.v1.ListFollowedThreadsRequest
-	(*ListFollowedThreadsResponse)(nil),   // 7: chatto.api.v1.ListFollowedThreadsResponse
-	(*Message)(nil),                       // 8: chatto.api.v1.Message
-	(*RoomSummary)(nil),                   // 9: chatto.api.v1.RoomSummary
-	(*ThreadSummary)(nil),                 // 10: chatto.api.v1.ThreadSummary
-	(*PageRequest)(nil),                   // 11: chatto.api.v1.PageRequest
-	(*RoomTimelineIncludes)(nil),          // 12: chatto.api.v1.RoomTimelineIncludes
-	(*PageInfo)(nil),                      // 13: chatto.api.v1.PageInfo
-	(*GetThreadEventsRequest)(nil),        // 14: chatto.api.v1.GetThreadEventsRequest
-	(*GetThreadEventsAroundRequest)(nil),  // 15: chatto.api.v1.GetThreadEventsAroundRequest
-	(*MarkThreadAsReadRequest)(nil),       // 16: chatto.api.v1.MarkThreadAsReadRequest
-	(*GetThreadEventsResponse)(nil),       // 17: chatto.api.v1.GetThreadEventsResponse
-	(*GetThreadEventsAroundResponse)(nil), // 18: chatto.api.v1.GetThreadEventsAroundResponse
-	(*MarkThreadAsReadResponse)(nil),      // 19: chatto.api.v1.MarkThreadAsReadResponse
+	(*ThreadFollowState)(nil),                // 0: chatto.api.v1.ThreadFollowState
+	(*FollowThreadRequest)(nil),              // 1: chatto.api.v1.FollowThreadRequest
+	(*FollowThreadResponse)(nil),             // 2: chatto.api.v1.FollowThreadResponse
+	(*UnfollowThreadRequest)(nil),            // 3: chatto.api.v1.UnfollowThreadRequest
+	(*UnfollowThreadResponse)(nil),           // 4: chatto.api.v1.UnfollowThreadResponse
+	(*FollowedThread)(nil),                   // 5: chatto.api.v1.FollowedThread
+	(*ListFollowedThreadsRequest)(nil),       // 6: chatto.api.v1.ListFollowedThreadsRequest
+	(*ListFollowedThreadsResponse)(nil),      // 7: chatto.api.v1.ListFollowedThreadsResponse
+	(*ListThreadParticipantsRequest)(nil),    // 8: chatto.api.v1.ListThreadParticipantsRequest
+	(*ListThreadParticipantsResponse)(nil),   // 9: chatto.api.v1.ListThreadParticipantsResponse
+	(*Message)(nil),                          // 10: chatto.api.v1.Message
+	(*RoomSummary)(nil),                      // 11: chatto.api.v1.RoomSummary
+	(*ThreadSummary)(nil),                    // 12: chatto.api.v1.ThreadSummary
+	(*PageRequest)(nil),                      // 13: chatto.api.v1.PageRequest
+	(*RoomTimelineIncludes)(nil),             // 14: chatto.api.v1.RoomTimelineIncludes
+	(*PageInfo)(nil),                         // 15: chatto.api.v1.PageInfo
+	(*GetThreadReadStateRequest)(nil),        // 16: chatto.api.v1.GetThreadReadStateRequest
+	(*BatchGetThreadReadStatesRequest)(nil),  // 17: chatto.api.v1.BatchGetThreadReadStatesRequest
+	(*GetThreadEventsRequest)(nil),           // 18: chatto.api.v1.GetThreadEventsRequest
+	(*GetThreadEventsAroundRequest)(nil),     // 19: chatto.api.v1.GetThreadEventsAroundRequest
+	(*MarkThreadAsReadRequest)(nil),          // 20: chatto.api.v1.MarkThreadAsReadRequest
+	(*GetThreadReadStateResponse)(nil),       // 21: chatto.api.v1.GetThreadReadStateResponse
+	(*BatchGetThreadReadStatesResponse)(nil), // 22: chatto.api.v1.BatchGetThreadReadStatesResponse
+	(*GetThreadEventsResponse)(nil),          // 23: chatto.api.v1.GetThreadEventsResponse
+	(*GetThreadEventsAroundResponse)(nil),    // 24: chatto.api.v1.GetThreadEventsAroundResponse
+	(*MarkThreadAsReadResponse)(nil),         // 25: chatto.api.v1.MarkThreadAsReadResponse
 }
 var file_chatto_api_v1_threads_proto_depIdxs = []int32{
 	0,  // 0: chatto.api.v1.FollowThreadResponse.state:type_name -> chatto.api.v1.ThreadFollowState
 	0,  // 1: chatto.api.v1.UnfollowThreadResponse.state:type_name -> chatto.api.v1.ThreadFollowState
-	8,  // 2: chatto.api.v1.FollowedThread.root_message:type_name -> chatto.api.v1.Message
-	9,  // 3: chatto.api.v1.FollowedThread.room:type_name -> chatto.api.v1.RoomSummary
-	10, // 4: chatto.api.v1.FollowedThread.thread:type_name -> chatto.api.v1.ThreadSummary
-	8,  // 5: chatto.api.v1.FollowedThread.latest_reply:type_name -> chatto.api.v1.Message
-	11, // 6: chatto.api.v1.ListFollowedThreadsRequest.page:type_name -> chatto.api.v1.PageRequest
+	10, // 2: chatto.api.v1.FollowedThread.root_message:type_name -> chatto.api.v1.Message
+	11, // 3: chatto.api.v1.FollowedThread.room:type_name -> chatto.api.v1.RoomSummary
+	12, // 4: chatto.api.v1.FollowedThread.thread:type_name -> chatto.api.v1.ThreadSummary
+	10, // 5: chatto.api.v1.FollowedThread.latest_reply:type_name -> chatto.api.v1.Message
+	13, // 6: chatto.api.v1.ListFollowedThreadsRequest.page:type_name -> chatto.api.v1.PageRequest
 	5,  // 7: chatto.api.v1.ListFollowedThreadsResponse.threads:type_name -> chatto.api.v1.FollowedThread
-	12, // 8: chatto.api.v1.ListFollowedThreadsResponse.includes:type_name -> chatto.api.v1.RoomTimelineIncludes
-	13, // 9: chatto.api.v1.ListFollowedThreadsResponse.page:type_name -> chatto.api.v1.PageInfo
-	6,  // 10: chatto.api.v1.ThreadService.ListFollowedThreads:input_type -> chatto.api.v1.ListFollowedThreadsRequest
-	1,  // 11: chatto.api.v1.ThreadService.FollowThread:input_type -> chatto.api.v1.FollowThreadRequest
-	3,  // 12: chatto.api.v1.ThreadService.UnfollowThread:input_type -> chatto.api.v1.UnfollowThreadRequest
-	14, // 13: chatto.api.v1.ThreadService.GetThreadEvents:input_type -> chatto.api.v1.GetThreadEventsRequest
-	15, // 14: chatto.api.v1.ThreadService.GetThreadEventsAround:input_type -> chatto.api.v1.GetThreadEventsAroundRequest
-	16, // 15: chatto.api.v1.ThreadService.MarkThreadAsRead:input_type -> chatto.api.v1.MarkThreadAsReadRequest
-	7,  // 16: chatto.api.v1.ThreadService.ListFollowedThreads:output_type -> chatto.api.v1.ListFollowedThreadsResponse
-	2,  // 17: chatto.api.v1.ThreadService.FollowThread:output_type -> chatto.api.v1.FollowThreadResponse
-	4,  // 18: chatto.api.v1.ThreadService.UnfollowThread:output_type -> chatto.api.v1.UnfollowThreadResponse
-	17, // 19: chatto.api.v1.ThreadService.GetThreadEvents:output_type -> chatto.api.v1.GetThreadEventsResponse
-	18, // 20: chatto.api.v1.ThreadService.GetThreadEventsAround:output_type -> chatto.api.v1.GetThreadEventsAroundResponse
-	19, // 21: chatto.api.v1.ThreadService.MarkThreadAsRead:output_type -> chatto.api.v1.MarkThreadAsReadResponse
-	16, // [16:22] is the sub-list for method output_type
-	10, // [10:16] is the sub-list for method input_type
-	10, // [10:10] is the sub-list for extension type_name
-	10, // [10:10] is the sub-list for extension extendee
-	0,  // [0:10] is the sub-list for field type_name
+	14, // 8: chatto.api.v1.ListFollowedThreadsResponse.includes:type_name -> chatto.api.v1.RoomTimelineIncludes
+	15, // 9: chatto.api.v1.ListFollowedThreadsResponse.page:type_name -> chatto.api.v1.PageInfo
+	13, // 10: chatto.api.v1.ListThreadParticipantsRequest.page:type_name -> chatto.api.v1.PageRequest
+	15, // 11: chatto.api.v1.ListThreadParticipantsResponse.page:type_name -> chatto.api.v1.PageInfo
+	16, // 12: chatto.api.v1.ThreadService.GetThreadReadState:input_type -> chatto.api.v1.GetThreadReadStateRequest
+	17, // 13: chatto.api.v1.ThreadService.BatchGetThreadReadStates:input_type -> chatto.api.v1.BatchGetThreadReadStatesRequest
+	8,  // 14: chatto.api.v1.ThreadService.ListThreadParticipants:input_type -> chatto.api.v1.ListThreadParticipantsRequest
+	6,  // 15: chatto.api.v1.ThreadService.ListFollowedThreads:input_type -> chatto.api.v1.ListFollowedThreadsRequest
+	1,  // 16: chatto.api.v1.ThreadService.FollowThread:input_type -> chatto.api.v1.FollowThreadRequest
+	3,  // 17: chatto.api.v1.ThreadService.UnfollowThread:input_type -> chatto.api.v1.UnfollowThreadRequest
+	18, // 18: chatto.api.v1.ThreadService.GetThreadEvents:input_type -> chatto.api.v1.GetThreadEventsRequest
+	19, // 19: chatto.api.v1.ThreadService.GetThreadEventsAround:input_type -> chatto.api.v1.GetThreadEventsAroundRequest
+	20, // 20: chatto.api.v1.ThreadService.MarkThreadAsRead:input_type -> chatto.api.v1.MarkThreadAsReadRequest
+	21, // 21: chatto.api.v1.ThreadService.GetThreadReadState:output_type -> chatto.api.v1.GetThreadReadStateResponse
+	22, // 22: chatto.api.v1.ThreadService.BatchGetThreadReadStates:output_type -> chatto.api.v1.BatchGetThreadReadStatesResponse
+	9,  // 23: chatto.api.v1.ThreadService.ListThreadParticipants:output_type -> chatto.api.v1.ListThreadParticipantsResponse
+	7,  // 24: chatto.api.v1.ThreadService.ListFollowedThreads:output_type -> chatto.api.v1.ListFollowedThreadsResponse
+	2,  // 25: chatto.api.v1.ThreadService.FollowThread:output_type -> chatto.api.v1.FollowThreadResponse
+	4,  // 26: chatto.api.v1.ThreadService.UnfollowThread:output_type -> chatto.api.v1.UnfollowThreadResponse
+	23, // 27: chatto.api.v1.ThreadService.GetThreadEvents:output_type -> chatto.api.v1.GetThreadEventsResponse
+	24, // 28: chatto.api.v1.ThreadService.GetThreadEventsAround:output_type -> chatto.api.v1.GetThreadEventsAroundResponse
+	25, // 29: chatto.api.v1.ThreadService.MarkThreadAsRead:output_type -> chatto.api.v1.MarkThreadAsReadResponse
+	21, // [21:30] is the sub-list for method output_type
+	12, // [12:21] is the sub-list for method input_type
+	12, // [12:12] is the sub-list for extension type_name
+	12, // [12:12] is the sub-list for extension extendee
+	0,  // [0:12] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_threads_proto_init() }
@@ -616,7 +759,7 @@ func file_chatto_api_v1_threads_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_api_v1_threads_proto_rawDesc), len(file_chatto_api_v1_threads_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   8,
+			NumMessages:   10,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -66,6 +66,12 @@ socket.
 | `chatto.api.v1` | `AssetService`, `AssetUploadService`, `BotService`, `MessageSearchService`, `MessageService`, `MyAccountService`, `NotificationPolicyService`, `NotificationService`, `PushNotificationService`, `RoleService`, `RoomDirectoryService`, `RoomService`, `ServerService`, `ThreadService`, `UserService`, `ViewerService`, `VoiceCallService` | Authenticated user; `ViewerService` also reports and changes privileged mode for the current human session |
 | `chatto.admin.v1` | `AdminDiagnosticsService`, `AdminEventLogService`, `AdminInviteLinkService`, `AdminOAuthClientService`, `AdminPermissionService`, `AdminRoleService`, `AdminRoomLayoutService`, `AdminServerService`, `AdminUserService` | Authenticated user; methods enforce administrative permissions |
 
+`MessageService` and `ThreadService` expose complete, paginated reaction-user
+and reply-author references in addition to bounded message previews.
+`RoomService` and `ThreadService` expose caller-owned read markers through
+singular and bounded batch reads. These reads use existing message-read
+authorization and do not initialize or advance markers.
+
 `AdminInviteLinkService` requires `user.invite`. Its resource includes the
 full, deterministically reconstructed invite link so authorised operators can
 copy it again; raw bearer tokens are not stored in `EVT`. Opening

--- a/docs/fdr/FDR-002-replies-and-threads.md
+++ b/docs/fdr/FDR-002-replies-and-threads.md
@@ -1,7 +1,7 @@
 # FDR-002: Replies & Threads
 
 **Status:** Active
-**Last reviewed:** 2026-09-02
+**Last reviewed:** 2026-09-10
 
 ## Overview
 
@@ -10,6 +10,14 @@ inside threads. Replies and threads are independent concepts. Channel rooms
 can configure their Threading Mode. DMs always use Enabled behavior.
 
 ## Behavior
+
+- Integrations can read all distinct authors of current thread replies in
+  bounded pages. Retracted replies and erased authors do not contribute. The
+  root author is included only if they also replied. Counts cover the full set.
+- Integrations can read their own stored room and thread read positions, one
+  target at a time or in bounded batches. A read does not mark content as read
+  or initialize a missing position. These positions are separate from
+  notification attention.
 
 - A message in a room can optionally reference another message as the one it's in reply to.
 - DMs support thread creation, replies, follows, unread state, links,

--- a/docs/fdr/FDR-005-reactions.md
+++ b/docs/fdr/FDR-005-reactions.md
@@ -1,13 +1,17 @@
 # FDR-005: Reactions
 
 **Status:** Active
-**Last reviewed:** 2026-08-30
+**Last reviewed:** 2026-09-10
 
 ## Overview
 
 Users can react to a message with emoji. Reactions are aggregated into pills shown below the message body, displaying the emoji, a count, and whether the current user has reacted. Multiple users can react with the same emoji on the same message; clicking a pill toggles the current user's vote.
 
 ## Behavior
+
+- Integrations can read all user IDs for a message reaction in bounded pages.
+  The five-user preview does not limit this list. The list requires the same
+  access as the message and accepts channel echoes as aliases.
 
 - Each pill shows: the emoji, how many users reacted with it, and a highlight when the current user has reacted.
 - Hovering a pill shows a tooltip with up to 5 reactor names plus an overflow count.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -11,10 +11,10 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
 | [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-09-09 |
-| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-09-04 |
+| [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-09-10 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-09-04 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-25 |
-| [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-08-30 |
+| [FDR-005](FDR-005-reactions.md) | Reactions | Active | 2026-09-10 |
 | [FDR-006](FDR-006-mentions.md) | @Mentions | Active | 2026-08-27 |
 | [FDR-007](FDR-007-direct-messages.md) | Direct Messages | Active | 2026-09-04 |
 | [FDR-008](FDR-008-file-attachments-and-video.md) | File Attachments & Video Processing | Active | 2026-09-05 |

--- a/packages/api-types/src/chatto/api/v1/messages_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/messages_connect.ts
@@ -3,10 +3,10 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { FetchLinkPreviewRequest, FetchLinkPreviewResponse } from "./link_previews_pb.js";
+import { AddReactionRequest, AddReactionResponse, ListReactionUsersRequest, ListReactionUsersResponse, RemoveReactionRequest, RemoveReactionResponse } from "./reactions_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
+import { FetchLinkPreviewRequest, FetchLinkPreviewResponse } from "./link_previews_pb.js";
 import { BatchGetMessagesRequest, BatchGetMessagesResponse, CreateMessageRequest, CreateMessageResponse, DeleteAttachmentRequest, DeleteAttachmentResponse, DeleteLinkPreviewRequest, DeleteLinkPreviewResponse, DeleteMessageRequest, DeleteMessageResponse, GetMessageRequest, GetMessageResponse, UpdateMessageRequest, UpdateMessageResponse } from "./messages_pb.js";
-import { AddReactionRequest, AddReactionResponse, RemoveReactionRequest, RemoveReactionResponse } from "./reactions_pb.js";
 
 /**
  * Creates messages in room and thread timelines.
@@ -16,6 +16,19 @@ import { AddReactionRequest, AddReactionResponse, RemoveReactionRequest, RemoveR
 export const MessageService = {
   typeName: "chatto.api.v1.MessageService",
   methods: {
+    /**
+     * Lists all users with the requested reaction. Requires room membership and
+     * permission to read the message. A missing reaction returns an empty page;
+     * a missing or hidden message returns NOT_FOUND or PERMISSION_DENIED.
+     *
+     * @generated from rpc chatto.api.v1.MessageService.ListReactionUsers
+     */
+    listReactionUsers: {
+      name: "ListReactionUsers",
+      I: ListReactionUsersRequest,
+      O: ListReactionUsersResponse,
+      kind: MethodKind.Unary,
+    },
     /**
      * Fetches and caches metadata for a composer URL. Authentication is required
      * to avoid exposing the preview fetcher as an unauthenticated network proxy.

--- a/packages/api-types/src/chatto/api/v1/reactions_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/reactions_pb.ts
@@ -6,6 +6,7 @@
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto3 } from "@bufbuild/protobuf";
 import { MessageReaction } from "./message_types_pb.js";
+import { PageInfo, PageRequest } from "./pagination_pb.js";
 
 /**
  * Request to add the current user's reaction to a message.
@@ -229,5 +230,120 @@ export class RemoveReactionResponse extends Message<RemoveReactionResponse> {
 
   static equals(a: RemoveReactionResponse | PlainMessage<RemoveReactionResponse> | undefined, b: RemoveReactionResponse | PlainMessage<RemoveReactionResponse> | undefined): boolean {
     return proto3.util.equals(RemoveReactionResponse, a, b);
+  }
+}
+
+/**
+ * Request all users with one emoji reaction on a message. Echo IDs resolve to
+ * the original message. Users are ordered by user ID ascending.
+ *
+ * @generated from message chatto.api.v1.ListReactionUsersRequest
+ */
+export class ListReactionUsersRequest extends Message<ListReactionUsersRequest> {
+  /**
+   * Room containing the message.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  /**
+   * Message or channel echo ID.
+   *
+   * @generated from field: string message_event_id = 2;
+   */
+  messageEventId = "";
+
+  /**
+   * Emoji shortcode, such as "thumbsup".
+   *
+   * @generated from field: string emoji = 3;
+   */
+  emoji = "";
+
+  /**
+   * Defaults to 50 results. Maximum: 100. Zero uses the default.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 4;
+   */
+  page?: PageRequest;
+
+  constructor(data?: PartialMessage<ListReactionUsersRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ListReactionUsersRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "message_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "emoji", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "page", kind: "message", T: PageRequest },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListReactionUsersRequest {
+    return new ListReactionUsersRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListReactionUsersRequest {
+    return new ListReactionUsersRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListReactionUsersRequest {
+    return new ListReactionUsersRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListReactionUsersRequest | PlainMessage<ListReactionUsersRequest> | undefined, b: ListReactionUsersRequest | PlainMessage<ListReactionUsersRequest> | undefined): boolean {
+    return proto3.util.equals(ListReactionUsersRequest, a, b);
+  }
+}
+
+/**
+ * Complete reaction membership is available by paging this collection.
+ *
+ * @generated from message chatto.api.v1.ListReactionUsersResponse
+ */
+export class ListReactionUsersResponse extends Message<ListReactionUsersResponse> {
+  /**
+   * User IDs in this page. Use UserService.BatchGetUsers for profiles.
+   *
+   * @generated from field: repeated string user_ids = 1;
+   */
+  userIds: string[] = [];
+
+  /**
+   * Count and continuation for the matching reaction users.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 2;
+   */
+  page?: PageInfo;
+
+  constructor(data?: PartialMessage<ListReactionUsersResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ListReactionUsersResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "user_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 2, name: "page", kind: "message", T: PageInfo },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListReactionUsersResponse {
+    return new ListReactionUsersResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListReactionUsersResponse {
+    return new ListReactionUsersResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListReactionUsersResponse {
+    return new ListReactionUsersResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListReactionUsersResponse | PlainMessage<ListReactionUsersResponse> | undefined, b: ListReactionUsersResponse | PlainMessage<ListReactionUsersResponse> | undefined): boolean {
+    return proto3.util.equals(ListReactionUsersResponse, a, b);
   }
 }

--- a/packages/api-types/src/chatto/api/v1/read_state_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/read_state_pb.ts
@@ -216,3 +216,544 @@ export class MarkThreadAsReadResponse extends Message<MarkThreadAsReadResponse> 
     return proto3.util.equals(MarkThreadAsReadResponse, a, b);
   }
 }
+
+/**
+ * Current stored read position. Its event can later be retracted. The timestamp
+ * is absent if the event can no longer be resolved. This is not Badge attention.
+ *
+ * @generated from message chatto.api.v1.ReadMarker
+ */
+export class ReadMarker extends Message<ReadMarker> {
+  /**
+   * Last-read event ID, to locate the boundary in a timeline.
+   *
+   * @generated from field: string last_read_event_id = 1;
+   */
+  lastReadEventId = "";
+
+  /**
+   * Creation time of the last-read event, when available.
+   *
+   * @generated from field: google.protobuf.Timestamp last_read_at = 2;
+   */
+  lastReadAt?: Timestamp;
+
+  constructor(data?: PartialMessage<ReadMarker>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ReadMarker";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "last_read_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "last_read_at", kind: "message", T: Timestamp },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ReadMarker {
+    return new ReadMarker().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ReadMarker {
+    return new ReadMarker().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ReadMarker {
+    return new ReadMarker().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ReadMarker | PlainMessage<ReadMarker> | undefined, b: ReadMarker | PlainMessage<ReadMarker> | undefined): boolean {
+    return proto3.util.equals(ReadMarker, a, b);
+  }
+}
+
+/**
+ * Current viewer's stored room read state.
+ *
+ * @generated from message chatto.api.v1.RoomReadState
+ */
+export class RoomReadState extends Message<RoomReadState> {
+  /**
+   * Room ID.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  /**
+   * Absent when no non-empty marker has been stored. Reading never initializes it.
+   *
+   * @generated from field: chatto.api.v1.ReadMarker marker = 2;
+   */
+  marker?: ReadMarker;
+
+  constructor(data?: PartialMessage<RoomReadState>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.RoomReadState";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "marker", kind: "message", T: ReadMarker },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RoomReadState {
+    return new RoomReadState().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): RoomReadState {
+    return new RoomReadState().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): RoomReadState {
+    return new RoomReadState().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: RoomReadState | PlainMessage<RoomReadState> | undefined, b: RoomReadState | PlainMessage<RoomReadState> | undefined): boolean {
+    return proto3.util.equals(RoomReadState, a, b);
+  }
+}
+
+/**
+ * Current viewer's stored thread read state.
+ *
+ * @generated from message chatto.api.v1.ThreadReadState
+ */
+export class ThreadReadState extends Message<ThreadReadState> {
+  /**
+   * Room ID.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  /**
+   * Root message ID.
+   *
+   * @generated from field: string thread_root_event_id = 2;
+   */
+  threadRootEventId = "";
+
+  /**
+   * Absent when no non-empty marker has been stored. Reading never advances it.
+   *
+   * @generated from field: chatto.api.v1.ReadMarker marker = 3;
+   */
+  marker?: ReadMarker;
+
+  constructor(data?: PartialMessage<ThreadReadState>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ThreadReadState";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "marker", kind: "message", T: ReadMarker },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ThreadReadState {
+    return new ThreadReadState().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ThreadReadState {
+    return new ThreadReadState().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ThreadReadState {
+    return new ThreadReadState().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ThreadReadState | PlainMessage<ThreadReadState> | undefined, b: ThreadReadState | PlainMessage<ThreadReadState> | undefined): boolean {
+    return proto3.util.equals(ThreadReadState, a, b);
+  }
+}
+
+/**
+ * Request current room read state without changing it.
+ *
+ * @generated from message chatto.api.v1.GetRoomReadStateRequest
+ */
+export class GetRoomReadStateRequest extends Message<GetRoomReadStateRequest> {
+  /**
+   * Room ID.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  constructor(data?: PartialMessage<GetRoomReadStateRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.GetRoomReadStateRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetRoomReadStateRequest {
+    return new GetRoomReadStateRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetRoomReadStateRequest {
+    return new GetRoomReadStateRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetRoomReadStateRequest {
+    return new GetRoomReadStateRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: GetRoomReadStateRequest | PlainMessage<GetRoomReadStateRequest> | undefined, b: GetRoomReadStateRequest | PlainMessage<GetRoomReadStateRequest> | undefined): boolean {
+    return proto3.util.equals(GetRoomReadStateRequest, a, b);
+  }
+}
+
+/**
+ * Current room read state, including an absent marker when none is stored.
+ *
+ * @generated from message chatto.api.v1.GetRoomReadStateResponse
+ */
+export class GetRoomReadStateResponse extends Message<GetRoomReadStateResponse> {
+  /**
+   * State for the requested room and viewer.
+   *
+   * @generated from field: chatto.api.v1.RoomReadState state = 1;
+   */
+  state?: RoomReadState;
+
+  constructor(data?: PartialMessage<GetRoomReadStateResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.GetRoomReadStateResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "state", kind: "message", T: RoomReadState },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetRoomReadStateResponse {
+    return new GetRoomReadStateResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetRoomReadStateResponse {
+    return new GetRoomReadStateResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetRoomReadStateResponse {
+    return new GetRoomReadStateResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: GetRoomReadStateResponse | PlainMessage<GetRoomReadStateResponse> | undefined, b: GetRoomReadStateResponse | PlainMessage<GetRoomReadStateResponse> | undefined): boolean {
+    return proto3.util.equals(GetRoomReadStateResponse, a, b);
+  }
+}
+
+/**
+ * Request room read states. Duplicates are removed in first-seen order.
+ *
+ * @generated from message chatto.api.v1.BatchGetRoomReadStatesRequest
+ */
+export class BatchGetRoomReadStatesRequest extends Message<BatchGetRoomReadStatesRequest> {
+  /**
+   * Up to 100 room IDs. Missing or inaccessible rooms are omitted.
+   *
+   * @generated from field: repeated string room_ids = 1;
+   */
+  roomIds: string[] = [];
+
+  constructor(data?: PartialMessage<BatchGetRoomReadStatesRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.BatchGetRoomReadStatesRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BatchGetRoomReadStatesRequest {
+    return new BatchGetRoomReadStatesRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): BatchGetRoomReadStatesRequest {
+    return new BatchGetRoomReadStatesRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): BatchGetRoomReadStatesRequest {
+    return new BatchGetRoomReadStatesRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: BatchGetRoomReadStatesRequest | PlainMessage<BatchGetRoomReadStatesRequest> | undefined, b: BatchGetRoomReadStatesRequest | PlainMessage<BatchGetRoomReadStatesRequest> | undefined): boolean {
+    return proto3.util.equals(BatchGetRoomReadStatesRequest, a, b);
+  }
+}
+
+/**
+ * Accessible room read states in first-seen request order.
+ *
+ * @generated from message chatto.api.v1.BatchGetRoomReadStatesResponse
+ */
+export class BatchGetRoomReadStatesResponse extends Message<BatchGetRoomReadStatesResponse> {
+  /**
+   * States for the current viewer. An absent marker does not omit the state.
+   *
+   * @generated from field: repeated chatto.api.v1.RoomReadState states = 1;
+   */
+  states: RoomReadState[] = [];
+
+  constructor(data?: PartialMessage<BatchGetRoomReadStatesResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.BatchGetRoomReadStatesResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "states", kind: "message", T: RoomReadState, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BatchGetRoomReadStatesResponse {
+    return new BatchGetRoomReadStatesResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): BatchGetRoomReadStatesResponse {
+    return new BatchGetRoomReadStatesResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): BatchGetRoomReadStatesResponse {
+    return new BatchGetRoomReadStatesResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: BatchGetRoomReadStatesResponse | PlainMessage<BatchGetRoomReadStatesResponse> | undefined, b: BatchGetRoomReadStatesResponse | PlainMessage<BatchGetRoomReadStatesResponse> | undefined): boolean {
+    return proto3.util.equals(BatchGetRoomReadStatesResponse, a, b);
+  }
+}
+
+/**
+ * Request current thread read state without changing it.
+ *
+ * @generated from message chatto.api.v1.GetThreadReadStateRequest
+ */
+export class GetThreadReadStateRequest extends Message<GetThreadReadStateRequest> {
+  /**
+   * Room ID.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  /**
+   * Root message ID.
+   *
+   * @generated from field: string thread_root_event_id = 2;
+   */
+  threadRootEventId = "";
+
+  constructor(data?: PartialMessage<GetThreadReadStateRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.GetThreadReadStateRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetThreadReadStateRequest {
+    return new GetThreadReadStateRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetThreadReadStateRequest {
+    return new GetThreadReadStateRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetThreadReadStateRequest {
+    return new GetThreadReadStateRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: GetThreadReadStateRequest | PlainMessage<GetThreadReadStateRequest> | undefined, b: GetThreadReadStateRequest | PlainMessage<GetThreadReadStateRequest> | undefined): boolean {
+    return proto3.util.equals(GetThreadReadStateRequest, a, b);
+  }
+}
+
+/**
+ * Current thread read state.
+ *
+ * @generated from message chatto.api.v1.GetThreadReadStateResponse
+ */
+export class GetThreadReadStateResponse extends Message<GetThreadReadStateResponse> {
+  /**
+   * State for the requested thread and viewer.
+   *
+   * @generated from field: chatto.api.v1.ThreadReadState state = 1;
+   */
+  state?: ThreadReadState;
+
+  constructor(data?: PartialMessage<GetThreadReadStateResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.GetThreadReadStateResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "state", kind: "message", T: ThreadReadState },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetThreadReadStateResponse {
+    return new GetThreadReadStateResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): GetThreadReadStateResponse {
+    return new GetThreadReadStateResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): GetThreadReadStateResponse {
+    return new GetThreadReadStateResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: GetThreadReadStateResponse | PlainMessage<GetThreadReadStateResponse> | undefined, b: GetThreadReadStateResponse | PlainMessage<GetThreadReadStateResponse> | undefined): boolean {
+    return proto3.util.equals(GetThreadReadStateResponse, a, b);
+  }
+}
+
+/**
+ * Request thread read states. Duplicates are removed in first-seen order.
+ *
+ * @generated from message chatto.api.v1.BatchGetThreadReadStatesRequest
+ */
+export class BatchGetThreadReadStatesRequest extends Message<BatchGetThreadReadStatesRequest> {
+  /**
+   * Up to 100 room/thread targets. Missing or inaccessible targets are omitted.
+   *
+   * @generated from field: repeated chatto.api.v1.ThreadReadStateTarget targets = 1;
+   */
+  targets: ThreadReadStateTarget[] = [];
+
+  constructor(data?: PartialMessage<BatchGetThreadReadStatesRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.BatchGetThreadReadStatesRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "targets", kind: "message", T: ThreadReadStateTarget, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BatchGetThreadReadStatesRequest {
+    return new BatchGetThreadReadStatesRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): BatchGetThreadReadStatesRequest {
+    return new BatchGetThreadReadStatesRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): BatchGetThreadReadStatesRequest {
+    return new BatchGetThreadReadStatesRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: BatchGetThreadReadStatesRequest | PlainMessage<BatchGetThreadReadStatesRequest> | undefined, b: BatchGetThreadReadStatesRequest | PlainMessage<BatchGetThreadReadStatesRequest> | undefined): boolean {
+    return proto3.util.equals(BatchGetThreadReadStatesRequest, a, b);
+  }
+}
+
+/**
+ * Accessible thread read states in first-seen request order.
+ *
+ * @generated from message chatto.api.v1.BatchGetThreadReadStatesResponse
+ */
+export class BatchGetThreadReadStatesResponse extends Message<BatchGetThreadReadStatesResponse> {
+  /**
+   * States for the current viewer. An absent marker does not omit the state.
+   *
+   * @generated from field: repeated chatto.api.v1.ThreadReadState states = 1;
+   */
+  states: ThreadReadState[] = [];
+
+  constructor(data?: PartialMessage<BatchGetThreadReadStatesResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.BatchGetThreadReadStatesResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "states", kind: "message", T: ThreadReadState, repeated: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BatchGetThreadReadStatesResponse {
+    return new BatchGetThreadReadStatesResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): BatchGetThreadReadStatesResponse {
+    return new BatchGetThreadReadStatesResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): BatchGetThreadReadStatesResponse {
+    return new BatchGetThreadReadStatesResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: BatchGetThreadReadStatesResponse | PlainMessage<BatchGetThreadReadStatesResponse> | undefined, b: BatchGetThreadReadStatesResponse | PlainMessage<BatchGetThreadReadStatesResponse> | undefined): boolean {
+    return proto3.util.equals(BatchGetThreadReadStatesResponse, a, b);
+  }
+}
+
+/**
+ * Room and root identity for one thread read state.
+ *
+ * @generated from message chatto.api.v1.ThreadReadStateTarget
+ */
+export class ThreadReadStateTarget extends Message<ThreadReadStateTarget> {
+  /**
+   * Room ID.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  /**
+   * Root message ID.
+   *
+   * @generated from field: string thread_root_event_id = 2;
+   */
+  threadRootEventId = "";
+
+  constructor(data?: PartialMessage<ThreadReadStateTarget>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ThreadReadStateTarget";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ThreadReadStateTarget {
+    return new ThreadReadStateTarget().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ThreadReadStateTarget {
+    return new ThreadReadStateTarget().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ThreadReadStateTarget {
+    return new ThreadReadStateTarget().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ThreadReadStateTarget | PlainMessage<ThreadReadStateTarget> | undefined, b: ThreadReadStateTarget | PlainMessage<ThreadReadStateTarget> | undefined): boolean {
+    return proto3.util.equals(ThreadReadStateTarget, a, b);
+  }
+}

--- a/packages/api-types/src/chatto/api/v1/rooms_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_connect.ts
@@ -3,11 +3,11 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { AddMemberRequest, AddMemberResponse, ArchiveRoomRequest, ArchiveRoomResponse, BanMemberRequest, BanMemberResponse, CreatePinnedMessageRequest, CreatePinnedMessageResponse, CreateRoomRequest, CreateRoomResponse, DeletePinnedMessageRequest, DeletePinnedMessageResponse, JoinRoomGroupRequest, JoinRoomGroupResponse, JoinRoomRequest, JoinRoomResponse, LeaveRoomRequest, LeaveRoomResponse, ListBansRequest, ListBansResponse, ListPinnedMessagesRequest, ListPinnedMessagesResponse, ListRoomAttachmentsRequest, ListRoomAttachmentsResponse, RefreshTypingIndicatorRequest, RefreshTypingIndicatorResponse, RemoveMemberRequest, RemoveMemberResponse, StartDMRequest, StartDMResponse, UnarchiveRoomRequest, UnarchiveRoomResponse, UnbanMemberRequest, UnbanMemberResponse, UpdateRoomRequest, UpdateRoomResponse } from "./rooms_pb.js";
+import { BatchGetRoomReadStatesRequest, BatchGetRoomReadStatesResponse, GetRoomReadStateRequest, GetRoomReadStateResponse, MarkRoomAsReadRequest, MarkRoomAsReadResponse } from "./read_state_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
+import { AddMemberRequest, AddMemberResponse, ArchiveRoomRequest, ArchiveRoomResponse, BanMemberRequest, BanMemberResponse, CreatePinnedMessageRequest, CreatePinnedMessageResponse, CreateRoomRequest, CreateRoomResponse, DeletePinnedMessageRequest, DeletePinnedMessageResponse, JoinRoomGroupRequest, JoinRoomGroupResponse, JoinRoomRequest, JoinRoomResponse, LeaveRoomRequest, LeaveRoomResponse, ListBansRequest, ListBansResponse, ListPinnedMessagesRequest, ListPinnedMessagesResponse, ListRoomAttachmentsRequest, ListRoomAttachmentsResponse, RefreshTypingIndicatorRequest, RefreshTypingIndicatorResponse, RemoveMemberRequest, RemoveMemberResponse, StartDMRequest, StartDMResponse, UnarchiveRoomRequest, UnarchiveRoomResponse, UnbanMemberRequest, UnbanMemberResponse, UpdateRoomRequest, UpdateRoomResponse } from "./rooms_pb.js";
 import { BatchGetMembersRequest, BatchGetMembersResponse, GetMemberRequest, GetMemberResponse, ListMembersRequest, ListMembersResponse } from "./member_directory_pb.js";
 import { GetRoomEventsAroundRequest, GetRoomEventsAroundResponse, GetRoomEventsRequest, GetRoomEventsResponse } from "./room_timeline_pb.js";
-import { MarkRoomAsReadRequest, MarkRoomAsReadResponse } from "./read_state_pb.js";
 
 /**
  * Manages room-scoped operations for the current user.
@@ -23,6 +23,31 @@ import { MarkRoomAsReadRequest, MarkRoomAsReadResponse } from "./read_state_pb.j
 export const RoomService = {
   typeName: "chatto.api.v1.RoomService",
   methods: {
+    /**
+     * Reads the current viewer's stored marker without changing it. Requires the
+     * same membership and read access as MarkRoomAsRead. Missing resources
+     * return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+     *
+     * @generated from rpc chatto.api.v1.RoomService.GetRoomReadState
+     */
+    getRoomReadState: {
+      name: "GetRoomReadState",
+      I: GetRoomReadStateRequest,
+      O: GetRoomReadStateResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Reads up to 100 states under the same authorization as GetRoomReadState.
+     * Missing and inaccessible resources are omitted; duplicates use first-seen order.
+     *
+     * @generated from rpc chatto.api.v1.RoomService.BatchGetRoomReadStates
+     */
+    batchGetRoomReadStates: {
+      name: "BatchGetRoomReadStates",
+      I: BatchGetRoomReadStatesRequest,
+      O: BatchGetRoomReadStatesResponse,
+      kind: MethodKind.Unary,
+    },
     /**
      * Creates a new channel room in a room group. The caller must be allowed to
      * create rooms in the target group.

--- a/packages/api-types/src/chatto/api/v1/threads_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/threads_connect.ts
@@ -3,10 +3,10 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { FollowThreadRequest, FollowThreadResponse, ListFollowedThreadsRequest, ListFollowedThreadsResponse, UnfollowThreadRequest, UnfollowThreadResponse } from "./threads_pb.js";
+import { BatchGetThreadReadStatesRequest, BatchGetThreadReadStatesResponse, GetThreadReadStateRequest, GetThreadReadStateResponse, MarkThreadAsReadRequest, MarkThreadAsReadResponse } from "./read_state_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
+import { FollowThreadRequest, FollowThreadResponse, ListFollowedThreadsRequest, ListFollowedThreadsResponse, ListThreadParticipantsRequest, ListThreadParticipantsResponse, UnfollowThreadRequest, UnfollowThreadResponse } from "./threads_pb.js";
 import { GetThreadEventsAroundRequest, GetThreadEventsAroundResponse, GetThreadEventsRequest, GetThreadEventsResponse } from "./room_timeline_pb.js";
-import { MarkThreadAsReadRequest, MarkThreadAsReadResponse } from "./read_state_pb.js";
 
 /**
  * Manages thread follow state for the current user.
@@ -16,6 +16,44 @@ import { MarkThreadAsReadRequest, MarkThreadAsReadResponse } from "./read_state_
 export const ThreadService = {
   typeName: "chatto.api.v1.ThreadService",
   methods: {
+    /**
+     * Reads the current viewer's stored marker without changing it. Requires the
+     * same membership and read access as MarkThreadAsRead. Missing resources
+     * return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+     *
+     * @generated from rpc chatto.api.v1.ThreadService.GetThreadReadState
+     */
+    getThreadReadState: {
+      name: "GetThreadReadState",
+      I: GetThreadReadStateRequest,
+      O: GetThreadReadStateResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Reads up to 100 states under the same authorization as GetThreadReadState.
+     * Missing and inaccessible resources are omitted; duplicates use first-seen order.
+     *
+     * @generated from rpc chatto.api.v1.ThreadService.BatchGetThreadReadStates
+     */
+    batchGetThreadReadStates: {
+      name: "BatchGetThreadReadStates",
+      I: BatchGetThreadReadStatesRequest,
+      O: BatchGetThreadReadStatesResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Lists distinct authors of non-retracted replies, excluding erased users.
+     * The root author is included only if they also replied. Requires the same
+     * membership and message-read access as GetThreadEvents.
+     *
+     * @generated from rpc chatto.api.v1.ThreadService.ListThreadParticipants
+     */
+    listThreadParticipants: {
+      name: "ListThreadParticipants",
+      I: ListThreadParticipantsRequest,
+      O: ListThreadParticipantsResponse,
+      kind: MethodKind.Unary,
+    },
     /**
      * Returns followed threads in rooms where the current user is a member.
      * All threads also require message.read or an active relationship with

--- a/packages/api-types/src/chatto/api/v1/threads_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/threads_pb.ts
@@ -428,3 +428,109 @@ export class ListFollowedThreadsResponse extends Message<ListFollowedThreadsResp
     return proto3.util.equals(ListFollowedThreadsResponse, a, b);
   }
 }
+
+/**
+ * Request a complete thread participant collection, ordered by user ID ascending.
+ *
+ * @generated from message chatto.api.v1.ListThreadParticipantsRequest
+ */
+export class ListThreadParticipantsRequest extends Message<ListThreadParticipantsRequest> {
+  /**
+   * Room containing the thread.
+   *
+   * @generated from field: string room_id = 1;
+   */
+  roomId = "";
+
+  /**
+   * Root message ID.
+   *
+   * @generated from field: string thread_root_event_id = 2;
+   */
+  threadRootEventId = "";
+
+  /**
+   * Defaults to 50 results. Maximum: 100. Zero uses the default.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 3;
+   */
+  page?: PageRequest;
+
+  constructor(data?: PartialMessage<ListThreadParticipantsRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ListThreadParticipantsRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "room_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "thread_root_event_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "page", kind: "message", T: PageRequest },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListThreadParticipantsRequest {
+    return new ListThreadParticipantsRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListThreadParticipantsRequest {
+    return new ListThreadParticipantsRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListThreadParticipantsRequest {
+    return new ListThreadParticipantsRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListThreadParticipantsRequest | PlainMessage<ListThreadParticipantsRequest> | undefined, b: ListThreadParticipantsRequest | PlainMessage<ListThreadParticipantsRequest> | undefined): boolean {
+    return proto3.util.equals(ListThreadParticipantsRequest, a, b);
+  }
+}
+
+/**
+ * A page of distinct reply authors. An empty thread returns an empty page.
+ *
+ * @generated from message chatto.api.v1.ListThreadParticipantsResponse
+ */
+export class ListThreadParticipantsResponse extends Message<ListThreadParticipantsResponse> {
+  /**
+   * User IDs in this page. Use UserService.BatchGetUsers for profiles.
+   *
+   * @generated from field: repeated string user_ids = 1;
+   */
+  userIds: string[] = [];
+
+  /**
+   * Count and continuation for all current participants.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 2;
+   */
+  page?: PageInfo;
+
+  constructor(data?: PartialMessage<ListThreadParticipantsResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.api.v1.ListThreadParticipantsResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "user_ids", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 2, name: "page", kind: "message", T: PageInfo },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListThreadParticipantsResponse {
+    return new ListThreadParticipantsResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListThreadParticipantsResponse {
+    return new ListThreadParticipantsResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListThreadParticipantsResponse {
+    return new ListThreadParticipantsResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListThreadParticipantsResponse | PlainMessage<ListThreadParticipantsResponse> | undefined, b: ListThreadParticipantsResponse | PlainMessage<ListThreadParticipantsResponse> | undefined): boolean {
+    return proto3.util.equals(ListThreadParticipantsResponse, a, b);
+  }
+}

--- a/proto/chatto/api/v1/messages.proto
+++ b/proto/chatto/api/v1/messages.proto
@@ -207,6 +207,11 @@ message BatchGetMessagesResponse {
 
 // Creates messages in room and thread timelines.
 service MessageService {
+  // Lists all users with the requested reaction. Requires room membership and
+  // permission to read the message. A missing reaction returns an empty page;
+  // a missing or hidden message returns NOT_FOUND or PERMISSION_DENIED.
+  rpc ListReactionUsers(ListReactionUsersRequest) returns (ListReactionUsersResponse);
+
   // Fetches and caches metadata for a composer URL. Authentication is required
   // to avoid exposing the preview fetcher as an unauthenticated network proxy.
   // Successful responses include a short-lived token accepted by CreateMessage.

--- a/proto/chatto/api/v1/reactions.proto
+++ b/proto/chatto/api/v1/reactions.proto
@@ -4,6 +4,7 @@ package chatto.api.v1;
 
 import "buf/validate/validate.proto";
 import "chatto/api/v1/message_types.proto";
+import "chatto/api/v1/pagination.proto";
 
 // Request to add the current user's reaction to a message.
 //
@@ -52,4 +53,25 @@ message RemoveReactionResponse {
   // Updated aggregate reaction state for this emoji. Empty when no reactions for
   // the emoji remain.
   MessageReaction reaction = 2;
+}
+
+// Request all users with one emoji reaction on a message. Echo IDs resolve to
+// the original message. Users are ordered by user ID ascending.
+message ListReactionUsersRequest {
+  // Room containing the message.
+  string room_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Message or channel echo ID.
+  string message_event_id = 2 [(buf.validate.field).string.min_len = 1];
+  // Emoji shortcode, such as "thumbsup".
+  string emoji = 3 [(buf.validate.field).string.min_len = 1];
+  // Defaults to 50 results. Maximum: 100. Zero uses the default.
+  PageRequest page = 4;
+}
+
+// Complete reaction membership is available by paging this collection.
+message ListReactionUsersResponse {
+  // User IDs in this page. Use UserService.BatchGetUsers for profiles.
+  repeated string user_ids = 1;
+  // Count and continuation for the matching reaction users.
+  PageInfo page = 2;
 }

--- a/proto/chatto/api/v1/read_state.proto
+++ b/proto/chatto/api/v1/read_state.proto
@@ -47,3 +47,83 @@ message MarkThreadAsReadResponse {
   // Absent when no marker exists.
   google.protobuf.Timestamp last_read_at = 2;
 }
+
+// Current stored read position. Its event can later be retracted. The timestamp
+// is absent if the event can no longer be resolved. This is not Badge attention.
+message ReadMarker {
+  // Last-read event ID, to locate the boundary in a timeline.
+  string last_read_event_id = 1;
+  // Creation time of the last-read event, when available.
+  google.protobuf.Timestamp last_read_at = 2;
+}
+
+// Current viewer's stored room read state.
+message RoomReadState {
+  // Room ID.
+  string room_id = 1;
+  // Absent when no non-empty marker has been stored. Reading never initializes it.
+  ReadMarker marker = 2;
+}
+
+// Current viewer's stored thread read state.
+message ThreadReadState {
+  // Room ID.
+  string room_id = 1;
+  // Root message ID.
+  string thread_root_event_id = 2;
+  // Absent when no non-empty marker has been stored. Reading never advances it.
+  ReadMarker marker = 3;
+}
+
+// Request current room read state without changing it.
+message GetRoomReadStateRequest {
+  // Room ID.
+  string room_id = 1 [(buf.validate.field).string.min_len = 1];
+}
+// Current room read state, including an absent marker when none is stored.
+message GetRoomReadStateResponse {
+  // State for the requested room and viewer.
+  RoomReadState state = 1;
+}
+// Request room read states. Duplicates are removed in first-seen order.
+message BatchGetRoomReadStatesRequest {
+  // Up to 100 room IDs. Missing or inaccessible rooms are omitted.
+  repeated string room_ids = 1 [(buf.validate.field).repeated = {
+    min_items: 1, max_items: 100, items: {string: {min_len: 1}}
+  }];
+}
+// Accessible room read states in first-seen request order.
+message BatchGetRoomReadStatesResponse {
+  // States for the current viewer. An absent marker does not omit the state.
+  repeated RoomReadState states = 1;
+}
+// Request current thread read state without changing it.
+message GetThreadReadStateRequest {
+  // Room ID.
+  string room_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Root message ID.
+  string thread_root_event_id = 2 [(buf.validate.field).string.min_len = 1];
+}
+// Current thread read state.
+message GetThreadReadStateResponse {
+  // State for the requested thread and viewer.
+  ThreadReadState state = 1;
+}
+// Request thread read states. Duplicates are removed in first-seen order.
+message BatchGetThreadReadStatesRequest {
+  // Up to 100 room/thread targets. Missing or inaccessible targets are omitted.
+  repeated ThreadReadStateTarget targets = 1 [(buf.validate.field).repeated = {min_items: 1, max_items: 100}];
+}
+// Accessible thread read states in first-seen request order.
+message BatchGetThreadReadStatesResponse {
+  // States for the current viewer. An absent marker does not omit the state.
+  repeated ThreadReadState states = 1;
+}
+
+// Room and root identity for one thread read state.
+message ThreadReadStateTarget {
+  // Room ID.
+  string room_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Root message ID.
+  string thread_root_event_id = 2 [(buf.validate.field).string.min_len = 1];
+}

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -414,6 +414,14 @@ message RefreshTypingIndicatorResponse {
 // should still be preferred when an operation is not naturally room-scoped or
 // when the resource needs an independent CRUD/batch surface.
 service RoomService {
+  // Reads the current viewer's stored marker without changing it. Requires the
+  // same membership and read access as MarkRoomAsRead. Missing resources
+  // return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+  rpc GetRoomReadState(GetRoomReadStateRequest) returns (GetRoomReadStateResponse);
+  // Reads up to 100 states under the same authorization as GetRoomReadState.
+  // Missing and inaccessible resources are omitted; duplicates use first-seen order.
+  rpc BatchGetRoomReadStates(BatchGetRoomReadStatesRequest) returns (BatchGetRoomReadStatesResponse);
+
   // Creates a new channel room in a room group. The caller must be allowed to
   // create rooms in the target group.
   rpc CreateRoom(CreateRoomRequest) returns (CreateRoomResponse);

--- a/proto/chatto/api/v1/threads.proto
+++ b/proto/chatto/api/v1/threads.proto
@@ -97,6 +97,19 @@ message ListFollowedThreadsResponse {
 
 // Manages thread follow state for the current user.
 service ThreadService {
+  // Reads the current viewer's stored marker without changing it. Requires the
+  // same membership and read access as MarkThreadAsRead. Missing resources
+  // return NOT_FOUND; inaccessible resources return PERMISSION_DENIED.
+  rpc GetThreadReadState(GetThreadReadStateRequest) returns (GetThreadReadStateResponse);
+  // Reads up to 100 states under the same authorization as GetThreadReadState.
+  // Missing and inaccessible resources are omitted; duplicates use first-seen order.
+  rpc BatchGetThreadReadStates(BatchGetThreadReadStatesRequest) returns (BatchGetThreadReadStatesResponse);
+
+  // Lists distinct authors of non-retracted replies, excluding erased users.
+  // The root author is included only if they also replied. Requires the same
+  // membership and message-read access as GetThreadEvents.
+  rpc ListThreadParticipants(ListThreadParticipantsRequest) returns (ListThreadParticipantsResponse);
+
   // Returns followed threads in rooms where the current user is a member.
   // All threads also require message.read or an active relationship with
   // message.read-interactions. Direct-message threads are returned only when
@@ -132,4 +145,22 @@ service ThreadService {
   // the room-level read marker. Room membership plus message.read or an active
   // relationship with message.read-interactions are required.
   rpc MarkThreadAsRead(MarkThreadAsReadRequest) returns (MarkThreadAsReadResponse);
+}
+
+// Request a complete thread participant collection, ordered by user ID ascending.
+message ListThreadParticipantsRequest {
+  // Room containing the thread.
+  string room_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Root message ID.
+  string thread_root_event_id = 2 [(buf.validate.field).string.min_len = 1];
+  // Defaults to 50 results. Maximum: 100. Zero uses the default.
+  PageRequest page = 3;
+}
+
+// A page of distinct reply authors. An empty thread returns an empty page.
+message ListThreadParticipantsResponse {
+  // User IDs in this page. Use UserService.BatchGetUsers for profiles.
+  repeated string user_ids = 1;
+  // Count and continuation for all current participants.
+  PageInfo page = 2;
 }


### PR DESCRIPTION
- **What:** Add paginated `ListReactionUsers` and `ListThreadParticipants`, plus singular and batch room/thread read-state RPCs. Correct thread participant counts beyond 50 authors. Include generated clients, reference docs, and a plain HTTP/JSON integration smoke test.
- **Why:** Integrations need complete relationships and stored read positions, while existing message previews remain small. Marker reads never initialize or advance a position. Lists return user IDs for separate profile hydration; batches accept at most 100 targets and omit missing or inaccessible targets.
- **Compatibility:** Six additive public RPCs and a participant-count correction. Existing authorization applies. No stored schema changes or data migration.
- **Verified:** Full core and ConnectAPI tests; HTTP Connect/JSON tests; pagination, access, alias, retraction, absent-marker, and JSON validation coverage; 60-participant snapshot regression; Buf lint/public breaking and storage compatibility checks; reproducible code generation, API-types build, docs build, license check, and whitespace check. Browser behavior was not tested; no UI changed.
- **Records:** [FDR-002](https://github.com/chattocorp/chatto/blob/88ef6e254ecdcf3cc9f9a0219f9ff248563cfc7c/docs/fdr/FDR-002-replies-and-threads.md), [FDR-005](https://github.com/chattocorp/chatto/blob/88ef6e254ecdcf3cc9f9a0219f9ff248563cfc7c/docs/fdr/FDR-005-reactions.md), and [public interfaces](https://github.com/chattocorp/chatto/blob/88ef6e254ecdcf3cc9f9a0219f9ff248563cfc7c/docs/architecture/interfaces.md).
