### PR TITLE
fix(frontend): smooth initial page transition

### DIFF
--- a/apps/frontend/DESIGN_SYSTEM.md
+++ b/apps/frontend/DESIGN_SYSTEM.md
@@ -469,5 +469,8 @@ Its critical styles are inline so it does not wait for application assets. It
 uses the background and emphasized-surface theme tokens, with matching light
 and dark fallbacks before CSS loads, and stays static with reduced motion. A
 faint, centred CHATTO wordmark uses a fixed system font to prevent size changes
-when application fonts load. The app removes the shell when its layout mounts.
-Automatic form focus does not stop the reveal.
+when application fonts load. When the app layout mounts, the shell fades and
+scales out while the page sections appear below it. The app removes the shell
+when this transition ends. Keyboard or pointer input ends all startup
+animations and shows the complete page immediately. Automatic form focus does
+not stop the reveal. Reduced motion removes the shell without a transition.

--- a/apps/frontend/src/app.html
+++ b/apps/frontend/src/app.html
@@ -190,6 +190,7 @@
         place-items: center;
         position: fixed;
         inset: 0;
+        z-index: 100;
         overflow: hidden;
         pointer-events: none;
         background: var(--color-background, var(--loading-background));
@@ -204,7 +205,9 @@
         color: var(--color-text, var(--loading-text));
         /* Keep metrics stable when application CSS and web fonts arrive. */
         box-sizing: border-box;
-        font: 600 20px / 1 system-ui, sans-serif;
+        font:
+          600 20px / 1 system-ui,
+          sans-serif;
         letter-spacing: 0.45em;
         padding-inline-start: 0.45em;
         opacity: 0.28;

--- a/apps/frontend/src/lib/attachments/initialPageReveal.svelte.spec.ts
+++ b/apps/frontend/src/lib/attachments/initialPageReveal.svelte.spec.ts
@@ -2,12 +2,21 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { initialPageReveal } from './initialPageReveal';
 
 let root: HTMLDivElement;
+let loading: HTMLDivElement;
 let motion: EventTarget & { matches: boolean };
 let cleanup: void | (() => void);
+
+function appendLoadingShell() {
+  const shell = document.createElement('div');
+  shell.id = 'app-loading';
+  document.body.append(shell);
+  return shell;
+}
 
 beforeEach(() => {
   motion = Object.assign(new EventTarget(), { matches: false });
   vi.spyOn(window, 'matchMedia').mockReturnValue(motion as MediaQueryList);
+  loading = appendLoadingShell();
   root = document.createElement('div');
   root.innerHTML = `<header>App</header><main><aside>Servers</aside><section data-page-reveal><h1 data-page-reveal>Title</h1><form data-page-reveal><input aria-label="Name"></form></section></main>`;
   document.body.append(root);
@@ -31,6 +40,21 @@ it('reveals separate sections without scaling nested sections twice', () => {
   expect(root.querySelector('section')?.getAnimations()).toHaveLength(0);
 });
 
+it('cross-fades and removes the startup shell', async () => {
+  cleanup = initialPageReveal(root);
+
+  expect(loading.isConnected).toBe(true);
+  const [animation] = loading.getAnimations();
+  expect(animation.effect?.getTiming()).toMatchObject({ duration: 540, easing: 'ease-out' });
+  expect((animation.effect as KeyframeEffect).getKeyframes()).toMatchObject([
+    { opacity: '1', transform: 'scale(1)' },
+    { opacity: '0', transform: 'scale(1.02)' }
+  ]);
+
+  animation.finish();
+  await vi.waitFor(() => expect(loading.isConnected).toBe(false));
+});
+
 it('does not animate content inserted by navigation or an asynchronous load', () => {
   cleanup = initialPageReveal(root);
   root.querySelector('main')!.innerHTML = '<section data-page-reveal>Next page</section>';
@@ -43,18 +67,22 @@ it('keeps automatic form focus but reveals all controls before keyboard input', 
   expect(root.getAnimations({ subtree: true }).length).toBeGreaterThan(0);
   window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
   expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+  expect(loading.isConnected).toBe(false);
 });
 
 it('skips reduced motion and cancels when the preference changes', () => {
   motion.matches = true;
   cleanup = initialPageReveal(root);
   expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+  expect(loading.isConnected).toBe(false);
   motion.matches = false;
+  loading = appendLoadingShell();
   cleanup = initialPageReveal(root);
   expect(root.getAnimations({ subtree: true }).length).toBeGreaterThan(0);
   motion.matches = true;
   motion.dispatchEvent(new Event('change'));
   expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+  expect(loading.isConnected).toBe(false);
 });
 
 it('removes animation effects after completion and on unmount', () => {
@@ -69,13 +97,14 @@ it('reveals controls before pointer interaction', () => {
   cleanup = initialPageReveal(root);
   root.querySelector('input')!.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
   expect(root.getAnimations({ subtree: true })).toHaveLength(0);
+  expect(loading.isConnected).toBe(false);
 });
 
-it('removes the startup shell even when reduced motion skips the reveal', () => {
-  const loading = document.createElement('div');
-  loading.id = 'app-loading';
-  document.body.append(loading);
-  motion.matches = true;
+it('removes the startup shell and animations on unmount', () => {
   cleanup = initialPageReveal(root);
+  cleanup?.();
+  cleanup = undefined;
+
   expect(loading.isConnected).toBe(false);
+  expect(root.getAnimations({ subtree: true })).toHaveLength(0);
 });

--- a/apps/frontend/src/lib/attachments/initialPageReveal.ts
+++ b/apps/frontend/src/lib/attachments/initialPageReveal.ts
@@ -15,9 +15,26 @@ function revealSections(element: Element): Element[] {
  */
 export const initialPageReveal: Attachment = (element) => {
   // The HTML shell is visible while SvelteKit resolves the initial route.
-  document.getElementById('app-loading')?.remove();
+  const loadingShell = document.getElementById('app-loading');
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
-  if (reducedMotion.matches) return;
+  if (reducedMotion.matches) {
+    loadingShell?.remove();
+    return;
+  }
+
+  const loadingAnimation = loadingShell?.animate(
+    [
+      { opacity: 1, transform: 'scale(1)' },
+      { opacity: 0, transform: 'scale(1.02)' }
+    ],
+    { duration: 540, easing: 'ease-out', fill: 'forwards' }
+  );
+  const removeLoadingShell = () => {
+    if (!loadingShell) return;
+    loadingAnimation?.cancel();
+    loadingShell.remove();
+  };
+  if (loadingAnimation) loadingAnimation.onfinish = removeLoadingShell;
 
   const sections = Array.from(element.children).flatMap(revealSections);
   const stagger = Math.min(90, 270 / Math.max(1, sections.length - 1));
@@ -31,6 +48,8 @@ export const initialPageReveal: Attachment = (element) => {
     )
   );
   const showAll = () => {
+    if (loadingAnimation) loadingAnimation.onfinish = null;
+    removeLoadingShell();
     for (const animation of animations) {
       animation.onfinish = null;
       animation.cancel();


### PR DESCRIPTION
## Summary

- cross-fade and subtly scale the CHATTO startup layer while the initial page sections appear
- keep the startup layer above application chrome until the transition completes
- remove all startup animation immediately for keyboard or pointer input and for reduced-motion preferences
- document the coordinated reveal and extend its browser-component coverage

## Why

- prevent the application background from replacing the startup gradient in a single frame
- make the initial page handoff feel like one continuous reveal without double-animating the page shell and its children
- preserve an immediate, animation-free experience when the browser or system requests reduced motion

## Verification

- `mise x -- pnpm exec vitest --run --project=client src/lib/attachments/initialPageReveal.svelte.spec.ts` (8 passed)
- `mise lint-frontend`
- Svelte autofixer (no issues)
- Prettier and `git diff --check`
- Chrome DevTools MCP inspection in light desktop and dark mobile layouts, including a throttled midpoint inspection
- confirmed client-side navigation does not replay the startup reveal