### PR TITLE
feat(api)!: paginate explicit role members

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -74,6 +74,16 @@ when `has_message_history` is explicitly false. A new client connected to an
 older server sees no empty DM rows, and it must treat an absent history value
 on a returned DM as unknown rather than false.
 
+Chatto 0.5 removes `AdminRoleService.GetRoleResponse.users`. Read explicit
+assignments through `AdminRoleService.ListMembers` instead. It returns canonical
+`User` records in `members`, with `PageInfo` in `page`. Pass `name` and a
+`PageRequest`; the default is 20 members and the maximum is 100. Results use
+ascending user ID order. Advance the offset until `page.hasMore` is false;
+concurrent assignment changes can shift offsets. The implicit `everyone` role
+returns an empty page. Each request requires `role.assign`, without
+`admin.view-users`. Older clients must migrate their roster reads; clients that
+use the new RPC need the updated server. Stored data is unchanged.
+
 Chatto 0.5 adds `archive_filter` to `RoomDirectoryService.ListRooms`. Omit it or
 select `ROOM_ARCHIVE_FILTER_ACTIVE` to keep the active-room list. Select
 `ROOM_ARCHIVE_FILTER_ARCHIVED` for the archive or `ROOM_ARCHIVE_FILTER_ALL` for

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-roles.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-roles.mdx
@@ -58,8 +58,7 @@ Finite role catalog snapshot plus viewer role-management capabilities.
 ### GetRole
 
 Gets one role plus admin detail metadata. Returns NOT_FOUND when the
-role does not exist. Requires an authenticated user; the assigned-user
-roster is empty unless the caller may assign roles.
+role does not exist. Requires an authenticated user.
 
 ```http
 POST /api/connect/chatto.admin.v1.AdminRoleService/GetRole
@@ -85,9 +84,45 @@ One role plus role-management metadata.
 | Field | Type | Description |
 | --- | --- | --- |
 | `role` | [`AdminRole`](/reference/connectrpc-api/types/#chatto-admin-v1-AdminRole) | Requested role. |
-| `users` | `repeated chatto.api.v1.User` | Explicit users with this role. Empty unless the caller may assign roles. |
 | `viewer_can_manage_roles` | `bool` | Whether the caller may create/update/delete role definitions. |
 | `viewer_can_assign_roles` | `bool` | Whether the caller may assign/revoke roles and view role rosters. |
+
+
+<a id="chatto-admin-v1-AdminRoleService-ListMembers"></a>
+
+### ListMembers
+
+Lists explicit role members. Requires role.assign, without requiring
+admin.view-users. Returns NOT_FOUND when the role does not exist.
+
+```http
+POST /api/connect/chatto.admin.v1.AdminRoleService/ListMembers
+```
+
+<a id="chatto-admin-v1-AdminRoleServiceListMembersRequest"></a>
+
+#### Input: AdminRoleServiceListMembersRequest
+
+Request a page of explicit role members.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Stable role name. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Defaults to 20 members; capped at 100. Offset counts explicit assignments. |
+
+
+<a id="chatto-admin-v1-AdminRoleServiceListMembersResponse"></a>
+
+#### Result: AdminRoleServiceListMembersResponse
+
+Explicit members sorted by user ID. Each page is a live read; assignment
+changes between requests can shift offsets. The implicit everyone role has
+no explicit members. Revoked assignments are excluded.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `members` | `repeated chatto.api.v1.User` | Canonical public user records for the selected assignments. |
+| `page` | [`chatto.api.v1.PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Total explicit assignment count and whether another page exists. |
 
 
 <a id="chatto-admin-v1-AdminRoleService-CreateRole"></a>

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -436,6 +436,11 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   omitted expiry means no expiry. See the
   [migration guide](/guides/integrations/api-compatibility/#resource-updates-in-05).
 
+- **API migration:** Role details no longer embed all assigned users. Replace
+  reads of `AdminRoleService.GetRoleResponse.users` with paginated
+  `AdminRoleService.ListMembers` calls. The default page contains 20 users;
+  the maximum is 100. The existing `role.assign` permission still controls
+  roster access. See [API Compatibility](/guides/integrations/api-compatibility/).
 - **API migration:** `RoomDirectoryService.ListRooms` now returns pages of 50
   rooms by default, capped at 100, ordered by room ID. Follow `page.hasMore`
   and advance the request offset to read the full directory. The bundled client

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -341,8 +341,7 @@ Finite role catalog snapshot plus viewer role-management capabilities.
 ### GetRole
 
 Gets one role plus admin detail metadata. Returns NOT_FOUND when the
-role does not exist. Requires an authenticated user; the assigned-user
-roster is empty unless the caller may assign roles.
+role does not exist. Requires an authenticated user.
 
 ```http
 POST /api/connect/chatto.admin.v1.AdminRoleService/GetRole
@@ -368,9 +367,45 @@ One role plus role-management metadata.
 | Field | Type | Description |
 | --- | --- | --- |
 | `role` | [`AdminRole`](#chatto-admin-v1-AdminRole) | Requested role. |
-| `users` | `repeated chatto.api.v1.User` | Explicit users with this role. Empty unless the caller may assign roles. |
 | `viewer_can_manage_roles` | `bool` | Whether the caller may create/update/delete role definitions. |
 | `viewer_can_assign_roles` | `bool` | Whether the caller may assign/revoke roles and view role rosters. |
+
+
+<a id="chatto-admin-v1-AdminRoleService-ListMembers"></a>
+
+### ListMembers
+
+Lists explicit role members. Requires role.assign, without requiring
+admin.view-users. Returns NOT_FOUND when the role does not exist.
+
+```http
+POST /api/connect/chatto.admin.v1.AdminRoleService/ListMembers
+```
+
+<a id="chatto-admin-v1-AdminRoleServiceListMembersRequest"></a>
+
+#### Input: AdminRoleServiceListMembersRequest
+
+Request a page of explicit role members.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `name` | `string` | Stable role name. |
+| `page` | `chatto.api.v1.PageRequest` | Defaults to 20 members; capped at 100. Offset counts explicit assignments. |
+
+
+<a id="chatto-admin-v1-AdminRoleServiceListMembersResponse"></a>
+
+#### Result: AdminRoleServiceListMembersResponse
+
+Explicit members sorted by user ID. Each page is a live read; assignment
+changes between requests can shift offsets. The implicit everyone role has
+no explicit members. Revoked assignments are excluded.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `members` | `repeated chatto.api.v1.User` | Canonical public user records for the selected assignments. |
+| `page` | `chatto.api.v1.PageInfo` | Total explicit assignment count and whether another page exists. |
 
 
 <a id="chatto-admin-v1-AdminRoleService-CreateRole"></a>

--- a/apps/frontend/e2e/server-roles.test.ts
+++ b/apps/frontend/e2e/server-roles.test.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 import { test } from './setup';
+import { AdminRoleServiceListMembersRequest } from '@chatto/api-types/admin/v1/roles_pb';
 import {
   activatePrivilegedMode,
   createAndLoginTestUser,
@@ -137,6 +138,45 @@ async function denyPermission(
 }
 
 test.describe('Server Roles Management', () => {
+  test('role member roster loads the next page when scrolled', async ({ serverRolesPage }) => {
+    const { page } = serverRolesPage;
+    const server = await usePrimaryServerViaAPI(page);
+    const roleName = generateRoleName('roster');
+    await connectPost(page, 'chatto.admin.v1.AdminRoleService/CreateRole', {
+      name: roleName, displayName: 'Paged roster'
+    });
+    for (let i = 0; i < 21; i++) {
+      const user = await createSecondTestUser(page);
+      await connectPost(page, 'chatto.admin.v1.AdminUserService/AssignRole', {
+        userId: user.id!, roleName
+      });
+    }
+    const memberRequests: number[] = [];
+    const errors: string[] = [];
+    page.on('pageerror', error => errors.push(error.message));
+    page.on('request', request => {
+      if (request.url().endsWith('/chatto.admin.v1.AdminRoleService/ListMembers')) {
+        const body = request.postDataBuffer();
+        if (body) memberRequests.push(AdminRoleServiceListMembersRequest.fromBinary(body).page?.offset ?? 0);
+      }
+    });
+    await serverRolesPage.gotoEditRole(server.id, roleName);
+    const rosterHeading = page.getByRole('heading', { name: 'Users with this Role' });
+    await rosterHeading.scrollIntoViewIfNeeded();
+    // Real wheel interaction reaches the trailing table sentinel.
+    await rosterHeading.hover();
+    await page.mouse.wheel(0, 3000);
+    await page.getByText('Showing 20 of 21 member(s)', { exact: true }).or(page.getByText('Showing 21 of 21 member(s)', { exact: true })).waitFor();
+    const table = page.locator('table').last();
+    await table.hover();
+    await page.mouse.wheel(0, 3000);
+    await expect(page.getByText('Showing 21 of 21 member(s)', { exact: true })).toBeVisible();
+    await expect(table.locator('tbody tr')).toHaveCount(21);
+    expect(memberRequests).toContain(0);
+    expect(memberRequests).toContain(20);
+    expect(errors).toEqual([]);
+  });
+
   test.describe('Roles List Page', () => {
     test('server admin can view roles list', async ({ serverRolesPage }) => {
       const { page } = serverRolesPage;

--- a/apps/frontend/src/lib/api-client-tests/roles.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/roles.spec.ts
@@ -9,6 +9,7 @@ const mocks = vi.hoisted(() => ({
   batchGetRoles: vi.fn(),
   listAdminRoles: vi.fn(),
   getRole: vi.fn(),
+  listMembers: vi.fn(),
   createRole: vi.fn(),
   updateRole: vi.fn(),
   deleteRole: vi.fn()
@@ -35,6 +36,7 @@ describe('createRoleAPI', () => {
     mocks.batchGetRoles.mockReset();
     mocks.listAdminRoles.mockReset();
     mocks.getRole.mockReset();
+    mocks.listMembers.mockReset();
     mocks.createRole.mockReset();
     mocks.updateRole.mockReset();
     mocks.deleteRole.mockReset();
@@ -50,6 +52,7 @@ describe('createRoleAPI', () => {
       return {
         listRoles: mocks.listAdminRoles,
         getRole: mocks.getRole,
+        listMembers: mocks.listMembers,
         createRole: mocks.createRole,
         updateRole: mocks.updateRole,
         deleteRole: mocks.deleteRole
@@ -173,7 +176,7 @@ describe('createRoleAPI', () => {
     });
   });
 
-  it('gets a role with users and no auth headers when no token is available', async () => {
+  it('gets role metadata and no auth headers when no token is available', async () => {
     mocks.getRole.mockResolvedValue({
       role: {
         role: {
@@ -187,7 +190,6 @@ describe('createRoleAPI', () => {
         permissions: [],
         permissionDenials: []
       },
-      users: [{ id: 'user-1', login: 'alice', displayName: 'Alice' }],
       viewerCanManageRoles: true,
       viewerCanAssignRoles: true
     });
@@ -212,10 +214,22 @@ describe('createRoleAPI', () => {
         position: 10,
         pingable: false
       },
-      users: [{ id: 'user-1', login: 'alice', displayName: 'Alice' }],
       viewerCanManageRoles: true,
       viewerCanAssignRoles: true
     });
+  });
+
+  it('loads an explicit role member page with authentication and cancellation', async () => {
+    const user = { id: 'user-1', login: 'alice', displayName: 'Alice', isBot: true };
+    mocks.listMembers.mockResolvedValue({ members: [user], page: { totalCount: 31n, hasMore: true } });
+    const api = createRoleAPI({ baseUrl: '/api/connect', bearerToken: 'token' });
+    const signal = new AbortController().signal;
+    expect(await api.listMembers('helpdesk', { limit: 20, offset: 20 }, { signal }))
+      .toEqual({ users: [user], totalCount: 31, hasMore: true });
+    expect(mocks.listMembers).toHaveBeenCalledWith(
+      { name: 'helpdesk', page: { limit: 20, offset: 20 } },
+      { headers: { Authorization: 'Bearer token' }, signal }
+    );
   });
 
   it('creates updates and deletes roles with auth headers', async () => {

--- a/apps/frontend/src/lib/api-client/roles.ts
+++ b/apps/frontend/src/lib/api-client/roles.ts
@@ -32,6 +32,7 @@ export type RoleUser = {
   id: string;
   login: string;
   displayName: string;
+  isBot: boolean;
 };
 
 export type RoleCatalog = {
@@ -42,7 +43,12 @@ export type RoleCatalog = {
 
 export type RoleDetails = RoleCatalog & {
   role: ServerRole | null;
+};
+
+export type RoleMemberPage = {
   users: RoleUser[];
+  totalCount: number;
+  hasMore: boolean;
 };
 
 export type CreateRoleInput = {
@@ -117,9 +123,24 @@ export function createRoleAPI(config: RoleAPIConfig) {
       return {
         roles: [],
         role: response.role ? serverRoleFromAdmin(response.role) : null,
-        users: response.users.map(roleUser),
         viewerCanManageRoles: response.viewerCanManageRoles,
         viewerCanAssignRoles: response.viewerCanAssignRoles,
+      };
+    },
+
+    async listMembers(
+      name: string,
+      page: { limit: number; offset: number },
+      options: { signal?: AbortSignal } = {},
+    ): Promise<RoleMemberPage> {
+      const response = await adminClient.listMembers(
+        { name, page },
+        { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) },
+      );
+      return {
+        users: response.members.map(roleUser),
+        totalCount: Number(response.page?.totalCount ?? 0),
+        hasMore: response.page?.hasMore ?? false,
       };
     },
 
@@ -192,5 +213,6 @@ function roleUser(user: APIUser): RoleUser {
     id: user.id,
     login: user.login,
     displayName: user.displayName,
+    isBot: user.isBot,
   };
 }

--- a/apps/frontend/src/lib/components/admin/UserList.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/UserList.stories.svelte
@@ -2,7 +2,11 @@
   import { defineMeta } from '@storybook/addon-svelte-csf';
   import UserList from './UserList.svelte';
 
-  const { Story } = defineMeta({ title: 'Admin/UserList', component: UserList, tags: ['autodocs'] });
+  const { Story } = defineMeta({
+    title: 'Admin/UserList',
+    component: UserList,
+    tags: ['autodocs']
+  });
 </script>
 
 <script lang="ts">
@@ -12,8 +16,10 @@
   import Panel from '$lib/ui/Panel.svelte';
 
   provideServerScope({
-    serverId: 'storybook', connection: {} as ServerConnection,
-    store: {} as ServerStateStore, isCurrent: () => true
+    serverId: 'storybook',
+    connection: {} as ServerConnection,
+    store: {} as ServerStateStore,
+    isCurrent: () => true
   });
   const users = [
     { id: 'user-1', login: 'alex', displayName: 'Alex' },

--- a/apps/frontend/src/lib/components/admin/UserList.stories.svelte
+++ b/apps/frontend/src/lib/components/admin/UserList.stories.svelte
@@ -1,0 +1,34 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import UserList from './UserList.svelte';
+
+  const { Story } = defineMeta({ title: 'Admin/UserList', component: UserList, tags: ['autodocs'] });
+</script>
+
+<script lang="ts">
+  import { provideServerScope } from '$lib/state/server/scope.svelte';
+  import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
+  import type { ServerStateStore } from '$lib/state/server/store.svelte';
+  import Panel from '$lib/ui/Panel.svelte';
+
+  provideServerScope({
+    serverId: 'storybook', connection: {} as ServerConnection,
+    store: {} as ServerStateStore, isCurrent: () => true
+  });
+  const users = [
+    { id: 'user-1', login: 'alex', displayName: 'Alex' },
+    { id: 'user-2', login: 'sam', displayName: 'Sam' }
+  ];
+</script>
+
+<Story name="Partial page" asChild>
+  <Panel title="Role members" noPadding>
+    <UserList {users} totalCount={45} hasMore loadingMore clickable={false} />
+  </Panel>
+</Story>
+
+<Story name="Complete list" asChild>
+  <Panel title="Role members" noPadding>
+    <UserList {users} clickable={false} />
+  </Panel>
+</Story>

--- a/apps/frontend/src/lib/components/admin/UserList.svelte
+++ b/apps/frontend/src/lib/components/admin/UserList.svelte
@@ -100,5 +100,7 @@ and supplies an optional row-navigation callback.
     {/snippet}
   </DataTable>
 
-  <div class="px-5 py-3 text-sm text-muted">{m('admin.members.showing', { shown: users.length, total: totalCount })}</div>
+  <div class="px-5 py-3 text-sm text-muted">
+    {m('admin.members.showing', { shown: users.length, total: totalCount })}
+  </div>
 {/if}

--- a/apps/frontend/src/lib/components/admin/UserList.svelte
+++ b/apps/frontend/src/lib/components/admin/UserList.svelte
@@ -26,13 +26,24 @@ and supplies an optional row-navigation callback.
     loading = false,
     clickable = true,
     emptyMessage = m('admin.users.empty'),
-    onUserClick
+    onUserClick,
+    totalCount = users.length,
+    hasMore = false,
+    loadingMore = false,
+    onLoadMore,
+    loadMoreRoot
   }: {
     users: User[];
     loading?: boolean;
     clickable?: boolean;
     emptyMessage?: string;
     onUserClick?: (user: User) => void;
+    /** Total matching users, including pages not yet loaded. */
+    totalCount?: number;
+    hasMore?: boolean;
+    loadingMore?: boolean;
+    onLoadMore?: () => void | Promise<void>;
+    loadMoreRoot?: HTMLElement;
   } = $props();
 
   const serverScope = useServerScope();
@@ -59,6 +70,10 @@ and supplies an optional row-navigation callback.
     items={users}
     columns={4}
     {emptyMessage}
+    {hasMore}
+    {loadingMore}
+    {onLoadMore}
+    {loadMoreRoot}
     onRowClick={clickable ? handleRowClick : undefined}
   >
     {#snippet header()}
@@ -85,5 +100,5 @@ and supplies an optional row-navigation callback.
     {/snippet}
   </DataTable>
 
-  <div class="px-5 py-3 text-sm text-muted">{m('admin.users.total', { count: users.length })}</div>
+  <div class="px-5 py-3 text-sm text-muted">{m('admin.members.showing', { shown: users.length, total: totalCount })}</div>
 {/if}

--- a/apps/frontend/src/lib/query/admin.ts
+++ b/apps/frontend/src/lib/query/admin.ts
@@ -55,6 +55,9 @@ export const adminQueryKeys = {
   userPermissions(serverId: string, connection: AdminQueryConnection, userId: string) {
     return [...userPermissionsRoot(serverId, connection), userId] as const;
   },
+  roleMembers(serverId: string, connection: AdminQueryConnection, roleName: string) {
+    return [...adminRoot(serverId, connection), 'role-members', roleName] as const;
+  },
   roleCatalog(serverId: string, connection: AdminQueryConnection) {
     return [...adminRoot(serverId, connection), 'roles'] as const;
   },

--- a/apps/frontend/src/lib/query/adminInvalidation.spec.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.spec.ts
@@ -15,6 +15,7 @@ const serverId = 'server-1';
 const tierKey = adminQueryKeys.permissionTiers(serverId, connection);
 const catalogKey = adminQueryKeys.roleCatalog(serverId, connection);
 const roleKey = adminQueryKeys.rolePermissions(serverId, connection, 'moderator');
+const membersKey = adminQueryKeys.roleMembers(serverId, connection, 'moderator');
 const roleDetailsKey = adminQueryKeys.role(serverId, connection, 'moderator');
 const userKey = adminQueryKeys.userPermissions(serverId, connection, 'user-1');
 const roomKey = adminQueryKeys.room(serverId, connection, 'room-1');
@@ -28,6 +29,7 @@ beforeEach(() => {
   queryClient.setQueryData(catalogKey, { roles: [] });
   queryClient.setQueryData(roleKey, { roleName: 'moderator' });
   queryClient.setQueryData(roleDetailsKey, { role: { name: 'moderator' } });
+  queryClient.setQueryData(membersKey, { pages: [{ users: [{ id: 'user-1' }] }], pageParams: [0] });
   queryClient.setQueryData(userKey, { userId: 'user-1' });
   queryClient.setQueryData(roomKey, { id: 'room-1', name: 'general' });
   queryClient.setQueryData(groupKey, { group: { id: 'group-1', name: 'Lobby' } });
@@ -80,6 +82,7 @@ describe('admin role query invalidation', () => {
 
     expect(queryClient.getQueryData(roleKey)).toBeUndefined();
     expect(queryClient.getQueryData(roleDetailsKey)).toBeUndefined();
+    expect(queryClient.getQueryData(membersKey)).toBeUndefined();
     expect(queryClient.getQueryState(tierKey)?.isInvalidated).toBe(true);
     expect(queryClient.getQueryState(userKey)?.isInvalidated).toBe(true);
   });

--- a/apps/frontend/src/lib/query/adminInvalidation.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.ts
@@ -52,6 +52,10 @@ export function removeDeletedRoleQueries(
   queryClient.setQueryData(roleDetailsKey, null);
   queryClient.removeQueries({ queryKey: roleKey, exact: true });
   queryClient.removeQueries({ queryKey: roleDetailsKey, exact: true });
+  const membersKey = adminQueryKeys.roleMembers(serverId, connection, roleName);
+  void queryClient.cancelQueries({ queryKey: membersKey, exact: true });
+  queryClient.resetQueries({ queryKey: membersKey, exact: true });
+  queryClient.removeQueries({ queryKey: membersKey, exact: true });
   invalidateRolePermissionDependents(serverId, connection, roleName);
 }
 

--- a/apps/frontend/src/lib/query/adminInvalidation.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.ts
@@ -54,7 +54,7 @@ export function removeDeletedRoleQueries(
   queryClient.removeQueries({ queryKey: roleDetailsKey, exact: true });
   const membersKey = adminQueryKeys.roleMembers(serverId, connection, roleName);
   void queryClient.cancelQueries({ queryKey: membersKey, exact: true });
-  queryClient.resetQueries({ queryKey: membersKey, exact: true });
+  queryClient.setQueryData(membersKey, null);
   queryClient.removeQueries({ queryKey: membersKey, exact: true });
   invalidateRolePermissionDependents(serverId, connection, roleName);
 }

--- a/apps/frontend/src/lib/query/client.spec.ts
+++ b/apps/frontend/src/lib/query/client.spec.ts
@@ -113,12 +113,22 @@ describe('server query cache', () => {
       ],
       pageParams: [0]
     });
-    queryClient.setQueryData(['server', 'one', 'session', 'scope', 'admin', 'role-members', 'moderator'], {
-      pages: [{ users: [
-        { id: 'removed', login: 'removed', displayName: 'Removed User' },
-        { id: 'retained', login: 'retained', displayName: 'Retained User' }
-      ], totalCount: 2, hasMore: false }], pageParams: [0]
-    });
+    queryClient.setQueryData(
+      ['server', 'one', 'session', 'scope', 'admin', 'role-members', 'moderator'],
+      {
+        pages: [
+          {
+            users: [
+              { id: 'removed', login: 'removed', displayName: 'Removed User' },
+              { id: 'retained', login: 'retained', displayName: 'Retained User' }
+            ],
+            totalCount: 2,
+            hasMore: false
+          }
+        ],
+        pageParams: [0]
+      }
+    );
 
     removeRegisteredAdminUserQueries('one', 'removed');
 
@@ -188,6 +198,30 @@ describe('server query cache', () => {
         'moderator'
       ])?.pages[0].users
     ).toEqual([{ id: 'retained', login: 'retained', displayName: 'Retained User' }]);
+  });
+
+  it('fences a late role-member page after deleted-user cleanup', async () => {
+    const key = ['server', 'one', 'session', 'scope', 'admin', 'role-members', 'moderator'];
+    const data = { pages: [{ users: [{ id: 'removed' }, { id: 'retained' }] }], pageParams: [0] };
+    queryClient.setQueryData(key, data);
+    let finish!: (value: typeof data) => void;
+    const oldRead = queryClient
+      .fetchQuery({
+        queryKey: key,
+        staleTime: 0,
+        queryFn: () =>
+          new Promise<typeof data>((resolve) => {
+            finish = resolve;
+          })
+      })
+      .catch(() => undefined);
+    removeRegisteredAdminUserQueries('one', 'removed');
+    finish(data);
+    await oldRead;
+    expect(queryClient.getQueryData(key)).toEqual({
+      pages: [{ users: [{ id: 'retained' }] }],
+      pageParams: [0]
+    });
   });
 
   it('invalidates room details across sessions and purges removed permission snapshots', () => {

--- a/apps/frontend/src/lib/query/client.spec.ts
+++ b/apps/frontend/src/lib/query/client.spec.ts
@@ -113,15 +113,11 @@ describe('server query cache', () => {
       ],
       pageParams: [0]
     });
-    queryClient.setQueryData(['server', 'one', 'session', 'scope', 'admin', 'role', 'moderator'], {
-      role: { name: 'moderator' },
-      users: [
+    queryClient.setQueryData(['server', 'one', 'session', 'scope', 'admin', 'role-members', 'moderator'], {
+      pages: [{ users: [
         { id: 'removed', login: 'removed', displayName: 'Removed User' },
         { id: 'retained', login: 'retained', displayName: 'Retained User' }
-      ],
-      roles: [],
-      viewerCanManageRoles: true,
-      viewerCanAssignRoles: true
+      ], totalCount: 2, hasMore: false }], pageParams: [0]
     });
 
     removeRegisteredAdminUserQueries('one', 'removed');
@@ -182,15 +178,15 @@ describe('server query cache', () => {
       ]
     });
     expect(
-      queryClient.getQueryData<{ users: Array<{ id: string }> }>([
+      queryClient.getQueryData<{ pages: Array<{ users: Array<{ id: string }> }> }>([
         'server',
         'one',
         'session',
         'scope',
         'admin',
-        'role',
+        'role-members',
         'moderator'
-      ])?.users
+      ])?.pages[0].users
     ).toEqual([{ id: 'retained', login: 'retained', displayName: 'Retained User' }]);
   });
 

--- a/apps/frontend/src/lib/query/client.ts
+++ b/apps/frontend/src/lib/query/client.ts
@@ -67,7 +67,8 @@ export function removeAdminUserQueries(serverId: string, userId: string): void {
     key[0] === 'server' &&
     key[1] === serverId &&
     key[4] === 'admin' &&
-    (key[5] === 'members' || key[5] === 'role-members' ||
+    (key[5] === 'members' ||
+      key[5] === 'role-members' ||
       (key[5] === 'member' && key[6] === userId) ||
       (key[5] === 'user-permissions' && key[6] === userId));
   const isMemberListQuery = (key: QueryKey): boolean =>

--- a/apps/frontend/src/lib/query/client.ts
+++ b/apps/frontend/src/lib/query/client.ts
@@ -1,7 +1,6 @@
 import { Code, ConnectError } from '@connectrpc/connect';
 import { QueryClient, type InfiniteData, type QueryKey } from '@tanstack/svelte-query';
 import type { RoomBanList } from '$lib/api-client/rooms';
-import type { RoleDetails } from '$lib/api-client/roles';
 import { registerServerQueryCache } from './cacheRegistry';
 
 const SERVER_QUERY_STALE_TIME_MS = 30_000;
@@ -68,11 +67,11 @@ export function removeAdminUserQueries(serverId: string, userId: string): void {
     key[0] === 'server' &&
     key[1] === serverId &&
     key[4] === 'admin' &&
-    (key[5] === 'members' ||
+    (key[5] === 'members' || key[5] === 'role-members' ||
       (key[5] === 'member' && key[6] === userId) ||
       (key[5] === 'user-permissions' && key[6] === userId));
   const isMemberListQuery = (key: QueryKey): boolean =>
-    isAdminUserQuery(key) && key[5] === 'members';
+    isAdminUserQuery(key) && (key[5] === 'members' || key[5] === 'role-members');
   const isDeletedUserSnapshot = (key: QueryKey): boolean =>
     isAdminUserQuery(key) && (key[5] === 'member' || key[5] === 'user-permissions');
 
@@ -102,6 +101,8 @@ export function removeAdminUserQueries(serverId: string, userId: string): void {
         : data
   );
 
+  // Cancel older pages before scrubbing; a late response must not restore PII.
+  void queryClient.cancelQueries({ predicate: (query) => isMemberListQuery(query.queryKey) });
   queryClient.setQueriesData<{
     pages: Array<{ users: Array<{ id: string }> }>;
     pageParams: unknown[];
@@ -121,18 +122,6 @@ export function removeAdminUserQueries(serverId: string, userId: string): void {
             }))
           }
         : data
-  );
-  queryClient.setQueriesData<RoleDetails>(
-    {
-      predicate: (query) => {
-        const key = query.queryKey;
-        return (
-          key[0] === 'server' && key[1] === serverId && key[4] === 'admin' && key[5] === 'role'
-        );
-      }
-    },
-    (details) =>
-      details ? { ...details, users: details.users.filter((user) => user.id !== userId) } : details
   );
   queryClient.setQueriesData(
     {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/members/[userId]/+page.svelte
@@ -163,7 +163,7 @@
 
   function invalidateRole(target: MemberMutationScope, roleName: string): void {
     void queryClient.invalidateQueries({
-      queryKey: adminQueryKeys.role(target.serverId, target.connection, roleName),
+      queryKey: adminQueryKeys.roleMembers(target.serverId, target.connection, roleName),
       exact: true
     });
   }

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
@@ -6,11 +6,7 @@
   import { onDestroy } from 'svelte';
   import { serverIdToSegment } from '$lib/navigation';
   import { useServerScope } from '$lib/state/server/scope.svelte';
-  import {
-    createRoleAPI,
-    type RoleDetails,
-    type UpdateRoleInput
-  } from '$lib/api-client/roles';
+  import { createRoleAPI, type RoleDetails, type UpdateRoleInput } from '$lib/api-client/roles';
   import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
   import { UserList } from '$lib/components/admin';
   import Panel from '$lib/ui/Panel.svelte';
@@ -29,7 +25,6 @@
   import { registerQueryCacheRemovalListener } from '$lib/query/cacheRegistry';
   import RoleMetadataPanel from './RoleMetadataPanel.svelte';
   import { m } from '$lib/i18n/messages';
-
 
   const serverScope = useServerScope();
   const serverSegment = $derived(serverIdToSegment(serverScope.serverId));
@@ -84,8 +79,10 @@
       return {
         queryKey: adminQueryKeys.roleMembers(serverScope.serverId, connection, name),
         enabled: canAssignRoles && name !== 'everyone',
-        queryFn: ({ pageParam, signal }) => connection.getAPI(createRoleAPI)
-          .listMembers(name, { limit: 20, offset: pageParam }, { signal }),
+        queryFn: ({ pageParam, signal }) =>
+          connection
+            .getAPI(createRoleAPI)
+            .listMembers(name, { limit: 20, offset: pageParam }, { signal }),
         initialPageParam: 0,
         getNextPageParam: (lastPage, _pages, offset) =>
           lastPage.hasMore && lastPage.users.length > 0 ? offset + lastPage.users.length : undefined
@@ -311,38 +308,38 @@
 
         <!-- Users with this role -->
         {#if canAssignRoles || role.name === 'everyone'}
-        <Panel
-          title={m('admin.permissions.users_with_role')}
-          icon="iconify icon-[uil--users-alt]"
-          noPadding
-        >
-          {#if role?.name === 'everyone'}
-            <p class="p-5 text-muted">{m('admin.permissions.everyone_implicit')}</p>
-          {:else if canAssignRoles}
-            {#if membersError}
-              <div class="p-5"><FormError error={membersError} /></div>
-            {:else}
-            <UserList
-              users={roleUsers}
-              loading={membersQuery.isPending}
-              totalCount={membersQuery.data?.pages.at(-1)?.totalCount ?? 0}
-              hasMore={membersQuery.hasNextPage && !membersError}
-              loadingMore={membersQuery.isFetchingNextPage}
-              onLoadMore={loadMoreMembers}
-              loadMoreRoot={scrollContainer}
-              clickable={canAssignRoles}
-              emptyMessage={m('admin.permissions.no_users_with_role')}
-              onUserClick={(user) =>
-                goto(
-                  resolve('/chat/[serverId]/manage/server/members/[userId]', {
-                    serverId: serverSegment,
-                    userId: user.id
-                  })
-                )}
-            />
+          <Panel
+            title={m('admin.permissions.users_with_role')}
+            icon="iconify icon-[uil--users-alt]"
+            noPadding
+          >
+            {#if role?.name === 'everyone'}
+              <p class="p-5 text-muted">{m('admin.permissions.everyone_implicit')}</p>
+            {:else if canAssignRoles}
+              {#if membersError}
+                <div class="p-5"><FormError error={membersError} /></div>
+              {:else}
+                <UserList
+                  users={roleUsers}
+                  loading={membersQuery.isPending}
+                  totalCount={membersQuery.data?.pages.at(-1)?.totalCount ?? 0}
+                  hasMore={membersQuery.hasNextPage && !membersError}
+                  loadingMore={membersQuery.isFetchingNextPage}
+                  onLoadMore={loadMoreMembers}
+                  loadMoreRoot={scrollContainer}
+                  clickable={canAssignRoles}
+                  emptyMessage={m('admin.permissions.no_users_with_role')}
+                  onUserClick={(user) =>
+                    goto(
+                      resolve('/chat/[serverId]/manage/server/members/[userId]', {
+                        serverId: serverSegment,
+                        userId: user.id
+                      })
+                    )}
+                />
+              {/if}
             {/if}
-          {/if}
-        </Panel>
+          </Panel>
         {/if}
       {/if}
     </div>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/+page.svelte
@@ -2,14 +2,13 @@
   import { goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import { createMutation, createQuery } from '@tanstack/svelte-query';
+  import { createInfiniteQuery, createMutation, createQuery } from '@tanstack/svelte-query';
   import { onDestroy } from 'svelte';
   import { serverIdToSegment } from '$lib/navigation';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import {
     createRoleAPI,
     type RoleDetails,
-    type RoleUser,
     type UpdateRoleInput
   } from '$lib/api-client/roles';
   import type { ServerConnection } from '$lib/state/server/serverConnection.svelte';
@@ -31,7 +30,6 @@
   import RoleMetadataPanel from './RoleMetadataPanel.svelte';
   import { m } from '$lib/i18n/messages';
 
-  type User = RoleUser;
 
   const serverScope = useServerScope();
   const serverSegment = $derived(serverIdToSegment(serverScope.serverId));
@@ -75,9 +73,36 @@
 
   const roleDetails = $derived(roleQuery.data ?? null);
   const role = $derived((roleDetails?.role ?? null) as Role | null);
-  const roleUsers = $derived((roleDetails?.users ?? []) as User[]);
+
   const canManageRoles = $derived(roleDetails?.viewerCanManageRoles ?? false);
   const canAssignRoles = $derived(roleDetails?.viewerCanAssignRoles ?? false);
+  let scrollContainer = $state<HTMLDivElement>();
+  const membersQuery = createInfiniteQuery(
+    () => {
+      const connection = serverScope.connection;
+      const name = roleName;
+      return {
+        queryKey: adminQueryKeys.roleMembers(serverScope.serverId, connection, name),
+        enabled: canAssignRoles && name !== 'everyone',
+        queryFn: ({ pageParam, signal }) => connection.getAPI(createRoleAPI)
+          .listMembers(name, { limit: 20, offset: pageParam }, { signal }),
+        initialPageParam: 0,
+        getNextPageParam: (lastPage, _pages, offset) =>
+          lastPage.hasMore && lastPage.users.length > 0 ? offset + lastPage.users.length : undefined
+      };
+    },
+    () => queryClient
+  );
+  const roleUsers = $derived.by(() => {
+    const users = (membersQuery.data?.pages ?? []).flatMap((page) => page.users);
+    return [...new Map(users.map((user) => [user.id, user])).values()];
+  });
+  const membersError = $derived(membersQuery.error?.message ?? null);
+  async function loadMoreMembers() {
+    if (membersQuery.hasNextPage && !membersQuery.isFetching && !membersError) {
+      await membersQuery.fetchNextPage();
+    }
+  }
   const loading = $derived(roleQuery.isPending);
   let deleteConfirmRoleName = $state<string | null>(null);
   let metadataRevision = $state(0);
@@ -245,7 +270,7 @@
     showMobileNav
   />
 
-  <PaneContent>
+  <PaneContent bind:scrollContainer>
     <div class="flex flex-col gap-6">
       {#if loading}
         <div class="text-muted">{m('admin.permissions.loading_role')}</div>
@@ -285,6 +310,7 @@
         {/if}
 
         <!-- Users with this role -->
+        {#if canAssignRoles || role.name === 'everyone'}
         <Panel
           title={m('admin.permissions.users_with_role')}
           icon="iconify icon-[uil--users-alt]"
@@ -292,9 +318,18 @@
         >
           {#if role?.name === 'everyone'}
             <p class="p-5 text-muted">{m('admin.permissions.everyone_implicit')}</p>
-          {:else}
+          {:else if canAssignRoles}
+            {#if membersError}
+              <div class="p-5"><FormError error={membersError} /></div>
+            {:else}
             <UserList
               users={roleUsers}
+              loading={membersQuery.isPending}
+              totalCount={membersQuery.data?.pages.at(-1)?.totalCount ?? 0}
+              hasMore={membersQuery.hasNextPage && !membersError}
+              loadingMore={membersQuery.isFetchingNextPage}
+              onLoadMore={loadMoreMembers}
+              loadMoreRoot={scrollContainer}
               clickable={canAssignRoles}
               emptyMessage={m('admin.permissions.no_users_with_role')}
               onUserClick={(user) =>
@@ -305,8 +340,10 @@
                   })
                 )}
             />
+            {/if}
           {/if}
         </Panel>
+        {/if}
       {/if}
     </div>
   </PaneContent>

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/RolePageUserListMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/RolePageUserListMock.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { RoleUser } from '$lib/api-client/roles';
 
-  let { users }: { users: RoleUser[] } = $props();
+  let { users, hasMore, onLoadMore }: { users: RoleUser[]; hasMore?: boolean; onLoadMore?: () => void } = $props();
 </script>
 
 <div data-testid="role-users">
@@ -9,3 +9,5 @@
     <span>{user.displayName}</span>
   {/each}
 </div>
+
+{#if hasMore}<button onclick={onLoadMore}>Load next test page</button>{/if}

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/RolePageUserListMock.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/RolePageUserListMock.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { RoleUser } from '$lib/api-client/roles';
 
-  let { users, hasMore, onLoadMore }: { users: RoleUser[]; hasMore?: boolean; onLoadMore?: () => void } = $props();
+  let {
+    users,
+    hasMore,
+    onLoadMore
+  }: { users: RoleUser[]; hasMore?: boolean; onLoadMore?: () => void } = $props();
 </script>
 
 <div data-testid="role-users">

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/role.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/role.page.svelte.spec.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { flushSync } from 'svelte';
 import { render } from 'vitest-browser-svelte';
-import type { RoleDetails, ServerRole } from '$lib/api-client/roles';
+import type { RoleDetails, RoleMemberPage, ServerRole } from '$lib/api-client/roles';
 import { adminQueryKeys } from '$lib/query/admin';
 import { queryClient } from '$lib/query/client';
 
 const { mocks } = vi.hoisted(() => ({
   mocks: {
     getRole: vi.fn(),
+    listMembers: vi.fn(),
     updateRole: vi.fn(),
     deleteRole: vi.fn(),
     goto: vi.fn()
@@ -41,6 +42,7 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
       queryScope: 'role-page-test',
       getAPI: () => ({
         getRole: mocks.getRole,
+        listMembers: mocks.listMembers,
         updateRole: mocks.updateRole,
         deleteRole: mocks.deleteRole
       })
@@ -102,7 +104,6 @@ function details(name: string, displayName: string, description: string): RoleDe
   return {
     roles: [],
     role: role(name, displayName, description),
-    users: [{ id: `${name}-user`, login: `${name}-user`, displayName: `${displayName} User` }],
     viewerCanManageRoles: true,
     viewerCanAssignRoles: true
   };
@@ -120,6 +121,43 @@ describe('role management page identity', () => {
     queryClient.clear();
     vi.clearAllMocks();
     activeRoleName = 'role-a';
+    mocks.listMembers.mockImplementation((name: string) => Promise.resolve({
+      users: [{ id: `${name}-user`, login: `${name}-user`, displayName: `${name === 'role-a' ? 'Role A' : 'Role B'} User`, isBot: false }],
+      totalCount: 1, hasMore: false
+    }));
+  });
+
+  it('loads member pages separately and fences a late page after a role switch', async () => {
+    mocks.getRole.mockImplementation((name: string) => Promise.resolve(details(name, name, '')));
+    const late = deferred<RoleMemberPage>();
+    mocks.listMembers.mockImplementation((name: string, page: { offset: number }) => {
+      if (name === 'role-a' && page.offset === 1) return late.promise;
+      return Promise.resolve({
+        users: [{ id: name, login: name, displayName: `${name} member`, isBot: false }],
+        totalCount: name === 'role-a' ? 2 : 1, hasMore: name === 'role-a'
+      });
+    });
+    const { container } = render(RolePage);
+    await vi.waitFor(() => expect(container.textContent).toContain('role-a member'));
+    (Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Load next test page') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(mocks.listMembers).toHaveBeenCalledWith(
+      'role-a', { limit: 20, offset: 1 }, expect.objectContaining({ signal: expect.any(AbortSignal) })
+    ));
+    activeRoleName = 'role-b';
+    flushSync();
+    await vi.waitFor(() => expect(container.textContent).toContain('role-b member'));
+    late.resolve({ users: [{ id: 'late', login: 'late', displayName: 'Late A member', isBot: false }], totalCount: 2, hasMore: false });
+    await settle();
+    expect(container.textContent).not.toContain('Late A member');
+    expect(container.textContent).not.toContain('role-a member');
+  });
+
+  it('does not request or render a roster without assignment authority', async () => {
+    mocks.getRole.mockResolvedValue({ ...details('role-a', 'Role A', ''), viewerCanAssignRoles: false });
+    const { container } = render(RolePage);
+    await vi.waitFor(() => expect(container.querySelector('#displayName')).not.toBeNull());
+    expect(mocks.listMembers).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="role-users"]')).toBeNull();
   });
 
   it('does not let a delayed role response overwrite a reused route', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/role.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/manage/server/permissions/[name]/role.page.svelte.spec.ts
@@ -121,10 +121,20 @@ describe('role management page identity', () => {
     queryClient.clear();
     vi.clearAllMocks();
     activeRoleName = 'role-a';
-    mocks.listMembers.mockImplementation((name: string) => Promise.resolve({
-      users: [{ id: `${name}-user`, login: `${name}-user`, displayName: `${name === 'role-a' ? 'Role A' : 'Role B'} User`, isBot: false }],
-      totalCount: 1, hasMore: false
-    }));
+    mocks.listMembers.mockImplementation((name: string) =>
+      Promise.resolve({
+        users: [
+          {
+            id: `${name}-user`,
+            login: `${name}-user`,
+            displayName: `${name === 'role-a' ? 'Role A' : 'Role B'} User`,
+            isBot: false
+          }
+        ],
+        totalCount: 1,
+        hasMore: false
+      })
+    );
   });
 
   it('loads member pages separately and fences a late page after a role switch', async () => {
@@ -134,26 +144,42 @@ describe('role management page identity', () => {
       if (name === 'role-a' && page.offset === 1) return late.promise;
       return Promise.resolve({
         users: [{ id: name, login: name, displayName: `${name} member`, isBot: false }],
-        totalCount: name === 'role-a' ? 2 : 1, hasMore: name === 'role-a'
+        totalCount: name === 'role-a' ? 2 : 1,
+        hasMore: name === 'role-a'
       });
     });
     const { container } = render(RolePage);
     await vi.waitFor(() => expect(container.textContent).toContain('role-a member'));
-    (Array.from(container.querySelectorAll('button')).find(button => button.textContent === 'Load next test page') as HTMLButtonElement).click();
-    await vi.waitFor(() => expect(mocks.listMembers).toHaveBeenCalledWith(
-      'role-a', { limit: 20, offset: 1 }, expect.objectContaining({ signal: expect.any(AbortSignal) })
-    ));
+    (
+      Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Load next test page'
+      ) as HTMLButtonElement
+    ).click();
+    await vi.waitFor(() =>
+      expect(mocks.listMembers).toHaveBeenCalledWith(
+        'role-a',
+        { limit: 20, offset: 1 },
+        expect.objectContaining({ signal: expect.any(AbortSignal) })
+      )
+    );
     activeRoleName = 'role-b';
     flushSync();
     await vi.waitFor(() => expect(container.textContent).toContain('role-b member'));
-    late.resolve({ users: [{ id: 'late', login: 'late', displayName: 'Late A member', isBot: false }], totalCount: 2, hasMore: false });
+    late.resolve({
+      users: [{ id: 'late', login: 'late', displayName: 'Late A member', isBot: false }],
+      totalCount: 2,
+      hasMore: false
+    });
     await settle();
     expect(container.textContent).not.toContain('Late A member');
     expect(container.textContent).not.toContain('role-a member');
   });
 
   it('does not request or render a roster without assignment authority', async () => {
-    mocks.getRole.mockResolvedValue({ ...details('role-a', 'Role A', ''), viewerCanAssignRoles: false });
+    mocks.getRole.mockResolvedValue({
+      ...details('role-a', 'Role A', ''),
+      viewerCanAssignRoles: false
+    });
     const { container } = render(RolePage);
     await vi.waitFor(() => expect(container.querySelector('#displayName')).not.toBeNull());
     expect(mocks.listMembers).not.toHaveBeenCalled();

--- a/cli/internal/connectapi/admin_services_test.go
+++ b/cli/internal/connectapi/admin_services_test.go
@@ -988,9 +988,14 @@ func TestAdminRoleServiceManagesRoles(t *testing.T) {
 	if !getResp.Msg.GetViewerCanManageRoles() || !getResp.Msg.GetViewerCanAssignRoles() {
 		t.Fatalf("GetRole capabilities manage=%v assign=%v, want true/true", getResp.Msg.GetViewerCanManageRoles(), getResp.Msg.GetViewerCanAssignRoles())
 	}
-	if len(getResp.Msg.GetUsers()) != 1 || getResp.Msg.GetUsers()[0].GetId() != member.Id {
-		t.Fatalf("GetRole users = %+v, want member %s", getResp.Msg.GetUsers(), member.Id)
+	membersResp, err := env.roles.ListMembers(withCaller(env.ctx, env.viewer), connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: "helpdesk"}))
+	if err != nil {
+		t.Fatal(err)
 	}
+	if len(membersResp.Msg.Members) != 1 || membersResp.Msg.Members[0].Id != member.Id {
+		t.Fatal("expected explicit member")
+	}
+
 	if _, err := env.roles.GetRole(withCaller(env.ctx, env.viewer), connect.NewRequest(&adminv1.GetRoleRequest{Name: "missing-role"})); connect.CodeOf(err) != connect.CodeNotFound {
 		t.Fatalf("missing GetRole code = %v, want not found", connect.CodeOf(err))
 	}

--- a/cli/internal/connectapi/api_test_helpers_test.go
+++ b/cli/internal/connectapi/api_test_helpers_test.go
@@ -145,6 +145,12 @@ type connectAPITestEnv struct {
 
 func newConnectAPITestEnv(t *testing.T) *connectAPITestEnv {
 	t.Helper()
+	return newConnectAPITestEnvWithTimeout(t, 30*time.Second)
+}
+
+// Larger fixtures can select a bounded lifecycle that also fits race-enabled runs.
+func newConnectAPITestEnvWithTimeout(t *testing.T, timeout time.Duration) *connectAPITestEnv {
+	t.Helper()
 
 	// Each environment owns its broker and event log. A shared broker reset
 	// can affect another core that still has subscriptions or pending work.
@@ -152,7 +158,7 @@ func newConnectAPITestEnv(t *testing.T) *connectAPITestEnv {
 	// Keep one bounded context for the complete integration-test lifecycle.
 	// Allow a delayed durable-worker acknowledgement without expiring the
 	// shared context before the test can run its later assertions.
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	t.Cleanup(cancel)
 
 	c, err := core.NewChattoCore(ctx, nc, config.CoreConfig{

--- a/cli/internal/connectapi/role_member_assembler.go
+++ b/cli/internal/connectapi/role_member_assembler.go
@@ -1,0 +1,21 @@
+package connectapi
+
+import (
+	"context"
+	"hmans.de/chatto/internal/parallel"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+)
+
+// roleMemberAssembler hydrates only the selected page, with bounded concurrency.
+// Failed reads fail the page instead of silently changing its membership.
+type roleMemberAssembler struct{ api *API }
+
+func (a *roleMemberAssembler) assemble(ctx context.Context, ids []string) ([]*apiv1.User, error) {
+	return parallel.Map(ctx, maxConnectAPIHydrationConcurrency, ids, func(ctx context.Context, _ int, id string) (*apiv1.User, error) {
+		user, err := a.api.core.GetUser(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		return requiredUserSummary(ctx, a.api, user)
+	})
+}

--- a/cli/internal/connectapi/role_member_assembler.go
+++ b/cli/internal/connectapi/role_member_assembler.go
@@ -2,6 +2,7 @@ package connectapi
 
 import (
 	"context"
+
 	"hmans.de/chatto/internal/parallel"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
 )

--- a/cli/internal/connectapi/role_members_test.go
+++ b/cli/internal/connectapi/role_members_test.go
@@ -1,17 +1,19 @@
 package connectapi
 
 import (
-	"connectrpc.com/connect"
 	"fmt"
+	"sort"
+	"testing"
+	"time"
+
+	"connectrpc.com/connect"
 	"hmans.de/chatto/internal/core"
 	adminv1 "hmans.de/chatto/internal/pb/chatto/admin/v1"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
-	"sort"
-	"testing"
 )
 
 func TestAdminRoleMembersPaginationAndAuthorization(t *testing.T) {
-	env := newConnectAPITestEnv(t)
+	env := newConnectAPITestEnvWithTimeout(t, 2*time.Minute)
 	request := connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: "missing"})
 	if _, err := env.roles.ListMembers(env.ctx, request); connect.CodeOf(err) != connect.CodeUnauthenticated {
 		t.Fatalf("anonymous: %v", err)

--- a/cli/internal/connectapi/role_members_test.go
+++ b/cli/internal/connectapi/role_members_test.go
@@ -1,0 +1,101 @@
+package connectapi
+
+import (
+	"connectrpc.com/connect"
+	"fmt"
+	"hmans.de/chatto/internal/core"
+	adminv1 "hmans.de/chatto/internal/pb/chatto/admin/v1"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+	"sort"
+	"testing"
+)
+
+func TestAdminRoleMembersPaginationAndAuthorization(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	request := connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: "missing"})
+	if _, err := env.roles.ListMembers(env.ctx, request); connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatalf("anonymous: %v", err)
+	}
+	ctx := withCaller(env.ctx, env.viewer)
+	if _, err := env.roles.ListMembers(ctx, request); connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("unauthorized missing role: %v", err)
+	}
+	if err := env.core.GrantUserPermission(env.ctx, core.SystemActorID, env.viewer.Id, core.PermRoleAssign); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := env.roles.ListMembers(ctx, request); connect.CodeOf(err) != connect.CodeNotFound {
+		t.Fatalf("authorized missing role: %v", err)
+	}
+	// Assignment authority alone must not grant the broader admin user directory.
+	if _, err := env.adminUsers.ListMembers(ctx, connect.NewRequest(&adminv1.ListMembersRequest{})); connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("admin directory: %v", err)
+	}
+	if _, err := env.core.CreateServerRole(env.ctx, core.SystemActorID, "paged", "Paged", ""); err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 103)
+	for i := range ids {
+		user, err := env.core.CreateUser(env.ctx, core.SystemActorID, fmt.Sprintf("roster-%03d", i), "Roster member", "password")
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids[i] = user.Id
+		if err := env.core.AssignServerRole(env.ctx, core.SystemActorID, user.Id, "paged"); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sort.Strings(ids)
+	for _, tc := range []struct {
+		name         string
+		page         *apiv1.PageRequest
+		start, count int
+		more         bool
+	}{
+		{"default", nil, 0, 20, true},
+		{"first", &apiv1.PageRequest{Limit: 2}, 0, 2, true},
+		{"next", &apiv1.PageRequest{Limit: 2, Offset: 2}, 2, 2, true},
+		{"cap", &apiv1.PageRequest{Limit: 500}, 0, 100, true},
+		{"last", &apiv1.PageRequest{Limit: 20, Offset: 100}, 100, 3, false},
+		{"past end", &apiv1.PageRequest{Offset: 2147483647}, 0, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := env.roles.ListMembers(ctx, connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: "paged", Page: tc.page}))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(res.Msg.Members) != tc.count || res.Msg.Page.TotalCount != 103 || res.Msg.Page.HasMore != tc.more {
+				t.Fatalf("unexpected page: %v", res.Msg.Page)
+			}
+			for i, user := range res.Msg.Members {
+				if user.Id != ids[tc.start+i] {
+					t.Fatal("unstable ordering")
+				}
+			}
+		})
+	}
+	for _, page := range []*apiv1.PageRequest{{Limit: -1}, {Offset: -1}} {
+		if _, err := env.roles.ListMembers(ctx, connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: "paged", Page: page})); connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("invalid page: %v", err)
+		}
+	}
+	res, err := env.roles.ListMembers(ctx, connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: core.RoleEveryone}))
+	if err != nil || len(res.Msg.GetMembers()) != 0 || res.Msg.Page.TotalCount != 0 || res.Msg.Page.HasMore {
+		t.Fatalf("everyone page: %v", err)
+	}
+	// Account deletion revokes its assignments; later pages reflect that change.
+	if err := env.core.DeleteUser(env.ctx, core.SystemActorID, ids[0]); err != nil {
+		t.Fatal(err)
+	}
+	res, err = env.roles.ListMembers(ctx, connect.NewRequest(&adminv1.AdminRoleServiceListMembersRequest{Name: "paged", Page: &apiv1.PageRequest{Limit: 1}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Msg.Members) != 1 || res.Msg.Members[0].Id != ids[1] || res.Msg.Page.TotalCount != 102 {
+		t.Fatal("expected deleted account to leave the roster")
+	}
+	// Detail reads do not carry roster data.
+	detail, err := env.roles.GetRole(ctx, connect.NewRequest(&adminv1.GetRoleRequest{Name: "paged"}))
+	if err != nil || detail.Msg.ProtoReflect().Descriptor().Fields().ByName("users") != nil {
+		t.Fatalf("role detail: %v", err)
+	}
+}

--- a/cli/internal/connectapi/roles.go
+++ b/cli/internal/connectapi/roles.go
@@ -101,7 +101,6 @@ func (s *roleService) GetRole(ctx context.Context, req *connect.Request[adminv1.
 	}
 	return connect.NewResponse(&adminv1.GetRoleResponse{
 		Role:                 adminAPIRole(details.Role),
-		Users:                s.apiRoleUsers(ctx, details.Users),
 		ViewerCanManageRoles: details.ViewerCanManageRoles,
 		ViewerCanAssignRoles: details.ViewerCanAssignRoles,
 	}), nil
@@ -210,22 +209,18 @@ func adminAPIRole(role *core.RoleWithPermissions) *adminv1.AdminRole {
 	}
 }
 
-func (s *roleService) apiRoleUsers(ctx context.Context, users []core.RoleUserSummary) []*apiv1.User {
-	out := make([]*apiv1.User, 0, len(users))
-	for _, user := range users {
-		presence, err := s.api.core.GetUserPresence(ctx, user.ID)
-		if err != nil {
-			presence = core.PresenceStatusOffline
-		}
-		out = append(out, &apiv1.User{
-			Id:             user.ID,
-			Login:          user.Login,
-			DisplayName:    user.DisplayName,
-			Deleted:        user.Deleted,
-			IsBot:          user.IsBot,
-			PresenceStatus: corePresenceStatusToAPI(presence),
-			CustomStatus:   coreCustomStatusToAPI(user.CustomStatus),
-		})
+func (s *roleService) ListMembers(ctx context.Context, req *connect.Request[adminv1.AdminRoleServiceListMembersRequest]) (*connect.Response[adminv1.AdminRoleServiceListMembersResponse], error) {
+	caller, err := requireCaller(ctx)
+	if err != nil {
+		return nil, err
 	}
-	return out
+	page, err := s.api.core.ListServerRoleMembers(ctx, caller.UserID, req.Msg.GetName(), int(req.Msg.GetPage().GetLimit()), int(req.Msg.GetPage().GetOffset()))
+	if err != nil {
+		return nil, connectError(err)
+	}
+	members, err := (&roleMemberAssembler{api: s.api}).assemble(ctx, page.UserIDs)
+	if err != nil {
+		return nil, connectError(err)
+	}
+	return connect.NewResponse(&adminv1.AdminRoleServiceListMembersResponse{Members: members, Page: apiPageInfo(page.TotalCount, page.HasMore)}), nil
 }

--- a/cli/internal/core/rbac_test.go
+++ b/cli/internal/core/rbac_test.go
@@ -2774,7 +2774,7 @@ func TestChattoCore_AdminRoleManagementAuthorization(t *testing.T) {
 	}
 }
 
-func TestChattoCore_ServerRoleDetailsRostersRequireAssign(t *testing.T) {
+func TestChattoCore_ServerRoleMembersRequireAssign(t *testing.T) {
 	core, _ := setupTestCore(t)
 	ctx := testContext(t)
 
@@ -2804,8 +2804,11 @@ func TestChattoCore_ServerRoleDetailsRostersRequireAssign(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetServerRoleDetails regular: %v", err)
 	}
-	if regularDetails.ViewerCanAssignRoles || len(regularDetails.Users) != 0 {
-		t.Fatalf("regular details canAssign=%v users=%d, want false/0", regularDetails.ViewerCanAssignRoles, len(regularDetails.Users))
+	if regularDetails.ViewerCanAssignRoles {
+		t.Fatal("regular ViewerCanAssignRoles = true, want false")
+	}
+	if _, err := core.ListServerRoleMembers(ctx, regular.Id, "support", 20, 0); !errors.Is(err, ErrPermissionDenied) {
+		t.Fatalf("regular role members: %v, want permission denied", err)
 	}
 
 	adminDetails, err := core.GetServerRoleDetails(ctx, admin.Id, "support")
@@ -2815,8 +2818,12 @@ func TestChattoCore_ServerRoleDetailsRostersRequireAssign(t *testing.T) {
 	if !adminDetails.ViewerCanAssignRoles {
 		t.Fatal("admin ViewerCanAssignRoles = false, want true")
 	}
-	if len(adminDetails.Users) != 1 || adminDetails.Users[0].ID != member.Id {
-		t.Fatalf("admin role users = %+v, want member %s", adminDetails.Users, member.Id)
+	members, err := core.ListServerRoleMembers(ctx, admin.Id, "support", 20, 0)
+	if err != nil {
+		t.Fatalf("ListServerRoleMembers admin: %v", err)
+	}
+	if len(members.UserIDs) != 1 || members.UserIDs[0] != member.Id || members.TotalCount != 1 || members.HasMore {
+		t.Fatalf("admin role members = %+v, want one member", members)
 	}
 }
 

--- a/cli/internal/core/role_management.go
+++ b/cli/internal/core/role_management.go
@@ -3,18 +3,7 @@ package core
 import (
 	"context"
 	"fmt"
-
-	evtv1 "hmans.de/chatto/internal/pb/chatto/core/evt/v1"
 )
-
-type RoleUserSummary struct {
-	ID           string
-	Login        string
-	DisplayName  string
-	Deleted      bool
-	IsBot  bool
-	CustomStatus *evtv1.CustomUserStatus
-}
 
 type RoleCatalog struct {
 	Roles                []RoleWithPermissions
@@ -24,7 +13,6 @@ type RoleCatalog struct {
 
 type RoleDetails struct {
 	Role                 *RoleWithPermissions
-	Users                []RoleUserSummary
 	ViewerCanManageRoles bool
 	ViewerCanAssignRoles bool
 }
@@ -89,13 +77,6 @@ func (c *ChattoCore) GetServerRoleDetails(ctx context.Context, actorID, roleName
 		Role:                 role,
 		ViewerCanManageRoles: canManage,
 		ViewerCanAssignRoles: canAssign,
-	}
-	if canAssign {
-		users, err := c.serverRoleUsers(ctx, roleName)
-		if err != nil {
-			return nil, err
-		}
-		details.Users = users
 	}
 	return details, nil
 }
@@ -170,25 +151,46 @@ func (c *ChattoCore) requireCanManageAdminRoles(ctx context.Context, actorID str
 	return nil
 }
 
-func (c *ChattoCore) serverRoleUsers(ctx context.Context, roleName string) ([]RoleUserSummary, error) {
-	userIDs, err := c.GetRoleUsers(ctx, roleName)
+// RoleMemberPage selects assignments before any user or profile hydration.
+// IDs are sorted, but separate requests do not share a fixed snapshot.
+type RoleMemberPage struct {
+	UserIDs    []string
+	TotalCount int
+	HasMore    bool
+}
+
+// ListServerRoleMembers gates every page with role.assign. The implicit
+// everyone role has no explicit assignments. Limits default to 20 and cap at 100.
+func (c *ChattoCore) ListServerRoleMembers(ctx context.Context, actorID, roleName string, limit, offset int) (*RoleMemberPage, error) {
+	if actorID == "" {
+		return nil, ErrNotAuthenticated
+	}
+	allowed, err := c.CanAssignRoles(ctx, actorID)
 	if err != nil {
 		return nil, err
 	}
-	users := make([]RoleUserSummary, 0, len(userIDs))
-	for _, userID := range userIDs {
-		user, err := c.GetUser(ctx, userID)
-		if err != nil {
-			continue
-		}
-		users = append(users, RoleUserSummary{
-			ID:           user.GetId(),
-			Login:        user.GetLogin(),
-			DisplayName:  user.GetDisplayName(),
-			Deleted:      user.GetDeleted(),
-			IsBot:  user.GetIsBot(),
-			CustomStatus: user.GetCustomStatus(),
-		})
+	if !allowed {
+		return nil, ErrPermissionDenied
 	}
-	return users, nil
+	if roleName == "" || limit < 0 || offset < 0 {
+		return nil, fmt.Errorf("%w: invalid role member page", ErrInvalidArgument)
+	}
+	if limit == 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	ids, err := c.GetRoleUsers(ctx, roleName)
+	if err != nil {
+		return nil, err
+	}
+	result := &RoleMemberPage{TotalCount: len(ids)}
+	if offset >= len(ids) {
+		return result, nil
+	}
+	end := offset + min(limit, len(ids)-offset)
+	result.UserIDs = ids[offset:end]
+	result.HasMore = end < len(ids)
+	return result, nil
 }

--- a/cli/internal/pb/chatto/admin/v1/adminv1connect/roles.connect.go
+++ b/cli/internal/pb/chatto/admin/v1/adminv1connect/roles.connect.go
@@ -39,6 +39,9 @@ const (
 	// AdminRoleServiceGetRoleProcedure is the fully-qualified name of the AdminRoleService's GetRole
 	// RPC.
 	AdminRoleServiceGetRoleProcedure = "/chatto.admin.v1.AdminRoleService/GetRole"
+	// AdminRoleServiceListMembersProcedure is the fully-qualified name of the AdminRoleService's
+	// ListMembers RPC.
+	AdminRoleServiceListMembersProcedure = "/chatto.admin.v1.AdminRoleService/ListMembers"
 	// AdminRoleServiceCreateRoleProcedure is the fully-qualified name of the AdminRoleService's
 	// CreateRole RPC.
 	AdminRoleServiceCreateRoleProcedure = "/chatto.admin.v1.AdminRoleService/CreateRole"
@@ -61,9 +64,11 @@ type AdminRoleServiceClient interface {
 	// effects; use chatto.api.v1.RoleService for lightweight catalog rendering.
 	ListRoles(context.Context, *connect.Request[v1.ListRolesRequest]) (*connect.Response[v1.ListRolesResponse], error)
 	// Gets one role plus admin detail metadata. Returns NOT_FOUND when the
-	// role does not exist. Requires an authenticated user; the assigned-user
-	// roster is empty unless the caller may assign roles.
+	// role does not exist. Requires an authenticated user.
 	GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.GetRoleResponse], error)
+	// Lists explicit role members. Requires role.assign, without requiring
+	// admin.view-users. Returns NOT_FOUND when the role does not exist.
+	ListMembers(context.Context, *connect.Request[v1.AdminRoleServiceListMembersRequest]) (*connect.Response[v1.AdminRoleServiceListMembersResponse], error)
 	// Creates a custom role. Requires role.manage.
 	CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.CreateRoleResponse], error)
 	// Updates role metadata. Requires role.manage.
@@ -97,6 +102,12 @@ func NewAdminRoleServiceClient(httpClient connect.HTTPClient, baseURL string, op
 			connect.WithSchema(adminRoleServiceMethods.ByName("GetRole")),
 			connect.WithClientOptions(opts...),
 		),
+		listMembers: connect.NewClient[v1.AdminRoleServiceListMembersRequest, v1.AdminRoleServiceListMembersResponse](
+			httpClient,
+			baseURL+AdminRoleServiceListMembersProcedure,
+			connect.WithSchema(adminRoleServiceMethods.ByName("ListMembers")),
+			connect.WithClientOptions(opts...),
+		),
 		createRole: connect.NewClient[v1.CreateRoleRequest, v1.CreateRoleResponse](
 			httpClient,
 			baseURL+AdminRoleServiceCreateRoleProcedure,
@@ -128,6 +139,7 @@ func NewAdminRoleServiceClient(httpClient connect.HTTPClient, baseURL string, op
 type adminRoleServiceClient struct {
 	listRoles    *connect.Client[v1.ListRolesRequest, v1.ListRolesResponse]
 	getRole      *connect.Client[v1.GetRoleRequest, v1.GetRoleResponse]
+	listMembers  *connect.Client[v1.AdminRoleServiceListMembersRequest, v1.AdminRoleServiceListMembersResponse]
 	createRole   *connect.Client[v1.CreateRoleRequest, v1.CreateRoleResponse]
 	updateRole   *connect.Client[v1.UpdateRoleRequest, v1.UpdateRoleResponse]
 	deleteRole   *connect.Client[v1.DeleteRoleRequest, v1.DeleteRoleResponse]
@@ -142,6 +154,11 @@ func (c *adminRoleServiceClient) ListRoles(ctx context.Context, req *connect.Req
 // GetRole calls chatto.admin.v1.AdminRoleService.GetRole.
 func (c *adminRoleServiceClient) GetRole(ctx context.Context, req *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.GetRoleResponse], error) {
 	return c.getRole.CallUnary(ctx, req)
+}
+
+// ListMembers calls chatto.admin.v1.AdminRoleService.ListMembers.
+func (c *adminRoleServiceClient) ListMembers(ctx context.Context, req *connect.Request[v1.AdminRoleServiceListMembersRequest]) (*connect.Response[v1.AdminRoleServiceListMembersResponse], error) {
+	return c.listMembers.CallUnary(ctx, req)
 }
 
 // CreateRole calls chatto.admin.v1.AdminRoleService.CreateRole.
@@ -172,9 +189,11 @@ type AdminRoleServiceHandler interface {
 	// effects; use chatto.api.v1.RoleService for lightweight catalog rendering.
 	ListRoles(context.Context, *connect.Request[v1.ListRolesRequest]) (*connect.Response[v1.ListRolesResponse], error)
 	// Gets one role plus admin detail metadata. Returns NOT_FOUND when the
-	// role does not exist. Requires an authenticated user; the assigned-user
-	// roster is empty unless the caller may assign roles.
+	// role does not exist. Requires an authenticated user.
 	GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.GetRoleResponse], error)
+	// Lists explicit role members. Requires role.assign, without requiring
+	// admin.view-users. Returns NOT_FOUND when the role does not exist.
+	ListMembers(context.Context, *connect.Request[v1.AdminRoleServiceListMembersRequest]) (*connect.Response[v1.AdminRoleServiceListMembersResponse], error)
 	// Creates a custom role. Requires role.manage.
 	CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.CreateRoleResponse], error)
 	// Updates role metadata. Requires role.manage.
@@ -202,6 +221,12 @@ func NewAdminRoleServiceHandler(svc AdminRoleServiceHandler, opts ...connect.Han
 		AdminRoleServiceGetRoleProcedure,
 		svc.GetRole,
 		connect.WithSchema(adminRoleServiceMethods.ByName("GetRole")),
+		connect.WithHandlerOptions(opts...),
+	)
+	adminRoleServiceListMembersHandler := connect.NewUnaryHandler(
+		AdminRoleServiceListMembersProcedure,
+		svc.ListMembers,
+		connect.WithSchema(adminRoleServiceMethods.ByName("ListMembers")),
 		connect.WithHandlerOptions(opts...),
 	)
 	adminRoleServiceCreateRoleHandler := connect.NewUnaryHandler(
@@ -234,6 +259,8 @@ func NewAdminRoleServiceHandler(svc AdminRoleServiceHandler, opts ...connect.Han
 			adminRoleServiceListRolesHandler.ServeHTTP(w, r)
 		case AdminRoleServiceGetRoleProcedure:
 			adminRoleServiceGetRoleHandler.ServeHTTP(w, r)
+		case AdminRoleServiceListMembersProcedure:
+			adminRoleServiceListMembersHandler.ServeHTTP(w, r)
 		case AdminRoleServiceCreateRoleProcedure:
 			adminRoleServiceCreateRoleHandler.ServeHTTP(w, r)
 		case AdminRoleServiceUpdateRoleProcedure:
@@ -257,6 +284,10 @@ func (UnimplementedAdminRoleServiceHandler) ListRoles(context.Context, *connect.
 
 func (UnimplementedAdminRoleServiceHandler) GetRole(context.Context, *connect.Request[v1.GetRoleRequest]) (*connect.Response[v1.GetRoleResponse], error) {
 	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.admin.v1.AdminRoleService.GetRole is not implemented"))
+}
+
+func (UnimplementedAdminRoleServiceHandler) ListMembers(context.Context, *connect.Request[v1.AdminRoleServiceListMembersRequest]) (*connect.Response[v1.AdminRoleServiceListMembersResponse], error) {
+	return nil, connect.NewError(connect.CodeUnimplemented, errors.New("chatto.admin.v1.AdminRoleService.ListMembers is not implemented"))
 }
 
 func (UnimplementedAdminRoleServiceHandler) CreateRole(context.Context, *connect.Request[v1.CreateRoleRequest]) (*connect.Response[v1.CreateRoleResponse], error) {

--- a/cli/internal/pb/chatto/admin/v1/roles.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/roles.pb.go
@@ -240,8 +240,6 @@ type GetRoleResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Requested role.
 	Role *AdminRole `protobuf:"bytes,1,opt,name=role,proto3" json:"role,omitempty"`
-	// Explicit users with this role. Empty unless the caller may assign roles.
-	Users []*v1.User `protobuf:"bytes,2,rep,name=users,proto3" json:"users,omitempty"`
 	// Whether the caller may create/update/delete role definitions.
 	ViewerCanManageRoles bool `protobuf:"varint,3,opt,name=viewer_can_manage_roles,json=viewerCanManageRoles,proto3" json:"viewer_can_manage_roles,omitempty"`
 	// Whether the caller may assign/revoke roles and view role rosters.
@@ -287,13 +285,6 @@ func (x *GetRoleResponse) GetRole() *AdminRole {
 	return nil
 }
 
-func (x *GetRoleResponse) GetUsers() []*v1.User {
-	if x != nil {
-		return x.Users
-	}
-	return nil
-}
-
 func (x *GetRoleResponse) GetViewerCanManageRoles() bool {
 	if x != nil {
 		return x.ViewerCanManageRoles
@@ -306,6 +297,118 @@ func (x *GetRoleResponse) GetViewerCanAssignRoles() bool {
 		return x.ViewerCanAssignRoles
 	}
 	return false
+}
+
+// Request a page of explicit role members.
+type AdminRoleServiceListMembersRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Stable role name.
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	// Defaults to 20 members; capped at 100. Offset counts explicit assignments.
+	Page          *v1.PageRequest `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdminRoleServiceListMembersRequest) Reset() {
+	*x = AdminRoleServiceListMembersRequest{}
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdminRoleServiceListMembersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdminRoleServiceListMembersRequest) ProtoMessage() {}
+
+func (x *AdminRoleServiceListMembersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdminRoleServiceListMembersRequest.ProtoReflect.Descriptor instead.
+func (*AdminRoleServiceListMembersRequest) Descriptor() ([]byte, []int) {
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{5}
+}
+
+func (x *AdminRoleServiceListMembersRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *AdminRoleServiceListMembersRequest) GetPage() *v1.PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+// Explicit members sorted by user ID. Each page is a live read; assignment
+// changes between requests can shift offsets. The implicit everyone role has
+// no explicit members. Revoked assignments are excluded.
+type AdminRoleServiceListMembersResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Canonical public user records for the selected assignments.
+	Members []*v1.User `protobuf:"bytes,1,rep,name=members,proto3" json:"members,omitempty"`
+	// Total explicit assignment count and whether another page exists.
+	Page          *v1.PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *AdminRoleServiceListMembersResponse) Reset() {
+	*x = AdminRoleServiceListMembersResponse{}
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[6]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *AdminRoleServiceListMembersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*AdminRoleServiceListMembersResponse) ProtoMessage() {}
+
+func (x *AdminRoleServiceListMembersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[6]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use AdminRoleServiceListMembersResponse.ProtoReflect.Descriptor instead.
+func (*AdminRoleServiceListMembersResponse) Descriptor() ([]byte, []int) {
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *AdminRoleServiceListMembersResponse) GetMembers() []*v1.User {
+	if x != nil {
+		return x.Members
+	}
+	return nil
+}
+
+func (x *AdminRoleServiceListMembersResponse) GetPage() *v1.PageInfo {
+	if x != nil {
+		return x.Page
+	}
+	return nil
 }
 
 // Request to create a role.
@@ -325,7 +428,7 @@ type CreateRoleRequest struct {
 
 func (x *CreateRoleRequest) Reset() {
 	*x = CreateRoleRequest{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[5]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -337,7 +440,7 @@ func (x *CreateRoleRequest) String() string {
 func (*CreateRoleRequest) ProtoMessage() {}
 
 func (x *CreateRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[5]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -350,7 +453,7 @@ func (x *CreateRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoleRequest.ProtoReflect.Descriptor instead.
 func (*CreateRoleRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{5}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CreateRoleRequest) GetName() string {
@@ -392,7 +495,7 @@ type CreateRoleResponse struct {
 
 func (x *CreateRoleResponse) Reset() {
 	*x = CreateRoleResponse{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[6]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -404,7 +507,7 @@ func (x *CreateRoleResponse) String() string {
 func (*CreateRoleResponse) ProtoMessage() {}
 
 func (x *CreateRoleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[6]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -417,7 +520,7 @@ func (x *CreateRoleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CreateRoleResponse.ProtoReflect.Descriptor instead.
 func (*CreateRoleResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{6}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *CreateRoleResponse) GetRole() *AdminRole {
@@ -449,7 +552,7 @@ type UpdateRoleRequest struct {
 
 func (x *UpdateRoleRequest) Reset() {
 	*x = UpdateRoleRequest{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[7]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -461,7 +564,7 @@ func (x *UpdateRoleRequest) String() string {
 func (*UpdateRoleRequest) ProtoMessage() {}
 
 func (x *UpdateRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[7]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -474,7 +577,7 @@ func (x *UpdateRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoleRequest.ProtoReflect.Descriptor instead.
 func (*UpdateRoleRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{7}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *UpdateRoleRequest) GetName() string {
@@ -523,7 +626,7 @@ type UpdateRoleResponse struct {
 
 func (x *UpdateRoleResponse) Reset() {
 	*x = UpdateRoleResponse{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[8]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -535,7 +638,7 @@ func (x *UpdateRoleResponse) String() string {
 func (*UpdateRoleResponse) ProtoMessage() {}
 
 func (x *UpdateRoleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[8]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -548,7 +651,7 @@ func (x *UpdateRoleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use UpdateRoleResponse.ProtoReflect.Descriptor instead.
 func (*UpdateRoleResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{8}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *UpdateRoleResponse) GetRole() *AdminRole {
@@ -569,7 +672,7 @@ type DeleteRoleRequest struct {
 
 func (x *DeleteRoleRequest) Reset() {
 	*x = DeleteRoleRequest{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[9]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -581,7 +684,7 @@ func (x *DeleteRoleRequest) String() string {
 func (*DeleteRoleRequest) ProtoMessage() {}
 
 func (x *DeleteRoleRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[9]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -594,7 +697,7 @@ func (x *DeleteRoleRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRoleRequest.ProtoReflect.Descriptor instead.
 func (*DeleteRoleRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{9}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *DeleteRoleRequest) GetName() string {
@@ -613,7 +716,7 @@ type DeleteRoleResponse struct {
 
 func (x *DeleteRoleResponse) Reset() {
 	*x = DeleteRoleResponse{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[10]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -625,7 +728,7 @@ func (x *DeleteRoleResponse) String() string {
 func (*DeleteRoleResponse) ProtoMessage() {}
 
 func (x *DeleteRoleResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[10]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -638,7 +741,7 @@ func (x *DeleteRoleResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeleteRoleResponse.ProtoReflect.Descriptor instead.
 func (*DeleteRoleResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{10}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{12}
 }
 
 // Request to replace custom role order.
@@ -653,7 +756,7 @@ type ReorderRolesRequest struct {
 
 func (x *ReorderRolesRequest) Reset() {
 	*x = ReorderRolesRequest{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[11]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -665,7 +768,7 @@ func (x *ReorderRolesRequest) String() string {
 func (*ReorderRolesRequest) ProtoMessage() {}
 
 func (x *ReorderRolesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[11]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -678,7 +781,7 @@ func (x *ReorderRolesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReorderRolesRequest.ProtoReflect.Descriptor instead.
 func (*ReorderRolesRequest) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{11}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *ReorderRolesRequest) GetRoleNames() []string {
@@ -699,7 +802,7 @@ type ReorderRolesResponse struct {
 
 func (x *ReorderRolesResponse) Reset() {
 	*x = ReorderRolesResponse{}
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[12]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -711,7 +814,7 @@ func (x *ReorderRolesResponse) String() string {
 func (*ReorderRolesResponse) ProtoMessage() {}
 
 func (x *ReorderRolesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_chatto_admin_v1_roles_proto_msgTypes[12]
+	mi := &file_chatto_admin_v1_roles_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -724,7 +827,7 @@ func (x *ReorderRolesResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReorderRolesResponse.ProtoReflect.Descriptor instead.
 func (*ReorderRolesResponse) Descriptor() ([]byte, []int) {
-	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{12}
+	return file_chatto_admin_v1_roles_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *ReorderRolesResponse) GetRoles() []*AdminRole {
@@ -738,7 +841,7 @@ var File_chatto_admin_v1_roles_proto protoreflect.FileDescriptor
 
 const file_chatto_admin_v1_roles_proto_rawDesc = "" +
 	"\n" +
-	"\x1bchatto/admin/v1/roles.proto\x12\x0fchatto.admin.v1\x1a google/protobuf/field_mask.proto\x1a\x1bbuf/validate/validate.proto\x1a\x19chatto/api/v1/roles.proto\x1a\x19chatto/api/v1/users.proto\"\x85\x01\n" +
+	"\x1bchatto/admin/v1/roles.proto\x12\x0fchatto.admin.v1\x1a google/protobuf/field_mask.proto\x1a\x1bbuf/validate/validate.proto\x1a\x19chatto/api/v1/roles.proto\x1a\x19chatto/api/v1/users.proto\x1a\x1echatto/api/v1/pagination.proto\"\x85\x01\n" +
 	"\tAdminRole\x12'\n" +
 	"\x04role\x18\x01 \x01(\v2\x13.chatto.api.v1.RoleR\x04role\x12 \n" +
 	"\vpermissions\x18\x02 \x03(\tR\vpermissions\x12-\n" +
@@ -749,12 +852,17 @@ const file_chatto_admin_v1_roles_proto_rawDesc = "" +
 	"\x17viewer_can_manage_roles\x18\x02 \x01(\bR\x14viewerCanManageRoles\x125\n" +
 	"\x17viewer_can_assign_roles\x18\x03 \x01(\bR\x14viewerCanAssignRoles\"-\n" +
 	"\x0eGetRoleRequest\x12\x1b\n" +
-	"\x04name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04name\"\xda\x01\n" +
+	"\x04name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04name\"\xbc\x01\n" +
 	"\x0fGetRoleResponse\x12.\n" +
-	"\x04role\x18\x01 \x01(\v2\x1a.chatto.admin.v1.AdminRoleR\x04role\x12)\n" +
-	"\x05users\x18\x02 \x03(\v2\x13.chatto.api.v1.UserR\x05users\x125\n" +
+	"\x04role\x18\x01 \x01(\v2\x1a.chatto.admin.v1.AdminRoleR\x04role\x125\n" +
 	"\x17viewer_can_manage_roles\x18\x03 \x01(\bR\x14viewerCanManageRoles\x125\n" +
-	"\x17viewer_can_assign_roles\x18\x04 \x01(\bR\x14viewerCanAssignRoles\"\xa4\x01\n" +
+	"\x17viewer_can_assign_roles\x18\x04 \x01(\bR\x14viewerCanAssignRolesJ\x04\b\x02\x10\x03R\x05users\"q\n" +
+	"\"AdminRoleServiceListMembersRequest\x12\x1b\n" +
+	"\x04name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04name\x12.\n" +
+	"\x04page\x18\x02 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\"\x81\x01\n" +
+	"#AdminRoleServiceListMembersResponse\x12-\n" +
+	"\amembers\x18\x01 \x03(\v2\x13.chatto.api.v1.UserR\amembers\x12+\n" +
+	"\x04page\x18\x02 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\"\xa4\x01\n" +
 	"\x11CreateRoleRequest\x12\x1b\n" +
 	"\x04name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x04name\x12*\n" +
 	"\fdisplay_name\x18\x02 \x01(\tB\a\xbaH\x04r\x02\x18PR\vdisplayName\x12*\n" +
@@ -781,10 +889,11 @@ const file_chatto_admin_v1_roles_proto_rawDesc = "" +
 	"\n" +
 	"role_names\x18\x01 \x03(\tB\x0f\xbaH\f\x92\x01\t\x10\xe8\a\"\x04r\x02\x10\x01R\troleNames\"H\n" +
 	"\x14ReorderRolesResponse\x120\n" +
-	"\x05roles\x18\x01 \x03(\v2\x1a.chatto.admin.v1.AdminRoleR\x05roles2\x96\x04\n" +
+	"\x05roles\x18\x01 \x03(\v2\x1a.chatto.admin.v1.AdminRoleR\x05roles2\x90\x05\n" +
 	"\x10AdminRoleService\x12R\n" +
 	"\tListRoles\x12!.chatto.admin.v1.ListRolesRequest\x1a\".chatto.admin.v1.ListRolesResponse\x12L\n" +
-	"\aGetRole\x12\x1f.chatto.admin.v1.GetRoleRequest\x1a .chatto.admin.v1.GetRoleResponse\x12U\n" +
+	"\aGetRole\x12\x1f.chatto.admin.v1.GetRoleRequest\x1a .chatto.admin.v1.GetRoleResponse\x12x\n" +
+	"\vListMembers\x123.chatto.admin.v1.AdminRoleServiceListMembersRequest\x1a4.chatto.admin.v1.AdminRoleServiceListMembersResponse\x12U\n" +
 	"\n" +
 	"CreateRole\x12\".chatto.admin.v1.CreateRoleRequest\x1a#.chatto.admin.v1.CreateRoleResponse\x12U\n" +
 	"\n" +
@@ -807,51 +916,59 @@ func file_chatto_admin_v1_roles_proto_rawDescGZIP() []byte {
 	return file_chatto_admin_v1_roles_proto_rawDescData
 }
 
-var file_chatto_admin_v1_roles_proto_msgTypes = make([]protoimpl.MessageInfo, 13)
+var file_chatto_admin_v1_roles_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
 var file_chatto_admin_v1_roles_proto_goTypes = []any{
-	(*AdminRole)(nil),             // 0: chatto.admin.v1.AdminRole
-	(*ListRolesRequest)(nil),      // 1: chatto.admin.v1.ListRolesRequest
-	(*ListRolesResponse)(nil),     // 2: chatto.admin.v1.ListRolesResponse
-	(*GetRoleRequest)(nil),        // 3: chatto.admin.v1.GetRoleRequest
-	(*GetRoleResponse)(nil),       // 4: chatto.admin.v1.GetRoleResponse
-	(*CreateRoleRequest)(nil),     // 5: chatto.admin.v1.CreateRoleRequest
-	(*CreateRoleResponse)(nil),    // 6: chatto.admin.v1.CreateRoleResponse
-	(*UpdateRoleRequest)(nil),     // 7: chatto.admin.v1.UpdateRoleRequest
-	(*UpdateRoleResponse)(nil),    // 8: chatto.admin.v1.UpdateRoleResponse
-	(*DeleteRoleRequest)(nil),     // 9: chatto.admin.v1.DeleteRoleRequest
-	(*DeleteRoleResponse)(nil),    // 10: chatto.admin.v1.DeleteRoleResponse
-	(*ReorderRolesRequest)(nil),   // 11: chatto.admin.v1.ReorderRolesRequest
-	(*ReorderRolesResponse)(nil),  // 12: chatto.admin.v1.ReorderRolesResponse
-	(*v1.Role)(nil),               // 13: chatto.api.v1.Role
-	(*v1.User)(nil),               // 14: chatto.api.v1.User
-	(*fieldmaskpb.FieldMask)(nil), // 15: google.protobuf.FieldMask
+	(*AdminRole)(nil),                           // 0: chatto.admin.v1.AdminRole
+	(*ListRolesRequest)(nil),                    // 1: chatto.admin.v1.ListRolesRequest
+	(*ListRolesResponse)(nil),                   // 2: chatto.admin.v1.ListRolesResponse
+	(*GetRoleRequest)(nil),                      // 3: chatto.admin.v1.GetRoleRequest
+	(*GetRoleResponse)(nil),                     // 4: chatto.admin.v1.GetRoleResponse
+	(*AdminRoleServiceListMembersRequest)(nil),  // 5: chatto.admin.v1.AdminRoleServiceListMembersRequest
+	(*AdminRoleServiceListMembersResponse)(nil), // 6: chatto.admin.v1.AdminRoleServiceListMembersResponse
+	(*CreateRoleRequest)(nil),                   // 7: chatto.admin.v1.CreateRoleRequest
+	(*CreateRoleResponse)(nil),                  // 8: chatto.admin.v1.CreateRoleResponse
+	(*UpdateRoleRequest)(nil),                   // 9: chatto.admin.v1.UpdateRoleRequest
+	(*UpdateRoleResponse)(nil),                  // 10: chatto.admin.v1.UpdateRoleResponse
+	(*DeleteRoleRequest)(nil),                   // 11: chatto.admin.v1.DeleteRoleRequest
+	(*DeleteRoleResponse)(nil),                  // 12: chatto.admin.v1.DeleteRoleResponse
+	(*ReorderRolesRequest)(nil),                 // 13: chatto.admin.v1.ReorderRolesRequest
+	(*ReorderRolesResponse)(nil),                // 14: chatto.admin.v1.ReorderRolesResponse
+	(*v1.Role)(nil),                             // 15: chatto.api.v1.Role
+	(*v1.PageRequest)(nil),                      // 16: chatto.api.v1.PageRequest
+	(*v1.User)(nil),                             // 17: chatto.api.v1.User
+	(*v1.PageInfo)(nil),                         // 18: chatto.api.v1.PageInfo
+	(*fieldmaskpb.FieldMask)(nil),               // 19: google.protobuf.FieldMask
 }
 var file_chatto_admin_v1_roles_proto_depIdxs = []int32{
-	13, // 0: chatto.admin.v1.AdminRole.role:type_name -> chatto.api.v1.Role
+	15, // 0: chatto.admin.v1.AdminRole.role:type_name -> chatto.api.v1.Role
 	0,  // 1: chatto.admin.v1.ListRolesResponse.roles:type_name -> chatto.admin.v1.AdminRole
 	0,  // 2: chatto.admin.v1.GetRoleResponse.role:type_name -> chatto.admin.v1.AdminRole
-	14, // 3: chatto.admin.v1.GetRoleResponse.users:type_name -> chatto.api.v1.User
-	0,  // 4: chatto.admin.v1.CreateRoleResponse.role:type_name -> chatto.admin.v1.AdminRole
-	15, // 5: chatto.admin.v1.UpdateRoleRequest.update_mask:type_name -> google.protobuf.FieldMask
-	0,  // 6: chatto.admin.v1.UpdateRoleResponse.role:type_name -> chatto.admin.v1.AdminRole
-	0,  // 7: chatto.admin.v1.ReorderRolesResponse.roles:type_name -> chatto.admin.v1.AdminRole
-	1,  // 8: chatto.admin.v1.AdminRoleService.ListRoles:input_type -> chatto.admin.v1.ListRolesRequest
-	3,  // 9: chatto.admin.v1.AdminRoleService.GetRole:input_type -> chatto.admin.v1.GetRoleRequest
-	5,  // 10: chatto.admin.v1.AdminRoleService.CreateRole:input_type -> chatto.admin.v1.CreateRoleRequest
-	7,  // 11: chatto.admin.v1.AdminRoleService.UpdateRole:input_type -> chatto.admin.v1.UpdateRoleRequest
-	9,  // 12: chatto.admin.v1.AdminRoleService.DeleteRole:input_type -> chatto.admin.v1.DeleteRoleRequest
-	11, // 13: chatto.admin.v1.AdminRoleService.ReorderRoles:input_type -> chatto.admin.v1.ReorderRolesRequest
-	2,  // 14: chatto.admin.v1.AdminRoleService.ListRoles:output_type -> chatto.admin.v1.ListRolesResponse
-	4,  // 15: chatto.admin.v1.AdminRoleService.GetRole:output_type -> chatto.admin.v1.GetRoleResponse
-	6,  // 16: chatto.admin.v1.AdminRoleService.CreateRole:output_type -> chatto.admin.v1.CreateRoleResponse
-	8,  // 17: chatto.admin.v1.AdminRoleService.UpdateRole:output_type -> chatto.admin.v1.UpdateRoleResponse
-	10, // 18: chatto.admin.v1.AdminRoleService.DeleteRole:output_type -> chatto.admin.v1.DeleteRoleResponse
-	12, // 19: chatto.admin.v1.AdminRoleService.ReorderRoles:output_type -> chatto.admin.v1.ReorderRolesResponse
-	14, // [14:20] is the sub-list for method output_type
-	8,  // [8:14] is the sub-list for method input_type
-	8,  // [8:8] is the sub-list for extension type_name
-	8,  // [8:8] is the sub-list for extension extendee
-	0,  // [0:8] is the sub-list for field type_name
+	16, // 3: chatto.admin.v1.AdminRoleServiceListMembersRequest.page:type_name -> chatto.api.v1.PageRequest
+	17, // 4: chatto.admin.v1.AdminRoleServiceListMembersResponse.members:type_name -> chatto.api.v1.User
+	18, // 5: chatto.admin.v1.AdminRoleServiceListMembersResponse.page:type_name -> chatto.api.v1.PageInfo
+	0,  // 6: chatto.admin.v1.CreateRoleResponse.role:type_name -> chatto.admin.v1.AdminRole
+	19, // 7: chatto.admin.v1.UpdateRoleRequest.update_mask:type_name -> google.protobuf.FieldMask
+	0,  // 8: chatto.admin.v1.UpdateRoleResponse.role:type_name -> chatto.admin.v1.AdminRole
+	0,  // 9: chatto.admin.v1.ReorderRolesResponse.roles:type_name -> chatto.admin.v1.AdminRole
+	1,  // 10: chatto.admin.v1.AdminRoleService.ListRoles:input_type -> chatto.admin.v1.ListRolesRequest
+	3,  // 11: chatto.admin.v1.AdminRoleService.GetRole:input_type -> chatto.admin.v1.GetRoleRequest
+	5,  // 12: chatto.admin.v1.AdminRoleService.ListMembers:input_type -> chatto.admin.v1.AdminRoleServiceListMembersRequest
+	7,  // 13: chatto.admin.v1.AdminRoleService.CreateRole:input_type -> chatto.admin.v1.CreateRoleRequest
+	9,  // 14: chatto.admin.v1.AdminRoleService.UpdateRole:input_type -> chatto.admin.v1.UpdateRoleRequest
+	11, // 15: chatto.admin.v1.AdminRoleService.DeleteRole:input_type -> chatto.admin.v1.DeleteRoleRequest
+	13, // 16: chatto.admin.v1.AdminRoleService.ReorderRoles:input_type -> chatto.admin.v1.ReorderRolesRequest
+	2,  // 17: chatto.admin.v1.AdminRoleService.ListRoles:output_type -> chatto.admin.v1.ListRolesResponse
+	4,  // 18: chatto.admin.v1.AdminRoleService.GetRole:output_type -> chatto.admin.v1.GetRoleResponse
+	6,  // 19: chatto.admin.v1.AdminRoleService.ListMembers:output_type -> chatto.admin.v1.AdminRoleServiceListMembersResponse
+	8,  // 20: chatto.admin.v1.AdminRoleService.CreateRole:output_type -> chatto.admin.v1.CreateRoleResponse
+	10, // 21: chatto.admin.v1.AdminRoleService.UpdateRole:output_type -> chatto.admin.v1.UpdateRoleResponse
+	12, // 22: chatto.admin.v1.AdminRoleService.DeleteRole:output_type -> chatto.admin.v1.DeleteRoleResponse
+	14, // 23: chatto.admin.v1.AdminRoleService.ReorderRoles:output_type -> chatto.admin.v1.ReorderRolesResponse
+	17, // [17:24] is the sub-list for method output_type
+	10, // [10:17] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_chatto_admin_v1_roles_proto_init() }
@@ -859,14 +976,14 @@ func file_chatto_admin_v1_roles_proto_init() {
 	if File_chatto_admin_v1_roles_proto != nil {
 		return
 	}
-	file_chatto_admin_v1_roles_proto_msgTypes[7].OneofWrappers = []any{}
+	file_chatto_admin_v1_roles_proto_msgTypes[9].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_chatto_admin_v1_roles_proto_rawDesc), len(file_chatto_admin_v1_roles_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   13,
+			NumMessages:   15,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -94,6 +94,12 @@ another account. These operations validate stable request-time authorization
 inputs, use OCC on the target user aggregate, and then return the ready user
 projection.
 
+`AdminRoleService` separates role details from explicit membership pages.
+`ListMembers` gates each request with `role.assign`; it selects assignment IDs
+before bounded user-profile hydration. It does not require `admin.view-users`.
+See [role operations](../../cli/internal/core/role_management.go) and the
+[role member assembler](../../cli/internal/connectapi/role_member_assembler.go).
+
 `BotService` exposes bot lifecycle, administrator-initiated owner reassignment,
 and create and revoke operations for as many as 20 named API keys and 20 named
 incoming webhooks for each bot. Bot

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -1,7 +1,7 @@
 # FDR-001: Roles & Permissions (RBAC)
 
 **Status:** Active
-**Last reviewed:** 2026-09-09
+**Last reviewed:** 2026-09-10
 
 ## Overview
 
@@ -27,6 +27,12 @@ including management overrides. Membership does not grant message permissions.
 See [FDR-038](FDR-038-bot-accounts.md).
 
 ## Behavior
+
+- Role details and assigned members are separate reads. Member lists load in
+  bounded pages so large roles do not require every user profile at once.
+  Roster access requires `role.assign`, not access to the full administrative
+  user directory. Only explicit assignments appear; `everyone` has no roster.
+  Pages reflect current assignments, so concurrent changes can shift offsets.
 
 - Every authenticated human user belongs to the implicit `everyone` role and may additionally hold one or more named roles. Bots inherit neither `everyone` nor named-role permissions.
 - The system roles are `owner`, `admin`, `moderator`, `everyone`. Role position controls ordering/display and legacy event compatibility; it is not an authorization rank.

--- a/docs/fdr/INDEX.md
+++ b/docs/fdr/INDEX.md
@@ -10,7 +10,7 @@ See [`.agents/skills/fdr/SKILL.md`](../../.agents/skills/fdr/SKILL.md) for the F
 
 | # | Feature | Status | Last reviewed |
 |---|---------|--------|---------------|
-| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-09-09 |
+| [FDR-001](FDR-001-roles-and-permissions.md) | Roles & Permissions (RBAC) | Active | 2026-09-10 |
 | [FDR-002](FDR-002-replies-and-threads.md) | Replies & Threads | Active | 2026-09-10 |
 | [FDR-003](FDR-003-thread-reply-echo.md) | Thread Reply Echo | Active | 2026-09-04 |
 | [FDR-004](FDR-004-message-editing-and-deletion.md) | Message Editing & Deletion | Active | 2026-08-25 |

--- a/packages/api-types/src/chatto/admin/v1/roles_connect.ts
+++ b/packages/api-types/src/chatto/admin/v1/roles_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CreateRoleRequest, CreateRoleResponse, DeleteRoleRequest, DeleteRoleResponse, GetRoleRequest, GetRoleResponse, ListRolesRequest, ListRolesResponse, ReorderRolesRequest, ReorderRolesResponse, UpdateRoleRequest, UpdateRoleResponse } from "./roles_pb.js";
+import { AdminRoleServiceListMembersRequest, AdminRoleServiceListMembersResponse, CreateRoleRequest, CreateRoleResponse, DeleteRoleRequest, DeleteRoleResponse, GetRoleRequest, GetRoleResponse, ListRolesRequest, ListRolesResponse, ReorderRolesRequest, ReorderRolesResponse, UpdateRoleRequest, UpdateRoleResponse } from "./roles_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -30,8 +30,7 @@ export const AdminRoleService = {
     },
     /**
      * Gets one role plus admin detail metadata. Returns NOT_FOUND when the
-     * role does not exist. Requires an authenticated user; the assigned-user
-     * roster is empty unless the caller may assign roles.
+     * role does not exist. Requires an authenticated user.
      *
      * @generated from rpc chatto.admin.v1.AdminRoleService.GetRole
      */
@@ -39,6 +38,18 @@ export const AdminRoleService = {
       name: "GetRole",
       I: GetRoleRequest,
       O: GetRoleResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * Lists explicit role members. Requires role.assign, without requiring
+     * admin.view-users. Returns NOT_FOUND when the role does not exist.
+     *
+     * @generated from rpc chatto.admin.v1.AdminRoleService.ListMembers
+     */
+    listMembers: {
+      name: "ListMembers",
+      I: AdminRoleServiceListMembersRequest,
+      O: AdminRoleServiceListMembersResponse,
       kind: MethodKind.Unary,
     },
     /**

--- a/packages/api-types/src/chatto/admin/v1/roles_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/roles_pb.ts
@@ -6,6 +6,7 @@
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { FieldMask, Message, proto3 } from "@bufbuild/protobuf";
 import { Role } from "../../api/v1/roles_pb.js";
+import { PageInfo, PageRequest } from "../../api/v1/pagination_pb.js";
 import { User } from "../../api/v1/users_pb.js";
 
 /**
@@ -210,13 +211,6 @@ export class GetRoleResponse extends Message<GetRoleResponse> {
   role?: AdminRole;
 
   /**
-   * Explicit users with this role. Empty unless the caller may assign roles.
-   *
-   * @generated from field: repeated chatto.api.v1.User users = 2;
-   */
-  users: User[] = [];
-
-  /**
    * Whether the caller may create/update/delete role definitions.
    *
    * @generated from field: bool viewer_can_manage_roles = 3;
@@ -239,7 +233,6 @@ export class GetRoleResponse extends Message<GetRoleResponse> {
   static readonly typeName = "chatto.admin.v1.GetRoleResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "role", kind: "message", T: AdminRole },
-    { no: 2, name: "users", kind: "message", T: User, repeated: true },
     { no: 3, name: "viewer_can_manage_roles", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
     { no: 4, name: "viewer_can_assign_roles", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ]);
@@ -258,6 +251,106 @@ export class GetRoleResponse extends Message<GetRoleResponse> {
 
   static equals(a: GetRoleResponse | PlainMessage<GetRoleResponse> | undefined, b: GetRoleResponse | PlainMessage<GetRoleResponse> | undefined): boolean {
     return proto3.util.equals(GetRoleResponse, a, b);
+  }
+}
+
+/**
+ * Request a page of explicit role members.
+ *
+ * @generated from message chatto.admin.v1.AdminRoleServiceListMembersRequest
+ */
+export class AdminRoleServiceListMembersRequest extends Message<AdminRoleServiceListMembersRequest> {
+  /**
+   * Stable role name.
+   *
+   * @generated from field: string name = 1;
+   */
+  name = "";
+
+  /**
+   * Defaults to 20 members; capped at 100. Offset counts explicit assignments.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 2;
+   */
+  page?: PageRequest;
+
+  constructor(data?: PartialMessage<AdminRoleServiceListMembersRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.admin.v1.AdminRoleServiceListMembersRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "page", kind: "message", T: PageRequest },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AdminRoleServiceListMembersRequest {
+    return new AdminRoleServiceListMembersRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AdminRoleServiceListMembersRequest {
+    return new AdminRoleServiceListMembersRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AdminRoleServiceListMembersRequest {
+    return new AdminRoleServiceListMembersRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AdminRoleServiceListMembersRequest | PlainMessage<AdminRoleServiceListMembersRequest> | undefined, b: AdminRoleServiceListMembersRequest | PlainMessage<AdminRoleServiceListMembersRequest> | undefined): boolean {
+    return proto3.util.equals(AdminRoleServiceListMembersRequest, a, b);
+  }
+}
+
+/**
+ * Explicit members sorted by user ID. Each page is a live read; assignment
+ * changes between requests can shift offsets. The implicit everyone role has
+ * no explicit members. Revoked assignments are excluded.
+ *
+ * @generated from message chatto.admin.v1.AdminRoleServiceListMembersResponse
+ */
+export class AdminRoleServiceListMembersResponse extends Message<AdminRoleServiceListMembersResponse> {
+  /**
+   * Canonical public user records for the selected assignments.
+   *
+   * @generated from field: repeated chatto.api.v1.User members = 1;
+   */
+  members: User[] = [];
+
+  /**
+   * Total explicit assignment count and whether another page exists.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 2;
+   */
+  page?: PageInfo;
+
+  constructor(data?: PartialMessage<AdminRoleServiceListMembersResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "chatto.admin.v1.AdminRoleServiceListMembersResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "members", kind: "message", T: User, repeated: true },
+    { no: 2, name: "page", kind: "message", T: PageInfo },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AdminRoleServiceListMembersResponse {
+    return new AdminRoleServiceListMembersResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): AdminRoleServiceListMembersResponse {
+    return new AdminRoleServiceListMembersResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): AdminRoleServiceListMembersResponse {
+    return new AdminRoleServiceListMembersResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: AdminRoleServiceListMembersResponse | PlainMessage<AdminRoleServiceListMembersResponse> | undefined, b: AdminRoleServiceListMembersResponse | PlainMessage<AdminRoleServiceListMembersResponse> | undefined): boolean {
+    return proto3.util.equals(AdminRoleServiceListMembersResponse, a, b);
   }
 }
 

--- a/proto/chatto/admin/v1/roles.proto
+++ b/proto/chatto/admin/v1/roles.proto
@@ -6,6 +6,7 @@ import "google/protobuf/field_mask.proto";
 import "buf/validate/validate.proto";
 import "chatto/api/v1/roles.proto";
 import "chatto/api/v1/users.proto";
+import "chatto/api/v1/pagination.proto";
 
 // Role metadata plus administrative permission state.
 message AdminRole {
@@ -40,12 +41,30 @@ message GetRoleRequest {
 message GetRoleResponse {
   // Requested role.
   AdminRole role = 1;
-  // Explicit users with this role. Empty unless the caller may assign roles.
-  repeated chatto.api.v1.User users = 2;
+  reserved 2;
+  reserved "users";
   // Whether the caller may create/update/delete role definitions.
   bool viewer_can_manage_roles = 3;
   // Whether the caller may assign/revoke roles and view role rosters.
   bool viewer_can_assign_roles = 4;
+}
+
+// Request a page of explicit role members.
+message AdminRoleServiceListMembersRequest {
+  // Stable role name.
+  string name = 1 [(buf.validate.field).string.min_len = 1];
+  // Defaults to 20 members; capped at 100. Offset counts explicit assignments.
+  chatto.api.v1.PageRequest page = 2;
+}
+
+// Explicit members sorted by user ID. Each page is a live read; assignment
+// changes between requests can shift offsets. The implicit everyone role has
+// no explicit members. Revoked assignments are excluded.
+message AdminRoleServiceListMembersResponse {
+  // Canonical public user records for the selected assignments.
+  repeated chatto.api.v1.User members = 1;
+  // Total explicit assignment count and whether another page exists.
+  chatto.api.v1.PageInfo page = 2;
 }
 
 // Request to create a role.
@@ -127,9 +146,11 @@ service AdminRoleService {
   // effects; use chatto.api.v1.RoleService for lightweight catalog rendering.
   rpc ListRoles(ListRolesRequest) returns (ListRolesResponse);
   // Gets one role plus admin detail metadata. Returns NOT_FOUND when the
-  // role does not exist. Requires an authenticated user; the assigned-user
-  // roster is empty unless the caller may assign roles.
+  // role does not exist. Requires an authenticated user.
   rpc GetRole(GetRoleRequest) returns (GetRoleResponse);
+  // Lists explicit role members. Requires role.assign, without requiring
+  // admin.view-users. Returns NOT_FOUND when the role does not exist.
+  rpc ListMembers(AdminRoleServiceListMembersRequest) returns (AdminRoleServiceListMembersResponse);
   // Creates a custom role. Requires role.manage.
   rpc CreateRole(CreateRoleRequest) returns (CreateRoleResponse);
   // Updates role metadata. Requires role.manage.


### PR DESCRIPTION
## Why

- Role detail reads loaded every assigned user, making a single lookup grow with the full roster

## What changed

- Add `AdminRoleService.ListMembers` with canonical users, shared pagination, stable user ID ordering, a default of 20, and a maximum of 100; hydrate only the selected page
- Migrate the role editor to automatic page loading and update assignment, role-deletion, and deleted-user cache handling
- Update generated clients/reference, [FDR-001](docs/fdr/FDR-001-roles-and-permissions.md), the interface inventory, and release/migration guidance

## API compatibility

- Breaking experimental API change, approved for 0.5: replace `GetRoleResponse.users` with `ListMembers` calls; retain `role.assign` authorization without requiring `admin.view-users`; no stored-data change

## Test plan

- Passed from `cli/`: `mise x -- go test ./internal/connectapi -count=1 -timeout 240s` and `mise x -- go test -race ./internal/connectapi -run TestAdminRoleMembersPaginationAndAuthorization -count=1 -timeout 240s`
- Passed: core role/RBAC tests and `TestProjectionSnapshotContractsIncludeCurrentSchema`
- Passed: 30 focused frontend/API/cache/component/Storybook tests; real-server 21-member scrolling test; frontend checks and docs build; protobuf lint and storage compatibility; license check
- Chrome DevTools: inspected the role page and member count against the local server; no console errors
- Buf reports only the intended `GetRoleResponse.users` removal
