### PR TITLE
docs(agents): require public API timing guidance

### DIFF
--- a/proto/AGENTS.md
+++ b/proto/AGENTS.md
@@ -27,6 +27,10 @@ For public API packages:
   and important field.
 - Explain what a call reads or changes, required IDs, pagination or cursor
   rules, required authorization, and important response behavior.
+- For APIs that require periodic refresh or expire automatically, document the
+  refresh interval, expiry duration, who owns the timer, and how clients stop
+  or clear the state. Include these rules in the public API reference;
+  internal docs and frontend constants are not sufficient.
 - Keep field comments short for generated tables. Put longer behavior notes on
   messages or RPCs.
 - Do not put maintainer workflow text, such as "run codegen", in comments that


### PR DESCRIPTION
- Add a rule to `proto/AGENTS.md` requiring public documentation of refresh intervals, expiry durations, timer ownership, and how clients stop or clear state.
- Capture the lesson from the presence and typing audit: independent clients need these rules without reading frontend code or internal docs. Follows #2347.
- Verified the complete diff against `origin/main` and ran `git diff --check`. No runtime tests or code generation are needed for this instruction-only change.
