### PR TITLE
feat(frontend): unify room search inputs

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -789,6 +789,13 @@
   @apply rounded-xl bg-surface;
 }
 
+/* Chat input rows share one stable height and surface treatment. Keep compact
+ * shelves on composer-surface when they do not contain the primary input.
+ */
+@utility chat-input-surface {
+  @apply min-h-12 rounded-xl bg-surface;
+}
+
 /* Server Gutter item — icon buttons in the leftmost sidebar (the Server Gutter). */
 @utility server-gutter-item {
   @apply shimmer-hover relative flex h-12 w-12 shrink-0 items-center justify-center rounded-xl text-3xl transition-[background-color,color] duration-150;

--- a/apps/frontend/src/lib/components/chat/ChatSearchInput.stories.svelte
+++ b/apps/frontend/src/lib/components/chat/ChatSearchInput.stories.svelte
@@ -1,0 +1,63 @@
+<script module lang="ts">
+  import { defineMeta } from '@storybook/addon-svelte-csf';
+  import ChatSearchInput from './ChatSearchInput.svelte';
+
+  const { Story } = defineMeta({
+    title: 'Chat/Search input',
+    component: ChatSearchInput,
+    tags: ['autodocs'],
+    parameters: {
+      docs: {
+        description: {
+          component:
+            'Search input for fixed chat action rails. It shares the message composer surface and height.'
+        }
+      }
+    }
+  });
+</script>
+
+<script lang="ts">
+  let emptyValue = $state('');
+  let populatedValue = $state('roadmap');
+  let narrowValue = $state('');
+  let disabledValue = $state('Search is unavailable');
+</script>
+
+<Story name="Empty" asChild>
+  <div class="w-96 max-w-full bg-background p-2">
+    <ChatSearchInput
+      label="Search messages"
+      placeholder="Words, phrases, or filters..."
+      bind:value={emptyValue}
+    />
+  </div>
+</Story>
+
+<Story name="Populated and clearable" asChild>
+  <div class="w-96 max-w-full bg-background p-2">
+    <ChatSearchInput
+      label="Search members"
+      placeholder="Search members"
+      clearLabel="Clear member search"
+      bind:value={populatedValue}
+      onclear={() => (populatedValue = '')}
+    />
+  </div>
+</Story>
+
+<Story name="Narrow" asChild>
+  <div class="w-52 bg-background p-2">
+    <ChatSearchInput
+      label="Search messages"
+      placeholder="Words, phrases, or filters..."
+      bind:value={narrowValue}
+    />
+  </div>
+</Story>
+
+<Story name="Disabled" asChild>
+  <div class="w-96 max-w-full bg-background p-2">
+    <ChatSearchInput label="Search messages" bind:value={disabledValue} disabled />
+  </div>
+</Story>

--- a/apps/frontend/src/lib/components/chat/ChatSearchInput.svelte
+++ b/apps/frontend/src/lib/components/chat/ChatSearchInput.svelte
@@ -1,0 +1,99 @@
+<!--
+@component
+
+A compact search field for chat surfaces. It shares the message composer's
+height, radius, background, and spacing while keeping native form behaviour.
+-->
+<script lang="ts">
+  import type { Attachment } from 'svelte/attachments';
+
+  const generatedId = $props.id();
+  let {
+    id = generatedId,
+    testid,
+    label,
+    placeholder,
+    value = $bindable(''),
+    disabled = false,
+    focusOnMount = false,
+    clearLabel,
+    oninput,
+    onsubmit,
+    onclear
+  }: {
+    id?: string;
+    testid?: string;
+    label: string;
+    placeholder?: string;
+    value?: string;
+    disabled?: boolean;
+    focusOnMount?: boolean;
+    clearLabel?: string;
+    oninput?: (event: Event) => void;
+    onsubmit?: () => void;
+    onclear?: () => void;
+  } = $props();
+
+  let inputElement: HTMLInputElement | null = null;
+
+  const observeInput: Attachment<HTMLInputElement> = (input) => {
+    inputElement = input;
+    if (focusOnMount) {
+      queueMicrotask(() => {
+        if (input.isConnected && !input.disabled) input.focus();
+      });
+    }
+    return () => {
+      if (inputElement === input) inputElement = null;
+    };
+  };
+
+  function submit(event: SubmitEvent): void {
+    event.preventDefault();
+    onsubmit?.();
+  }
+
+  function clear(): void {
+    value = '';
+    onclear?.();
+    inputElement?.focus();
+  }
+</script>
+
+<form
+  class={[
+    'relative flex h-12 min-w-0 items-center gap-1 chat-input-surface px-2.5 py-1.5 transition-opacity duration-100',
+    disabled && 'opacity-50'
+  ]}
+  onsubmit={submit}
+>
+  <label class="sr-only" for={id}>{label}</label>
+  <span
+    class="iconify icon-[uil--search] h-5 w-5 shrink-0 text-muted"
+    aria-hidden="true"
+  ></span>
+  <input
+    {@attach observeInput}
+    {id}
+    data-testid={testid}
+    type="search"
+    bind:value
+    {placeholder}
+    {disabled}
+    autocomplete="off"
+    class="search-cancel-hidden min-w-0 flex-1 bg-transparent px-1 py-1.5 text-text outline-none placeholder:text-muted/70"
+    {oninput}
+  />
+  {#if clearLabel && value}
+    <button
+      type="button"
+      class="inline-flex h-8 w-8 shrink-0 cursor-pointer items-center justify-center rounded text-muted transition-[background-color,color] duration-150 hover:bg-surface-emphasized hover:text-text active:bg-surface-selected focus-visible:bg-surface-emphasized focus-visible:outline-2 focus-visible:outline-action disabled:cursor-not-allowed disabled:opacity-50"
+      aria-label={clearLabel}
+      title={clearLabel}
+      {disabled}
+      onclick={clear}
+    >
+      <span class="iconify icon-[uil--times] text-base" aria-hidden="true"></span>
+    </button>
+  {/if}
+</form>

--- a/apps/frontend/src/lib/components/chat/ChatSearchInput.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/chat/ChatSearchInput.svelte.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import ChatSearchInputTestHarness from './ChatSearchInputTestHarness.svelte';
+
+describe('ChatSearchInput', () => {
+  it('binds its value, reports input, and submits with Enter', async () => {
+    const rendered = render(ChatSearchInputTestHarness);
+    const input = rendered.getByRole('searchbox', { name: 'Search messages' });
+    const surface = rendered.container.querySelector('form')!;
+
+    expect(surface).toHaveClass('h-12', 'chat-input-surface');
+    expect(surface.className).not.toContain('focus-within:ring');
+
+    await userEvent.fill(input, 'roadmap');
+    await expect.element(rendered.getByTestId('search-value')).toHaveTextContent('roadmap');
+    await expect.element(rendered.getByTestId('input-count')).toHaveTextContent('1');
+    expect(rendered.getByRole('button', { name: 'Clear search' }).element()).toHaveClass(
+      'h-8',
+      'w-8'
+    );
+    expect(surface).toHaveClass('h-12', 'chat-input-surface');
+
+    await userEvent.type(input, '{Enter}');
+    await expect.element(rendered.getByTestId('submit-count')).toHaveTextContent('1');
+  });
+
+  it('clears the value and restores focus', async () => {
+    const rendered = render(ChatSearchInputTestHarness, {
+      props: { value: 'roadmap' }
+    });
+    const input = rendered.getByRole('searchbox', { name: 'Search messages' });
+
+    await userEvent.click(rendered.getByRole('button', { name: 'Clear search' }));
+
+    await expect.element(input).toHaveValue('');
+    await expect.element(input).toHaveFocus();
+    await expect.element(rendered.getByTestId('clear-count')).toHaveTextContent('1');
+  });
+
+  it('focuses on mount and exposes its disabled state', async () => {
+    const focused = render(ChatSearchInputTestHarness, { props: { focusOnMount: true } });
+    await expect
+      .element(focused.getByRole('searchbox', { name: 'Search messages' }))
+      .toHaveFocus();
+    focused.unmount();
+
+    const disabled = render(ChatSearchInputTestHarness, { props: { disabled: true } });
+    await expect
+      .element(disabled.getByRole('searchbox', { name: 'Search messages' }))
+      .toBeDisabled();
+  });
+});

--- a/apps/frontend/src/lib/components/chat/ChatSearchInputTestHarness.svelte
+++ b/apps/frontend/src/lib/components/chat/ChatSearchInputTestHarness.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import ChatSearchInput from './ChatSearchInput.svelte';
+
+  let {
+    value = $bindable(''),
+    focusOnMount = false,
+    disabled = false
+  }: { value?: string; focusOnMount?: boolean; disabled?: boolean } = $props();
+
+  let inputCount = $state(0);
+  let submitCount = $state(0);
+  let clearCount = $state(0);
+</script>
+
+<ChatSearchInput
+  id="chat-search-test"
+  label="Search messages"
+  placeholder="Find messages"
+  clearLabel="Clear search"
+  bind:value
+  {focusOnMount}
+  {disabled}
+  oninput={() => inputCount++}
+  onsubmit={() => submitCount++}
+  onclear={() => clearCount++}
+/>
+
+<output data-testid="search-value">{value}</output>
+<output data-testid="input-count">{inputCount}</output>
+<output data-testid="submit-count">{submitCount}</output>
+<output data-testid="clear-count">{clearCount}</output>

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte
@@ -225,7 +225,7 @@
 
   <div
     data-testid="composer-input-surface"
-    class="@container relative flex min-h-12 min-w-0 items-end gap-1 composer-surface px-2.5 py-1.5"
+    class="@container relative flex min-w-0 items-end gap-1 chat-input-surface px-2.5 py-1.5"
     class:opacity-50={composer.inputDisabled}
   >
     {#if composer.autocomplete.emoji}

--- a/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
+++ b/apps/frontend/src/lib/components/composer/MessageComposer.svelte.spec.ts
@@ -462,7 +462,7 @@ describe('MessageComposer', () => {
       expect(actions?.contains(q(container, 'button[title="Attach file"]'))).toBe(true);
       expect(actions?.contains(q(container, 'button[aria-label="Insert timestamp"]'))).toBe(true);
       expect(actions?.contains(q(container, 'button[aria-label="Send message"]'))).toBe(true);
-      expect(surface).toHaveClass('composer-surface');
+      expect(surface).toHaveClass('chat-input-surface');
       expect(q(container, '[data-testid="composer-formatting-shelf"]')).toBeNull();
     });
 

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSearchPanel.svelte
@@ -5,7 +5,6 @@ Room-scoped message search for the room sidebar. Its store is retained per room
 so switching rooms cannot leak a query or plaintext results into another room.
 -->
 <script lang="ts">
-  import type { Attachment } from 'svelte/attachments';
   import SearchResult from '$lib/components/search/SearchResult.svelte';
   import SearchAvailability from '$lib/components/search/SearchAvailability.svelte';
   import { m } from '$lib/i18n/messages';
@@ -19,7 +18,7 @@ so switching rooms cannot leak a query or plaintext results into another room.
   import SearchResults from '$lib/components/search/SearchResults.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import { Hint, ScrollFader } from '$lib/ui';
-  import { TextInput } from '$lib/ui/form';
+  import ChatSearchInput from '$lib/components/chat/ChatSearchInput.svelte';
   import { formatDateTime, timeFormatSettingsFor } from '$lib/utils/formatTime';
   import ClampedMessagePreview from './ClampedMessagePreview.svelte';
 
@@ -47,18 +46,6 @@ so switching rooms cannot leak a query or plaintext results into another room.
     void store.ensureStatus();
   });
 
-  function submit(event: SubmitEvent): void {
-    event.preventDefault();
-    search.submitNow();
-  }
-
-  const focusSearchField: Attachment<HTMLFormElement> = (form) => {
-    queueMicrotask(() => {
-      if (!form.isConnected) return;
-      form.querySelector<HTMLInputElement>('input')?.focus();
-    });
-  };
-
   function scheduleSearch(event: Event): void {
     search.schedule((event.currentTarget as HTMLInputElement).value);
   }
@@ -83,26 +70,6 @@ so switching rooms cannot leak a query or plaintext results into another room.
     {/if}
   {/snippet}
   <div class="flex min-h-0 flex-1 flex-col">
-    <div class="border-b border-border p-2">
-      <form onsubmit={submit} {@attach focusSearchField}>
-        <TextInput
-          label={m('search.query.label')}
-          labelHidden
-          testid="room-search-query"
-          bind:value={store.query}
-          placeholder={m('search.query.placeholder')}
-          leadingIcon="icon-[uil--search]"
-          autocomplete="off"
-          oninput={scheduleSearch}
-        />
-      </form>
-      {#if store.status.state === MessageSearchState.DEGRADED}
-        <div class="mt-2">
-          <Hint tone="warning">{m('search.degraded')}</Hint>
-        </div>
-      {/if}
-    </div>
-
     <ScrollFader top bottom keyboardFocusable={false} class="min-h-0 flex-1">
       <SearchResults {store} compact>
         {#snippet children(result)}
@@ -133,5 +100,22 @@ so switching rooms cannot leak a query or plaintext results into another room.
         {/snippet}
       </SearchResults>
     </ScrollFader>
+
+    <div class="shrink-0 bg-background p-2" data-testid="room-search-input-block">
+      {#if store.status.state === MessageSearchState.DEGRADED}
+        <div class="mb-2">
+          <Hint tone="warning">{m('search.degraded')}</Hint>
+        </div>
+      {/if}
+      <ChatSearchInput
+        label={m('search.query.label')}
+        testid="room-search-query"
+        bind:value={store.query}
+        placeholder={m('search.query.placeholder')}
+        focusOnMount
+        oninput={scheduleSearch}
+        onsubmit={() => search.submitNow()}
+      />
+    </div>
   </div>
 </SearchAvailability>

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte
@@ -38,6 +38,7 @@ calls, and similar room-specific panels can plug into the same shell. See the
   } from '$lib/state/userProfiles.svelte';
   import { useServerScope } from '$lib/state/server/scope.svelte';
   import RoomGroupSection from '$lib/components/chat/RoomGroupSection.svelte';
+  import ChatSearchInput from '$lib/components/chat/ChatSearchInput.svelte';
   import { ScrollFader } from '$lib/ui';
   import PaneHeader from '$lib/ui/PaneHeader.svelte';
   import ResizeHandle from '$lib/components/ResizeHandle.svelte';
@@ -143,7 +144,6 @@ calls, and similar room-specific panels can plug into the same shell. See the
   let banError = $state<string | null>(null);
   const memberSearchDebounce = useDebounce();
   const presenceGroupingDebounce = useDebounce();
-  let memberSearchInput = $state<HTMLInputElement | null>(null);
   let groupedOnlineState = $state.raw(new Map<string, boolean>());
   let observedLiveOnlineState = new Map<string, boolean>();
   let groupedMembersSnapshot: RoomMember[] | null = null;
@@ -348,7 +348,6 @@ calls, and similar room-specific panels can plug into the same shell. See the
   function clearMemberSearch() {
     memberSearchDebounce.cancel();
     void membersStore.setSearch('');
-    memberSearchInput?.focus();
   }
 
   async function toggleCallFullscreen(): Promise<void> {
@@ -425,40 +424,6 @@ calls, and similar room-specific panels can plug into the same shell. See the
     <RoomSidebarProfile userId={activeProfileUserId} />
   {:else if activePanel === 'members'}
     <div class="flex min-h-0 flex-1 flex-col">
-      <div class="shrink-0 bg-background p-2" data-testid="room-member-search-block">
-        <label class="sr-only" for="room-member-search">{m('room.sidebar.search_members')}</label>
-        <div class="relative">
-          <span
-            class="iconify pointer-events-none absolute start-2 top-1/2 icon-[uil--search] h-4 w-4 -translate-y-1/2 text-muted"
-            aria-hidden="true"
-          ></span>
-          <input
-            bind:this={memberSearchInput}
-            id="room-member-search"
-            type="search"
-            value={membersStore.searchInput}
-            oninput={scheduleMemberSearch}
-            placeholder={m('room.sidebar.search_members_placeholder')}
-            class={[
-              'search-cancel-hidden h-10 w-full rounded-md bg-surface py-1 ps-8 text-sm transition-colors outline-none placeholder:text-muted',
-              membersStore.searchInput ? 'pe-12' : 'pe-2'
-            ]}
-          />
-          {#if membersStore.searchInput}
-            <button
-              type="button"
-              class="absolute end-1 top-1/2 pane-header-icon-button -translate-y-1/2"
-              aria-label={m('room.sidebar.clear_member_search')}
-              title={m('room.sidebar.clear_member_search')}
-              onclick={clearMemberSearch}
-            >
-              <span class="iconify icon-[uil--times] pane-header-icon-glyph" aria-hidden="true"
-              ></span>
-            </button>
-          {/if}
-        </div>
-      </div>
-
       <ScrollFader
         top
         bottom
@@ -491,6 +456,18 @@ calls, and similar room-specific panels can plug into the same shell. See the
           {/if}
         </nav>
       </ScrollFader>
+
+      <div class="shrink-0 bg-background p-2" data-testid="room-member-search-block">
+        <ChatSearchInput
+          id="room-member-search"
+          label={m('room.sidebar.search_members')}
+          placeholder={m('room.sidebar.search_members_placeholder')}
+          clearLabel={m('room.sidebar.clear_member_search')}
+          bind:value={membersStore.searchInput}
+          oninput={scheduleMemberSearch}
+          onclear={clearMemberSearch}
+        />
+      </div>
 
       {#if popoverMember && popoverAnchorRect}
         <UserContextMenu

--- a/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
+++ b/apps/frontend/src/routes/chat/[serverId]/[roomId]/RoomSidebar.svelte.spec.ts
@@ -452,8 +452,8 @@ describe('RoomSidebar', () => {
       .element(rendered.getByText('Search is unavailable', { exact: true }))
       .toBeVisible();
     await userEvent.click(rendered.getByRole('button', { name: 'Try Again' }));
-    await expect.element(rendered.getByRole('textbox')).toBeVisible();
-    await expect.element(rendered.getByRole('textbox')).toHaveFocus();
+    await expect.element(rendered.getByRole('searchbox')).toBeVisible();
+    await expect.element(rendered.getByRole('searchbox')).toHaveFocus();
     expect(getStatus).toHaveBeenCalledTimes(2);
   });
 
@@ -1464,7 +1464,7 @@ describe('RoomSidebar', () => {
     expect(memberDirectoryMocks.listRoomMembers).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps the member search fixed above a scroll-faded member list', async () => {
+  it('keeps the member search fixed below a scroll-faded member list', async () => {
     const { container } = render(RoomSidebarTestHarness, {
       props: {
         roomData: roomData([], 0, false)
@@ -1479,10 +1479,36 @@ describe('RoomSidebar', () => {
     const memberList = q(container, '[data-testid="room-member-list"]');
     const scrollFader = memberList?.parentElement;
 
-    expect(searchBlock?.nextElementSibling).toBe(scrollFader);
+    expect(scrollFader?.nextElementSibling).toBe(searchBlock);
     expect(searchBlock?.classList).not.toContain('overflow-y-auto');
     expect(memberList?.classList).toContain('overflow-y-auto');
+    expect(q(searchBlock!, 'form')).toHaveClass('chat-input-surface');
     expect(q(memberList!, 'nav[aria-label="Members"]')).toBeTruthy();
+    expect(scrollFader?.querySelector('.bg-gradient-to-b')).toBeTruthy();
+    expect(scrollFader?.querySelector('.bg-gradient-to-t')).toBeTruthy();
+  });
+
+  it('keeps room search fixed below its scroll-faded results', async () => {
+    const searchStore = new MessageSearchStore({
+      getStatus: vi.fn().mockResolvedValue({ state: MessageSearchState.READY, retryAfterMs: null }),
+      searchMessages: vi.fn()
+    });
+    await searchStore.ensureStatus();
+    const { container } = render(RoomSidebarTestHarness, {
+      props: {
+        activePanel: 'search',
+        roomData: roomData([member(1)], 1, false),
+        searchStore
+      }
+    });
+
+    const searchBlock = q(container, '[data-testid="room-search-input-block"]');
+    const scrollFader = searchBlock?.previousElementSibling;
+    const scrollRegion = scrollFader?.querySelector('.overflow-y-auto');
+
+    expect(scrollRegion).toBeTruthy();
+    expect(searchBlock?.classList).not.toContain('overflow-y-auto');
+    expect(q(searchBlock!, 'form')).toHaveClass('chat-input-surface');
     expect(scrollFader?.querySelector('.bg-gradient-to-b')).toBeTruthy();
     expect(scrollFader?.querySelector('.bg-gradient-to-t')).toBeTruthy();
   });
@@ -1515,7 +1541,7 @@ describe('RoomSidebar', () => {
       container,
       'button[aria-label="Clear member search"]'
     ) as HTMLButtonElement;
-    expect(clearButton.className).toContain('pane-header-icon-button');
+    expect(clearButton).toHaveClass('h-8', 'w-8');
     clearButton.click();
     await tick();
 


### PR DESCRIPTION
## Summary

- Move the room-member filter and room-message search below their scrollable content.
- Add a reusable chat search input and a shared 48 px chat input surface for consistent composer geometry.
- Preserve member filtering, message-search debounce and submission, focus behavior, degraded guidance, and result ordering.
- Add component, sidebar, composer, and Storybook coverage for the shared surface and its states.

## Why

- The previous top-aligned search fields did not match the message composer.
- The populated member filter grew taller because its clear action exceeded the intended control height.
- A shared component and semantic utility prevent these search surfaces from drifting apart.

## Design decisions

- Search footers use fixed padding below the scroll regions; only members and results scroll.
- Search surfaces have no focus outline or glow. The clear action retains its own keyboard-visible focus state.
- The composer and search controls share a 48 px minimum geometry, while the composer can still grow for multiline content.

## Verification

- Svelte autofixer: passed.
- Focused Vitest browser tests: 213 passed.
- Full frontend tests: 3,845 passed.
- Frontend lint, Svelte type checks, and design-system checks: passed.
- Production frontend build, bundle-size check, and CSP check: passed.
- REUSE license check and diff whitespace check: passed.
- Chrome DevTools verification: passed in wide and narrow layouts and in light and dark themes. Populated search and composer surfaces both measured 48 px, with no search-surface outline or shadow.

## Effects

- Compatibility and migration: none.
- Security and deployment: none.
- Public API, protocol, translation, and documentation changes: none.