### PR TITLE
docs(api): specify presence and typing timing

### DIFF
--- a/apps/docs-website/src/content/docs/guides/integrations/realtime-protocol.mdx
+++ b/apps/docs-website/src/content/docs/guides/integrations/realtime-protocol.mdx
@@ -161,6 +161,24 @@ New event variants are additive. You can ignore a variant that you do not use
 and still save the common cursor. If a complete top-level frame cannot be
 decoded, close the socket and keep the preceding cursor.
 
+## Refresh presence and typing
+
+Call `MyAccountService.SetPresence` every 30 seconds while your client is
+visible. The server expires presence after 60 seconds without a refresh.
+To appear offline, stop these calls; you can keep the realtime connection open.
+Another client signed in to the same account can keep presence active.
+
+Call `RoomService.RefreshTypingIndicator` at most once every 2 seconds while
+the user types. Include `threadRootEventId` for a thread; omit it for the room
+timeline. Stop sending when typing stops. After posting a message, the next
+typing activity can send immediately.
+
+On receipt of `UserTypingEvent`, track the event actor separately for each room
+and thread. Clear that indicator 6 seconds after the last received typing event,
+or when the actor posts a message in the same room or thread. The receiving
+client owns this timer. There is no stop-typing event, and missed typing events
+are not replayed.
+
 ## Notification creation hints
 
 `notification_occurrences_changed.created_notification_id` identifies a newly

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/account.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/account.mdx
@@ -258,8 +258,9 @@ Result of disconnecting a provider identity.
 ### SetPresence
 
 Updates the current user's live presence status. This state is transient:
-clients should refresh it periodically while visible, and should stop
-calling this RPC when the user chooses to appear offline.
+refresh every 30 seconds while visible. The server expires presence after
+60 seconds without a refresh. Stop calling this RPC to appear offline;
+another client for the same account can keep presence active.
 
 ```http
 POST /api/connect/chatto.api.v1.MyAccountService/SetPresence

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/realtime.mdx
@@ -652,7 +652,10 @@ minimum boundary.
 
 ### UserTypingEvent
 
-UserTypingEvent reports current typing activity.
+UserTypingEvent reports current typing activity for the event actor.
+Track each actor separately for each room and thread. Clear the indicator
+6 seconds after the last received typing event, or when that actor posts
+a message in the same room or thread. No stop-typing event is sent.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
+++ b/apps/docs-website/src/content/docs/reference/connectrpc-api/rooms.mdx
@@ -735,6 +735,9 @@ Result of unpinning a message.
 
 Refreshes the current user's live-only typing indicator for a room or
 thread. Room membership is required; message posting permission is not.
+Send at most once every 2 seconds while typing. After posting a message,
+the next typing activity can send immediately. Stop sending when typing
+stops; receivers clear the indicator after 6 seconds without an event.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/RefreshTypingIndicator

--- a/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/api.raw.mdx
@@ -918,6 +918,9 @@ Result of unpinning a message.
 
 Refreshes the current user's live-only typing indicator for a room or
 thread. Room membership is required; message posting permission is not.
+Send at most once every 2 seconds while typing. After posting a message,
+the next typing activity can send immediately. Stop sending when typing
+stops; receivers clear the indicator after 6 seconds without an event.
 
 ```http
 POST /api/connect/chatto.api.v1.RoomService/RefreshTypingIndicator
@@ -1693,8 +1696,9 @@ Result of disconnecting a provider identity.
 ### SetPresence
 
 Updates the current user's live presence status. This state is transient:
-clients should refresh it periodically while visible, and should stop
-calling this RPC when the user chooses to appear offline.
+refresh every 30 seconds while visible. The server expires presence after
+60 seconds without a refresh. Stop calling this RPC to appear offline;
+another client for the same account can keep presence active.
 
 ```http
 POST /api/connect/chatto.api.v1.MyAccountService/SetPresence

--- a/apps/docs-website/src/generated/connectrpc-api/realtime.raw.mdx
+++ b/apps/docs-website/src/generated/connectrpc-api/realtime.raw.mdx
@@ -515,7 +515,10 @@ minimum boundary.
 
 ### UserTypingEvent
 
-UserTypingEvent reports current typing activity.
+UserTypingEvent reports current typing activity for the event actor.
+Track each actor separately for each room and thread. Clear the indicator
+6 seconds after the last received typing event, or when that actor posts
+a message in the same room or thread. No stop-typing event is sent.
 
 | Field | Type | Description |
 | --- | --- | --- |

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/account.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/account.connect.go
@@ -92,8 +92,9 @@ type MyAccountServiceClient interface {
 	// Disconnects a provider identity from the authenticated account.
 	DisconnectExternalIdentity(context.Context, *connect.Request[v1.DisconnectExternalIdentityRequest]) (*connect.Response[v1.DisconnectExternalIdentityResponse], error)
 	// Updates the current user's live presence status. This state is transient:
-	// clients should refresh it periodically while visible, and should stop
-	// calling this RPC when the user chooses to appear offline.
+	// refresh every 30 seconds while visible. The server expires presence after
+	// 60 seconds without a refresh. Stop calling this RPC to appear offline;
+	// another client for the same account can keep presence active.
 	SetPresence(context.Context, *connect.Request[v1.SetPresenceRequest]) (*connect.Response[v1.SetPresenceResponse], error)
 	// Sets the current user's complete custom status. Emoji and text are required.
 	// Omit expires_at for no expiry, or supply a future time.
@@ -293,8 +294,9 @@ type MyAccountServiceHandler interface {
 	// Disconnects a provider identity from the authenticated account.
 	DisconnectExternalIdentity(context.Context, *connect.Request[v1.DisconnectExternalIdentityRequest]) (*connect.Response[v1.DisconnectExternalIdentityResponse], error)
 	// Updates the current user's live presence status. This state is transient:
-	// clients should refresh it periodically while visible, and should stop
-	// calling this RPC when the user chooses to appear offline.
+	// refresh every 30 seconds while visible. The server expires presence after
+	// 60 seconds without a refresh. Stop calling this RPC to appear offline;
+	// another client for the same account can keep presence active.
 	SetPresence(context.Context, *connect.Request[v1.SetPresenceRequest]) (*connect.Response[v1.SetPresenceResponse], error)
 	// Sets the current user's complete custom status. Emoji and text are required.
 	// Omit expires_at for no expiry, or supply a future time.

--- a/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
+++ b/cli/internal/pb/chatto/api/v1/apiv1connect/rooms.connect.go
@@ -180,6 +180,9 @@ type RoomServiceClient interface {
 	DeletePinnedMessage(context.Context, *connect.Request[v1.DeletePinnedMessageRequest]) (*connect.Response[v1.DeletePinnedMessageResponse], error)
 	// Refreshes the current user's live-only typing indicator for a room or
 	// thread. Room membership is required; message posting permission is not.
+	// Send at most once every 2 seconds while typing. After posting a message,
+	// the next typing activity can send immediately. Stop sending when typing
+	// stops; receivers clear the indicator after 6 seconds without an event.
 	RefreshTypingIndicator(context.Context, *connect.Request[v1.RefreshTypingIndicatorRequest]) (*connect.Response[v1.RefreshTypingIndicatorResponse], error)
 	// Returns one page of room timeline events, including related user data
 	// needed to render the page. Room membership is required. Reads also require
@@ -617,6 +620,9 @@ type RoomServiceHandler interface {
 	DeletePinnedMessage(context.Context, *connect.Request[v1.DeletePinnedMessageRequest]) (*connect.Response[v1.DeletePinnedMessageResponse], error)
 	// Refreshes the current user's live-only typing indicator for a room or
 	// thread. Room membership is required; message posting permission is not.
+	// Send at most once every 2 seconds while typing. After posting a message,
+	// the next typing activity can send immediately. Stop sending when typing
+	// stops; receivers clear the indicator after 6 seconds without an event.
 	RefreshTypingIndicator(context.Context, *connect.Request[v1.RefreshTypingIndicatorRequest]) (*connect.Response[v1.RefreshTypingIndicatorResponse], error)
 	// Returns one page of room timeline events, including related user data
 	// needed to render the page. Room membership is required. Reads also require

--- a/cli/internal/pb/chatto/realtime/v1/events.pb.go
+++ b/cli/internal/pb/chatto/realtime/v1/events.pb.go
@@ -2225,7 +2225,10 @@ func (*ServerProfileChangedEvent) Descriptor() ([]byte, []int) {
 	return file_chatto_realtime_v1_events_proto_rawDescGZIP(), []int{38}
 }
 
-// UserTypingEvent reports current typing activity.
+// UserTypingEvent reports current typing activity for the event actor.
+// Track each actor separately for each room and thread. Clear the indicator
+// 6 seconds after the last received typing event, or when that actor posts
+// a message in the same room or thread. No stop-typing event is sent.
 type UserTypingEvent struct {
 	state             protoimpl.MessageState `protogen:"open.v1"`
 	RoomId            string                 `protobuf:"bytes,1,opt,name=room_id,json=roomId,proto3" json:"room_id,omitempty"`

--- a/packages/api-types/src/chatto/api/v1/account_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/account_connect.ts
@@ -102,8 +102,9 @@ export const MyAccountService = {
     },
     /**
      * Updates the current user's live presence status. This state is transient:
-     * clients should refresh it periodically while visible, and should stop
-     * calling this RPC when the user chooses to appear offline.
+     * refresh every 30 seconds while visible. The server expires presence after
+     * 60 seconds without a refresh. Stop calling this RPC to appear offline;
+     * another client for the same account can keep presence active.
      *
      * @generated from rpc chatto.api.v1.MyAccountService.SetPresence
      */

--- a/packages/api-types/src/chatto/api/v1/rooms_connect.ts
+++ b/packages/api-types/src/chatto/api/v1/rooms_connect.ts
@@ -281,6 +281,9 @@ export const RoomService = {
     /**
      * Refreshes the current user's live-only typing indicator for a room or
      * thread. Room membership is required; message posting permission is not.
+     * Send at most once every 2 seconds while typing. After posting a message,
+     * the next typing activity can send immediately. Stop sending when typing
+     * stops; receivers clear the indicator after 6 seconds without an event.
      *
      * @generated from rpc chatto.api.v1.RoomService.RefreshTypingIndicator
      */

--- a/packages/api-types/src/chatto/realtime/v1/events_pb.ts
+++ b/packages/api-types/src/chatto/realtime/v1/events_pb.ts
@@ -1851,7 +1851,10 @@ export class ServerProfileChangedEvent extends Message<ServerProfileChangedEvent
 }
 
 /**
- * UserTypingEvent reports current typing activity.
+ * UserTypingEvent reports current typing activity for the event actor.
+ * Track each actor separately for each room and thread. Clear the indicator
+ * 6 seconds after the last received typing event, or when that actor posts
+ * a message in the same room or thread. No stop-typing event is sent.
  *
  * @generated from message chatto.realtime.v1.UserTypingEvent
  */

--- a/proto/chatto/api/v1/account.proto
+++ b/proto/chatto/api/v1/account.proto
@@ -134,8 +134,9 @@ service MyAccountService {
   // Disconnects a provider identity from the authenticated account.
   rpc DisconnectExternalIdentity(DisconnectExternalIdentityRequest) returns (DisconnectExternalIdentityResponse);
   // Updates the current user's live presence status. This state is transient:
-  // clients should refresh it periodically while visible, and should stop
-  // calling this RPC when the user chooses to appear offline.
+  // refresh every 30 seconds while visible. The server expires presence after
+  // 60 seconds without a refresh. Stop calling this RPC to appear offline;
+  // another client for the same account can keep presence active.
   rpc SetPresence(SetPresenceRequest) returns (SetPresenceResponse);
   // Sets the current user's complete custom status. Emoji and text are required.
   // Omit expires_at for no expiry, or supply a future time.

--- a/proto/chatto/api/v1/rooms.proto
+++ b/proto/chatto/api/v1/rooms.proto
@@ -492,6 +492,9 @@ service RoomService {
   rpc DeletePinnedMessage(DeletePinnedMessageRequest) returns (DeletePinnedMessageResponse);
   // Refreshes the current user's live-only typing indicator for a room or
   // thread. Room membership is required; message posting permission is not.
+  // Send at most once every 2 seconds while typing. After posting a message,
+  // the next typing activity can send immediately. Stop sending when typing
+  // stops; receivers clear the indicator after 6 seconds without an event.
   rpc RefreshTypingIndicator(RefreshTypingIndicatorRequest) returns (RefreshTypingIndicatorResponse);
   // Returns one page of room timeline events, including related user data
   // needed to render the page. Room membership is required. Reads also require

--- a/proto/chatto/realtime/v1/events.proto
+++ b/proto/chatto/realtime/v1/events.proto
@@ -276,7 +276,10 @@ message ThreadViewerStateChangedEvent {
 // Read ServerService with this event's resume cursor as the minimum boundary.
 message ServerProfileChangedEvent {}
 
-// UserTypingEvent reports current typing activity.
+// UserTypingEvent reports current typing activity for the event actor.
+// Track each actor separately for each room and thread. Clear the indicator
+// 6 seconds after the last received typing event, or when that actor posts
+// a message in the same room or thread. No stop-typing event is sent.
 message UserTypingEvent {
   string room_id = 1;
   optional string thread_root_event_id = 2;


### PR DESCRIPTION
- Document presence refresh every 30 seconds and expiry after 60 seconds, including multiple clients for one account.
- Document typing sends every 2 seconds, receiver expiry after 6 seconds, and room/thread scope. Independent clients can now use these rules without reading frontend code.
- Regenerate Go/TypeScript comments and the public API reference. This clarifies existing behavior from [FDR-010](../blob/main/docs/fdr/FDR-010-typing-indicators.md) and [FDR-011](../blob/main/docs/fdr/FDR-011-user-presence.md); no wire, runtime, or stored-data changes.
- Verified: protobuf generation, `mise lint-proto`, documentation build (79 pages), `git diff --check`, and full diff review. No runtime or browser tests were needed for this documentation-only change.
