### PR TITLE
fix(frontend): remove room sidebar skeletons

### DIFF
--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomFilesPanel.svelte
@@ -169,45 +169,39 @@ Room-scoped file list for the room sidebar.
   </button>
 {/snippet}
 
-<nav class="flex min-h-0 flex-1 flex-col overflow-y-auto" aria-label={m('room.sidebar.files')}>
-  {#if loading}
-    <ul role="list" class="space-y-1 p-2">
-      {#each Array(8) as _, i (i)}
-        <li class="flex items-center gap-3 rounded-md px-2 py-2">
-          <div class="skeleton h-10 w-10 shrink-0 rounded-md"></div>
-          <div class="min-w-0 flex-1 space-y-1">
-            <div class="skeleton h-3.5 w-32 rounded"></div>
-            <div class="skeleton h-3 w-24 rounded"></div>
-          </div>
-        </li>
-      {/each}
-    </ul>
-  {:else if files.length === 0}
-    <div
-      class="flex min-h-32 flex-1 items-center justify-center px-4 text-center text-sm text-muted"
-    >
-      {m('room.sidebar.no_files')}
-    </div>
-  {:else}
-    {#each fileSections as section, i (section.id)}
-      <RoomGroupSection
-        label={section.label}
-        items={section.items}
-        item={fileRow}
-        persistKey={section.persistKey}
-        testid={section.testid}
-        separated={i > 0}
-      />
-    {/each}
-
-    {#if store.hasMore}
+<nav
+  class="flex min-h-0 flex-1 flex-col overflow-y-auto"
+  aria-label={m('room.sidebar.files')}
+  aria-busy={loading}
+>
+  {#if !loading}
+    {#if files.length === 0}
       <div
-        class="flex justify-center px-3 py-4 text-sm text-muted"
-        data-testid="room-files-load-more-sentinel"
-        {@attach loadMoreWhenVisible}
+        class="flex min-h-32 flex-1 items-center justify-center px-4 text-center text-sm text-muted"
       >
-        {store.isLoadingMore ? m('room.sidebar.loading_files') : ''}
+        {m('room.sidebar.no_files')}
       </div>
+    {:else}
+      {#each fileSections as section, i (section.id)}
+        <RoomGroupSection
+          label={section.label}
+          items={section.items}
+          item={fileRow}
+          persistKey={section.persistKey}
+          testid={section.testid}
+          separated={i > 0}
+        />
+      {/each}
+
+      {#if store.hasMore}
+        <div
+          class="flex justify-center px-3 py-4 text-sm text-muted"
+          data-testid="room-files-load-more-sentinel"
+          {@attach loadMoreWhenVisible}
+        >
+          {store.isLoadingMore ? m('room.sidebar.loading_files') : ''}
+        </div>
+      {/if}
     {/if}
   {/if}
 </nav>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -383,7 +383,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
       label={m('room.sidebar.resize')}
     />
   {/if}
-  <PaneHeader {title} {loading} skeletonButtons={0}>
+  <PaneHeader {title}>
     {#snippet actions()}
       {#if showMaximizeButton}
         <HeaderIconButton
@@ -458,35 +458,28 @@ calls, and similar room-specific panels can plug into the same shell. See the
         data-testid="room-member-list"
         aria-label={m('room.sidebar.members')}
       >
-        <nav aria-label={m('room.sidebar.members')}>
-          {#if (loading || membersStore.isInitialLoading) && !membersStore.hasFirstPage}
-            <ul role="list" class="px-2">
-              {#each Array(8) as _, i (i)}
-                <li class="flex items-center gap-2 rounded-md px-2 py-1.5">
-                  <div class="skeleton h-8 w-8 shrink-0 rounded-full"></div>
-                  <div class="min-w-0 flex-1 space-y-1">
-                    <div class="skeleton h-3.5 w-24 rounded"></div>
-                    <div class="skeleton h-3 w-16 rounded"></div>
-                  </div>
-                </li>
+        <nav
+          aria-label={m('room.sidebar.members')}
+          aria-busy={(loading || membersStore.isInitialLoading) && !membersStore.hasFirstPage}
+        >
+          {#if !((loading || membersStore.isInitialLoading) && !membersStore.hasFirstPage)}
+            {#if members.length === 0}
+              <div class="px-2 py-8 text-center text-sm text-muted">
+                {m('room.sidebar.no_members')}
+              </div>
+            {:else}
+              {#each memberGroups as group (group.id)}
+                <RoomGroupSection
+                  label={group.label}
+                  items={group.items}
+                  item={memberRow}
+                  persistKey={group.persistKey}
+                  defaultCollapsed={group.defaultCollapsed}
+                  testid={group.testid}
+                  separated
+                />
               {/each}
-            </ul>
-          {:else if members.length === 0}
-            <div class="px-2 py-8 text-center text-sm text-muted">
-              {m('room.sidebar.no_members')}
-            </div>
-          {:else}
-            {#each memberGroups as group (group.id)}
-              <RoomGroupSection
-                label={group.label}
-                items={group.items}
-                item={memberRow}
-                persistKey={group.persistKey}
-                defaultCollapsed={group.defaultCollapsed}
-                testid={group.testid}
-                separated
-              />
-            {/each}
+            {/if}
           {/if}
         </nav>
       </ScrollFader>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -110,9 +110,17 @@ calls, and similar room-specific panels can plug into the same shell. See the
   const members = $derived(membersStore.filteredMembers);
   const allMembers = $derived(membersStore.members);
   const memberCount = $derived(membersStore.totalCount);
+  const membersPending = $derived(
+    !membersStore.hasFirstPage &&
+      (loading || membersStore.isInitialLoading || membersStore.loadError === null)
+  );
   const title = $derived.by(() => {
     if (activeProfileUserId) return m('chat.profile.title');
-    if (activePanel === 'members') return m('room.sidebar.members_title', { count: memberCount });
+    if (activePanel === 'members') {
+      return membersPending
+        ? m('room.sidebar.members')
+        : m('room.sidebar.members_title', { count: memberCount });
+    }
     if (activePanel === 'search') return m('search.in_room');
     if (activePanel === 'files') return m('room.sidebar.files');
     if (activePanel === 'pins') return m('room.sidebar.pins');
@@ -460,9 +468,9 @@ calls, and similar room-specific panels can plug into the same shell. See the
       >
         <nav
           aria-label={m('room.sidebar.members')}
-          aria-busy={(loading || membersStore.isInitialLoading) && !membersStore.hasFirstPage}
+          aria-busy={membersPending}
         >
-          {#if !((loading || membersStore.isInitialLoading) && !membersStore.hasFirstPage)}
+          {#if !membersPending}
             {#if members.length === 0}
               <div class="px-2 py-8 text-center text-sm text-muted">
                 {m('room.sidebar.no_members')}

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -575,6 +575,23 @@ describe('RoomSidebar', () => {
     expect(attachmentMocks.listRoomAttachments).not.toHaveBeenCalled();
   });
 
+  it('keeps the member list clear while its first page loads', async () => {
+    memberDirectoryMocks.listRoomMembers.mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        roomData: roomData([], 0, false)
+      }
+    });
+
+    await tick();
+    const memberList = q(container, 'nav[aria-label="Members"]');
+    expect(memberList?.getAttribute('aria-busy')).toBe('true');
+    expect(memberList?.querySelector('.skeleton')).toBeNull();
+    expect(memberList?.textContent).not.toContain('No members found.');
+    expect(q(container, 'h1')?.querySelector('.skeleton')).toBeNull();
+  });
+
   it('shows the exact total count and eagerly loads all member pages', async () => {
     const firstPage = Array.from({ length: 100 }, (_, index) => member(index + 1));
     const secondPage = Array.from({ length: 42 }, (_, index) => member(index + 101));
@@ -1938,6 +1955,23 @@ describe('RoomSidebar', () => {
       expect(container.textContent).toContain('No files in this room yet.');
     });
     expect(container.querySelector('[aria-label="Members"]')).toBeFalsy();
+  });
+
+  it('keeps the file list clear while its first page loads', async () => {
+    attachmentMocks.listRoomAttachments.mockReturnValue(new Promise(() => {}));
+
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        activePanel: 'files',
+        roomData: roomData([member(1)], 1, false)
+      }
+    });
+
+    await tick();
+    const fileList = q(container, 'nav[aria-label="Files"]');
+    expect(fileList?.getAttribute('aria-busy')).toBe('true');
+    expect(fileList?.querySelector('.skeleton')).toBeNull();
+    expect(fileList?.textContent).not.toContain('No files in this room yet.');
   });
 
   it('keeps the files panel usable when attachment loading fails', async () => {

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -589,7 +589,7 @@ describe('RoomSidebar', () => {
     expect(memberList?.getAttribute('aria-busy')).toBe('true');
     expect(memberList?.querySelector('.skeleton')).toBeNull();
     expect(memberList?.textContent).not.toContain('No members found.');
-    expect(q(container, 'h1')?.querySelector('.skeleton')).toBeNull();
+    expect(q(container, 'h1')?.textContent).toBe('Members');
   });
 
   it('shows the exact total count and eagerly loads all member pages', async () => {


### PR DESCRIPTION
## Summary

- **What changed:** Removed the loading skeletons from the Room Sidebar header, member list, and file list. Pending lists now stay clear and expose `aria-busy` until their first result arrives.
- **Why:** The animated placeholders made the Room Sidebar feel visually noisy. The pending member title now uses “Members” instead of showing an inaccurate zero count.
- **Design:** Existing loaded, empty, error, and pagination states are unchanged. This is a presentation-only change with no API, compatibility, migration, security, or deployment effect.

## Verification

- `mise x -- pnpm --filter chatto-frontend exec vitest --run src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts` — 50 tests passed.
- `mise lint-frontend` — passed, including design-system checks, Svelte diagnostics, and ESLint.
- Svelte autofixer — no issues in the changed components.
- Chrome DevTools — verified the Members and Files panes visually, confirmed no Room Sidebar skeleton elements, and found no console warnings or errors in the inspected state.