### PR TITLE
feat(api)!: paginate the room directory

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -78,8 +78,13 @@ Chatto 0.5 adds `archive_filter` to `RoomDirectoryService.ListRooms`. Omit it or
 select `ROOM_ARCHIVE_FILTER_ACTIVE` to keep the active-room list. Select
 `ROOM_ARCHIVE_FILTER_ARCHIVED` for the archive or `ROOM_ARCHIVE_FILTER_ALL` for
 both states. The filter combines with `scope` and preserves room visibility.
-Responses remain complete room snapshots. Existing clients keep their default
-results. Servers without this field do not provide the archive-filter contract;
+`ListRooms` now returns a page, with 50 rooms by default and at most 100.
+Read `page.hasMore` and advance the request's `page.offset` by the number of returned rooms
+until no more pages remain. Results are ordered by room ID ascending, after
+visibility and archive filtering. Clients that assume one response is the
+complete directory must migrate. Pages are live reads; changes can shift offsets.
+`ListRoomGroups` and realtime room snapshots remain complete navigation data.
+Servers without `archive_filter` do not provide the archive-filter contract;
 clients must use a supporting server release for archive discovery.
 
 The 0.5 authentication boundary also replaces sliding human bearer tokens with

--- a/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/chatto-api.mdx
@@ -231,3 +231,18 @@ format, and time-zone sharing preference. Human and bot credentials both work.
 The response contains the same `settings` resource as `UpdateSettings` and
 `GetViewer`. Unsaved settings return defaults; the read does not save them.
 Use `GetViewer` when you also need the combined account and capability response.
+
+## Page Through the Room Directory
+
+Call `RoomDirectoryService.ListRooms` with `page`, for example
+`{"page":{"limit":100,"offset":0}}`. The default is 50 rooms; the maximum
+is 100. Rooms are ordered by ID ascending. `scope` and `archiveFilter` apply
+before pagination and before `page.totalCount` is calculated.
+
+When `page.hasMore` is true, increase the request offset by the number of rooms
+returned and request the next page. Keep the filters unchanged. Pages are live
+reads, so changes between requests can shift offsets. When rebuilding local
+state, collect all pages before replacing the directory and discard partial
+results if a request fails. For realtime recovery, send the same minimum cursor
+on every page. `ListRoomGroups` remains the complete ordered navigation layout;
+realtime room snapshots also remain complete.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/room-directory.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/room-directory.mdx
@@ -28,8 +28,8 @@ Lists rooms visible to the current user. Defaults to active rooms; use
 archive_filter to discover archived rooms or include both states. Channel
 rooms require membership or room.list. DM membership exposes room and
 participant metadata. Message-derived DM state also requires current
-read permission. Accessible empty DMs are included. Results are returned as a finite
-navigation snapshot.
+read permission. Accessible empty DMs are included. Returns up to 100 rooms
+ordered by ID ascending; the default page size is 50.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomDirectoryService/ListRooms
@@ -45,17 +45,20 @@ Request for rooms visible to the current user.
 | --- | --- | --- |
 | `scope` | [`RoomDirectoryScope`](/reference/connectrpc-api/types/#chatto-api-v1-RoomDirectoryScope) | Which room kinds to include. Defaults to all. |
 | `archive_filter` | [`RoomArchiveFilter`](/reference/connectrpc-api/types/#chatto-api-v1-RoomArchiveFilter) | Archive state to include. Defaults to ACTIVE. Combined with scope; this filter does not grant access to hidden rooms. |
+| `page` | [`PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 50 rooms, capped at 100. Rooms are ordered by ID ascending. |
 
 
 <a id="chatto-api-v1-ListRoomsResponse"></a>
 
 #### Result: ListRoomsResponse
 
-Finite snapshot of rooms visible to the current user.
+One live page of rooms visible to the current user. Changes between requests
+can shift offsets. Follow page.has_more to read the complete directory.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `rooms` | repeated [`RoomWithViewerState`](/reference/connectrpc-api/types/#chatto-api-v1-RoomWithViewerState) | Visible rooms matching both the room-kind scope and archive filter. |
+| `page` | [`PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Count after visibility, scope, and archive filters, before pagination. |
 
 
 <a id="chatto-api-v1-RoomDirectoryService-ListRoomGroups"></a>

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -436,6 +436,12 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   omitted expiry means no expiry. See the
   [migration guide](/guides/integrations/api-compatibility/#resource-updates-in-05).
 
+- **API migration:** `RoomDirectoryService.ListRooms` now returns pages of 50
+  rooms by default, capped at 100, ordered by room ID. Follow `page.hasMore`
+  and advance the request offset to read the full directory. The bundled client
+  fetches all pages before replacing local state. Room-group and realtime
+  navigation snapshots remain complete.
+
 - Integrations can discover archived rooms with `RoomDirectoryService.ListRooms`
   by selecting active, archived, or all rooms. The default remains active rooms,
   and normal room visibility rules apply.

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -1146,8 +1146,8 @@ Lists rooms visible to the current user. Defaults to active rooms; use
 archive_filter to discover archived rooms or include both states. Channel
 rooms require membership or room.list. DM membership exposes room and
 participant metadata. Message-derived DM state also requires current
-read permission. Accessible empty DMs are included. Results are returned as a finite
-navigation snapshot.
+read permission. Accessible empty DMs are included. Returns up to 100 rooms
+ordered by ID ascending; the default page size is 50.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomDirectoryService/ListRooms
@@ -1163,17 +1163,20 @@ Request for rooms visible to the current user.
 | --- | --- | --- |
 | `scope` | [`RoomDirectoryScope`](#chatto-api-v1-RoomDirectoryScope) | Which room kinds to include. Defaults to all. |
 | `archive_filter` | [`RoomArchiveFilter`](#chatto-api-v1-RoomArchiveFilter) | Archive state to include. Defaults to ACTIVE. Combined with scope; this filter does not grant access to hidden rooms. |
+| `page` | [`PageRequest`](#chatto-api-v1-PageRequest) | Defaults to 50 rooms, capped at 100. Rooms are ordered by ID ascending. |
 
 
 <a id="chatto-api-v1-ListRoomsResponse"></a>
 
 #### Result: ListRoomsResponse
 
-Finite snapshot of rooms visible to the current user.
+One live page of rooms visible to the current user. Changes between requests
+can shift offsets. Follow page.has_more to read the complete directory.
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `rooms` | repeated [`RoomWithViewerState`](#chatto-api-v1-RoomWithViewerState) | Visible rooms matching both the room-kind scope and archive filter. |
+| `page` | [`PageInfo`](#chatto-api-v1-PageInfo) | Count after visibility, scope, and archive filters, before pagination. |
 
 
 <a id="chatto-api-v1-RoomDirectoryService-ListRoomGroups"></a>

--- a/apps/frontend/src/lib/api-client-tests/realtimeResources.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/realtimeResources.spec.ts
@@ -96,6 +96,40 @@ describe('createRealtimeResourceAPI', () => {
     expect(mocks.listUsers).not.toHaveBeenCalled();
   });
 
+  it('collects every room page before replacing the directory and retains the cursor', async () => {
+    mocks.listRooms
+      .mockResolvedValueOnce({ rooms: [{ room: { id: 'a' } }], page: { hasMore: true } })
+      .mockResolvedValueOnce({ rooms: [{ room: { id: 'b' } }], page: { hasMore: false } });
+    const api = createRealtimeResourceAPI({ baseUrl: 'https://chat.example.test/api/connect', bearerToken: 'token' });
+    const [update] = await api.read('rooms', 'cursor');
+    expect(update.replace).toBe(true);
+    expect(update.resource.case).toBe('rooms');
+    if (update.resource.case !== 'rooms') throw new Error('expected rooms');
+    expect(update.resource.value.rooms.map((entry) => entry.room?.id)).toEqual(['a', 'b']);
+    expect(mocks.listRooms.mock.calls.map(([request]) => request.page)).toEqual([
+      { limit: 100, offset: 0 }, { limit: 100, offset: 1 }
+    ]);
+    for (const [, options] of mocks.listRooms.mock.calls) {
+      expect(options.headers.get('Chatto-Realtime-Minimum-Cursor')).toBe('cursor');
+    }
+  });
+
+  it('rejects a failed later room page instead of returning a partial replacement', async () => {
+    const error = new Error('second page failed');
+    mocks.listRooms
+      .mockResolvedValueOnce({ rooms: [{ room: { id: 'a' } }], page: { hasMore: true } })
+      .mockRejectedValueOnce(error);
+    const api = createRealtimeResourceAPI({ baseUrl: 'https://chat.example.test/api/connect', bearerToken: null });
+    await expect(api.read('rooms')).rejects.toBe(error);
+  });
+
+  it('rejects an empty continuation instead of looping', async () => {
+    mocks.listRooms.mockResolvedValue({ rooms: [], page: { hasMore: true } });
+    const api = createRealtimeResourceAPI({ baseUrl: 'https://chat.example.test/api/connect', bearerToken: null });
+    await expect(api.read('rooms')).rejects.toThrow('empty continuation');
+    expect(mocks.listRooms).toHaveBeenCalledTimes(1);
+  });
+
   it('hydrates only requested users in bounded merge batches', async () => {
     const api = createRealtimeResourceAPI({
       baseUrl: 'https://chat.example.test/api/connect',

--- a/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roomDirectory.spec.ts
@@ -69,6 +69,21 @@ describe('createRoomDirectoryAPI', () => {
     });
   });
 
+  it('collects all directory pages with the same scope and abort signal', async () => {
+    mocks.listRooms
+      .mockResolvedValueOnce({ rooms: [{ room: { id: 'a', name: 'A' } }], page: { hasMore: true } })
+      .mockResolvedValueOnce({ rooms: [{ room: { id: 'b', name: 'B' } }], page: { hasMore: false } });
+    const api = createRoomDirectoryAPI({ baseUrl: 'https://remote.example.com/api/connect', bearerToken: null });
+    const signal = new AbortController().signal;
+    const rooms = await api.listRooms(RoomDirectoryScope.ALL, { signal });
+    expect(rooms.map((room) => room.id)).toEqual(['a', 'b']);
+    expect(mocks.listRooms.mock.calls.map(([request]) => request)).toEqual([
+      { scope: RoomDirectoryScope.ALL, page: { limit: 100, offset: 0 } },
+      { scope: RoomDirectoryScope.ALL, page: { limit: 100, offset: 1 } }
+    ]);
+    for (const [, options] of mocks.listRooms.mock.calls) expect(options.signal).toBe(signal);
+  });
+
   it('lists rooms for a scope with bearer auth and maps room state', async () => {
     mocks.listRooms.mockResolvedValue({
       rooms: [
@@ -118,7 +133,7 @@ describe('createRoomDirectoryAPI', () => {
       useBinaryFormat: true
     });
     expect(mocks.listRooms).toHaveBeenCalledWith(
-      { scope: RoomDirectoryScope.DMS },
+      { scope: RoomDirectoryScope.DMS, page: { limit: 100, offset: 0 } },
       { headers: { Authorization: 'Bearer token' }, signal }
     );
     expect(rooms).toEqual([
@@ -493,7 +508,7 @@ describe('createRoomDirectoryAPI', () => {
 
     await expect(api.listRooms(RoomDirectoryScope.CHANNELS)).rejects.toBe(err);
     expect(mocks.listRooms).toHaveBeenCalledWith(
-      { scope: RoomDirectoryScope.CHANNELS },
+      { scope: RoomDirectoryScope.CHANNELS, page: { limit: 100, offset: 0 } },
       { headers: undefined }
     );
     expect(mocks.handleAuthenticationRequired).toHaveBeenCalledWith('remote');

--- a/apps/frontend/src/lib/api-client/realtimeResources.ts
+++ b/apps/frontend/src/lib/api-client/realtimeResources.ts
@@ -1,3 +1,4 @@
+import { listAllDirectoryRooms } from './roomPages';
 import {
   authHeaders,
   createChattoClient,
@@ -11,8 +12,8 @@ import { UserService } from '@chatto/api-types/api/v1/user_service_connect';
 import { ViewerService } from '@chatto/api-types/api/v1/viewer_connect';
 import { VoiceCallService } from '@chatto/api-types/api/v1/voice_calls_connect';
 import type { DirectoryMember } from '@chatto/api-types/api/v1/member_directory_pb';
-import type {
-  ListRoomGroupsResponse,
+import {
+  type ListRoomGroupsResponse,
   ListRoomsResponse
 } from '@chatto/api-types/api/v1/room_directory_pb';
 import type { ServerPublicProfile } from '@chatto/api-types/api/v1/server_pb';
@@ -98,7 +99,10 @@ export function createRealtimeResourceAPI(config: ConnectAPIConfig) {
         return [new RealtimeResourceUpdate({ resource: { case: 'viewer', value: response } })];
       }
       case 'rooms': {
-        const response = await rooms.listRooms({}, options(minimumCursor));
+        const entries = await listAllDirectoryRooms((page) =>
+          rooms.listRooms({ page }, options(minimumCursor))
+        );
+        const response = new ListRoomsResponse({ rooms: entries });
         return [new RealtimeResourceUpdate({ resource: { case: 'rooms', value: response } })];
       }
       case 'roomGroups': {

--- a/apps/frontend/src/lib/api-client/roomDirectory.ts
+++ b/apps/frontend/src/lib/api-client/roomDirectory.ts
@@ -1,3 +1,4 @@
+import { listAllDirectoryRooms } from './roomPages';
 import {
   authHeaders,
   Code,
@@ -103,11 +104,11 @@ export function createRoomDirectoryAPI(config: RoomDirectoryAPIConfig) {
       options: { signal?: AbortSignal } = {}
     ): Promise<DirectoryRoomSummary[]> {
       try {
-        const response = await directory.listRooms(
-          { scope },
+        const rooms = await listAllDirectoryRooms((page) => directory.listRooms(
+          { scope, page },
           { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) }
-        );
-        return response.rooms.flatMap((entry) => mapDirectoryRoom(entry) ?? []);
+        ));
+        return rooms.flatMap((entry) => mapDirectoryRoom(entry) ?? []);
       } catch (err) {
         return handleAuthError(config, err);
       }

--- a/apps/frontend/src/lib/api-client/roomPages.ts
+++ b/apps/frontend/src/lib/api-client/roomPages.ts
@@ -1,0 +1,18 @@
+import type { ListRoomsResponse, RoomWithViewerState } from '@chatto/api-types/api/v1/room_directory_pb';
+
+/** Collect a complete directory before replacing local state. Pages are live reads. */
+export async function listAllDirectoryRooms(
+  readPage: (page: { limit: number; offset: number }) => Promise<ListRoomsResponse>
+): Promise<RoomWithViewerState[]> {
+  const rooms = new Map<string, RoomWithViewerState>();
+  let offset = 0;
+  for (;;) {
+    const response = await readPage({ limit: 100, offset });
+    for (const entry of response.rooms) {
+      if (entry.room?.id) rooms.set(entry.room.id, entry);
+    }
+    if (!response.page?.hasMore) return [...rooms.values()];
+    if (response.rooms.length === 0) throw new Error('Room directory returned an empty continuation page');
+    offset += response.rooms.length;
+  }
+}

--- a/cli/internal/connectapi/integration_reads_test.go
+++ b/cli/internal/connectapi/integration_reads_test.go
@@ -144,6 +144,9 @@ func TestIntegrationReadsThroughJSON(t *testing.T) {
 		body   any
 		status int
 	}{
+		{"RoomDirectoryService/ListRooms", map[string]any{"page": map[string]any{"limit": 1}}, 200},
+		{"RoomDirectoryService/ListRooms", map[string]any{"page": map[string]any{"limit": 501}}, 400},
+		{"RoomDirectoryService/ListRooms", map[string]any{"page": map[string]any{"offset": -1}}, 400},
 		{"MessageService/ListReactionUsers", map[string]any{"roomId": room.Id, "messageEventId": root.Id, "emoji": "heart"}, 200},
 		{"ThreadService/ListThreadParticipants", map[string]any{"roomId": room.Id, "threadRootEventId": root.Id}, 200},
 		{"RoomService/GetRoomReadState", map[string]any{"roomId": room.Id}, 200},

--- a/cli/internal/connectapi/room_directory.go
+++ b/cli/internal/connectapi/room_directory.go
@@ -24,18 +24,19 @@ func (s *roomDirectoryService) ListRooms(ctx context.Context, req *connect.Reque
 		return nil, connectError(err)
 	}
 
-	rooms, err := s.api.core.RoomDirectoryReads().ListRooms(ctx, caller.UserID, core.RoomDirectoryListOptions{
+	limit, offset := apiPagination(req.Msg.GetPage(), 50, 100)
+	page, err := s.api.core.RoomDirectoryReads().ListRoomsPage(ctx, caller.UserID, core.RoomDirectoryListOptions{
 		IncludeChannels: roomDirectoryScopeIncludesChannels(req.Msg.GetScope()),
 		IncludeDMs:      roomDirectoryScopeIncludesDMs(req.Msg.GetScope()),
 		IncludeEmptyDMs: true,
 		ArchiveFilter:   archiveFilter,
-	})
+	}, limit, offset)
 	if err != nil {
 		return nil, connectError(err)
 	}
 
-	apiRooms := make([]*apiv1.RoomWithViewerState, 0, len(rooms))
-	for _, room := range rooms {
+	apiRooms := make([]*apiv1.RoomWithViewerState, 0, len(page.Rooms))
+	for _, room := range page.Rooms {
 		apiRoom, err := s.api.apiRoomWithViewerState(ctx, caller.UserID, room)
 		if err != nil {
 			return nil, connectError(err)
@@ -43,7 +44,7 @@ func (s *roomDirectoryService) ListRooms(ctx context.Context, req *connect.Reque
 		apiRooms = append(apiRooms, apiRoom)
 	}
 
-	return connect.NewResponse(&apiv1.ListRoomsResponse{Rooms: apiRooms}), nil
+	return connect.NewResponse(&apiv1.ListRoomsResponse{Rooms: apiRooms, Page: apiPageInfo(page.TotalCount, page.HasMore)}), nil
 }
 
 func coreRoomArchiveFilter(filter apiv1.RoomArchiveFilter) (core.RoomArchiveFilter, error) {

--- a/cli/internal/connectapi/room_pagination_test.go
+++ b/cli/internal/connectapi/room_pagination_test.go
@@ -1,0 +1,50 @@
+package connectapi
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"connectrpc.com/connect"
+	"github.com/stretchr/testify/require"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+)
+
+func TestRoomDirectoryPagination(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	ctx := withCaller(env.ctx, env.viewer)
+	for i := 0; i < 103; i++ {
+		env.createJoinedRoom(fmt.Sprintf("paged-room-%03d", i))
+	}
+	request := func(limit, offset int32) *apiv1.ListRoomsResponse {
+		t.Helper()
+		response, err := env.directory.ListRooms(ctx, connect.NewRequest(&apiv1.ListRoomsRequest{Scope: apiv1.RoomDirectoryScope_ROOM_DIRECTORY_SCOPE_CHANNELS, Page: &apiv1.PageRequest{Limit: limit, Offset: offset}}))
+		require.NoError(t, err)
+		return response.Msg
+	}
+	first := request(0, 0)
+	require.Len(t, first.Rooms, 50)
+	require.True(t, first.Page.HasMore)
+	require.GreaterOrEqual(t, first.Page.TotalCount, int64(103))
+	capped := request(500, 0)
+	require.Len(t, capped.Rooms, 100)
+	var ids []string
+	for offset := int32(0); ; {
+		page := request(37, offset)
+		require.Equal(t, first.Page.TotalCount, page.Page.TotalCount)
+		for _, entry := range page.Rooms {
+			ids = append(ids, entry.Room.Id)
+		}
+		offset += int32(len(page.Rooms))
+		if !page.Page.HasMore {
+			break
+		}
+	}
+	require.Len(t, ids, int(first.Page.TotalCount))
+	require.True(t, slices.IsSorted(ids))
+	require.Equal(t, len(ids), len(slices.Compact(slices.Clone(ids))))
+	beyond := request(50, int32(first.Page.TotalCount)+1)
+	require.Empty(t, beyond.Rooms)
+	require.False(t, beyond.Page.HasMore)
+	require.Equal(t, first.Page.TotalCount, beyond.Page.TotalCount)
+}

--- a/cli/internal/connectapi/room_services_test.go
+++ b/cli/internal/connectapi/room_services_test.go
@@ -2773,6 +2773,9 @@ func TestRoomDirectoryServiceArchiveFilters(t *testing.T) {
 				if err != nil {
 					t.Fatalf("ListRooms: %v", err)
 				}
+				if response.Msg.GetPage().GetTotalCount() != int64(len(response.Msg.Rooms)) || response.Msg.GetPage().GetHasMore() {
+					t.Fatal("count must describe the visible, filtered result")
+				}
 				rooms := directoryRoomsByID(response.Msg.GetRooms())
 				for id, want := range map[string]bool{
 					active.Id:     filter.active && scope.channels,

--- a/cli/internal/core/room_directory_read_model.go
+++ b/cli/internal/core/room_directory_read_model.go
@@ -117,6 +117,90 @@ func (s *RoomDirectoryReadModel) ListRooms(ctx context.Context, actorID string, 
 	return rooms, nil
 }
 
+// RoomDirectoryPage contains a visible room page and its filtered count.
+type RoomDirectoryPage struct {
+	Rooms      []*DirectoryRoom
+	TotalCount int
+	HasMore    bool
+}
+
+// ListRoomsPage filters and orders room identities before hydrating the page.
+// Complete internal snapshots continue to use ListRooms.
+func (s *RoomDirectoryReadModel) ListRoomsPage(ctx context.Context, actorID string, opts RoomDirectoryListOptions, limit, offset int) (*RoomDirectoryPage, error) {
+	if err := requireAuthenticatedActor(actorID); err != nil {
+		return nil, err
+	}
+	if opts.ArchiveFilter < RoomArchiveActive || opts.ArchiveFilter > RoomArchiveAll {
+		return nil, invalidArgument("unknown room archive filter")
+	}
+	if limit <= 0 {
+		limit = 50
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var candidates []*evtv1.Room
+	if opts.IncludeChannels {
+		rooms, err := s.core.ListRooms(ctx, KindChannel)
+		if err != nil {
+			return nil, err
+		}
+		for _, room := range rooms {
+			if !opts.ArchiveFilter.matches(room.GetArchived()) {
+				continue
+			}
+			visible, err := s.core.CanSeeRoom(ctx, actorID, KindChannel, room.Id)
+			if err != nil {
+				return nil, err
+			}
+			if visible {
+				candidates = append(candidates, room)
+			}
+		}
+	}
+	if opts.IncludeDMs {
+		rooms, err := s.core.ListMemberRooms(ctx, KindDM, actorID, MemberRoomListOptions{})
+		if err != nil {
+			return nil, err
+		}
+		for _, room := range rooms {
+			if !opts.ArchiveFilter.matches(room.GetArchived()) {
+				continue
+			}
+			if !opts.IncludeEmptyDMs {
+				canAccess, err := s.core.CanAccessRoomMessages(ctx, actorID, KindDM, room.Id)
+				if err != nil {
+					return nil, err
+				}
+				if canAccess {
+					at, err := s.core.GetRoomLastMessageAt(ctx, KindDM, room.Id)
+					if err != nil {
+						return nil, err
+					}
+					if at.IsZero() {
+						continue
+					}
+				}
+			}
+			candidates = append(candidates, room)
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].Id < candidates[j].Id })
+	selected, total, more := paginateCoreSlice(candidates, limit, offset)
+	result := &RoomDirectoryPage{Rooms: make([]*DirectoryRoom, 0, len(selected)), TotalCount: total, HasMore: more}
+	for _, room := range selected {
+		entry, err := s.directoryRoom(ctx, actorID, room)
+		if err != nil {
+			return nil, err
+		}
+		result.Rooms = append(result.Rooms, entry)
+	}
+	return result, nil
+}
+
 func (s *RoomDirectoryReadModel) ListRoomGroups(ctx context.Context, actorID string, opts RoomDirectoryGroupOptions) ([]*DirectoryRoomGroup, error) {
 	if err := requireAuthenticatedActor(actorID); err != nil {
 		return nil, err

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/room_directory.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/room_directory.connect.go
@@ -59,8 +59,8 @@ type RoomDirectoryServiceClient interface {
 	// archive_filter to discover archived rooms or include both states. Channel
 	// rooms require membership or room.list. DM membership exposes room and
 	// participant metadata. Message-derived DM state also requires current
-	// read permission. Accessible empty DMs are included. Results are returned as a finite
-	// navigation snapshot.
+	// read permission. Accessible empty DMs are included. Returns up to 100 rooms
+	// ordered by ID ascending; the default page size is 50.
 	ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error)
 	// Lists ordered channel room groups and sidebar items visible to the current
 	// user as a finite navigation snapshot. Hidden room entries are omitted.
@@ -183,8 +183,8 @@ type RoomDirectoryServiceHandler interface {
 	// archive_filter to discover archived rooms or include both states. Channel
 	// rooms require membership or room.list. DM membership exposes room and
 	// participant metadata. Message-derived DM state also requires current
-	// read permission. Accessible empty DMs are included. Results are returned as a finite
-	// navigation snapshot.
+	// read permission. Accessible empty DMs are included. Returns up to 100 rooms
+	// ordered by ID ascending; the default page size is 50.
 	ListRooms(context.Context, *connect.Request[v1.ListRoomsRequest]) (*connect.Response[v1.ListRoomsResponse], error)
 	// Lists ordered channel room groups and sidebar items visible to the current
 	// user as a finite navigation snapshot. Hidden room entries are omitted.

--- a/cli/internal/pb/chatto/api/v1/room_directory.pb.go
+++ b/cli/internal/pb/chatto/api/v1/room_directory.pb.go
@@ -571,6 +571,8 @@ type ListRoomsRequest struct {
 	// Archive state to include. Defaults to ACTIVE. Combined with scope; this
 	// filter does not grant access to hidden rooms.
 	ArchiveFilter RoomArchiveFilter `protobuf:"varint,2,opt,name=archive_filter,json=archiveFilter,proto3,enum=chatto.api.v1.RoomArchiveFilter" json:"archive_filter,omitempty"`
+	// Defaults to 50 rooms, capped at 100. Rooms are ordered by ID ascending.
+	Page          *PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -619,11 +621,21 @@ func (x *ListRoomsRequest) GetArchiveFilter() RoomArchiveFilter {
 	return RoomArchiveFilter_ROOM_ARCHIVE_FILTER_UNSPECIFIED
 }
 
-// Finite snapshot of rooms visible to the current user.
+func (x *ListRoomsRequest) GetPage() *PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+// One live page of rooms visible to the current user. Changes between requests
+// can shift offsets. Follow page.has_more to read the complete directory.
 type ListRoomsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Visible rooms matching both the room-kind scope and archive filter.
-	Rooms         []*RoomWithViewerState `protobuf:"bytes,1,rep,name=rooms,proto3" json:"rooms,omitempty"`
+	Rooms []*RoomWithViewerState `protobuf:"bytes,1,rep,name=rooms,proto3" json:"rooms,omitempty"`
+	// Count after visibility, scope, and archive filters, before pagination.
+	Page          *PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -661,6 +673,13 @@ func (*ListRoomsResponse) Descriptor() ([]byte, []int) {
 func (x *ListRoomsResponse) GetRooms() []*RoomWithViewerState {
 	if x != nil {
 		return x.Rooms
+	}
+	return nil
+}
+
+func (x *ListRoomsResponse) GetPage() *PageInfo {
+	if x != nil {
+		return x.Page
 	}
 	return nil
 }
@@ -1122,7 +1141,7 @@ var File_chatto_api_v1_room_directory_proto protoreflect.FileDescriptor
 
 const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	"\n" +
-	"\"chatto/api/v1/room_directory.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fchatto/api/v1/permissions.proto\x1a\x19chatto/api/v1/rooms.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xdf\x01\n" +
+	"\"chatto/api/v1/room_directory.proto\x12\rchatto.api.v1\x1a\x1bbuf/validate/validate.proto\x1a\x1fchatto/api/v1/permissions.proto\x1a\x1echatto/api/v1/pagination.proto\x1a\x19chatto/api/v1/rooms.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xdf\x01\n" +
 	"\x0fRoomViewerState\x12\x1b\n" +
 	"\tis_member\x18\x01 \x01(\bR\bisMember\x12\x1d\n" +
 	"\n" +
@@ -1152,12 +1171,14 @@ const file_chatto_api_v1_room_directory_proto_rawDesc = "" +
 	"\x04name\x18\x02 \x01(\tR\x04name\x12 \n" +
 	"\vdescription\x18\x03 \x01(\tR\vdescription\x122\n" +
 	"\x05items\x18\x05 \x03(\v2\x1c.chatto.api.v1.RoomGroupItemR\x05items\x12F\n" +
-	"\fviewer_state\x18\x06 \x01(\v2#.chatto.api.v1.RoomGroupViewerStateR\vviewerStateJ\x04\b\x04\x10\x05R\x05rooms\"\xa8\x01\n" +
+	"\fviewer_state\x18\x06 \x01(\v2#.chatto.api.v1.RoomGroupViewerStateR\vviewerStateJ\x04\b\x04\x10\x05R\x05rooms\"\xd8\x01\n" +
 	"\x10ListRoomsRequest\x12A\n" +
 	"\x05scope\x18\x01 \x01(\x0e2!.chatto.api.v1.RoomDirectoryScopeB\b\xbaH\x05\x82\x01\x02\x10\x01R\x05scope\x12Q\n" +
-	"\x0earchive_filter\x18\x02 \x01(\x0e2 .chatto.api.v1.RoomArchiveFilterB\b\xbaH\x05\x82\x01\x02\x10\x01R\rarchiveFilter\"M\n" +
+	"\x0earchive_filter\x18\x02 \x01(\x0e2 .chatto.api.v1.RoomArchiveFilterB\b\xbaH\x05\x82\x01\x02\x10\x01R\rarchiveFilter\x12.\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\"z\n" +
 	"\x11ListRoomsResponse\x128\n" +
-	"\x05rooms\x18\x01 \x03(\v2\".chatto.api.v1.RoomWithViewerStateR\x05rooms\"5\n" +
+	"\x05rooms\x18\x01 \x03(\v2\".chatto.api.v1.RoomWithViewerStateR\x05rooms\x12+\n" +
+	"\x04page\x18\x02 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\"5\n" +
 	"\x15ListRoomGroupsRequestJ\x04\b\x01\x10\x02R\x16include_archived_rooms\"J\n" +
 	"\x16ListRoomGroupsResponse\x120\n" +
 	"\x06groups\x18\x01 \x03(\v2\x18.chatto.api.v1.RoomGroupR\x06groups\"W\n" +
@@ -1236,6 +1257,8 @@ var file_chatto_api_v1_room_directory_proto_goTypes = []any{
 	(*PermissionGrant)(nil),            // 20: chatto.api.v1.PermissionGrant
 	(*timestamppb.Timestamp)(nil),      // 21: google.protobuf.Timestamp
 	(*Room)(nil),                       // 22: chatto.api.v1.Room
+	(*PageRequest)(nil),                // 23: chatto.api.v1.PageRequest
+	(*PageInfo)(nil),                   // 24: chatto.api.v1.PageInfo
 }
 var file_chatto_api_v1_room_directory_proto_depIdxs = []int32{
 	20, // 0: chatto.api.v1.RoomViewerState.permissions:type_name -> chatto.api.v1.PermissionGrant
@@ -1249,29 +1272,31 @@ var file_chatto_api_v1_room_directory_proto_depIdxs = []int32{
 	6,  // 8: chatto.api.v1.RoomGroup.viewer_state:type_name -> chatto.api.v1.RoomGroupViewerState
 	0,  // 9: chatto.api.v1.ListRoomsRequest.scope:type_name -> chatto.api.v1.RoomDirectoryScope
 	1,  // 10: chatto.api.v1.ListRoomsRequest.archive_filter:type_name -> chatto.api.v1.RoomArchiveFilter
-	3,  // 11: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
-	7,  // 12: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	7,  // 13: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
-	7,  // 14: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
-	3,  // 15: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.RoomWithViewerState
-	3,  // 16: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
-	8,  // 17: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
-	10, // 18: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
-	12, // 19: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
-	14, // 20: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
-	16, // 21: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
-	18, // 22: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
-	9,  // 23: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
-	11, // 24: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
-	13, // 25: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
-	15, // 26: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
-	17, // 27: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
-	19, // 28: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
-	23, // [23:29] is the sub-list for method output_type
-	17, // [17:23] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	23, // 11: chatto.api.v1.ListRoomsRequest.page:type_name -> chatto.api.v1.PageRequest
+	3,  // 12: chatto.api.v1.ListRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
+	24, // 13: chatto.api.v1.ListRoomsResponse.page:type_name -> chatto.api.v1.PageInfo
+	7,  // 14: chatto.api.v1.ListRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	7,  // 15: chatto.api.v1.GetRoomGroupResponse.group:type_name -> chatto.api.v1.RoomGroup
+	7,  // 16: chatto.api.v1.BatchGetRoomGroupsResponse.groups:type_name -> chatto.api.v1.RoomGroup
+	3,  // 17: chatto.api.v1.GetRoomResponse.room:type_name -> chatto.api.v1.RoomWithViewerState
+	3,  // 18: chatto.api.v1.BatchGetRoomsResponse.rooms:type_name -> chatto.api.v1.RoomWithViewerState
+	8,  // 19: chatto.api.v1.RoomDirectoryService.ListRooms:input_type -> chatto.api.v1.ListRoomsRequest
+	10, // 20: chatto.api.v1.RoomDirectoryService.ListRoomGroups:input_type -> chatto.api.v1.ListRoomGroupsRequest
+	12, // 21: chatto.api.v1.RoomDirectoryService.GetRoomGroup:input_type -> chatto.api.v1.GetRoomGroupRequest
+	14, // 22: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:input_type -> chatto.api.v1.BatchGetRoomGroupsRequest
+	16, // 23: chatto.api.v1.RoomDirectoryService.GetRoom:input_type -> chatto.api.v1.GetRoomRequest
+	18, // 24: chatto.api.v1.RoomDirectoryService.BatchGetRooms:input_type -> chatto.api.v1.BatchGetRoomsRequest
+	9,  // 25: chatto.api.v1.RoomDirectoryService.ListRooms:output_type -> chatto.api.v1.ListRoomsResponse
+	11, // 26: chatto.api.v1.RoomDirectoryService.ListRoomGroups:output_type -> chatto.api.v1.ListRoomGroupsResponse
+	13, // 27: chatto.api.v1.RoomDirectoryService.GetRoomGroup:output_type -> chatto.api.v1.GetRoomGroupResponse
+	15, // 28: chatto.api.v1.RoomDirectoryService.BatchGetRoomGroups:output_type -> chatto.api.v1.BatchGetRoomGroupsResponse
+	17, // 29: chatto.api.v1.RoomDirectoryService.GetRoom:output_type -> chatto.api.v1.GetRoomResponse
+	19, // 30: chatto.api.v1.RoomDirectoryService.BatchGetRooms:output_type -> chatto.api.v1.BatchGetRoomsResponse
+	25, // [25:31] is the sub-list for method output_type
+	19, // [19:25] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_chatto_api_v1_room_directory_proto_init() }
@@ -1280,6 +1305,7 @@ func file_chatto_api_v1_room_directory_proto_init() {
 		return
 	}
 	file_chatto_api_v1_permissions_proto_init()
+	file_chatto_api_v1_pagination_proto_init()
 	file_chatto_api_v1_rooms_proto_init()
 	file_chatto_api_v1_room_directory_proto_msgTypes[1].OneofWrappers = []any{}
 	file_chatto_api_v1_room_directory_proto_msgTypes[3].OneofWrappers = []any{

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -111,7 +111,8 @@ or either human owner.
 `RoomDirectoryService.ListRooms` intersects the room-kind scope with an archive
 filter. The default returns active rooms; callers can select archived rooms or
 both states. The read uses the existing room catalog, visibility checks, and
-canonical room response. Archive discovery does not change membership or
+canonical room response. It filters room identities before pagination, orders
+them by ID, and hydrates viewer state only for the selected page. Archive discovery does not change membership or
 permissions. Room-group and realtime navigation snapshots keep their default
 active-room scope.
 

--- a/docs/fdr/FDR-019-room-lifecycle.md
+++ b/docs/fdr/FDR-019-room-lifecycle.md
@@ -1,7 +1,7 @@
 # FDR-019: Room Lifecycle
 
 **Status:** Active
-**Last reviewed:** 2026-09-09
+**Last reviewed:** 2026-09-10
 
 ## Overview
 
@@ -59,8 +59,10 @@ archive and unarchive facts change it. The room keeps its event history and
 members; active-room discovery filters on `archived: false`.
 `RoomDirectoryService.ListRooms` accepts an explicit archive filter for clients
 that need the archive. The room-kind scope and archive filter both apply.
-The list retains its complete navigation-snapshot response; it does not
-introduce a page limit that would truncate existing callers' room lists.
+Integrations read the directory in bounded pages, ordered by room ID. Counts
+include only visible rooms that match the filters. Clients that need a complete
+list collect all pages before replacing local state. Ordered room groups and
+realtime navigation snapshots remain complete.
 **Why:** Archive's purpose is "stop showing this room everywhere, but don't lose the history". A full archived-rooms-elsewhere migration would mean different code paths for archived rooms, divergent reads, and a hard road back to active state. A flag is enough.
 **Tradeoff:** Every "show me rooms" query needs to remember to filter on `archived`. Centralised in the resolver layer.
 

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -28,7 +28,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 | [FDR-016](FDR-016-voice-calls.md) | Voice Calls | Active | 2026-08-20 |
 | [FDR-017](FDR-017-room-groups-and-sidebar-layout.md) | Room Groups & Sidebar Layout | Active | 2026-08-29 |
 | [FDR-018](FDR-018-account-lifecycle.md) | Account Lifecycle | Active | 2026-08-28 |
-| [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-09-09 |
+| [FDR-019](FDR-019-room-lifecycle.md) | Room Lifecycle | Active | 2026-09-10 |
 | [FDR-020](FDR-020-server-branding-and-configuration.md) | Server Branding & Configuration | Active | 2026-08-30 |
 | [FDR-021](FDR-021-admin-dashboard.md) | Admin Dashboard & System Monitoring | Active | 2026-08-27 |
 | [FDR-022](FDR-022-user-profile.md) | User Profile | Active | 2026-09-09 |

--- a/packages/api-types/src/chatto/api/v1/room_directory_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/room_directory_connect.ts
@@ -19,8 +19,8 @@ export const RoomDirectoryService = {
      * archive_filter to discover archived rooms or include both states. Channel
      * rooms require membership or room.list. DM membership exposes room and
      * participant metadata. Message-derived DM state also requires current
-     * read permission. Accessible empty DMs are included. Results are returned as a finite
-     * navigation snapshot.
+     * read permission. Accessible empty DMs are included. Returns up to 100 rooms
+     * ordered by ID ascending; the default page size is 50.
      *
      * @generated from rpc chatto.api.v1.RoomDirectoryService.ListRooms
      */

--- a/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
+++ b/packages/api-types/src/chatto/api/v1/room_directory_pb.ts
@@ -7,6 +7,7 @@ import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialM
 import { Message, proto3, Timestamp } from "@bufbuild/protobuf";
 import { PermissionGrant } from "./permissions_pb.js";
 import { Room } from "./rooms_pb.js";
+import { PageInfo, PageRequest } from "./pagination_pb.js";
 
 /**
  * Room kinds to include in directory responses.
@@ -473,6 +474,13 @@ export class ListRoomsRequest extends Message<ListRoomsRequest> {
    */
   archiveFilter = RoomArchiveFilter.UNSPECIFIED;
 
+  /**
+   * Defaults to 50 rooms, capped at 100. Rooms are ordered by ID ascending.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 3;
+   */
+  page?: PageRequest;
+
   constructor(data?: PartialMessage<ListRoomsRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -483,6 +491,7 @@ export class ListRoomsRequest extends Message<ListRoomsRequest> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "scope", kind: "enum", T: proto3.getEnumType(RoomDirectoryScope) },
     { no: 2, name: "archive_filter", kind: "enum", T: proto3.getEnumType(RoomArchiveFilter) },
+    { no: 3, name: "page", kind: "message", T: PageRequest },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListRoomsRequest {
@@ -503,7 +512,8 @@ export class ListRoomsRequest extends Message<ListRoomsRequest> {
 }
 
 /**
- * Finite snapshot of rooms visible to the current user.
+ * One live page of rooms visible to the current user. Changes between requests
+ * can shift offsets. Follow page.has_more to read the complete directory.
  *
  * @generated from message chatto.api.v1.ListRoomsResponse
  */
@@ -515,6 +525,13 @@ export class ListRoomsResponse extends Message<ListRoomsResponse> {
    */
   rooms: RoomWithViewerState[] = [];
 
+  /**
+   * Count after visibility, scope, and archive filters, before pagination.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 2;
+   */
+  page?: PageInfo;
+
   constructor(data?: PartialMessage<ListRoomsResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -524,6 +541,7 @@ export class ListRoomsResponse extends Message<ListRoomsResponse> {
   static readonly typeName = "chatto.api.v1.ListRoomsResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "rooms", kind: "message", T: RoomWithViewerState, repeated: true },
+    { no: 2, name: "page", kind: "message", T: PageInfo },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListRoomsResponse {

--- a/proto/chatto/api/v1/room_directory.proto
+++ b/proto/chatto/api/v1/room_directory.proto
@@ -4,6 +4,7 @@ package chatto.api.v1;
 
 import "buf/validate/validate.proto";
 import "chatto/api/v1/permissions.proto";
+import "chatto/api/v1/pagination.proto";
 import "chatto/api/v1/rooms.proto";
 import "google/protobuf/timestamp.proto";
 
@@ -114,12 +115,17 @@ message ListRoomsRequest {
   // Archive state to include. Defaults to ACTIVE. Combined with scope; this
   // filter does not grant access to hidden rooms.
   RoomArchiveFilter archive_filter = 2 [(buf.validate.field).enum.defined_only = true];
+  // Defaults to 50 rooms, capped at 100. Rooms are ordered by ID ascending.
+  PageRequest page = 3;
 }
 
-// Finite snapshot of rooms visible to the current user.
+// One live page of rooms visible to the current user. Changes between requests
+// can shift offsets. Follow page.has_more to read the complete directory.
 message ListRoomsResponse {
   // Visible rooms matching both the room-kind scope and archive filter.
   repeated RoomWithViewerState rooms = 1;
+  // Count after visibility, scope, and archive filters, before pagination.
+  PageInfo page = 2;
 }
 
 // Request for ordered room groups visible to the current user.
@@ -208,8 +214,8 @@ service RoomDirectoryService {
   // archive_filter to discover archived rooms or include both states. Channel
   // rooms require membership or room.list. DM membership exposes room and
   // participant metadata. Message-derived DM state also requires current
-  // read permission. Accessible empty DMs are included. Results are returned as a finite
-  // navigation snapshot.
+  // read permission. Accessible empty DMs are included. Returns up to 100 rooms
+  // ordered by ID ascending; the default page size is 50.
   rpc ListRooms(ListRoomsRequest) returns (ListRoomsResponse);
   // Lists ordered channel room groups and sidebar items visible to the current
   // user as a finite navigation snapshot. Hidden room entries are omitted.


### PR DESCRIPTION
- **What:** Paginate `RoomDirectoryService.ListRooms` with shared `PageRequest`/`PageInfo`: default 50, maximum 100, ordered by room ID. Apply visibility, scope, and archive filters before counting and paging; hydrate detailed viewer state only for selected rooms.
- **Why:** Integrations can browse a bounded directory instead of downloading every room. Both bundled-client callers collect all pages before replacing state, preserve cancellation/cursor options, and propagate later-page failures. Room-group and realtime snapshots retain their complete navigation behavior.
- **Migration:** This is a behavioral breaking API change. Clients must follow `page.hasMore` and advance the request offset by the number of returned rooms. Pages are live reads, so concurrent changes can shift offsets. No persisted schema change or data migration.
- **Verified:** 103-room limit/order/pagination regression, filtered counts and visibility tests, JSON validation, full ConnectAPI/HTTP server suites, core directory tests, 195 frontend API-client tests, clean Svelte/type check, Buf lint/public and storage compatibility, generated API-types build, docs build, license and whitespace checks. No manual browser test; no UI components changed.
- **Docs:** Updated the integration and compatibility guides, 0.5 release notes, FDR-019, architecture interfaces, and generated API reference.
