### PR TITLE
feat(frontend): add shared startup and page entrance animations

### DIFF
--- a/apps/docs-website/src/content/docs/getting-started/faq.mdx
+++ b/apps/docs-website/src/content/docs/getting-started/faq.mdx
@@ -47,6 +47,16 @@ Not yet. Dedicated desktop and mobile apps are planned, but we do not have an es
 
 In the meantime, Chatto is an excellent Progressive Web App (PWA) on both desktop and mobile devices. You can install it from a supported browser or add it to your Home Screen, then launch it like any other app. Installed PWAs also support features such as app badges and [push notifications](/guides/operations/notifications-web-push/) where the operating system and browser allow them.
 
+## Can I disable the startup animations?
+
+Enable reduced motion in your operating system or browser. Chatto then shows a
+static loading background and skips the page entrance animation.
+
+The loading screen follows your selected light or dark theme. The page entrance
+animation runs once when you open or reload the app. It does not repeat when
+you navigate between pages. Typing or clicking stops the entrance animation
+immediately.
+
 ## Where can I get help or report a problem?
 
 Join [Chatto HQ](https://chat.chatto.run/) and visit the `#self-hosting-support` channel for setup questions, operational help, or general feedback. Report bugs in the `#bug-reports` channel; maintainers will create GitHub issues for actionable reports.

--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -450,3 +450,24 @@ style blocks are expected in a few specialized areas: media overlays, rich-text
 editing, viewport/safe-area chrome, and content whose geometry comes from
 external media. Keep those exceptions local and document why the semantic
 system does not apply.
+
+## Initial Page Reveal
+
+The app layout reveals the first page with a short, staggered fade and scale.
+It runs once per full page load. Route changes and later content updates do not
+start it again. Reduced motion skips the reveal; keyboard or pointer input stops it.
+
+Shared pane and authentication components mark sections with `data-page-reveal`.
+Use this attribute to split a custom page into smaller reveal sections. The
+layout animates separate sections, never a parent and its children together.
+Keep content visible in its base styles. Do not add a second entrance animation
+to a page.
+
+Before the initial route is ready, the HTML shell shows soft, blurry neutral
+blobs that drift across the viewport.
+Its critical styles are inline so it does not wait for application assets. It
+uses the background and emphasized-surface theme tokens, with matching light
+and dark fallbacks before CSS loads, and stays static with reduced motion. A
+faint, centred CHATTO wordmark uses a fixed system font to prevent size changes
+when application fonts load. The app removes the shell when its layout mounts.
+Automatic form focus does not stop the reveal.

--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -179,6 +179,75 @@
         });
       })();
     </script>
+    <!-- Critical startup styles must work before the application CSS downloads. -->
+    <style>
+      #app-loading {
+        /* Match the theme tokens even before the application stylesheet arrives. */
+        --loading-background: #f3f4f6;
+        --loading-highlight: #dadde2;
+        --loading-text: #4b5563;
+        display: grid;
+        place-items: center;
+        position: fixed;
+        inset: 0;
+        overflow: hidden;
+        pointer-events: none;
+        background: var(--color-background, var(--loading-background));
+      }
+      :root[data-theme='dark'] #app-loading {
+        --loading-background: #171717;
+        --loading-highlight: #404040;
+        --loading-text: #d4d4d4;
+      }
+      #app-loading > span {
+        position: relative;
+        color: var(--color-text, var(--loading-text));
+        /* Keep metrics stable when application CSS and web fonts arrive. */
+        box-sizing: border-box;
+        font: 600 20px / 1 system-ui, sans-serif;
+        letter-spacing: 0.45em;
+        padding-inline-start: 0.45em;
+        opacity: 0.28;
+      }
+      #app-loading::before {
+        content: '';
+        position: absolute;
+        inset: -25%;
+        background:
+          radial-gradient(
+            ellipse at 35% 40%,
+            color-mix(
+              in srgb,
+              var(--color-surface-emphasized, var(--loading-highlight)) 75%,
+              transparent
+            ),
+            transparent 50%
+          ),
+          radial-gradient(
+            ellipse at 65% 60%,
+            color-mix(
+              in srgb,
+              var(--color-surface-emphasized, var(--loading-highlight)) 55%,
+              transparent
+            ),
+            transparent 50%
+          );
+        animation: app-loading-drift 2.6s ease-in-out infinite alternate;
+      }
+      @keyframes app-loading-drift {
+        from {
+          transform: translate(-12%, -6%) scale(0.95);
+        }
+        to {
+          transform: translate(12%, 6%) scale(1.05);
+        }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        #app-loading::before {
+          animation: none;
+        }
+      }
+    </style>
     <!-- OG_META_PLACEHOLDER -->
     <meta
       name="viewport"
@@ -192,6 +261,7 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon" />
   </head>
   <body>
+    <div id="app-loading" aria-hidden="true"><span dir="ltr">CHATTO</span></div>
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/apps/frontend/src/lib/attachments/initialPageReveal.svelte.spec.ts
+++ b/apps/frontend/src/lib/attachments/initialPageReveal.svelte.spec.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { initialPageReveal } from './initialPageReveal';
+
+let root: HTMLDivElement;
+let motion: EventTarget & { matches: boolean };
+let cleanup: void | (() => void);
+
+beforeEach(() => {
+  motion = Object.assign(new EventTarget(), { matches: false });
+  vi.spyOn(window, 'matchMedia').mockReturnValue(motion as MediaQueryList);
+  root = document.createElement('div');
+  root.innerHTML = `<header>App</header><main><aside>Servers</aside><section data-page-reveal><h1 data-page-reveal>Title</h1><form data-page-reveal><input aria-label="Name"></form></section></main>`;
+  document.body.append(root);
+});
+
+afterEach(() => {
+  cleanup?.();
+  cleanup = undefined;
+  root.remove();
+  vi.restoreAllMocks();
+});
+
+it('reveals separate sections without scaling nested sections twice', () => {
+  cleanup = initialPageReveal(root);
+  const animations = root.getAnimations({ subtree: true });
+  const targets = animations.map((animation) => (animation.effect as KeyframeEffect).target);
+  expect(targets).toEqual(Array.from(root.querySelectorAll('header, aside, h1, form')));
+  expect(animations.map((animation) => animation.effect?.getTiming().delay)).toEqual([
+    0, 90, 180, 270
+  ]);
+  expect(root.querySelector('section')?.getAnimations()).toHaveLength(0);
+});
+
+it('does not animate content inserted by navigation or an asynchronous load', () => {
+  cleanup = initialPageReveal(root);
+  root.querySelector('main')!.innerHTML = '<section data-page-reveal>Next page</section>';
+  expect(root.querySelector('section')?.getAnimations({ subtree: true })).toHaveLength(0);
+});
+
+it('keeps automatic form focus but reveals all controls before keyboard input', () => {
+  root.querySelector('input')!.focus();
+  cleanup = initialPageReveal(root);
+  expect(root.getAnimations({ subtree: true }).length).toBeGreaterThan(0);
+  window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+  expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+});
+
+it('skips reduced motion and cancels when the preference changes', () => {
+  motion.matches = true;
+  cleanup = initialPageReveal(root);
+  expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+  motion.matches = false;
+  cleanup = initialPageReveal(root);
+  expect(root.getAnimations({ subtree: true }).length).toBeGreaterThan(0);
+  motion.matches = true;
+  motion.dispatchEvent(new Event('change'));
+  expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+});
+
+it('removes animation effects after completion and on unmount', () => {
+  cleanup = initialPageReveal(root);
+  for (const animation of root.getAnimations({ subtree: true })) animation.finish();
+  expect(getComputedStyle(root.querySelector('form')!).scale).toBe('none');
+  cleanup?.();
+  expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+});
+
+it('reveals controls before pointer interaction', () => {
+  cleanup = initialPageReveal(root);
+  root.querySelector('input')!.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+  expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+});
+
+it('removes the startup shell even when reduced motion skips the reveal', () => {
+  const loading = document.createElement('div');
+  loading.id = 'app-loading';
+  document.body.append(loading);
+  motion.matches = true;
+  cleanup = initialPageReveal(root);
+  expect(loading.isConnected).toBe(false);
+});

--- a/apps/frontend/src/lib/attachments/initialPageReveal.ts
+++ b/apps/frontend/src/lib/attachments/initialPageReveal.ts
@@ -1,0 +1,59 @@
+import type { Attachment } from 'svelte/attachments';
+
+/** Split the initial app into sections, without animating both a parent and its children. */
+function revealSections(element: Element): Element[] {
+  if (element.querySelector('[data-page-reveal]')) {
+    return Array.from(element.children).flatMap(revealSections);
+  }
+  return element.getBoundingClientRect().height > 0 ? [element] : [];
+}
+
+/**
+ * Reveal the initial app once per root-layout mount. Later route changes and
+ * asynchronously loaded content stay immediately visible. Mark sections with
+ * data-page-reveal to control the stagger; unmarked siblings remain whole.
+ */
+export const initialPageReveal: Attachment = (element) => {
+  // The HTML shell is visible while SvelteKit resolves the initial route.
+  document.getElementById('app-loading')?.remove();
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  if (reducedMotion.matches) return;
+
+  const sections = Array.from(element.children).flatMap(revealSections);
+  const stagger = Math.min(90, 270 / Math.max(1, sections.length - 1));
+  const animations = sections.map((part, index) =>
+    part.animate(
+      [
+        { opacity: 0, scale: '0.98' },
+        { opacity: 1, scale: '1' }
+      ],
+      { duration: 540, delay: index * stagger, easing: 'ease-out', fill: 'backwards' }
+    )
+  );
+  const showAll = () => {
+    for (const animation of animations) {
+      animation.onfinish = null;
+      animation.cancel();
+    }
+    // Release initial route elements when the reveal ends, before later navigation.
+    animations.length = 0;
+    window.removeEventListener('keydown', showAll, true);
+    element.removeEventListener('pointerdown', showAll, true);
+    reducedMotion.removeEventListener('change', stopForReducedMotion);
+  };
+  const stopForReducedMotion = () => {
+    if (reducedMotion.matches) showAll();
+  };
+  // Automatic form focus must not cancel the reveal. Real input makes every
+  // control visible before the browser handles the key or pointer action.
+  window.addEventListener('keydown', showAll, true);
+  element.addEventListener('pointerdown', showAll, true);
+  reducedMotion.addEventListener('change', stopForReducedMotion);
+  let remaining = animations.length;
+  for (const animation of animations) {
+    animation.onfinish = () => {
+      if (--remaining === 0) showAll();
+    };
+  }
+  return showAll;
+};

--- a/apps/frontend/src/lib/components/AuthLayout.svelte
+++ b/apps/frontend/src/lib/components/AuthLayout.svelte
@@ -29,7 +29,7 @@
   <!-- Left pane: server branding (hidden on mobile, hidden entirely if no branding content) -->
   {#if showBranding && hasBranding && !compact}
     <div class="hidden flex-1 overflow-y-auto border-r border-border bg-surface/30 p-8 md:block">
-      <div class="mx-auto max-w-md">
+      <div data-page-reveal class="mx-auto max-w-md">
         <ServerBranding name={serverName} {iconUrl} {bannerUrl} {description} {welcomeMessage} />
       </div>
     </div>
@@ -43,18 +43,18 @@
       compact ? 'p-5 sm:p-6' : 'p-8'
     ]}
   >
-    <div class="w-full max-w-sm">
+    <div data-page-reveal class="w-full max-w-sm">
       <!-- Show compact branding header on mobile, or when no left pane -->
       {#if showBranding && compact}
-        <div class="mb-5">
+        <div data-page-reveal class="mb-5">
           <ServerBranding name={serverName} {iconUrl} compact />
         </div>
       {:else if showBranding && !hasBranding}
-        <div class="mb-8">
+        <div data-page-reveal class="mb-8">
           <ServerBranding name={serverName} {iconUrl} />
         </div>
       {:else if showBranding}
-        <div class="mb-8 md:hidden">
+        <div data-page-reveal class="mb-8 md:hidden">
           <ServerBranding name={serverName} {iconUrl} {bannerUrl} {description} {welcomeMessage} />
         </div>
       {/if}

--- a/apps/frontend/src/lib/ui/PaneContent.svelte
+++ b/apps/frontend/src/lib/ui/PaneContent.svelte
@@ -16,7 +16,10 @@
 
 <ScrollFader top bottom bind:scrollEl={scrollContainer}>
   <!-- A zero-length basis keeps tall children bounded inside the min-height content wrapper. -->
-  <div class={['w-full max-w-5xl p-6', fillHeight && 'flex min-h-0 flex-1 basis-0 flex-col']}>
+  <div
+    data-page-reveal
+    class={['w-full max-w-5xl p-6', fillHeight && 'flex min-h-0 flex-1 basis-0 flex-col']}
+  >
     {@render children()}
   </div>
 </ScrollFader>

--- a/apps/frontend/src/lib/ui/PaneHeader.svelte
+++ b/apps/frontend/src/lib/ui/PaneHeader.svelte
@@ -70,6 +70,7 @@ choice).
 </script>
 
 <div
+  data-page-reveal
   class={[
     'flex h-14 shrink-0 items-center justify-between border-b border-border pe-2',
     hasBack ? 'ps-2' : 'ps-4'

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { initialPageReveal } from '$lib/attachments/initialPageReveal';
   import { afterNavigate, goto } from '$app/navigation';
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
@@ -83,6 +84,7 @@
 </svelte:head>
 
 <div
+  {@attach initialPageReveal}
   use:sidebarSwipe
   class="flex h-full w-full flex-col overscroll-y-contain bg-surface pt-[env(safe-area-inset-top,0px)] md:p-3 md:pt-0"
 >

--- a/apps/frontend/src/routes/setup/+page.svelte
+++ b/apps/frontend/src/routes/setup/+page.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import type { Attachment } from 'svelte/attachments';
 	import { Code, ConnectError } from '@connectrpc/connect';
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
@@ -21,33 +20,6 @@
 	let busy = $state(false);
 	let error = $state('');
 	let closed = $state(false);
-
-	/** Reveal the server pane in order without delaying keyboard access to its form. */
-	const revealPage: Attachment = (element) => {
-		const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-		if (reducedMotion.matches) return;
-		const animations = Array.from(element.querySelectorAll('[data-setup-reveal]'), (part, index) =>
-			part.animate(
-				[
-					{ opacity: 0, transform: 'scale(0.98)' },
-					{ opacity: 1, transform: 'scale(1)' }
-				],
-				{ duration: 600, delay: index * 100, easing: 'ease-out', fill: 'both' }
-			)
-		);
-		const showAll = () => animations.forEach((animation) => animation.cancel());
-		const stopForReducedMotion = () => {
-			if (reducedMotion.matches) showAll();
-		};
-		// Keyboard navigation must never focus a control that is still transparent.
-		element.addEventListener('focusin', showAll);
-		reducedMotion.addEventListener('change', stopForReducedMotion);
-		return () => {
-			showAll();
-			element.removeEventListener('focusin', showAll);
-			reducedMotion.removeEventListener('change', stopForReducedMotion);
-		};
-	};
 
 	async function submit(event: SubmitEvent) {
 		event.preventDefault();
@@ -106,22 +78,22 @@
 
 <!-- @component Single-form origin-server setup inside the shared client shell. -->
 <PageTitle title={m('auth.setup.title')} />
-<div class="pane-page" {@attach revealPage}>
-	<div class="shrink-0" data-setup-reveal>
+<div class="pane-page">
+	<div class="shrink-0" data-page-reveal>
 		<PaneHeader title={m('auth.setup.title')} />
 	</div>
 	<PaneContent>
 		<div class="flex flex-col gap-6">
 			<div class="flex flex-col items-start gap-5 py-2 sm:flex-row sm:items-center">
-				<div class="shrink-0" aria-hidden="true" data-setup-reveal>
+				<div class="shrink-0" aria-hidden="true" data-page-reveal>
 					<img src={chattoIcon} alt="" width="96" height="96" class="size-24 outline-none" />
 				</div>
-				<div class="flex max-w-xl flex-col gap-2" data-setup-reveal>
+				<div class="flex max-w-xl flex-col gap-2" data-page-reveal>
 					<h2 class="text-2xl font-bold text-balance text-text-top">{m('auth.setup.welcome')}</h2>
 					<p class="text-pretty text-muted">{m('auth.setup.intro')}</p>
 				</div>
 			</div>
-			<div data-setup-reveal>
+			<div data-page-reveal>
 				<Panel title={m('auth.setup.title')}>
 					{#if closed}
 						<div class="flex flex-col items-start gap-4">

--- a/apps/frontend/src/routes/setup/setup.page.svelte.spec.ts
+++ b/apps/frontend/src/routes/setup/setup.page.svelte.spec.ts
@@ -22,27 +22,12 @@ function renderSetup() {
 describe('first-run wizard', () => {
   beforeEach(() => { vi.clearAllMocks(); mocks.discovery.mockResolvedValue({ setupRequired: true }); });
 
-  it('shows the complete form without decorative animation when reduced motion is enabled', async () => {
-    const original = window.matchMedia.bind(window);
-    const media = vi.spyOn(window, 'matchMedia').mockImplementation((query) => {
-      const result = original(query);
-      if (query === '(prefers-reduced-motion: reduce)') {
-        Object.defineProperty(result, 'matches', { value: true });
-      }
-      return result;
-    });
-    try {
-      const view = renderSetup();
-      await expect.element(view.getByLabelText('Server name')).toBeVisible();
-      await expect.element(view.getByLabelText('Username', { exact: true })).toBeVisible();
-      expect(view.container.querySelectorAll('form')).toHaveLength(1);
-      for (const part of view.container.querySelectorAll('[data-setup-reveal]')) {
-        expect(part.getAnimations()).toHaveLength(0);
-      }
-      expect(view.container.querySelector('svg')).toBeNull();
-    } finally {
-      media.mockRestore();
-    }
+  it('shows the complete form without starting a page-local animation', async () => {
+    const view = renderSetup();
+    await expect.element(view.getByLabelText('Server name')).toBeVisible();
+    await expect.element(view.getByLabelText('Username', { exact: true })).toBeVisible();
+    expect(view.container.querySelectorAll('form')).toHaveLength(1);
+    expect(view.container.getAnimations({ subtree: true })).toHaveLength(0);
   });
 
   it('keeps the draft after validation failure and submits all fields together', async () => {

--- a/docs/fdr/FDR-047-first-run-setup.md
+++ b/docs/fdr/FDR-047-first-run-setup.md
@@ -40,8 +40,10 @@ unavailable in release builds.
 
 The wizard collects server details and the owner account in one form. Password
 confirmation must match before submission. Account validation errors appear
-below the affected field; connection and setup-state errors apply to the form. A short
-Chatto logo reveal welcomes the operator and respects reduced-motion settings.
+below the affected field; connection and setup-state errors apply to the form. The page uses
+the shared initial-load reveal: sections fade and scale in with a short stagger.
+This runs once per full page load on all pages, respects reduced-motion settings,
+and stops on keyboard or pointer input. Client-side navigation does not replay it.
 The wizard uses the normal app header, frame, and server gutter. Selecting an
 uninitialized origin server opens setup instead of sign-in. Users can still add
 other servers and use their accounts on those servers. Setup does not block


### PR DESCRIPTION
- **What:** Move the setup wizard’s staggered fade and zoom into the shared app layout. Every initial page load gets the same reveal, including signed-out pages; client-side navigation does not replay it.
- **Why:** Replace the blank startup pause with soft, drifting neutral blobs and a faint, centred CHATTO wordmark. The loading screen follows light/dark preferences before app assets arrive, and the wordmark stays fixed when fonts load.
- **Behavior:** Respect reduced motion, stop the entrance on keyboard or pointer input, preserve automatic form focus, and remove loading/animation state when it finishes. No API, data migration, or dependency changes.
- **Documentation:** Update [FDR-047](https://github.com/chattocorp/chatto/blob/92314992e8a7660c88d4455dac91f2984b6434b4/docs/fdr/FDR-047-first-run-setup.md), the [design system](https://github.com/chattocorp/chatto/blob/92314992e8a7660c88d4455dac91f2984b6434b4/apps/frontend/DESIGN_SYSTEM.md#initial-page-reveal), and the public FAQ with shared startup behavior and reduced-motion support.
- **Verified:** 18 targeted browser tests; Svelte check with zero errors/warnings; targeted ESLint; production frontend build including bundle and CSP checks; docs build; REUSE license check. Chrome DevTools verification covered desktop/mobile, light/dark themes, delayed startup, autofocus, navigation without replay, and stable wordmark dimensions before and after font loading.
