### PR TITLE
feat(api)!: bound permission reads by scope

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -91,8 +91,8 @@ Read scope counts from response `page`. Advance `offset` by the number of
 returned scopes, not by the number of decisions. Matrix scopes are in
 `matrix.scopes`; decision-list scopes are in `scopes`, including scopes without
 applicable decisions. Repeat with the same filters while `page.hasMore` is true.
-Order is server, direct messages, groups, then rooms, with ascending resource
-IDs within each kind. Pages are live reads; concurrent changes can shift offsets.
+Order is server, direct messages, then each group followed by its rooms. Groups
+and rooms within each group use ascending resource IDs. Pages are live reads; concurrent changes can shift offsets.
 Deduplicate by scope and permission when combining pages.
 
 To inspect only one room, add

--- a/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/api-compatibility.mdx
@@ -74,6 +74,34 @@ when `has_message_history` is explicitly false. A new client connected to an
 older server sees no empty DM rows, and it must treat an absent history value
 on a returned DM as unknown rather than false.
 
+Chatto 0.5 bounds `AdminPermissionService.GetRolePermissionMatrix`,
+`GetUserPermissionMatrix`, `ListRolePermissionDecisions`, and
+`ListUserPermissionDecisions` by scope. All four accept `page` and an optional
+exact typed `scope` filter. Omitted pages now return at most 20 scopes, with a
+maximum of 100. An older client that assumes a complete response will show an
+incomplete configuration. Regenerate clients and consume all required pages.
+
+For example, request a role's first scope page with:
+
+```json
+{"roleName":"moderator","page":{"limit":20,"offset":0},"includeDirectMessageScope":true}
+```
+
+Read scope counts from response `page`. Advance `offset` by the number of
+returned scopes, not by the number of decisions. Matrix scopes are in
+`matrix.scopes`; decision-list scopes are in `scopes`, including scopes without
+applicable decisions. Repeat with the same filters while `page.hasMore` is true.
+Order is server, direct messages, groups, then rooms, with ascending resource
+IDs within each kind. Pages are live reads; concurrent changes can shift offsets.
+Deduplicate by scope and permission when combining pages.
+
+To inspect only one room, add
+`"scope":{"kind":"PERMISSION_SCOPE_KIND_ROOM","id":"<room-id>"}`.
+An exact DM filter selects direct messages without the include flag. Missing or
+inaccessible scopes return an empty page. Inherited decisions still use broader
+scopes outside the page. Authorization is unchanged; bot room visibility applies
+before scope counts. Stored permissions and upgrade data are unchanged.
+
 Chatto 0.5 removes `AdminRoleService.GetRoleResponse.users`. Read explicit
 assignments through `AdminRoleService.ListMembers` instead. It returns canonical
 `User` records in `members`, with `PageInfo` in `page`. Pass `name` and a

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-permissions.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-permissions.mdx
@@ -18,7 +18,12 @@ Shared message and enum definitions are documented in [Shared Types And Enums](/
 
 ## AdminPermissionService
 
-Provides permission matrix reads and admin permission writes.
+Provides permission reads and admin permission writes.
+Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
+then ascending resource ID within each kind. Only requested scopes are evaluated.
+Pages are live reads; layout or visibility changes can shift offsets. Keep the
+same filters on each request and advance by the number of returned scopes.
+A scope filter of DM selects DM even when include_direct_message_scope is false.
 
 <a id="chatto-admin-v1-AdminPermissionService-GetRolePermissionTierMatrix"></a>
 
@@ -58,7 +63,7 @@ Response containing a role-permission tier matrix.
 
 ### GetRolePermissionMatrix
 
-Gets one role's full permission matrix. Requires role.manage. Returns
+Gets one page of a role's permission matrix. Requires role.manage. Returns
 NOT_FOUND when the role does not exist.
 
 ```http
@@ -75,6 +80,8 @@ Request one role's permission matrix.
 | --- | --- | --- |
 | `role_name` | `string` | Stable role name. |
 | `include_direct_message_scope` | `bool` | Include the direct-message scope column. Defaults to false so an older client does not receive a scope kind that it cannot interpret. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](/reference/connectrpc-api/types/#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-GetRolePermissionMatrixResponse"></a>
@@ -86,6 +93,7 @@ Response containing one role's permission matrix.
 | Field | Type | Description |
 | --- | --- | --- |
 | `matrix` | [`RolePermissionMatrix`](/reference/connectrpc-api/types/#chatto-admin-v1-RolePermissionMatrix) | Requested matrix. |
+| `page` | [`chatto.api.v1.PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Total matching scopes and whether another scope page exists. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-ListRolePermissionDecisions"></a>
@@ -109,6 +117,8 @@ Request explicit/effective permission decisions for one role.
 | --- | --- | --- |
 | `role_name` | `string` | Stable role name. |
 | `include_direct_message_scope` | `bool` | Include direct-message decisions. Defaults to false for older clients. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](/reference/connectrpc-api/types/#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-ListRolePermissionDecisionsResponse"></a>
@@ -121,13 +131,15 @@ Resource-oriented permission decisions for one role.
 | --- | --- | --- |
 | `role_name` | `string` | Stable role name. |
 | `decisions` | repeated [`ScopedPermissionDecision`](/reference/connectrpc-api/types/#chatto-admin-v1-ScopedPermissionDecision) | Permission decisions keyed by permission and typed scope. |
+| `page` | [`chatto.api.v1.PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Total matching scopes and whether another scope page exists. |
+| `scopes` | repeated [`PermissionScope`](/reference/connectrpc-api/types/#chatto-admin-v1-PermissionScope) | Scopes in this page, including scopes with no applicable decisions. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-GetUserPermissionMatrix"></a>
 
 ### GetUserPermissionMatrix
 
-Gets one user's full permission matrix. Human targets require
+Gets one page of a user's permission matrix. Human targets require
 user.manage-permissions; bot targets require ownership or bot.manage.
 Returns NOT_FOUND when the user does not exist.
 
@@ -145,6 +157,8 @@ Request one user's permission matrix.
 | --- | --- | --- |
 | `user_id` | `string` | User ID. |
 | `include_direct_message_scope` | `bool` | Include the direct-message scope column. Defaults to false so an older client does not receive a scope kind that it cannot interpret. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](/reference/connectrpc-api/types/#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-GetUserPermissionMatrixResponse"></a>
@@ -156,6 +170,7 @@ Response containing one user's permission matrix.
 | Field | Type | Description |
 | --- | --- | --- |
 | `matrix` | [`UserPermissionMatrix`](/reference/connectrpc-api/types/#chatto-admin-v1-UserPermissionMatrix) | Requested matrix. |
+| `page` | [`chatto.api.v1.PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Total matching scopes and whether another scope page exists. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-ListUserPermissionDecisions"></a>
@@ -180,6 +195,8 @@ Request explicit/effective permission decisions for one user.
 | --- | --- | --- |
 | `user_id` | `string` | User ID. |
 | `include_direct_message_scope` | `bool` | Include direct-message decisions. Defaults to false for older clients. |
+| `page` | [`chatto.api.v1.PageRequest`](/reference/connectrpc-api/types/#chatto-api-v1-PageRequest) | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](/reference/connectrpc-api/types/#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-ListUserPermissionDecisionsResponse"></a>
@@ -192,6 +209,8 @@ Resource-oriented permission decisions for one user.
 | --- | --- | --- |
 | `user_id` | `string` | User ID. |
 | `decisions` | repeated [`ScopedPermissionDecision`](/reference/connectrpc-api/types/#chatto-admin-v1-ScopedPermissionDecision) | Permission decisions keyed by permission and typed scope. |
+| `page` | [`chatto.api.v1.PageInfo`](/reference/connectrpc-api/types/#chatto-api-v1-PageInfo) | Total matching scopes and whether another scope page exists. |
+| `scopes` | repeated [`PermissionScope`](/reference/connectrpc-api/types/#chatto-admin-v1-PermissionScope) | Scopes in this page, including scopes with no applicable decisions. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-ExplainPermissions"></a>

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-permissions.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/admin-permissions.mdx
@@ -19,8 +19,9 @@ Shared message and enum definitions are documented in [Shared Types And Enums](/
 ## AdminPermissionService
 
 Provides permission reads and admin permission writes.
-Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
-then ascending resource ID within each kind. Only requested scopes are evaluated.
+Matrix and decision pages use the same scope order: SERVER, DM, then each GROUP
+followed by its ROOM scopes. Groups and rooms within each group use ascending
+resource IDs. Only requested scopes are evaluated.
 Pages are live reads; layout or visibility changes can shift offsets. Keep the
 same filters on each request and advance by the number of returned scopes.
 A scope filter of DM selects DM even when include_direct_message_scope is false.

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -1629,7 +1629,7 @@ One explicit decision encountered while explaining a permission.
 
 ### RolePermissionMatrix
 
-Permission matrix for one role across all scopes.
+Permission matrix for one role for one page of scopes.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -1693,7 +1693,7 @@ Role permission matrix for one tier.
 
 ### UserPermissionMatrix
 
-Permission matrix for one user across all scopes.
+Permission matrix for one user for one page of scopes.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/types.mdx
@@ -1629,7 +1629,7 @@ One explicit decision encountered while explaining a permission.
 
 ### RolePermissionMatrix
 
-Permission matrix for one role for one page of scopes.
+Permission matrix for one role within a scope page.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -1693,7 +1693,7 @@ Role permission matrix for one tier.
 
 ### UserPermissionMatrix
 
-Permission matrix for one user for one page of scopes.
+Permission matrix for one user within a scope page.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/docs-website/src/content/docs/releases/0-5-0.mdx
+++ b/apps/docs-website/src/content/docs/releases/0-5-0.mdx
@@ -436,6 +436,11 @@ import ReleaseHero from "../../../components/release-notes/ReleaseHero.astro";
   omitted expiry means no expiry. See the
   [migration guide](/guides/integrations/api-compatibility/#resource-updates-in-05).
 
+- **API migration:** Role and user permission matrix/decision reads now return
+  scope pages: 20 scopes by default, capped at 100. Consume `page` metadata or
+  request one typed `scope`. Offsets count scopes, not decisions. The editors
+  load columns as you scroll. Stored permission rules are unchanged. See
+  [API Compatibility](/guides/integrations/api-compatibility/).
 - **API migration:** Role details no longer embed all assigned users. Replace
   reads of `AdminRoleService.GetRoleResponse.users` with paginated
   `AdminRoleService.ListMembers` calls. The default page contains 20 users;

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -966,7 +966,12 @@ Returns the OAuth client with its updated policy.
 
 ## AdminPermissionService
 
-Provides permission matrix reads and admin permission writes.
+Provides permission reads and admin permission writes.
+Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
+then ascending resource ID within each kind. Only requested scopes are evaluated.
+Pages are live reads; layout or visibility changes can shift offsets. Keep the
+same filters on each request and advance by the number of returned scopes.
+A scope filter of DM selects DM even when include_direct_message_scope is false.
 
 <a id="chatto-admin-v1-AdminPermissionService-GetRolePermissionTierMatrix"></a>
 
@@ -1006,7 +1011,7 @@ Response containing a role-permission tier matrix.
 
 ### GetRolePermissionMatrix
 
-Gets one role's full permission matrix. Requires role.manage. Returns
+Gets one page of a role's permission matrix. Requires role.manage. Returns
 NOT_FOUND when the role does not exist.
 
 ```http
@@ -1023,6 +1028,8 @@ Request one role's permission matrix.
 | --- | --- | --- |
 | `role_name` | `string` | Stable role name. |
 | `include_direct_message_scope` | `bool` | Include the direct-message scope column. Defaults to false so an older client does not receive a scope kind that it cannot interpret. |
+| `page` | `chatto.api.v1.PageRequest` | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-GetRolePermissionMatrixResponse"></a>
@@ -1034,6 +1041,7 @@ Response containing one role's permission matrix.
 | Field | Type | Description |
 | --- | --- | --- |
 | `matrix` | [`RolePermissionMatrix`](#chatto-admin-v1-RolePermissionMatrix) | Requested matrix. |
+| `page` | `chatto.api.v1.PageInfo` | Total matching scopes and whether another scope page exists. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-ListRolePermissionDecisions"></a>
@@ -1057,6 +1065,8 @@ Request explicit/effective permission decisions for one role.
 | --- | --- | --- |
 | `role_name` | `string` | Stable role name. |
 | `include_direct_message_scope` | `bool` | Include direct-message decisions. Defaults to false for older clients. |
+| `page` | `chatto.api.v1.PageRequest` | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-ListRolePermissionDecisionsResponse"></a>
@@ -1069,13 +1079,15 @@ Resource-oriented permission decisions for one role.
 | --- | --- | --- |
 | `role_name` | `string` | Stable role name. |
 | `decisions` | repeated [`ScopedPermissionDecision`](#chatto-admin-v1-ScopedPermissionDecision) | Permission decisions keyed by permission and typed scope. |
+| `page` | `chatto.api.v1.PageInfo` | Total matching scopes and whether another scope page exists. |
+| `scopes` | repeated [`PermissionScope`](#chatto-admin-v1-PermissionScope) | Scopes in this page, including scopes with no applicable decisions. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-GetUserPermissionMatrix"></a>
 
 ### GetUserPermissionMatrix
 
-Gets one user's full permission matrix. Human targets require
+Gets one page of a user's permission matrix. Human targets require
 user.manage-permissions; bot targets require ownership or bot.manage.
 Returns NOT_FOUND when the user does not exist.
 
@@ -1093,6 +1105,8 @@ Request one user's permission matrix.
 | --- | --- | --- |
 | `user_id` | `string` | User ID. |
 | `include_direct_message_scope` | `bool` | Include the direct-message scope column. Defaults to false so an older client does not receive a scope kind that it cannot interpret. |
+| `page` | `chatto.api.v1.PageRequest` | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-GetUserPermissionMatrixResponse"></a>
@@ -1104,6 +1118,7 @@ Response containing one user's permission matrix.
 | Field | Type | Description |
 | --- | --- | --- |
 | `matrix` | [`UserPermissionMatrix`](#chatto-admin-v1-UserPermissionMatrix) | Requested matrix. |
+| `page` | `chatto.api.v1.PageInfo` | Total matching scopes and whether another scope page exists. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-ListUserPermissionDecisions"></a>
@@ -1128,6 +1143,8 @@ Request explicit/effective permission decisions for one user.
 | --- | --- | --- |
 | `user_id` | `string` | User ID. |
 | `include_direct_message_scope` | `bool` | Include direct-message decisions. Defaults to false for older clients. |
+| `page` | `chatto.api.v1.PageRequest` | Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions. |
+| `scope` | [`PermissionScope`](#chatto-admin-v1-PermissionScope) | Optional exact scope filter. Missing or inaccessible scopes produce an empty page. SERVER and DM require an empty ID; GROUP and ROOM require an ID. |
 
 
 <a id="chatto-admin-v1-ListUserPermissionDecisionsResponse"></a>
@@ -1140,6 +1157,8 @@ Resource-oriented permission decisions for one user.
 | --- | --- | --- |
 | `user_id` | `string` | User ID. |
 | `decisions` | repeated [`ScopedPermissionDecision`](#chatto-admin-v1-ScopedPermissionDecision) | Permission decisions keyed by permission and typed scope. |
+| `page` | `chatto.api.v1.PageInfo` | Total matching scopes and whether another scope page exists. |
+| `scopes` | repeated [`PermissionScope`](#chatto-admin-v1-PermissionScope) | Scopes in this page, including scopes with no applicable decisions. |
 
 
 <a id="chatto-admin-v1-AdminPermissionService-ExplainPermissions"></a>
@@ -2590,7 +2609,7 @@ One explicit decision encountered while explaining a permission.
 
 ### RolePermissionMatrix
 
-Permission matrix for one role across all scopes.
+Permission matrix for one role for one page of scopes.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -2664,7 +2683,7 @@ Role permission matrix for one tier.
 
 ### UserPermissionMatrix
 
-Permission matrix for one user across all scopes.
+Permission matrix for one user for one page of scopes.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/admin.raw.mdx
@@ -967,8 +967,9 @@ Returns the OAuth client with its updated policy.
 ## AdminPermissionService
 
 Provides permission reads and admin permission writes.
-Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
-then ascending resource ID within each kind. Only requested scopes are evaluated.
+Matrix and decision pages use the same scope order: SERVER, DM, then each GROUP
+followed by its ROOM scopes. Groups and rooms within each group use ascending
+resource IDs. Only requested scopes are evaluated.
 Pages are live reads; layout or visibility changes can shift offsets. Keep the
 same filters on each request and advance by the number of returned scopes.
 A scope filter of DM selects DM even when include_direct_message_scope is false.
@@ -2609,7 +2610,7 @@ One explicit decision encountered while explaining a permission.
 
 ### RolePermissionMatrix
 
-Permission matrix for one role for one page of scopes.
+Permission matrix for one role within a scope page.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -2683,7 +2684,7 @@ Role permission matrix for one tier.
 
 ### UserPermissionMatrix
 
-Permission matrix for one user for one page of scopes.
+Permission matrix for one user within a scope page.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/frontend/e2e/server-roles.test.ts
+++ b/apps/frontend/e2e/server-roles.test.ts
@@ -1,5 +1,6 @@
 import { expect, type Page } from '@playwright/test';
 import { test } from './setup';
+import { GetRolePermissionMatrixRequest } from '@chatto/api-types/admin/v1/permissions_pb';
 import { AdminRoleServiceListMembersRequest } from '@chatto/api-types/admin/v1/roles_pb';
 import {
   activatePrivilegedMode,
@@ -138,6 +139,32 @@ async function denyPermission(
 }
 
 test.describe('Server Roles Management', () => {
+  test('permission matrix loads scope pages at the horizontal edge', async ({ serverRolesPage }) => {
+    const { page } = serverRolesPage;
+    const server = await usePrimaryServerViaAPI(page);
+    const groupId = await getDefaultRoomGroupId(page);
+    for (let i = 0; i < 24; i++) await createRoomViaConnect(page, `paged-permissions-${i}`, groupId);
+    const offsets: number[] = [];
+    const errors: string[] = [];
+    page.on('pageerror', error => errors.push(error.stack ?? error.message));
+    page.on('request', request => {
+      if (request.url().endsWith('/chatto.admin.v1.AdminPermissionService/GetRolePermissionMatrix')) {
+        const body = request.postDataBuffer();
+        if (body) offsets.push(GetRolePermissionMatrixRequest.fromBinary(body).page?.offset ?? 0);
+      }
+    });
+    await page.setViewportSize({ width: 1000, height: 800 });
+    await page.goto(routes.serverAdminPermission('moderator'));
+    await expect(page.getByRole('heading', { name: 'Edit Role' })).toBeVisible();
+    const viewport = page.locator('.data-table-viewport').filter({ has: page.locator('th[data-scope]') });
+    await expect(viewport.locator('th[data-scope]')).toHaveCount(20);
+    await viewport.hover();
+    await page.mouse.wheel(3000, 0);
+    await expect.poll(() => offsets.includes(20)).toBe(true);
+    await expect.poll(() => viewport.locator('th[data-scope]').count()).toBeGreaterThan(20);
+    expect(errors).toEqual([]);
+  });
+
   test('role member roster loads the next page when scrolled', async ({ serverRolesPage }) => {
     const { page } = serverRolesPage;
     const server = await usePrimaryServerViaAPI(page);

--- a/apps/frontend/e2e/server-roles.test.ts
+++ b/apps/frontend/e2e/server-roles.test.ts
@@ -142,7 +142,9 @@ test.describe('Server Roles Management', () => {
   test('permission matrix loads scope pages at the horizontal edge', async ({ serverRolesPage }) => {
     const { page } = serverRolesPage;
     const server = await usePrimaryServerViaAPI(page);
-    const groupId = await getDefaultRoomGroupId(page);
+    const otherGroup = await connectPost<{ group: { id: string } }>(page,
+      'chatto.admin.v1.AdminRoomLayoutService/CreateRoomGroup', { name: 'Other scope group' });
+    const groupId = [await getDefaultRoomGroupId(page), otherGroup.group.id].sort()[0];
     for (let i = 0; i < 24; i++) await createRoomViaConnect(page, `paged-permissions-${i}`, groupId);
     const offsets: number[] = [];
     const errors: string[] = [];
@@ -158,10 +160,13 @@ test.describe('Server Roles Management', () => {
     await expect(page.getByRole('heading', { name: 'Edit Role' })).toBeVisible();
     const viewport = page.locator('.data-table-viewport').filter({ has: page.locator('th[data-scope]') });
     await expect(viewport.locator('th[data-scope]')).toHaveCount(20);
+    const initialColumns = await viewport.locator('th[data-scope]').evaluateAll(heads => heads.map(head => head.getAttribute('data-scope')));
     await viewport.hover();
     await page.mouse.wheel(3000, 0);
     await expect.poll(() => offsets.includes(20)).toBe(true);
     await expect.poll(() => viewport.locator('th[data-scope]').count()).toBeGreaterThan(20);
+    const allColumns = await viewport.locator('th[data-scope]').evaluateAll(heads => heads.map(head => head.getAttribute('data-scope')));
+    expect(allColumns.slice(0, initialColumns.length)).toEqual(initialColumns);
     expect(errors).toEqual([]);
   });
 

--- a/apps/frontend/src/lib/api-client-tests/permissions.spec.ts
+++ b/apps/frontend/src/lib/api-client-tests/permissions.spec.ts
@@ -112,6 +112,7 @@ describe('createPermissionAPI', () => {
 
   it('maps role matrix enum values to frontend strings', async () => {
     mocks.getRolePermissionMatrix.mockResolvedValue({
+      page: { totalCount: 2n, hasMore: false },
       matrix: {
         roleName: 'admin',
         applicablePermissions: ['message.post'],
@@ -148,6 +149,7 @@ describe('createPermissionAPI', () => {
       { headers: undefined }
     );
     expect(result).toEqual({
+      page: { totalCount: 2, hasMore: false },
       roleName: 'admin',
       applicablePermissions: ['message.post'],
       scopes: [
@@ -167,6 +169,7 @@ describe('createPermissionAPI', () => {
 
   it('rejects unknown permission matrix scope kinds', async () => {
     mocks.getRolePermissionMatrix.mockResolvedValue({
+      page: { totalCount: 2n, hasMore: false },
       matrix: {
         roleName: 'admin',
         applicablePermissions: [],
@@ -183,7 +186,9 @@ describe('createPermissionAPI', () => {
 
   it('loads role permission decisions as scoped entries', async () => {
     mocks.listRolePermissionDecisions.mockResolvedValue({
+      page: { totalCount: 2n, hasMore: false },
       roleName: 'admin',
+      scopes: [],
       decisions: [
         {
           permission: 'message.post',
@@ -208,7 +213,9 @@ describe('createPermissionAPI', () => {
       { headers: { Authorization: 'Bearer token' } }
     );
     expect(result).toEqual({
+      page: { totalCount: 2, hasMore: false },
       roleName: 'admin',
+      scopes: [],
       decisions: [
         {
           permission: 'message.post',
@@ -228,6 +235,7 @@ describe('createPermissionAPI', () => {
 
   it('loads user matrices and maps missing decisions to NONE', async () => {
     mocks.getUserPermissionMatrix.mockResolvedValue({
+      page: { totalCount: 2n, hasMore: false },
       matrix: {
         userId: 'U1',
         applicablePermissions: ['room.create'],
@@ -250,6 +258,7 @@ describe('createPermissionAPI', () => {
     const result = await api.getUserPermissionMatrix('U1');
 
     expect(result).toEqual({
+      page: { totalCount: 2, hasMore: false },
       userId: 'U1',
       applicablePermissions: ['room.create'],
       scopes: [{ id: 'group:G1', label: 'Lobby', kind: 'GROUP', parentGroupId: '' }],
@@ -267,7 +276,9 @@ describe('createPermissionAPI', () => {
 
   it('loads user permission decisions as scoped entries', async () => {
     mocks.listUserPermissionDecisions.mockResolvedValue({
+      page: { totalCount: 2n, hasMore: false },
       userId: 'U1',
+      scopes: [],
       decisions: [
         {
           permission: 'room.create',
@@ -286,7 +297,9 @@ describe('createPermissionAPI', () => {
       { headers: undefined }
     );
     expect(result).toEqual({
+      page: { totalCount: 2, hasMore: false },
       userId: 'U1',
+      scopes: [],
       decisions: [
         {
           permission: 'room.create',
@@ -359,4 +372,24 @@ describe('createPermissionAPI', () => {
       { headers: { Authorization: 'Bearer token' } }
     );
   });
+
+it('sends scope pages and cancellation for JSON-compatible decision reads', async () => {
+  mocks.listRolePermissionDecisions.mockResolvedValue({
+    roleName: 'moderator', decisions: [],
+    scopes: [{ kind: PermissionScopeKind.ROOM, id: 'room-1' }],
+    page: { totalCount: 1n, hasMore: false }
+  });
+  const api = createPermissionAPI({ baseUrl: '/api/connect', bearerToken: 'token' });
+  const signal = new AbortController().signal;
+  const result = await api.listRolePermissionDecisions('moderator', {
+    signal, page: { limit: 10, offset: 0 }, scope: { tier: 'room', roomId: 'room-1' }
+  });
+  expect(mocks.listRolePermissionDecisions).toHaveBeenCalledWith({
+    roleName: 'moderator', includeDirectMessageScope: true,
+    page: { limit: 10, offset: 0 }, scope: { kind: PermissionScopeKind.ROOM, id: 'room-1' }
+  }, { headers: { Authorization: 'Bearer token' }, signal });
+  expect(result.scopes).toEqual([{ tier: 'room', roomId: 'room-1' }]);
+  expect(result.page).toEqual({ totalCount: 1, hasMore: false });
+});
+
 });

--- a/apps/frontend/src/lib/api-client/permissions.ts
+++ b/apps/frontend/src/lib/api-client/permissions.ts
@@ -72,12 +72,22 @@ export type MatrixData = {
   cells: MatrixCell[];
 };
 
+/** Scope counts, rather than permission-cell counts. */
+export type PermissionScopePage = { totalCount: number; hasMore: boolean };
+export type PermissionReadOptions = {
+  signal?: AbortSignal;
+  page?: { limit?: number; offset?: number };
+  scope?: PermissionScope;
+};
+
 export type RolePermissionMatrix = MatrixData & {
   roleName: string;
+  page: PermissionScopePage;
 };
 
 export type UserPermissionMatrix = MatrixData & {
   userId: string;
+  page: PermissionScopePage;
 };
 
 export type PermissionDecisionEntry = {
@@ -96,11 +106,15 @@ export type PermissionDecisionUpdate = {
 export type RolePermissionDecisions = {
   roleName: string;
   decisions: PermissionDecisionEntry[];
+  scopes: PermissionScope[];
+  page: PermissionScopePage;
 };
 
 export type UserPermissionDecisions = {
   userId: string;
   decisions: PermissionDecisionEntry[];
+  scopes: PermissionScope[];
+  page: PermissionScopePage;
 };
 
 export function createPermissionAPI(config: PermissionAPIConfig) {
@@ -126,45 +140,79 @@ export function createPermissionAPI(config: PermissionAPIConfig) {
 
     async getRolePermissionMatrix(
       roleName: string,
-      options: { signal?: AbortSignal } = {}
+      options: PermissionReadOptions = {}
     ): Promise<RolePermissionMatrix | null> {
       const response = await client.getRolePermissionMatrix(
-        { roleName, includeDirectMessageScope: true },
+        {
+          roleName,
+          includeDirectMessageScope: true,
+          page: options.page,
+          scope: options.scope ? apiScope(options.scope) : undefined
+        },
         { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) }
       );
-      return response.matrix ? rolePermissionMatrix(response.matrix) : null;
+      return response.matrix
+        ? { ...rolePermissionMatrix(response.matrix), page: scopePage(response.page) }
+        : null;
     },
 
-    async listRolePermissionDecisions(roleName: string): Promise<RolePermissionDecisions> {
+    async listRolePermissionDecisions(
+      roleName: string,
+      options: PermissionReadOptions = {}
+    ): Promise<RolePermissionDecisions> {
       const response = await client.listRolePermissionDecisions(
-        { roleName, includeDirectMessageScope: true },
-        { headers: headers() }
+        {
+          roleName,
+          includeDirectMessageScope: true,
+          page: options.page,
+          scope: options.scope ? apiScope(options.scope) : undefined
+        },
+        { headers: headers(), signal: options.signal }
       );
       return {
         roleName: response.roleName,
-        decisions: response.decisions.map(permissionDecisionEntry)
+        decisions: response.decisions.map(permissionDecisionEntry),
+        scopes: response.scopes.map(permissionScope),
+        page: scopePage(response.page)
       };
     },
 
     async getUserPermissionMatrix(
       userId: string,
-      options: { signal?: AbortSignal } = {}
+      options: PermissionReadOptions = {}
     ): Promise<UserPermissionMatrix | null> {
       const response = await client.getUserPermissionMatrix(
-        { userId, includeDirectMessageScope: true },
+        {
+          userId,
+          includeDirectMessageScope: true,
+          page: options.page,
+          scope: options.scope ? apiScope(options.scope) : undefined
+        },
         { headers: headers(), ...(options.signal ? { signal: options.signal } : {}) }
       );
-      return response.matrix ? userPermissionMatrix(response.matrix) : null;
+      return response.matrix
+        ? { ...userPermissionMatrix(response.matrix), page: scopePage(response.page) }
+        : null;
     },
 
-    async listUserPermissionDecisions(userId: string): Promise<UserPermissionDecisions> {
+    async listUserPermissionDecisions(
+      userId: string,
+      options: PermissionReadOptions = {}
+    ): Promise<UserPermissionDecisions> {
       const response = await client.listUserPermissionDecisions(
-        { userId, includeDirectMessageScope: true },
-        { headers: headers() }
+        {
+          userId,
+          includeDirectMessageScope: true,
+          page: options.page,
+          scope: options.scope ? apiScope(options.scope) : undefined
+        },
+        { headers: headers(), signal: options.signal }
       );
       return {
         userId: response.userId,
-        decisions: response.decisions.map(permissionDecisionEntry)
+        decisions: response.decisions.map(permissionDecisionEntry),
+        scopes: response.scopes.map(permissionScope),
+        page: scopePage(response.page)
       };
     },
 
@@ -236,7 +284,7 @@ function tierRole(role: APITierRole): TierRole {
   };
 }
 
-function rolePermissionMatrix(matrix: APIRolePermissionMatrix): RolePermissionMatrix {
+function rolePermissionMatrix(matrix: APIRolePermissionMatrix): Omit<RolePermissionMatrix, 'page'> {
   return {
     roleName: matrix.roleName,
     applicablePermissions: [...matrix.applicablePermissions],
@@ -245,7 +293,7 @@ function rolePermissionMatrix(matrix: APIRolePermissionMatrix): RolePermissionMa
   };
 }
 
-function userPermissionMatrix(matrix: APIUserPermissionMatrix): UserPermissionMatrix {
+function userPermissionMatrix(matrix: APIUserPermissionMatrix): Omit<UserPermissionMatrix, 'page'> {
   return {
     userId: matrix.userId,
     applicablePermissions: [...matrix.applicablePermissions],
@@ -356,4 +404,11 @@ function apiTierMatrixScope(input: { roomId?: string | null; groupId?: string | 
     return { kind: PermissionScopeKind.GROUP, id: input.groupId };
   }
   return { kind: PermissionScopeKind.SERVER, id: '' };
+}
+
+function scopePage(
+  page: { totalCount: bigint; hasMore: boolean } | undefined
+): PermissionScopePage {
+  if (!page) throw new Error('permission response did not include scope page metadata');
+  return { totalCount: Number(page.totalCount), hasMore: page.hasMore };
 }

--- a/apps/frontend/src/lib/components/rbac/RolePermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/RolePermissionsMatrix.svelte
@@ -9,6 +9,7 @@ rendering to `SubjectPermissionsMatrix` (shared with the user variant).
 -->
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { Button } from '$lib/ui/form';
   import { Hint } from '$lib/ui';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { createPermissionAPI } from '$lib/api-client/permissions';
@@ -24,34 +25,47 @@ rendering to `SubjectPermissionsMatrix` (shared with the user variant).
     type MatrixScope,
     type CellState
   } from './SubjectPermissionsMatrix.svelte';
-  import { createQuery } from '@tanstack/svelte-query';
+  import { createInfiniteQuery } from '@tanstack/svelte-query';
   import { adminQueryKeys } from '$lib/query/admin';
   import { queryClient } from '$lib/query/client';
   import { invalidateRolePermissionDependents } from '$lib/query/adminInvalidation';
 
-  type Matrix = MatrixData & { roleName: string };
+  import { mergePermissionPages } from './permissionPages';
+  import type { PermissionScopePage } from '$lib/api-client/permissions';
+
+  type Matrix = MatrixData & { page: PermissionScopePage; roleName: string };
 
   let { roleName }: { roleName: string } = $props();
 
   const serverScope = useServerScope();
 
-  const matrixQuery = createQuery(
+  const matrixQuery = createInfiniteQuery(
     () => {
       const serverId = serverScope.serverId;
       const activeConnection = serverScope.connection;
       const activeRoleName = roleName;
       return {
         queryKey: adminQueryKeys.rolePermissions(serverId, activeConnection, activeRoleName),
-        queryFn: ({ signal }) =>
-          activeConnection
-            .getAPI(createPermissionAPI)
-            .getRolePermissionMatrix(activeRoleName, { signal })
+        initialPageParam: 0,
+        getNextPageParam: (last: Matrix | null, pages: (Matrix | null)[]) =>
+          last?.page.hasMore
+            ? pages.reduce((count, page) => count + (page?.scopes.length ?? 0), 0)
+            : undefined,
+        queryFn: ({ signal, pageParam }) =>
+          activeConnection.getAPI(createPermissionAPI).getRolePermissionMatrix(activeRoleName, {
+            signal,
+            page: { limit: 20, offset: pageParam }
+          })
       };
     },
     () => queryClient
   );
 
-  const data = $derived<Matrix | null>(matrixQuery.data ?? null);
+  const data = $derived<Matrix | null>(
+    mergePermissionPages(
+      (matrixQuery.data?.pages ?? []).filter((page): page is Matrix => page !== null)
+    )
+  );
   const loading = $derived(matrixQuery.isPending);
   const loadError = $derived(matrixQuery.error instanceof Error ? matrixQuery.error.message : null);
   let mutationError = $state<{ context: string; message: string } | null>(null);
@@ -126,6 +140,12 @@ rendering to `SubjectPermissionsMatrix` (shared with the user variant).
   <Hint tone="danger">{visibleMutationError ?? loadError}</Hint>
 {/if}
 
+{#if matrixQuery.isFetchNextPageError}
+  <Button variant="secondary" onclick={() => matrixQuery.fetchNextPage()}
+    >{m('common.retry')}</Button
+  >
+{/if}
+
 {#if loading}
   <div class="text-muted">{m('rbac.permissions.loading')}</div>
 {:else if !data}
@@ -133,6 +153,9 @@ rendering to `SubjectPermissionsMatrix` (shared with the user variant).
 {:else}
   <SubjectPermissionsMatrix
     {data}
+    hasMore={matrixQuery.hasNextPage && !matrixQuery.isFetchNextPageError}
+    loadingMore={matrixQuery.isFetching}
+    onLoadMore={() => matrixQuery.fetchNextPage()}
     updatingKey={visibleUpdatingKey}
     onCycle={handleCycle}
     subjectKind="role"

--- a/apps/frontend/src/lib/components/rbac/SubjectPermissionLoaders.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/rbac/SubjectPermissionLoaders.svelte.spec.ts
@@ -40,6 +40,7 @@ vi.mock('$lib/state/server/scope.svelte', () => ({
 function matrix(subject: { roleName: string } | { userId: string }) {
   return {
     ...subject,
+    page: { totalCount: 1, hasMore: false },
     applicablePermissions: ['message.post', 'room.manage'],
     scopes: [{ id: 'server', label: 'Server', kind: 'SERVER', parentGroupId: '' }],
     cells: [
@@ -92,6 +93,7 @@ beforeEach(() => {
     if (userId === 'bot-a') {
       return Promise.resolve({
         userId,
+        page: { totalCount: 1, hasMore: false },
         applicablePermissions: ['message.post'],
         scopes: [{ id: 'server', label: 'Server', kind: 'SERVER', parentGroupId: '' }],
         cells: [
@@ -118,6 +120,7 @@ describe('subject permission loaders', () => {
     let resolveRefresh: ((value: ReturnType<typeof matrix>) => void) | undefined;
     const rendered = render(RolePermissionsMatrix, { props: { roleName: 'role-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
     const originalTable = rendered.container.querySelector('table');
     const originalCell = rendered.container.querySelector(
       'td[data-scope="server"][data-permission="message.post"]'
@@ -161,6 +164,7 @@ describe('subject permission loaders', () => {
     );
     const rendered = render(RolePermissionsMatrix, { props: { roleName: 'role-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     cellButton(rendered.container, 'message.post').click();
     await rendered.rerender({ roleName: 'role-b' });
@@ -201,6 +205,7 @@ describe('subject permission loaders', () => {
     );
     const rendered = render(UserPermissionsMatrix, { props: { userId: 'user-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     cellButton(rendered.container, 'message.post').click();
     await rendered.rerender({ userId: 'user-b' });
@@ -231,6 +236,7 @@ describe('subject permission loaders', () => {
   it('scrubs a mounted user matrix without refetching after realtime user removal', async () => {
     const rendered = render(UserPermissionsMatrix, { props: { userId: 'user-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
     expect(rendered.container.querySelector('table')).not.toBeNull();
 
     removeRegisteredAdminUserQueries('origin', 'user-a');
@@ -247,6 +253,7 @@ describe('subject permission loaders', () => {
     );
     const rendered = render(UserPermissionsMatrix, { props: { userId: 'user-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
     rendered.container.style.height = '80px';
     rendered.container.style.overflowY = 'auto';
     rendered.container.scrollTop = 60;
@@ -273,6 +280,7 @@ describe('subject permission loaders', () => {
       props: { userId: 'user-a', decisionMode: 'binary' }
     });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
     const originalTable = rendered.container.querySelector('table');
     const originalTarget = cellButton(rendered.container, 'message.post');
     const originalOther = cellButton(rendered.container, 'room.manage');
@@ -306,6 +314,7 @@ describe('subject permission loaders', () => {
   it('keeps a ceiling-blocked inherited room inert without writing a denial', async () => {
     permissionMocks.getUserPermissionMatrix.mockResolvedValue({
       userId: 'bot-inheritance',
+      page: { totalCount: 1, hasMore: false },
       applicablePermissions: ['message.post'],
       scopes: [
         { id: 'server', label: 'Server', kind: 'SERVER', parentGroupId: '' },
@@ -352,6 +361,7 @@ describe('subject permission loaders', () => {
 
     room.click();
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     expect(permissionMocks.setUserPermission).not.toHaveBeenCalled();
     expect(rendered.container.querySelector('table')).toBe(table);
@@ -367,6 +377,7 @@ describe('subject permission loaders', () => {
   it('shows a bot narrow permission as enabled when message.read includes it', async () => {
     permissionMocks.getUserPermissionMatrix.mockResolvedValue({
       userId: 'bot-read',
+      page: { totalCount: 1, hasMore: false },
       applicablePermissions: ['message.read', 'message.read-interactions'],
       scopes: [{ id: 'server', label: 'Server', kind: 'SERVER', parentGroupId: '' }],
       cells: [
@@ -390,6 +401,7 @@ describe('subject permission loaders', () => {
       props: { userId: 'bot-read', decisionMode: 'binary', ownerCapped: true }
     });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     const child = scopedCellButton(rendered.container, 'server', 'message.read-interactions');
     expect(child.title).toContain('Included by message.read');
@@ -404,6 +416,7 @@ describe('subject permission loaders', () => {
     );
     const rendered = render(RolePermissionsMatrix, { props: { roleName: 'role-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     cellButton(rendered.container, 'message.post').click();
     await settle();
@@ -423,9 +436,13 @@ describe('subject permission loaders', () => {
   it('invalidates cached user matrices after a role permission changes', async () => {
     const connection = { queryScope: 'permission-loader-test' };
     const userPermissionKey = adminQueryKeys.userPermissions('origin', connection, 'user-a');
-    queryClient.setQueryData(userPermissionKey, matrix({ userId: 'user-a' }));
+    queryClient.setQueryData(userPermissionKey, {
+      pages: [matrix({ userId: 'user-a' })],
+      pageParams: [0]
+    });
     const rendered = render(RolePermissionsMatrix, { props: { roleName: 'role-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     cellButton(rendered.container, 'message.post').click();
 
@@ -441,6 +458,7 @@ describe('subject permission loaders', () => {
     );
     const rendered = render(UserPermissionsMatrix, { props: { userId: 'user-a' } });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     cellButton(rendered.container, 'message.post').click();
     await settle();
@@ -462,6 +480,7 @@ describe('subject permission loaders', () => {
       props: { userId: 'bot-a', subjectKind: 'bot', ownerCapped: true }
     });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
 
     const button = cellButton(rendered.container, 'message.post');
     expect(button.querySelector('[class~="icon-[uil--exclamation-triangle]"]')).not.toBeNull();
@@ -623,6 +642,7 @@ describe('account membership mutations', () => {
     await expect.poll(() => document.querySelector('dialog[open]')).toBeNull();
     await rendered.rerender({ userId: 'membership-bot' });
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
     expect(document.querySelector('dialog[open]')).toBeNull();
     expect(permissionMocks.addMember).not.toHaveBeenCalled();
   });
@@ -649,8 +669,9 @@ describe('account membership mutations', () => {
     await expect
       .poll(
         () =>
-          queryClient.getQueryData<{ scopes: { membership?: { canJoin: boolean } }[] }>(key)
-            ?.scopes[0]?.membership?.canJoin
+          queryClient.getQueryData<{
+            pages: { scopes: { membership?: { canJoin: boolean } }[] }[];
+          }>(key)?.pages[0]?.scopes[0]?.membership?.canJoin
       )
       .toBe(false);
     await confirmMembership();
@@ -729,6 +750,7 @@ describe('account membership mutations', () => {
       .toBe(true);
     rejectJoin!(new Error('stale failure'));
     await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
     expect(rendered.container.textContent).not.toContain('Failed to join room');
     expect(
       rendered.container.querySelector<HTMLButtonElement>(
@@ -737,3 +759,41 @@ describe('account membership mutations', () => {
     ).toBe(false);
   });
 });
+
+it.each(['role', 'user'] as const)(
+  'fences a delayed next scope page after %s navigation',
+  async (kind) => {
+    const read =
+      kind === 'role'
+        ? permissionMocks.getRolePermissionMatrix
+        : permissionMocks.getUserPermissionMatrix;
+    const subject = (id: string) => (kind === 'role' ? { roleName: id } : { userId: id });
+    let resolveNext!: (value: ReturnType<typeof matrix>) => void;
+    read.mockImplementation((id: string, options: { page: { offset: number } }) => {
+      if (id === 'first' && options.page.offset > 0)
+        return new Promise((resolve) => {
+          resolveNext = resolve;
+        });
+      return Promise.resolve({
+        ...matrix(subject(id)),
+        page: { totalCount: id === 'first' ? 2 : 1, hasMore: id === 'first' }
+      });
+    });
+    const rendered =
+      kind === 'role'
+        ? render(RolePermissionsMatrix, { props: { roleName: 'first' } })
+        : render(UserPermissionsMatrix, { props: { userId: 'first' } });
+    await vi.waitFor(() => expect(resolveNext).toBeTypeOf('function'));
+    const signal = read.mock.calls.find(
+      ([id, options]) => id === 'first' && options.page.offset === 1
+    )?.[1].signal as AbortSignal;
+    await rendered.rerender(kind === 'role' ? { roleName: 'second' } : { userId: 'second' });
+    await vi.waitFor(() => expect(signal.aborted).toBe(true));
+    const late = matrix(subject('first'));
+    late.scopes = [{ id: 'room:late', label: 'Late scope', kind: 'ROOM', parentGroupId: '' }];
+    resolveNext(late);
+    await settle();
+    await vi.waitFor(() => expect(rendered.container.querySelector('table')).not.toBeNull());
+    expect(rendered.container.querySelector('[data-scope="room:late"]')).toBeNull();
+  }
+);

--- a/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
@@ -71,9 +71,16 @@ scrolling; the table only scrolls horizontally when its columns overflow.
     forceAllow = false,
     readOnly = false,
     decisionMode = 'tri-state',
-    onMembershipChange
+    onMembershipChange,
+    hasMore = false,
+    loadingMore = false,
+    onLoadMore
   }: {
     data: MatrixData;
+    /** Load scope columns as the horizontal edge becomes visible. */
+    hasMore?: boolean;
+    loadingMore?: boolean;
+    onLoadMore?: () => unknown;
     /** `${scopeId}::${permission}` of the cell whose mutation is in flight. */
     updatingKey?: string | null;
     onCycle: (scope: MatrixScope, permission: string, next: CellState) => void;
@@ -238,6 +245,9 @@ scrolling; the table only scrolls horizontally when its columns overflow.
     {/snippet}
     <MatrixTable
       {rows}
+      {hasMore}
+      {loadingMore}
+      {onLoadMore}
       columns={matrixScopes}
       getRowKey={(permission) => permission}
       getColumnKey={(scope) => scope.id}

--- a/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/SubjectPermissionsMatrix.svelte
@@ -99,8 +99,8 @@ scrolling; the table only scrolls horizontally when its columns overflow.
   // ----- Column layout ----------------------------------------------------
 
   // Order columns: server first, then each group followed by its rooms.
-  // Backend returns server, then all groups, then all rooms — we re-order
-  // here so rooms nest visually under their parent group.
+  // The API uses this order too, so new pages append columns. Keep grouping
+  // here for local fixtures and callers that supply an unordered matrix.
   const orderedScopes = $derived.by<MatrixScope[]>(() => {
     const server = data.scopes.filter((s) => s.kind === 'SERVER');
     const dm = data.scopes.filter((s) => s.kind === 'DM');

--- a/apps/frontend/src/lib/components/rbac/UserPermissionsMatrix.svelte
+++ b/apps/frontend/src/lib/components/rbac/UserPermissionsMatrix.svelte
@@ -7,6 +7,7 @@ rendering to `SubjectPermissionsMatrix`.
 -->
 <script lang="ts">
   import { onDestroy } from 'svelte';
+  import { Button } from '$lib/ui/form';
   import { ConfirmDialog, Hint } from '$lib/ui';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { loadAccountMemberships } from './accountMemberships';
@@ -25,11 +26,14 @@ rendering to `SubjectPermissionsMatrix`.
     type CellState,
     type DecisionMode
   } from './SubjectPermissionsMatrix.svelte';
-  import { createQuery } from '@tanstack/svelte-query';
+  import { createInfiniteQuery, type InfiniteData } from '@tanstack/svelte-query';
   import { adminQueryKeys } from '$lib/query/admin';
   import { queryClient } from '$lib/query/client';
 
-  type Matrix = MatrixData & { userId: string };
+  import { mergePermissionPages } from './permissionPages';
+  import type { PermissionScopePage } from '$lib/api-client/permissions';
+
+  type Matrix = MatrixData & { page: PermissionScopePage; userId: string };
 
   let {
     userId,
@@ -45,7 +49,7 @@ rendering to `SubjectPermissionsMatrix`.
 
   const serverScope = useServerScope();
 
-  const matrixQuery = createQuery(
+  const matrixQuery = createInfiniteQuery(
     () => {
       const serverId = serverScope.serverId;
       const activeConnection = serverScope.connection;
@@ -54,10 +58,18 @@ rendering to `SubjectPermissionsMatrix`.
       const canManageAccounts = serverScope.store.permissions.canAdminManageAccounts;
       return {
         queryKey: adminQueryKeys.userPermissions(serverId, activeConnection, activeUserId),
-        queryFn: async ({ signal }) => {
+        initialPageParam: 0,
+        getNextPageParam: (last: Matrix | null, pages: (Matrix | null)[]) =>
+          last?.page.hasMore
+            ? pages.reduce((count, page) => count + (page?.scopes.length ?? 0), 0)
+            : undefined,
+        queryFn: async ({ signal, pageParam }) => {
           const matrix = await activeConnection
             .getAPI(createPermissionAPI)
-            .getUserPermissionMatrix(activeUserId, { signal });
+            .getUserPermissionMatrix(activeUserId, {
+              signal,
+              page: { limit: 20, offset: pageParam }
+            });
           if (!matrix) return null;
           return loadAccountMemberships(activeConnection, matrix, isBot, canManageAccounts, signal);
         }
@@ -66,7 +78,11 @@ rendering to `SubjectPermissionsMatrix`.
     () => queryClient
   );
 
-  const data = $derived<Matrix | null>(matrixQuery.data ?? null);
+  const data = $derived<Matrix | null>(
+    mergePermissionPages(
+      (matrixQuery.data?.pages ?? []).filter((page): page is Matrix => page !== null)
+    )
+  );
   const loading = $derived(matrixQuery.isPending);
   const loadError = $derived(matrixQuery.error instanceof Error ? matrixQuery.error.message : null);
   let mutationError = $state<{ context: string; message: string } | null>(null);
@@ -208,14 +224,21 @@ rendering to `SubjectPermissionsMatrix`.
 
     if (result.update) {
       const decision = result.update.decision;
-      queryClient.setQueryData<Matrix | null>(queryKey, (current) =>
+      queryClient.setQueryData<InfiniteData<Matrix | null, number>>(queryKey, (current) =>
         current
           ? {
               ...current,
-              cells: current.cells.map((cell) =>
-                cell.scopeId === scope.id && cell.permission === permission
-                  ? { ...cell, override: decision }
-                  : cell
+              pages: current.pages.map((page) =>
+                page
+                  ? {
+                      ...page,
+                      cells: page.cells.map((cell) =>
+                        cell.scopeId === scope.id && cell.permission === permission
+                          ? { ...cell, override: decision }
+                          : cell
+                      )
+                    }
+                  : page
               )
             }
           : current
@@ -241,6 +264,12 @@ rendering to `SubjectPermissionsMatrix`.
   <Hint tone="danger">{visibleMutationError ?? loadError}</Hint>
 {/if}
 
+{#if matrixQuery.isFetchNextPageError}
+  <Button variant="secondary" onclick={() => matrixQuery.fetchNextPage()}
+    >{m('common.retry')}</Button
+  >
+{/if}
+
 {#if loading}
   <div class="text-muted">{m('rbac.permissions.loading')}</div>
 {:else if !data}
@@ -248,6 +277,9 @@ rendering to `SubjectPermissionsMatrix`.
 {:else}
   <SubjectPermissionsMatrix
     {data}
+    hasMore={matrixQuery.hasNextPage && !matrixQuery.isFetchNextPageError}
+    loadingMore={matrixQuery.isFetching}
+    onLoadMore={() => matrixQuery.fetchNextPage()}
     updatingKey={visibleUpdatingKey}
     onCycle={handleCycle}
     {subjectKind}

--- a/apps/frontend/src/lib/components/rbac/accountMemberships.ts
+++ b/apps/frontend/src/lib/components/rbac/accountMemberships.ts
@@ -15,7 +15,7 @@ export async function loadAccountMemberships(
   isBot: boolean,
   canManageAccounts: boolean,
   signal: AbortSignal
-): Promise<MatrixData & { userId: string }> {
+): Promise<MatrixData & Pick<UserPermissionMatrix, 'userId' | 'page'>> {
   const scopes: MatrixScope[] = matrix.scopes.map((scope) => ({ ...scope }));
   const roomScopes = scopes.filter((scope) => scope.kind === 'ROOM');
   const joinableScopes = new Set(

--- a/apps/frontend/src/lib/components/rbac/permissionPages.ts
+++ b/apps/frontend/src/lib/components/rbac/permissionPages.ts
@@ -1,0 +1,13 @@
+import type { MatrixData } from '$lib/api-client/permissions';
+
+/** Join live scope pages. Later copies replace earlier ones after layout changes. */
+export function mergePermissionPages<T extends MatrixData>(pages: T[]): T | null {
+  if (!pages.length) return null;
+  const scopes = new Map<string, T['scopes'][number]>();
+  const cells = new Map<string, T['cells'][number]>();
+  for (const page of pages) {
+    for (const scope of page.scopes) scopes.set(scope.id, scope);
+    for (const cell of page.cells) cells.set(`${cell.scopeId}|${cell.permission}`, cell);
+  }
+  return { ...pages[0], scopes: [...scopes.values()], cells: [...cells.values()] };
+}

--- a/apps/frontend/src/lib/query/adminInvalidation.ts
+++ b/apps/frontend/src/lib/query/adminInvalidation.ts
@@ -48,6 +48,7 @@ export function removeDeletedRoleQueries(
 ): void {
   const roleKey = adminQueryKeys.rolePermissions(serverId, connection, roleName);
   const roleDetailsKey = adminQueryKeys.role(serverId, connection, roleName);
+  void queryClient.cancelQueries({ queryKey: roleKey, exact: true });
   queryClient.setQueryData(roleKey, null);
   queryClient.setQueryData(roleDetailsKey, null);
   queryClient.removeQueries({ queryKey: roleKey, exact: true });

--- a/apps/frontend/src/lib/ui/matrix/MatrixTable.stories.svelte
+++ b/apps/frontend/src/lib/ui/matrix/MatrixTable.stories.svelte
@@ -162,6 +162,26 @@
   </div>
 </Story>
 
+<Story name="Scope columns loading" asChild>
+  <div class="max-w-3xl rounded-lg bg-background p-4">
+    <MatrixTable
+      {rows}
+      {columns}
+      getRowKey={(row) => row.id}
+      getColumnKey={(column) => column.id}
+      {columnClass}
+      emptyMessage="No rows"
+      leadingHeader={activityHeader}
+      rowHeader={labelRow}
+      columnHeader={labelColumn}
+      cell={interactiveCell}
+      hasMore
+      loadingMore
+      onLoadMore={() => undefined}
+    />
+  </div>
+</Story>
+
 {#snippet activityHeader()}
   Activity
 {/snippet}

--- a/apps/frontend/src/lib/ui/matrix/MatrixTable.svelte
+++ b/apps/frontend/src/lib/ui/matrix/MatrixTable.svelte
@@ -8,6 +8,8 @@ cell content with snippets.
 -->
 <script lang="ts" generics="TRow, TColumn">
   import type { Snippet } from 'svelte';
+  import type { Attachment } from 'svelte/attachments';
+  import { m } from '$lib/i18n/messages';
   import DataTable from '$lib/ui/DataTable.svelte';
   import MatrixColumnHeading from './MatrixColumnHeading.svelte';
 
@@ -36,8 +38,15 @@ cell content with snippets.
     rowHeaderWidth = '14rem',
     columnHeaderHeight = '12rem',
     spacerTestId = 'matrix-spacer',
-    compact = false
+    compact = false,
+    hasMore = false,
+    loadingMore = false,
+    onLoadMore
   }: {
+    /** Incrementally load columns when their horizontal edge is visible. */
+    hasMore?: boolean;
+    loadingMore?: boolean;
+    onLoadMore?: () => unknown;
     rows: TRow[];
     columns: TColumn[];
     getRowKey: (row: TRow) => string;
@@ -65,6 +74,24 @@ cell content with snippets.
     /** Reduce padding around the standard 40-pixel cell controls. */
     compact?: boolean;
   } = $props();
+
+  const columnSentinel: Attachment<HTMLTableCellElement> = (element) => {
+    if (!hasMore || loadingMore || !onLoadMore) return;
+    const callback = onLoadMore;
+    const root = element.closest('.data-table-viewport');
+    if (!root) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          observer.disconnect();
+          callback();
+        }
+      },
+      { root, rootMargin: '0px 160px 0px 160px' }
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  };
 
   type Coordinate = { row: string; column: string };
   let hoveredCell = $state<Coordinate | null>(null);
@@ -144,7 +171,15 @@ cell content with snippets.
       </th>
     {/each}
     {@render trailingHeader?.()}
-    <th class="w-full bg-background p-0" aria-hidden="true"></th>
+    <th class="w-full bg-background p-0" aria-hidden={!loadingMore} {@attach columnSentinel}>
+      {#if loadingMore}
+        <span
+          role="status"
+          aria-label={m('ui.data_table.loading_more')}
+          class="iconify icon-[uil--spinner-alt] animate-spin text-muted"
+        ></span>
+      {/if}
+    </th>
   {/snippet}
   {#snippet row(row)}
     <th

--- a/cli/internal/connectapi/permission_pages_test.go
+++ b/cli/internal/connectapi/permission_pages_test.go
@@ -1,12 +1,13 @@
 package connectapi
 
 import (
-	"connectrpc.com/connect"
 	"fmt"
+	"testing"
+
+	"connectrpc.com/connect"
 	"hmans.de/chatto/internal/core"
 	adminv1 "hmans.de/chatto/internal/pb/chatto/admin/v1"
 	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
-	"testing"
 )
 
 func TestPermissionScopePagesAndInheritance(t *testing.T) {
@@ -94,5 +95,4 @@ func TestPermissionScopePagesAndInheritance(t *testing.T) {
 	if connect.CodeOf(err) != connect.CodePermissionDenied {
 		t.Fatalf("revoked reader code=%v", connect.CodeOf(err))
 	}
-
 }

--- a/cli/internal/connectapi/permission_pages_test.go
+++ b/cli/internal/connectapi/permission_pages_test.go
@@ -1,0 +1,98 @@
+package connectapi
+
+import (
+	"connectrpc.com/connect"
+	"fmt"
+	"hmans.de/chatto/internal/core"
+	adminv1 "hmans.de/chatto/internal/pb/chatto/admin/v1"
+	apiv1 "hmans.de/chatto/internal/pb/chatto/api/v1"
+	"testing"
+)
+
+func TestPermissionScopePagesAndInheritance(t *testing.T) {
+	env := newConnectAPITestEnv(t)
+	for _, perm := range []core.Permission{core.PermRoleManage, core.PermUserManagePermissions} {
+		if err := env.core.GrantUserPermission(env.ctx, core.SystemActorID, env.viewer.Id, perm); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ctx := withCaller(env.ctx, env.viewer)
+	groupID := env.defaultRoomGroupID(t)
+	var roomID string
+	for i := 0; i < 24; i++ {
+		room, err := env.core.CreateRoom(env.ctx, core.SystemActorID, core.KindChannel, groupID, fmt.Sprintf("scope-page-%d", i), "Scope page")
+		if err != nil {
+			t.Fatal(err)
+		}
+		roomID = room.Id
+	}
+	_, err := env.permissions.SetRolePermission(ctx, connect.NewRequest(&adminv1.SetRolePermissionRequest{
+		RoleName: core.RoleModerator, Permission: string(core.PermMessagePost), Decision: adminv1.PermissionDecision_PERMISSION_DECISION_ALLOW,
+		Scope: &adminv1.PermissionScope{Kind: adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_GROUP, Id: groupID},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	first, err := env.permissions.GetRolePermissionMatrix(ctx, connect.NewRequest(&adminv1.GetRolePermissionMatrixRequest{RoleName: core.RoleModerator}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(first.Msg.Matrix.Scopes) != 20 || !first.Msg.Page.HasMore {
+		t.Fatalf("first scope count=%d page=%v", len(first.Msg.Matrix.Scopes), first.Msg.Page)
+	}
+	second, err := env.permissions.ListRolePermissionDecisions(ctx, connect.NewRequest(&adminv1.ListRolePermissionDecisionsRequest{RoleName: core.RoleModerator, Page: &apiv1.PageRequest{Offset: 20}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int(first.Msg.Page.TotalCount) != 20+len(second.Msg.Scopes) || second.Msg.Page.HasMore {
+		t.Fatal("scope page counts disagree")
+	}
+	target := &adminv1.PermissionScope{Kind: adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_ROOM, Id: roomID}
+	exact, err := env.permissions.GetRolePermissionMatrix(ctx, connect.NewRequest(&adminv1.GetRolePermissionMatrixRequest{RoleName: core.RoleModerator, Scope: target}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(exact.Msg.Matrix.Scopes) != 1 || exact.Msg.Page.TotalCount != 1 {
+		t.Fatal("exact filter did not restrict scopes")
+	}
+	cell := findAPIPermissionCell(exact.Msg.Matrix.Cells, "room:"+roomID, string(core.PermMessagePost))
+	if cell == nil || cell.Effective != adminv1.PermissionDecision_PERMISSION_DECISION_ALLOW || cell.Override != adminv1.PermissionDecision_PERMISSION_DECISION_NONE {
+		t.Fatalf("parent outside page lost: %v", cell)
+	}
+	users, err := env.permissions.ListUserPermissionDecisions(ctx, connect.NewRequest(&adminv1.ListUserPermissionDecisionsRequest{UserId: env.viewer.Id, Scope: target}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(users.Msg.Scopes) != 1 || users.Msg.Page.TotalCount != 1 {
+		t.Fatal("user decisions did not filter scopes")
+	}
+	matrix, err := env.permissions.GetUserPermissionMatrix(ctx, connect.NewRequest(&adminv1.GetUserPermissionMatrixRequest{UserId: env.viewer.Id, Page: &apiv1.PageRequest{Limit: 1, Offset: 1}}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matrix.Msg.Matrix.Scopes) != 1 || !matrix.Msg.Page.HasMore {
+		t.Fatal("user matrix did not page")
+	}
+	dm, err := env.permissions.ListRolePermissionDecisions(ctx, connect.NewRequest(&adminv1.ListRolePermissionDecisionsRequest{RoleName: core.RoleModerator, Scope: &adminv1.PermissionScope{Kind: adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_DM}}))
+	if err != nil || len(dm.Msg.Scopes) != 1 || dm.Msg.Scopes[0].Kind != adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_DM {
+		t.Fatalf("explicit DM: %v", err)
+	}
+	for _, scope := range []*adminv1.PermissionScope{{}, {Kind: adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_ROOM}, {Kind: adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_SERVER, Id: "bad"}} {
+		_, err := env.permissions.GetRolePermissionMatrix(ctx, connect.NewRequest(&adminv1.GetRolePermissionMatrixRequest{RoleName: core.RoleModerator, Scope: scope}))
+		if connect.CodeOf(err) != connect.CodeInvalidArgument {
+			t.Fatalf("invalid scope code=%v", connect.CodeOf(err))
+		}
+	}
+	_, err = env.permissions.ListRolePermissionDecisions(env.ctx, connect.NewRequest(&adminv1.ListRolePermissionDecisionsRequest{RoleName: "missing"}))
+	if connect.CodeOf(err) != connect.CodeUnauthenticated {
+		t.Fatal("anonymous read accepted")
+	}
+	if err := env.core.ClearUserPermissionState(env.ctx, core.SystemActorID, env.viewer.Id, core.PermRoleManage); err != nil {
+		t.Fatal(err)
+	}
+	_, err = env.permissions.ListRolePermissionDecisions(ctx, connect.NewRequest(&adminv1.ListRolePermissionDecisionsRequest{RoleName: "missing", Page: &apiv1.PageRequest{Offset: 20}}))
+	if connect.CodeOf(err) != connect.CodePermissionDenied {
+		t.Fatalf("revoked reader code=%v", connect.CodeOf(err))
+	}
+
+}

--- a/cli/internal/connectapi/permissions.go
+++ b/cli/internal/connectapi/permissions.go
@@ -45,11 +45,15 @@ func (s *permissionService) GetRolePermissionMatrix(ctx context.Context, req *co
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetRolePermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope())
+	query, err := permissionScopeQuery(req.Msg.GetPage(), req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	matrix, err := s.api.core.GetRolePermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.GetRolePermissionMatrixResponse{Matrix: apiRolePermissionMatrix(matrix)}), nil
+	return connect.NewResponse(&adminv1.GetRolePermissionMatrixResponse{Matrix: apiRolePermissionMatrix(matrix), Page: apiPermissionScopePage(matrix.Page)}), nil
 }
 
 func (s *permissionService) ListRolePermissionDecisions(ctx context.Context, req *connect.Request[adminv1.ListRolePermissionDecisionsRequest]) (*connect.Response[adminv1.ListRolePermissionDecisionsResponse], error) {
@@ -57,13 +61,19 @@ func (s *permissionService) ListRolePermissionDecisions(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetRolePermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope())
+	query, err := permissionScopeQuery(req.Msg.GetPage(), req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	matrix, err := s.api.core.GetRolePermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&adminv1.ListRolePermissionDecisionsResponse{
 		RoleName:  matrix.RoleName,
 		Decisions: apiPermissionDecisionEntries(matrix.Scopes, matrix.Cells),
+		Page:      apiPermissionScopePage(matrix.Page),
+		Scopes:    apiPermissionScopes(matrix.Scopes),
 	}), nil
 }
 
@@ -72,11 +82,15 @@ func (s *permissionService) GetUserPermissionMatrix(ctx context.Context, req *co
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetUserPermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope())
+	query, err := permissionScopeQuery(req.Msg.GetPage(), req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	matrix, err := s.api.core.GetUserPermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
-	return connect.NewResponse(&adminv1.GetUserPermissionMatrixResponse{Matrix: apiUserPermissionMatrix(matrix)}), nil
+	return connect.NewResponse(&adminv1.GetUserPermissionMatrixResponse{Matrix: apiUserPermissionMatrix(matrix), Page: apiPermissionScopePage(matrix.Page)}), nil
 }
 
 func (s *permissionService) ListUserPermissionDecisions(ctx context.Context, req *connect.Request[adminv1.ListUserPermissionDecisionsRequest]) (*connect.Response[adminv1.ListUserPermissionDecisionsResponse], error) {
@@ -84,13 +98,19 @@ func (s *permissionService) ListUserPermissionDecisions(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetUserPermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope())
+	query, err := permissionScopeQuery(req.Msg.GetPage(), req.Msg.GetScope())
+	if err != nil {
+		return nil, err
+	}
+	matrix, err := s.api.core.GetUserPermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
 	return connect.NewResponse(&adminv1.ListUserPermissionDecisionsResponse{
 		UserId:    matrix.UserID,
 		Decisions: apiPermissionDecisionEntries(matrix.Scopes, matrix.Cells),
+		Page:      apiPermissionScopePage(matrix.Page),
+		Scopes:    apiPermissionScopes(matrix.Scopes),
 	}), nil
 }
 
@@ -496,4 +516,35 @@ func explanationTarget(req *adminv1.ExplainPermissionsRequest) (core.PermissionT
 		return core.PermissionTargetScope{}, invalidArgument("room_id and scope identify different targets")
 	}
 	return target, nil
+}
+
+// permissionScopeQuery decodes the shared scope-page contract without applying policy.
+func permissionScopeQuery(page *apiv1.PageRequest, scope *adminv1.PermissionScope) (core.PermissionScopeQuery, error) {
+	query := core.PermissionScopeQuery{Limit: int(page.GetLimit()), Offset: int(page.GetOffset())}
+	if scope != nil {
+		if scope.GetKind() == adminv1.PermissionScopeKind_PERMISSION_SCOPE_KIND_UNSPECIFIED {
+			return query, invalidArgument("explicit scope kind is required")
+		}
+		target, err := corePermissionTargetScope(scope)
+		if err != nil {
+			return query, err
+		}
+		if target.Kind == "" {
+			target.Kind = core.MatrixScopeServer
+		}
+		query.Scope = &target
+	}
+	return query, nil
+}
+
+func apiPermissionScopePage(page core.PermissionScopePage) *apiv1.PageInfo {
+	return &apiv1.PageInfo{TotalCount: int64(page.TotalCount), HasMore: page.HasMore}
+}
+
+func apiPermissionScopes(scopes []core.PermissionMatrixScope) []*adminv1.PermissionScope {
+	out := make([]*adminv1.PermissionScope, 0, len(scopes))
+	for _, scope := range scopes {
+		out = append(out, apiPermissionEntryScope(scope))
+	}
+	return out
 }

--- a/cli/internal/connectapi/permissions.go
+++ b/cli/internal/connectapi/permissions.go
@@ -49,7 +49,7 @@ func (s *permissionService) GetRolePermissionMatrix(ctx context.Context, req *co
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetRolePermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope(), query)
+	matrix, err := s.api.core.GetRolePermissionMatrixPage(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -65,7 +65,7 @@ func (s *permissionService) ListRolePermissionDecisions(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetRolePermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope(), query)
+	matrix, err := s.api.core.GetRolePermissionMatrixPage(ctx, caller.UserID, req.Msg.GetRoleName(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -86,7 +86,7 @@ func (s *permissionService) GetUserPermissionMatrix(ctx context.Context, req *co
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetUserPermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope(), query)
+	matrix, err := s.api.core.GetUserPermissionMatrixPage(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}
@@ -102,7 +102,7 @@ func (s *permissionService) ListUserPermissionDecisions(ctx context.Context, req
 	if err != nil {
 		return nil, err
 	}
-	matrix, err := s.api.core.GetUserPermissionMatrixIncludingDM(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope(), query)
+	matrix, err := s.api.core.GetUserPermissionMatrixPage(ctx, caller.UserID, req.Msg.GetUserId(), req.Msg.GetIncludeDirectMessageScope(), query)
 	if err != nil {
 		return nil, connectError(err)
 	}

--- a/cli/internal/core/bots_test.go
+++ b/cli/internal/core/bots_test.go
@@ -1264,6 +1264,16 @@ func TestCanonicalUserPermissionMatrixForBotFiltersHiddenRoomsAndKeepsDirectoryG
 	if err != nil {
 		t.Fatalf("GetUserPermissionMatrix: %v", err)
 	}
+	filtered, err := c.GetUserPermissionMatrixIncludingDM(ctx, owner.GetId(), bot.User.GetId(), false, PermissionScopeQuery{
+		Scope: &PermissionTargetScope{Kind: MatrixScopeRoom, ID: room.GetId()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered.Scopes) != 0 || len(filtered.Cells) != 0 || filtered.Page.TotalCount != 0 || filtered.Page.HasMore {
+		t.Fatal("hidden bot room leaked through scope filter or counts")
+	}
+
 	groupFound := false
 	for _, scope := range matrix.Scopes {
 		if scope.ID == "group:"+group.GetId() && scope.Label == group.GetName() {

--- a/cli/internal/core/bots_test.go
+++ b/cli/internal/core/bots_test.go
@@ -1264,7 +1264,7 @@ func TestCanonicalUserPermissionMatrixForBotFiltersHiddenRoomsAndKeepsDirectoryG
 	if err != nil {
 		t.Fatalf("GetUserPermissionMatrix: %v", err)
 	}
-	filtered, err := c.GetUserPermissionMatrixIncludingDM(ctx, owner.GetId(), bot.User.GetId(), false, PermissionScopeQuery{
+	filtered, err := c.GetUserPermissionMatrixPage(ctx, owner.GetId(), bot.User.GetId(), false, PermissionScopeQuery{
 		Scope: &PermissionTargetScope{Kind: MatrixScopeRoom, ID: room.GetId()},
 	})
 	if err != nil {

--- a/cli/internal/core/permission_management.go
+++ b/cli/internal/core/permission_management.go
@@ -80,8 +80,7 @@ type PermissionMatrixCell struct {
 }
 
 type RolePermissionMatrix struct {
-	Page PermissionScopePage
-
+	Page                  PermissionScopePage
 	RoleName              string
 	ApplicablePermissions []string
 	Scopes                []PermissionMatrixScope
@@ -89,8 +88,7 @@ type RolePermissionMatrix struct {
 }
 
 type UserPermissionMatrix struct {
-	Page PermissionScopePage
-
+	Page                  PermissionScopePage
 	UserID                string
 	ApplicablePermissions []string
 	Scopes                []PermissionMatrixScope
@@ -179,22 +177,30 @@ func (c *ChattoCore) GetRolePermissionMatrix(ctx context.Context, actorID, roleN
 	return c.GetRolePermissionMatrixIncludingDM(ctx, actorID, roleName, false)
 }
 
-// GetRolePermissionMatrixIncludingDM returns a bounded scope page after authorization.
-// An omitted query uses 20 scopes. IncludeDM adds the direct-message scope.
-func (c *ChattoCore) GetRolePermissionMatrixIncludingDM(ctx context.Context, actorID, roleName string, includeDM bool, pages ...PermissionScopeQuery) (*RolePermissionMatrix, error) {
+// GetRolePermissionMatrixIncludingDM returns the first scope page, optionally including DMs.
+func (c *ChattoCore) GetRolePermissionMatrixIncludingDM(ctx context.Context, actorID, roleName string, includeDM bool) (*RolePermissionMatrix, error) {
+	return c.GetRolePermissionMatrixPage(ctx, actorID, roleName, includeDM, PermissionScopeQuery{})
+}
+
+// GetRolePermissionMatrixPage authorizes and evaluates one bounded scope page.
+func (c *ChattoCore) GetRolePermissionMatrixPage(ctx context.Context, actorID, roleName string, includeDM bool, query PermissionScopeQuery) (*RolePermissionMatrix, error) {
 	if err := c.requireCanManageAdminRoles(ctx, actorID); err != nil {
 		return nil, err
 	}
-	return c.buildRolePermissionMatrix(ctx, roleName, includeDM, firstPermissionScopeQuery(pages))
+	return c.buildRolePermissionMatrix(ctx, roleName, includeDM, query)
 }
 
 func (c *ChattoCore) GetUserPermissionMatrix(ctx context.Context, actorID, userID string) (*UserPermissionMatrix, error) {
 	return c.GetUserPermissionMatrixIncludingDM(ctx, actorID, userID, false)
 }
 
-// GetUserPermissionMatrixIncludingDM returns a bounded scope page after authorization.
-// An omitted query uses 20 scopes. IncludeDM adds the direct-message scope.
-func (c *ChattoCore) GetUserPermissionMatrixIncludingDM(ctx context.Context, actorID, userID string, includeDM bool, pages ...PermissionScopeQuery) (*UserPermissionMatrix, error) {
+// GetUserPermissionMatrixIncludingDM returns the first scope page, optionally including DMs.
+func (c *ChattoCore) GetUserPermissionMatrixIncludingDM(ctx context.Context, actorID, userID string, includeDM bool) (*UserPermissionMatrix, error) {
+	return c.GetUserPermissionMatrixPage(ctx, actorID, userID, includeDM, PermissionScopeQuery{})
+}
+
+// GetUserPermissionMatrixPage authorizes and evaluates one bounded scope page.
+func (c *ChattoCore) GetUserPermissionMatrixPage(ctx context.Context, actorID, userID string, includeDM bool, query PermissionScopeQuery) (*UserPermissionMatrix, error) {
 	if actorID == "" {
 		return nil, ErrNotAuthenticated
 	}
@@ -210,7 +216,7 @@ func (c *ChattoCore) GetUserPermissionMatrixIncludingDM(ctx context.Context, act
 	} else if err := c.requireCanManageUserPermissionTarget(ctx, actorID); err != nil {
 		return nil, err
 	}
-	return c.buildUserPermissionMatrix(ctx, actorID, user, includeDM, firstPermissionScopeQuery(pages))
+	return c.buildUserPermissionMatrix(ctx, actorID, user, includeDM, query)
 }
 
 func (c *ChattoCore) SetRolePermissionState(ctx context.Context, actorID, roleName string, scope PermissionTargetScope, perm Permission, state PermissionState) error {

--- a/cli/internal/core/permission_management.go
+++ b/cli/internal/core/permission_management.go
@@ -80,6 +80,8 @@ type PermissionMatrixCell struct {
 }
 
 type RolePermissionMatrix struct {
+	Page PermissionScopePage
+
 	RoleName              string
 	ApplicablePermissions []string
 	Scopes                []PermissionMatrixScope
@@ -87,6 +89,8 @@ type RolePermissionMatrix struct {
 }
 
 type UserPermissionMatrix struct {
+	Page PermissionScopePage
+
 	UserID                string
 	ApplicablePermissions []string
 	Scopes                []PermissionMatrixScope
@@ -175,18 +179,22 @@ func (c *ChattoCore) GetRolePermissionMatrix(ctx context.Context, actorID, roleN
 	return c.GetRolePermissionMatrixIncludingDM(ctx, actorID, roleName, false)
 }
 
-func (c *ChattoCore) GetRolePermissionMatrixIncludingDM(ctx context.Context, actorID, roleName string, includeDM bool) (*RolePermissionMatrix, error) {
+// GetRolePermissionMatrixIncludingDM returns a bounded scope page after authorization.
+// An omitted query uses 20 scopes. IncludeDM adds the direct-message scope.
+func (c *ChattoCore) GetRolePermissionMatrixIncludingDM(ctx context.Context, actorID, roleName string, includeDM bool, pages ...PermissionScopeQuery) (*RolePermissionMatrix, error) {
 	if err := c.requireCanManageAdminRoles(ctx, actorID); err != nil {
 		return nil, err
 	}
-	return c.buildRolePermissionMatrix(ctx, roleName, includeDM)
+	return c.buildRolePermissionMatrix(ctx, roleName, includeDM, firstPermissionScopeQuery(pages))
 }
 
 func (c *ChattoCore) GetUserPermissionMatrix(ctx context.Context, actorID, userID string) (*UserPermissionMatrix, error) {
 	return c.GetUserPermissionMatrixIncludingDM(ctx, actorID, userID, false)
 }
 
-func (c *ChattoCore) GetUserPermissionMatrixIncludingDM(ctx context.Context, actorID, userID string, includeDM bool) (*UserPermissionMatrix, error) {
+// GetUserPermissionMatrixIncludingDM returns a bounded scope page after authorization.
+// An omitted query uses 20 scopes. IncludeDM adds the direct-message scope.
+func (c *ChattoCore) GetUserPermissionMatrixIncludingDM(ctx context.Context, actorID, userID string, includeDM bool, pages ...PermissionScopeQuery) (*UserPermissionMatrix, error) {
 	if actorID == "" {
 		return nil, ErrNotAuthenticated
 	}
@@ -202,7 +210,7 @@ func (c *ChattoCore) GetUserPermissionMatrixIncludingDM(ctx context.Context, act
 	} else if err := c.requireCanManageUserPermissionTarget(ctx, actorID); err != nil {
 		return nil, err
 	}
-	return c.buildUserPermissionMatrix(ctx, actorID, user, includeDM)
+	return c.buildUserPermissionMatrix(ctx, actorID, user, includeDM, firstPermissionScopeQuery(pages))
 }
 
 func (c *ChattoCore) SetRolePermissionState(ctx context.Context, actorID, roleName string, scope PermissionTargetScope, perm Permission, state PermissionState) error {
@@ -593,7 +601,7 @@ func (c *ChattoCore) buildTierRole(ctx context.Context, role RoleWithPermissions
 	return out, nil
 }
 
-func (c *ChattoCore) buildRolePermissionMatrix(ctx context.Context, roleName string, includeDM bool) (*RolePermissionMatrix, error) {
+func (c *ChattoCore) buildRolePermissionMatrix(ctx context.Context, roleName string, includeDM bool, query PermissionScopeQuery) (*RolePermissionMatrix, error) {
 	role, err := c.GetServerRole(ctx, roleName)
 	if err != nil {
 		return nil, fmt.Errorf("load role: %w", err)
@@ -603,7 +611,12 @@ func (c *ChattoCore) buildRolePermissionMatrix(ctx context.Context, roleName str
 	}
 
 	applicable := matrixApplicablePermissions()
-	scopes, err := c.buildMatrixScopes(ctx, includeDM)
+	scopes, err := c.buildMatrixScopes(ctx, includeDM || query.includesDM())
+	if err != nil {
+		return nil, err
+	}
+
+	scopes, page, err := selectPermissionScopes(scopes, query)
 	if err != nil {
 		return nil, err
 	}
@@ -648,6 +661,16 @@ func (c *ChattoCore) buildRolePermissionMatrix(ctx context.Context, roleName str
 			roomGrants[roomID] = g
 			roomDenials[roomID] = d
 			roomToGroup[roomID] = scope.ParentGroupID
+			// The parent may be outside the requested page. Its rules still apply.
+			if groupID := scope.ParentGroupID; groupID != "" {
+				if _, loaded := groupGrants[groupID]; !loaded {
+					g, d, err := c.GetGroupRolePermissions(ctx, groupID, roleName)
+					if err != nil {
+						return nil, fmt.Errorf("load parent group permissions: %w", err)
+					}
+					groupGrants[groupID], groupDenials[groupID] = g, d
+				}
+			}
 		}
 	}
 
@@ -671,13 +694,14 @@ func (c *ChattoCore) buildRolePermissionMatrix(ctx context.Context, roleName str
 
 	return &RolePermissionMatrix{
 		RoleName:              roleName,
+		Page:                  page,
 		ApplicablePermissions: applicable,
 		Scopes:                scopes,
 		Cells:                 cells,
 	}, nil
 }
 
-func (c *ChattoCore) buildUserPermissionMatrix(ctx context.Context, actorID string, user *evtv1.User, includeDM bool) (*UserPermissionMatrix, error) {
+func (c *ChattoCore) buildUserPermissionMatrix(ctx context.Context, actorID string, user *evtv1.User, includeDM bool, query PermissionScopeQuery) (*UserPermissionMatrix, error) {
 	userID := user.GetId()
 	applicable := matrixApplicablePermissions()
 	bot := user.GetIsBot()
@@ -695,13 +719,18 @@ func (c *ChattoCore) buildUserPermissionMatrix(ctx context.Context, actorID stri
 		err    error
 	)
 	if bot {
-		scopes, err = c.buildBotMatrixScopes(ctx, user.GetBotOwnerUserId(), actorID, includeDM)
+		scopes, err = c.buildBotMatrixScopes(ctx, user.GetBotOwnerUserId(), actorID, includeDM || query.includesDM())
 	} else {
-		scopes, err = c.buildMatrixScopes(ctx, includeDM)
+		scopes, err = c.buildMatrixScopes(ctx, includeDM || query.includesDM())
 	}
 	if err != nil {
 		return nil, err
 	}
+	scopes, page, err := selectPermissionScopes(scopes, query)
+	if err != nil {
+		return nil, err
+	}
+
 	cells := make([]PermissionMatrixCell, 0, len(applicable)*len(scopes))
 	for _, permStr := range applicable {
 		perm := Permission(permStr)
@@ -724,6 +753,7 @@ func (c *ChattoCore) buildUserPermissionMatrix(ctx context.Context, actorID stri
 	}
 	return &UserPermissionMatrix{
 		UserID:                userID,
+		Page:                  page,
 		ApplicablePermissions: applicable,
 		Scopes:                scopes,
 		Cells:                 cells,

--- a/cli/internal/core/permission_scope_page.go
+++ b/cli/internal/core/permission_scope_page.go
@@ -19,18 +19,11 @@ type PermissionScopePage struct {
 	HasMore    bool
 }
 
-func firstPermissionScopeQuery(queries []PermissionScopeQuery) PermissionScopeQuery {
-	if len(queries) == 0 {
-		return PermissionScopeQuery{}
-	}
-	return queries[0]
-}
-
 func (q PermissionScopeQuery) includesDM() bool {
 	return q.Scope != nil && q.Scope.Kind == MatrixScopeDM
 }
 
-// selectPermissionScopes uses stable kind/ID ordering. Enumeration can still
+// selectPermissionScopes uses stable group/room ID ordering. Enumeration can still
 // scale with the directory; permission evaluation and result size are bounded.
 func selectPermissionScopes(scopes []PermissionMatrixScope, q PermissionScopeQuery) ([]PermissionMatrixScope, PermissionScopePage, error) {
 	if q.Limit < 0 || q.Offset < 0 {
@@ -68,23 +61,36 @@ func selectPermissionScopes(scopes []PermissionMatrixScope, q PermissionScopeQue
 		}
 		scopes = filtered
 	}
+	// Keep each group beside its rooms so appending pages never reorders
+	// already rendered columns in a grouped matrix.
 	rank := func(kind MatrixScopeKind) int {
 		switch kind {
 		case MatrixScopeServer:
 			return 0
 		case MatrixScopeDM:
 			return 1
-		case MatrixScopeGroup:
-			return 2
 		default:
-			return 3
+			return 2
 		}
 	}
-	sort.Slice(scopes, func(i, j int) bool {
-		if scopes[i].Kind != scopes[j].Kind {
-			return rank(scopes[i].Kind) < rank(scopes[j].Kind)
+	groupID := func(scope PermissionMatrixScope) string {
+		if scope.Kind == MatrixScopeGroup {
+			return scopeRefID(scope.ID, "group:")
 		}
-		return scopes[i].ID < scopes[j].ID
+		return scope.ParentGroupID
+	}
+	sort.Slice(scopes, func(i, j int) bool {
+		a, b := scopes[i], scopes[j]
+		if rank(a.Kind) != rank(b.Kind) {
+			return rank(a.Kind) < rank(b.Kind)
+		}
+		if groupID(a) != groupID(b) {
+			return groupID(a) < groupID(b)
+		}
+		if a.Kind != b.Kind {
+			return a.Kind == MatrixScopeGroup
+		}
+		return a.ID < b.ID
 	})
 	page := PermissionScopePage{TotalCount: len(scopes)}
 	if q.Offset >= len(scopes) {

--- a/cli/internal/core/permission_scope_page.go
+++ b/cli/internal/core/permission_scope_page.go
@@ -1,0 +1,103 @@
+package core
+
+import (
+	"fmt"
+	"sort"
+)
+
+// PermissionScopeQuery selects a live page of scopes before permission evaluation.
+// Scope is an optional exact filter. Limit and Offset count scopes, not cells.
+type PermissionScopeQuery struct {
+	Scope  *PermissionTargetScope
+	Limit  int
+	Offset int
+}
+
+// PermissionScopePage describes the matching visible scope collection.
+type PermissionScopePage struct {
+	TotalCount int
+	HasMore    bool
+}
+
+func firstPermissionScopeQuery(queries []PermissionScopeQuery) PermissionScopeQuery {
+	if len(queries) == 0 {
+		return PermissionScopeQuery{}
+	}
+	return queries[0]
+}
+
+func (q PermissionScopeQuery) includesDM() bool {
+	return q.Scope != nil && q.Scope.Kind == MatrixScopeDM
+}
+
+// selectPermissionScopes uses stable kind/ID ordering. Enumeration can still
+// scale with the directory; permission evaluation and result size are bounded.
+func selectPermissionScopes(scopes []PermissionMatrixScope, q PermissionScopeQuery) ([]PermissionMatrixScope, PermissionScopePage, error) {
+	if q.Limit < 0 || q.Offset < 0 {
+		return nil, PermissionScopePage{}, fmt.Errorf("%w: negative scope page", ErrInvalidArgument)
+	}
+	if q.Scope != nil {
+		target := *q.Scope
+		switch target.Kind {
+		case MatrixScopeServer, MatrixScopeDM:
+			if target.ID != "" {
+				return nil, PermissionScopePage{}, fmt.Errorf("%w: scope id must be empty", ErrInvalidArgument)
+			}
+		case MatrixScopeGroup, MatrixScopeRoom:
+			if target.ID == "" {
+				return nil, PermissionScopePage{}, fmt.Errorf("%w: scope id is required", ErrInvalidArgument)
+			}
+		default:
+			return nil, PermissionScopePage{}, fmt.Errorf("%w: explicit scope kind is required", ErrInvalidArgument)
+		}
+		filtered := make([]PermissionMatrixScope, 0, 1)
+		for _, scope := range scopes {
+			id := scope.ID
+			if scope.Kind == MatrixScopeGroup {
+				id = scopeRefID(id, "group:")
+			}
+			if scope.Kind == MatrixScopeRoom {
+				id = scopeRefID(id, "room:")
+			}
+			if scope.Kind == MatrixScopeServer || scope.Kind == MatrixScopeDM {
+				id = ""
+			}
+			if scope.Kind == target.Kind && id == target.ID {
+				filtered = append(filtered, scope)
+			}
+		}
+		scopes = filtered
+	}
+	rank := func(kind MatrixScopeKind) int {
+		switch kind {
+		case MatrixScopeServer:
+			return 0
+		case MatrixScopeDM:
+			return 1
+		case MatrixScopeGroup:
+			return 2
+		default:
+			return 3
+		}
+	}
+	sort.Slice(scopes, func(i, j int) bool {
+		if scopes[i].Kind != scopes[j].Kind {
+			return rank(scopes[i].Kind) < rank(scopes[j].Kind)
+		}
+		return scopes[i].ID < scopes[j].ID
+	})
+	page := PermissionScopePage{TotalCount: len(scopes)}
+	if q.Offset >= len(scopes) {
+		return []PermissionMatrixScope{}, page, nil
+	}
+	limit := q.Limit
+	if limit == 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	end := q.Offset + min(limit, len(scopes)-q.Offset)
+	page.HasMore = end < len(scopes)
+	return scopes[q.Offset:end], page, nil
+}

--- a/cli/internal/core/permission_scope_page_test.go
+++ b/cli/internal/core/permission_scope_page_test.go
@@ -1,0 +1,42 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestPermissionScopePagination(t *testing.T) {
+	scopes := []PermissionMatrixScope{{ID: "server", Kind: MatrixScopeServer}, {ID: "dm", Kind: MatrixScopeDM}}
+	for i := 109; i >= 0; i-- {
+		scopes = append(scopes, PermissionMatrixScope{ID: fmt.Sprintf("room:%03d", i), Kind: MatrixScopeRoom})
+	}
+	for _, tc := range []struct {
+		name         string
+		q            PermissionScopeQuery
+		count, total int
+		more         bool
+	}{
+		{"default", PermissionScopeQuery{}, 20, 112, true},
+		{"cap", PermissionScopeQuery{Limit: 500}, 100, 112, true},
+		{"last", PermissionScopeQuery{Offset: 100}, 12, 112, false},
+		{"past end", PermissionScopeQuery{Offset: int(^uint(0) >> 1)}, 0, 112, false},
+		{"room", PermissionScopeQuery{Scope: &PermissionTargetScope{Kind: MatrixScopeRoom, ID: "009"}}, 1, 1, false},
+		{"missing", PermissionScopeQuery{Scope: &PermissionTargetScope{Kind: MatrixScopeRoom, ID: "missing"}}, 0, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, page, err := selectPermissionScopes(append([]PermissionMatrixScope(nil), scopes...), tc.q)
+			if err != nil || len(got) != tc.count || page.TotalCount != tc.total || page.HasMore != tc.more {
+				t.Fatalf("len=%d page=%+v err=%v", len(got), page, err)
+			}
+			if tc.name == "default" && (got[0].ID != "server" || got[1].ID != "dm" || got[2].ID != "room:000") {
+				t.Fatal("unstable scope ordering")
+			}
+		})
+	}
+	for _, q := range []PermissionScopeQuery{{Limit: -1}, {Offset: -1}, {Scope: &PermissionTargetScope{}}, {Scope: &PermissionTargetScope{Kind: MatrixScopeRoom}}, {Scope: &PermissionTargetScope{Kind: MatrixScopeServer, ID: "bad"}}} {
+		if _, _, err := selectPermissionScopes(scopes, q); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("invalid query accepted: %+v", q)
+		}
+	}
+}

--- a/cli/internal/pb/chatto/admin/v1/adminv1connect/permissions.connect.go
+++ b/cli/internal/pb/chatto/admin/v1/adminv1connect/permissions.connect.go
@@ -65,13 +65,13 @@ type AdminPermissionServiceClient interface {
 	// role.manage; group and room scopes require role.manage or effective
 	// room.manage at the requested resource.
 	GetRolePermissionTierMatrix(context.Context, *connect.Request[v1.GetRolePermissionTierMatrixRequest]) (*connect.Response[v1.GetRolePermissionTierMatrixResponse], error)
-	// Gets one role's full permission matrix. Requires role.manage. Returns
+	// Gets one page of a role's permission matrix. Requires role.manage. Returns
 	// NOT_FOUND when the role does not exist.
 	GetRolePermissionMatrix(context.Context, *connect.Request[v1.GetRolePermissionMatrixRequest]) (*connect.Response[v1.GetRolePermissionMatrixResponse], error)
 	// Lists one role's permission decisions as resource-oriented rows. Requires
 	// role.manage. Returns NOT_FOUND when the role does not exist.
 	ListRolePermissionDecisions(context.Context, *connect.Request[v1.ListRolePermissionDecisionsRequest]) (*connect.Response[v1.ListRolePermissionDecisionsResponse], error)
-	// Gets one user's full permission matrix. Human targets require
+	// Gets one page of a user's permission matrix. Human targets require
 	// user.manage-permissions; bot targets require ownership or bot.manage.
 	// Returns NOT_FOUND when the user does not exist.
 	GetUserPermissionMatrix(context.Context, *connect.Request[v1.GetUserPermissionMatrixRequest]) (*connect.Response[v1.GetUserPermissionMatrixResponse], error)
@@ -214,13 +214,13 @@ type AdminPermissionServiceHandler interface {
 	// role.manage; group and room scopes require role.manage or effective
 	// room.manage at the requested resource.
 	GetRolePermissionTierMatrix(context.Context, *connect.Request[v1.GetRolePermissionTierMatrixRequest]) (*connect.Response[v1.GetRolePermissionTierMatrixResponse], error)
-	// Gets one role's full permission matrix. Requires role.manage. Returns
+	// Gets one page of a role's permission matrix. Requires role.manage. Returns
 	// NOT_FOUND when the role does not exist.
 	GetRolePermissionMatrix(context.Context, *connect.Request[v1.GetRolePermissionMatrixRequest]) (*connect.Response[v1.GetRolePermissionMatrixResponse], error)
 	// Lists one role's permission decisions as resource-oriented rows. Requires
 	// role.manage. Returns NOT_FOUND when the role does not exist.
 	ListRolePermissionDecisions(context.Context, *connect.Request[v1.ListRolePermissionDecisionsRequest]) (*connect.Response[v1.ListRolePermissionDecisionsResponse], error)
-	// Gets one user's full permission matrix. Human targets require
+	// Gets one page of a user's permission matrix. Human targets require
 	// user.manage-permissions; bot targets require ownership or bot.manage.
 	// Returns NOT_FOUND when the user does not exist.
 	GetUserPermissionMatrix(context.Context, *connect.Request[v1.GetUserPermissionMatrixRequest]) (*connect.Response[v1.GetUserPermissionMatrixResponse], error)

--- a/cli/internal/pb/chatto/admin/v1/permissions.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/permissions.pb.go
@@ -688,7 +688,7 @@ func (x *PermissionMatrixCell) GetAllowPermitted() bool {
 	return false
 }
 
-// Permission matrix for one role across all scopes.
+// Permission matrix for one role for one page of scopes.
 type RolePermissionMatrix struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Role name.
@@ -769,8 +769,13 @@ type GetRolePermissionMatrixRequest struct {
 	// Include the direct-message scope column. Defaults to false so an older
 	// client does not receive a scope kind that it cannot interpret.
 	IncludeDirectMessageScope bool `protobuf:"varint,2,opt,name=include_direct_message_scope,json=includeDirectMessageScope,proto3" json:"include_direct_message_scope,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+	Page *v1.PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+	// SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+	Scope         *PermissionScope `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetRolePermissionMatrixRequest) Reset() {
@@ -817,11 +822,27 @@ func (x *GetRolePermissionMatrixRequest) GetIncludeDirectMessageScope() bool {
 	return false
 }
 
+func (x *GetRolePermissionMatrixRequest) GetPage() *v1.PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+func (x *GetRolePermissionMatrixRequest) GetScope() *PermissionScope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
 // Response containing one role's permission matrix.
 type GetRolePermissionMatrixResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Requested matrix.
-	Matrix        *RolePermissionMatrix `protobuf:"bytes,1,opt,name=matrix,proto3" json:"matrix,omitempty"`
+	Matrix *RolePermissionMatrix `protobuf:"bytes,1,opt,name=matrix,proto3" json:"matrix,omitempty"`
+	// Total matching scopes and whether another scope page exists.
+	Page          *v1.PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -863,7 +884,14 @@ func (x *GetRolePermissionMatrixResponse) GetMatrix() *RolePermissionMatrix {
 	return nil
 }
 
-// Permission matrix for one user across all scopes.
+func (x *GetRolePermissionMatrixResponse) GetPage() *v1.PageInfo {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+// Permission matrix for one user for one page of scopes.
 type UserPermissionMatrix struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// User ID.
@@ -1083,8 +1111,13 @@ type ListRolePermissionDecisionsRequest struct {
 	RoleName string `protobuf:"bytes,1,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
 	// Include direct-message decisions. Defaults to false for older clients.
 	IncludeDirectMessageScope bool `protobuf:"varint,2,opt,name=include_direct_message_scope,json=includeDirectMessageScope,proto3" json:"include_direct_message_scope,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+	Page *v1.PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+	// SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+	Scope         *PermissionScope `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListRolePermissionDecisionsRequest) Reset() {
@@ -1131,13 +1164,31 @@ func (x *ListRolePermissionDecisionsRequest) GetIncludeDirectMessageScope() bool
 	return false
 }
 
+func (x *ListRolePermissionDecisionsRequest) GetPage() *v1.PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+func (x *ListRolePermissionDecisionsRequest) GetScope() *PermissionScope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
 // Resource-oriented permission decisions for one role.
 type ListRolePermissionDecisionsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Stable role name.
 	RoleName string `protobuf:"bytes,1,opt,name=role_name,json=roleName,proto3" json:"role_name,omitempty"`
 	// Permission decisions keyed by permission and typed scope.
-	Decisions     []*ScopedPermissionDecision `protobuf:"bytes,2,rep,name=decisions,proto3" json:"decisions,omitempty"`
+	Decisions []*ScopedPermissionDecision `protobuf:"bytes,2,rep,name=decisions,proto3" json:"decisions,omitempty"`
+	// Total matching scopes and whether another scope page exists.
+	Page *v1.PageInfo `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// Scopes in this page, including scopes with no applicable decisions.
+	Scopes        []*PermissionScope `protobuf:"bytes,4,rep,name=scopes,proto3" json:"scopes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1186,6 +1237,20 @@ func (x *ListRolePermissionDecisionsResponse) GetDecisions() []*ScopedPermission
 	return nil
 }
 
+func (x *ListRolePermissionDecisionsResponse) GetPage() *v1.PageInfo {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+func (x *ListRolePermissionDecisionsResponse) GetScopes() []*PermissionScope {
+	if x != nil {
+		return x.Scopes
+	}
+	return nil
+}
+
 // Request explicit/effective permission decisions for one user.
 type ListUserPermissionDecisionsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1193,8 +1258,13 @@ type ListUserPermissionDecisionsRequest struct {
 	UserId string `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
 	// Include direct-message decisions. Defaults to false for older clients.
 	IncludeDirectMessageScope bool `protobuf:"varint,2,opt,name=include_direct_message_scope,json=includeDirectMessageScope,proto3" json:"include_direct_message_scope,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+	Page *v1.PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+	// SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+	Scope         *PermissionScope `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *ListUserPermissionDecisionsRequest) Reset() {
@@ -1241,13 +1311,31 @@ func (x *ListUserPermissionDecisionsRequest) GetIncludeDirectMessageScope() bool
 	return false
 }
 
+func (x *ListUserPermissionDecisionsRequest) GetPage() *v1.PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+func (x *ListUserPermissionDecisionsRequest) GetScope() *PermissionScope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
 // Resource-oriented permission decisions for one user.
 type ListUserPermissionDecisionsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// User ID.
 	UserId string `protobuf:"bytes,1,opt,name=user_id,json=userId,proto3" json:"user_id,omitempty"`
 	// Permission decisions keyed by permission and typed scope.
-	Decisions     []*ScopedPermissionDecision `protobuf:"bytes,2,rep,name=decisions,proto3" json:"decisions,omitempty"`
+	Decisions []*ScopedPermissionDecision `protobuf:"bytes,2,rep,name=decisions,proto3" json:"decisions,omitempty"`
+	// Total matching scopes and whether another scope page exists.
+	Page *v1.PageInfo `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// Scopes in this page, including scopes with no applicable decisions.
+	Scopes        []*PermissionScope `protobuf:"bytes,4,rep,name=scopes,proto3" json:"scopes,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1292,6 +1380,20 @@ func (x *ListUserPermissionDecisionsResponse) GetUserId() string {
 func (x *ListUserPermissionDecisionsResponse) GetDecisions() []*ScopedPermissionDecision {
 	if x != nil {
 		return x.Decisions
+	}
+	return nil
+}
+
+func (x *ListUserPermissionDecisionsResponse) GetPage() *v1.PageInfo {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+func (x *ListUserPermissionDecisionsResponse) GetScopes() []*PermissionScope {
+	if x != nil {
+		return x.Scopes
 	}
 	return nil
 }
@@ -1581,8 +1683,13 @@ type GetUserPermissionMatrixRequest struct {
 	// Include the direct-message scope column. Defaults to false so an older
 	// client does not receive a scope kind that it cannot interpret.
 	IncludeDirectMessageScope bool `protobuf:"varint,2,opt,name=include_direct_message_scope,json=includeDirectMessageScope,proto3" json:"include_direct_message_scope,omitempty"`
-	unknownFields             protoimpl.UnknownFields
-	sizeCache                 protoimpl.SizeCache
+	// Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+	Page *v1.PageRequest `protobuf:"bytes,3,opt,name=page,proto3" json:"page,omitempty"`
+	// Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+	// SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+	Scope         *PermissionScope `protobuf:"bytes,4,opt,name=scope,proto3" json:"scope,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *GetUserPermissionMatrixRequest) Reset() {
@@ -1629,11 +1736,27 @@ func (x *GetUserPermissionMatrixRequest) GetIncludeDirectMessageScope() bool {
 	return false
 }
 
+func (x *GetUserPermissionMatrixRequest) GetPage() *v1.PageRequest {
+	if x != nil {
+		return x.Page
+	}
+	return nil
+}
+
+func (x *GetUserPermissionMatrixRequest) GetScope() *PermissionScope {
+	if x != nil {
+		return x.Scope
+	}
+	return nil
+}
+
 // Response containing one user's permission matrix.
 type GetUserPermissionMatrixResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Requested matrix.
-	Matrix        *UserPermissionMatrix `protobuf:"bytes,1,opt,name=matrix,proto3" json:"matrix,omitempty"`
+	Matrix *UserPermissionMatrix `protobuf:"bytes,1,opt,name=matrix,proto3" json:"matrix,omitempty"`
+	// Total matching scopes and whether another scope page exists.
+	Page          *v1.PageInfo `protobuf:"bytes,2,opt,name=page,proto3" json:"page,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1671,6 +1794,13 @@ func (*GetUserPermissionMatrixResponse) Descriptor() ([]byte, []int) {
 func (x *GetUserPermissionMatrixResponse) GetMatrix() *UserPermissionMatrix {
 	if x != nil {
 		return x.Matrix
+	}
+	return nil
+}
+
+func (x *GetUserPermissionMatrixResponse) GetPage() *v1.PageInfo {
+	if x != nil {
+		return x.Page
 	}
 	return nil
 }
@@ -1917,7 +2047,7 @@ var File_chatto_admin_v1_permissions_proto protoreflect.FileDescriptor
 
 const file_chatto_admin_v1_permissions_proto_rawDesc = "" +
 	"\n" +
-	"!chatto/admin/v1/permissions.proto\x12\x0fchatto.admin.v1\x1a\x1bbuf/validate/validate.proto\x1a\x19chatto/api/v1/roles.proto\"e\n" +
+	"!chatto/admin/v1/permissions.proto\x12\x0fchatto.admin.v1\x1a\x1bbuf/validate/validate.proto\x1a\x19chatto/api/v1/roles.proto\x1a\x1echatto/api/v1/pagination.proto\"e\n" +
 	"\x0fPermissionScope\x12B\n" +
 	"\x04kind\x18\x01 \x01(\x0e2$.chatto.admin.v1.PermissionScopeKindB\b\xbaH\x05\x82\x01\x02\x10\x01R\x04kind\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\"b\n" +
@@ -1954,12 +2084,15 @@ const file_chatto_admin_v1_permissions_proto_rawDesc = "" +
 	"\trole_name\x18\x01 \x01(\tR\broleName\x125\n" +
 	"\x16applicable_permissions\x18\x02 \x03(\tR\x15applicablePermissions\x12>\n" +
 	"\x06scopes\x18\x03 \x03(\v2&.chatto.admin.v1.PermissionMatrixScopeR\x06scopes\x12;\n" +
-	"\x05cells\x18\x04 \x03(\v2%.chatto.admin.v1.PermissionMatrixCellR\x05cells\"\x87\x01\n" +
+	"\x05cells\x18\x04 \x03(\v2%.chatto.admin.v1.PermissionMatrixCellR\x05cells\"\xef\x01\n" +
 	"\x1eGetRolePermissionMatrixRequest\x12$\n" +
 	"\trole_name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\broleName\x12?\n" +
-	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\"`\n" +
+	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\x12.\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\x126\n" +
+	"\x05scope\x18\x04 \x01(\v2 .chatto.admin.v1.PermissionScopeR\x05scope\"\x8d\x01\n" +
 	"\x1fGetRolePermissionMatrixResponse\x12=\n" +
-	"\x06matrix\x18\x01 \x01(\v2%.chatto.admin.v1.RolePermissionMatrixR\x06matrix\"\xe3\x01\n" +
+	"\x06matrix\x18\x01 \x01(\v2%.chatto.admin.v1.RolePermissionMatrixR\x06matrix\x12+\n" +
+	"\x04page\x18\x02 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\"\xe3\x01\n" +
 	"\x14UserPermissionMatrix\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x125\n" +
 	"\x16applicable_permissions\x18\x02 \x03(\tR\x15applicablePermissions\x12>\n" +
@@ -1977,19 +2110,27 @@ const file_chatto_admin_v1_permissions_proto_rawDesc = "" +
 	"permission\x18\x01 \x01(\tR\n" +
 	"permission\x126\n" +
 	"\x05scope\x18\x02 \x01(\v2 .chatto.admin.v1.PermissionScopeR\x05scope\x12?\n" +
-	"\bdecision\x18\x03 \x01(\x0e2#.chatto.admin.v1.PermissionDecisionR\bdecision\"\x8b\x01\n" +
+	"\bdecision\x18\x03 \x01(\x0e2#.chatto.admin.v1.PermissionDecisionR\bdecision\"\xf3\x01\n" +
 	"\"ListRolePermissionDecisionsRequest\x12$\n" +
 	"\trole_name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\broleName\x12?\n" +
-	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\"\x8b\x01\n" +
+	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\x12.\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\x126\n" +
+	"\x05scope\x18\x04 \x01(\v2 .chatto.admin.v1.PermissionScopeR\x05scope\"\xf2\x01\n" +
 	"#ListRolePermissionDecisionsResponse\x12\x1b\n" +
 	"\trole_name\x18\x01 \x01(\tR\broleName\x12G\n" +
-	"\tdecisions\x18\x02 \x03(\v2).chatto.admin.v1.ScopedPermissionDecisionR\tdecisions\"\x87\x01\n" +
+	"\tdecisions\x18\x02 \x03(\v2).chatto.admin.v1.ScopedPermissionDecisionR\tdecisions\x12+\n" +
+	"\x04page\x18\x03 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\x128\n" +
+	"\x06scopes\x18\x04 \x03(\v2 .chatto.admin.v1.PermissionScopeR\x06scopes\"\xef\x01\n" +
 	"\"ListUserPermissionDecisionsRequest\x12 \n" +
 	"\auser_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userId\x12?\n" +
-	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\"\x87\x01\n" +
+	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\x12.\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\x126\n" +
+	"\x05scope\x18\x04 \x01(\v2 .chatto.admin.v1.PermissionScopeR\x05scope\"\xee\x01\n" +
 	"#ListUserPermissionDecisionsResponse\x12\x17\n" +
 	"\auser_id\x18\x01 \x01(\tR\x06userId\x12G\n" +
-	"\tdecisions\x18\x02 \x03(\v2).chatto.admin.v1.ScopedPermissionDecisionR\tdecisions\"\xce\x01\n" +
+	"\tdecisions\x18\x02 \x03(\v2).chatto.admin.v1.ScopedPermissionDecisionR\tdecisions\x12+\n" +
+	"\x04page\x18\x03 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\x128\n" +
+	"\x06scopes\x18\x04 \x03(\v2 .chatto.admin.v1.PermissionScopeR\x06scopes\"\xce\x01\n" +
 	"\x14PermissionTraceEntry\x12>\n" +
 	"\x05level\x18\x01 \x01(\x0e2(.chatto.admin.v1.PermissionDecisionLevelR\x05level\x12\x1b\n" +
 	"\trole_name\x18\x02 \x01(\tR\broleName\x12?\n" +
@@ -2010,12 +2151,15 @@ const file_chatto_admin_v1_permissions_proto_rawDesc = "" +
 	"\aroom_id\x18\x02 \x01(\tR\x06roomId\x126\n" +
 	"\x05scope\x18\x03 \x01(\v2 .chatto.admin.v1.PermissionScopeR\x05scope\"h\n" +
 	"\x1aExplainPermissionsResponse\x12J\n" +
-	"\fexplanations\x18\x01 \x03(\v2&.chatto.admin.v1.PermissionExplanationR\fexplanations\"\x83\x01\n" +
+	"\fexplanations\x18\x01 \x03(\v2&.chatto.admin.v1.PermissionExplanationR\fexplanations\"\xeb\x01\n" +
 	"\x1eGetUserPermissionMatrixRequest\x12 \n" +
 	"\auser_id\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\x06userId\x12?\n" +
-	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\"`\n" +
+	"\x1cinclude_direct_message_scope\x18\x02 \x01(\bR\x19includeDirectMessageScope\x12.\n" +
+	"\x04page\x18\x03 \x01(\v2\x1a.chatto.api.v1.PageRequestR\x04page\x126\n" +
+	"\x05scope\x18\x04 \x01(\v2 .chatto.admin.v1.PermissionScopeR\x05scope\"\x8d\x01\n" +
 	"\x1fGetUserPermissionMatrixResponse\x12=\n" +
-	"\x06matrix\x18\x01 \x01(\v2%.chatto.admin.v1.UserPermissionMatrixR\x06matrix\"\xee\x01\n" +
+	"\x06matrix\x18\x01 \x01(\v2%.chatto.admin.v1.UserPermissionMatrixR\x06matrix\x12+\n" +
+	"\x04page\x18\x02 \x01(\v2\x17.chatto.api.v1.PageInfoR\x04page\"\xee\x01\n" +
 	"\x18SetRolePermissionRequest\x12$\n" +
 	"\trole_name\x18\x01 \x01(\tB\a\xbaH\x04r\x02\x10\x01R\broleName\x12'\n" +
 	"\n" +
@@ -2111,6 +2255,8 @@ var file_chatto_admin_v1_permissions_proto_goTypes = []any{
 	(*SetUserPermissionRequest)(nil),            // 29: chatto.admin.v1.SetUserPermissionRequest
 	(*SetUserPermissionResponse)(nil),           // 30: chatto.admin.v1.SetUserPermissionResponse
 	(*v1.Role)(nil),                             // 31: chatto.api.v1.Role
+	(*v1.PageRequest)(nil),                      // 32: chatto.api.v1.PageRequest
+	(*v1.PageInfo)(nil),                         // 33: chatto.api.v1.PageInfo
 }
 var file_chatto_admin_v1_permissions_proto_depIdxs = []int32{
 	1,  // 0: chatto.admin.v1.PermissionScope.kind:type_name -> chatto.admin.v1.PermissionScopeKind
@@ -2124,51 +2270,65 @@ var file_chatto_admin_v1_permissions_proto_depIdxs = []int32{
 	0,  // 8: chatto.admin.v1.PermissionMatrixCell.effective:type_name -> chatto.admin.v1.PermissionDecision
 	9,  // 9: chatto.admin.v1.RolePermissionMatrix.scopes:type_name -> chatto.admin.v1.PermissionMatrixScope
 	10, // 10: chatto.admin.v1.RolePermissionMatrix.cells:type_name -> chatto.admin.v1.PermissionMatrixCell
-	11, // 11: chatto.admin.v1.GetRolePermissionMatrixResponse.matrix:type_name -> chatto.admin.v1.RolePermissionMatrix
-	9,  // 12: chatto.admin.v1.UserPermissionMatrix.scopes:type_name -> chatto.admin.v1.PermissionMatrixScope
-	10, // 13: chatto.admin.v1.UserPermissionMatrix.cells:type_name -> chatto.admin.v1.PermissionMatrixCell
-	3,  // 14: chatto.admin.v1.ScopedPermissionDecision.scope:type_name -> chatto.admin.v1.PermissionScope
-	0,  // 15: chatto.admin.v1.ScopedPermissionDecision.override:type_name -> chatto.admin.v1.PermissionDecision
-	0,  // 16: chatto.admin.v1.ScopedPermissionDecision.effective:type_name -> chatto.admin.v1.PermissionDecision
-	3,  // 17: chatto.admin.v1.PermissionDecisionUpdate.scope:type_name -> chatto.admin.v1.PermissionScope
-	0,  // 18: chatto.admin.v1.PermissionDecisionUpdate.decision:type_name -> chatto.admin.v1.PermissionDecision
-	15, // 19: chatto.admin.v1.ListRolePermissionDecisionsResponse.decisions:type_name -> chatto.admin.v1.ScopedPermissionDecision
-	15, // 20: chatto.admin.v1.ListUserPermissionDecisionsResponse.decisions:type_name -> chatto.admin.v1.ScopedPermissionDecision
-	2,  // 21: chatto.admin.v1.PermissionTraceEntry.level:type_name -> chatto.admin.v1.PermissionDecisionLevel
-	0,  // 22: chatto.admin.v1.PermissionTraceEntry.decision:type_name -> chatto.admin.v1.PermissionDecision
-	0,  // 23: chatto.admin.v1.PermissionExplanation.state:type_name -> chatto.admin.v1.PermissionDecision
-	2,  // 24: chatto.admin.v1.PermissionExplanation.decided_at:type_name -> chatto.admin.v1.PermissionDecisionLevel
-	21, // 25: chatto.admin.v1.PermissionExplanation.trace:type_name -> chatto.admin.v1.PermissionTraceEntry
-	3,  // 26: chatto.admin.v1.ExplainPermissionsRequest.scope:type_name -> chatto.admin.v1.PermissionScope
-	22, // 27: chatto.admin.v1.ExplainPermissionsResponse.explanations:type_name -> chatto.admin.v1.PermissionExplanation
-	14, // 28: chatto.admin.v1.GetUserPermissionMatrixResponse.matrix:type_name -> chatto.admin.v1.UserPermissionMatrix
-	0,  // 29: chatto.admin.v1.SetRolePermissionRequest.decision:type_name -> chatto.admin.v1.PermissionDecision
-	3,  // 30: chatto.admin.v1.SetRolePermissionRequest.scope:type_name -> chatto.admin.v1.PermissionScope
-	16, // 31: chatto.admin.v1.SetRolePermissionResponse.decision:type_name -> chatto.admin.v1.PermissionDecisionUpdate
-	0,  // 32: chatto.admin.v1.SetUserPermissionRequest.decision:type_name -> chatto.admin.v1.PermissionDecision
-	3,  // 33: chatto.admin.v1.SetUserPermissionRequest.scope:type_name -> chatto.admin.v1.PermissionScope
-	16, // 34: chatto.admin.v1.SetUserPermissionResponse.decision:type_name -> chatto.admin.v1.PermissionDecisionUpdate
-	7,  // 35: chatto.admin.v1.AdminPermissionService.GetRolePermissionTierMatrix:input_type -> chatto.admin.v1.GetRolePermissionTierMatrixRequest
-	12, // 36: chatto.admin.v1.AdminPermissionService.GetRolePermissionMatrix:input_type -> chatto.admin.v1.GetRolePermissionMatrixRequest
-	17, // 37: chatto.admin.v1.AdminPermissionService.ListRolePermissionDecisions:input_type -> chatto.admin.v1.ListRolePermissionDecisionsRequest
-	25, // 38: chatto.admin.v1.AdminPermissionService.GetUserPermissionMatrix:input_type -> chatto.admin.v1.GetUserPermissionMatrixRequest
-	19, // 39: chatto.admin.v1.AdminPermissionService.ListUserPermissionDecisions:input_type -> chatto.admin.v1.ListUserPermissionDecisionsRequest
-	23, // 40: chatto.admin.v1.AdminPermissionService.ExplainPermissions:input_type -> chatto.admin.v1.ExplainPermissionsRequest
-	27, // 41: chatto.admin.v1.AdminPermissionService.SetRolePermission:input_type -> chatto.admin.v1.SetRolePermissionRequest
-	29, // 42: chatto.admin.v1.AdminPermissionService.SetUserPermission:input_type -> chatto.admin.v1.SetUserPermissionRequest
-	8,  // 43: chatto.admin.v1.AdminPermissionService.GetRolePermissionTierMatrix:output_type -> chatto.admin.v1.GetRolePermissionTierMatrixResponse
-	13, // 44: chatto.admin.v1.AdminPermissionService.GetRolePermissionMatrix:output_type -> chatto.admin.v1.GetRolePermissionMatrixResponse
-	18, // 45: chatto.admin.v1.AdminPermissionService.ListRolePermissionDecisions:output_type -> chatto.admin.v1.ListRolePermissionDecisionsResponse
-	26, // 46: chatto.admin.v1.AdminPermissionService.GetUserPermissionMatrix:output_type -> chatto.admin.v1.GetUserPermissionMatrixResponse
-	20, // 47: chatto.admin.v1.AdminPermissionService.ListUserPermissionDecisions:output_type -> chatto.admin.v1.ListUserPermissionDecisionsResponse
-	24, // 48: chatto.admin.v1.AdminPermissionService.ExplainPermissions:output_type -> chatto.admin.v1.ExplainPermissionsResponse
-	28, // 49: chatto.admin.v1.AdminPermissionService.SetRolePermission:output_type -> chatto.admin.v1.SetRolePermissionResponse
-	30, // 50: chatto.admin.v1.AdminPermissionService.SetUserPermission:output_type -> chatto.admin.v1.SetUserPermissionResponse
-	43, // [43:51] is the sub-list for method output_type
-	35, // [35:43] is the sub-list for method input_type
-	35, // [35:35] is the sub-list for extension type_name
-	35, // [35:35] is the sub-list for extension extendee
-	0,  // [0:35] is the sub-list for field type_name
+	32, // 11: chatto.admin.v1.GetRolePermissionMatrixRequest.page:type_name -> chatto.api.v1.PageRequest
+	3,  // 12: chatto.admin.v1.GetRolePermissionMatrixRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	11, // 13: chatto.admin.v1.GetRolePermissionMatrixResponse.matrix:type_name -> chatto.admin.v1.RolePermissionMatrix
+	33, // 14: chatto.admin.v1.GetRolePermissionMatrixResponse.page:type_name -> chatto.api.v1.PageInfo
+	9,  // 15: chatto.admin.v1.UserPermissionMatrix.scopes:type_name -> chatto.admin.v1.PermissionMatrixScope
+	10, // 16: chatto.admin.v1.UserPermissionMatrix.cells:type_name -> chatto.admin.v1.PermissionMatrixCell
+	3,  // 17: chatto.admin.v1.ScopedPermissionDecision.scope:type_name -> chatto.admin.v1.PermissionScope
+	0,  // 18: chatto.admin.v1.ScopedPermissionDecision.override:type_name -> chatto.admin.v1.PermissionDecision
+	0,  // 19: chatto.admin.v1.ScopedPermissionDecision.effective:type_name -> chatto.admin.v1.PermissionDecision
+	3,  // 20: chatto.admin.v1.PermissionDecisionUpdate.scope:type_name -> chatto.admin.v1.PermissionScope
+	0,  // 21: chatto.admin.v1.PermissionDecisionUpdate.decision:type_name -> chatto.admin.v1.PermissionDecision
+	32, // 22: chatto.admin.v1.ListRolePermissionDecisionsRequest.page:type_name -> chatto.api.v1.PageRequest
+	3,  // 23: chatto.admin.v1.ListRolePermissionDecisionsRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	15, // 24: chatto.admin.v1.ListRolePermissionDecisionsResponse.decisions:type_name -> chatto.admin.v1.ScopedPermissionDecision
+	33, // 25: chatto.admin.v1.ListRolePermissionDecisionsResponse.page:type_name -> chatto.api.v1.PageInfo
+	3,  // 26: chatto.admin.v1.ListRolePermissionDecisionsResponse.scopes:type_name -> chatto.admin.v1.PermissionScope
+	32, // 27: chatto.admin.v1.ListUserPermissionDecisionsRequest.page:type_name -> chatto.api.v1.PageRequest
+	3,  // 28: chatto.admin.v1.ListUserPermissionDecisionsRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	15, // 29: chatto.admin.v1.ListUserPermissionDecisionsResponse.decisions:type_name -> chatto.admin.v1.ScopedPermissionDecision
+	33, // 30: chatto.admin.v1.ListUserPermissionDecisionsResponse.page:type_name -> chatto.api.v1.PageInfo
+	3,  // 31: chatto.admin.v1.ListUserPermissionDecisionsResponse.scopes:type_name -> chatto.admin.v1.PermissionScope
+	2,  // 32: chatto.admin.v1.PermissionTraceEntry.level:type_name -> chatto.admin.v1.PermissionDecisionLevel
+	0,  // 33: chatto.admin.v1.PermissionTraceEntry.decision:type_name -> chatto.admin.v1.PermissionDecision
+	0,  // 34: chatto.admin.v1.PermissionExplanation.state:type_name -> chatto.admin.v1.PermissionDecision
+	2,  // 35: chatto.admin.v1.PermissionExplanation.decided_at:type_name -> chatto.admin.v1.PermissionDecisionLevel
+	21, // 36: chatto.admin.v1.PermissionExplanation.trace:type_name -> chatto.admin.v1.PermissionTraceEntry
+	3,  // 37: chatto.admin.v1.ExplainPermissionsRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	22, // 38: chatto.admin.v1.ExplainPermissionsResponse.explanations:type_name -> chatto.admin.v1.PermissionExplanation
+	32, // 39: chatto.admin.v1.GetUserPermissionMatrixRequest.page:type_name -> chatto.api.v1.PageRequest
+	3,  // 40: chatto.admin.v1.GetUserPermissionMatrixRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	14, // 41: chatto.admin.v1.GetUserPermissionMatrixResponse.matrix:type_name -> chatto.admin.v1.UserPermissionMatrix
+	33, // 42: chatto.admin.v1.GetUserPermissionMatrixResponse.page:type_name -> chatto.api.v1.PageInfo
+	0,  // 43: chatto.admin.v1.SetRolePermissionRequest.decision:type_name -> chatto.admin.v1.PermissionDecision
+	3,  // 44: chatto.admin.v1.SetRolePermissionRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	16, // 45: chatto.admin.v1.SetRolePermissionResponse.decision:type_name -> chatto.admin.v1.PermissionDecisionUpdate
+	0,  // 46: chatto.admin.v1.SetUserPermissionRequest.decision:type_name -> chatto.admin.v1.PermissionDecision
+	3,  // 47: chatto.admin.v1.SetUserPermissionRequest.scope:type_name -> chatto.admin.v1.PermissionScope
+	16, // 48: chatto.admin.v1.SetUserPermissionResponse.decision:type_name -> chatto.admin.v1.PermissionDecisionUpdate
+	7,  // 49: chatto.admin.v1.AdminPermissionService.GetRolePermissionTierMatrix:input_type -> chatto.admin.v1.GetRolePermissionTierMatrixRequest
+	12, // 50: chatto.admin.v1.AdminPermissionService.GetRolePermissionMatrix:input_type -> chatto.admin.v1.GetRolePermissionMatrixRequest
+	17, // 51: chatto.admin.v1.AdminPermissionService.ListRolePermissionDecisions:input_type -> chatto.admin.v1.ListRolePermissionDecisionsRequest
+	25, // 52: chatto.admin.v1.AdminPermissionService.GetUserPermissionMatrix:input_type -> chatto.admin.v1.GetUserPermissionMatrixRequest
+	19, // 53: chatto.admin.v1.AdminPermissionService.ListUserPermissionDecisions:input_type -> chatto.admin.v1.ListUserPermissionDecisionsRequest
+	23, // 54: chatto.admin.v1.AdminPermissionService.ExplainPermissions:input_type -> chatto.admin.v1.ExplainPermissionsRequest
+	27, // 55: chatto.admin.v1.AdminPermissionService.SetRolePermission:input_type -> chatto.admin.v1.SetRolePermissionRequest
+	29, // 56: chatto.admin.v1.AdminPermissionService.SetUserPermission:input_type -> chatto.admin.v1.SetUserPermissionRequest
+	8,  // 57: chatto.admin.v1.AdminPermissionService.GetRolePermissionTierMatrix:output_type -> chatto.admin.v1.GetRolePermissionTierMatrixResponse
+	13, // 58: chatto.admin.v1.AdminPermissionService.GetRolePermissionMatrix:output_type -> chatto.admin.v1.GetRolePermissionMatrixResponse
+	18, // 59: chatto.admin.v1.AdminPermissionService.ListRolePermissionDecisions:output_type -> chatto.admin.v1.ListRolePermissionDecisionsResponse
+	26, // 60: chatto.admin.v1.AdminPermissionService.GetUserPermissionMatrix:output_type -> chatto.admin.v1.GetUserPermissionMatrixResponse
+	20, // 61: chatto.admin.v1.AdminPermissionService.ListUserPermissionDecisions:output_type -> chatto.admin.v1.ListUserPermissionDecisionsResponse
+	24, // 62: chatto.admin.v1.AdminPermissionService.ExplainPermissions:output_type -> chatto.admin.v1.ExplainPermissionsResponse
+	28, // 63: chatto.admin.v1.AdminPermissionService.SetRolePermission:output_type -> chatto.admin.v1.SetRolePermissionResponse
+	30, // 64: chatto.admin.v1.AdminPermissionService.SetUserPermission:output_type -> chatto.admin.v1.SetUserPermissionResponse
+	57, // [57:65] is the sub-list for method output_type
+	49, // [49:57] is the sub-list for method input_type
+	49, // [49:49] is the sub-list for extension type_name
+	49, // [49:49] is the sub-list for extension extendee
+	0,  // [0:49] is the sub-list for field type_name
 }
 
 func init() { file_chatto_admin_v1_permissions_proto_init() }

--- a/cli/internal/pb/chatto/admin/v1/permissions.pb.go
+++ b/cli/internal/pb/chatto/admin/v1/permissions.pb.go
@@ -688,7 +688,7 @@ func (x *PermissionMatrixCell) GetAllowPermitted() bool {
 	return false
 }
 
-// Permission matrix for one role for one page of scopes.
+// Permission matrix for one role within a scope page.
 type RolePermissionMatrix struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Role name.
@@ -891,7 +891,7 @@ func (x *GetRolePermissionMatrixResponse) GetPage() *v1.PageInfo {
 	return nil
 }
 
-// Permission matrix for one user for one page of scopes.
+// Permission matrix for one user within a scope page.
 type UserPermissionMatrix struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// User ID.

--- a/docs/architecture/interfaces.md
+++ b/docs/architecture/interfaces.md
@@ -94,6 +94,12 @@ another account. These operations validate stable request-time authorization
 inputs, use OCC on the target user aggregate, and then return the ready user
 projection.
 
+`AdminPermissionService` uses the same scope pagination for role/user matrix
+and decision reads. The core selects at most 100 scopes before cell evaluation
+and loads parent-group rules independently of the page. Scope enumeration still
+scans the directory. Bot reads filter room visibility before pagination and
+counts. See [permission scope selection](../../cli/internal/core/permission_scope_page.go).
+
 `AdminRoleService` separates role details from explicit membership pages.
 `ListMembers` gates each request with `role.assign`; it selects assignment IDs
 before bounded user-profile hydration. It does not require `admin.view-users`.

--- a/docs/fdr/FDR-001-roles-and-permissions.md
+++ b/docs/fdr/FDR-001-roles-and-permissions.md
@@ -28,6 +28,12 @@ See [FDR-038](FDR-038-bot-accounts.md).
 
 ## Behavior
 
+- Role and account permission reads use bounded scope pages or an exact scope
+  filter. Each scope includes its applicable decisions, with inheritance from
+  broader scopes even when those scopes are outside the page. The editors load
+  more columns at the horizontal scroll edge. This bounds each calculation
+  while allowing large servers to expose their full configuration.
+
 - Role details and assigned members are separate reads. Member lists load in
   bounded pages so large roles do not require every user profile at once.
   Roster access requires `role.assign`, not access to the full administrative

--- a/packages/api-types/src/chatto/admin/v1/permissions_connect.ts
+++ b/packages/api-types/src/chatto/admin/v1/permissions_connect.ts
@@ -7,7 +7,12 @@ import { ExplainPermissionsRequest, ExplainPermissionsResponse, GetRolePermissio
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
- * Provides permission matrix reads and admin permission writes.
+ * Provides permission reads and admin permission writes.
+ * Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
+ * then ascending resource ID within each kind. Only requested scopes are evaluated.
+ * Pages are live reads; layout or visibility changes can shift offsets. Keep the
+ * same filters on each request and advance by the number of returned scopes.
+ * A scope filter of DM selects DM even when include_direct_message_scope is false.
  *
  * @generated from service chatto.admin.v1.AdminPermissionService
  */
@@ -28,7 +33,7 @@ export const AdminPermissionService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Gets one role's full permission matrix. Requires role.manage. Returns
+     * Gets one page of a role's permission matrix. Requires role.manage. Returns
      * NOT_FOUND when the role does not exist.
      *
      * @generated from rpc chatto.admin.v1.AdminPermissionService.GetRolePermissionMatrix
@@ -52,7 +57,7 @@ export const AdminPermissionService = {
       kind: MethodKind.Unary,
     },
     /**
-     * Gets one user's full permission matrix. Human targets require
+     * Gets one page of a user's permission matrix. Human targets require
      * user.manage-permissions; bot targets require ownership or bot.manage.
      * Returns NOT_FOUND when the user does not exist.
      *

--- a/packages/api-types/src/chatto/admin/v1/permissions_connect.ts
+++ b/packages/api-types/src/chatto/admin/v1/permissions_connect.ts
@@ -8,8 +8,9 @@ import { MethodKind } from "@bufbuild/protobuf";
 
 /**
  * Provides permission reads and admin permission writes.
- * Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
- * then ascending resource ID within each kind. Only requested scopes are evaluated.
+ * Matrix and decision pages use the same scope order: SERVER, DM, then each GROUP
+ * followed by its ROOM scopes. Groups and rooms within each group use ascending
+ * resource IDs. Only requested scopes are evaluated.
  * Pages are live reads; layout or visibility changes can shift offsets. Keep the
  * same filters on each request and advance by the number of returned scopes.
  * A scope filter of DM selects DM even when include_direct_message_scope is false.

--- a/packages/api-types/src/chatto/admin/v1/permissions_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/permissions_pb.ts
@@ -6,6 +6,7 @@
 import type { BinaryReadOptions, FieldList, JsonReadOptions, JsonValue, PartialMessage, PlainMessage } from "@bufbuild/protobuf";
 import { Message, proto3 } from "@bufbuild/protobuf";
 import { Role } from "../../api/v1/roles_pb.js";
+import { PageInfo, PageRequest } from "../../api/v1/pagination_pb.js";
 
 /**
  * Trinary permission decision used by permission matrices and write requests.
@@ -583,7 +584,7 @@ export class PermissionMatrixCell extends Message<PermissionMatrixCell> {
 }
 
 /**
- * Permission matrix for one role across all scopes.
+ * Permission matrix for one role for one page of scopes.
  *
  * @generated from message chatto.admin.v1.RolePermissionMatrix
  */
@@ -668,6 +669,21 @@ export class GetRolePermissionMatrixRequest extends Message<GetRolePermissionMat
    */
   includeDirectMessageScope = false;
 
+  /**
+   * Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 3;
+   */
+  page?: PageRequest;
+
+  /**
+   * Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+   * SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+   *
+   * @generated from field: chatto.admin.v1.PermissionScope scope = 4;
+   */
+  scope?: PermissionScope;
+
   constructor(data?: PartialMessage<GetRolePermissionMatrixRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -678,6 +694,8 @@ export class GetRolePermissionMatrixRequest extends Message<GetRolePermissionMat
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "role_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "include_direct_message_scope", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "page", kind: "message", T: PageRequest },
+    { no: 4, name: "scope", kind: "message", T: PermissionScope },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetRolePermissionMatrixRequest {
@@ -710,6 +728,13 @@ export class GetRolePermissionMatrixResponse extends Message<GetRolePermissionMa
    */
   matrix?: RolePermissionMatrix;
 
+  /**
+   * Total matching scopes and whether another scope page exists.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 2;
+   */
+  page?: PageInfo;
+
   constructor(data?: PartialMessage<GetRolePermissionMatrixResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -719,6 +744,7 @@ export class GetRolePermissionMatrixResponse extends Message<GetRolePermissionMa
   static readonly typeName = "chatto.admin.v1.GetRolePermissionMatrixResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "matrix", kind: "message", T: RolePermissionMatrix },
+    { no: 2, name: "page", kind: "message", T: PageInfo },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetRolePermissionMatrixResponse {
@@ -739,7 +765,7 @@ export class GetRolePermissionMatrixResponse extends Message<GetRolePermissionMa
 }
 
 /**
- * Permission matrix for one user across all scopes.
+ * Permission matrix for one user for one page of scopes.
  *
  * @generated from message chatto.admin.v1.UserPermissionMatrix
  */
@@ -948,6 +974,21 @@ export class ListRolePermissionDecisionsRequest extends Message<ListRolePermissi
    */
   includeDirectMessageScope = false;
 
+  /**
+   * Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 3;
+   */
+  page?: PageRequest;
+
+  /**
+   * Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+   * SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+   *
+   * @generated from field: chatto.admin.v1.PermissionScope scope = 4;
+   */
+  scope?: PermissionScope;
+
   constructor(data?: PartialMessage<ListRolePermissionDecisionsRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -958,6 +999,8 @@ export class ListRolePermissionDecisionsRequest extends Message<ListRolePermissi
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "role_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "include_direct_message_scope", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "page", kind: "message", T: PageRequest },
+    { no: 4, name: "scope", kind: "message", T: PermissionScope },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListRolePermissionDecisionsRequest {
@@ -997,6 +1040,20 @@ export class ListRolePermissionDecisionsResponse extends Message<ListRolePermiss
    */
   decisions: ScopedPermissionDecision[] = [];
 
+  /**
+   * Total matching scopes and whether another scope page exists.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 3;
+   */
+  page?: PageInfo;
+
+  /**
+   * Scopes in this page, including scopes with no applicable decisions.
+   *
+   * @generated from field: repeated chatto.admin.v1.PermissionScope scopes = 4;
+   */
+  scopes: PermissionScope[] = [];
+
   constructor(data?: PartialMessage<ListRolePermissionDecisionsResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1007,6 +1064,8 @@ export class ListRolePermissionDecisionsResponse extends Message<ListRolePermiss
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "role_name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "decisions", kind: "message", T: ScopedPermissionDecision, repeated: true },
+    { no: 3, name: "page", kind: "message", T: PageInfo },
+    { no: 4, name: "scopes", kind: "message", T: PermissionScope, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListRolePermissionDecisionsResponse {
@@ -1046,6 +1105,21 @@ export class ListUserPermissionDecisionsRequest extends Message<ListUserPermissi
    */
   includeDirectMessageScope = false;
 
+  /**
+   * Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 3;
+   */
+  page?: PageRequest;
+
+  /**
+   * Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+   * SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+   *
+   * @generated from field: chatto.admin.v1.PermissionScope scope = 4;
+   */
+  scope?: PermissionScope;
+
   constructor(data?: PartialMessage<ListUserPermissionDecisionsRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1056,6 +1130,8 @@ export class ListUserPermissionDecisionsRequest extends Message<ListUserPermissi
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "include_direct_message_scope", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "page", kind: "message", T: PageRequest },
+    { no: 4, name: "scope", kind: "message", T: PermissionScope },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListUserPermissionDecisionsRequest {
@@ -1095,6 +1171,20 @@ export class ListUserPermissionDecisionsResponse extends Message<ListUserPermiss
    */
   decisions: ScopedPermissionDecision[] = [];
 
+  /**
+   * Total matching scopes and whether another scope page exists.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 3;
+   */
+  page?: PageInfo;
+
+  /**
+   * Scopes in this page, including scopes with no applicable decisions.
+   *
+   * @generated from field: repeated chatto.admin.v1.PermissionScope scopes = 4;
+   */
+  scopes: PermissionScope[] = [];
+
   constructor(data?: PartialMessage<ListUserPermissionDecisionsResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1105,6 +1195,8 @@ export class ListUserPermissionDecisionsResponse extends Message<ListUserPermiss
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "decisions", kind: "message", T: ScopedPermissionDecision, repeated: true },
+    { no: 3, name: "page", kind: "message", T: PageInfo },
+    { no: 4, name: "scopes", kind: "message", T: PermissionScope, repeated: true },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListUserPermissionDecisionsResponse {
@@ -1392,6 +1484,21 @@ export class GetUserPermissionMatrixRequest extends Message<GetUserPermissionMat
    */
   includeDirectMessageScope = false;
 
+  /**
+   * Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+   *
+   * @generated from field: chatto.api.v1.PageRequest page = 3;
+   */
+  page?: PageRequest;
+
+  /**
+   * Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+   * SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+   *
+   * @generated from field: chatto.admin.v1.PermissionScope scope = 4;
+   */
+  scope?: PermissionScope;
+
   constructor(data?: PartialMessage<GetUserPermissionMatrixRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1402,6 +1509,8 @@ export class GetUserPermissionMatrixRequest extends Message<GetUserPermissionMat
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "include_direct_message_scope", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 3, name: "page", kind: "message", T: PageRequest },
+    { no: 4, name: "scope", kind: "message", T: PermissionScope },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetUserPermissionMatrixRequest {
@@ -1434,6 +1543,13 @@ export class GetUserPermissionMatrixResponse extends Message<GetUserPermissionMa
    */
   matrix?: UserPermissionMatrix;
 
+  /**
+   * Total matching scopes and whether another scope page exists.
+   *
+   * @generated from field: chatto.api.v1.PageInfo page = 2;
+   */
+  page?: PageInfo;
+
   constructor(data?: PartialMessage<GetUserPermissionMatrixResponse>) {
     super();
     proto3.util.initPartial(data, this);
@@ -1443,6 +1559,7 @@ export class GetUserPermissionMatrixResponse extends Message<GetUserPermissionMa
   static readonly typeName = "chatto.admin.v1.GetUserPermissionMatrixResponse";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "matrix", kind: "message", T: UserPermissionMatrix },
+    { no: 2, name: "page", kind: "message", T: PageInfo },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): GetUserPermissionMatrixResponse {

--- a/packages/api-types/src/chatto/admin/v1/permissions_pb.ts
+++ b/packages/api-types/src/chatto/admin/v1/permissions_pb.ts
@@ -584,7 +584,7 @@ export class PermissionMatrixCell extends Message<PermissionMatrixCell> {
 }
 
 /**
- * Permission matrix for one role for one page of scopes.
+ * Permission matrix for one role within a scope page.
  *
  * @generated from message chatto.admin.v1.RolePermissionMatrix
  */
@@ -765,7 +765,7 @@ export class GetRolePermissionMatrixResponse extends Message<GetRolePermissionMa
 }
 
 /**
- * Permission matrix for one user for one page of scopes.
+ * Permission matrix for one user within a scope page.
  *
  * @generated from message chatto.admin.v1.UserPermissionMatrix
  */

--- a/proto/chatto/admin/v1/permissions.proto
+++ b/proto/chatto/admin/v1/permissions.proto
@@ -4,6 +4,7 @@ package chatto.admin.v1;
 
 import "buf/validate/validate.proto";
 import "chatto/api/v1/roles.proto";
+import "chatto/api/v1/pagination.proto";
 
 // Trinary permission decision used by permission matrices and write requests.
 enum PermissionDecision {
@@ -109,7 +110,7 @@ message PermissionMatrixCell {
   optional bool allow_permitted = 5;
 }
 
-// Permission matrix for one role across all scopes.
+// Permission matrix for one role for one page of scopes.
 message RolePermissionMatrix {
   // Role name.
   string role_name = 1;
@@ -128,15 +129,22 @@ message GetRolePermissionMatrixRequest {
   // Include the direct-message scope column. Defaults to false so an older
   // client does not receive a scope kind that it cannot interpret.
   bool include_direct_message_scope = 2;
+  // Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+  chatto.api.v1.PageRequest page = 3;
+  // Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+  // SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+  PermissionScope scope = 4;
 }
 
 // Response containing one role's permission matrix.
 message GetRolePermissionMatrixResponse {
   // Requested matrix.
   RolePermissionMatrix matrix = 1;
+  // Total matching scopes and whether another scope page exists.
+  chatto.api.v1.PageInfo page = 2;
 }
 
-// Permission matrix for one user across all scopes.
+// Permission matrix for one user for one page of scopes.
 message UserPermissionMatrix {
   // User ID.
   string user_id = 1;
@@ -179,6 +187,11 @@ message ListRolePermissionDecisionsRequest {
   string role_name = 1 [(buf.validate.field).string.min_len = 1];
   // Include direct-message decisions. Defaults to false for older clients.
   bool include_direct_message_scope = 2;
+  // Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+  chatto.api.v1.PageRequest page = 3;
+  // Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+  // SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+  PermissionScope scope = 4;
 }
 
 // Resource-oriented permission decisions for one role.
@@ -187,6 +200,10 @@ message ListRolePermissionDecisionsResponse {
   string role_name = 1;
   // Permission decisions keyed by permission and typed scope.
   repeated ScopedPermissionDecision decisions = 2;
+  // Total matching scopes and whether another scope page exists.
+  chatto.api.v1.PageInfo page = 3;
+  // Scopes in this page, including scopes with no applicable decisions.
+  repeated PermissionScope scopes = 4;
 }
 
 // Request explicit/effective permission decisions for one user.
@@ -195,6 +212,11 @@ message ListUserPermissionDecisionsRequest {
   string user_id = 1 [(buf.validate.field).string.min_len = 1];
   // Include direct-message decisions. Defaults to false for older clients.
   bool include_direct_message_scope = 2;
+  // Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+  chatto.api.v1.PageRequest page = 3;
+  // Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+  // SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+  PermissionScope scope = 4;
 }
 
 // Resource-oriented permission decisions for one user.
@@ -203,6 +225,10 @@ message ListUserPermissionDecisionsResponse {
   string user_id = 1;
   // Permission decisions keyed by permission and typed scope.
   repeated ScopedPermissionDecision decisions = 2;
+  // Total matching scopes and whether another scope page exists.
+  chatto.api.v1.PageInfo page = 3;
+  // Scopes in this page, including scopes with no applicable decisions.
+  repeated PermissionScope scopes = 4;
 }
 
 // Level at which a permission explanation found a decision.
@@ -273,12 +299,19 @@ message GetUserPermissionMatrixRequest {
   // Include the direct-message scope column. Defaults to false so an older
   // client does not receive a scope kind that it cannot interpret.
   bool include_direct_message_scope = 2;
+  // Scope page. Default 20 scopes, maximum 100. Offsets count scopes, not decisions.
+  chatto.api.v1.PageRequest page = 3;
+  // Optional exact scope filter. Missing or inaccessible scopes produce an empty page.
+  // SERVER and DM require an empty ID; GROUP and ROOM require an ID.
+  PermissionScope scope = 4;
 }
 
 // Response containing one user's permission matrix.
 message GetUserPermissionMatrixResponse {
   // Requested matrix.
   UserPermissionMatrix matrix = 1;
+  // Total matching scopes and whether another scope page exists.
+  chatto.api.v1.PageInfo page = 2;
 }
 
 // Request to set one role permission state.
@@ -323,19 +356,24 @@ message SetUserPermissionResponse {
   PermissionDecisionUpdate decision = 1;
 }
 
-// Provides permission matrix reads and admin permission writes.
+// Provides permission reads and admin permission writes.
+// Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
+// then ascending resource ID within each kind. Only requested scopes are evaluated.
+// Pages are live reads; layout or visibility changes can shift offsets. Keep the
+// same filters on each request and advance by the number of returned scopes.
+// A scope filter of DM selects DM even when include_direct_message_scope is false.
 service AdminPermissionService {
   // Gets the role-permission matrix for a single tier. Server scope requires
   // role.manage; group and room scopes require role.manage or effective
   // room.manage at the requested resource.
   rpc GetRolePermissionTierMatrix(GetRolePermissionTierMatrixRequest) returns (GetRolePermissionTierMatrixResponse);
-  // Gets one role's full permission matrix. Requires role.manage. Returns
+  // Gets one page of a role's permission matrix. Requires role.manage. Returns
   // NOT_FOUND when the role does not exist.
   rpc GetRolePermissionMatrix(GetRolePermissionMatrixRequest) returns (GetRolePermissionMatrixResponse);
   // Lists one role's permission decisions as resource-oriented rows. Requires
   // role.manage. Returns NOT_FOUND when the role does not exist.
   rpc ListRolePermissionDecisions(ListRolePermissionDecisionsRequest) returns (ListRolePermissionDecisionsResponse);
-  // Gets one user's full permission matrix. Human targets require
+  // Gets one page of a user's permission matrix. Human targets require
   // user.manage-permissions; bot targets require ownership or bot.manage.
   // Returns NOT_FOUND when the user does not exist.
   rpc GetUserPermissionMatrix(GetUserPermissionMatrixRequest) returns (GetUserPermissionMatrixResponse);

--- a/proto/chatto/admin/v1/permissions.proto
+++ b/proto/chatto/admin/v1/permissions.proto
@@ -110,7 +110,7 @@ message PermissionMatrixCell {
   optional bool allow_permitted = 5;
 }
 
-// Permission matrix for one role for one page of scopes.
+// Permission matrix for one role within a scope page.
 message RolePermissionMatrix {
   // Role name.
   string role_name = 1;
@@ -144,7 +144,7 @@ message GetRolePermissionMatrixResponse {
   chatto.api.v1.PageInfo page = 2;
 }
 
-// Permission matrix for one user for one page of scopes.
+// Permission matrix for one user within a scope page.
 message UserPermissionMatrix {
   // User ID.
   string user_id = 1;
@@ -357,8 +357,9 @@ message SetUserPermissionResponse {
 }
 
 // Provides permission reads and admin permission writes.
-// Matrix and decision pages use the same scope order: SERVER, DM, GROUP, ROOM,
-// then ascending resource ID within each kind. Only requested scopes are evaluated.
+// Matrix and decision pages use the same scope order: SERVER, DM, then each GROUP
+// followed by its ROOM scopes. Groups and rooms within each group use ascending
+// resource IDs. Only requested scopes are evaluated.
 // Pages are live reads; layout or visibility changes can shift offsets. Keep the
 // same filters on each request and advance by the number of returned scopes.
 // A scope filter of DM selects DM even when include_direct_message_scope is false.


### PR DESCRIPTION
## Why

- Permission reads evaluated every scope at once, so their cost grew with the number of rooms and permissions

## What changed

- Scope pages and exact typed filters on all four role/user matrix and decision reads: default 20, maximum 100 scopes, with scope counts and live offsets
- Scope selection before permission evaluation; parent inheritance and bot visibility preserved; directory enumeration still scans the directory
- Automatic horizontal page loading, cancellation, paged cache updates, and stable group/room order in the permission editors
- Generated clients/reference, [FDR-001](https://github.com/chattocorp/chatto/blob/main/docs/fdr/FDR-001-roles-and-permissions.md), [interface inventory](https://github.com/chattocorp/chatto/blob/main/docs/architecture/interfaces.md), migration guidance, and release notes

## API compatibility

- Breaking experimental API behavior, approved for 0.5; additive protobuf schema
- Older client → newer server: incomplete configuration unless it consumes scope pages
- Newer client → older server: unsupported permission-page contract; regenerate clients for the target server release
- No new capability flags or stored-data migration; existing authorization preserved

## Test plan

- Full Go Connect API suite; focused core permission/RBAC tests; scope-page race test — passed
- 64 frontend API, cache, component, and Storybook tests; frontend lint/type checks and Svelte autofixer — passed
- Real Playwright horizontal scrolling and stable-column regression — passed; reproduced column movement before the fix
- Chrome DevTools: 20 columns followed by the remaining nine, no editor console errors
- Production frontend/bundle checks, 79-page docs build, Buf lint/public compatibility, storage compatibility, and REUSE license check — passed
