### PR TITLE
fix(frontend): retain room timelines across navigation

### DIFF
--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -728,6 +728,41 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('retries a failed historical-window restoration at the next route boundary', async () => {
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockResolvedValueOnce(pageFromEvent(threadMessageEvent('initial-latest')))
+      .mockRejectedValueOnce(new Error('network failed'))
+      .mockResolvedValueOnce(pageFromEvent(threadMessageEvent('restored-latest')));
+    const timeline = fakeTimelineAPI({
+      getRoomEvents,
+      getRoomEventsAround: vi.fn(async () => ({
+        events: [threadMessageEvent('historical-target') as never],
+        startCursor: 'tl:historical',
+        endCursor: 'tl:historical',
+        hasOlder: true,
+        hasNewer: true
+      }))
+    });
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      timeline
+    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    store.setRoom('room-1');
+    await settle();
+    await store.jumpToMessage('historical-target', new JumpToMessageState());
+    await expect(store.restoreLatestWindow()).resolves.toBe(false);
+    await expect(store.restoreLatestWindow()).resolves.toBe(true);
+
+    expect(getRoomEvents).toHaveBeenCalledTimes(3);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['restored-latest']);
+    expect(consoleError).toHaveBeenCalledOnce();
+    store.dispose();
+  });
+
   it('cancels a pending historical jump without restarting the latest read', async () => {
     type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;
     const around = deferred<AroundPage>();

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -654,6 +654,115 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('keeps a retained latest room window across route boundaries', async () => {
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockResolvedValue(pageFromEvent(threadMessageEvent('latest-message')));
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      fakeTimelineAPI({ getRoomEvents })
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    await expect(store.restoreLatestWindow()).resolves.toBe(false);
+
+    expect(getRoomEvents).toHaveBeenCalledOnce();
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['latest-message']);
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
+  it('keeps the initial latest read alive across a route boundary', async () => {
+    type RoomPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEvents']>>;
+    const initial = deferred<RoomPage>();
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockImplementation(() => initial.promise);
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      fakeTimelineAPI({ getRoomEvents })
+    );
+
+    store.setRoom('room-1');
+    await expect(store.restoreLatestWindow()).resolves.toBe(false);
+    initial.resolve(pageFromEvent(threadMessageEvent('loaded-after-boundary')));
+    await settle();
+
+    expect(getRoomEvents).toHaveBeenCalledOnce();
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['loaded-after-boundary']);
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
+  it('restores the latest window after leaving a completed historical jump', async () => {
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockResolvedValueOnce(pageFromEvent(threadMessageEvent('initial-latest')))
+      .mockResolvedValueOnce(pageFromEvent(threadMessageEvent('restored-latest')));
+    const timeline = fakeTimelineAPI({
+      getRoomEvents,
+      getRoomEventsAround: vi.fn(async () => ({
+        events: [threadMessageEvent('historical-target') as never],
+        startCursor: 'tl:historical',
+        endCursor: 'tl:historical',
+        hasOlder: true,
+        hasNewer: true
+      }))
+    });
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      timeline
+    );
+
+    store.setRoom('room-1');
+    await settle();
+    await store.jumpToMessage('historical-target', new JumpToMessageState());
+    await expect(store.restoreLatestWindow()).resolves.toBe(true);
+
+    expect(getRoomEvents).toHaveBeenCalledTimes(2);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['restored-latest']);
+    store.dispose();
+  });
+
+  it('cancels a pending historical jump without restarting the latest read', async () => {
+    type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;
+    const around = deferred<AroundPage>();
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockResolvedValue(pageFromEvent(threadMessageEvent('latest-message')));
+    const timeline = fakeTimelineAPI({
+      getRoomEvents,
+      getRoomEventsAround: vi.fn(() => around.promise)
+    });
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      timeline
+    );
+    store.setRoom('room-1');
+    await settle();
+
+    const jumping = store.jumpToMessage('historical-target', new JumpToMessageState());
+    await expect(store.restoreLatestWindow()).resolves.toBe(false);
+    around.resolve({
+      events: [threadMessageEvent('historical-target') as never],
+      startCursor: 'tl:historical',
+      endCursor: 'tl:historical',
+      hasOlder: true,
+      hasNewer: true
+    });
+
+    await expect(jumping).resolves.toBe(false);
+    expect(getRoomEvents).toHaveBeenCalledOnce();
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['latest-message']);
+    expect(store.isInitialLoading).toBe(false);
+    store.dispose();
+  });
+
   it('keeps an in-flight message jump when lazy latest-page hydration arrives', async () => {
     const fake = new FakeQueryClient();
     type AroundPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEventsAround']>>;
@@ -2493,15 +2602,26 @@ describe('MessagesStore — room lifecycle ownership', () => {
       .fn<RoomTimelineAPI['getRoomEvents']>()
       .mockResolvedValueOnce(pageFromEvent(threadMessageEvent('m1')))
       .mockRejectedValueOnce(new ConnectError('permission denied', Code.PermissionDenied));
+    const timeline = fakeTimelineAPI({
+      getRoomEvents,
+      getRoomEventsAround: vi.fn(async () => ({
+        events: [threadMessageEvent('historical') as never],
+        startCursor: 'tl:historical',
+        endCursor: 'tl:historical',
+        hasOlder: true,
+        hasNewer: true
+      }))
+    });
     const store = new MessagesStore(
       {} as ServerConnection,
       () => null,
-      fakeTimelineAPI({ getRoomEvents })
+      timeline
     );
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     store.setRoom('room-1');
     await settle();
+    await store.jumpToMessage('historical', new JumpToMessageState());
     await expect(store.restoreLatestWindow()).resolves.toBe(false);
 
     expect(store.rootEvents).toEqual([]);

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -697,6 +697,30 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('retries a failed initial latest read at the next route boundary', async () => {
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockRejectedValueOnce(new Error('network failed'))
+      .mockResolvedValueOnce(pageFromEvent(threadMessageEvent('retried-latest')));
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      fakeTimelineAPI({ getRoomEvents })
+    );
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    store.setRoom('room-1');
+    await settle();
+    await expect(store.restoreLatestWindow()).resolves.toBe(true);
+
+    expect(getRoomEvents).toHaveBeenCalledTimes(2);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['retried-latest']);
+    expect(store.isInitialLoading).toBe(false);
+    expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+    store.dispose();
+  });
+
   it('restores the latest window after leaving a completed historical jump', async () => {
     const getRoomEvents = vi
       .fn<RoomTimelineAPI['getRoomEvents']>()
@@ -760,6 +784,7 @@ describe('MessagesStore — room lifecycle ownership', () => {
     expect(getRoomEvents).toHaveBeenCalledTimes(3);
     expect(store.rootEvents.map((event) => event.id)).toEqual(['restored-latest']);
     expect(consoleError).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
     store.dispose();
   });
 

--- a/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
+++ b/apps/frontend/src/lib/state/room/messages.svelte.spec.ts
@@ -721,6 +721,36 @@ describe('MessagesStore — room lifecycle ownership', () => {
     store.dispose();
   });
 
+  it('keeps a newer latest read active when an older read settles', async () => {
+    type RoomPage = Awaited<ReturnType<RoomTimelineAPI['getRoomEvents']>>;
+    const initial = deferred<RoomPage>();
+    const replacement = deferred<RoomPage>();
+    const getRoomEvents = vi
+      .fn<RoomTimelineAPI['getRoomEvents']>()
+      .mockImplementationOnce(() => initial.promise)
+      .mockImplementationOnce(() => replacement.promise);
+    const store = new MessagesStore(
+      new FakeQueryClient() as unknown as ServerConnection,
+      () => null,
+      fakeTimelineAPI({ getRoomEvents })
+    );
+
+    store.setRoom('room-1');
+    const replacing = store.jumpToPresent(new JumpToMessageState());
+    initial.resolve(pageFromEvent(threadMessageEvent('stale-latest')));
+    await settle();
+
+    await expect(store.restoreLatestWindow()).resolves.toBe(false);
+    expect(getRoomEvents).toHaveBeenCalledTimes(2);
+
+    replacement.resolve(pageFromEvent(threadMessageEvent('current-latest')));
+    await expect(replacing).resolves.toBe(true);
+    await expect(store.restoreLatestWindow()).resolves.toBe(false);
+    expect(getRoomEvents).toHaveBeenCalledTimes(2);
+    expect(store.rootEvents.map((event) => event.id)).toEqual(['current-latest']);
+    store.dispose();
+  });
+
   it('restores the latest window after leaving a completed historical jump', async () => {
     const getRoomEvents = vi
       .fn<RoomTimelineAPI['getRoomEvents']>()

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -162,6 +162,7 @@ export class MessagesStore {
   #pendingAuthoritativeLoadId: number | null = null;
   #pendingJumpId: number | null = null;
   #hasHistoricalWindow = false;
+  #isRestoringHistoricalWindow = false;
   #projectionAccessRevoked = false;
   #previewGeneration = 0;
 
@@ -442,8 +443,18 @@ export class MessagesStore {
   restoreLatestWindow(): Promise<boolean> {
     if (this.scope !== 'room') return Promise.resolve(false);
     this.cancelPendingHistoricalJump();
+    if (this.#isRestoringHistoricalWindow) return Promise.resolve(false);
     if (!this.#hasHistoricalWindow) return Promise.resolve(false);
-    return this.resetAndFetchLatest();
+    const source = this.source;
+    const restoration = this.resetAndFetchLatest();
+    this.#isRestoringHistoricalWindow = true;
+    return restoration.then((restored) => {
+      if (this.source === source && this.#isRestoringHistoricalWindow) {
+        this.#hasHistoricalWindow = !restored;
+        this.#isRestoringHistoricalWindow = false;
+      }
+      return restored;
+    });
   }
 
   /** Restore this retained room's canonical latest projection at a route boundary. */
@@ -1172,6 +1183,7 @@ export class MessagesStore {
     this.events = [];
     this.seenIds = new SvelteSet();
     this.#hasHistoricalWindow = false;
+    this.#isRestoringHistoricalWindow = false;
     this.previewEvents.clear();
     this.invalidatePendingPreviewFetches();
     this.optimisticReactions.clearAll();

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -162,7 +162,7 @@ export class MessagesStore {
   #pendingAuthoritativeLoadId: number | null = null;
   #pendingJumpId: number | null = null;
   #needsLatestWindowRestore = false;
-  #isLoadingLatestWindow = false;
+  #latestWindowLoadId: number | null = null;
   #projectionAccessRevoked = false;
   #previewGeneration = 0;
 
@@ -443,7 +443,7 @@ export class MessagesStore {
   restoreLatestWindow(): Promise<boolean> {
     if (this.scope !== 'room') return Promise.resolve(false);
     this.cancelPendingHistoricalJump();
-    if (this.#isLoadingLatestWindow) return Promise.resolve(false);
+    if (this.#latestWindowLoadId !== null) return Promise.resolve(false);
     if (!this.#needsLatestWindowRestore) return Promise.resolve(false);
     return this.resetAndFetchLatest();
   }
@@ -1174,7 +1174,7 @@ export class MessagesStore {
     this.events = [];
     this.seenIds = new SvelteSet();
     this.#needsLatestWindowRestore = false;
-    this.#isLoadingLatestWindow = false;
+    this.#latestWindowLoadId = null;
     this.previewEvents.clear();
     this.invalidatePendingPreviewFetches();
     this.optimisticReactions.clearAll();
@@ -1369,12 +1369,12 @@ export class MessagesStore {
     const thisLoad = this.startLoad();
     this.#pendingAuthoritativeLoadId = thisLoad;
     this.resetState();
-    this.#isLoadingLatestWindow = true;
+    this.#latestWindowLoadId = thisLoad;
     this.isInitialLoading = true;
     return this.fetchCurrent(thisLoad).then((loaded) => {
-      if (this.source === source && this.#isLoadingLatestWindow) {
+      if (this.source === source && this.#latestWindowLoadId === thisLoad) {
         this.#needsLatestWindowRestore = !loaded;
-        this.#isLoadingLatestWindow = false;
+        this.#latestWindowLoadId = null;
       }
       return loaded;
     });

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -161,8 +161,8 @@ export class MessagesStore {
   #windowId = 0;
   #pendingAuthoritativeLoadId: number | null = null;
   #pendingJumpId: number | null = null;
-  #needsLatestWindowRestore = false;
-  #latestWindowLoadId: number | null = null;
+  /** True when the retained room window is historical or its latest read failed. */
+  #needsLatestWindow = false;
   #projectionAccessRevoked = false;
   #previewGeneration = 0;
 
@@ -422,7 +422,7 @@ export class MessagesStore {
     this.selectRoom(roomId);
     this.#pendingAuthoritativeLoadId = null;
     const connection = roomTimelinePageToEventConnectionPage(page);
-    this.#needsLatestWindowRestore = false;
+    this.#needsLatestWindow = false;
     // Reset already purged the pre-prefix state. Preserve writes ingested
     // after that reset: the snapshot page was captured before those writes
     // and its later arrival must not erase read-your-writes.
@@ -439,12 +439,13 @@ export class MessagesStore {
     if (this.#pendingAuthoritativeLoadId === null) this.isInitialLoading = false;
   }
 
-  /** Restore a historical room window after crossing a route boundary. */
+  /** Load the latest room window at a route boundary when retained data needs it. */
   restoreLatestWindow(): Promise<boolean> {
     if (this.scope !== 'room') return Promise.resolve(false);
     this.cancelPendingHistoricalJump();
-    if (this.#latestWindowLoadId !== null) return Promise.resolve(false);
-    if (!this.#needsLatestWindowRestore) return Promise.resolve(false);
+    if (this.#pendingAuthoritativeLoadId !== null || !this.#needsLatestWindow) {
+      return Promise.resolve(false);
+    }
     return this.resetAndFetchLatest();
   }
 
@@ -459,7 +460,7 @@ export class MessagesStore {
     for (const event of projected) this.clearOptimisticVersionForEvent(event.id);
     this.events = source.sort(projected);
     this.seenIds = new SvelteSet(projected.map((event) => event.id));
-    this.#needsLatestWindowRestore = false;
+    this.#needsLatestWindow = false;
     this.oldestCursor = connection.startCursor ?? undefined;
     this.newestCursor = connection.endCursor ?? undefined;
     this.hasReachedStart = !connection.hasOlder;
@@ -753,7 +754,7 @@ export class MessagesStore {
       }
 
       if (!page.hasNewer) jumpState.hasReachedEnd = true;
-      if (!page.hasNewer) this.#needsLatestWindowRestore = false;
+      if (!page.hasNewer) this.#needsLatestWindow = false;
     } catch (error) {
       console.error('MessagesStore: loadNewer failed:', error);
     } finally {
@@ -809,7 +810,7 @@ export class MessagesStore {
       this.oldestCursor = startCursor ?? undefined;
       this.newestCursor = endCursor ?? undefined;
       this.hasReachedStart = !hasOlder;
-      this.#needsLatestWindowRestore = hasNewer;
+      this.#needsLatestWindow = hasNewer;
 
       // Only enter jumped mode when newer messages exist beyond this window.
       jumpState.isJumpedMode = hasNewer;
@@ -1173,8 +1174,7 @@ export class MessagesStore {
   private resetState(): void {
     this.events = [];
     this.seenIds = new SvelteSet();
-    this.#needsLatestWindowRestore = false;
-    this.#latestWindowLoadId = null;
+    this.#needsLatestWindow = false;
     this.previewEvents.clear();
     this.invalidatePendingPreviewFetches();
     this.optimisticReactions.clearAll();
@@ -1364,20 +1364,15 @@ export class MessagesStore {
     );
   }
 
-  private resetAndFetchLatest(): Promise<boolean> {
+  private async resetAndFetchLatest(): Promise<boolean> {
     const source = this.source;
     const thisLoad = this.startLoad();
     this.#pendingAuthoritativeLoadId = thisLoad;
     this.resetState();
-    this.#latestWindowLoadId = thisLoad;
     this.isInitialLoading = true;
-    return this.fetchCurrent(thisLoad).then((loaded) => {
-      if (this.source === source && this.#latestWindowLoadId === thisLoad) {
-        this.#needsLatestWindowRestore = !loaded;
-        this.#latestWindowLoadId = null;
-      }
-      return loaded;
-    });
+    const loaded = await this.fetchCurrent(thisLoad);
+    if (this.source === source && !this.isStale(thisLoad)) this.#needsLatestWindow = !loaded;
+    return loaded;
   }
 
   private async fetchCurrent(

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -161,8 +161,8 @@ export class MessagesStore {
   #windowId = 0;
   #pendingAuthoritativeLoadId: number | null = null;
   #pendingJumpId: number | null = null;
-  #hasHistoricalWindow = false;
-  #isRestoringHistoricalWindow = false;
+  #needsLatestWindowRestore = false;
+  #isLoadingLatestWindow = false;
   #projectionAccessRevoked = false;
   #previewGeneration = 0;
 
@@ -422,7 +422,7 @@ export class MessagesStore {
     this.selectRoom(roomId);
     this.#pendingAuthoritativeLoadId = null;
     const connection = roomTimelinePageToEventConnectionPage(page);
-    this.#hasHistoricalWindow = false;
+    this.#needsLatestWindowRestore = false;
     // Reset already purged the pre-prefix state. Preserve writes ingested
     // after that reset: the snapshot page was captured before those writes
     // and its later arrival must not erase read-your-writes.
@@ -443,18 +443,9 @@ export class MessagesStore {
   restoreLatestWindow(): Promise<boolean> {
     if (this.scope !== 'room') return Promise.resolve(false);
     this.cancelPendingHistoricalJump();
-    if (this.#isRestoringHistoricalWindow) return Promise.resolve(false);
-    if (!this.#hasHistoricalWindow) return Promise.resolve(false);
-    const source = this.source;
-    const restoration = this.resetAndFetchLatest();
-    this.#isRestoringHistoricalWindow = true;
-    return restoration.then((restored) => {
-      if (this.source === source && this.#isRestoringHistoricalWindow) {
-        this.#hasHistoricalWindow = !restored;
-        this.#isRestoringHistoricalWindow = false;
-      }
-      return restored;
-    });
+    if (this.#isLoadingLatestWindow) return Promise.resolve(false);
+    if (!this.#needsLatestWindowRestore) return Promise.resolve(false);
+    return this.resetAndFetchLatest();
   }
 
   /** Restore this retained room's canonical latest projection at a route boundary. */
@@ -468,7 +459,7 @@ export class MessagesStore {
     for (const event of projected) this.clearOptimisticVersionForEvent(event.id);
     this.events = source.sort(projected);
     this.seenIds = new SvelteSet(projected.map((event) => event.id));
-    this.#hasHistoricalWindow = false;
+    this.#needsLatestWindowRestore = false;
     this.oldestCursor = connection.startCursor ?? undefined;
     this.newestCursor = connection.endCursor ?? undefined;
     this.hasReachedStart = !connection.hasOlder;
@@ -762,7 +753,7 @@ export class MessagesStore {
       }
 
       if (!page.hasNewer) jumpState.hasReachedEnd = true;
-      if (!page.hasNewer) this.#hasHistoricalWindow = false;
+      if (!page.hasNewer) this.#needsLatestWindowRestore = false;
     } catch (error) {
       console.error('MessagesStore: loadNewer failed:', error);
     } finally {
@@ -818,7 +809,7 @@ export class MessagesStore {
       this.oldestCursor = startCursor ?? undefined;
       this.newestCursor = endCursor ?? undefined;
       this.hasReachedStart = !hasOlder;
-      this.#hasHistoricalWindow = hasNewer;
+      this.#needsLatestWindowRestore = hasNewer;
 
       // Only enter jumped mode when newer messages exist beyond this window.
       jumpState.isJumpedMode = hasNewer;
@@ -1182,8 +1173,8 @@ export class MessagesStore {
   private resetState(): void {
     this.events = [];
     this.seenIds = new SvelteSet();
-    this.#hasHistoricalWindow = false;
-    this.#isRestoringHistoricalWindow = false;
+    this.#needsLatestWindowRestore = false;
+    this.#isLoadingLatestWindow = false;
     this.previewEvents.clear();
     this.invalidatePendingPreviewFetches();
     this.optimisticReactions.clearAll();
@@ -1374,11 +1365,19 @@ export class MessagesStore {
   }
 
   private resetAndFetchLatest(): Promise<boolean> {
+    const source = this.source;
     const thisLoad = this.startLoad();
     this.#pendingAuthoritativeLoadId = thisLoad;
     this.resetState();
+    this.#isLoadingLatestWindow = true;
     this.isInitialLoading = true;
-    return this.fetchCurrent(thisLoad);
+    return this.fetchCurrent(thisLoad).then((loaded) => {
+      if (this.source === source && this.#isLoadingLatestWindow) {
+        this.#needsLatestWindowRestore = !loaded;
+        this.#isLoadingLatestWindow = false;
+      }
+      return loaded;
+    });
   }
 
   private async fetchCurrent(

--- a/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
+++ b/apps/frontend/src/lib/state/room/messages/MessagesStore.svelte.ts
@@ -161,6 +161,7 @@ export class MessagesStore {
   #windowId = 0;
   #pendingAuthoritativeLoadId: number | null = null;
   #pendingJumpId: number | null = null;
+  #hasHistoricalWindow = false;
   #projectionAccessRevoked = false;
   #previewGeneration = 0;
 
@@ -420,6 +421,7 @@ export class MessagesStore {
     this.selectRoom(roomId);
     this.#pendingAuthoritativeLoadId = null;
     const connection = roomTimelinePageToEventConnectionPage(page);
+    this.#hasHistoricalWindow = false;
     // Reset already purged the pre-prefix state. Preserve writes ingested
     // after that reset: the snapshot page was captured before those writes
     // and its later arrival must not erase read-your-writes.
@@ -433,14 +435,14 @@ export class MessagesStore {
     this.#jumpId++;
     this.#windowId++;
     this.#pendingJumpId = null;
+    if (this.#pendingAuthoritativeLoadId === null) this.isInitialLoading = false;
   }
 
-  /** Restore the authoritative latest room window after crossing a route boundary. */
+  /** Restore a historical room window after crossing a route boundary. */
   restoreLatestWindow(): Promise<boolean> {
     if (this.scope !== 'room') return Promise.resolve(false);
-    this.#jumpId++;
-    this.#windowId++;
-    this.#pendingJumpId = null;
+    this.cancelPendingHistoricalJump();
+    if (!this.#hasHistoricalWindow) return Promise.resolve(false);
     return this.resetAndFetchLatest();
   }
 
@@ -455,6 +457,7 @@ export class MessagesStore {
     for (const event of projected) this.clearOptimisticVersionForEvent(event.id);
     this.events = source.sort(projected);
     this.seenIds = new SvelteSet(projected.map((event) => event.id));
+    this.#hasHistoricalWindow = false;
     this.oldestCursor = connection.startCursor ?? undefined;
     this.newestCursor = connection.endCursor ?? undefined;
     this.hasReachedStart = !connection.hasOlder;
@@ -748,6 +751,7 @@ export class MessagesStore {
       }
 
       if (!page.hasNewer) jumpState.hasReachedEnd = true;
+      if (!page.hasNewer) this.#hasHistoricalWindow = false;
     } catch (error) {
       console.error('MessagesStore: loadNewer failed:', error);
     } finally {
@@ -803,6 +807,7 @@ export class MessagesStore {
       this.oldestCursor = startCursor ?? undefined;
       this.newestCursor = endCursor ?? undefined;
       this.hasReachedStart = !hasOlder;
+      this.#hasHistoricalWindow = hasNewer;
 
       // Only enter jumped mode when newer messages exist beyond this window.
       jumpState.isJumpedMode = hasNewer;
@@ -1166,6 +1171,7 @@ export class MessagesStore {
   private resetState(): void {
     this.events = [];
     this.seenIds = new SvelteSet();
+    this.#hasHistoricalWindow = false;
     this.previewEvents.clear();
     this.invalidatePendingPreviewFetches();
     this.optimisticReactions.clearAll();

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -480,7 +480,7 @@ export class ServerStateStore {
     return store;
   }
 
-  /** Restore a retained historical window when a route crosses this room's boundary. */
+  /** Load the latest room window at a route boundary when retained data needs it. */
   restoreProjectedRoomWindow(roomId: string): void {
     const messages = this.messagesForRoom(roomId);
     void messages.restoreLatestWindow();

--- a/apps/frontend/src/lib/state/server/store.svelte.ts
+++ b/apps/frontend/src/lib/state/server/store.svelte.ts
@@ -480,7 +480,7 @@ export class ServerStateStore {
     return store;
   }
 
-  /** Restore the canonical latest window when a route selects this room. */
+  /** Restore a retained historical window when a route crosses this room's boundary. */
   restoreProjectedRoomWindow(roomId: string): void {
     const messages = this.messagesForRoom(roomId);
     void messages.restoreLatestWindow();


### PR DESCRIPTION
## Summary

- Keep a loaded latest room timeline in its per-server memory store when the route enters or leaves the room.
- Cancel incomplete historical jumps without clearing the retained latest window.
- Retry failed initial reads and failed historical-window restorations at the next route boundary.
- Reuse the existing load generation to isolate overlapping latest-window reads.
- Keep route restoration state to one documented Boolean.
- Add regression coverage for retained, in-flight, historical, failed, overlapping, and authorization-boundary lifecycle cases.

## Why

- The semantic realtime migration changed route-boundary restoration into an unconditional timeline reset and network read.
- Normal room switches therefore cleared retained data and made redundant `GetRoomEvents` requests, although realtime updates already keep retained stores current.
- A transient first-read failure could leave a retained room empty without a later retry.

## Verification

- `mise lint-frontend`
- `mise test-frontend`
- Chrome DevTools network inspection: one timeline request per room on first load and no additional request when returning to an already loaded room.
